### PR TITLE
Support: bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           sudo apt-get install -y cmake ninja-build g++ clang-tidy
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -39,7 +39,7 @@ jobs:
         run: pip install .
 
       - name: Cache cmake build directories
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: build/cache
           key: cmake-sim-${{ runner.os }}-${{ hashFiles('src/**/CMakeLists.txt', 'src/**/build_config.py', 'simpler_setup/runtime_compiler.py', 'simpler_setup/kernel_compiler.py', 'simpler_setup/toolchain.py') }}
@@ -69,7 +69,7 @@ jobs:
         python-version: ['3.10']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up C++ compiler (Linux)
         if: runner.os == 'Linux'
@@ -84,7 +84,7 @@ jobs:
           brew install gcc@15 || brew install gcc
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -111,10 +111,10 @@ jobs:
         python-version: ['3.10']
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -134,7 +134,7 @@ jobs:
           brew install googletest
 
       - name: Cache pip packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up C++ compiler
         run: |
@@ -184,12 +184,12 @@ jobs:
           fi
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up C++ compiler
         run: |
@@ -242,12 +242,12 @@ jobs:
           fi
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Cache pip packages
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
@@ -279,7 +279,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         run: |
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         run: |
@@ -352,7 +352,7 @@ jobs:
       a5_changed: ${{ steps.check.outputs.a5_changed }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check file changes
@@ -395,7 +395,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         run: |
@@ -433,7 +433,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up environment
         run: |


### PR DESCRIPTION
## Summary

- GitHub will force Actions to run on Node.js 24 starting 2026-06-02 and remove the Node.js 20 runtime on 2026-09-16. CI currently emits `Node.js 20 actions are deprecated` on every job.
- Bump the three first-party actions on this repo to the earliest release that explicitly migrated to the `node24` runtime:
  - `actions/checkout@v4` → `@v5` (v5.0.0 node24)
  - `actions/setup-python@v5` → `@v6` (v6.0.0 node24)
  - `actions/cache@v3` → `@v5` (v5.0.0 node24; v4 was still node20)
- Only the version pins are changed — no step inputs, ordering, or behavior. `pre-commit/action@v3.0.0` is a composite action and is not subject to the Node.js runtime migration, so it is left as-is.

Minimum runner version for all three bumped actions is `v2.327.1`, satisfied by current `ubuntu-latest` / `macos-latest` images and any self-hosted runner updated in the last ~12 months.

## Test plan

- [ ] CI pre-commit / packaging-matrix / ut / st-sim jobs pass on this PR.
- [ ] Inspect one Ubuntu job log and confirm the `Node.js 20 actions are deprecated` warning is no longer present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)