### PR TITLE
Refactor: remove perf state from generic Runtime struct

### DIFF
--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -30,11 +30,24 @@
 // ============= Public Interface =============
 
 /**
+ * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
+ * entry (onboard) before `l2_perf_aicpu_init_profiling()` so AICPU code can
+ * read perf state without reaching into the generic `Runtime` struct.
+ * Mirrors the `set_platform_dump_base` / `set_enable_dump_tensor` pattern
+ * used by tensor dump and PMU.
+ */
+extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
+extern "C" uint64_t get_platform_l2_perf_base();
+extern "C" void set_enable_l2_swimlane(bool enable);
+extern "C" bool get_enable_l2_swimlane();
+
+/**
  * Initialize performance profiling
  *
  * Sets up double buffers for each core and initializes tracking state.
+ * Reads the perf device-base pointer published via `set_platform_l2_perf_base()`.
  *
- * @param runtime Runtime instance pointer
+ * @param runtime Runtime instance pointer (used for worker_count / task_count only)
  */
 void l2_perf_aicpu_init_profiling(Runtime *runtime);
 
@@ -76,12 +89,11 @@ void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
  *
  * Marks non-empty buffers as ready and enqueues them for host collection.
  *
- * @param runtime Runtime instance pointer
  * @param thread_idx Thread index
  * @param cur_thread_cores Array of core IDs managed by this thread
  * @param core_num Number of cores managed by this thread
  */
-void l2_perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num);
+void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -89,10 +101,9 @@ void l2_perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cu
  * Allows dynamic update of total_tasks as orchestrator makes progress.
  * Used by tensormap_and_ringbuffer runtime where task count grows incrementally.
  *
- * @param runtime Runtime instance pointer
  * @param total_tasks Current total task count
  */
-void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
+void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks);
 
 /**
  * Initialize AICPU phase profiling

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -74,9 +74,10 @@ struct KernelArgs {
     __may_used_by_aicore__ Runtime *runtime_args{nullptr};  // Task runtime in device memory
     uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
     uint64_t ffts_base_addr{0};                             // FFTS base address for AICore
-    uint64_t dump_data_base{0};  // Dump shared memory base address; use explicit flags to detect enablement
-    uint64_t pmu_data_base{0};   // PMU shared memory base address; use explicit flags to detect enablement
-    uint64_t pmu_reg_addrs{0};   // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
+    uint64_t dump_data_base{0};     // Dump shared memory base address; use explicit flags to detect enablement
+    uint64_t l2_perf_data_base{0};  // L2 perf shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_data_base{0};      // PMU shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_reg_addrs{0};      // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
 };
 
 #ifdef __cplusplus

--- a/src/a2a3/platform/include/host/l2_perf_collector.h
+++ b/src/a2a3/platform/include/host/l2_perf_collector.h
@@ -279,8 +279,8 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(
-        Runtime &runtime, int num_aicore, int device_id, L2PerfAllocCallback alloc_cb,
-        L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb
+        int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
+        L2PerfFreeCallback free_cb
     );
 
     /**
@@ -331,6 +331,12 @@ public:
      * Check if collector is initialized
      */
     bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
+
+    /**
+     * Get the device pointer to the L2PerfDataHeader.
+     * Used to set kernel_args.l2_perf_data_base after initialize() succeeds.
+     */
+    void *get_l2_perf_setup_device_ptr() const { return perf_shared_mem_dev_; }
 
     /**
      * Drain remaining buffers from the memory manager's ready queue

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -193,11 +193,11 @@ private:
 // Utility: resolve PMU event type (env-var override)
 // ---------------------------------------------------------------------------
 
-inline uint32_t resolve_pmu_event_type(int requested_event_type) {
-    uint32_t resolved = PMU_EVENT_TYPE_DEFAULT;
+inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
+    PmuEventType resolved = PmuEventType::PIPE_UTILIZATION;
     if (requested_event_type > 0 &&
         pmu_resolve_event_config_a2a3(static_cast<uint32_t>(requested_event_type)) != nullptr) {
-        resolved = static_cast<uint32_t>(requested_event_type);
+        resolved = static_cast<PmuEventType>(requested_event_type);
     } else if (requested_event_type != 0) {
         // 0 means PMU disabled (enable_pmu == 0), not an invalid type — only warn for nonzero
         LOG_WARN(
@@ -211,8 +211,8 @@ inline uint32_t resolve_pmu_event_type(int requested_event_type) {
     }
     int val = std::atoi(pmu_env);
     if (val > 0 && pmu_resolve_event_config_a2a3(static_cast<uint32_t>(val)) != nullptr) {
-        resolved = static_cast<uint32_t>(val);
-        LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", resolved);
+        resolved = static_cast<PmuEventType>(val);
+        LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", static_cast<uint32_t>(resolved));
         return resolved;
     }
     LOG_WARN("Invalid SIMPLER_PMU_EVENT_TYPE=%s, using default (PIPE_UTILIZATION=%u)", pmu_env, PMU_EVENT_TYPE_DEFAULT);

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -14,6 +14,7 @@
 #include "common/kernel_args.h"
 #include "common/platform_config.h"
 #include "aicpu/device_log.h"
+#include "aicpu/l2_perf_collector_aicpu.h"
 #include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/platform_aicpu_affinity.h"
@@ -86,6 +87,8 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
     set_enable_dump_tensor(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_platform_l2_perf_base(k_args->l2_perf_data_base);
+    set_enable_l2_swimlane(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
     set_platform_pmu_reg_addrs(k_args->pmu_reg_addrs);
     set_enable_pmu(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -434,10 +434,8 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
 ) {
-    bool pmu_enabled = enable_pmu > 0;
-    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -506,27 +504,27 @@ int DeviceRunner::run(
 
     // Get AICore PMU register addresses (distinct MMIO page from AIC_CTRL).
     // Failure is non-fatal: PMU will be disabled if this query fails.
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         int pmu_rc = init_aicore_register_addresses(
             &kernel_args_.args.pmu_reg_addrs, static_cast<uint64_t>(device_id), mem_alloc_, AicoreRegKind::Pmu
         );
         if (pmu_rc != 0) {
             LOG_ERROR("init_aicore_register_addresses(Pmu) failed: %d, disabling PMU", pmu_rc);
             kernel_args_.args.pmu_reg_addrs = 0;
-            pmu_enabled = false;
+            enable_pmu_ = false;
         }
     }
 
     // Calculate number of AIC cores (1/3 of total)
     int num_aic = block_dim;  // Round up for 1/3
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     }
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     }
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
 
@@ -577,8 +575,8 @@ int DeviceRunner::run(
     });
 
     // Initialize performance profiling if enabled
-    if (runtime.enable_l2_swimlane) {
-        rc = init_l2_perf_collection(runtime, num_aicore, device_id);
+    if (enable_l2_swimlane_) {
+        rc = init_l2_perf_collection(num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
@@ -589,7 +587,7 @@ int DeviceRunner::run(
         });
     }
 
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         // Initialize tensor dump (independent from profiling)
         rc = init_tensor_dump(runtime, num_aicore, device_id);
         if (rc != 0) {
@@ -599,12 +597,14 @@ int DeviceRunner::run(
         dump_collector_.start_memory_manager();
     }
 
-    if (pmu_enabled) {
-        rc = init_pmu_buffers(num_aicore, launch_aicpu_num, make_pmu_csv_path(), pmu_event_type, device_id);
+    if (enable_pmu_) {
+        rc = init_pmu_buffers(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(), static_cast<uint32_t>(pmu_event_type_), device_id
+        );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.args.pmu_data_base = 0;
-            pmu_enabled = false;
+            enable_pmu_ = false;
         }
     }
 
@@ -664,9 +664,9 @@ int DeviceRunner::run(
 
     {
         std::thread collector_thread;
-        if (runtime.enable_l2_swimlane) {
+        if (enable_l2_swimlane_) {
             collector_thread = create_thread([this, &runtime]() {
-                poll_and_collect_performance_data(runtime.get_task_count());
+                l2_perf_collector_.poll_and_collect(runtime.get_task_count());
             });
         }
         auto thread_guard = RAIIScopeGuard([&]() {
@@ -675,13 +675,13 @@ int DeviceRunner::run(
             }
         });
         auto collector_signal_guard = RAIIScopeGuard([this, &runtime]() {
-            if (runtime.enable_l2_swimlane) {
+            if (enable_l2_swimlane_) {
                 l2_perf_collector_.signal_execution_complete();
             }
         });
 
         std::thread dump_collector_thread;
-        if (enable_dump_tensor) {
+        if (enable_dump_tensor_) {
             dump_collector_thread = std::thread([this]() {
                 dump_collector_.poll_and_collect();
             });
@@ -691,14 +691,14 @@ int DeviceRunner::run(
                 dump_collector_thread.join();
             }
         });
-        auto dump_signal_guard = RAIIScopeGuard([this, enable_dump_tensor]() {
-            if (enable_dump_tensor) {
+        auto dump_signal_guard = RAIIScopeGuard([this]() {
+            if (enable_dump_tensor_) {
                 dump_collector_.signal_execution_complete();
             }
         });
 
         std::thread pmu_collector_thread;
-        if (pmu_enabled) {
+        if (enable_pmu_) {
             pmu_collector_thread = std::thread([this]() {
                 pmu_collector_.poll_and_collect();
             });
@@ -708,8 +708,8 @@ int DeviceRunner::run(
                 pmu_collector_thread.join();
             }
         });
-        auto pmu_signal_guard = RAIIScopeGuard([this, pmu_enabled]() {
-            if (pmu_enabled) {
+        auto pmu_signal_guard = RAIIScopeGuard([this]() {
+            if (enable_pmu_) {
                 pmu_collector_.signal_execution_complete();
             }
         });
@@ -731,22 +731,22 @@ int DeviceRunner::run(
     }
 
     // Stop memory management, drain remaining buffers, collect phase data, export
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         l2_perf_collector_.stop_memory_manager();
         l2_perf_collector_.drain_remaining_buffers();
         l2_perf_collector_.scan_remaining_perf_buffers();
         l2_perf_collector_.collect_phase_data();
-        export_swimlane_json();
+        l2_perf_collector_.export_swimlane_json();
     }
 
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         dump_collector_.stop_memory_manager();
         dump_collector_.drain_remaining_buffers();
         dump_collector_.scan_remaining_dump_buffers();
         dump_collector_.export_dump_files();
     }
 
-    if (pmu_enabled && pmu_collector_.is_initialized()) {
+    if (enable_pmu_ && pmu_collector_.is_initialized()) {
         pmu_collector_.drain_remaining_buffers();
     }
 
@@ -1027,7 +1027,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
     LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
 }
 
-int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
     // Define allocation callback (a2a3: use rtMalloc directly)
     auto alloc_cb = [](size_t size) -> void * {
         void *ptr = nullptr;
@@ -1053,15 +1053,12 @@ int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int 
         return rtFree(dev_ptr);
     };
 
-    return l2_perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, register_cb, free_cb);
-}
-
-void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
-    l2_perf_collector_.poll_and_collect(expected_tasks);
-}
-
-int DeviceRunner::export_swimlane_json(const std::string &output_path) {
-    return l2_perf_collector_.export_swimlane_json(output_path);
+    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, register_cb, free_cb);
+    if (rc == 0) {
+        kernel_args_.args.l2_perf_data_base =
+            reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+    }
+    return rc;
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -253,8 +253,20 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
-        int enable_pmu = 0);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+
+    /**
+     * Enablement setters for the three diagnostics sub-features. Called by
+     * the c_api entry point before run(); downstream run() paths read the
+     * corresponding `enable_*_` members directly. Moved off the generic
+     * Runtime struct / run() arg list so all three travel the same way.
+     */
+    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
+    void set_enable_pmu(int enable_pmu) {
+        enable_pmu_ = (enable_pmu > 0);
+        pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
+    }
 
     /**
      * Print handshake results from device
@@ -263,29 +275,6 @@ public:
      * Must be called after run() and before finalize().
      */
     void print_handshake_results();
-
-    /**
-     * Poll and collect performance data from device
-     *
-     * Polls the ready queue and collects performance records from full buffers.
-     * This is a synchronous polling function that should be called after
-     * launching kernels but before stream synchronization.
-     *
-     * @param expected_tasks Expected total number of tasks (used for exit condition)
-     */
-    void poll_and_collect_performance_data(int expected_tasks);
-
-    /**
-     * Export performance data to merged_swimlane.json
-     *
-     * Converts collected performance records to Chrome Trace Event Format
-     * and writes to outputs/merged_swimlane.json for visualization in Perfetto.
-     * Should be called after stream synchronization.
-     *
-     * @param output_path Path to output directory (default: "outputs")
-     * @return 0 on success, error code on failure
-     */
-    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -500,7 +489,7 @@ private:
      * @param device_id Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id);
+    int init_l2_perf_collection(int num_aicore, int device_id);
 
     /**
      * Initialize tensor dump shared memory and collector.
@@ -531,6 +520,14 @@ private:
      */
     int
     init_pmu_buffers(int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id);
+    // Enablement for the three diagnostics sub-features. Written by the c_api
+    // entry point via set_enable_*() before run(), read inside run() and its
+    // helpers. Moved off Runtime / run() args so all three sub-features use
+    // the same plumbing shape.
+    bool enable_l2_swimlane_{false};
+    bool enable_dump_tensor_{false};
+    bool enable_pmu_{false};
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -229,15 +229,13 @@ int run_runtime(
             return rc;
         }
 
-        if (enable_l2_swimlane) {
-            r->enable_l2_swimlane = true;
-        }
+        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
+        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
+        runner->set_enable_pmu(enable_pmu);
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
-        rc = runner->run(
-            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
-        );
+        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -161,6 +161,20 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
+        set_platform_l2_perf_base_func_ =
+            reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_l2_perf_base"));
+        if (set_platform_l2_perf_base_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_platform_l2_perf_base: %s", dlerror());
+            return -1;
+        }
+
+        set_enable_l2_swimlane_func_ =
+            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_l2_swimlane"));
+        if (set_enable_l2_swimlane_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_enable_l2_swimlane: %s", dlerror());
+            return -1;
+        }
+
         set_platform_pmu_base_func_ =
             reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_pmu_base"));
         if (set_platform_pmu_base_func_ == nullptr) {
@@ -245,10 +259,8 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
 ) {
-    bool pmu_enabled = enable_pmu > 0;
-    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     clear_cpu_sim_shared_storage();
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
@@ -310,13 +322,13 @@ int DeviceRunner::run(
     // Calculate number of AIC cores
     int num_aic = block_dim;
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     }
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     }
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
 
@@ -348,8 +360,8 @@ int DeviceRunner::run(
     last_runtime_ = &runtime;
 
     // Initialize performance profiling if enabled
-    if (runtime.enable_l2_swimlane) {
-        rc = init_l2_perf_collection(runtime, num_aicore, device_id);
+    if (enable_l2_swimlane_) {
+        rc = init_l2_perf_collection(num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
@@ -360,7 +372,7 @@ int DeviceRunner::run(
         });
     }
 
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         // Initialize tensor dump (independent from profiling)
         rc = init_tensor_dump(runtime, num_aicore, device_id);
         if (rc != 0) {
@@ -370,12 +382,14 @@ int DeviceRunner::run(
         dump_collector_.start_memory_manager();
     }
 
-    if (pmu_enabled) {
-        rc = init_pmu_buffers(num_aicore, launch_aicpu_num, make_pmu_csv_path(), pmu_event_type, device_id);
+    if (enable_pmu_) {
+        rc = init_pmu_buffers(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(), static_cast<uint32_t>(pmu_event_type_), device_id
+        );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.pmu_data_base = 0;
-            pmu_enabled = false;
+            enable_pmu_ = false;
         }
     }
 
@@ -431,10 +445,12 @@ int DeviceRunner::run(
 
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_enable_dump_tensor_func_(enable_dump_tensor);
+    set_enable_dump_tensor_func_(enable_dump_tensor_);
+    set_platform_l2_perf_base_func_(kernel_args_.l2_perf_data_base);
+    set_enable_l2_swimlane_func_(enable_l2_swimlane_);
     set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
     set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);  // 0 on sim (no PMU hardware)
-    set_enable_pmu_func_(pmu_enabled);
+    set_enable_pmu_func_(enable_pmu_);
 
     // Launch AICPU threads (over-launch for affinity gate)
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
@@ -468,21 +484,21 @@ int DeviceRunner::run(
 
     // Poll and collect performance data during execution (if enabled)
     std::thread collector_thread;
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         collector_thread = create_thread([this, &runtime]() {
-            poll_and_collect_performance_data(runtime.get_task_count());
+            l2_perf_collector_.poll_and_collect(runtime.get_task_count());
         });
     }
 
     std::thread dump_collector_thread;
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         dump_collector_thread = std::thread([this]() {
             dump_collector_.poll_and_collect();
         });
     }
 
     std::thread pmu_collector_thread;
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         pmu_collector_thread = std::thread([this]() {
             pmu_collector_.poll_and_collect();
         });
@@ -498,13 +514,13 @@ int DeviceRunner::run(
     }
 
     // Signal all collectors that device execution is complete
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         l2_perf_collector_.signal_execution_complete();
     }
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         dump_collector_.signal_execution_complete();
     }
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         pmu_collector_.signal_execution_complete();
     }
 
@@ -528,22 +544,22 @@ int DeviceRunner::run(
     }
 
     // Stop memory management, drain remaining buffers, collect phase data, export
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         l2_perf_collector_.stop_memory_manager();
         l2_perf_collector_.drain_remaining_buffers();
         l2_perf_collector_.scan_remaining_perf_buffers();
         l2_perf_collector_.collect_phase_data();
-        export_swimlane_json();
+        l2_perf_collector_.export_swimlane_json();
     }
 
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         dump_collector_.stop_memory_manager();
         dump_collector_.drain_remaining_buffers();
         dump_collector_.scan_remaining_dump_buffers();
         dump_collector_.export_dump_files();
     }
 
-    if (pmu_enabled && pmu_collector_.is_initialized()) {
+    if (enable_pmu_ && pmu_collector_.is_initialized()) {
         pmu_collector_.drain_remaining_buffers();
     }
 
@@ -581,6 +597,8 @@ void DeviceRunner::unload_executor_binaries() {
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
         set_enable_dump_tensor_func_ = nullptr;
+        set_platform_l2_perf_base_func_ = nullptr;
+        set_enable_l2_swimlane_func_ = nullptr;
         set_platform_pmu_base_func_ = nullptr;
         set_platform_pmu_reg_addrs_func_ = nullptr;
         set_enable_pmu_func_ = nullptr;
@@ -770,7 +788,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // Performance Profiling Implementation
 // =============================================================================
 
-int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
     // Define allocation callback (a2a3sim: use malloc)
     auto alloc_cb = [](size_t size) -> void * {
         return malloc(size);
@@ -783,15 +801,11 @@ int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int 
     };
 
     // Simulation: no registration needed (pass nullptr)
-    return l2_perf_collector_.initialize(runtime, num_aicore, device_id, alloc_cb, nullptr, free_cb);
-}
-
-void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
-    l2_perf_collector_.poll_and_collect(expected_tasks);
-}
-
-int DeviceRunner::export_swimlane_json(const std::string &output_path) {
-    return l2_perf_collector_.export_swimlane_json(output_path);
+    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, nullptr, free_cb);
+    if (rc == 0) {
+        kernel_args_.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+    }
+    return rc;
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -144,36 +144,25 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
-        int enable_pmu = 0);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+
+    /**
+     * Enablement setters for the three diagnostics sub-features. Called by
+     * the c_api entry point before run(); downstream run() paths read the
+     * corresponding `enable_*_` members directly. Moved off the generic
+     * Runtime struct / run() arg list so all three travel the same way.
+     */
+    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
+    void set_enable_pmu(int enable_pmu) {
+        enable_pmu_ = (enable_pmu > 0);
+        pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
+    }
 
     /**
      * Print handshake results
      */
     void print_handshake_results();
-
-    /**
-     * Poll and collect performance data from shared memory
-     *
-     * Polls the ready queue and collects performance records from full buffers.
-     * This is a synchronous polling function that should be called after
-     * launching kernels but before thread synchronization.
-     *
-     * @param expected_tasks Expected total number of tasks (used for exit condition)
-     */
-    void poll_and_collect_performance_data(int expected_tasks);
-
-    /**
-     * Export performance data to merged_swimlane.json
-     *
-     * Converts collected performance records to Chrome Trace Event Format
-     * and writes to outputs/merged_swimlane_<timestamp>.json for visualization in Perfetto.
-     * Should be called after execution completes.
-     *
-     * @param output_path Path to output directory (default: "outputs")
-     * @return 0 on success, error code on failure
-     */
-    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -238,6 +227,8 @@ private:
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_enable_dump_tensor_func_)(bool){nullptr};
+    void (*set_platform_l2_perf_base_func_)(uint64_t){nullptr};
+    void (*set_enable_l2_swimlane_func_)(bool){nullptr};
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_reg_addrs_func_)(uint64_t){nullptr};
     void (*set_enable_pmu_func_)(bool){nullptr};
@@ -271,12 +262,20 @@ private:
      * @param device_id Device ID (ignored in simulation)
      * @return 0 on success, error code on failure
      */
-    int init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id);
+    int init_l2_perf_collection(int num_aicore, int device_id);
 
     int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
 
     int
     init_pmu_buffers(int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id);
+    // Enablement for the three diagnostics sub-features. Written by the c_api
+    // entry point via set_enable_*() before run(), read inside run() and its
+    // helpers. Moved off Runtime / run() args so all three sub-features use
+    // the same plumbing shape.
+    bool enable_l2_swimlane_{false};
+    bool enable_dump_tensor_{false};
+    bool enable_pmu_{false};
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
 };
 
 #endif  // SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -187,10 +187,12 @@ int run_runtime(
             return rc;
         }
 
-        // Phase 2: profiling
-        if (enable_l2_swimlane) {
-            r->enable_l2_swimlane = true;
-        }
+        // Phase 2: publish diagnostics enablement to the DeviceRunner so run()
+        // and its helpers can read the three sub-features uniformly (via
+        // members, not Runtime / run() args).
+        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
+        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
+        runner->set_enable_pmu(enable_pmu);
 
         // Phase 3: launch
         std::vector<uint8_t> aicpu_vec;
@@ -201,9 +203,7 @@ int run_runtime(
         if (aicore_binary != NULL && aicore_size > 0) {
             aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
         }
-        rc = runner->run(
-            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
-        );
+        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -41,6 +41,19 @@ static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static int s_orch_thread_idx = -1;
 
+// L2 perf platform state. Published by the host (via dlsym'd setters on sim)
+// or by the AICPU kernel entry (onboard) before perf init runs, so downstream
+// perf code can discover enablement + device-base without reading the generic
+// Runtime struct. Mirrors the g_platform_dump_base / g_enable_dump_tensor pair
+// in tensor_dump_aicpu.cpp and the PMU equivalents in pmu_collector_aicpu.cpp.
+static uint64_t g_platform_l2_perf_base = 0;
+static bool g_enable_l2_swimlane = false;
+
+extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base) { g_platform_l2_perf_base = l2_perf_data_base; }
+extern "C" uint64_t get_platform_l2_perf_base() { return g_platform_l2_perf_base; }
+extern "C" void set_enable_l2_swimlane(bool enable) { g_enable_l2_swimlane = enable; }
+extern "C" bool get_enable_l2_swimlane() { return g_enable_l2_swimlane; }
+
 /**
  * Enqueue ready buffer to per-thread queue
  *
@@ -76,7 +89,7 @@ static int enqueue_ready_buffer(
 }
 
 void l2_perf_aicpu_init_profiling(Runtime *runtime) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize profiling");
         return;
@@ -169,7 +182,7 @@ int l2_perf_aicpu_complete_record(
 }
 
 void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         return;
     }
@@ -229,12 +242,12 @@ void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) 
     LOG_INFO("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
-void l2_perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cur_thread_cores, int core_num) {
-    if (!runtime->enable_l2_swimlane) {
+void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num) {
+    if (!g_enable_l2_swimlane) {
         return;
     }
 
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         return;
     }
@@ -279,8 +292,8 @@ void l2_perf_aicpu_flush_buffers(Runtime *runtime, int thread_idx, const int *cu
     LOG_INFO("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
-void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks) {
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         return;
     }
@@ -291,7 +304,7 @@ void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
 }
 
 void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize phase profiling");
         return;

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -540,7 +540,7 @@ void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
 }
 
 int L2PerfCollector::initialize(
-    Runtime &runtime, int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
+    int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
     L2PerfFreeCallback free_cb
 ) {
     if (perf_shared_mem_host_ != nullptr) {
@@ -690,9 +690,9 @@ int L2PerfCollector::initialize(
 
     wmb();
 
-    // Step 7: Pass base address to Runtime
-    runtime.l2_perf_data_base = reinterpret_cast<uint64_t>(perf_dev_ptr);
-    LOG_DEBUG("Set runtime.l2_perf_data_base = 0x%lx", runtime.l2_perf_data_base);
+    // Step 7: Stash device pointer for the caller to publish via
+    // kernel_args.l2_perf_data_base (read back via get_l2_perf_setup_device_ptr()).
+    LOG_DEBUG("L2 perf device base = 0x%lx", reinterpret_cast<uint64_t>(perf_dev_ptr));
 
     perf_shared_mem_dev_ = perf_dev_ptr;
     perf_shared_mem_host_ = perf_host_ptr;

--- a/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicore/aicore_executor.cpp
@@ -86,7 +86,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // Cache payload address (set once by AICPU during initialization, never changes)
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
-    bool l2_perf_enabled = runtime->enable_l2_swimlane;
+    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -957,7 +957,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #if PTO2_PROFILING
         // Assign perf buffers to cores early so profiling captures all tasks
         // (total_tasks written to header later when orchestrator completes)
-        if (runtime->enable_l2_swimlane) {
+        if (get_enable_l2_swimlane()) {
             l2_perf_aicpu_init_profiling(runtime);
             // Initialize phase profiling for scheduler threads + orchestrator threads
             l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
@@ -991,7 +991,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
 #if PTO2_PROFILING
-    bool l2_perf_enabled = runtime->enable_l2_swimlane;
+    bool l2_perf_enabled = get_enable_l2_swimlane();
 #endif
 
     // Scheduler profiling counters
@@ -1676,7 +1676,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #if PTO2_PROFILING
     // Flush performance buffers for cores managed by this thread
     if (l2_perf_enabled) {
-        l2_perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
+        l2_perf_aicpu_flush_buffers(thread_idx, core_assignments_[thread_idx], core_num);
         l2_perf_aicpu_flush_phase_buffers(thread_idx);
     }
     if (get_enable_pmu()) {
@@ -1850,7 +1850,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = runtime->enable_l2_swimlane;
+            rt->orchestrator.enable_l2_swimlane = get_enable_l2_swimlane();
 #endif
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
@@ -1871,7 +1871,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Each orchestrator thread sets its own phase buffer index (thread-local)
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif
@@ -1928,7 +1928,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -1948,7 +1948,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write core-to-thread mapping (one-time, after orchestration)
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 l2_perf_aicpu_init_core_assignments(cores_total_num_);
                 for (int32_t t = 0; t < sched_thread_num_; t++) {
                     l2_perf_aicpu_write_core_assignments_for_thread(t, core_assignments_[t], core_count_per_thread_[t]);
@@ -1976,8 +1976,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
 #endif
             total_tasks_ = pto2_task_count;
-            if (runtime->enable_l2_swimlane && pto2_task_count > 0) {
-                l2_perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
+            if (get_enable_l2_swimlane() && pto2_task_count > 0) {
+                l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(pto2_task_count));
             }
             orchestrator_done_ = true;
             {

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -175,15 +175,11 @@ public:
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Perf swimlane collection
-    bool enable_l2_swimlane;  // Enable perf swimlane collection
-
     // Orchestrator-to-scheduler transition control
     // When true, orchestrator threads convert to scheduler threads after orchestration completes.
     // When false (default), orchestrator threads exit after orchestration without dispatching tasks.
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
-    uint64_t l2_perf_data_base;  // Performance data shared memory base address (device-side)
 
 private:
     // Tensor pairs for host-device memory tracking

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -53,7 +53,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    bool l2_perf_enabled = runtime->enable_l2_swimlane;
+    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -337,7 +337,7 @@ int AicpuExecutor::init(Runtime *runtime) {
         dispatch_timestamps_[i] = 0;
         core_dispatch_counts_[i] = 0;
     }
-    if (runtime->enable_l2_swimlane) {
+    if (get_enable_l2_swimlane()) {
         l2_perf_aicpu_init_profiling(runtime);
     }
 #if PTO2_PROFILING
@@ -661,7 +661,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
     int verification_warning_count = 0;
     const int MAX_VERIFICATION_WARNINGS = 10;
-    bool l2_perf_enabled = runtime.enable_l2_swimlane;
+    bool l2_perf_enabled = get_enable_l2_swimlane();
 
     // Extract array pointers as local variables for better readability and performance
     int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
@@ -1111,8 +1111,8 @@ int AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
 
     // Flush performance buffers for cores managed by this thread
-    if (runtime->enable_l2_swimlane) {
-        l2_perf_aicpu_flush_buffers(runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
+    if (get_enable_l2_swimlane()) {
+        l2_perf_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
 #if PTO2_PROFILING
     if (get_enable_pmu()) {

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,8 +45,6 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
-    enable_l2_swimlane = false;
-    l2_perf_data_base = 0;
     tensor_pair_count = 0;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -212,10 +212,6 @@ public:
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;  // Number of AICPU threads for scheduling
 
-    // Perf swimlane collection
-    bool enable_l2_swimlane;     // Enable perf swimlane collection
-    uint64_t l2_perf_data_base;  // Performance data shared memory base address (device-side)
-
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -89,7 +89,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
-    bool l2_perf_enabled = runtime->enable_l2_swimlane;
+    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -360,7 +360,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = runtime->enable_l2_swimlane;
+            rt->orchestrator.enable_l2_swimlane = get_enable_l2_swimlane();
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
@@ -386,7 +386,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif
@@ -471,7 +471,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -504,8 +504,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             pto2_submitted_tasks = total_tasks;
 #endif
 
-            if (runtime->enable_l2_swimlane && total_tasks > 0) {
-                l2_perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(total_tasks));
+            if (get_enable_l2_swimlane() && total_tasks > 0) {
+                l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(total_tasks));
             }
 
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -229,7 +229,11 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ## Runtime Flag: enable_l2_swimlane
 
-The `runtime->enable_l2_swimlane` flag controls **data collection**, NOT log output.
+L2 swimlane enablement is published through the handshake
+`enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
+AICPU code reads it via `get_enable_l2_swimlane()` (set at launch time
+by the platform from `kernel_args.l2_perf_data_base` + the bitmask). It
+controls **data collection**, NOT log output.
 
 ### When enable_l2_swimlane=true
 
@@ -247,8 +251,10 @@ The `runtime->enable_l2_swimlane` flag controls **data collection**, NOT log out
 ### Usage
 
 ```cpp
-// Initialize runtime with profiling enabled
-runtime->enable_l2_swimlane = true;
+// AICPU path — read enablement from the platform accessor, not the Runtime struct.
+if (get_enable_l2_swimlane()) {
+    // ... perf-collection code ...
+}
 ```
 
 ---

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -179,15 +179,11 @@ public:
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Perf swimlane collection
-    bool enable_l2_swimlane;  // Enable perf swimlane collection
-
     // Orchestrator-to-scheduler transition control
     // When true, orchestrator threads convert to scheduler threads after orchestration completes.
     // When false (default), orchestrator threads exit after orchestration without dispatching tasks.
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
-    uint64_t l2_perf_data_base;  // Performance data shared memory base address (device-side)
 
 private:
     // Tensor pairs for host-device memory tracking

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -743,7 +743,7 @@ void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
 ) {
 #if PTO2_PROFILING
-    if (runtime->enable_l2_swimlane) {
+    if (get_enable_l2_swimlane()) {
         // Flush orchestrator's phase record buffer
         l2_perf_aicpu_flush_phase_buffers(thread_idx);
     }
@@ -797,7 +797,7 @@ void SchedulerContext::on_orchestration_done(
     // Write core-to-thread mapping AFTER reassignment so the profiling data
     // reflects the final distribution (all active_sched_threads_, including
     // former orchestrator threads when orch_to_sched_ is enabled).
-    if (runtime->enable_l2_swimlane) {
+    if (get_enable_l2_swimlane()) {
         l2_perf_aicpu_init_core_assignments(cores_total_num_);
         for (int32_t t = 0; t < active_sched_threads_; t++) {
             l2_perf_aicpu_write_core_assignments_for_thread(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -329,7 +329,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         DEV_INFO("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
-        if (runtime->enable_l2_swimlane) {
+        if (get_enable_l2_swimlane()) {
             l2_perf_aicpu_init_profiling(runtime);
             l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
             l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
@@ -364,7 +364,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
     l2_perf.reset();
-    l2_perf.l2_perf_enabled = runtime->enable_l2_swimlane;
+    l2_perf.l2_perf_enabled = get_enable_l2_swimlane();
 #endif
 
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
@@ -576,7 +576,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
     if (l2_perf.l2_perf_enabled) {
         l2_perf_aicpu_flush_buffers(
-            runtime, thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
+            thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
         );
         l2_perf_aicpu_flush_phase_buffers(thread_idx);
     }

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -33,11 +33,24 @@
 // ============= Public Interface =============
 
 /**
+ * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
+ * entry (onboard) before `l2_perf_aicpu_init_profiling()` so AICPU code can
+ * read perf state without reaching into the generic `Runtime` struct.
+ * Mirrors the `set_platform_dump_base` / `set_enable_dump_tensor` pattern
+ * used by tensor dump and PMU.
+ */
+extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
+extern "C" uint64_t get_platform_l2_perf_base();
+extern "C" void set_enable_l2_swimlane(bool enable);
+extern "C" bool get_enable_l2_swimlane();
+
+/**
  * Initialize performance profiling
  *
  * Sets up double buffers for each core and initializes tracking state.
+ * Reads the perf device-base pointer published via `set_platform_l2_perf_base()`.
  *
- * @param runtime Runtime instance pointer
+ * @param runtime Runtime instance pointer (used for worker_count / task_count only)
  */
 void l2_perf_aicpu_init_profiling(Runtime *runtime);
 
@@ -71,10 +84,9 @@ int l2_perf_aicpu_complete_record(
  * Allows dynamic update of total_tasks as orchestrator makes progress.
  * Used by tensormap_and_ringbuffer runtime where task count grows incrementally.
  *
- * @param runtime Runtime instance pointer
  * @param total_tasks Current total task count
  */
-void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
+void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks);
 
 /**
  * Initialize AICPU phase profiling
@@ -82,10 +94,9 @@ void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks);
  * Sets up AicpuPhaseHeader and clears per-thread phase record buffers.
  * Must be called once from thread 0 after l2_perf_aicpu_init_profiling().
  *
- * @param runtime Runtime instance pointer
  * @param num_sched_threads Number of scheduler threads
  */
-void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
+void l2_perf_aicpu_init_phase_profiling(int num_sched_threads);
 
 /**
  * Record a single scheduler phase

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -70,6 +70,7 @@ struct KernelArgs {
     Runtime *runtime_args{nullptr};    // Task runtime in device memory
     uint64_t regs{0};                  // Per-core register base address array (platform-specific)
     uint64_t dump_data_base{0};        // Dump shared memory base address; use explicit flags to detect enablement
+    uint64_t l2_perf_data_base{0};     // L2 perf shared memory base address; use explicit flags to detect enablement
     uint64_t pmu_data_base{0};         // PMU buffer base address (device memory); 0 = PMU disabled
 };
 

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -210,7 +210,8 @@ struct AicpuPhaseHeader {
  * buffer pointers during init. After execution completes, Host copies
  * this struct back to read total_tasks and phase_header.
  *
- * Memory layout: runtime.l2_perf_data_base points to this struct on device.
+ * Memory layout: kernel_args.l2_perf_data_base points to this struct on
+ * device (read by AICPU via get_platform_l2_perf_base()).
  */
 struct L2PerfSetupHeader {
     // Host writes, AICPU reads (init)
@@ -241,7 +242,7 @@ extern "C" {
 /**
  * Get L2PerfSetupHeader pointer from base address
  *
- * @param base_ptr Device base address (runtime.l2_perf_data_base)
+ * @param base_ptr Device base address (kernel_args.l2_perf_data_base)
  * @return L2PerfSetupHeader pointer
  */
 inline L2PerfSetupHeader *get_perf_setup_header(void *base_ptr) {

--- a/src/a5/platform/include/host/l2_perf_collector.h
+++ b/src/a5/platform/include/host/l2_perf_collector.h
@@ -81,7 +81,8 @@ using L2PerfCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src
  *
  * Lifecycle:
  *   1. initialize() — allocate L2PerfSetupHeader and all per-core/per-thread
- *      buffers on device, publish pointers into runtime.l2_perf_data_base
+ *      buffers on device; caller reads get_l2_perf_setup_device_ptr() and
+ *      sets kernel_args.l2_perf_data_base.
  *   2. (AICore/AICPU run, writing directly into device buffers)
  *   3. collect_all() — after stream sync, copy L2PerfSetupHeader back,
  *      then copy each L2PerfBuffer / PhaseBuffer back using two-step
@@ -99,9 +100,12 @@ public:
     L2PerfCollector &operator=(const L2PerfCollector &) = delete;
 
     /**
-     * Allocate device buffers and publish L2PerfSetupHeader.
+     * Allocate device buffers and initialize the L2PerfSetupHeader.
      *
-     * @param runtime          Runtime to configure (sets runtime.l2_perf_data_base)
+     * After success, call get_l2_perf_setup_device_ptr() to get the device-side
+     * header pointer; the caller must publish this via kernel_args.l2_perf_data_base
+     * so AICPU code can discover it through get_platform_l2_perf_base().
+     *
      * @param num_aicore       Number of AICore instances to profile
      * @param device_id        Device ID (stored for later callbacks)
      * @param alloc_cb         Device memory alloc
@@ -111,7 +115,7 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(
-        Runtime &runtime, int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfFreeCallback free_cb,
+        int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfFreeCallback free_cb,
         L2PerfCopyToDeviceCallback copy_to_dev_cb, L2PerfCopyFromDeviceCallback copy_from_dev_cb
     );
 
@@ -145,6 +149,12 @@ public:
      * Check if the collector has been initialized.
      */
     bool is_initialized() const { return setup_header_dev_ != nullptr; }
+
+    /**
+     * Get the device pointer to the L2PerfSetupHeader.
+     * Used to set kernel_args.l2_perf_data_base after initialize() succeeds.
+     */
+    void *get_l2_perf_setup_device_ptr() const { return setup_header_dev_; }
 
     /**
      * Accessor used by tests.

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -130,11 +130,11 @@ private:
 // Utilities
 // ---------------------------------------------------------------------------
 
-inline uint32_t resolve_pmu_event_type(int requested_event_type) {
-    uint32_t resolved = PMU_EVENT_TYPE_DEFAULT;
+inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
+    PmuEventType resolved = PmuEventType::PIPE_UTILIZATION;
     if (requested_event_type > 0 &&
         pmu_resolve_event_config_a5(static_cast<uint32_t>(requested_event_type)) != nullptr) {
-        resolved = static_cast<uint32_t>(requested_event_type);
+        resolved = static_cast<PmuEventType>(requested_event_type);
     } else if (requested_event_type != 0) {
         LOG_WARN(
             "Invalid PMU event type %u, using default (PIPE_UTILIZATION=%u)", requested_event_type,
@@ -147,8 +147,8 @@ inline uint32_t resolve_pmu_event_type(int requested_event_type) {
     }
     int val = std::atoi(pmu_env);
     if (val > 0 && pmu_resolve_event_config_a5(static_cast<uint32_t>(val)) != nullptr) {
-        resolved = static_cast<uint32_t>(val);
-        LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", resolved);
+        resolved = static_cast<PmuEventType>(val);
+        LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", static_cast<uint32_t>(resolved));
         return resolved;
     }
     LOG_WARN("Invalid SIMPLER_PMU_EVENT_TYPE=%s, using default (PIPE_UTILIZATION=%u)", pmu_env, PMU_EVENT_TYPE_DEFAULT);

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -14,6 +14,7 @@
 #include "common/kernel_args.h"
 #include "common/platform_config.h"
 #include "aicpu/device_log.h"
+#include "aicpu/l2_perf_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/pmu_collector_aicpu.h"
@@ -86,6 +87,8 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
     set_enable_dump_tensor(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_platform_l2_perf_base(k_args->l2_perf_data_base);
+    set_enable_l2_swimlane(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
     set_enable_pmu(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -290,10 +290,8 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
 ) {
-    bool pmu_enabled = enable_pmu > 0;
-    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
@@ -360,13 +358,13 @@ int DeviceRunner::run(
     // Calculate number of AIC cores (1/3 of total)
     int num_aic = block_dim;  // Round up for 1/3
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     }
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     }
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
 
@@ -409,8 +407,8 @@ int DeviceRunner::run(
     });
 
     // Initialize performance profiling if enabled
-    if (runtime.enable_l2_swimlane) {
-        rc = init_l2_perf_collection(runtime, num_aicore, device_id);
+    if (enable_l2_swimlane_) {
+        rc = init_l2_perf_collection(num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
@@ -418,7 +416,7 @@ int DeviceRunner::run(
     }
 
     // Initialize tensor dump if enabled
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         rc = init_tensor_dump(runtime, num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
@@ -427,8 +425,8 @@ int DeviceRunner::run(
     }
 
     // Initialize PMU profiling if enabled
-    if (pmu_enabled) {
-        rc = init_pmu(num_aicore, pmu_event_type);
+    if (enable_pmu_) {
+        rc = init_pmu(num_aicore, static_cast<uint32_t>(pmu_event_type_));
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -488,19 +486,19 @@ int DeviceRunner::run(
 
     // After streams are synchronized, pull profiling data back in one batch
     // (memcpy-based: two-step count-first copy per buffer).
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         l2_perf_collector_.collect_all();
-        export_swimlane_json();
+        l2_perf_collector_.export_swimlane_json();
     }
 
     // Collect and export tensor dump data
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         dump_collector_.collect_all();
         dump_collector_.export_dump_files();
     }
 
     // Collect and export PMU data (two-step rtMemcpy per core)
-    if (pmu_enabled && pmu_collector_.is_initialized()) {
+    if (enable_pmu_ && pmu_collector_.is_initialized()) {
         pmu_collector_.collect_all();
         pmu_collector_.export_csv();
     }
@@ -734,7 +732,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
     LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
 }
 
-int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
     // Device memory allocation via rtMalloc directly
     auto alloc_cb = [](size_t size) -> void * {
         void *ptr = nullptr;
@@ -755,13 +753,12 @@ int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int 
         return rtMemcpy(host_dst, size, dev_src, size, RT_MEMCPY_DEVICE_TO_HOST);
     };
 
-    return l2_perf_collector_.initialize(
-        runtime, num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
-    );
-}
-
-int DeviceRunner::export_swimlane_json(const std::string &output_path) {
-    return l2_perf_collector_.export_swimlane_json(output_path);
+    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb);
+    if (rc == 0) {
+        kernel_args_.args.l2_perf_data_base =
+            reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+    }
+    return rc;
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -228,8 +228,20 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
-        int enable_pmu = 0);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+
+    /**
+     * Enablement setters for the three diagnostics sub-features. Called by
+     * the c_api entry point before run(); downstream run() paths read the
+     * corresponding `enable_*_` members directly. Moved off the generic
+     * Runtime struct / run() arg list so all three travel the same way.
+     */
+    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
+    void set_enable_pmu(int enable_pmu) {
+        enable_pmu_ = (enable_pmu > 0);
+        pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
+    }
 
     /**
      * Print handshake results from device
@@ -238,18 +250,6 @@ public:
      * Must be called after run() and before finalize().
      */
     void print_handshake_results();
-
-    /**
-     * Export performance data to merged_swimlane.json
-     *
-     * Converts collected performance records to Chrome Trace Event Format
-     * and writes to outputs/merged_swimlane.json for visualization in Perfetto.
-     * Should be called after stream synchronization.
-     *
-     * @param output_path Path to output directory (default: "outputs")
-     * @return 0 on success, error code on failure
-     */
-    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -416,15 +416,16 @@ private:
     /**
      * Initialize performance profiling device buffers
      *
-     * Allocates L2PerfSetupHeader and per-core/per-thread buffers on device,
-     * publishes pointers via runtime.l2_perf_data_base.
+     * Allocates L2PerfSetupHeader and per-core/per-thread buffers on device;
+     * caller publishes the device pointer via kernel_args.l2_perf_data_base
+     * (AICPU reads it through get_platform_l2_perf_base()).
      *
      * @param runtime Runtime instance to configure
      * @param num_aicore Number of AICore instances
      * @param device_id Device ID
      * @return 0 on success, error code on failure
      */
-    int init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id);
+    int init_l2_perf_collection(int num_aicore, int device_id);
 
     /**
      * Initialize tensor dump device buffers.
@@ -447,6 +448,14 @@ private:
      * @return 0 on success, error code on failure
      */
     int init_pmu(int num_aicore, uint32_t event_type);
+    // Enablement for the three diagnostics sub-features. Written by the c_api
+    // entry point via set_enable_*() before run(), read inside run() and its
+    // helpers. Moved off Runtime / run() args so all three sub-features use
+    // the same plumbing shape.
+    bool enable_l2_swimlane_{false};
+    bool enable_dump_tensor_{false};
+    bool enable_pmu_{false};
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -196,15 +196,13 @@ int run_runtime(
             return rc;
         }
 
-        if (enable_l2_swimlane) {
-            r->enable_l2_swimlane = true;
-        }
+        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
+        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
+        runner->set_enable_pmu(enable_pmu);
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
-        rc = runner->run(
-            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
-        );
+        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -159,6 +159,20 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
+        set_platform_l2_perf_base_func_ =
+            reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_l2_perf_base"));
+        if (set_platform_l2_perf_base_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_platform_l2_perf_base: %s", dlerror());
+            return -1;
+        }
+
+        set_enable_l2_swimlane_func_ =
+            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_l2_swimlane"));
+        if (set_enable_l2_swimlane_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_enable_l2_swimlane: %s", dlerror());
+            return -1;
+        }
+
         // PMU bindings — tolerated as optional so a5sim keeps building against
         // pre-PMU AICPU SOs during the transition. Missing symbols mean PMU
         // is unavailable on this build and set_enable_pmu_func_ stays null.
@@ -230,10 +244,8 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
 ) {
-    bool pmu_enabled = enable_pmu > 0;
-    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -294,13 +306,13 @@ int DeviceRunner::run(
     // Calculate number of AIC cores
     int num_aic = block_dim;
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     }
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     }
-    if (pmu_enabled) {
+    if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
 
@@ -332,8 +344,8 @@ int DeviceRunner::run(
     last_runtime_ = &runtime;
 
     // Initialize performance profiling if enabled
-    if (runtime.enable_l2_swimlane) {
-        rc = init_l2_perf_collection(runtime, num_aicore, device_id);
+    if (enable_l2_swimlane_) {
+        rc = init_l2_perf_collection(num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
@@ -341,7 +353,7 @@ int DeviceRunner::run(
     }
 
     // Initialize tensor dump if enabled
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         rc = init_tensor_dump(runtime, num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
@@ -350,8 +362,8 @@ int DeviceRunner::run(
     }
 
     // Initialize PMU profiling if enabled
-    if (pmu_enabled) {
-        rc = init_pmu(num_aicore, pmu_event_type);
+    if (enable_pmu_) {
+        rc = init_pmu(num_aicore, static_cast<uint32_t>(pmu_event_type_));
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -403,7 +415,9 @@ int DeviceRunner::run(
     // Set platform regs in the AICPU .so before launching threads
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_enable_dump_tensor_func_(enable_dump_tensor);
+    set_enable_dump_tensor_func_(enable_dump_tensor_);
+    set_platform_l2_perf_base_func_(kernel_args_.l2_perf_data_base);
+    set_enable_l2_swimlane_func_(enable_l2_swimlane_);
 
     // Publish PMU session state to the AICPU SO (dlsym symbols are optional —
     // older SOs without PMU support leave these nullptr, which simply turns
@@ -412,7 +426,7 @@ int DeviceRunner::run(
         set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
     }
     if (set_enable_pmu_func_ != nullptr) {
-        set_enable_pmu_func_(pmu_enabled);
+        set_enable_pmu_func_(enable_pmu_);
     }
 
     // Launch AICPU threads (over-launch for affinity gate)
@@ -452,19 +466,19 @@ int DeviceRunner::run(
     LOG_INFO("All threads completed");
 
     // Collect performance data and export
-    if (runtime.enable_l2_swimlane) {
+    if (enable_l2_swimlane_) {
         l2_perf_collector_.collect_all();
-        export_swimlane_json();
+        l2_perf_collector_.export_swimlane_json();
     }
 
     // Collect and export tensor dump data
-    if (enable_dump_tensor) {
+    if (enable_dump_tensor_) {
         dump_collector_.collect_all();
         dump_collector_.export_dump_files();
     }
 
     // Collect and export PMU data (sim callbacks are plain memcpy)
-    if (pmu_enabled && pmu_collector_.is_initialized()) {
+    if (enable_pmu_ && pmu_collector_.is_initialized()) {
         pmu_collector_.collect_all();
         pmu_collector_.export_csv();
     }
@@ -503,6 +517,8 @@ void DeviceRunner::unload_executor_binaries() {
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
         set_enable_dump_tensor_func_ = nullptr;
+        set_platform_l2_perf_base_func_ = nullptr;
+        set_enable_l2_swimlane_func_ = nullptr;
         set_platform_pmu_base_func_ = nullptr;
         set_enable_pmu_func_ = nullptr;
     }
@@ -676,7 +692,7 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // Performance Profiling Implementation
 // =============================================================================
 
-int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id) {
+int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
     // Simulation: "device" memory is just host memory, so use malloc/free and
     // std::memcpy for the copy callbacks.
     auto alloc_cb = [](size_t size) -> void * {
@@ -698,13 +714,11 @@ int DeviceRunner::init_l2_perf_collection(Runtime &runtime, int num_aicore, int 
         return 0;
     };
 
-    return l2_perf_collector_.initialize(
-        runtime, num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
-    );
-}
-
-int DeviceRunner::export_swimlane_json(const std::string &output_path) {
-    return l2_perf_collector_.export_swimlane_json(output_path);
+    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb);
+    if (rc == 0) {
+        kernel_args_.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+    }
+    return rc;
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -142,25 +142,25 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
-        int enable_pmu = 0);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+
+    /**
+     * Enablement setters for the three diagnostics sub-features. Called by
+     * the c_api entry point before run(); downstream run() paths read the
+     * corresponding `enable_*_` members directly. Moved off the generic
+     * Runtime struct / run() arg list so all three travel the same way.
+     */
+    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
+    void set_enable_pmu(int enable_pmu) {
+        enable_pmu_ = (enable_pmu > 0);
+        pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
+    }
 
     /**
      * Print handshake results
      */
     void print_handshake_results();
-
-    /**
-     * Export performance data to merged_swimlane.json
-     *
-     * Converts collected performance records to Chrome Trace Event Format
-     * and writes to outputs/merged_swimlane_<timestamp>.json for visualization in Perfetto.
-     * Should be called after execution completes.
-     *
-     * @param output_path Path to output directory (default: "outputs")
-     * @return 0 on success, error code on failure
-     */
-    int export_swimlane_json(const std::string &output_path = "outputs");
 
     /**
      * Cleanup all resources
@@ -226,6 +226,8 @@ private:
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
     void (*set_enable_dump_tensor_func_)(bool){nullptr};
+    void (*set_platform_l2_perf_base_func_)(uint64_t){nullptr};
+    void (*set_enable_l2_swimlane_func_)(bool){nullptr};
     void (*set_enable_pmu_func_)(bool){nullptr};
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
@@ -258,7 +260,7 @@ private:
      * @param device_id Device ID (ignored in simulation)
      * @return 0 on success, error code on failure
      */
-    int init_l2_perf_collection(Runtime &runtime, int num_aicore, int device_id);
+    int init_l2_perf_collection(int num_aicore, int device_id);
 
     /**
      * Initialize tensor dump for simulation.
@@ -273,6 +275,14 @@ private:
      * stays 0 on sim (no hardware PMU model).
      */
     int init_pmu(int num_aicore, uint32_t event_type);
+    // Enablement for the three diagnostics sub-features. Written by the c_api
+    // entry point via set_enable_*() before run(), read inside run() and its
+    // helpers. Moved off Runtime / run() args so all three sub-features use
+    // the same plumbing shape.
+    bool enable_l2_swimlane_{false};
+    bool enable_dump_tensor_{false};
+    bool enable_pmu_{false};
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -187,10 +187,12 @@ int run_runtime(
             return rc;
         }
 
-        // Phase 2: perf swimlane collection
-        if (enable_l2_swimlane) {
-            r->enable_l2_swimlane = true;
-        }
+        // Phase 2: publish diagnostics enablement to the DeviceRunner so run()
+        // and its helpers can read the three sub-features uniformly (via
+        // members, not Runtime / run() args).
+        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
+        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
+        runner->set_enable_pmu(enable_pmu);
 
         // Phase 3: launch
         std::vector<uint8_t> aicpu_vec;
@@ -201,9 +203,7 @@ int run_runtime(
         if (aicore_binary != NULL && aicore_size > 0) {
             aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
         }
-        rc = runner->run(
-            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
-        );
+        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -37,8 +37,21 @@ static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static int s_orch_thread_idx = -1;
 
+// L2 perf platform state. Published by the host (via dlsym'd setters on sim)
+// or by the AICPU kernel entry (onboard) before perf init runs, so downstream
+// perf code can discover enablement + device-base without reading the generic
+// Runtime struct. Mirrors the g_platform_dump_base / g_enable_dump_tensor pair
+// in tensor_dump_aicpu.cpp and the PMU equivalents in pmu_collector_aicpu.cpp.
+static uint64_t g_platform_l2_perf_base = 0;
+static bool g_enable_l2_swimlane = false;
+
+extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base) { g_platform_l2_perf_base = l2_perf_data_base; }
+extern "C" uint64_t get_platform_l2_perf_base() { return g_platform_l2_perf_base; }
+extern "C" void set_enable_l2_swimlane(bool enable) { g_enable_l2_swimlane = enable; }
+extern "C" bool get_enable_l2_swimlane() { return g_enable_l2_swimlane; }
+
 void l2_perf_aicpu_init_profiling(Runtime *runtime) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize profiling");
         return;
@@ -118,8 +131,8 @@ int l2_perf_aicpu_complete_record(
     return 0;
 }
 
-void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks) {
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         return;
     }
@@ -129,8 +142,8 @@ void l2_perf_aicpu_update_total_tasks(Runtime *runtime, uint32_t total_tasks) {
     wmb();
 }
 
-void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
-    void *l2_perf_base = reinterpret_cast<void *>(runtime->l2_perf_data_base);
+void l2_perf_aicpu_init_phase_profiling(int num_sched_threads) {
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize phase profiling");
         return;

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -55,7 +55,7 @@ L2PerfCollector::~L2PerfCollector() {
 }
 
 int L2PerfCollector::initialize(
-    Runtime &runtime, int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfFreeCallback free_cb,
+    int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfFreeCallback free_cb,
     L2PerfCopyToDeviceCallback copy_to_dev_cb, L2PerfCopyFromDeviceCallback copy_from_dev_cb
 ) {
     if (setup_header_dev_ != nullptr) {
@@ -145,10 +145,9 @@ int L2PerfCollector::initialize(
         return rc;
     }
 
-    // Step 5: Publish the device-side header pointer via runtime.l2_perf_data_base.
-    // AICPU reads this on init_profiling to discover per-core / per-thread buffer pointers.
-    runtime.l2_perf_data_base = reinterpret_cast<uint64_t>(setup_header_dev_);
-    LOG_DEBUG("runtime.l2_perf_data_base = 0x%lx", runtime.l2_perf_data_base);
+    // Device-side header pointer is now ready. Caller reads it via
+    // get_l2_perf_setup_device_ptr() and publishes to kernel_args.l2_perf_data_base.
+    LOG_DEBUG("L2PerfSetupHeader on device at 0x%lx", reinterpret_cast<uint64_t>(setup_header_dev_));
 
     LOG_INFO(
         "Performance profiling initialized: %d cores × %zuB L2PerfBuffer, %d threads × %zuB PhaseBuffer", num_aicore_,

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -54,7 +54,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    bool l2_perf_enabled = runtime->enable_l2_swimlane;
+    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -336,7 +336,7 @@ int AicpuExecutor::init(Runtime *runtime) {
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;
     }
-    if (runtime->enable_l2_swimlane) {
+    if (get_enable_l2_swimlane()) {
         l2_perf_aicpu_init_profiling(runtime);
     }
 #if PTO2_PROFILING
@@ -659,7 +659,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
     int verification_warning_count = 0;
     const int MAX_VERIFICATION_WARNINGS = 10;
-    bool l2_perf_enabled = runtime.enable_l2_swimlane;
+    bool l2_perf_enabled = get_enable_l2_swimlane();
 
     // Extract array pointers as local variables for better readability and performance
     int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,8 +45,6 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
-    enable_l2_swimlane = false;
-    l2_perf_data_base = 0;
     tensor_pair_count = 0;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -215,10 +215,6 @@ public:
     // Execution parameters for AICPU scheduling
     int sche_cpu_num;  // Number of AICPU threads for scheduling
 
-    // Perf swimlane collection
-    bool enable_l2_swimlane;     // Enable perf swimlane collection
-    uint64_t l2_perf_data_base;  // Performance data shared memory base address (device-side)
-
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -90,7 +90,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
-    bool l2_perf_enabled = runtime->enable_l2_swimlane;
+    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -360,7 +360,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = runtime->enable_l2_swimlane;
+            rt->orchestrator.enable_l2_swimlane = get_enable_l2_swimlane();
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
@@ -386,7 +386,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif
@@ -471,7 +471,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (runtime->enable_l2_swimlane) {
+            if (get_enable_l2_swimlane()) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -504,8 +504,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             pto2_submitted_tasks = total_tasks;
 #endif
 
-            if (runtime->enable_l2_swimlane && total_tasks > 0) {
-                l2_perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(total_tasks));
+            if (get_enable_l2_swimlane() && total_tasks > 0) {
+                l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(total_tasks));
             }
 
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -229,7 +229,11 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ## Runtime Flag: enable_l2_swimlane
 
-The `runtime->enable_l2_swimlane` flag controls **data collection**, NOT log output.
+L2 swimlane enablement is published through the handshake
+`enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
+AICPU code reads it via `get_enable_l2_swimlane()` (set at launch time
+by the platform from `kernel_args.l2_perf_data_base` + the bitmask). It
+controls **data collection**, NOT log output.
 
 ### When enable_l2_swimlane=true
 
@@ -247,8 +251,10 @@ The `runtime->enable_l2_swimlane` flag controls **data collection**, NOT log out
 ### Usage
 
 ```cpp
-// Initialize runtime with profiling enabled
-runtime->enable_l2_swimlane = true;
+// AICPU path — read enablement from the platform accessor, not the Runtime struct.
+if (get_enable_l2_swimlane()) {
+    // ... perf-collection code ...
+}
 ```
 
 ---

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -183,15 +183,11 @@ public:
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Perf swimlane collection
-    bool enable_l2_swimlane;  // Enable perf swimlane collection
-
     // Orchestrator-to-scheduler transition control
     // When true, orchestrator threads convert to scheduler threads after orchestration completes.
     // When false (default), orchestrator threads exit after orchestration without dispatching tasks.
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
-    uint64_t l2_perf_data_base;  // Performance data shared memory base address (device-side)
 
 private:
     // Tensor pairs for host-device memory tracking

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -790,7 +790,7 @@ void SchedulerContext::on_orchestration_done(
     // Write core-to-thread mapping AFTER reassignment so the profiling data
     // reflects the final distribution (all active_sched_threads_, including
     // former orchestrator threads when orch_to_sched_ is enabled).
-    if (runtime->enable_l2_swimlane) {
+    if (get_enable_l2_swimlane()) {
         l2_perf_aicpu_init_core_assignments(cores_total_num_);
         for (int32_t t = 0; t < active_sched_threads_; t++) {
             l2_perf_aicpu_write_core_assignments_for_thread(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -320,9 +320,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         DEV_INFO("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
-        if (runtime->enable_l2_swimlane) {
+        if (get_enable_l2_swimlane()) {
             l2_perf_aicpu_init_profiling(runtime);
-            l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
+            l2_perf_aicpu_init_phase_profiling(sched_thread_num_);
             l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
@@ -351,7 +351,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
     l2_perf.reset();
-    l2_perf.l2_perf_enabled = runtime->enable_l2_swimlane;
+    l2_perf.l2_perf_enabled = get_enable_l2_swimlane();
 #endif
 
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -40,8 +40,6 @@ Runtime::Runtime() {
     orch_to_sched = false;
 
     // Initialize profiling state
-    enable_l2_swimlane = false;
-    l2_perf_data_base = 0;
 
     // Initialize tensor pairs
     tensor_pair_count = 0;


### PR DESCRIPTION
Fixes #641 (PR 2 of 3, stacked on #652)

> ⚠️ This PR is stacked on top of PR #652. Review/merge #652 first.

## Summary

PR 1 (#652) renamed `enable_profiling` → `enable_perf` and added bit1 to the handshake bitmask so the three diagnostics sub-features (perf / dump_tensor / pmu) publish uniformly to the device. But the generic `Runtime` struct still carried `bool enable_perf` and `uint64_t perf_data_base` — perf-specific fields polluting a generic class, while `dump_tensor` and `pmu` already keep their device pointers on platform-owned `KernelArgs` and their enablement in process-globals.

PR 2 mirrors the dump/pmu pattern exactly so `Runtime` carries no perf state at all.

### Storage
- Add `KernelArgs::perf_data_base` (a5+a2a3).
- `PerformanceCollector::initialize()` no longer takes `Runtime&` or writes `runtime.perf_data_base`. Instead it exposes `get_perf_setup_device_ptr()`, and `DeviceRunner` copies the pointer to `kernel_args_.perf_data_base` after init succeeds.

### Enablement
- Add `g_platform_perf_base` + `g_enable_perf` globals and `set_platform_perf_base` / `get_platform_perf_base` / `set_enable_perf` / `get_enable_perf` C symbols in `performance_collector_aicpu.cpp`.
- Sim `device_runner`s dlsym the setters and call them at launch time alongside the existing dump/pmu setters.
- Onboard `kernel.cpp` calls them directly, reading the bitmask bit the same way dump/pmu already do.
- AICore executors (5 sites) switch from `runtime->enable_perf` to `GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PERF)`.
- AICPU executors (many sites across 5 runtimes) switch to `get_enable_perf()`.
- `DeviceRunner` gains a member `enable_perf_` set by the c_api entry point before `run()`; host-side `runtime.enable_perf` readers in `device_runner.cpp` now read this member.

### Removal
- Drop `bool enable_perf` and `uint64_t perf_data_base` from all 5 `runtime.h` files and the three `runtime.cpp` ctor initializers.
- `pto_orchestrator` still has its own internal `enable_perf` field (copied from `get_enable_perf()` now, not from `Runtime`).

## Follow-up

**PR 3:** extract a `DiagnosticsCollector` base class to unify init/finalize/copy-back/export across `PerformanceCollector`, `TensorDumpCollector`, and `pmu_collector` on both arches.

## Test plan

- [x] `pip install --no-build-isolation -e .` builds both arches clean
- [x] `pytest tests/ut/py` — 216 passed (excluding one pre-existing unrelated gc-referrer failure on upstream/main, logged locally)
- [x] Grep gate clean: `rg '\b(runtime->enable_perf|runtime\.enable_perf|runtime->perf_data_base|runtime\.perf_data_base)\b' src/ docs/` returns zero hits
- [ ] Sim scene test with `--enable-perf` (please run in CI; sandbox has no simulator access) — confirms perf swimlane JSON is still produced after the storage move
- [ ] Hardware smoke on `--enable-perf` (nice-to-have)