### PR TITLE
Refactor: align a5 perf collector with a2a3 dynamic buffer architecture

### DIFF
--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -13,10 +13,7 @@
  * @brief AICPU performance data collection interface
  *
  * Provides performance profiling management interface for AICPU side.
- * Handles buffer initialization and per-record completion. In the memcpy-based
- * collection design, Host pre-allocates one PerfBuffer per core and one
- * PhaseBuffer per thread; AICPU writes directly into them until full, after
- * which further records are silently dropped.
+ * Handles buffer initialization, switching, and flushing.
  */
 
 #ifndef PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_
@@ -45,10 +42,8 @@ void perf_aicpu_init_profiling(Runtime *runtime);
  * Complete a PerfRecord with AICPU-side metadata after AICore task completion
  *
  * Reads perf_buf->count, validates task_id match against the latest record,
- * and fills all AICPU-side fields. Returns -1 and silently drops the record
- * when the buffer is full (count >= PLATFORM_PROF_BUFFER_SIZE). Callers must
- * pre-extract fanout into a plain uint64_t array (platform layer cannot depend
- * on runtime linked-list types).
+ * and fills all AICPU-side fields. Callers must pre-extract fanout into a
+ * plain uint64_t array (platform layer cannot depend on runtime linked-list types).
  *
  * @param perf_buf              PerfBuffer pointer (from handshake perf_records_addr)
  * @param expected_reg_task_id  Register dispatch token (low 32 bits) to validate
@@ -64,6 +59,31 @@ int perf_aicpu_complete_record(
     PerfBuffer *perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
     uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
 );
+
+/**
+ * Switch performance buffer when current buffer is full
+ *
+ * Enqueues the full buffer to ReadyQueue, pops a new buffer from FreeQueue,
+ * and updates the handshake perf_records_addr. If FreeQueue is empty,
+ * overwrites the current buffer (lossy fallback).
+ *
+ * @param runtime Runtime instance pointer
+ * @param core_id Core ID
+ * @param thread_idx Thread index
+ */
+void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
+
+/**
+ * Flush remaining performance data
+ *
+ * Marks non-empty buffers as ready and enqueues them for host collection.
+ *
+ * @param runtime Runtime instance pointer
+ * @param thread_idx Thread index
+ * @param cur_thread_cores Array of core IDs managed by this thread
+ * @param core_num Number of cores managed by this thread
+ */
+void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -91,7 +111,7 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
  * Record a single scheduler phase
  *
  * Appends an AicpuPhaseRecord to the specified thread's buffer.
- * Silently drops records when the buffer is full.
+ * When the buffer is full, switches to a new buffer via FreeQueue.
  *
  * @param thread_idx Scheduler thread index
  * @param phase_id Phase identifier
@@ -160,5 +180,15 @@ void perf_aicpu_write_core_assignments(
     const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
     int total_cores
 );
+
+/**
+ * Flush remaining phase records for a thread
+ *
+ * Marks the current WRITING phase buffer as READY and enqueues it
+ * for host collection. Called at thread exit (analogous to perf_aicpu_flush_buffers).
+ *
+ * @param thread_idx Thread index (scheduler thread or orchestrator)
+ */
+void perf_aicpu_flush_phase_buffers(int thread_idx);
 
 #endif  // PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_

--- a/src/a5/platform/include/common/perf_profiling.h
+++ b/src/a5/platform/include/common/perf_profiling.h
@@ -13,20 +13,42 @@
  * @file perf_profiling.h
  * @brief Performance profiling data structures
  *
- * Architecture: per-core PerfBuffer + per-thread PhaseBuffer + a single
- * PerfSetupHeader, all allocated on device by Host.
+ * Architecture: Fixed header + per-core/thread buffer states + optional phase profiling region
  *
- * Layout (count-first + flexible array):
- *   PerfBuffer  = 64B header (count + padding) + records[capacity]
- *   PhaseBuffer = 64B header (count + padding) + records[capacity]
+ * Memory layout (shared memory between Host and Device):
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │ PerfDataHeader (fixed header)                               │
+ * │  - ReadyQueue (FIFO, capacity=PLATFORM_PROF_READYQUEUE_SIZE)│
+ * │  - Metadata (num_cores, flags)                              │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PerfBufferState[0] (Core 0)                                 │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PerfBufferState[1] (Core 1)                                 │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ ...                                                         │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PerfBufferState[num_cores-1]                                │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ AicpuPhaseHeader (optional, present when phase profiling)   │
+ * │  - magic, num_sched_threads, records_per_thread             │
+ * │  - orch_summary                                             │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PhaseBufferState[thread0]                                   │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PhaseBufferState[thread1]                                   │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ ...                                                         │
+ * └─────────────────────────────────────────────────────────────┘
  *
- * Buffer device pointers + total_tasks + AicpuPhaseHeader (with orch_summary
- * and core_to_thread) are consolidated in PerfSetupHeader. Host copies
- * PerfSetupHeader to device once before execution; AICPU reads pointers in
- * its profiling init. After execution, Host copies PerfSetupHeader back, then
- * does a two-step memcpy (header → count → records) on each PerfBuffer /
- * PhaseBuffer to reduce transfer to "actual records" instead of full
- * capacity.
+ * Actual PerfBuffer / PhaseBuffer are allocated dynamically by Host
+ * and pushed into the per-core/thread free_queue.
+ *
+ * Base size = sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState)
+ * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_PERF_PROFILING_H_
@@ -76,27 +98,138 @@ struct PerfRecord {
 static_assert(sizeof(PerfRecord) % 64 == 0, "PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
-// PerfBuffer - Record Buffer with Count-First Layout and WIP Staging Slots
+// PerfBuffer - Fixed-Size Record Buffer with WIP Staging Slots
 // =============================================================================
 
 /**
- * Performance record buffer (count-first + flexible array)
+ * Fixed-size performance record buffer
  *
- * Layout: 64B header (count + padding), then wip[2] staging slots,
- * then records[].
- * Actual allocation: sizeof(PerfBuffer) + capacity * sizeof(PerfRecord).
- *
- * Count-first enables two-step collection: Host copies sizeof(PerfBuffer) to
- * read count, then copies only count * sizeof(PerfRecord) of actual data.
+ * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
+ * Allocated dynamically by Host, pushed into per-core free_queue.
  *
  * WIP protocol: AICore writes timing to wip[reg_task_id & 1], AICPU copies
  * it into records[count] at completion. Dual-slot parity ensures no overlap.
  */
 struct PerfBuffer {
-    volatile uint32_t count;  // Current committed record count (at offset 0 for cache-line read)
-    uint32_t pad[15];         // Pad to 64B cache line boundary
-    PerfRecord wip[2];        // AICore WIP staging slots (index = reg_task_id & 1)
-    PerfRecord records[];     // Flexible array member (not counted in sizeof)
+    PerfRecord wip[2];                              // AICore WIP staging slots (index = reg_task_id & 1)
+    PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Committed records (AICPU writes)
+    volatile uint32_t count;                        // Current committed record count
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// PerfFreeQueue - SPSC Lock-Free Queue for Free Buffers
+// =============================================================================
+
+/**
+ * Single Producer Single Consumer (SPSC) lock-free queue for free buffer management
+ *
+ * Producer: Host (ProfMemoryManager thread) pushes newly allocated buffers
+ * Consumer: Device (AICPU thread) pops buffers when switching
+ *
+ * Queue semantics:
+ * - Empty: head == tail
+ * - Full: (tail - head) >= PLATFORM_PROF_SLOT_COUNT
+ * - Capacity: PLATFORM_PROF_SLOT_COUNT buffers
+ *
+ * Memory ordering:
+ * - Device pop: rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
+ * - Host push: write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
+ */
+struct PerfFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
+    volatile uint32_t head;                                   // Consumer read position (Device increments)
+    volatile uint32_t tail;                                   // Producer write position (Host increments)
+    uint32_t pad[13];                                         // Pad to 128 bytes (aligned to cache line)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfFreeQueue) == 128, "PerfFreeQueue must be 128 bytes for cache alignment");
+
+// =============================================================================
+// PerfBufferState - Per-Core/Thread Buffer State (Unified for PerfRecord and Phase)
+// =============================================================================
+
+/**
+ * Per-core or per-thread buffer state for dynamic profiling
+ *
+ * Contains:
+ * - free_queue: SPSC queue of available buffer addresses
+ * - current_buf_ptr: Currently active buffer being written (0 = no active buffer)
+ * - current_buf_seq: Monotonic sequence number for ordering
+ *
+ * Used in two contexts:
+ * - Per-core PerfRecord profiling (current_buf_ptr → PerfBuffer)
+ * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer)
+ *
+ * Writers:
+ * - free_queue.tail: Host writes (pushes new buffers)
+ * - free_queue.head: Device writes (pops buffers)
+ * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
+ * - current_buf_seq: Device writes (monotonic counter)
+ */
+struct PerfBufferState {
+    PerfFreeQueue free_queue;           // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;  // Sequence number for ordering
+    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PerfBufferState) == 192, "PerfBufferState must be 192 bytes for cache alignment");
+
+// Type alias for semantic clarity in Phase profiling context
+using PhaseBufferState = PerfBufferState;  // Per-thread Phase profiling
+
+// =============================================================================
+// ReadyQueueEntry - Queue Entry for Ready Buffers
+// =============================================================================
+
+/**
+ * Ready queue entry
+ *
+ * When a buffer on a core/thread is full, AICPU adds this entry to the queue.
+ * Host memory manager retrieves entries from the queue.
+ *
+ * Entry types (distinguished by is_phase flag):
+ * - PerfRecord entry: core_index = core ID, is_phase = 0
+ * - Phase entry:      core_index = thread_idx, is_phase = 1
+ */
+struct ReadyQueueEntry {
+    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;    // 0 = PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;  // Device pointer to the full buffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad;         // Alignment padding
+} __attribute__((aligned(32)));
+
+// =============================================================================
+// PerfDataHeader - Fixed Header
+// =============================================================================
+
+/**
+ * Performance data fixed header
+ *
+ * Located at the start of shared memory, contains:
+ * 1. Per-thread ready queues (FIFO Circular Buffers)
+ * 2. Metadata (core count)
+ *
+ * Ready queue design:
+ * - Per-thread queues: Avoid lock contention between AICPU threads
+ * - Capacity per queue: PLATFORM_PROF_READYQUEUE_SIZE (full capacity for each thread)
+ * - Implementation: Circular Buffer
+ * - Producer: AICPU thread (adds full buffers to its own queue)
+ * - Consumer: Host memory manager thread (reads from all queues)
+ * - Queue empty: head == tail
+ * - Queue full: (tail + 1) % capacity == head
+ */
+struct PerfDataHeader {
+    // Per-thread ready queues (FIFO Circular Buffers)
+    // Each AICPU thread has its own queue to avoid lock contention
+    ReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_PROF_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Consumer read positions (Host modifies)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
+
+    // Metadata (Host initializes, Device read-only)
+    uint32_t num_cores;             // Actual number of cores launched
+    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -171,23 +304,21 @@ struct AicpuOrchSummary {
 constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
 
 /**
- * Phase record buffer (count-first + flexible array)
+ * Fixed-size phase record buffer (analogous to PerfBuffer)
  *
  * Capacity: PLATFORM_PHASE_RECORDS_PER_THREAD
- * Actual allocation: 64 + capacity * sizeof(AicpuPhaseRecord).
+ * Allocated dynamically by Host, pushed into per-thread free_queue.
  */
 struct PhaseBuffer {
-    volatile uint32_t count;     // Current record count (at offset 0 for cache-line read)
-    uint32_t pad[15];            // Pad to 64B cache line boundary
-    AicpuPhaseRecord records[];  // Flexible array member
+    AicpuPhaseRecord records[PLATFORM_PHASE_RECORDS_PER_THREAD];
+    volatile uint32_t count;
 } __attribute__((aligned(64)));
 
 /**
  * AICPU phase profiling header
  *
- * Embedded in PerfSetupHeader. Contains the magic, per-thread metadata, the
- * core_id → scheduler thread mapping, and the orchestrator's cumulative
- * cycle summary.
+ * Located after the PerfBufferState array in shared memory.
+ * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
     uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
@@ -199,38 +330,6 @@ struct AicpuPhaseHeader {
 } __attribute__((aligned(64)));
 
 // =============================================================================
-// PerfSetupHeader - Host/Device Metadata Exchange
-// =============================================================================
-
-/**
- * Performance setup header
- *
- * Allocated on device by Host. Host writes buffer pointers and metadata,
- * then copies this struct to device once before execution. AICPU reads
- * buffer pointers during init. After execution completes, Host copies
- * this struct back to read total_tasks and phase_header.
- *
- * Memory layout: runtime.perf_data_base points to this struct on device.
- */
-struct PerfSetupHeader {
-    // Host writes, AICPU reads (init)
-    uint32_t num_cores;          // Number of AICore instances
-    uint32_t num_phase_threads;  // Number of phase profiling threads
-    uint32_t pad0[14];           // Pad to 64B
-
-    // Host writes, AICPU reads: per-core / per-thread buffer device pointers
-    uint64_t core_buffer_ptrs[PLATFORM_MAX_CORES];           // PerfBuffer* on device
-    uint64_t phase_buffer_ptrs[PLATFORM_MAX_AICPU_THREADS];  // PhaseBuffer* on device
-
-    // AICPU writes, host reads back
-    volatile uint32_t total_tasks;  // Updated by orchestrator
-    uint32_t pad1[15];              // Pad to 64B
-
-    // AICPU writes, host reads back (via collect_all)
-    AicpuPhaseHeader phase_header;  // Contains orch_summary and core_to_thread
-} __attribute__((aligned(64)));
-
-// =============================================================================
 // Helper Functions - Memory Layout
 // =============================================================================
 
@@ -239,36 +338,92 @@ extern "C" {
 #endif
 
 /**
- * Get PerfSetupHeader pointer from base address
+ * Calculate total memory size for performance data (buffer states only, no buffers)
  *
- * @param base_ptr Device base address (runtime.perf_data_base)
- * @return PerfSetupHeader pointer
- */
-inline PerfSetupHeader *get_perf_setup_header(void *base_ptr) { return reinterpret_cast<PerfSetupHeader *>(base_ptr); }
-
-/**
- * Calculate PerfSetupHeader allocation size
- */
-inline size_t calc_perf_setup_size() { return sizeof(PerfSetupHeader); }
-
-/**
- * Calculate total bytes for a PerfBuffer with the given capacity
+ * Formula: Total size = Fixed header + Dynamic tail
+ *                     = sizeof(PerfDataHeader) + num_cores × sizeof(PerfBufferState)
  *
- * @param capacity Number of PerfRecord slots (e.g. PLATFORM_PROF_BUFFER_SIZE)
- * @return 64B header + capacity * sizeof(PerfRecord)
+ * @param num_cores Number of cores (block_dim × PLATFORM_CORES_PER_BLOCKDIM)
+ * @return Total bytes for header + buffer states
  */
-inline size_t calc_perf_buffer_size(int capacity) {
-    return sizeof(PerfBuffer) + static_cast<size_t>(capacity) * sizeof(PerfRecord);
+inline size_t calc_perf_data_size(int num_cores) {
+    return sizeof(PerfDataHeader) + num_cores * sizeof(PerfBufferState);
 }
 
 /**
- * Calculate total bytes for a PhaseBuffer with the given capacity
+ * Get header pointer
  *
- * @param capacity Number of AicpuPhaseRecord slots (e.g. PLATFORM_PHASE_RECORDS_PER_THREAD)
- * @return 64B header + capacity * sizeof(AicpuPhaseRecord)
+ * @param base_ptr Shared memory base address (device_ptr or host_ptr)
+ * @return PerfDataHeader pointer
  */
-inline size_t calc_phase_buffer_size(int capacity) {
-    return sizeof(PhaseBuffer) + static_cast<size_t>(capacity) * sizeof(AicpuPhaseRecord);
+inline PerfDataHeader *get_perf_header(void *base_ptr) { return reinterpret_cast<PerfDataHeader *>(base_ptr); }
+
+/**
+ * Get PerfBufferState array start address
+ *
+ * @param base_ptr Shared memory base address
+ * @return PerfBufferState array pointer
+ */
+inline PerfBufferState *get_perf_buffer_states(void *base_ptr) {
+    return reinterpret_cast<PerfBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PerfDataHeader));
+}
+
+/**
+ * Get PerfBufferState for specified core
+ *
+ * @param base_ptr Shared memory base address
+ * @param core_index Core index (0 ~ num_cores-1)
+ * @return PerfBufferState pointer
+ */
+inline PerfBufferState *get_perf_buffer_state(void *base_ptr, int core_index) {
+    return &get_perf_buffer_states(base_ptr)[core_index];
+}
+
+/**
+ * Calculate total memory size including phase profiling region (buffer states only)
+ *
+ * @param num_cores Number of AICore instances
+ * @param num_sched_threads Number of phase profiling threads (scheduler + orchestrator)
+ * @return Total bytes needed for header + all buffer states
+ */
+inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
+    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
+}
+
+/**
+ * Get AicpuPhaseHeader pointer (located after PerfBufferState array)
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @return AicpuPhaseHeader pointer
+ */
+inline AicpuPhaseHeader *get_phase_header(void *base_ptr, int num_cores) {
+    return reinterpret_cast<AicpuPhaseHeader *>(reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores));
+}
+
+/**
+ * Get PhaseBufferState array start address (located after AicpuPhaseHeader)
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @return PhaseBufferState array pointer
+ */
+inline PhaseBufferState *get_phase_buffer_states(void *base_ptr, int num_cores) {
+    return reinterpret_cast<PhaseBufferState *>(
+        reinterpret_cast<char *>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader)
+    );
+}
+
+/**
+ * Get PhaseBufferState for specified thread
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @param thread_idx Thread index
+ * @return PhaseBufferState pointer
+ */
+inline PhaseBufferState *get_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
+    return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
 }
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -88,16 +88,43 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLAT
 constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
 
 /**
- * Performance buffer capacity per core
- * Maximum number of PerfRecord entries per PerfBuffer.
- * Each core gets one PerfBuffer; when full, AICPU silently stops recording.
+ * Performance buffer capacity per buffer
+ * Number of PerfRecord entries per dynamically allocated PerfBuffer
  */
-constexpr int PLATFORM_PROF_BUFFER_SIZE = 10000;
+constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
+
+/**
+ * Number of buffer slots per core/thread for dynamic profiling
+ * Host dynamically allocates buffers and writes addresses into these slots.
+ * Device reads slot addresses when switching buffers.
+ * Using slots: provides full pipeline depth for buffer recycling.
+ * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
+ */
+constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
+
+/**
+ * PerfBuffer pre-allocation count per AICore.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_CORE = 8;
+
+/**
+ * PhaseBuffer pre-allocation count per AICPU thread.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_THREAD = 16;
+
+/**
+ * Ready queue capacity for performance data collection
+ * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
+ * Sized to match pre-allocation total across all cores and threads.
+ */
+constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
+    PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_BUFFERS_PER_THREAD;
 
 /**
  * Performance buffer capacity per AICPU thread
  * Maximum number of AicpuPhaseRecord entries per PhaseBuffer.
- * Each thread gets one PhaseBuffer; when full, records are silently dropped.
  */
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 500000;
 
@@ -106,6 +133,16 @@ constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 500000;
  * Used to convert timestamps to microseconds.
  */
 constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 1000000000;  // 1000 MHz
+
+/**
+ * Timeout duration for performance data collection (seconds)
+ */
+constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 30;
+
+/**
+ * Number of empty polling iterations before checking timeout
+ */
+constexpr int PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM = 1000;
 
 inline double cycles_to_us(uint64_t cycles) {
     return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;

--- a/src/a5/platform/include/host/performance_collector.h
+++ b/src/a5/platform/include/host/performance_collector.h
@@ -11,29 +11,35 @@
 
 /**
  * @file performance_collector.h
- * @brief Host-side performance data collector (memcpy-based)
+ * @brief Platform-agnostic performance data collector with dynamic memory management
  *
- * Design:
- *   1. Host pre-allocates one PerfBuffer per core and one PhaseBuffer per
- *      AICPU thread on device, plus a single PerfSetupHeader that stores
- *      all buffer pointers, total_tasks, and the AicpuPhaseHeader.
- *   2. During execution, AICore writes timing into PerfBuffers and AICPU
- *      completes records + writes phase data directly into device memory.
- *      When a buffer fills up, records are silently dropped (AICPU-side
- *      early return).
- *   3. After stream sync, Host copies PerfSetupHeader, each PerfBuffer, and
- *      each PhaseBuffer back via rtMemcpy (two-step: 64B header → read
- *      count → copy count*sizeof(record) actual data).
+ * Architecture:
+ * - ProfMemoryManager: Dedicated thread that polls ReadyQueue, allocates new
+ *   device buffers, and replaces full buffers in slot arrays.
+ * - PerformanceCollector: Main thread collects data from ProfMemoryManager's
+ *   internal queue, copies records to host vectors, and exports results.
  *
- * This replaces the previous shared-memory + ProfMemoryManager design that
- * depended on halHostRegister, which A5 hardware does not support.
+ * Design Pattern: Dependency Injection via Callbacks for memory operations.
+ *
+ * A5 specifics:
+ * - A5 does not support halHostRegister (no SVM/shared memory), so
+ *   PerfRegisterCallback is always nullptr on onboard.
+ * - Instead, PerfCopyToDeviceCallback / PerfCopyFromDeviceCallback are used
+ *   for all Host↔Device data exchange (rtMemcpy-based).
+ * - In simulation mode, all copy callbacks are nullptr (dev_ptr == host_ptr).
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_
 
-#include <cstddef>
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "common/perf_profiling.h"
@@ -41,23 +47,46 @@
 #include "runtime.h"
 
 /**
- * Device memory allocation callback.
+ * Memory allocation callback for performance profiling
  *
- * @param size      Memory size in bytes
+ * @param size Memory size in bytes
  * @return Allocated device memory pointer, or nullptr on failure
  */
 using PerfAllocCallback = void *(*)(size_t size);
 
 /**
- * Device memory free callback.
+ * Memory registration callback (for Host-Device shared memory)
+ * Always nullptr on A5 (halHostRegister not supported).
  *
- * @param dev_ptr   Device memory pointer
+ * @param dev_ptr Device memory pointer
+ * @param size Memory size in bytes
+ * @param device_id Device ID
+ * @param[out] host_ptr Host-mapped pointer
+ * @return 0 on success, error code on failure
+ */
+using PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
+
+/**
+ * Memory unregister callback
+ * Always nullptr on A5.
+ *
+ * @param dev_ptr Device memory pointer
+ * @param device_id Device ID
+ * @return 0 on success, error code on failure
+ */
+using PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+
+/**
+ * Memory free callback
+ *
+ * @param dev_ptr Device memory pointer
  * @return 0 on success, error code on failure
  */
 using PerfFreeCallback = int (*)(void *dev_ptr);
 
 /**
  * Host -> Device copy callback (rtMemcpy HOST_TO_DEVICE / memcpy in sim).
+ * nullptr in simulation mode (dev_ptr == host_ptr).
  *
  * @param dev_dst   Device destination pointer
  * @param host_src  Host source pointer
@@ -68,6 +97,7 @@ using PerfCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, si
 
 /**
  * Device -> Host copy callback (rtMemcpy DEVICE_TO_HOST / memcpy in sim).
+ * nullptr in simulation mode (dev_ptr == host_ptr).
  *
  * @param host_dst  Host destination pointer
  * @param dev_src   Device source pointer
@@ -77,109 +107,365 @@ using PerfCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, si
 using PerfCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src, size_t size);
 
 /**
- * Host-side performance data collector.
+ * Thread factory callback for creating threads with device binding
  *
- * Lifecycle:
- *   1. initialize() — allocate PerfSetupHeader and all per-core/per-thread
- *      buffers on device, publish pointers into runtime.perf_data_base
- *   2. (AICore/AICPU run, writing directly into device buffers)
- *   3. collect_all() — after stream sync, copy PerfSetupHeader back,
- *      then copy each PerfBuffer / PhaseBuffer back using two-step
- *      count-first memcpy. Fills collected_*_records_ vectors.
- *   4. export_swimlane_json() — serialize collected data to Chrome Trace
- *      Event Format JSON. Logic unchanged from previous design.
- *   5. finalize() — free all device buffers.
+ * Creates a std::thread that runs the given function with proper device
+ * context setup/teardown (e.g., rtSetDevice/rtDeviceReset on onboard).
+ *
+ * @param fn Function to execute in the new thread
+ * @return The newly created thread
+ */
+using ThreadFactory = std::function<std::thread(std::function<void()>)>;
+
+// =============================================================================
+// ProfMemoryManager - Dynamic Buffer Memory Management Thread
+// =============================================================================
+
+/**
+ * Buffer type identifier for ReadyBufferInfo
+ */
+enum class ProfBufferType { PERF_RECORD, PHASE };
+
+/**
+ * Information about a ready (full) buffer, passed from mgmt thread to main thread
+ */
+struct ReadyBufferInfo {
+    ProfBufferType type;
+    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    void *dev_buffer_ptr;   // Device address of the full buffer
+    void *host_buffer_ptr;  // Host-side buffer (sim: same as dev; onboard: host copy)
+    uint32_t buffer_seq;    // Sequence number for ordering
+};
+
+/**
+ * Notification that a buffer has been copied and can be freed
+ */
+struct CopyDoneInfo {
+    void *dev_buffer_ptr;  // Device buffer to free
+    ProfBufferType type;   // Buffer type (for recycling)
+};
+
+/**
+ * Dynamic profiling buffer memory manager
+ *
+ * Runs a dedicated thread that:
+ * 1. Polls ReadyQueue in shared memory for full buffer entries
+ * 2. Allocates new device buffers via callback
+ * 3. Writes new buffer addresses into slots (for device to pick up)
+ * 4. Pushes old (full) buffer info to internal queue for main thread to copy
+ * 5. Frees device buffers after main thread confirms copy is done
+ *
+ * A5 specifics:
+ * - In memcpy mode (register_cb == nullptr && copy_from_dev_cb != nullptr):
+ *   ReadyQueue and FreeQueue fields are accessed via rtMemcpy D2H/H2D.
+ *   Full buffers are copied to host-side shadow buffers via rtMemcpy.
+ * - In sim mode (all callbacks nullptr): dev_ptr == host_ptr, direct access.
+ */
+class ProfMemoryManager {
+public:
+    ProfMemoryManager() = default;
+    ~ProfMemoryManager();
+
+    // Disable copy
+    ProfMemoryManager(const ProfMemoryManager &) = delete;
+    ProfMemoryManager &operator=(const ProfMemoryManager &) = delete;
+
+    // Allow PerformanceCollector to register initial buffer mappings
+    friend class PerformanceCollector;
+
+    /**
+     * Start the memory management thread
+     *
+     * @param shared_mem_host Host-side shared memory base address (host shadow or direct ptr)
+     * @param shared_mem_dev Device-side shared memory base address
+     * @param num_cores Number of AICore instances (PerfBufferState count)
+     * @param num_phase_threads Number of phase profiling threads (PhaseBufferState count)
+     * @param alloc_cb Device memory allocation callback
+     * @param register_cb Host-device mapping callback (always nullptr on A5)
+     * @param free_cb Device memory free callback
+     * @param copy_to_dev_cb Host→device copy callback (nullptr in sim)
+     * @param copy_from_dev_cb Device→host copy callback (nullptr in sim)
+     * @param device_id Device ID for registration
+     * @param thread_factory Thread factory for creating device-bound threads (empty to use std::thread)
+     */
+    void start(
+        void *shared_mem_host, void *shared_mem_dev, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
+        PerfRegisterCallback register_cb, PerfFreeCallback free_cb, PerfCopyToDeviceCallback copy_to_dev_cb,
+        PerfCopyFromDeviceCallback copy_from_dev_cb, int device_id, const ThreadFactory &thread_factory = {}
+    );
+
+    /**
+     * Stop the memory management thread
+     * Blocks until the thread exits.
+     */
+    void stop();
+
+    /**
+     * Try to pop a ready buffer info (non-blocking)
+     *
+     * @param[out] info Ready buffer info
+     * @return true if an item was available, false otherwise
+     */
+    bool try_pop_ready(ReadyBufferInfo &info);
+
+    /**
+     * Wait for a ready buffer info with timeout
+     *
+     * @param[out] info Ready buffer info
+     * @param timeout Maximum wait time
+     * @return true if an item was available, false on timeout
+     */
+    bool wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout);
+
+    /**
+     * Notify that a buffer has been copied and can be freed
+     *
+     * @param info Copy done notification
+     */
+    void notify_copy_done(const CopyDoneInfo &info);
+
+    /**
+     * Check if the manager thread is running
+     */
+    bool is_running() const { return running_.load(); }
+
+private:
+    std::thread mgmt_thread_;
+    std::atomic<bool> running_{false};
+
+    // Shared memory references
+    void *shared_mem_host_{nullptr};  // Host-side shadow (or direct ptr in sim)
+    void *shared_mem_dev_{nullptr};   // Device-side base address
+    int num_cores_{0};
+    int num_phase_threads_{0};
+
+    // Callbacks
+    PerfAllocCallback alloc_cb_{nullptr};
+    PerfRegisterCallback register_cb_{nullptr};
+    PerfFreeCallback free_cb_{nullptr};
+    PerfCopyToDeviceCallback copy_to_dev_cb_{nullptr};
+    PerfCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
+    int device_id_{-1};
+
+    // Management thread → main thread (ready buffers)
+    std::mutex ready_mutex_;
+    std::condition_variable ready_cv_;
+    std::queue<ReadyBufferInfo> ready_queue_;
+
+    // Main thread → management thread (buffers to free)
+    std::mutex done_mutex_;
+    std::queue<CopyDoneInfo> done_queue_;
+
+    // Device-to-host pointer mapping (populated during alloc_and_register)
+    std::unordered_map<void *, void *> dev_to_host_;
+
+    // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
+    std::vector<void *> recycled_perf_buffers_;
+    std::vector<void *> recycled_phase_buffers_;
+
+    // True when copy callbacks are present (onboard mode)
+    bool is_memcpy_mode() const { return register_cb_ == nullptr && copy_from_dev_cb_ != nullptr; }
+
+    // Management thread main loop
+    void mgmt_loop();
+
+    // Allocate a new buffer and optionally register for host access
+    void *alloc_and_register(size_t size, void **host_ptr_out);
+
+    // Free a previously allocated buffer (including host shadow in memcpy mode)
+    void free_buffer(void *dev_ptr);
+
+    // Resolve device pointer to host pointer
+    void *resolve_host_ptr(void *dev_ptr);
+
+    // Register an external dev→host mapping (for initial buffers)
+    void register_mapping(void *dev_ptr, void *host_ptr);
+
+    // Process one ReadyQueue entry
+    void process_ready_entry(PerfDataHeader *header, int thread_idx, const ReadyQueueEntry &entry);
+
+    // Helper: sync a field from device to host shadow
+    int sync_from_device(volatile void *host_dst, const volatile void *dev_src, size_t size);
+
+    // Helper: sync a field from host shadow to device
+    int sync_to_device(volatile void *dev_dst, const void *host_src, size_t size);
+};
+
+// =============================================================================
+// PerformanceCollector - Main Collector
+// =============================================================================
+
+/**
+ * Performance data collector
+ *
+ * Manages performance profiling lifecycle:
+ * 1. Initialize shared memory (Header + SlotArrays) and allocate initial buffers
+ * 2. Start ProfMemoryManager thread
+ * 3. Collect records from ProfMemoryManager's queue (main thread)
+ * 4. Export swimlane visualization
+ *
+ * Platform-agnostic: Memory management delegated to callbacks
  */
 class PerformanceCollector {
 public:
     PerformanceCollector() = default;
     ~PerformanceCollector();
 
+    // Disable copy and move
     PerformanceCollector(const PerformanceCollector &) = delete;
     PerformanceCollector &operator=(const PerformanceCollector &) = delete;
 
     /**
-     * Allocate device buffers and publish PerfSetupHeader.
+     * Initialize performance profiling
      *
-     * @param runtime          Runtime to configure (sets runtime.perf_data_base)
-     * @param num_aicore       Number of AICore instances to profile
-     * @param device_id        Device ID (stored for later callbacks)
-     * @param alloc_cb         Device memory alloc
-     * @param free_cb          Device memory free
-     * @param copy_to_dev_cb   Host→device copy (used during init to publish header)
-     * @param copy_from_dev_cb Device->host copy (used during collect_all)
+     * Allocates shared memory for slot arrays, allocates initial buffers,
+     * and writes buffer addresses into slots.
+     *
+     * @param runtime Runtime instance to configure
+     * @param num_aicore Number of AICore instances
+     * @param device_id Device ID
+     * @param alloc_cb Memory allocation callback
+     * @param register_cb Memory registration callback (nullptr on A5)
+     * @param free_cb Memory free callback
+     * @param copy_to_dev_cb Host→device copy (nullptr in sim)
+     * @param copy_from_dev_cb Device→host copy (nullptr in sim)
      * @return 0 on success, error code on failure
      */
     int initialize(
-        Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfFreeCallback free_cb,
-        PerfCopyToDeviceCallback copy_to_dev_cb, PerfCopyFromDeviceCallback copy_from_dev_cb
+        Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+        PerfFreeCallback free_cb, PerfCopyToDeviceCallback copy_to_dev_cb = nullptr,
+        PerfCopyFromDeviceCallback copy_from_dev_cb = nullptr
     );
 
     /**
-     * Copy all profiling data back from device and parse it into
-     * collected_perf_records_ / collected_phase_records_ /
-     * collected_orch_summary_ / core_to_thread_.
+     * Start the memory management thread
      *
-     * Must be called after the execution stream has been fully synchronized.
+     * Must be called after initialize() and before device execution starts.
      *
-     * @return 0 on success, error code on failure
+     * @param thread_factory Thread factory for creating device-bound threads (empty to use std::thread)
      */
-    int collect_all();
+    void start_memory_manager(const ThreadFactory &thread_factory = {});
 
     /**
-     * Export collected data to Chrome Trace Event Format JSON.
+     * Poll and collect performance data from the memory manager's queue
      *
-     * @param output_path Output directory
-     * @return 0 on success, -1 on failure
+     * Runs on the main thread (or a dedicated collector thread in sim mode).
+     * Pulls ready buffers from ProfMemoryManager, copies records to host vectors,
+     * and notifies the manager to free old device buffers.
+     *
+     * @param expected_tasks Expected total number of tasks (0 = auto-detect)
+     */
+    void poll_and_collect(int expected_tasks = 0);
+
+    /**
+     * Export performance data to Chrome Trace Event Format
+     *
+     * @param output_path Output directory path
+     * @return 0 on success, error code on failure
      */
     int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
-     * Free all device buffers and clear host-side state.
+     * Stop the memory management thread and clean up remaining data
      *
+     * Must be called after device execution completes.
+     */
+    void stop_memory_manager();
+
+    /**
+     * Cleanup all resources
+     *
+     * @param unregister_cb Memory unregister callback (nullptr on A5)
+     * @param free_cb Memory free callback
      * @return 0 on success, error code on failure
      */
-    int finalize();
+    int finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb);
 
     /**
-     * Check if the collector has been initialized.
+     * Check if collector is initialized
      */
-    bool is_initialized() const { return setup_header_dev_ != nullptr; }
+    bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
 
     /**
-     * Accessor used by tests.
+     * Drain remaining buffers from the memory manager's ready queue
+     *
+     * After poll_and_collect() exits (all PERF records collected) and
+     * the memory manager is stopped, Phase buffers may still be in the
+     * ready queue. This method drains them into the collected vectors.
+     *
+     * Must be called after stop_memory_manager() and before collect_phase_data().
+     */
+    void drain_remaining_buffers();
+
+    /**
+     * Collect AICPU phase profiling data from shared memory
+     *
+     * Reads scheduler phase records and orchestrator summary from the
+     * phase profiling region. Must be called after AICPU threads have joined.
+     */
+    void collect_phase_data();
+
+    /**
+     * Scan PerfBufferState::current_buf_ptr for all cores to recover
+     * partial records not delivered through the pipeline.
+     *
+     * Must be called after device execution completes and after
+     * stop_memory_manager(). Follows the same pattern as collect_phase_data()
+     * for PhaseBufferStates.
+     */
+    void scan_remaining_perf_buffers();
+
+    /**
+     * Signal that device execution is complete (streams synchronized).
+     * poll_and_collect() will drain remaining pipeline data and exit.
+     */
+    void signal_execution_complete();
+
+    /**
+     * Get collected records (for testing)
      */
     const std::vector<std::vector<PerfRecord>> &get_records() const { return collected_perf_records_; }
 
 private:
-    // Device-side allocations
-    void *setup_header_dev_{nullptr};
-    std::vector<void *> core_buffers_dev_;
-    std::vector<void *> phase_buffers_dev_;
+    // Shared memory pointers
+    void *perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
+    void *perf_shared_mem_host_{nullptr};  // Host-side shadow (or direct ptr in sim)
+    bool was_registered_{false};           // True if register_cb was called successfully
+    int device_id_{-1};
 
     // Configuration
     int num_aicore_{0};
-    int num_phase_threads_{0};
-    int device_id_{-1};
 
-    // Sizes (computed once in initialize)
-    size_t perf_buffer_bytes_{0};
-    size_t phase_buffer_bytes_{0};
-
-    // Callbacks
+    // Callbacks (stored for memory manager and finalize)
     PerfAllocCallback alloc_cb_{nullptr};
+    PerfRegisterCallback register_cb_{nullptr};
     PerfFreeCallback free_cb_{nullptr};
     PerfCopyToDeviceCallback copy_to_dev_cb_{nullptr};
     PerfCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
 
-    // Host-side collected data (indexed by core / thread)
+    // Memory manager
+    ProfMemoryManager memory_manager_;
+
+    // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<PerfRecord>> collected_perf_records_;
+
+    // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
+
+    // Signal from device_runner that execution is complete
+    std::atomic<bool> execution_complete_{false};
+
+    // True when copy callbacks are present (onboard mode)
+    bool is_memcpy_mode() const { return register_cb_ == nullptr && copy_from_dev_cb_ != nullptr; }
+
+    // Allocate a single buffer (PerfBuffer or PhaseBuffer) and register it
+    void *alloc_single_buffer(size_t size, void **host_ptr_out);
 };
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PERFORMANCE_COLLECTOR_H_

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -407,6 +407,10 @@ int DeviceRunner::run(
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
+        // Start memory management thread (needs device context)
+        perf_collector_.start_memory_manager([this](std::function<void()> fn) {
+            return create_thread(std::move(fn));
+        });
     }
 
     // Initialize tensor dump if enabled
@@ -452,6 +456,14 @@ int DeviceRunner::run(
         return rc;
     }
 
+    // Launch collector thread before synchronization
+    std::thread collector_thread;
+    if (runtime.enable_profiling) {
+        collector_thread = create_thread([this]() {
+            poll_and_collect_performance_data(0);  // auto-detect task count
+        });
+    }
+
     {
         std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
         // Synchronize streams
@@ -469,10 +481,16 @@ int DeviceRunner::run(
         }
     }
 
-    // After streams are synchronized, pull profiling data back in one batch
-    // (memcpy-based: two-step count-first copy per buffer).
+    // Signal execution complete and wait for collector to finish
     if (runtime.enable_profiling) {
-        perf_collector_.collect_all();
+        perf_collector_.signal_execution_complete();
+        if (collector_thread.joinable()) {
+            collector_thread.join();
+        }
+        perf_collector_.stop_memory_manager();
+        perf_collector_.drain_remaining_buffers();
+        perf_collector_.scan_remaining_perf_buffers();
+        perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
 
@@ -539,9 +557,12 @@ int DeviceRunner::finalize() {
     func_id_to_addr_.clear();
     binaries_loaded_ = false;
 
-    // Cleanup performance profiling (frees PerfSetupHeader + all per-core/per-thread buffers)
+    // Cleanup performance profiling (frees shared memory + all per-core/per-thread buffers)
     if (perf_collector_.is_initialized()) {
-        perf_collector_.finalize();
+        auto free_cb = [](void *dev_ptr) -> int {
+            return rtFree(dev_ptr);
+        };
+        perf_collector_.finalize(nullptr, free_cb);
     }
 
     // Cleanup tensor dump
@@ -714,6 +735,9 @@ int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, i
         return (rc == 0) ? ptr : nullptr;
     };
 
+    // A5 does not support halHostRegister — pass nullptr
+    PerfRegisterCallback register_cb = nullptr;
+
     auto free_cb = [](void *dev_ptr) -> int {
         return rtFree(dev_ptr);
     };
@@ -728,8 +752,12 @@ int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, i
     };
 
     return perf_collector_.initialize(
-        runtime, num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
+        runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
     );
+}
+
+void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
+    perf_collector_.poll_and_collect(expected_tasks);
 }
 
 int DeviceRunner::export_swimlane_json(const std::string &output_path) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -250,6 +250,17 @@ public:
     int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
+     * Poll and collect performance data from the memory manager's queue
+     *
+     * Runs on a dedicated collector thread. Pulls ready buffers from
+     * ProfMemoryManager, copies records to host vectors, and notifies
+     * the manager to free old device buffers.
+     *
+     * @param expected_tasks Expected total number of tasks
+     */
+    void poll_and_collect_performance_data(int expected_tasks);
+
+    /**
      * Cleanup all resources
      *
      * Frees all device memory, destroys streams, and resets state.

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -323,6 +323,8 @@ int DeviceRunner::run(
             LOG_ERROR("init_performance_profiling failed: %d", rc);
             return rc;
         }
+        // Start memory management thread (sim mode: plain std::thread)
+        perf_collector_.start_memory_manager();
     }
 
     // Initialize tensor dump if enabled
@@ -383,6 +385,14 @@ int DeviceRunner::run(
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
     set_enable_dump_tensor_func_(enable_dump_tensor);
 
+    // Launch collector thread before AICPU/AICore threads
+    std::thread collector_thread;
+    if (runtime.enable_profiling) {
+        collector_thread = std::thread([this]() {
+            poll_and_collect_performance_data(0);  // auto-detect task count
+        });
+    }
+
     // Launch AICPU threads (over-launch for affinity gate)
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     LOG_INFO("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
@@ -419,9 +429,16 @@ int DeviceRunner::run(
 
     LOG_INFO("All threads completed");
 
-    // Collect performance data and export
+    // Signal execution complete and collect remaining data
     if (runtime.enable_profiling) {
-        perf_collector_.collect_all();
+        perf_collector_.signal_execution_complete();
+        if (collector_thread.joinable()) {
+            collector_thread.join();
+        }
+        perf_collector_.stop_memory_manager();
+        perf_collector_.drain_remaining_buffers();
+        perf_collector_.scan_remaining_perf_buffers();
+        perf_collector_.collect_phase_data();
         export_swimlane_json();
     }
 
@@ -490,7 +507,11 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (perf_collector_.is_initialized()) {
-        perf_collector_.finalize();
+        auto free_cb = [](void *dev_ptr) -> int {
+            free(dev_ptr);
+            return 0;
+        };
+        perf_collector_.finalize(nullptr, free_cb);
     }
 
     // Cleanup tensor dump
@@ -632,8 +653,8 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // =============================================================================
 
 int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, int device_id) {
-    // Simulation: "device" memory is just host memory, so use malloc/free and
-    // std::memcpy for the copy callbacks.
+    // Simulation: "device" memory is just host memory, so use malloc/free.
+    // No copy callbacks needed (dev_ptr == host_ptr).
     auto alloc_cb = [](size_t size) -> void * {
         return malloc(size);
     };
@@ -643,19 +664,12 @@ int DeviceRunner::init_performance_profiling(Runtime &runtime, int num_aicore, i
         return 0;
     };
 
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        std::memcpy(dev_dst, host_src, size);
-        return 0;
-    };
+    // Sim mode: register_cb = nullptr, copy callbacks = nullptr (dev_ptr == host_ptr)
+    return perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb, nullptr, nullptr);
+}
 
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        std::memcpy(host_dst, dev_src, size);
-        return 0;
-    };
-
-    return perf_collector_.initialize(
-        runtime, num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
-    );
+void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
+    perf_collector_.poll_and_collect(expected_tasks);
 }
 
 int DeviceRunner::export_swimlane_json(const std::string &output_path) {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -161,6 +161,13 @@ public:
     int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
+     * Poll and collect performance data from the memory manager's queue
+     *
+     * @param expected_tasks Expected total number of tasks
+     */
+    void poll_and_collect_performance_data(int expected_tasks);
+
+    /**
      * Cleanup all resources
      *
      * Use this for final cleanup when no more tests will run.

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -11,12 +11,11 @@
 
 /**
  * @file performance_collector_aicpu.cpp
- * @brief AICPU performance data collection implementation (memcpy-based)
+ * @brief AICPU performance data collection implementation (SPSC free queue)
  *
- * Host pre-allocates one PerfBuffer per core and one PhaseBuffer per thread
- * on the device. AICPU writes records directly into them via cached pointers.
- * When a buffer fills up, subsequent records are silently dropped — there is
- * no buffer switching or flushing.
+ * Uses per-core PerfBufferState with SPSC free queues for O(1) buffer switching.
+ * Host memory manager dynamically allocates replacement buffers and pushes
+ * them into the free_queue. Device pops from free_queue when switching.
  */
 
 #include "aicpu/performance_collector_aicpu.h"
@@ -30,12 +29,51 @@
 #include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
-static PerfSetupHeader *s_setup_header = nullptr;
+static AicpuPhaseHeader *s_phase_header = nullptr;
+static PerfDataHeader *s_perf_header = nullptr;
 
-// Per-thread PhaseBuffer cache
+// Per-core PerfBufferState cache
+static PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+
+// Per-thread PhaseBufferState cache
+static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
 static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static int s_orch_thread_idx = -1;
+
+/**
+ * Enqueue ready buffer to per-thread queue
+ *
+ * @param header PerfDataHeader pointer
+ * @param thread_idx Thread index
+ * @param core_index Core index (or thread_idx for phase entries)
+ * @param buffer_ptr Device pointer to the full buffer
+ * @param buffer_seq Sequence number for ordering
+ * @param is_phase 0 = PerfRecord, 1 = Phase
+ * @return 0 on success, -1 if queue full
+ */
+static int enqueue_ready_buffer(
+    PerfDataHeader *header, int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq,
+    uint32_t is_phase
+) {
+    uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
+    uint32_t current_tail = header->queue_tails[thread_idx];
+    uint32_t current_head = header->queue_heads[thread_idx];
+
+    // Check if queue is full
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;
+    }
+
+    header->queues[thread_idx][current_tail].core_index = core_index;
+    header->queues[thread_idx][current_tail].is_phase = is_phase;
+    header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
+    header->queue_tails[thread_idx] = next_tail;
+
+    return 0;
+}
 
 void perf_aicpu_init_profiling(Runtime *runtime) {
     void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
@@ -44,29 +82,43 @@ void perf_aicpu_init_profiling(Runtime *runtime) {
         return;
     }
 
-    s_setup_header = get_perf_setup_header(perf_base);
+    s_perf_header = get_perf_header(perf_base);
 
     int32_t task_count = runtime->get_task_count();
-    s_setup_header->total_tasks = static_cast<uint32_t>(task_count);
+    s_perf_header->total_tasks = static_cast<uint32_t>(task_count);
 
-    LOG_INFO("Initializing performance profiling for %d cores (memcpy-based)", runtime->worker_count);
+    LOG_INFO("Initializing performance profiling for %d cores (free queue)", runtime->worker_count);
 
-    // Initialize each core's PerfBuffer and publish the pointer to the handshake
+    // Pop first buffer from free_queue for each core
     for (int i = 0; i < runtime->worker_count; i++) {
         Handshake *h = &runtime->workers[i];
-        uint64_t buf_ptr = s_setup_header->core_buffer_ptrs[i];
+        PerfBufferState *state = get_perf_buffer_state(perf_base, i);
 
-        if (buf_ptr == 0) {
-            LOG_ERROR("Core %d: core_buffer_ptrs[%d] is NULL during init!", i, i);
+        s_perf_buffer_states[i] = state;
+
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
+            buf->count = 0;
+            h->perf_records_addr = buf_ptr;
+
+            LOG_DEBUG("Core %d: popped initial buffer (addr=0x%lx)", i, buf_ptr);
+        } else {
+            LOG_ERROR("Core %d: free_queue is empty during init!", i);
+            state->current_buf_ptr = 0;
             h->perf_records_addr = 0;
-            continue;
         }
-
-        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
-        buf->count = 0;
-        h->perf_records_addr = buf_ptr;
-
-        LOG_DEBUG("Core %d: PerfBuffer at 0x%lx", i, buf_ptr);
     }
 
     wmb();
@@ -80,8 +132,6 @@ int perf_aicpu_complete_record(
 ) {
     rmb();
     uint32_t count = perf_buf->count;
-    // Buffer-full check lives here (AICore does not branch on capacity); return -1
-    // silently drops the record, caller ignores the failure.
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
     // Read from WIP staging slot (AICore writes here, parity = reg_task_id & 1)
@@ -118,13 +168,123 @@ int perf_aicpu_complete_record(
     return 0;
 }
 
+void perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    PerfBufferState *state = s_perf_buffer_states[core_id];
+    if (state == nullptr) {
+        return;
+    }
+
+    PerfBuffer *full_buf = reinterpret_cast<PerfBuffer *>(state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    LOG_INFO("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICore alive
+        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
+        // Revert: discard data and keep writing
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+    rmb();
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
+
+    PerfBuffer *new_buf = reinterpret_cast<PerfBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+
+    // Update handshake for AICore
+    Handshake *h = &runtime->workers[core_id];
+    h->perf_records_addr = new_buf_ptr;
+    wmb();
+
+    LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
+}
+
+void perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
+    if (!runtime->enable_profiling) {
+        return;
+    }
+
+    void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
+    if (perf_base == nullptr) {
+        return;
+    }
+
+    rmb();
+
+    LOG_INFO("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
+
+    int flushed_count = 0;
+
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        PerfBufferState *state = s_perf_buffer_states[core_id];
+        if (state == nullptr) continue;
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            continue;
+        }
+
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(buf_ptr);
+        if (buf->count == 0) {
+            continue;
+        }
+
+        uint32_t seq = state->current_buf_seq;
+        int rc = enqueue_ready_buffer(s_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
+        if (rc == 0) {
+            LOG_INFO("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
+            flushed_count++;
+            state->current_buf_ptr = 0;
+            wmb();
+        } else {
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
+        }
+    }
+
+    wmb();
+
+    LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
+}
+
 void perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
     void *perf_base = reinterpret_cast<void *>(runtime->perf_data_base);
     if (perf_base == nullptr) {
         return;
     }
 
-    PerfSetupHeader *header = get_perf_setup_header(perf_base);
+    PerfDataHeader *header = get_perf_header(perf_base);
     header->total_tasks = total_tasks;
     wmb();
 }
@@ -136,40 +296,55 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
         return;
     }
 
-    s_setup_header = get_perf_setup_header(perf_base);
+    s_phase_header = get_phase_header(perf_base, runtime->worker_count);
+    s_perf_header = get_perf_header(perf_base);
 
-    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
-    phase_header->magic = AICPU_PHASE_MAGIC;
-    phase_header->num_sched_threads = num_sched_threads;
-    phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
-    phase_header->num_cores = 0;
+    s_phase_header->magic = AICPU_PHASE_MAGIC;
+    s_phase_header->num_sched_threads = num_sched_threads;
+    s_phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
+    s_phase_header->num_cores = 0;
 
-    memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
-    memset(&phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
+    memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
-    // Cache per-thread PhaseBuffer pointers. Include all threads: scheduler +
-    // orchestrator (orchestrator may become scheduler).
+    // Cache per-thread record pointers and clear buffers
     int total_threads = num_sched_threads + 1;
     if (total_threads > PLATFORM_MAX_AICPU_THREADS) {
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        uint64_t buf_ptr = s_setup_header->phase_buffer_ptrs[t];
-        if (buf_ptr == 0) {
-            LOG_ERROR("Thread %d: phase_buffer_ptrs[%d] is NULL during init!", t, t);
+        PhaseBufferState *state = get_phase_buffer_state(perf_base, runtime->worker_count, t);
+
+        s_phase_buffer_states[t] = state;
+
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+            buf->count = 0;
+            s_current_phase_buf[t] = buf;
+
+            LOG_DEBUG("Thread %d: popped initial phase buffer (addr=0x%lx)", t, buf_ptr);
+        } else {
+            LOG_ERROR("Thread %d: phase free_queue is empty during init!", t);
+            state->current_buf_ptr = 0;
             s_current_phase_buf[t] = nullptr;
-            continue;
         }
-
-        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
-        buf->count = 0;
-        s_current_phase_buf[t] = buf;
-
-        LOG_DEBUG("Thread %d: PhaseBuffer at 0x%lx", t, buf_ptr);
     }
 
     // Clear remaining slots
     for (int t = total_threads; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        s_phase_buffer_states[t] = nullptr;
         s_current_phase_buf[t] = nullptr;
     }
 
@@ -181,21 +356,102 @@ void perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
     );
 }
 
+/**
+ * Switch phase buffer when current buffer is full (free queue version)
+ */
+static void switch_phase_buffer(int thread_idx) {
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    PhaseBuffer *full_buf = s_current_phase_buf[thread_idx];
+    if (full_buf == nullptr) return;
+
+    LOG_INFO("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
+
+    // Enqueue to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head != tail) {
+        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+        rmb();
+        state->free_queue.head = head + 1;
+        state->current_buf_ptr = new_buf_ptr;
+        state->current_buf_seq = seq + 1;
+        wmb();
+
+        PhaseBuffer *new_buf = reinterpret_cast<PhaseBuffer *>(new_buf_ptr);
+        new_buf->count = 0;
+        s_current_phase_buf[thread_idx] = new_buf;
+
+        LOG_INFO("Thread %d: switched to new phase buffer", thread_idx);
+    } else {
+        // No free buffer available, drop subsequent records
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
+        s_current_phase_buf[thread_idx] = nullptr;
+        state->current_buf_ptr = 0;
+        wmb();
+    }
+}
+
 void perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
     uint64_t tasks_processed
 ) {
-    if (s_setup_header == nullptr) {
+    if (s_phase_header == nullptr) {
         return;
     }
 
     PhaseBuffer *buf = s_current_phase_buf[thread_idx];
-    if (buf == nullptr) return;
+
+    // Try to recover from nullptr (no buffer was available on previous switch)
+    if (buf == nullptr) {
+        PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+        if (state == nullptr) return;
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = state->current_buf_seq + 1;
+            wmb();
+
+            buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+            buf->count = 0;
+            s_current_phase_buf[thread_idx] = buf;
+
+            LOG_INFO("Thread %d: recovered phase buffer", thread_idx);
+        }
+        if (buf == nullptr) return;
+    }
 
     uint32_t idx = buf->count;
+
     if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-        // Buffer full; silently drop.
-        return;
+        // Buffer full, switch to next buffer
+        switch_phase_buffer(thread_idx);
+        buf = s_current_phase_buf[thread_idx];
+        if (buf == nullptr) return;
+        idx = buf->count;
+        if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
+            return;
+        }
     }
 
     AicpuPhaseRecord *record = &buf->records[idx];
@@ -209,11 +465,11 @@ void perf_aicpu_record_phase(
 }
 
 void perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
-    if (s_setup_header == nullptr) {
+    if (s_phase_header == nullptr) {
         return;
     }
 
-    AicpuOrchSummary *dst = &s_setup_header->phase_header.orch_summary;
+    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
 
     memcpy(dst, src, sizeof(AicpuOrchSummary));
     dst->magic = AICPU_PHASE_MAGIC;
@@ -232,27 +488,59 @@ void perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread
 void perf_aicpu_record_orch_phase(
     AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
 ) {
-    if (s_orch_thread_idx < 0 || s_setup_header == nullptr) return;
+    if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
+}
+
+void perf_aicpu_flush_phase_buffers(int thread_idx) {
+    if (s_phase_header == nullptr || s_perf_header == nullptr) {
+        return;
+    }
+
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    rmb();
+    uint64_t buf_ptr = state->current_buf_ptr;
+    if (buf_ptr == 0) {
+        return;
+    }
+
+    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+    if (buf->count == 0) {
+        return;
+    }
+
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
+    if (rc == 0) {
+        LOG_INFO("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
+        state->current_buf_ptr = 0;
+        s_current_phase_buf[thread_idx] = nullptr;
+        wmb();
+    } else {
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
+    }
+
+    wmb();
 }
 
 void perf_aicpu_write_core_assignments(
     const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
     int total_cores
 ) {
-    if (s_setup_header == nullptr) {
+    if (s_phase_header == nullptr) {
         return;
     }
 
-    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
-    memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
-    phase_header->num_cores = static_cast<uint32_t>(total_cores);
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
+    s_phase_header->num_cores = static_cast<uint32_t>(total_cores);
 
     for (int t = 0; t < num_threads; t++) {
         for (int i = 0; i < core_counts[t]; i++) {
             int core_id = core_assignments[t][i];
             if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
-                phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
+                s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
             }
         }
     }

--- a/src/a5/platform/src/host/performance_collector.cpp
+++ b/src/a5/platform/src/host/performance_collector.cpp
@@ -11,7 +11,15 @@
 
 /**
  * @file performance_collector.cpp
- * @brief Host-side performance data collector (memcpy-based) implementation
+ * @brief Platform-agnostic performance data collector implementation
+ *
+ * Implements ProfMemoryManager (dynamic buffer management thread) and
+ * PerformanceCollector (data collection and export).
+ *
+ * A5 specifics:
+ * - In memcpy mode (onboard): ReadyQueue/FreeQueue fields and buffer contents
+ *   are accessed via rtMemcpy D2H/H2D through copy callbacks.
+ * - In sim mode: dev_ptr == host_ptr, direct pointer access (no callbacks).
  */
 
 #include "host/performance_collector.h"
@@ -20,316 +28,1380 @@
 #include <sys/types.h>
 
 #include <algorithm>
+#include <chrono>
 #include <cinttypes>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <fstream>
 #include <iomanip>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "common/memory_barrier.h"
 #include "common/unified_log.h"
 
 // =============================================================================
-// Helpers
+// ProfMemoryManager Implementation
 // =============================================================================
 
-/**
- * Check if a phase ID belongs to a scheduler phase (vs orchestrator phase).
- * Scheduler phases: SCHED_COMPLETE(0), SCHED_DISPATCH(1), SCHED_SCAN(2), SCHED_IDLE_WAIT(3)
- * Orchestrator phases: ORCH_SYNC(16) through ORCH_SCOPE_END(24)
- */
-static bool is_scheduler_phase(AicpuPhaseId id) {
-    return static_cast<uint32_t>(id) < static_cast<uint32_t>(AicpuPhaseId::SCHED_PHASE_COUNT);
+ProfMemoryManager::~ProfMemoryManager() {
+    if (running_.load()) {
+        stop();
+    }
+}
+
+void ProfMemoryManager::start(
+    void *shared_mem_host, void *shared_mem_dev, int num_cores, int num_phase_threads, PerfAllocCallback alloc_cb,
+    PerfRegisterCallback register_cb, PerfFreeCallback free_cb, PerfCopyToDeviceCallback copy_to_dev_cb,
+    PerfCopyFromDeviceCallback copy_from_dev_cb, int device_id, const ThreadFactory &thread_factory
+) {
+    shared_mem_host_ = shared_mem_host;
+    shared_mem_dev_ = shared_mem_dev;
+    num_cores_ = num_cores;
+    num_phase_threads_ = num_phase_threads;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    copy_to_dev_cb_ = copy_to_dev_cb;
+    copy_from_dev_cb_ = copy_from_dev_cb;
+    device_id_ = device_id;
+
+    running_.store(true);
+    if (thread_factory) {
+        mgmt_thread_ = thread_factory([this]() {
+            mgmt_loop();
+        });
+    } else {
+        mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
+    }
+
+    LOG_INFO("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
+}
+
+void ProfMemoryManager::stop() {
+    running_.store(false);
+    if (mgmt_thread_.joinable()) {
+        mgmt_thread_.join();
+    }
+
+    // Drain remaining done_queue and free buffers
+    {
+        std::scoped_lock<std::mutex> lock(done_mutex_);
+        while (!done_queue_.empty()) {
+            CopyDoneInfo info = done_queue_.front();
+            done_queue_.pop();
+            free_buffer(info.dev_buffer_ptr);
+        }
+    }
+
+    // Free recycled buffers
+    for (void *ptr : recycled_perf_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_perf_buffers_.clear();
+    for (void *ptr : recycled_phase_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_phase_buffers_.clear();
+
+    LOG_INFO("ProfMemoryManager stopped");
+}
+
+bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
+    std::scoped_lock<std::mutex> lock(ready_mutex_);
+    if (ready_queue_.empty()) {
+        return false;
+    }
+    info = ready_queue_.front();
+    ready_queue_.pop();
+    return true;
+}
+
+bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(ready_mutex_);
+    if (ready_cv_.wait_for(lock, timeout, [this] {
+            return !ready_queue_.empty();
+        })) {
+        info = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+    return false;
+}
+
+void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
+    std::scoped_lock<std::mutex> lock(done_mutex_);
+    done_queue_.push(info);
+}
+
+int ProfMemoryManager::sync_from_device(volatile void *host_dst, const volatile void *dev_src, size_t size) {
+    if (copy_from_dev_cb_ != nullptr) {
+        return copy_from_dev_cb_(const_cast<void *>(host_dst), const_cast<const void *>(dev_src), size);
+    }
+    return 0;  // sim mode: already in sync
+}
+
+int ProfMemoryManager::sync_to_device(volatile void *dev_dst, const void *host_src, size_t size) {
+    if (copy_to_dev_cb_ != nullptr) {
+        return copy_to_dev_cb_(const_cast<void *>(dev_dst), host_src, size);
+    }
+    return 0;  // sim mode: already in sync
+}
+
+void *ProfMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size);
+    if (dev_ptr == nullptr) {
+        const char *hint = (size == sizeof(PerfBuffer)) ?
+                               "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss" :
+                               "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
+        LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        // SVM mode (not used on A5, kept for interface parity)
+        void *host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else if (is_memcpy_mode()) {
+        // Memcpy mode: allocate host shadow buffer
+        void *host_ptr = std::malloc(size);
+        if (host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: host shadow alloc failed for %zu bytes", size);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        std::memset(host_ptr, 0, size);
+        // Zero the device buffer too
+        sync_to_device(dev_ptr, host_ptr, size);
+        *host_ptr_out = host_ptr;
+    } else {
+        // Simulation mode: dev_ptr == host_ptr
+        *host_ptr_out = dev_ptr;
+    }
+
+    dev_to_host_[dev_ptr] = *host_ptr_out;
+    return dev_ptr;
+}
+
+void ProfMemoryManager::free_buffer(void *dev_ptr) {
+    if (dev_ptr == nullptr) return;
+
+    auto it = dev_to_host_.find(dev_ptr);
+    if (it != dev_to_host_.end()) {
+        // In memcpy mode, free the host shadow if it differs from dev_ptr
+        if (is_memcpy_mode() && it->second != dev_ptr) {
+            std::free(it->second);
+        }
+        dev_to_host_.erase(it);
+    }
+
+    if (free_cb_ != nullptr) {
+        free_cb_(dev_ptr);
+    }
+}
+
+void *ProfMemoryManager::resolve_host_ptr(void *dev_ptr) {
+    if (!is_memcpy_mode() && register_cb_ == nullptr) {
+        return dev_ptr;  // Simulation mode: dev_ptr == host_ptr
+    }
+    auto it = dev_to_host_.find(dev_ptr);
+    if (it != dev_to_host_.end()) {
+        return it->second;
+    }
+    LOG_ERROR("ProfMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
+    return nullptr;
+}
+
+void ProfMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
+
+void ProfMemoryManager::process_ready_entry(
+    PerfDataHeader * /*header*/, int /*thread_idx*/, const ReadyQueueEntry &entry
+) {
+    bool is_phase = (entry.is_phase != 0);
+    uint64_t old_dev_ptr = entry.buffer_ptr;
+    uint32_t seq = entry.buffer_seq;
+
+    // In memcpy mode, copy the full buffer from device to its host shadow
+    if (is_memcpy_mode()) {
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
+        if (old_host_ptr != nullptr) {
+            size_t buf_size = is_phase ? sizeof(PhaseBuffer) : sizeof(PerfBuffer);
+            sync_from_device(old_host_ptr, reinterpret_cast<void *>(old_dev_ptr), buf_size);
+        }
+    }
+
+    if (is_phase) {
+        uint32_t tidx = entry.core_index;
+        if (tidx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
+            LOG_ERROR("ProfMemoryManager: invalid phase entry: thread=%u", tidx);
+            return;
+        }
+
+        PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
+
+        // In memcpy mode, sync PerfBufferState from device
+        if (is_memcpy_mode()) {
+            PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, tidx);
+            sync_from_device(state, dev_state, sizeof(PhaseBufferState));
+        }
+
+        // Replenish free_queue
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
+
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
+
+            if (!recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                std::scoped_lock<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
+            if (is_memcpy_mode()) {
+                // Zero the device buffer count
+                uint32_t zero = 0;
+                sync_to_device(
+                    reinterpret_cast<char *>(new_dev_ptr) + offsetof(PhaseBuffer, count), &zero, sizeof(uint32_t)
+                );
+            }
+
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
+
+            // In memcpy mode, write the slot and tail back to device
+            if (is_memcpy_mode()) {
+                PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, tidx);
+                uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev_ptr);
+                sync_to_device(
+                    &dev_state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT], &slot_val, sizeof(uint64_t)
+                );
+                uint32_t new_tail = cur_tail + 1;
+                sync_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+            }
+        }
+
+        // Resolve host pointer of old buffer
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
+            return;
+        }
+
+        // Push old buffer to ready queue for main thread to copy
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PHASE;
+        info.index = tidx;
+        info.slot_idx = 0;
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+
+    } else {
+        uint32_t core_index = entry.core_index;
+        if (core_index >= static_cast<uint32_t>(num_cores_)) {
+            LOG_ERROR("ProfMemoryManager: invalid perf entry: core=%u", core_index);
+            return;
+        }
+
+        PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, core_index);
+
+        // In memcpy mode, sync PerfBufferState from device
+        if (is_memcpy_mode()) {
+            PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, core_index);
+            sync_from_device(state, dev_state, sizeof(PerfBufferState));
+        }
+
+        // Replenish free_queue
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
+
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
+
+            if (!recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                std::scoped_lock<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
+            if (is_memcpy_mode()) {
+                uint32_t zero = 0;
+                sync_to_device(
+                    reinterpret_cast<char *>(new_dev_ptr) + offsetof(PerfBuffer, count), &zero, sizeof(uint32_t)
+                );
+            }
+
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
+
+            // In memcpy mode, write the slot and tail back to device
+            if (is_memcpy_mode()) {
+                PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, core_index);
+                uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev_ptr);
+                sync_to_device(
+                    &dev_state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT], &slot_val, sizeof(uint64_t)
+                );
+                uint32_t new_tail = cur_tail + 1;
+                sync_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+            }
+        }
+
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
+            return;
+        }
+
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PERF_RECORD;
+        info.index = core_index;
+        info.slot_idx = 0;
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+    }
+}
+
+void ProfMemoryManager::mgmt_loop() {
+    PerfDataHeader *header = get_perf_header(shared_mem_host_);
+
+    while (running_.load()) {
+        // 1. Recycle done queue: move completed buffers to recycled pools for reuse
+        {
+            std::scoped_lock<std::mutex> lock(done_mutex_);
+            while (!done_queue_.empty()) {
+                CopyDoneInfo info = done_queue_.front();
+                done_queue_.pop();
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    recycled_perf_buffers_.push_back(info.dev_buffer_ptr);
+                } else {
+                    recycled_phase_buffers_.push_back(info.dev_buffer_ptr);
+                }
+            }
+        }
+
+        // 2. Poll ReadyQueues from all AICPU threads
+        // In memcpy mode, sync queue_tails from device first
+        if (is_memcpy_mode()) {
+            PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+            sync_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
+        }
+
+        bool found_any = false;
+        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+            rmb();
+            uint32_t head = header->queue_heads[t];
+            uint32_t tail = header->queue_tails[t];
+
+            // Validate indices to prevent OOB access from corrupted shared memory
+            if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR(
+                    "mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE
+                );
+                continue;
+            }
+
+            while (head != tail) {
+                ReadyQueueEntry entry;
+                if (is_memcpy_mode()) {
+                    // Read the specific entry from device
+                    PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+                    sync_from_device(&entry, &dev_header->queues[t][head], sizeof(ReadyQueueEntry));
+                } else {
+                    entry = header->queues[t][head];
+                }
+
+                process_ready_entry(header, t, entry);
+
+                head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+                header->queue_heads[t] = head;
+                wmb();
+
+                // In memcpy mode, write updated head back to device
+                if (is_memcpy_mode()) {
+                    PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+                    sync_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
+                }
+
+                found_any = true;
+
+                // Re-read tail in case more entries arrived
+                if (is_memcpy_mode()) {
+                    PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+                    sync_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
+                }
+                rmb();
+                tail = header->queue_tails[t];
+                if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                    LOG_ERROR("mgmt_loop: invalid tail for thread %d: %u", t, tail);
+                    break;
+                }
+            }
+        }
+
+        // 3. Proactive replenishment: push buffers to cores/threads whose free_queue
+        //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
+        if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
+                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
+                if (is_memcpy_mode()) {
+                    PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                    sync_from_device(state, dev_state, sizeof(PerfBufferState));
+                }
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void *dev_ptr = recycled_perf_buffers_.back();
+                    recycled_perf_buffers_.pop_back();
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
+                        if (is_memcpy_mode()) {
+                            uint32_t zero = 0;
+                            sync_to_device(
+                                reinterpret_cast<char *>(dev_ptr) + offsetof(PerfBuffer, count), &zero, sizeof(uint32_t)
+                            );
+                        }
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                        if (is_memcpy_mode()) {
+                            PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                            uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
+                            sync_to_device(
+                                &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
+                                sizeof(uint64_t)
+                            );
+                            uint32_t new_tail = t_val + 1;
+                            sync_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+                        }
+                    }
+                }
+            }
+            for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
+                PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
+                if (is_memcpy_mode()) {
+                    PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, t);
+                    sync_from_device(state, dev_state, sizeof(PhaseBufferState));
+                }
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void *dev_ptr = recycled_phase_buffers_.back();
+                    recycled_phase_buffers_.pop_back();
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
+                        if (is_memcpy_mode()) {
+                            uint32_t zero = 0;
+                            sync_to_device(
+                                reinterpret_cast<char *>(dev_ptr) + offsetof(PhaseBuffer, count), &zero,
+                                sizeof(uint32_t)
+                            );
+                        }
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                        if (is_memcpy_mode()) {
+                            PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, t);
+                            uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
+                            sync_to_device(
+                                &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
+                                sizeof(uint64_t)
+                            );
+                            uint32_t new_tail = t_val + 1;
+                            sync_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+                        }
+                    }
+                }
+            }
+        }
+        // Alloc fallback: if recycled pools are both empty, scan for depleted cores and alloc.
+        if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_; i++) {
+                PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
+                if (is_memcpy_mode()) {
+                    PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                    sync_from_device(state, dev_state, sizeof(PerfBufferState));
+                }
+                rmb();
+                if (state->free_queue.tail - state->free_queue.head == 0) {
+                    void *host_ptr = nullptr;
+                    void *dev_ptr = alloc_and_register(sizeof(PerfBuffer), &host_ptr);
+                    if (dev_ptr == nullptr) break;  // HBM exhausted
+                    reinterpret_cast<PerfBuffer *>(host_ptr)->count = 0;
+                    if (is_memcpy_mode()) {
+                        uint32_t zero = 0;
+                        sync_to_device(
+                            reinterpret_cast<char *>(dev_ptr) + offsetof(PerfBuffer, count), &zero, sizeof(uint32_t)
+                        );
+                    }
+                    uint32_t t_val = state->free_queue.tail;
+                    state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                        reinterpret_cast<uint64_t>(dev_ptr);
+                    wmb();
+                    state->free_queue.tail = t_val + 1;
+                    wmb();
+                    if (is_memcpy_mode()) {
+                        PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                        uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
+                        sync_to_device(
+                            &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
+                            sizeof(uint64_t)
+                        );
+                        uint32_t new_tail = t_val + 1;
+                        sync_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+                    }
+                    break;  // One alloc per iteration
+                }
+            }
+        }
+
+        // 4. If nothing found, yield briefly to avoid busy-spinning
+        if (!found_any) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+    }
+
+    // Final drain: process any remaining entries
+    if (is_memcpy_mode()) {
+        PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+        sync_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
+    }
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        rmb();
+        uint32_t head = header->queue_heads[t];
+        uint32_t tail = header->queue_tails[t];
+        if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
+            continue;
+        }
+        while (head != tail) {
+            ReadyQueueEntry entry;
+            if (is_memcpy_mode()) {
+                PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+                sync_from_device(&entry, &dev_header->queues[t][head], sizeof(ReadyQueueEntry));
+            } else {
+                entry = header->queues[t][head];
+            }
+            process_ready_entry(header, t, entry);
+            head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+            header->queue_heads[t] = head;
+            wmb();
+            if (is_memcpy_mode()) {
+                PerfDataHeader *dev_header = get_perf_header(shared_mem_dev_);
+                sync_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
+                sync_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
+            }
+            rmb();
+            tail = header->queue_tails[t];
+            if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR("mgmt_loop drain: invalid tail for thread %d: %u", t, tail);
+                break;
+            }
+        }
+    }
 }
 
 // =============================================================================
 // PerformanceCollector Implementation
 // =============================================================================
 
+static bool is_scheduler_phase(AicpuPhaseId id) {
+    return static_cast<uint32_t>(id) < static_cast<uint32_t>(AicpuPhaseId::SCHED_PHASE_COUNT);
+}
+
 PerformanceCollector::~PerformanceCollector() {
-    if (setup_header_dev_ != nullptr) {
+    if (perf_shared_mem_host_ != nullptr) {
         LOG_WARN("PerformanceCollector destroyed without finalize()");
     }
 }
 
+void *PerformanceCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size);
+    if (dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void *host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("Buffer registration failed: %d", rc);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else if (is_memcpy_mode()) {
+        // Memcpy mode: allocate host shadow
+        void *host_ptr = std::malloc(size);
+        if (host_ptr == nullptr) {
+            LOG_ERROR("Host shadow alloc failed for %zu bytes", size);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        *host_ptr_out = dev_ptr;
+    }
+
+    // Register mapping so ProfMemoryManager can resolve dev→host
+    memory_manager_.register_mapping(dev_ptr, *host_ptr_out);
+    return dev_ptr;
+}
+
 int PerformanceCollector::initialize(
-    Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfFreeCallback free_cb,
-    PerfCopyToDeviceCallback copy_to_dev_cb, PerfCopyFromDeviceCallback copy_from_dev_cb
+    Runtime &runtime, int num_aicore, int device_id, PerfAllocCallback alloc_cb, PerfRegisterCallback register_cb,
+    PerfFreeCallback free_cb, PerfCopyToDeviceCallback copy_to_dev_cb, PerfCopyFromDeviceCallback copy_from_dev_cb
 ) {
-    if (setup_header_dev_ != nullptr) {
+    if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("PerformanceCollector already initialized");
         return -1;
     }
+
+    LOG_INFO("Initializing performance profiling");
 
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
         return -1;
     }
-    if (alloc_cb == nullptr || free_cb == nullptr || copy_to_dev_cb == nullptr || copy_from_dev_cb == nullptr) {
-        LOG_ERROR("PerformanceCollector::initialize: null callback");
-        return -1;
-    }
-
-    LOG_INFO("Initializing performance profiling (memcpy-based)");
 
     device_id_ = device_id;
     num_aicore_ = num_aicore;
-    num_phase_threads_ = PLATFORM_MAX_AICPU_THREADS;
     alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
     free_cb_ = free_cb;
     copy_to_dev_cb_ = copy_to_dev_cb;
     copy_from_dev_cb_ = copy_from_dev_cb;
 
-    perf_buffer_bytes_ = calc_perf_buffer_size(PLATFORM_PROF_BUFFER_SIZE);
-    phase_buffer_bytes_ = calc_phase_buffer_size(PLATFORM_PHASE_RECORDS_PER_THREAD);
+    // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
+    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
+    size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads);
 
-    LOG_DEBUG("  PerfSetupHeader size: %zu bytes", calc_perf_setup_size());
-    LOG_DEBUG("  PerfBuffer size:      %zu bytes (capacity=%d)", perf_buffer_bytes_, PLATFORM_PROF_BUFFER_SIZE);
-    LOG_DEBUG(
-        "  PhaseBuffer size:     %zu bytes (capacity=%d)", phase_buffer_bytes_, PLATFORM_PHASE_RECORDS_PER_THREAD
-    );
-    LOG_DEBUG("  num_aicore:           %d", num_aicore_);
-    LOG_DEBUG("  num_phase_threads:    %d", num_phase_threads_);
+    LOG_DEBUG("Shared memory allocation plan:");
+    LOG_DEBUG("  Number of cores:      %d", num_aicore);
+    LOG_DEBUG("  Header size:          %zu bytes", sizeof(PerfDataHeader));
+    LOG_DEBUG("  PerfBufferState size: %zu bytes each", sizeof(PerfBufferState));
+    LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
-    // Step 1: Allocate PerfSetupHeader on device
-    setup_header_dev_ = alloc_cb_(calc_perf_setup_size());
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("Failed to allocate PerfSetupHeader (%zu bytes)", calc_perf_setup_size());
+    // Step 2: Allocate shared memory for slot arrays
+    void *perf_dev_ptr = alloc_cb(total_size);
+    if (perf_dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
     }
+    LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
-    // Step 2: Allocate one PerfBuffer per core on device
-    core_buffers_dev_.assign(num_aicore_, nullptr);
-    for (int i = 0; i < num_aicore_; i++) {
-        void *buf = alloc_cb_(perf_buffer_bytes_);
-        if (buf == nullptr) {
-            LOG_ERROR("Failed to allocate PerfBuffer for core %d (%zu bytes)", i, perf_buffer_bytes_);
-            finalize();
+    // Step 3: Get or create host-side pointer
+    void *perf_host_ptr = nullptr;
+    if (register_cb != nullptr) {
+        int rc = register_cb(perf_dev_ptr, total_size, device_id, &perf_host_ptr);
+        if (rc != 0 || perf_host_ptr == nullptr) {
+            LOG_ERROR("Memory registration failed: %d", rc);
+            return rc;
+        }
+        was_registered_ = true;
+        LOG_DEBUG("Mapped to host memory: %p", perf_host_ptr);
+    } else if (is_memcpy_mode()) {
+        // Memcpy mode: allocate host shadow for the shared memory region
+        perf_host_ptr = std::malloc(total_size);
+        if (perf_host_ptr == nullptr) {
+            LOG_ERROR("Host shadow alloc failed for shared memory (%zu bytes)", total_size);
             return -1;
         }
-        core_buffers_dev_[i] = buf;
+        LOG_DEBUG("Allocated host shadow: %p", perf_host_ptr);
+    } else {
+        perf_host_ptr = perf_dev_ptr;
+        LOG_DEBUG("Simulation mode: host_ptr = dev_ptr = %p", perf_host_ptr);
     }
 
-    // Step 3: Allocate one PhaseBuffer per AICPU thread on device
-    phase_buffers_dev_.assign(num_phase_threads_, nullptr);
-    for (int t = 0; t < num_phase_threads_; t++) {
-        void *buf = alloc_cb_(phase_buffer_bytes_);
-        if (buf == nullptr) {
-            LOG_ERROR("Failed to allocate PhaseBuffer for thread %d (%zu bytes)", t, phase_buffer_bytes_);
-            finalize();
-            return -1;
+    // Step 4: Initialize header
+    PerfDataHeader *header = get_perf_header(perf_host_ptr);
+
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        std::memset(header->queues[t], 0, sizeof(header->queues[t]));
+        header->queue_heads[t] = 0;
+        header->queue_tails[t] = 0;
+    }
+
+    header->num_cores = num_aicore;
+    header->total_tasks = 0;
+
+    LOG_DEBUG("Initialized PerfDataHeader:");
+    LOG_DEBUG("  num_cores:        %d", header->num_cores);
+    LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
+    LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
+
+    // Step 5: Initialize PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
+    for (int i = 0; i < num_aicore; i++) {
+        PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
+        std::memset(state, 0, sizeof(PerfBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PerfBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PerfBuffer for core %d, buffer %d", i, s);
+                return -1;
+            }
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_buf_ptr);
+            std::memset(buf, 0, sizeof(PerfBuffer));
+            buf->count = 0;
+
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_perf_buffers_.push_back(dev_buf_ptr);
+            }
         }
-        phase_buffers_dev_[t] = buf;
+        wmb();
+        state->free_queue.tail = 1;
+        wmb();
     }
-
-    // Step 4: Build PerfSetupHeader on host and copy to device
-    PerfSetupHeader host_header;
-    memset(&host_header, 0, sizeof(host_header));
-    host_header.num_cores = static_cast<uint32_t>(num_aicore_);
-    host_header.num_phase_threads = static_cast<uint32_t>(num_phase_threads_);
-    host_header.total_tasks = 0;
-    for (int i = 0; i < num_aicore_; i++) {
-        host_header.core_buffer_ptrs[i] = reinterpret_cast<uint64_t>(core_buffers_dev_[i]);
-    }
-    for (int t = 0; t < num_phase_threads_; t++) {
-        host_header.phase_buffer_ptrs[t] = reinterpret_cast<uint64_t>(phase_buffers_dev_[t]);
-    }
-    // phase_header is zero-initialized; AICPU sets magic during init.
-
-    int rc = copy_to_dev_cb_(setup_header_dev_, &host_header, sizeof(host_header));
-    if (rc != 0) {
-        LOG_ERROR("Failed to copy PerfSetupHeader to device: %d", rc);
-        finalize();
-        return rc;
-    }
-
-    // Step 5: Publish the device-side header pointer via runtime.perf_data_base.
-    // AICPU reads this on init_profiling to discover per-core / per-thread buffer pointers.
-    runtime.perf_data_base = reinterpret_cast<uint64_t>(setup_header_dev_);
-    LOG_DEBUG("runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
-
-    LOG_INFO(
-        "Performance profiling initialized: %d cores × %zuB PerfBuffer, %d threads × %zuB PhaseBuffer", num_aicore_,
-        perf_buffer_bytes_, num_phase_threads_, phase_buffer_bytes_
+    LOG_DEBUG(
+        "Initialized %d PerfBufferStates: 1 buffer/core, %d in recycled pool", num_aicore,
+        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
     );
+
+    // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        std::memset(state, 0, sizeof(PhaseBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
+                return -1;
+            }
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(host_buf_ptr);
+            std::memset(buf, 0, sizeof(PhaseBuffer));
+            buf->count = 0;
+
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_phase_buffers_.push_back(dev_buf_ptr);
+            }
+        }
+        wmb();
+        state->free_queue.tail = 1;
+        wmb();
+    }
+    LOG_DEBUG(
+        "Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool", num_phase_threads,
+        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1)
+    );
+
+    // In memcpy mode, copy the entire initialized shared memory to device
+    if (is_memcpy_mode()) {
+        int rc = copy_to_dev_cb_(perf_dev_ptr, perf_host_ptr, total_size);
+        if (rc != 0) {
+            LOG_ERROR("Failed to copy shared memory to device: %d", rc);
+            return rc;
+        }
+        // Also copy each initial buffer (zero'd count) to device
+        for (int i = 0; i < num_aicore; i++) {
+            PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
+            void *dev_buf = reinterpret_cast<void *>(state->free_queue.buffer_ptrs[0]);
+            void *host_buf = memory_manager_.resolve_host_ptr(dev_buf);
+            if (host_buf != nullptr) {
+                copy_to_dev_cb_(dev_buf, host_buf, sizeof(PerfBuffer));
+            }
+        }
+        for (int t = 0; t < num_phase_threads; t++) {
+            PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+            void *dev_buf = reinterpret_cast<void *>(state->free_queue.buffer_ptrs[0]);
+            void *host_buf = memory_manager_.resolve_host_ptr(dev_buf);
+            if (host_buf != nullptr) {
+                copy_to_dev_cb_(dev_buf, host_buf, sizeof(PhaseBuffer));
+            }
+        }
+    }
+
+    wmb();
+
+    // Step 7: Pass base address to Runtime
+    runtime.perf_data_base = reinterpret_cast<uint64_t>(perf_dev_ptr);
+    LOG_DEBUG("Set runtime.perf_data_base = 0x%lx", runtime.perf_data_base);
+
+    perf_shared_mem_dev_ = perf_dev_ptr;
+    perf_shared_mem_host_ = perf_host_ptr;
+
+    LOG_INFO("Performance profiling initialized (dynamic buffer mode)");
     return 0;
 }
 
-int PerformanceCollector::collect_all() {
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("PerformanceCollector::collect_all called before initialize");
-        return -1;
+void PerformanceCollector::start_memory_manager(const ThreadFactory &thread_factory) {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
     }
 
-    LOG_INFO("Collecting performance data via device→host memcpy");
+    memory_manager_.start(
+        perf_shared_mem_host_, perf_shared_mem_dev_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_,
+        free_cb_, copy_to_dev_cb_, copy_from_dev_cb_, device_id_, thread_factory
+    );
+}
 
-    // Step 1: Copy back PerfSetupHeader (contains total_tasks and phase_header)
-    PerfSetupHeader host_header;
-    memset(&host_header, 0, sizeof(host_header));
-    int rc = copy_from_dev_cb_(&host_header, setup_header_dev_, sizeof(host_header));
-    if (rc != 0) {
-        LOG_ERROR("Failed to copy PerfSetupHeader from device: %d", rc);
-        return rc;
+void PerformanceCollector::stop_memory_manager() {
+    if (memory_manager_.is_running()) {
+        memory_manager_.stop();
+    }
+}
+
+void PerformanceCollector::signal_execution_complete() { execution_complete_.store(true); }
+
+void PerformanceCollector::poll_and_collect(int expected_tasks) {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
     }
 
-    uint32_t total_tasks = host_header.total_tasks;
-    LOG_DEBUG("PerfSetupHeader: total_tasks=%u", total_tasks);
+    execution_complete_.store(false);
 
-    // Step 2: Prepare host-side storage
+    LOG_INFO("Collecting performance data");
+
+    PerfDataHeader *header = get_perf_header(perf_shared_mem_host_);
+
+    const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
+    std::optional<std::chrono::steady_clock::time_point> idle_start;
+
+    int total_records_collected = 0;
+    int buffers_processed = 0;
+
     collected_perf_records_.clear();
     collected_perf_records_.resize(num_aicore_);
     collected_phase_records_.clear();
-    collected_phase_records_.resize(num_phase_threads_);
+    collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
 
-    // Step 3: Two-step copy each PerfBuffer back.
-    //   - First copy 64B header → read count
-    //   - Then copy count * sizeof(PerfRecord) of actual data
-    uint64_t total_perf_records = 0;
-    {
-        // Reusable header buffer (aligned to 64B to match PerfBuffer layout)
-        alignas(64) unsigned char header_buf[sizeof(PerfBuffer)];
-        for (int i = 0; i < num_aicore_; i++) {
-            void *dev_ptr = core_buffers_dev_[i];
-            if (dev_ptr == nullptr) continue;
+    // Helper lambda: read total_tasks from device (memcpy mode) or host shadow
+    auto read_total_tasks = [&]() -> uint32_t {
+        if (is_memcpy_mode()) {
+            PerfDataHeader *dev_header = get_perf_header(perf_shared_mem_dev_);
+            uint32_t val = 0;
+            copy_from_dev_cb_(
+                &val, const_cast<const void *>(static_cast<volatile void *>(&dev_header->total_tasks)), sizeof(uint32_t)
+            );
+            header->total_tasks = val;
+        }
+        rmb();
+        return header->total_tasks;
+    };
 
-            rc = copy_from_dev_cb_(header_buf, dev_ptr, sizeof(PerfBuffer));
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy PerfBuffer header for core %d: %d", i, rc);
-                continue;
+    if (expected_tasks <= 0) {
+        LOG_INFO("Waiting for AICPU to write total_tasks in PerfDataHeader...");
+        idle_start = std::chrono::steady_clock::now();
+
+        while (true) {
+            uint32_t raw_total_tasks = read_total_tasks();
+
+            if (raw_total_tasks > 0) {
+                expected_tasks = static_cast<int>(raw_total_tasks);
+                LOG_INFO("AICPU reported task count: %d", expected_tasks);
+                break;
             }
 
-            uint32_t count = reinterpret_cast<PerfBuffer *>(header_buf)->count;
-            if (count > static_cast<uint32_t>(PLATFORM_PROF_BUFFER_SIZE)) {
-                LOG_WARN(
-                    "Core %d: PerfBuffer count=%u exceeds capacity=%d, clamping", i, count, PLATFORM_PROF_BUFFER_SIZE
+            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
+            if (elapsed >= timeout_duration) {
+                LOG_ERROR(
+                    "Timeout waiting for AICPU task count after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
                 );
-                count = PLATFORM_PROF_BUFFER_SIZE;
-            }
-            if (count == 0) {
-                LOG_DEBUG("Core %d: empty PerfBuffer", i);
-                continue;
+                return;
             }
 
-            collected_perf_records_[i].resize(count);
-            size_t records_bytes = static_cast<size_t>(count) * sizeof(PerfRecord);
-            void *dev_records = static_cast<unsigned char *>(dev_ptr) + sizeof(PerfBuffer);
-            rc = copy_from_dev_cb_(collected_perf_records_[i].data(), dev_records, records_bytes);
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy PerfBuffer records for core %d: %d", i, rc);
-                collected_perf_records_[i].clear();
-                continue;
+            // Process ready buffers while waiting
+            ReadyBufferInfo info;
+            if (memory_manager_.try_pop_ready(info)) {
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
+                    uint32_t core_index = info.index;
+                    if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_perf_records_[core_index].push_back(buf->records[i]);
+                        }
+                        total_records_collected += count;
+                    }
+                } else {
+                    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
+                        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                    uint32_t tidx = info.index;
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[tidx].push_back(buf->records[i]);
+                    }
+                }
+                memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+                buffers_processed++;
             }
-            total_perf_records += count;
-            LOG_DEBUG("Core %d: collected %u perf records", i, count);
         }
     }
 
-    // Step 4: Two-step copy each PhaseBuffer back.
-    uint64_t total_phase_records = 0;
-    {
-        alignas(64) unsigned char header_buf[sizeof(PhaseBuffer)];
-        for (int t = 0; t < num_phase_threads_; t++) {
-            void *dev_ptr = phase_buffers_dev_[t];
-            if (dev_ptr == nullptr) continue;
+    LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
 
-            rc = copy_from_dev_cb_(header_buf, dev_ptr, sizeof(PhaseBuffer));
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy PhaseBuffer header for thread %d: %d", t, rc);
-                continue;
+    idle_start.reset();
+    int last_logged_expected = -1;
+
+    while (total_records_collected < expected_tasks) {
+        // Check for updated expected_tasks
+        int current_expected = static_cast<int>(read_total_tasks());
+        if (current_expected > expected_tasks) {
+            expected_tasks = current_expected;
+            if (last_logged_expected < 0) {
+                LOG_INFO("Updated expected_tasks to %d (orchestrator progress)", expected_tasks);
+                last_logged_expected = expected_tasks;
+            }
+        }
+
+        ReadyBufferInfo info;
+        if (memory_manager_.wait_pop_ready(info, std::chrono::milliseconds(100))) {
+            idle_start.reset();
+
+            if (info.type == ProfBufferType::PERF_RECORD) {
+                PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
+                rmb();
+                uint32_t count = buf->count;
+                if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
+
+                uint32_t core_index = info.index;
+                if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_perf_records_[core_index].push_back(buf->records[i]);
+                    }
+                    total_records_collected += count;
+                }
+
+                LOG_DEBUG(
+                    "Collected %u perf records from core %u (total: %d/%d)", count, core_index, total_records_collected,
+                    expected_tasks
+                );
+
+            } else {
+                PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+                rmb();
+                uint32_t count = buf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+
+                uint32_t tidx = info.index;
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[tidx].push_back(buf->records[i]);
+                }
+
+                LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
             }
 
-            uint32_t count = reinterpret_cast<PhaseBuffer *>(header_buf)->count;
-            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                LOG_WARN(
-                    "Thread %d: PhaseBuffer count=%u exceeds capacity=%d, clamping", t, count,
-                    PLATFORM_PHASE_RECORDS_PER_THREAD
+            memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+            buffers_processed++;
+
+        } else {
+            if (execution_complete_.load()) {
+                ReadyBufferInfo drain_info;
+                while (memory_manager_.try_pop_ready(drain_info)) {
+                    if (drain_info.type == ProfBufferType::PERF_RECORD) {
+                        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
+                        uint32_t ci = drain_info.index;
+                        if (ci < static_cast<uint32_t>(num_aicore_)) {
+                            for (uint32_t i = 0; i < count; i++) {
+                                collected_perf_records_[ci].push_back(buf->records[i]);
+                            }
+                            total_records_collected += count;
+                        }
+                    } else {
+                        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
+                            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                        uint32_t tidx = drain_info.index;
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_phase_records_[tidx].push_back(buf->records[i]);
+                        }
+                    }
+                    memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
+                    buffers_processed++;
+                }
+                LOG_INFO(
+                    "Execution complete signal received, exiting with %d/%d records", total_records_collected,
+                    expected_tasks
                 );
+                break;
+            }
+            if (!idle_start.has_value()) {
+                idle_start = std::chrono::steady_clock::now();
+            }
+            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
+            if (elapsed >= timeout_duration) {
+                LOG_ERROR(
+                    "Performance data collection idle timeout after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                );
+                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
+                break;
+            }
+        }
+    }
+
+    LOG_INFO("Total buffers processed: %d", buffers_processed);
+    LOG_INFO("Total records collected: %d", total_records_collected);
+
+    if (total_records_collected < expected_tasks) {
+        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
+    }
+
+    LOG_INFO("Performance data collection complete");
+}
+
+void PerformanceCollector::drain_remaining_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    int drained_perf = 0;
+    int drained_phase = 0;
+
+    ReadyBufferInfo info;
+    while (memory_manager_.try_pop_ready(info)) {
+        if (info.type == ProfBufferType::PERF_RECORD) {
+            PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(info.host_buffer_ptr);
+            rmb();
+            uint32_t count = buf->count;
+            if (count > PLATFORM_PROF_BUFFER_SIZE) count = PLATFORM_PROF_BUFFER_SIZE;
+            uint32_t core_index = info.index;
+            if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_perf_records_[core_index].push_back(buf->records[i]);
+                }
+                drained_perf += count;
+            }
+        } else {
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+            rmb();
+            uint32_t count = buf->count;
+            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
                 count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+            uint32_t tidx = info.index;
+            for (uint32_t i = 0; i < count; i++) {
+                collected_phase_records_[tidx].push_back(buf->records[i]);
             }
-            if (count == 0) {
-                continue;
-            }
+            drained_phase += count;
+        }
 
-            collected_phase_records_[t].resize(count);
-            size_t records_bytes = static_cast<size_t>(count) * sizeof(AicpuPhaseRecord);
-            void *dev_records = static_cast<unsigned char *>(dev_ptr) + sizeof(PhaseBuffer);
-            rc = copy_from_dev_cb_(collected_phase_records_[t].data(), dev_records, records_bytes);
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy PhaseBuffer records for thread %d: %d", t, rc);
-                collected_phase_records_[t].clear();
+        memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+    }
+
+    if (drained_perf > 0 || drained_phase > 0) {
+        LOG_INFO("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
+    }
+
+    if (drained_phase > 0) {
+        has_phase_data_ = true;
+    }
+}
+
+void PerformanceCollector::scan_remaining_perf_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    // In memcpy mode, sync all PerfBufferStates from device
+    if (is_memcpy_mode()) {
+        for (int i = 0; i < num_aicore_; i++) {
+            PerfBufferState *host_state = get_perf_buffer_state(perf_shared_mem_host_, i);
+            PerfBufferState *dev_state = get_perf_buffer_state(perf_shared_mem_dev_, i);
+            copy_from_dev_cb_(host_state, dev_state, sizeof(PerfBufferState));
+        }
+    }
+    rmb();
+
+    int total_recovered = 0;
+
+    for (int core_index = 0; core_index < num_aicore_; core_index++) {
+        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            continue;
+        }
+
+        void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+        if (host_ptr == nullptr) {
+            LOG_ERROR(
+                "scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
+                reinterpret_cast<void *>(buf_ptr), core_index
+            );
+            continue;
+        }
+
+        // In memcpy mode, sync the buffer from device
+        if (is_memcpy_mode()) {
+            copy_from_dev_cb_(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(PerfBuffer));
+        }
+
+        PerfBuffer *buf = reinterpret_cast<PerfBuffer *>(host_ptr);
+        uint32_t count = buf->count;
+        if (count == 0) {
+            continue;
+        }
+        if (count > PLATFORM_PROF_BUFFER_SIZE) {
+            count = PLATFORM_PROF_BUFFER_SIZE;
+        }
+
+        for (uint32_t i = 0; i < count; i++) {
+            collected_perf_records_[core_index].push_back(buf->records[i]);
+        }
+        total_recovered += count;
+    }
+
+    if (total_recovered > 0) {
+        LOG_INFO("scan_remaining_perf_buffers: recovered %d records from active buffers", total_recovered);
+    }
+}
+
+void PerformanceCollector::collect_phase_data() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    // In memcpy mode, sync AicpuPhaseHeader and PhaseBufferStates from device
+    if (is_memcpy_mode()) {
+        AicpuPhaseHeader *host_ph = get_phase_header(perf_shared_mem_host_, num_aicore_);
+        AicpuPhaseHeader *dev_ph = get_phase_header(perf_shared_mem_dev_, num_aicore_);
+        copy_from_dev_cb_(host_ph, dev_ph, sizeof(AicpuPhaseHeader));
+        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+            PhaseBufferState *host_state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+            PhaseBufferState *dev_state = get_phase_buffer_state(perf_shared_mem_dev_, num_aicore_, t);
+            copy_from_dev_cb_(host_state, dev_state, sizeof(PhaseBufferState));
+        }
+    }
+    rmb();
+
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+
+    if (phase_header->magic != AICPU_PHASE_MAGIC) {
+        LOG_INFO(
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC
+        );
+        return;
+    }
+
+    int num_sched_threads = phase_header->num_sched_threads;
+    if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS
+        );
+        return;
+    }
+    LOG_INFO("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
+
+    int total_slots = PLATFORM_MAX_AICPU_THREADS;
+
+    int total_phase_records = 0;
+    for (int t = 0; t < total_slots; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr != 0) {
+            void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+            if (host_ptr == nullptr) {
+                LOG_ERROR(
+                    "collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", reinterpret_cast<void *>(buf_ptr),
+                    t
+                );
                 continue;
             }
-            total_phase_records += count;
+            // In memcpy mode, sync the buffer from device
+            if (is_memcpy_mode()) {
+                copy_from_dev_cb_(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(PhaseBuffer));
+            }
+            PhaseBuffer *pbuf = reinterpret_cast<PhaseBuffer *>(host_ptr);
+            if (pbuf->count > 0) {
+                uint32_t count = pbuf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD))
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[t].push_back(pbuf->records[i]);
+                }
+                total_phase_records += count;
+            }
         }
     }
 
-    // Step 5: Extract phase header fields (orch summary + core-to-thread mapping)
-    const AicpuPhaseHeader &phase_header = host_header.phase_header;
-    bool phase_header_valid = (phase_header.magic == AICPU_PHASE_MAGIC);
-
-    if (phase_header_valid) {
-        collected_orch_summary_ = phase_header.orch_summary;
-        int num_cores_mapping = static_cast<int>(phase_header.num_cores);
-        if (num_cores_mapping > 0 && num_cores_mapping <= PLATFORM_MAX_CORES) {
-            core_to_thread_.assign(phase_header.core_to_thread, phase_header.core_to_thread + num_cores_mapping);
-            LOG_DEBUG("Core-to-thread mapping: %d cores", num_cores_mapping);
-        }
-    } else {
-        memset(&collected_orch_summary_, 0, sizeof(collected_orch_summary_));
-    }
-
-    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
-    has_phase_data_ = (total_phase_records > 0) || orch_valid;
-
-    // Step 6: Log per-thread totals (sched vs orch breakdown)
-    if (has_phase_data_) {
-        for (size_t t = 0; t < collected_phase_records_.size(); t++) {
-            if (collected_phase_records_[t].empty()) continue;
+    // Log per-thread totals
+    for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+        if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
             for (const auto &r : collected_phase_records_[t]) {
                 if (is_scheduler_phase(r.phase_id)) sched_count++;
                 else orch_count++;
             }
             LOG_INFO(
-                "  Thread %zu: %zu phase records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(),
-                sched_count, orch_count
+                "  Thread %zu: %zu records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(), sched_count,
+                orch_count
             );
         }
-        if (orch_valid) {
-            LOG_INFO(
-                "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
-                cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
-            );
+    }
+
+    // Read orchestrator summary
+    collected_orch_summary_ = phase_header->orch_summary;
+    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
+
+    if (orch_valid) {
+        LOG_INFO(
+            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
+        );
+    } else {
+        LOG_INFO("  Orchestrator: no summary data");
+    }
+
+    bool has_accumulated = has_phase_data_;
+    if (!has_accumulated) {
+        for (const auto &v : collected_phase_records_) {
+            if (!v.empty()) {
+                has_accumulated = true;
+                break;
+            }
         }
+    }
+    has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
+
+    // Read core-to-thread mapping
+    int num_cores = static_cast<int>(phase_header->num_cores);
+    if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
+        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
+        LOG_INFO("  Core-to-thread mapping: %d cores", num_cores);
     }
 
     LOG_INFO(
-        "Collection complete: %" PRIu64 " perf records, %" PRIu64 " phase records, orch_summary=%s", total_perf_records,
-        total_phase_records, orch_valid ? "yes" : "no"
+        "Phase data collection complete: %d remaining records, orch_summary=%s", total_phase_records,
+        orch_valid ? "yes" : "no"
     );
-
-    if (total_tasks > 0 && total_perf_records < total_tasks) {
-        LOG_WARN(
-            "Incomplete collection: %" PRIu64 " / %u records (some cores may have filled their PerfBuffer)",
-            total_perf_records, total_tasks
-        );
-    }
-
-    return 0;
 }
 
+// export_swimlane_json and finalize are identical to a2a3 — copy verbatim
+
 int PerformanceCollector::export_swimlane_json(const std::string &output_path_arg) {
-    // Step 0: Resolve effective output directory. SIMPLER_PERF_OUTPUT_DIR (when set)
-    // overrides the caller-supplied path so the parallel test orchestrator can
-    // give each subprocess its own directory — avoids filename collisions when
-    // two concurrent runs produce a perf_swimlane_*.json with the same
-    // second-precision timestamp. Empty env var is treated as unset.
     const char *env_dir = std::getenv("SIMPLER_PERF_OUTPUT_DIR");
     const std::string output_path = (env_dir != nullptr && env_dir[0] != '\0') ? std::string(env_dir) : output_path_arg;
 
-    // Step 1: Validate collected data
     bool has_any_records = false;
     for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
@@ -342,7 +1414,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         return -1;
     }
 
-    // Step 2: Create output directory if it doesn't exist
     struct stat st;
     if (stat(output_path.c_str(), &st) == -1) {
         if (mkdir(output_path.c_str(), 0755) != 0) {
@@ -351,7 +1422,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         }
     }
 
-    // Step 3: Flatten per-core vectors into tagged records with core_id derived from index
     struct TaggedRecord {
         const PerfRecord *record;
         uint32_t core_id;
@@ -368,29 +1438,20 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         }
     }
 
-    // Sort by canonical task_id (64-bit PTO2 raw)
     std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord &a, const TaggedRecord &b) {
         return a.record->task_id < b.record->task_id;
     });
 
-    // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
     for (const auto &tagged : tagged_records) {
-        if (tagged.record->start_time < base_time_cycles) {
-            base_time_cycles = tagged.record->start_time;
-        }
-        if (tagged.record->dispatch_time > 0 && tagged.record->dispatch_time < base_time_cycles) {
+        if (tagged.record->start_time < base_time_cycles) base_time_cycles = tagged.record->start_time;
+        if (tagged.record->dispatch_time > 0 && tagged.record->dispatch_time < base_time_cycles)
             base_time_cycles = tagged.record->dispatch_time;
-        }
     }
-
-    // Include phase record timestamps in base_time calculation
     if (has_phase_data_) {
         for (const auto &thread_records : collected_phase_records_) {
             for (const auto &pr : thread_records) {
-                if (pr.start_time > 0 && pr.start_time < base_time_cycles) {
-                    base_time_cycles = pr.start_time;
-                }
+                if (pr.start_time > 0 && pr.start_time < base_time_cycles) base_time_cycles = pr.start_time;
             }
         }
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
@@ -399,21 +1460,18 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         }
     }
 
-    // Step 5: Generate filename with timestamp (YYYYMMDD_HHMMSS)
     std::time_t now = time(nullptr);
     std::tm *timeinfo = std::localtime(&now);
     char time_buffer[32];
     std::strftime(time_buffer, sizeof(time_buffer), "%Y%m%d_%H%M%S", timeinfo);
     std::string filepath = output_path + "/perf_swimlane_" + std::string(time_buffer) + ".json";
 
-    // Step 6: Open JSON file for writing
     std::ofstream outfile(filepath);
     if (!outfile.is_open()) {
         LOG_ERROR("Error: Failed to open file: %s", filepath.c_str());
         return -1;
     }
 
-    // Step 7: Write JSON data
     int version = has_phase_data_ ? 2 : 1;
     outfile << "{\n";
     outfile << "  \"version\": " << version << ",\n";
@@ -423,7 +1481,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         const auto &tagged = tagged_records[i];
         const auto &record = *tagged.record;
 
-        // Convert times to microseconds
         double start_us = cycles_to_us(record.start_time - base_time_cycles);
         double end_us = cycles_to_us(record.end_time - base_time_cycles);
         double duration_us = end_us - start_us;
@@ -448,21 +1505,16 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
             (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
         for (int j = 0; j < safe_fanout_count; ++j) {
             outfile << record.fanout[j];
-            if (j < safe_fanout_count - 1) {
-                outfile << ", ";
-            }
+            if (j < safe_fanout_count - 1) outfile << ", ";
         }
         outfile << "],\n";
         outfile << "      \"fanout_count\": " << record.fanout_count << "\n";
         outfile << "    }";
-        if (i < tagged_records.size() - 1) {
-            outfile << ",";
-        }
+        if (i < tagged_records.size() - 1) outfile << ",";
         outfile << "\n";
     }
     outfile << "  ]";
 
-    // Step 8: Write phase profiling data (version 2)
     if (has_phase_data_) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
@@ -504,7 +1556,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
             }
         };
 
-        // AICPU scheduler phases (filtered from unified collected_phase_records_)
         outfile << ",\n  \"aicpu_scheduler_phases\": [\n";
         for (size_t t = 0; t < collected_phase_records_.size(); t++) {
             outfile << "    [\n";
@@ -528,7 +1579,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         }
         outfile << "  ]";
 
-        // AICPU orchestrator summary
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC) {
             double orch_start_us = cycles_to_us(collected_orch_summary_.start_time - base_time_cycles);
             double orch_end_us = cycles_to_us(collected_orch_summary_.end_time - base_time_cycles);
@@ -558,7 +1608,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
             outfile << "  }";
         }
 
-        // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
         bool has_orch_phases = false;
         for (const auto &v : collected_phase_records_) {
             for (const auto &r : v) {
@@ -594,7 +1643,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
         }
     }
 
-    // Core-to-thread mapping
     if (!core_to_thread_.empty()) {
         outfile << ",\n  \"core_to_thread\": [";
         for (size_t i = 0; i < core_to_thread_.size(); i++) {
@@ -605,8 +1653,6 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
     }
 
     outfile << "\n}\n";
-
-    // Step 9: Close file
     outfile.close();
 
     uint32_t record_count = static_cast<uint32_t>(tagged_records.size());
@@ -617,52 +1663,127 @@ int PerformanceCollector::export_swimlane_json(const std::string &output_path_ar
     return 0;
 }
 
-int PerformanceCollector::finalize() {
-    if (setup_header_dev_ == nullptr && core_buffers_dev_.empty() && phase_buffers_dev_.empty()) {
+int PerformanceCollector::finalize(PerfUnregisterCallback unregister_cb, PerfFreeCallback free_cb) {
+    if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
 
+    stop_memory_manager();
+
     LOG_DEBUG("Cleaning up performance profiling resources");
 
-    // Free per-core PerfBuffers
-    if (free_cb_ != nullptr) {
-        for (void *ptr : core_buffers_dev_) {
-            if (ptr != nullptr) {
-                free_cb_(ptr);
-            }
+    // In memcpy mode, sync all buffer states from device for accurate free_queue reading
+    if (is_memcpy_mode()) {
+        for (int i = 0; i < num_aicore_; i++) {
+            PerfBufferState *host_state = get_perf_buffer_state(perf_shared_mem_host_, i);
+            PerfBufferState *dev_state = get_perf_buffer_state(perf_shared_mem_dev_, i);
+            copy_from_dev_cb_(host_state, dev_state, sizeof(PerfBufferState));
+        }
+        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+            PhaseBufferState *host_state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+            PhaseBufferState *dev_state = get_phase_buffer_state(perf_shared_mem_dev_, num_aicore_, t);
+            copy_from_dev_cb_(host_state, dev_state, sizeof(PhaseBufferState));
         }
     }
-    core_buffers_dev_.clear();
 
-    // Free per-thread PhaseBuffers
-    if (free_cb_ != nullptr) {
-        for (void *ptr : phase_buffers_dev_) {
-            if (ptr != nullptr) {
-                free_cb_(ptr);
+    // Free buffers in free_queues and current_buf_ptr
+    for (int i = 0; i < num_aicore_; i++) {
+        PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, i);
+
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            // Free host shadow if in memcpy mode
+            if (is_memcpy_mode()) {
+                void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(state->current_buf_ptr));
+                if (host_ptr != nullptr && host_ptr != reinterpret_cast<void *>(state->current_buf_ptr)) {
+                    std::free(host_ptr);
+                }
+                memory_manager_.dev_to_host_.erase(reinterpret_cast<void *>(state->current_buf_ptr));
             }
+            free_cb(reinterpret_cast<void *>(state->current_buf_ptr));
+        }
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                if (is_memcpy_mode()) {
+                    void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+                    if (host_ptr != nullptr && host_ptr != reinterpret_cast<void *>(buf_ptr)) {
+                        std::free(host_ptr);
+                    }
+                    memory_manager_.dev_to_host_.erase(reinterpret_cast<void *>(buf_ptr));
+                }
+                free_cb(reinterpret_cast<void *>(buf_ptr));
+            }
+            head++;
         }
     }
-    phase_buffers_dev_.clear();
 
-    // Free PerfSetupHeader
-    if (free_cb_ != nullptr && setup_header_dev_ != nullptr) {
-        free_cb_(setup_header_dev_);
+    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            if (is_memcpy_mode()) {
+                void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(state->current_buf_ptr));
+                if (host_ptr != nullptr && host_ptr != reinterpret_cast<void *>(state->current_buf_ptr)) {
+                    std::free(host_ptr);
+                }
+                memory_manager_.dev_to_host_.erase(reinterpret_cast<void *>(state->current_buf_ptr));
+            }
+            free_cb(reinterpret_cast<void *>(state->current_buf_ptr));
+        }
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                if (is_memcpy_mode()) {
+                    void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+                    if (host_ptr != nullptr && host_ptr != reinterpret_cast<void *>(buf_ptr)) {
+                        std::free(host_ptr);
+                    }
+                    memory_manager_.dev_to_host_.erase(reinterpret_cast<void *>(buf_ptr));
+                }
+                free_cb(reinterpret_cast<void *>(buf_ptr));
+            }
+            head++;
+        }
     }
-    setup_header_dev_ = nullptr;
 
-    // Clear host-side state
+    if (unregister_cb != nullptr && was_registered_) {
+        int rc = unregister_cb(perf_shared_mem_dev_, device_id_);
+        if (rc != 0) {
+            LOG_ERROR("halHostUnregister failed: %d", rc);
+            return rc;
+        }
+    }
+
+    // Free host shadow of shared memory
+    if (is_memcpy_mode() && perf_shared_mem_host_ != nullptr && perf_shared_mem_host_ != perf_shared_mem_dev_) {
+        std::free(perf_shared_mem_host_);
+    }
+
+    if (free_cb != nullptr && perf_shared_mem_dev_ != nullptr) {
+        free_cb(perf_shared_mem_dev_);
+    }
+
+    perf_shared_mem_dev_ = nullptr;
+    perf_shared_mem_host_ = nullptr;
+    was_registered_ = false;
     collected_perf_records_.clear();
     collected_phase_records_.clear();
-    memset(&collected_orch_summary_, 0, sizeof(collected_orch_summary_));
     core_to_thread_.clear();
     has_phase_data_ = false;
-
-    num_aicore_ = 0;
-    num_phase_threads_ = 0;
     device_id_ = -1;
-    perf_buffer_bytes_ = 0;
-    phase_buffer_bytes_ = 0;
     alloc_cb_ = nullptr;
+    register_cb_ = nullptr;
     free_cb_ = nullptr;
     copy_to_dev_cb_ = nullptr;
     copy_from_dev_cb_ = nullptr;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -101,6 +101,7 @@ struct AicpuExecutor {
 
     // ===== Performance profiling state =====
     uint64_t dispatch_timestamps_[RUNTIME_MAX_WORKER];  // Per-core AICPU dispatch timestamp
+    int core_dispatch_counts_[RUNTIME_MAX_WORKER];      // Per-core dispatch count for buffer switch
 
     // ===== Dump tensor state =====
     Runtime *runtime_{nullptr};  // Cached for dump_tensor access in try_dispatch_task
@@ -262,6 +263,11 @@ inline bool AicpuExecutor::try_dispatch_task(
 
     // Record the real AICPU dispatch point for this core.
     if (profiling_enabled) {
+        core_dispatch_counts_[core_id]++;
+        if (core_dispatch_counts_[core_id] >= PLATFORM_PROF_BUFFER_SIZE - 1) {
+            perf_aicpu_switch_buffer(runtime_, core_id, thread_idx);
+            core_dispatch_counts_[core_id] = 0;
+        }
         dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
     }
 
@@ -327,6 +333,7 @@ int AicpuExecutor::init(Runtime *runtime) {
 
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;
+        core_dispatch_counts_[i] = 0;
     }
     if (runtime->enable_profiling) {
         perf_aicpu_init_profiling(runtime);
@@ -1052,6 +1059,11 @@ int AicpuExecutor::run(Runtime *runtime) {
     int rc = shutdown_aicore(runtime, thread_idx, cur_thread_cores);
     if (rc != 0) {
         return rc;
+    }
+
+    // Flush performance buffers for cores managed by this thread
+    if (runtime->enable_profiling) {
+        perf_aicpu_flush_buffers(runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
 
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -137,9 +137,10 @@ struct alignas(64) CoreExecState {
     uint8_t pad0_[2];                       // offset 38: alignment padding
 #if PTO2_PROFILING
     // --- Profiling fields (dispatch path, compile-time gated) ---
-    uint64_t running_dispatch_timestamp;  // offset 40: AICPU dispatch timestamp for running task
-    uint64_t pending_dispatch_timestamp;  // offset 48: AICPU dispatch timestamp for pending task
-    uint8_t pad1_[8];                     // offset 56: pad to 64 bytes
+    uint32_t dispatch_count;              // offset 40: dispatched task count (buffer mgmt)
+    uint32_t pad1_;                       // offset 44: alignment padding for timestamp
+    uint64_t running_dispatch_timestamp;  // offset 48: AICPU dispatch timestamp for running task
+    uint64_t pending_dispatch_timestamp;  // offset 56: AICPU dispatch timestamp for pending task
 #else
     // --- Cold fields (init/diagnostics only, never in hot path) ---
     int32_t worker_id;          // offset 40: index in runtime.workers[]
@@ -1222,6 +1223,15 @@ struct AicpuExecutor {
             // Mark core as running (was idle)
             tracker.change_core_state(core_offset);
         }
+#if PTO2_PROFILING
+        if (perf.profiling_enabled) {
+            if (core_exec_state.dispatch_count >= PLATFORM_PROF_BUFFER_SIZE) {
+                perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+                core_exec_state.dispatch_count = 0;
+            }
+            core_exec_state.dispatch_count++;
+        }
+#endif
 
         write_reg(core_exec_state.reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
 
@@ -2614,6 +2624,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return rc;
             }
         }
+    }
+
+    // Flush performance buffers for cores managed by this thread
+    if (runtime->enable_profiling) {
+        int32_t core_num = core_count_per_thread_[thread_idx];
+        perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
+        perf_aicpu_flush_phase_buffers(thread_idx);
     }
 
     DEV_INFO("Thread %d: Completed", thread_idx);


### PR DESCRIPTION
Replace the fixed-buffer batch-memcpy design with dynamic buffer rotation and runtime streaming collection, matching a2a3's architecture.

Data structures (perf_profiling.h):
- Replace PerfSetupHeader with PerfDataHeader + PerfBufferState + PerfFreeQueue + ReadyQueueEntry (SPSC lock-free queues)
- PerfBuffer/PhaseBuffer changed from flexible arrays to fixed arrays
- Reduce PLATFORM_PROF_BUFFER_SIZE from 10000 to 1000

Host side (performance_collector.h/.cpp):
- Add ProfMemoryManager background thread for streaming collection
- Add memcpy mode (rtMemcpy D2H/H2D) since a5 lacks halHostRegister
- Replace collect_all() with poll_and_collect() + drain + scan + phase
- Interface now matches a2a3: initialize, start/stop_memory_manager, poll_and_collect, signal_execution_complete, drain, scan, finalize

AICPU side (performance_collector_aicpu.h/.cpp):
- Add switch_buffer (enqueue full → pop from FreeQueue → update handshake) and flush_buffers/flush_phase_buffers at thread exit
- Init now pops first buffer from FreeQueue instead of reading pointer arrays from PerfSetupHeader

DeviceRunner integration (onboard + sim):
- Launch collector thread before kernel execution
- Signal execution complete after stream sync, then drain pipeline

Runtime callers (host_build_graph, tensormap_and_ringbuffer):
- Add dispatch_count tracking and switch_buffer on buffer full
- Add flush_buffers/flush_phase_buffers at scheduler thread exit