### PR TITLE
Refactor: unify PerfRecord dependency field and fix PTO2 profiling race

### DIFF
--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -42,7 +42,7 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime);
  * Complete a L2PerfRecord with AICPU-side metadata after AICore task completion
  *
  * Reads l2_perf_buf->count, validates task_id match against the latest record,
- * and fills all AICPU-side fields. Callers must pre-extract fanout into a
+ * and fills all AICPU-side fields. Callers must pre-extract dependency tasks into a
  * plain uint64_t array (platform layer cannot depend on runtime linked-list types).
  *
  * @param l2_perf_buf              L2PerfBuffer pointer (from handshake l2_perf_records_addr)
@@ -52,12 +52,13 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime);
  * @param core_type             Core type (AIC/AIV)
  * @param dispatch_time         AICPU timestamp when task was dispatched
  * @param finish_time           AICPU timestamp when task completion was observed
- * @param fanout                Pre-extracted successor task ID array (nullptr if none)
- * @param fanout_count          Number of entries in fanout array (0 if none)
+ * @param fan_tasks             Dependency task ID array (nullptr if none)
+ * @param fan_tasks_count       Number of entries in fan_tasks array (0 if none)
+ * @param is_fanin              true = fan_tasks are producers (fanin), false = successors (fanout)
  */
 int l2_perf_aicpu_complete_record(
     L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
-    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fan_tasks, int32_t fan_tasks_count, bool is_fanin
 );
 
 /**

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -60,9 +60,9 @@
 #include "common/core_type.h"
 #include "common/platform_config.h"
 
-// Maximum number of successor tasks per L2PerfRecord (matches Task::fanout)
-#ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 128
+// Maximum number of dependency tasks per L2PerfRecord (fanin or fanout depending on runtime)
+#ifndef RUNTIME_MAX_FAN_TASKS
+#define RUNTIME_MAX_FAN_TASKS 128
 #endif
 
 // =============================================================================
@@ -90,9 +90,13 @@ struct L2PerfRecord {
     uint32_t func_id;    // Kernel function identifier
     CoreType core_type;  // Core type (AIC/AIV)
 
-    // Dependency relationship (fanout only)
-    uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
-    int32_t fanout_count;                 // Number of successor tasks
+    // Dependency relationship (fanin or fanout, indicated by is_fanin).
+    // PTO2 runtimes record consumer-side fanin (producer task_ids).
+    // host_build_graph records producer-side fanout (successor task_ids).
+    // Host exporter normalizes both into fanout edges for swimlane JSON.
+    uint64_t fan_tasks[RUNTIME_MAX_FAN_TASKS];  // Dependent task_id array
+    int32_t fan_tasks_count;                    // Number of dependent tasks recorded
+    uint8_t is_fanin;                           // 1 = fan_tasks are producers, 0 = successors
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(L2PerfRecord) % 64 == 0, "L2PerfRecord must be 64-byte aligned for optimal cache performance");

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -128,7 +128,7 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
 
 int l2_perf_aicpu_complete_record(
     L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
-    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fan_tasks, int32_t fan_tasks_count, bool is_fanin
 ) {
     rmb();
     uint32_t count = l2_perf_buf->count;
@@ -153,15 +153,16 @@ int l2_perf_aicpu_complete_record(
     record->dispatch_time = dispatch_time;
     record->finish_time = finish_time;
 
-    if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
+    if (fan_tasks != nullptr && fan_tasks_count > 0) {
+        int32_t n = (fan_tasks_count > RUNTIME_MAX_FAN_TASKS) ? RUNTIME_MAX_FAN_TASKS : fan_tasks_count;
         for (int32_t i = 0; i < n; i++) {
-            record->fanout[i] = fanout[i];
+            record->fan_tasks[i] = fan_tasks[i];
         }
-        record->fanout_count = n;
+        record->fan_tasks_count = n;
     } else {
-        record->fanout_count = 0;
+        record->fan_tasks_count = 0;
     }
+    record->is_fanin = is_fanin;  // bool → uint8_t: true→1, false→0
 
     l2_perf_buf->count = count + 1;
     wmb();

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -31,6 +31,7 @@
 #include <iomanip>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/memory_barrier.h"
@@ -1254,6 +1255,20 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path_arg) {
     }
 
     // Step 7: Write JSON data
+    // Build producer→consumers map from fanin records (PTO2 runtimes).
+    // Fanout records (host_build_graph) contribute directly per-record.
+    std::unordered_map<uint64_t, std::vector<uint64_t>> producer_to_consumers;
+    producer_to_consumers.reserve(tagged_records.size());
+    for (const auto &tagged : tagged_records) {
+        const auto &rec = *tagged.record;
+        if (!rec.is_fanin) continue;  // fanout records are handled per-record below
+        int safe_count =
+            (rec.fan_tasks_count >= 0 && rec.fan_tasks_count <= RUNTIME_MAX_FAN_TASKS) ? rec.fan_tasks_count : 0;
+        for (int k = 0; k < safe_count; k++) {
+            producer_to_consumers[rec.fan_tasks[k]].push_back(rec.task_id);
+        }
+    }
+
     int version = has_phase_data_ ? 2 : 1;
     outfile << "{\n";
     outfile << "  \"version\": " << version << ",\n";
@@ -1284,16 +1299,35 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path_arg) {
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
         outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
         outfile << "      \"fanout\": [";
-        int safe_fanout_count =
-            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
-        for (int j = 0; j < safe_fanout_count; ++j) {
-            outfile << record.fanout[j];
-            if (j < safe_fanout_count - 1) {
-                outfile << ", ";
+        int fanout_emitted = 0;
+        if (!record.is_fanin) {
+            // Direct fanout: fan_tasks[] already contains successor task_ids
+            int safe_count = (record.fan_tasks_count >= 0 && record.fan_tasks_count <= RUNTIME_MAX_FAN_TASKS) ?
+                                 record.fan_tasks_count :
+                                 0;
+            for (int j = 0; j < safe_count; ++j) {
+                if (j > 0) {
+                    outfile << ", ";
+                }
+                outfile << record.fan_tasks[j];
+                fanout_emitted++;
+            }
+        } else {
+            // Inverted fanin: look up from producer_to_consumers map
+            const auto it = producer_to_consumers.find(record.task_id);
+            if (it != producer_to_consumers.end()) {
+                const auto &successors = it->second;
+                for (size_t j = 0; j < successors.size(); ++j) {
+                    if (j > 0) {
+                        outfile << ", ";
+                    }
+                    outfile << successors[j];
+                    fanout_emitted++;
+                }
             }
         }
         outfile << "],\n";
-        outfile << "      \"fanout_count\": " << record.fanout_count << "\n";
+        outfile << "      \"fanout_count\": " << fanout_emitted << "\n";
         outfile << "    }";
         if (i < tagged_records.size() - 1) {
             outfile << ",";

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -382,20 +382,15 @@ struct AicpuExecutor {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
                     L2PerfBuffer *l2_perf_buf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
 
-                    // Pre-extract fanout (platform layer cannot depend on PTO2DepListEntry)
-                    uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                    int32_t fanout_n = 0;
-                    PTO2DepListEntry *cur = slot_state.fanout_head;
-                    while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
-                        fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
-                        cur = cur->next;
-                    }
+                    // Pre-extract fanin on the consumer side.
+                    const uint64_t *fanin_ids = slot_state.payload->fanin_resolved_ids;
+                    int32_t fanin_n = slot_state.payload->fanin_resolved_count;
 
                     int32_t perf_slot_idx = static_cast<int32_t>(executing_subslot_by_core_[core_id]);
                     if (l2_perf_aicpu_complete_record(
                             l2_perf_buf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
                             slot_state.task->kernel_id[perf_slot_idx], CT, dispatch_timestamps_[core_id], finish_ts,
-                            fanout_arr, fanout_n
+                            fanin_ids, fanin_n, true
                         ) != 0) {
                         DEV_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_orchestrator.cpp
@@ -476,6 +476,13 @@ void pto2_add_dependency(PTO2OrchestratorState *orch, PTO2TaskId producer_id, PT
         cons_payload->fanin_slot_states[cons_payload->fanin_actual_count] = &prod_state;
         cons_payload->fanin_actual_count++;
     }
+#if PTO2_PROFILING
+    // Resolve producer task_id now while slot_state is still valid.
+    if (cons_payload->fanin_resolved_count < PTO2TaskPayload::kMaxFaninResolved) {
+        cons_payload->fanin_resolved_ids[cons_payload->fanin_resolved_count] = prod_state.task->task_id.raw;
+        cons_payload->fanin_resolved_count++;
+    }
+#endif
 
     // Wire the fanout edge from producer to consumer.
     // Always use fanout_lock: the producer may be from a previous scope

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2_types.h
@@ -275,6 +275,13 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalar_data(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
     }
+
+#if PTO2_PROFILING
+    // Resolved producer task_ids for consumer-side fanin recording (profiling only).
+    static constexpr int32_t kMaxFaninResolved = 128;  // Matches RUNTIME_MAX_FAN_TASKS
+    uint64_t fanin_resolved_ids[kMaxFaninResolved];
+    int32_t fanin_resolved_count{0};
+#endif
 };
 
 /**

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -726,7 +726,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         if (l2_perf_aicpu_complete_record(
                                 l2_perf_buf, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count, false
                             ) != 0) {
                             DEV_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
@@ -745,7 +745,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     if (l2_perf_aicpu_complete_record(
                             l2_perf_buf, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count, false
                         ) != 0) {
                         DEV_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
@@ -851,7 +851,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         if (l2_perf_aicpu_complete_record(
                                 l2_perf_buf, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count, false
                             ) != 0) {
                             DEV_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
@@ -904,7 +904,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     if (l2_perf_aicpu_complete_record(
                             l2_perf_buf, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count, false
                         ) != 0) {
                         DEV_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -288,6 +288,13 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
     }
+
+#if PTO2_PROFILING
+    // Resolved producer task_ids for consumer-side fanin recording (profiling only).
+    static constexpr int32_t kMaxFaninResolved = 128;  // Matches RUNTIME_MAX_FAN_TASKS
+    uint64_t fanin_resolved_ids[kMaxFaninResolved];
+    int32_t fanin_resolved_count{0};
+#endif
 };
 
 // PTO2TaskPayload layout verification (offsetof requires complete type).

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -661,8 +661,19 @@ struct PTO2SchedulerState {
 
         if (wfanin != 0) {
             int32_t early_finished = 0;
+#if PTO2_PROFILING
+            // Snapshot producer task_ids under fanout_lock (same visit order as fanin wiring).
+            // Completion-time perf reads this; avoids orch-time second pass over fanin_builder.
+            int32_t resolved = 0;
+#endif
             pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
                 pto2_fanout_lock(*producer);
+#if PTO2_PROFILING
+                if (resolved < PTO2TaskPayload::kMaxFaninResolved) {
+                    wp->fanin_resolved_ids[resolved] = producer->task->task_id.raw;
+                }
+                resolved++;
+#endif
                 int32_t pstate = producer->task_state.load(std::memory_order_acquire);
                 if (pstate >= PTO2_TASK_COMPLETED) {
                     early_finished++;
@@ -672,12 +683,19 @@ struct PTO2SchedulerState {
                 pto2_fanout_unlock(*producer);
             });
 
+#if PTO2_PROFILING
+            wp->fanin_resolved_count =
+                (resolved < PTO2TaskPayload::kMaxFaninResolved) ? resolved : PTO2TaskPayload::kMaxFaninResolved;
+#endif
             int32_t init_rc = early_finished + 1;
             int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
             if (new_rc >= ws->fanin_count) {
                 ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
             }
         } else {
+#if PTO2_PROFILING
+            wp->fanin_resolved_count = 0;
+#endif
             ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
             ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -130,19 +130,15 @@ void SchedulerContext::complete_slot_task(
         uint64_t finish_ts = get_sys_cnt_aicpu();
         L2PerfBuffer *pbuf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
 
-        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-        int32_t fanout_n = 0;
-        PTO2DepListEntry *cur = slot_state.fanout_head;
-        while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
-            fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
-            cur = cur->next;
-        }
+        // Consumer-side fanin: resolved at submit time in payload (race-free vs fanout_head).
+        const uint64_t *fanin_ids = slot_state.payload->fanin_resolved_ids;
+        int32_t fanin_n = slot_state.payload->fanin_resolved_count;
 
         int32_t perf_slot_idx = static_cast<int32_t>(subslot);
         if (l2_perf_aicpu_complete_record(
                 pbuf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
-                slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanout_arr,
-                fanout_n
+                slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanin_ids,
+                fanin_n, true
             ) != 0) {
             DEV_ERROR(
                 "Core %d: l2_perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -47,8 +47,8 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime);
  * Reads l2_perf_buf->count, validates task_id match against the latest record,
  * and fills all AICPU-side fields. Returns -1 and silently drops the record
  * when the buffer is full (count >= PLATFORM_PROF_BUFFER_SIZE). Callers must
- * pre-extract fanout into a plain uint64_t array (platform layer cannot depend
- * on runtime linked-list types).
+ * pre-extract dependency tasks into a plain uint64_t array (platform layer cannot
+ * depend on runtime linked-list types).
  *
  * @param l2_perf_buf              L2PerfBuffer pointer (from handshake l2_perf_records_addr)
  * @param expected_reg_task_id  Register dispatch token (low 32 bits) to validate
@@ -57,12 +57,13 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime);
  * @param core_type             Core type (AIC/AIV)
  * @param dispatch_time         AICPU timestamp when task was dispatched
  * @param finish_time           AICPU timestamp when task completion was observed
- * @param fanout                Pre-extracted successor task ID array (nullptr if none)
- * @param fanout_count          Number of entries in fanout array (0 if none)
+ * @param fan_tasks             Dependency task ID array (nullptr if none)
+ * @param fan_tasks_count       Number of entries in fan_tasks array (0 if none)
+ * @param is_fanin              true = fan_tasks are producers (fanin), false = successors (fanout)
  */
 int l2_perf_aicpu_complete_record(
     L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
-    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fan_tasks, int32_t fan_tasks_count, bool is_fanin
 );
 
 /**

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -38,9 +38,9 @@
 #include "common/core_type.h"
 #include "common/platform_config.h"
 
-// Maximum number of successor tasks per L2PerfRecord (matches Task::fanout)
-#ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 128
+// Maximum number of dependency tasks per L2PerfRecord (fanin or fanout depending on runtime)
+#ifndef RUNTIME_MAX_FAN_TASKS
+#define RUNTIME_MAX_FAN_TASKS 128
 #endif
 
 // =============================================================================
@@ -68,9 +68,13 @@ struct L2PerfRecord {
     uint32_t func_id;    // Kernel function identifier
     CoreType core_type;  // Core type (AIC/AIV)
 
-    // Dependency relationship (fanout only)
-    uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
-    int32_t fanout_count;                 // Number of successor tasks
+    // Dependency relationship (fanin or fanout, indicated by is_fanin).
+    // PTO2 runtimes record consumer-side fanin (producer task_ids).
+    // host_build_graph records producer-side fanout (successor task_ids).
+    // Host exporter normalizes both into fanout edges for swimlane JSON.
+    uint64_t fan_tasks[RUNTIME_MAX_FAN_TASKS];  // Dependent task_id array
+    int32_t fan_tasks_count;                    // Number of dependent tasks recorded
+    uint8_t is_fanin;                           // 1 = fan_tasks are producers, 0 = successors
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(L2PerfRecord) % 64 == 0, "L2PerfRecord must be 64-byte aligned for optimal cache performance");

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -76,7 +76,7 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
 
 int l2_perf_aicpu_complete_record(
     L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
-    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fan_tasks, int32_t fan_tasks_count, bool is_fanin
 ) {
     rmb();
     uint32_t count = l2_perf_buf->count;
@@ -103,15 +103,16 @@ int l2_perf_aicpu_complete_record(
     record->dispatch_time = dispatch_time;
     record->finish_time = finish_time;
 
-    if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
+    if (fan_tasks != nullptr && fan_tasks_count > 0) {
+        int32_t n = (fan_tasks_count > RUNTIME_MAX_FAN_TASKS) ? RUNTIME_MAX_FAN_TASKS : fan_tasks_count;
         for (int32_t i = 0; i < n; i++) {
-            record->fanout[i] = fanout[i];
+            record->fan_tasks[i] = fan_tasks[i];
         }
-        record->fanout_count = n;
+        record->fan_tasks_count = n;
     } else {
-        record->fanout_count = 0;
+        record->fan_tasks_count = 0;
     }
+    record->is_fanin = is_fanin;
 
     l2_perf_buf->count = count + 1;
     wmb();

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 #include <iomanip>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "common/unified_log.h"
@@ -414,6 +415,20 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path_arg) {
     }
 
     // Step 7: Write JSON data
+    // Build producer→consumers map from fanin records (PTO2 runtimes).
+    // Fanout records (host_build_graph) contribute directly per-record.
+    std::unordered_map<uint64_t, std::vector<uint64_t>> producer_to_consumers;
+    producer_to_consumers.reserve(tagged_records.size());
+    for (const auto &tagged : tagged_records) {
+        const auto &rec = *tagged.record;
+        if (!rec.is_fanin) continue;
+        int safe_count =
+            (rec.fan_tasks_count >= 0 && rec.fan_tasks_count <= RUNTIME_MAX_FAN_TASKS) ? rec.fan_tasks_count : 0;
+        for (int k = 0; k < safe_count; k++) {
+            producer_to_consumers[rec.fan_tasks[k]].push_back(rec.task_id);
+        }
+    }
+
     int version = has_phase_data_ ? 2 : 1;
     outfile << "{\n";
     outfile << "  \"version\": " << version << ",\n";
@@ -444,16 +459,33 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path_arg) {
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
         outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
         outfile << "      \"fanout\": [";
-        int safe_fanout_count =
-            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
-        for (int j = 0; j < safe_fanout_count; ++j) {
-            outfile << record.fanout[j];
-            if (j < safe_fanout_count - 1) {
-                outfile << ", ";
+        int fanout_emitted = 0;
+        if (!record.is_fanin) {
+            int safe_count = (record.fan_tasks_count >= 0 && record.fan_tasks_count <= RUNTIME_MAX_FAN_TASKS) ?
+                                 record.fan_tasks_count :
+                                 0;
+            for (int j = 0; j < safe_count; ++j) {
+                if (j > 0) {
+                    outfile << ", ";
+                }
+                outfile << record.fan_tasks[j];
+                fanout_emitted++;
+            }
+        } else {
+            const auto it = producer_to_consumers.find(record.task_id);
+            if (it != producer_to_consumers.end()) {
+                const auto &successors = it->second;
+                for (size_t j = 0; j < successors.size(); ++j) {
+                    if (j > 0) {
+                        outfile << ", ";
+                    }
+                    outfile << successors[j];
+                    fanout_emitted++;
+                }
             }
         }
         outfile << "],\n";
-        outfile << "      \"fanout_count\": " << record.fanout_count << "\n";
+        outfile << "      \"fanout_count\": " << fanout_emitted << "\n";
         outfile << "    }";
         if (i < tagged_records.size() - 1) {
             outfile << ",";

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -724,7 +724,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         if (l2_perf_aicpu_complete_record(
                                 l2_perf_buf, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count, false
                             ) != 0) {
                             DEV_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
@@ -743,7 +743,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     if (l2_perf_aicpu_complete_record(
                             l2_perf_buf, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count, false
                         ) != 0) {
                         DEV_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
@@ -850,7 +850,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         if (l2_perf_aicpu_complete_record(
                                 l2_perf_buf, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count, false
                             ) != 0) {
                             DEV_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
@@ -903,7 +903,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     if (l2_perf_aicpu_complete_record(
                             l2_perf_buf, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count, false
                         ) != 0) {
                         DEV_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -275,6 +275,13 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
     }
+
+#if PTO2_PROFILING
+    // Resolved producer task_ids for consumer-side fanin recording (profiling only).
+    static constexpr int32_t kMaxFaninResolved = 128;  // Matches RUNTIME_MAX_FAN_TASKS
+    uint64_t fanin_resolved_ids[kMaxFaninResolved];
+    int32_t fanin_resolved_count{0};
+#endif
 };
 
 // PTO2TaskPayload layout verification (offsetof requires complete type).

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -664,8 +664,19 @@ struct PTO2SchedulerState {
 
         if (wfanin != 0) {
             int32_t early_finished = 0;
+#if PTO2_PROFILING
+            // Snapshot producer task_ids under fanout_lock (same visit order as fanin wiring).
+            // Completion-time perf reads this; avoids orch-time second pass over fanin_builder.
+            int32_t resolved = 0;
+#endif
             pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
                 pto2_fanout_lock(*producer);
+#if PTO2_PROFILING
+                if (resolved < PTO2TaskPayload::kMaxFaninResolved) {
+                    wp->fanin_resolved_ids[resolved] = producer->task->task_id.raw;
+                }
+                resolved++;
+#endif
                 int32_t pstate = producer->task_state.load(std::memory_order_acquire);
                 if (pstate >= PTO2_TASK_COMPLETED) {
                     early_finished++;
@@ -675,12 +686,19 @@ struct PTO2SchedulerState {
                 pto2_fanout_unlock(*producer);
             });
 
+#if PTO2_PROFILING
+            wp->fanin_resolved_count =
+                (resolved < PTO2TaskPayload::kMaxFaninResolved) ? resolved : PTO2TaskPayload::kMaxFaninResolved;
+#endif
             int32_t init_rc = early_finished + 1;
             int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
             if (new_rc >= ws->fanin_count) {
                 ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
             }
         } else {
+#if PTO2_PROFILING
+            wp->fanin_resolved_count = 0;
+#endif
             ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
             ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -130,19 +130,15 @@ void SchedulerContext::complete_slot_task(
         uint64_t finish_ts = get_sys_cnt_aicpu();
         L2PerfBuffer *pbuf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
 
-        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-        int32_t fanout_n = 0;
-        PTO2DepListEntry *cur = slot_state.fanout_head;
-        while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
-            fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
-            cur = cur->next;
-        }
+        // Consumer-side fanin: resolved at submit time in payload (race-free vs fanout_head).
+        const uint64_t *fanin_ids = slot_state.payload->fanin_resolved_ids;
+        int32_t fanin_n = slot_state.payload->fanin_resolved_count;
 
         int32_t perf_slot_idx = static_cast<int32_t>(subslot);
         if (l2_perf_aicpu_complete_record(
                 pbuf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
-                slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanout_arr,
-                fanout_n
+                slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanin_ids,
+                fanin_n, true
             ) != 0) {
             DEV_ERROR(
                 "Core %d: l2_perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,


### PR DESCRIPTION
PTO2 runtimes recorded fanout by walking the producer's linked list at
task completion, but the producer slot may already be recycled by then.
Switch to consumer-side fanin: resolve producer task_ids into
PTO2TaskPayload::fanin_resolved_ids at wiring time, when slot pointers
are still valid.

PerfRecord replaces fanout[]/fanout_count with a direction-neutral
fan_tasks[]/fan_tasks_count plus is_fanin flag. host_build_graph still
records fanout (Task lifetimes span the full session, no race). The host
JSON exporter inverts fanin records into fanout edges, keeping swimlane
dependency edges backward-compatible.