### PR TITLE
Support: add a5 PMU profiling path

### DIFF
--- a/src/a5/docs/pmu-profiling.md
+++ b/src/a5/docs/pmu-profiling.md
@@ -1,0 +1,235 @@
+# PMU Profiling (a5)
+
+This document describes how to use a5 PMU profiling, what output it produces,
+and the current usage limitations.
+
+## Overview
+
+PMU profiling collects per-task AICore hardware counter data and exports a
+LuoPan-compatible CSV file on the host side. It targets DAV_3510 hardware
+(10 counters + dual PMU CTRL register).
+
+Use `a5` hardware runs for meaningful PMU data. The simulation path can
+exercise the PMU export flow, but does not provide real hardware counters.
+
+## Design
+
+### Layered Responsibilities
+
+- **Host** owns user entry, event-type selection, PMU session setup, and
+  final CSV export
+- **AICPU** owns PMU init/finalize (event selectors, `PMU_CTRL_0/1`
+  start, CTRL restore), publishes per-core `PmuBuffer` and PMU MMIO base
+  into each `Handshake`, and on each task FIN copies AICore's
+  `dual_issue_slots[]` snapshot into `PmuBuffer::records[]` while
+  filling `func_id` / `core_type`. AICPU also stamps each core's
+  `PmuBufferState::owning_thread_id` (the AICPU scheduler thread that
+  drives that core) so host can emit a per-record `thread_id` column.
+- **AICore** gates the counting window around the kernel body via CTRL
+  SPR bit 0, reads the 10 PMU counters + `PMU_CNT_TOTAL` via the
+  `ld_dev` MMIO load intrinsic after each task, and writes the snapshot
+  into `PmuBuffer::dual_issue_slots[reg_task_id & 1]` (the 32-bit
+  `DATA_MAIN_BASE` register token, not the 64-bit logical task id)
+
+This AICore/AICPU split mirrors the a2a3 perf collector's producer/
+consumer protocol (counter and timing writes on the core that ran the
+task; metadata and commit on the controller). The two slots exist
+because AICore's dual-issue dispatch can have up to two tasks in flight
+per core — parity `reg_task_id & 1` keeps adjacent dispatches from
+colliding (the runtime's `dispatch_seq++` guarantees neighboring
+register tokens differ by 1, so they always land on different slots).
+
+### Slot Match Key vs Logical task_id
+
+`pmu_aicpu_complete_record` takes both a 32-bit `reg_task_id` (used to
+select and validate the dual-issue slot — must equal the value AICore
+read from `DATA_MAIN_BASE` and stored in `slot->task_id`) and a 64-bit
+logical `task_id` written into the record itself. In runtimes whose
+logical id encodes more than 32 bits (e.g. PTO2's
+`(ring_id<<32)|local_id` in `tensormap_and_ringbuffer`), the two
+values differ — slot match must use the register token, otherwise the
+slot will never validate and every commit silently drops.
+
+### Device Memory Layout
+
+```text
+[ PmuSetupHeader ]              ← num_cores, event_type, buffer_ptrs[N]
+[ PmuBufferState[num_cores] ]   ← owning_thread_id, dropped_record_count,
+                                   total_record_count (per core)
+```
+
+This single shared region (`calc_pmu_setup_size`) is allocated once at
+init and pulled back via one `rtMemcpy` at finalize. The per-core
+`PmuBuffer`s themselves are separate device allocations (one per core),
+copied back individually on demand because their `count`-sized payloads
+vary.
+
+### Device → Host Transfer
+
+halHostRegister is not supported on DAV_3510, so the PMU collector uses
+the same two-step rtMemcpy pattern already used by the performance and
+tensor-dump collectors:
+
+1. At init: host allocates the `[PmuSetupHeader][PmuBufferState[]]`
+   region plus one `PmuBuffer` per core. The setup region's device
+   address is published into `kernel_args.pmu_data_base`. AICPU then
+   publishes each core's `PmuBuffer` address and PMU MMIO base into
+   the matching `Handshake` (`pmu_buffer_addr`, `pmu_reg_base`) so
+   AICore can do its own MMIO read — parallels `perf_records_addr`.
+2. During execution: AICore, after each kernel completes, reads the
+   10 PMU counters via `ld_dev(base, offset)` and writes them into
+   `PmuBuffer::dual_issue_slots[reg_task_id & 1]`. AICPU, on observing
+   COND FIN, validates that slot's `task_id` against the register
+   token (`pmu_aicpu_complete_record`), copies register state into
+   `PmuBuffer::records[count]`, fills `func_id` / `core_type`, stamps
+   `PmuBufferState::owning_thread_id`, and advances `count`.
+3. After stream sync: host pulls back the entire setup region (all
+   `PmuBufferState`s in one shot) plus each core's `PmuBuffer` payload
+   (header first to learn `count`, then `count * sizeof(PmuRecord)`
+   records). The host writes a CSV under `outputs/` and emits a
+   cross-check log line:
+
+   ```text
+   PMU collector: record counts match (collected=N, dropped=K, device_total=N+K)
+   ```
+
+   If `collected + dropped != device_total`, the difference is silent
+   slot-mismatch loss (AICore had not yet published the slot when
+   AICPU tried to commit) and the line becomes a `record count
+   mismatch (... diff=M silent slot-mismatch losses)` warning.
+
+This design fits naturally into the existing a5 `PerformanceCollector` /
+`TensorDumpCollector` lifecycle — `initialize / collect_all / export /
+finalize` is called from `DeviceRunner::run`.
+
+## Usage
+
+### SceneTest CLI
+
+Enable PMU with the default event group:
+
+```bash
+python tests/st/<case>/test_<name>.py -p a5 -d 0 --enable-pmu
+```
+
+or with pytest:
+
+```bash
+pytest tests/st/<case> --platform a5 -d 0 --enable-pmu
+```
+
+The bare flag is equivalent to:
+
+```bash
+--enable-pmu 2
+```
+
+which selects `PIPE_UTILIZATION`.
+
+Pass an explicit event type to collect a different counter group:
+
+```bash
+python tests/st/<case>/test_<name>.py -p a5 -d 0 --enable-pmu 4
+```
+
+`--rounds > 1` disables PMU collection in the test harness.
+
+### Event Types
+
+| Value | Event Type | Example Counters |
+| ----- | ---------- | ---------------- |
+| `1` | `ARITHMETIC_UTILIZATION` | cube/vector execution counters |
+| `2` | `PIPE_UTILIZATION` | vector, cube, scalar, MTE busy cycles |
+| `4` | `MEMORY` | UB/L1/L2/main memory requests |
+| `5` | `MEMORY_L0` | L0A/L0B/L0C requests |
+| `6` | `RESOURCE_CONFLICT` | bank and vector resource stalls |
+| `7` | `MEMORY_UB` | UB and memory bandwidth counters |
+| `8` | `L2_CACHE` | L2 cache hit/miss allocation counters |
+
+Invalid nonzero values fall back to `PIPE_UTILIZATION`. The
+`SIMPLER_PMU_EVENT_TYPE` environment variable overrides the CLI value.
+
+DAV_3510 has its own per-counter event-code space (see pypto
+`pmu_common.cpp::SetPmuEventTypeDAV3510`); the CSV counter column set
+depends on which event group is selected. a5 has 10 hardware counter
+slots; unused slots in a given event group are zero.
+
+## Output
+
+The PMU artifact is a CSV file under `outputs/`:
+
+```text
+outputs/pmu_<YYYYMMDD>_<HHMMSS>_<mmm>.csv
+```
+
+Columns (in order) — matches a2a3 host PMU CSV for tooling parity:
+
+| Column | Meaning |
+| ------ | ------- |
+| `thread_id` | AICPU scheduler thread that drives this core (read from `PmuBufferState::owning_thread_id`) |
+| `core_id` | Logical AICore id in the runtime |
+| `task_id` | Runtime task id, printed as hex |
+| `func_id` | Kernel function id |
+| `core_type` | `0` = AIC, `1` = AIV |
+| `pmu_total_cycles` | 64-bit PMU total cycle counter snapshot |
+| event-specific counters | Counter columns selected by the event type |
+| `event_type` | Numeric event type used for the run |
+
+For the default `PIPE_UTILIZATION` event type (`2`), the counter columns
+on a5 are (from pypto `tilefwk_pmu_to_csv.py` table_pmu_header_3510):
+
+```text
+pmu_idc_aic_vec_busy_o,cube_instr_busy,scalar_instr_busy,mte1_instr_busy,
+mte2_instr_busy,mte3_instr_busy,icache_req,icache_miss,pmu_fix_instr_busy
+```
+
+The number of counter columns varies by event type — each DAV_3510 event
+group populates a different subset of the 10 hardware counter slots and
+the CSV lists only the slots that have a defined name in pypto's
+`table_pmu_header_3510`. Consumers should use the `event_type` column to
+discover which columns are present.
+
+## Limitations
+
+- `a5sim` can validate the PMU export path, but the simulated counter
+  register block does not model AICore execution, so counter values are
+  always 0. The AICPU still programs the PMU event selectors and the CSV
+  still carries one row per task with a zero counter tuple — useful for
+  verifying the end-to-end data flow but not for performance analysis.
+- The per-core on-device `PmuBuffer` is a fixed size
+  (`PLATFORM_PMU_RECORDS_PER_BUFFER = 4096`). Tasks past that count are
+  dropped and accounted in `PmuBufferState::dropped_record_count`; the
+  host surfaces the total in the finalize log line. Increase the
+  constant in [platform_config.h](../platform/include/common/platform_config.h)
+  if your workload executes more tasks per core.
+- A non-zero `diff` in the host's `record count mismatch` warning means
+  AICPU attempted to commit `diff` records whose dual-issue slot still
+  carried an older `task_id`. Under the current design on DAV_3510
+  hardware **this should always be zero** — AICore's slot-write order
+  is `counters → pmu_total_cycles → store barrier → task_id → dcci →
+  dsb → write FIN to COND`, so by the time AICPU observes FIN and
+  invalidates the slot, the slot write is guaranteed visible.
+
+  A persistent non-zero `diff` therefore indicates a regression in
+  one of four places, not a tolerable tail loss:
+
+  1. The `reg_task_id` producer/consumer drifted out of sync (AICPU
+     uses a different task-id encoding than AICore wrote into the
+     slot — this was the bug behind `collected=4 / diff=32` during
+     the AICore-side PMU rewrite).
+  2. AICPU calls `pmu_aicpu_complete_record` for a task AICore never
+     executed (e.g. a new code path that commits PMU for an
+     AICPU-only task; AICore never wrote that slot, so `task_id`
+     stays stale).
+  3. AICore's `dcci` / `dsb` ordering around the slot write was
+     rearranged, or a barrier was weakened from the required full
+     `dsb` to a store-only flavor.
+  4. The hardware target's `dcci(..., CACHELINE_OUT)` semantics differ
+     (e.g. non-DAV_3510 ports) and no longer guarantee HBM
+     writeback before the following `dsb`.
+
+  Treat `diff != 0` as a sharp diagnostic — find the regression, do
+  not tune `PLATFORM_PMU_RECORDS_PER_BUFFER` around it.
+
+Keep PMU comparisons consistent across runs by using the same runtime
+build flags.

--- a/src/a5/platform/include/aicore/pmu_collector_aicore.h
+++ b/src/a5/platform/include/aicore/pmu_collector_aicore.h
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * @file pmu_collector_aicore.h
+ * @brief AICore-side PMU gate + per-task MMIO record (a5)
+ *
+ * Split of duties (mirrors a2a3 perf):
+ *   - AICPU programs event selectors + starts PMU_CTRL_0/1 once at init,
+ *     and restores them at finalize.
+ *   - AICore gates counting around each kernel execution via CTRL SPR bit 0
+ *     (pmu_aicore_begin / pmu_aicore_end), reads the 10 PMU counters +
+ *     PMU_CNT_TOTAL via MMIO using the handshake-supplied reg_base, and
+ *     writes the snapshot into PmuBuffer::dual_issue_slots[task_id & 1].
+ *   - AICPU, on COND FIN, validates the slot and copies it into
+ *     PmuBuffer::records[count] while filling func_id / core_type
+ *     (pmu_aicpu_complete_record).
+ *
+ * The two dual_issue_slots exist because AICore's dual-issue dispatch
+ * can have up to two tasks in flight per core — the parity task_id & 1
+ * keeps N and N+1 from colliding. This is the same reason a2a3 perf
+ * uses wip[2].
+ */
+
+#ifndef PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_
+#define PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_
+
+#include "aicore/aicore.h"
+#include "common/platform_config.h"
+#include "common/pmu_profiling.h"
+
+// PMU enable bit in the AICore CTRL SPR (bit 0 = GLB_PMU_EN).
+constexpr uint64_t PMU_AICORE_CTRL_ENABLE_BIT = 0x1ULL;
+
+/**
+ * Begin PMU counting window: set CTRL bit 0 so hardware counters start accruing.
+ */
+__aicore__ __attribute__((always_inline)) static inline void pmu_aicore_begin() {
+    write_reg(RegId::CTRL, read_reg(RegId::CTRL) | PMU_AICORE_CTRL_ENABLE_BIT);
+}
+
+/**
+ * End PMU counting window: clear CTRL bit 0 so counters freeze until next begin.
+ */
+__aicore__ __attribute__((always_inline)) static inline void pmu_aicore_end() {
+    write_reg(RegId::CTRL, read_reg(RegId::CTRL) & ~PMU_AICORE_CTRL_ENABLE_BIT);
+}
+
+/**
+ * Record PMU counters for one completed task into the dual-issue slot
+ * (AICore-side producer half of the PMU record path).
+ *
+ * Must be called after pmu_aicore_end() has frozen the counters.
+ * AICPU picks up the slot and commits it via pmu_aicpu_complete_record.
+ *
+ * Leaves func_id and core_type untouched — those are AICPU-owned fields,
+ * mirroring the a2a3 perf producer/consumer split.
+ *
+ * @param buf       Per-core PmuBuffer (from Handshake.pmu_buffer_addr)
+ * @param reg_base  Per-core PMU MMIO base (from Handshake.pmu_reg_base)
+ * @param task_id   Register dispatch token (DATA_MAIN_BASE value for this task)
+ */
+__aicore__ __attribute__((always_inline)) static inline void
+pmu_aicore_record_task(__gm__ PmuBuffer *buf, uint64_t reg_base, uint32_t task_id) {
+    if (buf == nullptr || reg_base == 0) {
+        return;
+    }
+
+    __gm__ PmuRecord *slot = &buf->dual_issue_slots[task_id & 1u];
+
+    // Read the 10 event counters + 64-bit cycle counter via the AICore MMIO
+    // load intrinsic ld_dev(base, offset) — the only legal way for AICore to
+    // read its own MMIO regs. CCE constrains `offset` to a 12-bit signed
+    // immediate ([-2048, 2047]), so we rebase the pointer to the start of
+    // the PMU CTRL/CNT block (0x4200) — relative offsets then fit within
+    // [0x10, 0x64] and stay inside the immediate range.
+    int32_t *pmu_base = reinterpret_cast<int32_t *>(reg_base + REG_MMIO_PMU_CTRL_0_OFFSET);
+    constexpr int16_t REL = static_cast<int16_t>(REG_MMIO_PMU_CTRL_0_OFFSET);
+    slot->pmu_counters[0] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT0_OFFSET - REL));
+    slot->pmu_counters[1] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT1_OFFSET - REL));
+    slot->pmu_counters[2] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT2_OFFSET - REL));
+    slot->pmu_counters[3] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT3_OFFSET - REL));
+    slot->pmu_counters[4] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT4_OFFSET - REL));
+    slot->pmu_counters[5] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT5_OFFSET - REL));
+    slot->pmu_counters[6] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT6_OFFSET - REL));
+    slot->pmu_counters[7] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT7_OFFSET - REL));
+    slot->pmu_counters[8] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT8_OFFSET - REL));
+    slot->pmu_counters[9] = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT9_OFFSET - REL));
+    uint64_t lo = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT_TOTAL0_OFFSET - REL));
+    uint64_t hi = static_cast<uint32_t>(ld_dev(pmu_base, REG_MMIO_PMU_CNT_TOTAL1_OFFSET - REL));
+    slot->pmu_total_cycles = lo | (hi << 32);
+
+    // Publish task_id last so AICPU can validate the slot is ready.
+    OUT_OF_ORDER_STORE_BARRIER();
+    slot->task_id = static_cast<uint64_t>(task_id);
+
+    // Flush cache to make data visible to AICPU.
+    dcci(slot, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    dsb((mem_dsb_t)0);
+}
+
+#endif  // PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -49,6 +49,10 @@ void set_platform_regs(uint64_t regs);
  * Get the platform register base address array.
  * Called by runtime AICPU executor code that needs register access.
  *
+ * On DAV_3510 the per-core halResMap(RES_AICORE) mapping covers both the
+ * AICore SPR page (DATA_MAIN_BASE, COND, CTRL) and the PMU MMIO page, so
+ * PMU helpers also read counters through this same register-base array.
+ *
  * @return Pointer (as uint64_t) to per-core register base address array
  */
 uint64_t get_platform_regs();

--- a/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_collector_aicpu.h
+ * @brief AICPU-side PMU collection interface (a5)
+ *
+ * Split of duties (mirrors a2a3 perf):
+ *   - AICPU owns init (event selectors, PMU_CTRL_0/1 start) and finalize
+ *     (CTRL restore). It also publishes per-core pmu_buffer_addr /
+ *     pmu_reg_base into Handshake at init time so AICore can do the
+ *     MMIO read itself.
+ *   - AICore reads PMU counters + PMU_CNT_TOTAL via MMIO after each task
+ *     (pmu_aicore_record_task), writing into PmuBuffer::dual_issue_slots.
+ *   - AICPU, on COND FIN, validates the slot and commits a full PmuRecord
+ *     into PmuBuffer::records[] (pmu_aicpu_complete_record).
+ *
+ * Lifecycle (called from aicpu_executor.cpp):
+ *   pmu_aicpu_init()              — resolve per-core PMU MMIO bases + buffer
+ *                                   pointers, program events, start counters,
+ *                                   publish (pmu_buffer_addr, pmu_reg_base)
+ *                                   to each Handshake.
+ *   [task loop]
+ *     pmu_aicpu_complete_record() — copy the dual-issue slot AICore wrote
+ *                                   into PmuBuffer::records[count], filling
+ *                                   func_id + core_type. Drops the record
+ *                                   silently if the buffer is full.
+ *   pmu_aicpu_finalize()          — per-thread: restore CTRL registers.
+ *
+ * a5 uses a single pre-allocated PmuBuffer per core; the host drains it via
+ * rtMemcpy after stream sync (see src/a5/platform/src/host/pmu_collector.cpp).
+ * There is no SPSC queue and no per-thread flush step.
+ */
+
+#ifndef PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_
+#define PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_
+
+#include <cstdint>
+
+#include "common/core_type.h"
+#include "common/pmu_profiling.h"
+#include "runtime.h"  // Handshake
+
+extern "C" void set_platform_pmu_base(uint64_t pmu_data_base);
+extern "C" uint64_t get_platform_pmu_base();
+extern "C" void set_enable_pmu(bool enable);
+extern "C" bool get_enable_pmu();
+
+/**
+ * Initialize PMU for all cores.
+ *
+ * For each logical core i in [0, num_cores):
+ *   - Resolve the PMU MMIO base from physical_core_ids[i] via the platform's
+ *     PMU reg-addr table.
+ *   - Program event selectors (PMU_CNT0_IDX..CNT9_IDX).
+ *   - Start counters (set PMU_CTRL_0 and PMU_CTRL_1).
+ *   - Publish (pmu_buffer_addr, pmu_reg_base) into handshakes[i] so the
+ *     matching AICore can read PMU MMIO and write the dual-issue slot.
+ *
+ * On sim (or when a core has no PMU reg addr), the core is skipped for MMIO
+ * programming. The handshake fields still carry whatever reg_base the
+ * platform reg table returns (0 on sim for missing entries), so AICore
+ * no-ops the read if reg_base is 0.
+ *
+ * Must be called after the host has published pmu_data_base (via
+ * set_platform_pmu_base) and after every active core has reported its
+ * physical_core_id via handshake. Must be called BEFORE the caller
+ * sets aicpu_regs_ready=1 on each handshake, so AICore observes the
+ * new fields via the same release/acquire boundary.
+ *
+ * @param handshakes         Handshake array (one per core). This function
+ *                           writes pmu_buffer_addr and pmu_reg_base into
+ *                           handshakes[0..num_cores). Caller owns lifetime.
+ * @param physical_core_ids  Array of hardware physical core ids, indexed by
+ *                           logical core_id. Caller owns the memory; this
+ *                           function does not retain the pointer.
+ * @param num_cores          Number of active cores (logical core_id range is [0, num_cores))
+ */
+void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, int num_cores);
+
+/**
+ * Commit one PmuRecord from the dual-issue staging slot that AICore wrote
+ * into PmuBuffer::dual_issue_slots[task_id & 1]. Copies register state
+ * (pmu_counters + pmu_total_cycles) and fills AICPU-owned metadata
+ * (task_id, func_id, core_type). When the buffer is full the record is
+ * dropped and the core's PmuBufferState::dropped_record_count is incremented.
+ * Every call bumps PmuBufferState::total_record_count so host can cross-check
+ * collected + dropped against the AICPU's attempted-commit count.
+ * No-op if PMU is not enabled or the core has no PMU buffer bound.
+ *
+ * Mirrors a2a3's perf_aicpu_complete_record.
+ *
+ * @param core_id     Logical core index
+ * @param thread_idx  AICPU thread index (reserved; not used on a5 memcpy path)
+ * @param reg_task_id Register dispatch token (DATA_MAIN_BASE value). AICore
+ *                    wrote this 32-bit value into dual_issue_slots[...].task_id,
+ *                    so AICPU uses it to locate the slot and validate its
+ *                    freshness. Callers should pass the same register token
+ *                    they observed on COND / wrote via DATA_MAIN_BASE.
+ * @param task_id     Full task_id to store in the PmuRecord (e.g. PTO2's
+ *                    (ring_id<<32)|local_id). May differ from reg_task_id.
+ * @param func_id     kernel_id from the completed task slot
+ * @param core_type   AIC or AIV
+ */
+void pmu_aicpu_complete_record(
+    int core_id, int thread_idx, uint32_t reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type
+);
+
+/**
+ * Per-thread PMU finalize: restore CTRL registers for this thread's cores.
+ *
+ * @param cur_thread_cores  Array of logical core ids owned by this thread
+ * @param core_num          Entries in cur_thread_cores
+ */
+void pmu_aicpu_finalize(const int *cur_thread_cores, int core_num);
+
+#endif  // PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -70,6 +70,7 @@ struct KernelArgs {
     Runtime *runtime_args{nullptr};    // Task runtime in device memory
     uint64_t regs{0};                  // Per-core register base address array (platform-specific)
     uint64_t dump_data_base{0};        // Dump shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_data_base{0};         // PMU buffer base address (device memory); 0 = PMU disabled
 };
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -116,7 +116,7 @@ inline double cycles_to_us(uint64_t cycles) {
 #define PROFILING_FLAG_NONE 0u
 #define PROFILING_FLAG_DUMP_TENSOR (1u << 0)
 #define PROFILING_FLAG_L2_SWIMLANE (1u << 1)
-#define PROFILING_FLAG_PMU (1u << 2)  // a5: reserved (no PMU support yet)
+#define PROFILING_FLAG_PMU (1u << 2)
 #define GET_PROFILING_FLAG(flags, bit) ((((uint32_t)(flags)) & ((uint32_t)(bit))) != 0u)
 #define SET_PROFILING_FLAG(flags, bit) ((flags) |= (uint32_t)(bit))
 #define CLEAR_PROFILING_FLAG(flags, bit) ((flags) &= ~((uint32_t)(bit)))
@@ -171,12 +171,30 @@ constexpr int PLATFORM_DUMP_READYQUEUE_SIZE = PLATFORM_MAX_AICPU_THREADS * PLATF
 constexpr int PLATFORM_DUMP_TIMEOUT_SECONDS = 30;
 
 // =============================================================================
+// PMU Profiling Configuration
+// =============================================================================
+
+/**
+ * Number of PmuRecord entries per PmuBuffer.
+ * A5 uses a single pre-allocated PmuBuffer per core (no SPSC free-queue
+ * streaming — device memory is drained via rtMemcpy after stream sync).
+ * Tasks past this count are dropped and counted in the buffer header.
+ */
+constexpr int PLATFORM_PMU_RECORDS_PER_BUFFER = 4096;
+
+/**
+ * Idle timeout duration for PMU collection (seconds)
+ */
+constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
+
+// =============================================================================
 // Register Communication Configuration
 // =============================================================================
 
 // Register offsets for AICore SPR access
 constexpr uint32_t REG_SPR_DATA_MAIN_BASE_OFFSET = 0xD0;  // Task dispatch (AICPU→AICore)
 constexpr uint32_t REG_SPR_COND_OFFSET = 0x5108;          // Status (AICore→AICPU): 0=IDLE, 1=BUSY
+constexpr uint32_t REG_SPR_CTRL_OFFSET = 0x0;             // AICore internal CTRL SPR (bit0 = PMU enable)
 
 // Exit signal for AICore shutdown
 constexpr uint32_t AICORE_EXIT_SIGNAL = 0x7FFFFFF0;
@@ -184,13 +202,108 @@ constexpr uint32_t AICORE_EXIT_SIGNAL = 0x7FFFFFF0;
 // Physical core ID mask for get_coreid()
 constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
 
+// DAV_3510 hardware counter count.
+constexpr int PMU_COUNTER_COUNT_A5 = 10;
+
+// PMU MMIO register offsets (DAV_3510 / a5). Values ported from pypto
+// aicore_prof_dav3510_pmu.h. Accessed by AICPU through the per-core PMU
+// register block (separate from the AICore SPR block used for DATA_MAIN_BASE
+// and COND). AICore does not touch these — it only toggles its internal
+// CTRL SPR (REG_SPR_CTRL_OFFSET) for per-task counter gating.
+constexpr uint32_t REG_MMIO_PMU_CTRL_0_OFFSET = 0x4200;      // PMU framework enable (GLB_PMU_EN | USER | SAMPLE)
+constexpr uint32_t REG_MMIO_PMU_CTRL_1_OFFSET = 0x2400;      // PMU secondary control (a5 only)
+constexpr uint32_t REG_MMIO_PMU_CNT0_OFFSET = 0x4210;        // Event counter 0
+constexpr uint32_t REG_MMIO_PMU_CNT1_OFFSET = 0x4218;        // Event counter 1
+constexpr uint32_t REG_MMIO_PMU_CNT2_OFFSET = 0x4220;        // Event counter 2
+constexpr uint32_t REG_MMIO_PMU_CNT3_OFFSET = 0x4228;        // Event counter 3
+constexpr uint32_t REG_MMIO_PMU_CNT4_OFFSET = 0x4230;        // Event counter 4
+constexpr uint32_t REG_MMIO_PMU_CNT5_OFFSET = 0x4238;        // Event counter 5
+constexpr uint32_t REG_MMIO_PMU_CNT6_OFFSET = 0x4240;        // Event counter 6
+constexpr uint32_t REG_MMIO_PMU_CNT7_OFFSET = 0x4248;        // Event counter 7
+constexpr uint32_t REG_MMIO_PMU_CNT8_OFFSET = 0x4250;        // Event counter 8 (a5 only)
+constexpr uint32_t REG_MMIO_PMU_CNT9_OFFSET = 0x4254;        // Event counter 9 (a5 only)
+constexpr uint32_t REG_MMIO_PMU_CNT_TOTAL0_OFFSET = 0x4260;  // Total cycle counter, low 32 bits
+constexpr uint32_t REG_MMIO_PMU_CNT_TOTAL1_OFFSET = 0x4264;  // Total cycle counter, high 32 bits
+constexpr uint32_t REG_MMIO_PMU_START_CYC0_OFFSET = 0x42A0;  // Counting-range start cycle, low 32 bits
+constexpr uint32_t REG_MMIO_PMU_START_CYC1_OFFSET = 0x42A4;  // Counting-range start cycle, high 32 bits
+constexpr uint32_t REG_MMIO_PMU_STOP_CYC0_OFFSET = 0x42A8;   // Counting-range stop cycle, low 32 bits
+constexpr uint32_t REG_MMIO_PMU_STOP_CYC1_OFFSET = 0x42AC;   // Counting-range stop cycle, high 32 bits
+constexpr uint32_t REG_MMIO_PMU_CNT0_IDX_OFFSET = 0x2500;    // Event selector for CNT0
+constexpr uint32_t REG_MMIO_PMU_CNT1_IDX_OFFSET = 0x2504;    // Event selector for CNT1
+constexpr uint32_t REG_MMIO_PMU_CNT2_IDX_OFFSET = 0x2508;    // Event selector for CNT2
+constexpr uint32_t REG_MMIO_PMU_CNT3_IDX_OFFSET = 0x250C;    // Event selector for CNT3
+constexpr uint32_t REG_MMIO_PMU_CNT4_IDX_OFFSET = 0x2510;    // Event selector for CNT4
+constexpr uint32_t REG_MMIO_PMU_CNT5_IDX_OFFSET = 0x2514;    // Event selector for CNT5
+constexpr uint32_t REG_MMIO_PMU_CNT6_IDX_OFFSET = 0x2518;    // Event selector for CNT6
+constexpr uint32_t REG_MMIO_PMU_CNT7_IDX_OFFSET = 0x251C;    // Event selector for CNT7
+constexpr uint32_t REG_MMIO_PMU_CNT8_IDX_OFFSET = 0x2520;    // Event selector for CNT8 (a5 only)
+constexpr uint32_t REG_MMIO_PMU_CNT9_IDX_OFFSET = 0x2524;    // Event selector for CNT9 (a5 only)
+
+// PMU_CTRL_0 enable value: GLB_PMU_EN | (USER_PMU_MODE_EN << 1) | (SAMPLE_PMU_MODE_EN << 2)
+constexpr uint32_t REG_MMIO_PMU_CTRL_0_ENABLE_VAL = 0x7;
+// PMU_CTRL_1 enable value: GLB_PMU_EN (a5 only; second control register)
+constexpr uint32_t REG_MMIO_PMU_CTRL_1_ENABLE_VAL = 0x1;
+
 /**
- * Register identifier for unified read_reg/write_reg interface
+ * Register identifier for unified read_reg/write_reg interface.
+ *
+ * The PMU counter slots (PMU_CNT0..PMU_CNT9) and event selector slots
+ * (PMU_CNT0_IDX..PMU_CNT9_IDX) are assigned contiguous values so that
+ * reg_index(base, i) can index into them as arrays. Keep these runs
+ * contiguous — static_asserts below enforce this.
  */
 enum class RegId : uint8_t {
     DATA_MAIN_BASE = 0,  // Task dispatch (AICPU→AICore)
     COND = 1,            // Status (AICore→AICPU)
+    CTRL = 2,            // AICore internal CTRL SPR (PMU enable, etc.) — AICore-only
+
+    // PMU framework (AICPU-only; AICore does not access these)
+    PMU_CTRL_0 = 3,
+    PMU_CTRL_1 = 4,
+
+    // PMU counters (10 contiguous slots)
+    PMU_CNT0 = 5,
+    PMU_CNT1 = 6,
+    PMU_CNT2 = 7,
+    PMU_CNT3 = 8,
+    PMU_CNT4 = 9,
+    PMU_CNT5 = 10,
+    PMU_CNT6 = 11,
+    PMU_CNT7 = 12,
+    PMU_CNT8 = 13,
+    PMU_CNT9 = 14,
+
+    // PMU total cycle counter (64-bit split across two 32-bit regs)
+    PMU_CNT_TOTAL0 = 15,
+    PMU_CNT_TOTAL1 = 16,
+
+    // PMU counting-range start/stop cycle bounds
+    PMU_START_CYC0 = 17,
+    PMU_START_CYC1 = 18,
+    PMU_STOP_CYC0 = 19,
+    PMU_STOP_CYC1 = 20,
+
+    // PMU event selectors (10 contiguous slots, parallel to PMU_CNT0..CNT9)
+    PMU_CNT0_IDX = 21,
+    PMU_CNT1_IDX = 22,
+    PMU_CNT2_IDX = 23,
+    PMU_CNT3_IDX = 24,
+    PMU_CNT4_IDX = 25,
+    PMU_CNT5_IDX = 26,
+    PMU_CNT6_IDX = 27,
+    PMU_CNT7_IDX = 28,
+    PMU_CNT8_IDX = 29,
+    PMU_CNT9_IDX = 30,
 };
+
+static_assert(
+    static_cast<int>(RegId::PMU_CNT9) - static_cast<int>(RegId::PMU_CNT0) == 9,
+    "PMU_CNT0..PMU_CNT9 must be contiguous for reg_index()"
+);
+static_assert(
+    static_cast<int>(RegId::PMU_CNT9_IDX) - static_cast<int>(RegId::PMU_CNT0_IDX) == 9,
+    "PMU_CNT0_IDX..PMU_CNT9_IDX must be contiguous for reg_index()"
+);
 
 /**
  * Map RegId to hardware register offset
@@ -201,28 +314,97 @@ constexpr uint32_t reg_offset(RegId reg) {
         return REG_SPR_DATA_MAIN_BASE_OFFSET;
     case RegId::COND:
         return REG_SPR_COND_OFFSET;
+    case RegId::CTRL:
+        return REG_SPR_CTRL_OFFSET;
+    case RegId::PMU_CTRL_0:
+        return REG_MMIO_PMU_CTRL_0_OFFSET;
+    case RegId::PMU_CTRL_1:
+        return REG_MMIO_PMU_CTRL_1_OFFSET;
+    case RegId::PMU_CNT0:
+        return REG_MMIO_PMU_CNT0_OFFSET;
+    case RegId::PMU_CNT1:
+        return REG_MMIO_PMU_CNT1_OFFSET;
+    case RegId::PMU_CNT2:
+        return REG_MMIO_PMU_CNT2_OFFSET;
+    case RegId::PMU_CNT3:
+        return REG_MMIO_PMU_CNT3_OFFSET;
+    case RegId::PMU_CNT4:
+        return REG_MMIO_PMU_CNT4_OFFSET;
+    case RegId::PMU_CNT5:
+        return REG_MMIO_PMU_CNT5_OFFSET;
+    case RegId::PMU_CNT6:
+        return REG_MMIO_PMU_CNT6_OFFSET;
+    case RegId::PMU_CNT7:
+        return REG_MMIO_PMU_CNT7_OFFSET;
+    case RegId::PMU_CNT8:
+        return REG_MMIO_PMU_CNT8_OFFSET;
+    case RegId::PMU_CNT9:
+        return REG_MMIO_PMU_CNT9_OFFSET;
+    case RegId::PMU_CNT_TOTAL0:
+        return REG_MMIO_PMU_CNT_TOTAL0_OFFSET;
+    case RegId::PMU_CNT_TOTAL1:
+        return REG_MMIO_PMU_CNT_TOTAL1_OFFSET;
+    case RegId::PMU_START_CYC0:
+        return REG_MMIO_PMU_START_CYC0_OFFSET;
+    case RegId::PMU_START_CYC1:
+        return REG_MMIO_PMU_START_CYC1_OFFSET;
+    case RegId::PMU_STOP_CYC0:
+        return REG_MMIO_PMU_STOP_CYC0_OFFSET;
+    case RegId::PMU_STOP_CYC1:
+        return REG_MMIO_PMU_STOP_CYC1_OFFSET;
+    case RegId::PMU_CNT0_IDX:
+        return REG_MMIO_PMU_CNT0_IDX_OFFSET;
+    case RegId::PMU_CNT1_IDX:
+        return REG_MMIO_PMU_CNT1_IDX_OFFSET;
+    case RegId::PMU_CNT2_IDX:
+        return REG_MMIO_PMU_CNT2_IDX_OFFSET;
+    case RegId::PMU_CNT3_IDX:
+        return REG_MMIO_PMU_CNT3_IDX_OFFSET;
+    case RegId::PMU_CNT4_IDX:
+        return REG_MMIO_PMU_CNT4_IDX_OFFSET;
+    case RegId::PMU_CNT5_IDX:
+        return REG_MMIO_PMU_CNT5_IDX_OFFSET;
+    case RegId::PMU_CNT6_IDX:
+        return REG_MMIO_PMU_CNT6_IDX_OFFSET;
+    case RegId::PMU_CNT7_IDX:
+        return REG_MMIO_PMU_CNT7_IDX_OFFSET;
+    case RegId::PMU_CNT8_IDX:
+        return REG_MMIO_PMU_CNT8_IDX_OFFSET;
+    case RegId::PMU_CNT9_IDX:
+        return REG_MMIO_PMU_CNT9_IDX_OFFSET;
     }
     return 0;  // unreachable: all RegId cases handled above
 }
+
+/**
+ * Index into a contiguous RegId run (e.g. reg_index(PMU_CNT0, 3) == PMU_CNT3).
+ * Caller is responsible for keeping `i` within the run's length.
+ */
+constexpr RegId reg_index(RegId base, int i) { return static_cast<RegId>(static_cast<uint8_t>(base) + i); }
 
 // =============================================================================
 // Simulated Register Sparse Mapping Configuration
 // =============================================================================
 
 /**
- * DAV_3510 register layout is sparse with two non-contiguous pages:
- * - Page 0: 0x0000-0x0FFF (DATA_MAIN_BASE at 0xD0)
- * - Page 1: 0x5000-0x5FFF (COND at 0x5108)
+ * DAV_3510 register layout is sparse with three non-contiguous regions:
+ * - Page 0: 0x0000-0x0FFF  (AICore SPR low: CTRL at 0x0, DATA_MAIN_BASE at 0xD0)
+ * - Page 2: 0x2400-0x43FF  (PMU MMIO: CNT*_IDX 0x2500-0x2524, CTRL_1 0x2400,
+ *                            CTRL_0 0x4200, CNT0-9 0x4210-0x4254, TOTAL 0x4260-64,
+ *                            START/STOP_CYC 0x42A0-0x42AC)
+ * - Page 1: 0x5000-0x5FFF  (AICore SPR high: COND at 0x5108)
  *
- * To save memory, we allocate two separate 4KB pages per core instead of
- * a single 24KB block (which would waste 16KB in the gap 0x1000-0x4FFF).
+ * To save memory, we allocate three separate pages per core instead of
+ * a single 24KB block.
  */
 constexpr uint32_t SIM_REG_PAGE0_SIZE = 0x1000;  // 4KB for page 0x0000-0x0FFF
+constexpr uint32_t SIM_REG_PAGE2_SIZE = 0x2000;  // 8KB for PMU page 0x2400-0x43FF
 constexpr uint32_t SIM_REG_PAGE1_SIZE = 0x1000;  // 4KB for page 0x5000-0x5FFF
-constexpr uint32_t SIM_REG_PAGE1_BASE = 0x5000;  // Base address of page 1
+constexpr uint32_t SIM_REG_PAGE2_BASE = 0x2400;  // Base address of PMU page
+constexpr uint32_t SIM_REG_PAGE1_BASE = 0x5000;  // Base address of SPR high page
 
-// Total size per core (two 4KB pages = 8KB, saves 16KB vs. contiguous mapping)
-constexpr uint32_t SIM_REG_TOTAL_SIZE = SIM_REG_PAGE0_SIZE + SIM_REG_PAGE1_SIZE;
+// Total size per core (three pages = 16KB)
+constexpr uint32_t SIM_REG_TOTAL_SIZE = SIM_REG_PAGE0_SIZE + SIM_REG_PAGE2_SIZE + SIM_REG_PAGE1_SIZE;
 
 /**
  * Calculate actual memory pointer for a hardware register offset in sparse layout
@@ -231,16 +413,19 @@ constexpr uint32_t SIM_REG_TOTAL_SIZE = SIM_REG_PAGE0_SIZE + SIM_REG_PAGE1_SIZE;
  * Callers are responsible for casting to/from uint8_t*.
  *
  * @param reg_base  Base address of the sparse register block (page 0 start)
- * @param offset    Hardware register offset (e.g., 0xD0, 0x5108)
+ * @param offset    Hardware register offset (e.g., 0xD0, 0x2500, 0x4210, 0x5108)
  * @return Pointer to the actual memory location (as uint8_t*)
  */
 inline volatile uint8_t *sparse_reg_ptr(volatile uint8_t *reg_base, uint32_t offset) {
-    if (offset < SIM_REG_PAGE1_BASE) {
+    if (offset < SIM_REG_PAGE2_BASE) {
         // Register in page 0 (0x0000-0x0FFF)
         return reg_base + offset;
+    } else if (offset < SIM_REG_PAGE1_BASE) {
+        // Register in page 2 (PMU, 0x2400-0x43FF)
+        return reg_base + SIM_REG_PAGE0_SIZE + (offset - SIM_REG_PAGE2_BASE);
     } else {
         // Register in page 1 (0x5000-0x5FFF)
-        return reg_base + SIM_REG_PAGE0_SIZE + (offset - SIM_REG_PAGE1_BASE);
+        return reg_base + SIM_REG_PAGE0_SIZE + SIM_REG_PAGE2_SIZE + (offset - SIM_REG_PAGE1_BASE);
     }
 }
 

--- a/src/a5/platform/include/common/pmu_profiling.h
+++ b/src/a5/platform/include/common/pmu_profiling.h
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_profiling.h
+ * @brief DAV_3510 (a5) AICore Performance Monitoring Unit configuration
+ *
+ * PMU event ID tables (values from pypto's aicore_prof.h DAV_3510 config,
+ * CANN Open Software License 2.0). Register offsets live in platform_config.h
+ * and are accessed via RegId / reg_index().
+ *
+ * a5 has no shared-memory transport (halHostRegister is not supported on
+ * DAV_3510). The PMU buffer is a single per-core PmuBuffer allocated on
+ * device at init time, written to by AICPU during task execution, and
+ * drained to the host via rtMemcpy after stream sync. This mirrors the
+ * memcpy pattern already used by PerformanceCollector and TensorDumpCollector.
+ */
+
+#ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_
+#define SRC_A5_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_
+
+#include <cstdint>
+#include <cstddef>
+
+#include "common/core_type.h"
+#include "common/platform_config.h"
+
+/**
+ * PMU event type selector. Values match pypto's PROF_PMU_EVENT_TYPE (see
+ * pmu_common.cpp::SetPmuEventTypeDAV3510 for the per-counter event IDs
+ * used on DAV_3510).
+ */
+enum class PmuEventType : uint32_t {
+    ARITHMETIC_UTILIZATION = 1,
+    PIPE_UTILIZATION = 2,  // default
+    MEMORY = 4,
+    MEMORY_L0 = 5,
+    RESOURCE_CONFLICT = 6,
+    MEMORY_UB = 7,
+    L2_CACHE = 8,
+};
+
+constexpr uint32_t PMU_EVENT_TYPE_DEFAULT = static_cast<uint32_t>(PmuEventType::PIPE_UTILIZATION);
+
+/**
+ * Event ID table for a single event type.
+ * event_ids[i] programs PMU_CNTi_IDX; counters[i] in the PmuRecord is the
+ * value of PMU_CNTi after the task completes.
+ * counter_names[i] is the human-readable CSV column name for counter i.
+ * Empty string ("") marks an unused slot.
+ *
+ * Names match pypto's tilefwk_pmu_to_csv.py table_pmu_header_3510 tables.
+ * a5 has 10 counter slots; unused slots are "" / 0.
+ */
+struct PmuEventConfig {
+    uint32_t event_ids[PMU_COUNTER_COUNT_A5];
+    const char *counter_names[PMU_COUNTER_COUNT_A5];
+};
+
+// DAV_3510 event tables. Event IDs come from pypto's
+// pmu_common.cpp::SetPmuEventTypeDAV3510; counter names come from pypto's
+// tilefwk_pmu_to_csv.py table_pmu_header_3510. Empty string "" marks an
+// unused counter slot.
+constexpr PmuEventConfig PMU_EVENTS_A5_ARITHMETIC = {
+    {0x323, 0x324, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+    {"cube_fp_instr_busy", "cube_int_instr_busy", "", "", "", "", "", "", "", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A5_PIPE_UTIL = {
+    {0x501, 0x301, 0x1, 0x701, 0x202, 0x203, 0x34, 0x35, 0x714, 0x0},
+    {"pmu_idc_aic_vec_busy_o", "cube_instr_busy", "scalar_instr_busy", "mte1_instr_busy", "mte2_instr_busy",
+     "mte3_instr_busy", "icache_req", "icache_miss", "pmu_fix_instr_busy", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A5_MEMORY = {
+    {0x0, 0x0, 0x400, 0x401, 0x56f, 0x571, 0x570, 0x572, 0x707, 0x709},
+    {"", "", "bif_sc_pmu_read_main_instr_core", "bif_sc_pmu_write_main_instr_core", "pmu_aiv_ext_rd_ub_instr",
+     "ub_pmu_vec_rd_ub_acc", "pmu_aiv_ext_wr_ub_instr", "ub_pmu_vec_wr_ub_acc", "pmu_rd_l1_instr", "pmu_wr_l1_instr"},
+};
+constexpr PmuEventConfig PMU_EVENTS_A5_MEMORY_L0 = {
+    {0x304, 0x703, 0x306, 0x705, 0x712, 0x30a, 0x308, 0x0, 0x0, 0x0},
+    {"cube_sc_pmu_read_l0a_instr", "pmu_wr_l0a_instr", "cube_sc_pmu_read_l0b_instr", "pmu_wr_l0b_instr",
+     "fixp_rd_l0c_instr", "cube_sc_pmu_read_l0c_instr", "cube_sc_pmu_write_l0c_instr", "", "", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A5_RESOURCE_CONFLICT = {
+    {0x3556, 0x3540, 0x3502, 0x3528, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+    {"stu_pmu_wctl_ub_cflt", "ldu_pmu_ib_ub_cflt", "pmu_idc_aic_vec_instr_vf_busy_o", "idu_pmu_ins_iss_cnt", "", "", "",
+     "", "", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A5_MEMORY_UB = {
+    {0x3, 0x5, 0x70c, 0x206, 0x204, 0x571, 0x572, 0x0, 0x0, 0x0},
+    {"pmu_rd_acc_ub_instr_p", "pmu_wr_acc_ub_instr_p", "pmu_fix_wr_ub_instr", "mte_sc_pmu_write_acc_ub_instr_0",
+     "mte_sc_pmu_read_acc_ub_instr_0", "ub_pmu_vec_rd_ub_acc", "ub_pmu_vec_wr_ub_acc", "", "", ""},
+};
+constexpr PmuEventConfig PMU_EVENTS_A5_L2_CACHE = {
+    {0x424, 0x425, 0x426, 0x42a, 0x42b, 0x42c, 0x0, 0x0, 0x0, 0x0},
+    {"bif_sc_pmu_ar_close_l2_hit_core", "bif_sc_pmu_ar_close_l2_miss_core", "bif_sc_pmu_ar_close_l2_victim_core",
+     "bif_sc_pmu_aw_close_l2_hit_core", "bif_sc_pmu_aw_close_l2_miss_core", "bif_sc_pmu_aw_close_l2_victim_core", "",
+     "", "", ""},
+};
+
+/**
+ * Resolve an event type to the DAV_3510 event table. Returns nullptr for
+ * unknown values (caller falls back to PIPE_UTILIZATION).
+ */
+inline const PmuEventConfig *pmu_resolve_event_config_a5(uint32_t event_type) {
+    switch (static_cast<PmuEventType>(event_type)) {
+    case PmuEventType::ARITHMETIC_UTILIZATION:
+        return &PMU_EVENTS_A5_ARITHMETIC;
+    case PmuEventType::PIPE_UTILIZATION:
+        return &PMU_EVENTS_A5_PIPE_UTIL;
+    case PmuEventType::MEMORY:
+        return &PMU_EVENTS_A5_MEMORY;
+    case PmuEventType::MEMORY_L0:
+        return &PMU_EVENTS_A5_MEMORY_L0;
+    case PmuEventType::RESOURCE_CONFLICT:
+        return &PMU_EVENTS_A5_RESOURCE_CONFLICT;
+    case PmuEventType::MEMORY_UB:
+        return &PMU_EVENTS_A5_MEMORY_UB;
+    case PmuEventType::L2_CACHE:
+        return &PMU_EVENTS_A5_L2_CACHE;
+    }
+    return nullptr;
+}
+
+// =============================================================================
+// PMU Record + Buffer
+// =============================================================================
+
+/**
+ * Per-task PMU snapshot written by AICPU after each AICore task FIN.
+ *
+ * AICore writes task_id / pmu_total_cycles / pmu_counters[] into the
+ * dual-issue staging slot. AICPU fills func_id / core_type on commit —
+ * those are consumer-owned and AICore never touches them.
+ *
+ * Thread ownership is tracked per-core in PmuBufferState::owning_thread_id,
+ * not per-record — it's a buffer-level attribute (same core is always
+ * driven by the same AICPU scheduler thread). Mirrors a2a3's per-queue
+ * thread association.
+ */
+struct PmuRecord {
+    uint64_t task_id;                             // Runtime task id
+    uint32_t func_id;                             // Kernel function identifier (AICPU-owned)
+    CoreType core_type;                           // AIC or AIV (AICPU-owned)
+    uint64_t pmu_total_cycles;                    // PMU_CNT_TOTAL (64-bit combined)
+    uint32_t pmu_counters[PMU_COUNTER_COUNT_A5];  // PMU_CNT0..CNT9
+} __attribute__((aligned(64)));
+
+/**
+ * Fixed-capacity per-core PMU record buffer.
+ *
+ * Layout:
+ *   [0,64)              — header: count + padding (host reads this 64-byte
+ *                         header first to learn how many records to drain)
+ *   [64, 64+2*PmuRecord) — dual_issue_slots: AICore writes a PmuRecord
+ *                         here after each task, indexed by task_id & 1
+ *   [...)                — records: AICPU commits finished PmuRecords here
+ *
+ * The two dual_issue_slots exist because AICore's dual-issue dispatch
+ * can have up to two tasks in flight per core (task N+1 can begin
+ * before AICPU has committed the record for N). Parity `task_id & 1`
+ * picks the slot so N and N+1 never collide — this is exactly the
+ * reason a2a3 perf uses `wip[2]` on PerfBuffer.
+ *
+ * dropped_record_count / total_record_count live on PmuBufferState (mirrors
+ * a2a3) so cross-checking is centralized in a single per-core state region.
+ *
+ * Written by AICore (dual_issue_slots) + AICPU (records/count); drained
+ * to host via rtMemcpy after stream sync.
+ */
+struct PmuBuffer {
+    // Header (first 64 bytes) — host copies this alone first to learn count.
+    volatile uint32_t count;  // Number of valid records
+    uint32_t pad[15];         // Pad header to 64 bytes
+
+    // Dual-issue staging slots — AICore writes a PmuRecord here after
+    // each task, then AICPU copies it into records[count] and fills
+    // func_id / core_type on FIN. Index = task_id & 1.
+    PmuRecord dual_issue_slots[2];
+
+    // Records (flexible-size, up to PLATFORM_PMU_RECORDS_PER_BUFFER)
+    PmuRecord records[PLATFORM_PMU_RECORDS_PER_BUFFER];
+} __attribute__((aligned(64)));
+
+static_assert(
+    offsetof(PmuBuffer, dual_issue_slots) == 64, "PmuBuffer header must be exactly 64 bytes before dual_issue_slots"
+);
+static_assert(
+    offsetof(PmuBuffer, records) == 64 + 2 * sizeof(PmuRecord),
+    "PmuBuffer records must follow header + 2 dual_issue_slots"
+);
+
+/**
+ * Per-core PMU buffer state. Mirrors a2a3 PmuBufferState (minus the
+ * free_queue / current_buf_ptr fields, which a5 doesn't need because it
+ * uses a single pre-allocated PmuBuffer per core).
+ *
+ * Writers (AICPU only):
+ *   owning_thread_id:     AICPU scheduler thread that drives this core.
+ *                         Stamped on first PMU commit and stable thereafter
+ *                         (a5 binds core→thread at scheduler init).
+ *   dropped_record_count: Tasks whose record was dropped on device
+ *                         (PmuBuffer full).
+ *   total_record_count:   Monotonic count of every task the AICPU attempted
+ *                         to record (success + dropped + slot-mismatch).
+ *
+ * Host reads dropped / total at finalize time to cross-check:
+ *   collected_on_host + dropped == total
+ * Any shortfall is silent slot-mismatch loss (AICore hadn't yet published
+ * its dual-issue slot when AICPU tried to commit).
+ */
+struct PmuBufferState {
+    volatile uint32_t owning_thread_id;
+    volatile uint32_t dropped_record_count;
+    volatile uint32_t total_record_count;
+    uint32_t pad[13];
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PmuBufferState) == 64, "PmuBufferState must be 64 bytes");
+
+/**
+ * PMU setup header, allocated once on device and published into
+ * kernel_args.pmu_data_base.
+ *
+ * The on-device shared region layout is:
+ *   [PmuSetupHeader] [PmuBufferState[num_cores]]
+ *
+ * a5 uses one rtMemcpy at finalize to bring all PmuBufferState back to
+ * host (mirrors a2a3's get_pmu_buffer_state offset math).
+ */
+struct PmuSetupHeader {
+    uint32_t num_cores;
+    uint32_t event_type;  // PmuEventType value
+    uint32_t pad[14];     // Pad header to 64 bytes
+    // Device pointers to the per-core PmuBuffer, one entry per core.
+    // AICPU reads buffer_ptrs[core_id] to get its PmuBuffer.
+    uint64_t buffer_ptrs[PLATFORM_MAX_CORES];
+} __attribute__((aligned(64)));
+
+static_assert(offsetof(PmuSetupHeader, buffer_ptrs) == 64, "PmuSetupHeader header must be exactly 64 bytes");
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+constexpr size_t PMU_BUFFER_HEADER_BYTES = 64;
+constexpr size_t PMU_SETUP_HEADER_BYTES = 64;
+
+/**
+ * Total bytes of the [PmuSetupHeader][PmuBufferState[num_cores]] shared region.
+ */
+inline size_t calc_pmu_setup_size(int num_cores) {
+    return sizeof(PmuSetupHeader) + static_cast<size_t>(num_cores) * sizeof(PmuBufferState);
+}
+
+inline PmuSetupHeader *get_pmu_setup_header(void *base_ptr) { return reinterpret_cast<PmuSetupHeader *>(base_ptr); }
+
+inline PmuBufferState *get_pmu_buffer_state(void *base_ptr, int core_id) {
+    return reinterpret_cast<PmuBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PmuSetupHeader)) + core_id;
+}
+
+#endif  // SRC_A5_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_collector.h
+ * @brief Host-side PMU data collector (memcpy-based)
+ *
+ * Design:
+ *   1. Host pre-allocates one PmuBuffer per AICore on device, plus a single
+ *      PmuSetupHeader that stores all buffer device pointers, core count,
+ *      and the selected PMU event type.
+ *   2. During execution, AICPU reads PMU MMIO counters after each task FIN
+ *      and writes one PmuRecord into that core's PmuBuffer (silently
+ *      incrementing PmuBufferState::dropped_record_count when the buffer is full).
+ *   3. After stream sync, host copies the PmuBuffer header (to learn count)
+ *      and then count*sizeof(PmuRecord) actual records back, per core.
+ *   4. Host exports a LuoPan-compatible CSV under outputs/.
+ *
+ * halHostRegister is not supported on DAV_3510, so the collector uses
+ * post-stream-sync memcpy rather than a shared-memory + SPSC-queue +
+ * background-collector-thread streaming model.
+ */
+
+#ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
+#define SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
+
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <string>
+#include <sys/stat.h>
+#include <vector>
+
+#include "common/pmu_profiling.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+
+// ---------------------------------------------------------------------------
+// Memory operation callbacks (injected by DeviceRunner)
+// ---------------------------------------------------------------------------
+
+using PmuAllocCallback = void *(*)(size_t size);
+using PmuFreeCallback = int (*)(void *dev_ptr);
+using PmuCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, size_t size);
+using PmuCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src, size_t size);
+
+// ---------------------------------------------------------------------------
+// PmuCollector
+// ---------------------------------------------------------------------------
+
+class PmuCollector {
+public:
+    PmuCollector() = default;
+    ~PmuCollector();
+
+    PmuCollector(const PmuCollector &) = delete;
+    PmuCollector &operator=(const PmuCollector &) = delete;
+
+    /**
+     * Allocate device-side PMU buffers and publish the setup header pointer.
+     *
+     * @param num_cores        Number of AICore instances to profile
+     * @param event_type       PmuEventType value (stored in header, used by AICPU)
+     * @param kernel_args_pmu_data_base Out: device address of PmuSetupHeader
+     * @param alloc_cb         Device memory alloc
+     * @param free_cb          Device memory free
+     * @param copy_to_dev_cb   Host→device (for publishing header)
+     * @param copy_from_dev_cb Device→host (for collect_all)
+     * @return 0 on success
+     */
+    int initialize(
+        int num_cores, uint32_t event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
+        PmuFreeCallback free_cb, PmuCopyToDeviceCallback copy_to_dev_cb, PmuCopyFromDeviceCallback copy_from_dev_cb
+    );
+
+    /**
+     * Copy all PMU buffers back from device. Fills collected_records_.
+     * Must be called after the execution stream has been fully synchronized.
+     */
+    int collect_all();
+
+    /**
+     * Export collected records to a LuoPan-compatible CSV under output_dir/.
+     */
+    int export_csv(const std::string &output_dir = "outputs");
+
+    /**
+     * Free all device buffers and reset host state.
+     */
+    int finalize();
+
+    bool is_initialized() const { return setup_header_dev_ != nullptr; }
+
+    const std::vector<std::vector<PmuRecord>> &get_records() const { return collected_records_; }
+
+private:
+    void *setup_header_dev_{nullptr};
+    std::vector<void *> core_buffers_dev_;  // PmuBuffer* per core (device)
+
+    int num_cores_{0};
+    uint32_t event_type_{0};
+    size_t pmu_buffer_bytes_{0};
+    size_t setup_region_bytes_{0};
+
+    PmuAllocCallback alloc_cb_{nullptr};
+    PmuFreeCallback free_cb_{nullptr};
+    PmuCopyToDeviceCallback copy_to_dev_cb_{nullptr};
+    PmuCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
+
+    // Host-side collected data (indexed by core id)
+    std::vector<std::vector<PmuRecord>> collected_records_;
+    std::vector<uint32_t> dropped_counts_;
+    std::vector<uint32_t> total_counts_;
+    std::vector<uint32_t> owning_thread_ids_;
+};
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+inline uint32_t resolve_pmu_event_type(int requested_event_type) {
+    uint32_t resolved = PMU_EVENT_TYPE_DEFAULT;
+    if (requested_event_type > 0 &&
+        pmu_resolve_event_config_a5(static_cast<uint32_t>(requested_event_type)) != nullptr) {
+        resolved = static_cast<uint32_t>(requested_event_type);
+    } else if (requested_event_type != 0) {
+        LOG_WARN(
+            "Invalid PMU event type %u, using default (PIPE_UTILIZATION=%u)", requested_event_type,
+            PMU_EVENT_TYPE_DEFAULT
+        );
+    }
+    const char *pmu_env = std::getenv("SIMPLER_PMU_EVENT_TYPE");
+    if (pmu_env == nullptr) {
+        return resolved;
+    }
+    int val = std::atoi(pmu_env);
+    if (val > 0 && pmu_resolve_event_config_a5(static_cast<uint32_t>(val)) != nullptr) {
+        resolved = static_cast<uint32_t>(val);
+        LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", resolved);
+        return resolved;
+    }
+    LOG_WARN("Invalid SIMPLER_PMU_EVENT_TYPE=%s, using default (PIPE_UTILIZATION=%u)", pmu_env, PMU_EVENT_TYPE_DEFAULT);
+    return resolved;
+}
+
+inline std::string make_pmu_csv_path(const std::string &output_dir) {
+    if (mkdir(output_dir.c_str(), 0755) != 0 && errno != EEXIST) {
+        LOG_WARN("Failed to create PMU output directory %s: errno=%d", output_dir.c_str(), errno);
+    }
+    char csv_name[128];
+    auto now = std::chrono::system_clock::now();
+    std::time_t t_now = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count() % 1000;
+    std::tm *tm_info = std::localtime(&t_now);
+    if (tm_info != nullptr) {
+        char base[96];
+        std::strftime(base, sizeof(base), "pmu_%Y%m%d_%H%M%S", tm_info);
+        std::snprintf(csv_name, sizeof(csv_name), "%s_%03ld.csv", base, static_cast<long>(ms));
+    } else {
+        std::snprintf(csv_name, sizeof(csv_name), "pmu_output.csv");
+    }
+    return output_dir + "/" + csv_name;
+}
+
+#endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_

--- a/src/a5/platform/onboard/aicore/inner_kernel.h
+++ b/src/a5/platform/onboard/aicore/inner_kernel.h
@@ -57,7 +57,13 @@ __aicore__ inline uint64_t read_reg(RegId reg) {
         __asm__ volatile("MOV %0, DATA_MAIN_BASE\n" : "=l"(val));
         return static_cast<uint64_t>(val);
     }
+    case RegId::CTRL:
+        return static_cast<uint64_t>(get_ctrl());
     case RegId::COND:
+    default:
+        // PMU MMIO regs are read via ld_dev(base, offset) — see
+        // pmu_collector_aicore.h. This single-arg SPR form only covers
+        // DATA_MAIN_BASE / CTRL / COND.
         return 0;
     }
 }
@@ -73,7 +79,13 @@ __aicore__ inline void write_reg(RegId reg, uint64_t value) {
     case RegId::COND:
         set_cond(static_cast<uint32_t>(value));
         break;
-    case RegId::DATA_MAIN_BASE:
+    case RegId::CTRL:
+        set_ctrl(value);
+        break;
+    default:
+        // DATA_MAIN_BASE is write-only from AICPU; PMU MMIO regs are
+        // written only by AICPU (init/finalize path). AICore does not
+        // need a write path here.
         break;
     }
 }

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -16,6 +16,7 @@
 #include "aicpu/device_log.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/platform_aicpu_affinity.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "runtime.h"
 
@@ -85,6 +86,8 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
     set_enable_dump_tensor(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_platform_pmu_base(k_args->pmu_data_base);
+    set_enable_pmu(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
     if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/l2_perf_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/tensor_dump_collector.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -290,8 +290,10 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
 ) {
+    bool pmu_enabled = enable_pmu > 0;
+    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
@@ -364,6 +366,9 @@ int DeviceRunner::run(
     if (runtime.enable_l2_swimlane) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     }
+    if (pmu_enabled) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
+    }
 
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
@@ -417,6 +422,15 @@ int DeviceRunner::run(
         rc = init_tensor_dump(runtime, num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
+            return rc;
+        }
+    }
+
+    // Initialize PMU profiling if enabled
+    if (pmu_enabled) {
+        rc = init_pmu(num_aicore, pmu_event_type);
+        if (rc != 0) {
+            LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
         }
     }
@@ -485,6 +499,12 @@ int DeviceRunner::run(
         dump_collector_.export_dump_files();
     }
 
+    // Collect and export PMU data (two-step rtMemcpy per core)
+    if (pmu_enabled && pmu_collector_.is_initialized()) {
+        pmu_collector_.collect_all();
+        pmu_collector_.export_csv();
+    }
+
     // Print handshake results (reads from device memory, must be before free)
     print_handshake_results();
 
@@ -550,6 +570,11 @@ int DeviceRunner::finalize() {
     // Cleanup tensor dump
     if (dump_collector_.is_initialized()) {
         dump_collector_.finalize();
+    }
+
+    // Cleanup PMU profiling
+    if (pmu_collector_.is_initialized()) {
+        pmu_collector_.finalize();
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
@@ -769,4 +794,26 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
 
     kernel_args_.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_setup_device_ptr());
     return 0;
+}
+
+int DeviceRunner::init_pmu(int num_aicore, uint32_t event_type) {
+    auto alloc_cb = [](size_t size) -> void * {
+        void *ptr = nullptr;
+        int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
+        return (rc == 0) ? ptr : nullptr;
+    };
+    auto free_cb = [](void *dev_ptr) -> int {
+        return rtFree(dev_ptr);
+    };
+    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
+        return rtMemcpy(dev_dst, size, host_src, size, RT_MEMCPY_HOST_TO_DEVICE);
+    };
+    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
+        return rtMemcpy(host_dst, size, dev_src, size, RT_MEMCPY_DEVICE_TO_HOST);
+    };
+
+    int rc = pmu_collector_.initialize(
+        num_aicore, event_type, &kernel_args_.args.pmu_data_base, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
+    );
+    return rc;
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -43,6 +43,7 @@
 #include "host/function_cache.h"
 #include "host/memory_allocator.h"
 #include "host/l2_perf_collector.h"
+#include "host/pmu_collector.h"
 #include "host/tensor_dump_collector.h"
 #include "runtime.h"
 
@@ -227,7 +228,8 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
+        int enable_pmu = 0);
 
     /**
      * Print handshake results from device
@@ -375,6 +377,9 @@ private:
     // Tensor dump (independent from profiling)
     TensorDumpCollector dump_collector_;
 
+    // PMU profiling (per-task AICore hardware counters)
+    PmuCollector pmu_collector_;
+
     /**
      * Ensure device is initialized (lazy initialization)
      *
@@ -430,6 +435,18 @@ private:
      * @return 0 on success, error code on failure
      */
     int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
+
+    /**
+     * Initialize PMU profiling device buffers.
+     *
+     * Allocates a PmuSetupHeader and one PmuBuffer per core on device, then
+     * publishes the setup-header pointer into kernel_args.pmu_data_base.
+     *
+     * @param num_aicore   Number of AICore instances to profile
+     * @param event_type   Resolved PmuEventType value
+     * @return 0 on success, error code on failure
+     */
+    int init_pmu(int num_aicore, uint32_t event_type);
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -202,7 +202,9 @@ int run_runtime(
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0);
+        rc = runner->run(
+            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
+        );
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -114,6 +114,24 @@ typedef int mem_dsb_t;
 #define OUT_OF_ORDER_FULL_BARRIER() __sync_synchronize()
 
 // =============================================================================
+// MMIO Load/Store Intrinsics (sim stubs)
+// =============================================================================
+
+// ld_dev — AICore MMIO load intrinsic. CANN provides this on real AICore
+// (cce_aicore_intrinsics.h):
+//   int64_t ld_dev(int32_t *src, int16_t offset)
+// In simulation we route it through sparse_reg_ptr so PMU MMIO reads land
+// on the same per-core sim register block that AICPU uses (the PMU page
+// covers offsets 0x2400-0x43FF in the sparse layout).
+inline int64_t ld_dev(int32_t *src, int16_t offset) {
+    auto *base = reinterpret_cast<volatile uint8_t *>(src);
+    auto *p = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(base, static_cast<uint32_t>(offset)));
+    int64_t val = static_cast<int64_t>(*p);
+    OUT_OF_ORDER_LOAD_BARRIER();
+    return val;
+}
+
+// =============================================================================
 // System Counter Simulation
 // =============================================================================
 

--- a/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
@@ -12,10 +12,11 @@
  * @file inner_platform_regs.cpp
  * @brief AICPU register read/write for simulation (a5sim)
  *
- * Simulated registers are two compact 4KB pages per core (8KB total).
- * sparse_reg_ptr() remaps hardware offsets to this layout:
- *   offset < 0x5000  -> page 0: reg_base + offset
- *   offset >= 0x5000 -> page 1: reg_base + 0x1000 + (offset - 0x5000)
+ * Simulated registers are three compact pages per core (16KB total):
+ *   0x0000-0x0FFF -> page 0 (AICore SPR low: CTRL, DATA_MAIN_BASE)
+ *   0x2400-0x43FF -> page 2 (PMU MMIO)
+ *   0x5000-0x5FFF -> page 1 (AICore SPR high: COND)
+ * sparse_reg_ptr() performs the offset remapping.
  */
 
 #include <cstdint>

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -43,6 +43,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/unified_log_host.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/l2_perf_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pmu_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/tensor_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../aicpu/platform_aicpu_affinity.cpp"
     # Shared POSIX-shm sim comm backend (same source as a2a3 sim).

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -159,6 +159,13 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
+        // PMU bindings — tolerated as optional so a5sim keeps building against
+        // pre-PMU AICPU SOs during the transition. Missing symbols mean PMU
+        // is unavailable on this build and set_enable_pmu_func_ stays null.
+        set_platform_pmu_base_func_ =
+            reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_pmu_base"));
+        set_enable_pmu_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_pmu"));
+
         LOG_INFO("DeviceRunner(sim): Loaded aicpu_execute from %s", aicpu_so_path_.c_str());
     }
 
@@ -223,8 +230,10 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
 
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor
+    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num, bool enable_dump_tensor, int enable_pmu
 ) {
+    bool pmu_enabled = enable_pmu > 0;
+    uint32_t pmu_event_type = resolve_pmu_event_type(enable_pmu);
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -291,6 +300,9 @@ int DeviceRunner::run(
     if (runtime.enable_l2_swimlane) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     }
+    if (pmu_enabled) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
+    }
 
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
@@ -337,6 +349,15 @@ int DeviceRunner::run(
         }
     }
 
+    // Initialize PMU profiling if enabled
+    if (pmu_enabled) {
+        rc = init_pmu(num_aicore, pmu_event_type);
+        if (rc != 0) {
+            LOG_ERROR("init_pmu failed: %d", rc);
+            return rc;
+        }
+    }
+
     // Allocate simulated register blocks for all AICore cores
     // Using sparse mapping: 2 x 4KB pages per core instead of 24KB contiguous block
     size_t total_reg_size = num_aicore * SIM_REG_TOTAL_SIZE;
@@ -371,9 +392,7 @@ int DeviceRunner::run(
         }
     });
 
-    LOG_INFO(
-        "Allocated simulated registers: %d cores x 0x%x bytes (sparse: 2x4KB pages)", num_aicore, SIM_REG_TOTAL_SIZE
-    );
+    LOG_INFO("Allocated simulated registers: %d cores x 0x%x bytes (sparse: 3 pages)", num_aicore, SIM_REG_TOTAL_SIZE);
 
     // Check if executors are loaded
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr) {
@@ -385,6 +404,16 @@ int DeviceRunner::run(
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
     set_enable_dump_tensor_func_(enable_dump_tensor);
+
+    // Publish PMU session state to the AICPU SO (dlsym symbols are optional —
+    // older SOs without PMU support leave these nullptr, which simply turns
+    // PMU into a no-op in the AICPU executors).
+    if (set_platform_pmu_base_func_ != nullptr) {
+        set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+    }
+    if (set_enable_pmu_func_ != nullptr) {
+        set_enable_pmu_func_(pmu_enabled);
+    }
 
     // Launch AICPU threads (over-launch for affinity gate)
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
@@ -434,6 +463,12 @@ int DeviceRunner::run(
         dump_collector_.export_dump_files();
     }
 
+    // Collect and export PMU data (sim callbacks are plain memcpy)
+    if (pmu_enabled && pmu_collector_.is_initialized()) {
+        pmu_collector_.collect_all();
+        pmu_collector_.export_csv();
+    }
+
     // Print handshake results at end of run
     print_handshake_results();
 
@@ -468,6 +503,8 @@ void DeviceRunner::unload_executor_binaries() {
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
         set_enable_dump_tensor_func_ = nullptr;
+        set_platform_pmu_base_func_ = nullptr;
+        set_enable_pmu_func_ = nullptr;
     }
     if (!aicpu_so_path_.empty()) {
         std::remove(aicpu_so_path_.c_str());
@@ -499,6 +536,11 @@ int DeviceRunner::finalize() {
     // Cleanup tensor dump
     if (dump_collector_.is_initialized()) {
         dump_collector_.finalize();
+    }
+
+    // Cleanup PMU profiling
+    if (pmu_collector_.is_initialized()) {
+        pmu_collector_.finalize();
     }
 
     // Kernel binaries should have been removed by validate_runtime_impl()
@@ -696,4 +738,27 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
 
     kernel_args_.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_setup_device_ptr());
     return 0;
+}
+
+int DeviceRunner::init_pmu(int num_aicore, uint32_t event_type) {
+    auto alloc_cb = [](size_t size) -> void * {
+        return malloc(size);
+    };
+    auto free_cb = [](void *dev_ptr) -> int {
+        free(dev_ptr);
+        return 0;
+    };
+    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
+        std::memcpy(dev_dst, host_src, size);
+        return 0;
+    };
+    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
+        std::memcpy(host_dst, dev_src, size);
+        return 0;
+    };
+
+    int rc = pmu_collector_.initialize(
+        num_aicore, event_type, &kernel_args_.pmu_data_base, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
+    );
+    return rc;
 }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -48,6 +48,7 @@
 #include "host/function_cache.h"
 #include "host/memory_allocator.h"
 #include "host/l2_perf_collector.h"
+#include "host/pmu_collector.h"
 #include "host/tensor_dump_collector.h"
 #include "runtime.h"
 
@@ -141,7 +142,8 @@ public:
      */
     int
     run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false);
+        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1, bool enable_dump_tensor = false,
+        int enable_pmu = 0);
 
     /**
      * Print handshake results
@@ -222,7 +224,9 @@ private:
     void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
+    void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
     void (*set_enable_dump_tensor_func_)(bool){nullptr};
+    void (*set_enable_pmu_func_)(bool){nullptr};
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
 
@@ -231,6 +235,9 @@ private:
 
     // Tensor dump (independent from profiling)
     TensorDumpCollector dump_collector_;
+
+    // PMU profiling (per-task AICore hardware counters)
+    PmuCollector pmu_collector_;
 
     // Private helper methods
     int ensure_device_initialized(
@@ -257,6 +264,15 @@ private:
      * Initialize tensor dump for simulation.
      */
     int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
+
+    /**
+     * Initialize PMU profiling buffers for simulation.
+     *
+     * Allocates PmuSetupHeader + per-core PmuBuffer on host memory, publishes
+     * the setup-header pointer into kernel_args.pmu_data_base. pmu_reg_addrs
+     * stays 0 on sim (no hardware PMU model).
+     */
+    int init_pmu(int num_aicore, uint32_t event_type);
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -201,7 +201,9 @@ int run_runtime(
         if (aicore_binary != NULL && aicore_size > 0) {
             aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
         }
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0);
+        rc = runner->run(
+            *r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num, enable_dump_tensor != 0, enable_pmu
+        );
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file pmu_collector_aicpu.cpp
+ * @brief AICPU-side PMU init/finalize + record commit from AICore slot (a5)
+ *
+ * AICPU programs PMU event selectors and starts PMU_CTRL_0/1 once at init,
+ * publishes (pmu_buffer_addr, pmu_reg_base) into each Handshake so AICore
+ * can read PMU MMIO itself, and commits slots AICore wrote into
+ * PmuBuffer::dual_issue_slots on each task FIN. At finalize it restores
+ * CTRL to the pre-run state.
+ *
+ * On DAV_3510 the halResMap mapping is a single 3 MB page per AICore that
+ * covers CTRL offsets (0x0, 0x5108) and PMU offsets (0x2400-0x2524,
+ * 0x4200-0x42AC), so the same per-core reg base is used for init/finalize
+ * (here) and for AICore-side MMIO reads.
+ */
+
+#include "aicpu/pmu_collector_aicpu.h"
+
+#include <cstring>
+
+#include "aicpu/platform_regs.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+
+static uint64_t g_platform_pmu_base = 0;
+static bool g_enable_pmu = false;
+
+// Saved CTRL register state per core, indexed by logical core_id.
+// Populated by pmu_aicpu_init(), consumed by pmu_aicpu_finalize().
+static uint32_t g_pmu_saved_ctrl0[PLATFORM_MAX_CORES];
+static uint32_t g_pmu_saved_ctrl1[PLATFORM_MAX_CORES];
+
+// Per-core cached PmuBuffer pointer.
+static PmuBuffer *s_pmu_buffers[PLATFORM_MAX_CORES];
+static PmuSetupHeader *s_pmu_header = nullptr;
+
+// Per-core resolved register base address, keyed by logical core_id.
+// Populated by pmu_aicpu_init() from get_platform_regs() — the same halResMap
+// mapping used for CTRL MMIO also covers PMU MMIO on DAV_3510.
+static uint64_t s_pmu_reg_addrs[PLATFORM_MAX_CORES] = {0};
+
+extern "C" void set_platform_pmu_base(uint64_t pmu_data_base) { g_platform_pmu_base = pmu_data_base; }
+
+extern "C" uint64_t get_platform_pmu_base() { return g_platform_pmu_base; }
+
+extern "C" void set_enable_pmu(bool enable) { g_enable_pmu = enable; }
+
+extern "C" bool get_enable_pmu() { return g_enable_pmu; }
+
+// ---------------------------------------------------------------------------
+// Low-level MMIO helpers (internal use only)
+// ---------------------------------------------------------------------------
+
+static void pmu_program_events(uint64_t reg_base, const PmuEventConfig &events) {
+    for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
+        write_reg(reg_base, reg_index(RegId::PMU_CNT0_IDX, i), events.event_ids[i]);
+    }
+}
+
+static void pmu_start(uint64_t reg_base, uint32_t &saved_ctrl0, uint32_t &saved_ctrl1) {
+    // Clear counters by reading them once
+    for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
+        (void)read_reg(reg_base, reg_index(RegId::PMU_CNT0, i));
+    }
+    (void)read_reg(reg_base, RegId::PMU_CNT_TOTAL0);
+    (void)read_reg(reg_base, RegId::PMU_CNT_TOTAL1);
+
+    // Full cycle counting range: start at 0, stop at 0xFFFFFFFF
+    write_reg(reg_base, RegId::PMU_START_CYC0, 0x0);
+    write_reg(reg_base, RegId::PMU_START_CYC1, 0x0);
+    write_reg(reg_base, RegId::PMU_STOP_CYC0, 0xFFFFFFFF);
+    write_reg(reg_base, RegId::PMU_STOP_CYC1, 0xFFFFFFFF);
+
+    // Save and set CTRL_0 / CTRL_1 (a5 has dual control registers)
+    saved_ctrl0 = static_cast<uint32_t>(read_reg(reg_base, RegId::PMU_CTRL_0));
+    saved_ctrl1 = static_cast<uint32_t>(read_reg(reg_base, RegId::PMU_CTRL_1));
+    write_reg(reg_base, RegId::PMU_CTRL_0, REG_MMIO_PMU_CTRL_0_ENABLE_VAL);
+    write_reg(reg_base, RegId::PMU_CTRL_1, REG_MMIO_PMU_CTRL_1_ENABLE_VAL);
+}
+
+static void pmu_stop(uint64_t reg_base, uint32_t saved_ctrl0, uint32_t saved_ctrl1) {
+    write_reg(reg_base, RegId::PMU_CTRL_0, saved_ctrl0);
+    write_reg(reg_base, RegId::PMU_CTRL_1, saved_ctrl1);
+}
+
+// ---------------------------------------------------------------------------
+// High-level interface
+// ---------------------------------------------------------------------------
+
+void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, int num_cores) {
+    void *pmu_base = reinterpret_cast<void *>(get_platform_pmu_base());
+    if (pmu_base == nullptr) {
+        LOG_ERROR("pmu_aicpu_init: pmu_data_base is NULL");
+        return;
+    }
+    if (handshakes == nullptr) {
+        LOG_ERROR("pmu_aicpu_init: handshakes is NULL");
+        return;
+    }
+    s_pmu_header = reinterpret_cast<PmuSetupHeader *>(pmu_base);
+    uint32_t pmu_event_type = s_pmu_header->event_type;
+
+    // Resolve per-core register base from physical_core_ids. On DAV_3510 the
+    // halResMap(RES_AICORE) mapping covers CTRL + PMU in a single per-core
+    // page, so PMU helpers reuse get_platform_regs().
+    uint64_t *regs_array = reinterpret_cast<uint64_t *>(get_platform_regs());
+    for (int i = 0; i < num_cores; i++) {
+        if (i >= PLATFORM_MAX_CORES) {
+            LOG_ERROR("pmu_aicpu_init: num_cores %d exceeds PLATFORM_MAX_CORES %d", num_cores, PLATFORM_MAX_CORES);
+            break;
+        }
+        s_pmu_reg_addrs[i] = regs_array ? regs_array[physical_core_ids[i]] : 0;
+        s_pmu_buffers[i] = reinterpret_cast<PmuBuffer *>(s_pmu_header->buffer_ptrs[i]);
+        g_pmu_saved_ctrl0[i] = 0;
+        g_pmu_saved_ctrl1[i] = 0;
+    }
+
+    // Program event selectors and start PMU counters on all cores with a valid
+    // PMU reg base.
+    const PmuEventConfig *evt = pmu_resolve_event_config_a5(pmu_event_type);
+    if (evt == nullptr) {
+        evt = &PMU_EVENTS_A5_PIPE_UTIL;
+    }
+    for (int i = 0; i < num_cores; i++) {
+        uint64_t reg_addr = s_pmu_reg_addrs[i];
+        if (reg_addr == 0) {
+            LOG_WARN("pmu_aicpu_init: core %d has no PMU reg_addr, skipping MMIO programming", i);
+            continue;
+        }
+        pmu_program_events(reg_addr, *evt);
+        pmu_start(reg_addr, g_pmu_saved_ctrl0[i], g_pmu_saved_ctrl1[i]);
+    }
+
+    // Publish per-core (pmu_buffer_addr, pmu_reg_base) into the matching
+    // Handshake so AICore can read PMU MMIO and write the dual-issue slot.
+    // Must happen before the caller sets aicpu_regs_ready=1 — AICore spins
+    // on that and reads these fields under the same release/acquire pair.
+    for (int i = 0; i < num_cores; i++) {
+        handshakes[i].pmu_buffer_addr = reinterpret_cast<uint64_t>(s_pmu_buffers[i]);
+        handshakes[i].pmu_reg_base = s_pmu_reg_addrs[i];
+    }
+
+    LOG_INFO("PMU initialized: %d cores, event_type=%u", num_cores, pmu_event_type);
+}
+
+void pmu_aicpu_complete_record(
+    int core_id, int thread_idx, uint32_t reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type
+) {
+    if (s_pmu_header == nullptr || core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
+        return;
+    }
+    PmuBuffer *buf = s_pmu_buffers[core_id];
+    if (buf == nullptr) {
+        return;
+    }
+    PmuBufferState *state = get_pmu_buffer_state(s_pmu_header, core_id);
+
+    // Stamp thread ownership on every commit. a5 binds each core to a fixed
+    // AICPU scheduler thread at init time, so this value is stable — host
+    // reads it at collect time to emit the CSV thread_id column (mirrors
+    // a2a3's per-queue thread association).
+    state->owning_thread_id = static_cast<uint32_t>(thread_idx);
+
+    // Account for every commit attempt so host can detect silent slot loss.
+    state->total_record_count += 1;
+
+    uint32_t idx = buf->count;
+    if (idx >= static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
+        // Buffer full — drop the record. Host surfaces the total at finalize.
+        state->dropped_record_count += 1;
+        return;
+    }
+
+    // Fetch AICore's writes into the dual-issue slot (index = reg_task_id & 1).
+    // Match the slot on the 32-bit register token AICore wrote, not the logical
+    // task_id (which may be a 64-bit PTO2 (ring<<32|local) value).
+    PmuRecord *slot = &buf->dual_issue_slots[reg_task_id & 1u];
+    cache_invalidate_range(slot, sizeof(PmuRecord));
+
+    if (static_cast<uint32_t>(slot->task_id) != reg_task_id) {
+        // AICore hasn't published this slot yet. Should not happen because
+        // AICore writes task_id last + dcci flush before COND FIN, but bail
+        // out defensively rather than committing stale counter values.
+        // Counted in total_record_count above so host sees the gap.
+        return;
+    }
+
+    PmuRecord *rec = &buf->records[idx];
+    rec->task_id = task_id;
+    rec->func_id = func_id;
+    rec->core_type = core_type;
+    rec->pmu_total_cycles = slot->pmu_total_cycles;
+    for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
+        rec->pmu_counters[i] = slot->pmu_counters[i];
+    }
+    buf->count = idx + 1;
+}
+
+void pmu_aicpu_finalize(const int *cur_thread_cores, int core_num) {
+    if (s_pmu_header == nullptr) {
+        return;
+    }
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        if (core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
+            LOG_ERROR("pmu_aicpu_finalize: invalid core_id %d (max %d)", core_id, PLATFORM_MAX_CORES);
+            continue;
+        }
+        uint64_t reg_addr = s_pmu_reg_addrs[core_id];
+        if (reg_addr != 0) {
+            pmu_stop(reg_addr, g_pmu_saved_ctrl0[core_id], g_pmu_saved_ctrl1[core_id]);
+        }
+    }
+}

--- a/src/a5/platform/src/host/pmu_collector.cpp
+++ b/src/a5/platform/src/host/pmu_collector.cpp
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/pmu_collector.h"
+
+#include <cstring>
+#include <fstream>
+
+PmuCollector::~PmuCollector() {
+    if (setup_header_dev_ != nullptr) {
+        // Not called finalize() — best-effort free to avoid leaking device memory
+        // on abnormal exits. Errors swallowed because we are already unwinding.
+        (void)finalize();
+    }
+}
+
+int PmuCollector::initialize(
+    int num_cores, uint32_t event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
+    PmuFreeCallback free_cb, PmuCopyToDeviceCallback copy_to_dev_cb, PmuCopyFromDeviceCallback copy_from_dev_cb
+) {
+    if (num_cores <= 0 || num_cores > PLATFORM_MAX_CORES || kernel_args_pmu_data_base == nullptr ||
+        alloc_cb == nullptr || free_cb == nullptr || copy_to_dev_cb == nullptr || copy_from_dev_cb == nullptr) {
+        LOG_ERROR("PmuCollector::initialize invalid arguments (num_cores=%d)", num_cores);
+        return -1;
+    }
+
+    num_cores_ = num_cores;
+    event_type_ = event_type;
+    alloc_cb_ = alloc_cb;
+    free_cb_ = free_cb;
+    copy_to_dev_cb_ = copy_to_dev_cb;
+    copy_from_dev_cb_ = copy_from_dev_cb;
+    pmu_buffer_bytes_ = sizeof(PmuBuffer);
+    setup_region_bytes_ = calc_pmu_setup_size(num_cores_);
+
+    // Allocate the [PmuSetupHeader][PmuBufferState[num_cores]] shared region
+    // on device, mirroring a2a3's single-allocation layout.
+    setup_header_dev_ = alloc_cb_(setup_region_bytes_);
+    if (setup_header_dev_ == nullptr) {
+        LOG_ERROR("PmuCollector::initialize: failed to alloc PMU setup region (%zu bytes)", setup_region_bytes_);
+        return -1;
+    }
+
+    // Allocate one PmuBuffer per core and remember the device pointers.
+    core_buffers_dev_.assign(num_cores_, nullptr);
+    std::vector<uint8_t> host_setup(setup_region_bytes_, 0);
+    PmuSetupHeader *host_header = get_pmu_setup_header(host_setup.data());
+    host_header->num_cores = static_cast<uint32_t>(num_cores_);
+    host_header->event_type = event_type_;
+    for (int i = 0; i < num_cores_; ++i) {
+        void *buf_dev = alloc_cb_(pmu_buffer_bytes_);
+        if (buf_dev == nullptr) {
+            LOG_ERROR("PmuCollector::initialize: failed to alloc PmuBuffer for core %d", i);
+            finalize();
+            return -1;
+        }
+        core_buffers_dev_[i] = buf_dev;
+        host_header->buffer_ptrs[i] = reinterpret_cast<uint64_t>(buf_dev);
+
+        // Zero the buffer header on device so count starts at 0. Per-core
+        // dropped/total counters live in PmuBufferState (zero-init below).
+        PmuBuffer zero_hdr{};
+        int rc = copy_to_dev_cb_(buf_dev, &zero_hdr, PMU_BUFFER_HEADER_BYTES);
+        if (rc != 0) {
+            LOG_ERROR("PmuCollector::initialize: failed to zero PmuBuffer header for core %d (rc=%d)", i, rc);
+            finalize();
+            return rc;
+        }
+    }
+
+    // Publish the setup region (header + zero-initialized PmuBufferState[]) to device.
+    int rc = copy_to_dev_cb_(setup_header_dev_, host_setup.data(), setup_region_bytes_);
+    if (rc != 0) {
+        LOG_ERROR("PmuCollector::initialize: failed to publish PMU setup region (rc=%d)", rc);
+        finalize();
+        return rc;
+    }
+
+    *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(setup_header_dev_);
+    LOG_INFO(
+        "PMU collector initialized: %d cores, event_type=%u, setup_header=0x%lx", num_cores_, event_type_,
+        static_cast<unsigned long>(*kernel_args_pmu_data_base)
+    );
+    return 0;
+}
+
+int PmuCollector::collect_all() {
+    if (setup_header_dev_ == nullptr) {
+        LOG_ERROR("PmuCollector::collect_all: not initialized");
+        return -1;
+    }
+    collected_records_.assign(num_cores_, {});
+    dropped_counts_.assign(num_cores_, 0);
+    total_counts_.assign(num_cores_, 0);
+    owning_thread_ids_.assign(num_cores_, 0);
+
+    // Pull the full setup region back to read all PmuBufferState[] in one shot.
+    std::vector<uint8_t> host_setup(setup_region_bytes_, 0);
+    int rc = copy_from_dev_cb_(host_setup.data(), setup_header_dev_, setup_region_bytes_);
+    if (rc != 0) {
+        LOG_ERROR("PmuCollector::collect_all: setup region copy failed (rc=%d)", rc);
+        return rc;
+    }
+    for (int i = 0; i < num_cores_; ++i) {
+        PmuBufferState *state = get_pmu_buffer_state(host_setup.data(), i);
+        dropped_counts_[i] = state->dropped_record_count;
+        total_counts_[i] = state->total_record_count;
+        owning_thread_ids_[i] = state->owning_thread_id;
+    }
+
+    PmuBuffer header_buf{};
+    for (int i = 0; i < num_cores_; ++i) {
+        void *buf_dev = core_buffers_dev_[i];
+        if (buf_dev == nullptr) {
+            continue;
+        }
+        // Copy the 64-byte header to learn record count.
+        rc = copy_from_dev_cb_(&header_buf, buf_dev, PMU_BUFFER_HEADER_BYTES);
+        if (rc != 0) {
+            LOG_ERROR("PmuCollector::collect_all: header copy failed for core %d (rc=%d)", i, rc);
+            return rc;
+        }
+        uint32_t count = header_buf.count;
+        if (count > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
+            LOG_WARN(
+                "PmuCollector::collect_all: core %d count=%u clamped to capacity %d", i, count,
+                PLATFORM_PMU_RECORDS_PER_BUFFER
+            );
+            count = PLATFORM_PMU_RECORDS_PER_BUFFER;
+        }
+        if (count == 0) {
+            continue;
+        }
+
+        // Copy just the used portion of the records array.
+        collected_records_[i].resize(count);
+        const uint8_t *records_dev = reinterpret_cast<const uint8_t *>(buf_dev) + offsetof(PmuBuffer, records);
+        rc = copy_from_dev_cb_(
+            collected_records_[i].data(), const_cast<uint8_t *>(records_dev),
+            static_cast<size_t>(count) * sizeof(PmuRecord)
+        );
+        if (rc != 0) {
+            LOG_ERROR("PmuCollector::collect_all: records copy failed for core %d (rc=%d)", i, rc);
+            return rc;
+        }
+    }
+    return 0;
+}
+
+int PmuCollector::export_csv(const std::string &output_dir) {
+    if (setup_header_dev_ == nullptr) {
+        return -1;
+    }
+
+    const PmuEventConfig *cfg = pmu_resolve_event_config_a5(event_type_);
+    if (cfg == nullptr) {
+        cfg = &PMU_EVENTS_A5_PIPE_UTIL;
+    }
+
+    std::string csv_path = make_pmu_csv_path(output_dir);
+    std::ofstream csv(csv_path);
+    if (!csv.is_open()) {
+        LOG_ERROR("PmuCollector::export_csv: failed to open %s", csv_path.c_str());
+        return -1;
+    }
+
+    // Count named columns. Matches pypto's tilefwk_pmu_to_csv.py
+    // table_pmu_header_3510 — each event group lists only the columns that
+    // correspond to a named counter. pypto then trims each row to
+    // len(fixed_header) + len(named) via _trim_task_pmu_list; we do the
+    // equivalent positional trim here (first `named_count` counter values,
+    // pmu_counters[0..named_count-1]).
+    int named_count = 0;
+    for (int i = 0; i < PMU_COUNTER_COUNT_A5; ++i) {
+        if (cfg->counter_names[i] != nullptr && cfg->counter_names[i][0] != '\0') {
+            ++named_count;
+        }
+    }
+
+    // Header: fixed columns + named counter names + event_type column.
+    // Column order matches a2a3 host pmu_collector for downstream tooling parity.
+    csv << "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
+    int emitted = 0;
+    for (int i = 0; i < PMU_COUNTER_COUNT_A5 && emitted < named_count; ++i) {
+        if (cfg->counter_names[i] != nullptr && cfg->counter_names[i][0] != '\0') {
+            csv << "," << cfg->counter_names[i];
+            ++emitted;
+        }
+    }
+    csv << ",event_type\n";
+
+    uint64_t total_rows = 0;
+    uint64_t total_dropped = 0;
+    uint64_t device_total = 0;
+    for (int core_id = 0; core_id < num_cores_; ++core_id) {
+        const auto &records = collected_records_[core_id];
+        uint32_t thread_id = owning_thread_ids_[core_id];
+        for (const auto &rec : records) {
+            csv << thread_id << "," << core_id << ",0x" << std::hex << rec.task_id << std::dec << "," << rec.func_id
+                << "," << static_cast<int>(rec.core_type) << "," << rec.pmu_total_cycles;
+            for (int i = 0; i < named_count; ++i) {
+                csv << "," << rec.pmu_counters[i];
+            }
+            csv << "," << event_type_ << "\n";
+            ++total_rows;
+        }
+        total_dropped += dropped_counts_[core_id];
+        device_total += total_counts_[core_id];
+    }
+    csv.flush();
+    LOG_INFO("PMU CSV written to %s", csv_path.c_str());
+
+    // Cross-check device-side totals against what we wrote to CSV. Mirrors
+    // the a2a3 host collector. Invariant:
+    //   device_total == collected + dropped (buffer-full) + slot-mismatch
+    // collected + dropped should account for every commit attempt; any
+    // remainder is silent slot-mismatch loss (AICore not yet published).
+    if (total_dropped > 0) {
+        LOG_WARN(
+            "PMU collector: %lu records dropped on device side (PmuBuffer full). "
+            "Increase PLATFORM_PMU_RECORDS_PER_BUFFER if this is frequent.",
+            static_cast<unsigned long>(total_dropped)
+        );
+    }
+    if (total_rows + total_dropped != device_total) {
+        LOG_WARN(
+            "PMU collector: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu, "
+            "diff=%ld silent slot-mismatch losses)",
+            static_cast<unsigned long>(total_rows), static_cast<unsigned long>(total_dropped),
+            static_cast<unsigned long>(device_total),
+            static_cast<long>(device_total) - static_cast<long>(total_rows + total_dropped)
+        );
+    } else {
+        LOG_INFO(
+            "PMU collector: record counts match (collected=%lu, dropped=%lu, device_total=%lu)",
+            static_cast<unsigned long>(total_rows), static_cast<unsigned long>(total_dropped),
+            static_cast<unsigned long>(device_total)
+        );
+    }
+    return 0;
+}
+
+int PmuCollector::finalize() {
+    int rc = 0;
+    for (void *&buf : core_buffers_dev_) {
+        if (buf != nullptr) {
+            int r = free_cb_ ? free_cb_(buf) : 0;
+            if (r != 0 && rc == 0) {
+                rc = r;
+            }
+            buf = nullptr;
+        }
+    }
+    core_buffers_dev_.clear();
+
+    if (setup_header_dev_ != nullptr && free_cb_ != nullptr) {
+        int r = free_cb_(setup_header_dev_);
+        if (r != 0 && rc == 0) {
+            rc = r;
+        }
+    }
+    setup_header_dev_ = nullptr;
+
+    num_cores_ = 0;
+    event_type_ = 0;
+    pmu_buffer_bytes_ = 0;
+    setup_region_bytes_ = 0;
+    collected_records_.clear();
+    dropped_counts_.clear();
+    total_counts_.clear();
+    owning_thread_ids_.clear();
+    alloc_cb_ = nullptr;
+    free_cb_ = nullptr;
+    copy_to_dev_cb_ = nullptr;
+    copy_from_dev_cb_ = nullptr;
+    return rc;
+}

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -11,8 +11,10 @@
 
 #include "aicore/aicore.h"
 #include "aicore/l2_perf_collector_aicore.h"
+#include "aicore/pmu_collector_aicore.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"  // Platform configuration (C/C++ compatible)
+#include "common/pmu_profiling.h"
 #include "runtime.h"
 
 typedef void (*KernelFunc)(__gm__ int64_t *);
@@ -54,6 +56,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     bool l2_perf_enabled = runtime->enable_l2_swimlane;
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 
     volatile uint32_t task_id = AICPU_IDLE_TASK_ID;
     volatile uint32_t last_task_id = AICPU_IDLE_TASK_ID;
@@ -78,7 +81,20 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             __gm__ Task *task_ptr = &(runtime->tasks[actual_task_id]);
             uint64_t start_time = get_sys_cnt_aicore();
 
+            if (pmu_enabled) {
+                pmu_aicore_begin();
+            }
+
             execute_task(task_ptr);
+
+            if (pmu_enabled) {
+                pmu_aicore_end();
+                // Read pmu_buffer_addr / pmu_reg_base per-task (mirrors how
+                // perf_records_addr is read below): by the time AICPU dispatches
+                // a real task_id, pmu_aicpu_init has already published these.
+                __gm__ PmuBuffer *pmu_buf = reinterpret_cast<__gm__ PmuBuffer *>(my_hank->pmu_buffer_addr);
+                pmu_aicore_record_task(pmu_buf, my_hank->pmu_reg_base, actual_task_id);
+            }
 
             if (dump_tensor_enabled) {
                 pipe_barrier(PIPE_ALL);

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -17,6 +17,7 @@
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_perf_collector_aicpu.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "callable.h"
@@ -63,6 +64,13 @@ struct AicpuExecutor {
 
     // Fast lookup: core_id -> reg_addr
     uint64_t core_id_to_reg_addr_[MAX_CORES_PER_THREAD];
+
+#if PTO2_PROFILING
+    // Physical core ids keyed by logical worker id. Populated by discover_cores()
+    // and handed to pmu_aicpu_init() so the platform can resolve per-core PMU
+    // MMIO bases from the host-supplied pmu_reg_addrs table.
+    uint32_t physical_core_ids_[MAX_CORES_PER_THREAD]{};
+#endif
 
     // Platform register base address array (set via get_platform_regs())
     uint64_t regs_{0};
@@ -335,6 +343,10 @@ int AicpuExecutor::init(Runtime *runtime) {
     if (get_enable_dump_tensor()) {
         dump_tensor_init(thread_num_);
     }
+    if (get_enable_pmu()) {
+        pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
+        LOG_INFO("PMU profiling started on %d cores", cores_total_num_);
+    }
 #endif
 
     init_done_.store(true, std::memory_order_release);
@@ -437,6 +449,9 @@ int AicpuExecutor::handshake_all_cores(Runtime *runtime) {
         }
 
         core_id_to_reg_addr_[i] = reg_addr;
+#if PTO2_PROFILING
+        physical_core_ids_[i] = physical_core_id;
+#endif
 
         LOG_INFO(
             "  Core %d: type=%s, physical_id=%u, reg_addr=0x%lx", i, core_type_to_string(type), physical_core_id,
@@ -772,6 +787,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
 
+#if PTO2_PROFILING
+                    if (get_enable_pmu()) {
+                        pmu_aicpu_complete_record(
+                            core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
+                            static_cast<uint64_t>(prev_running_id), prev_running_task->func_id, h->core_type
+                        );
+                    }
+#endif
+
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
@@ -780,6 +804,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
                     cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
+
+#if PTO2_PROFILING
+                if (get_enable_pmu()) {
+                    pmu_aicpu_complete_record(
+                        core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
+                        static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
+                    );
+                }
+#endif
 
                 made_progress = true;
 
@@ -835,6 +868,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         prev_running_task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
                         cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
+
+#if PTO2_PROFILING
+                    if (get_enable_pmu()) {
+                        pmu_aicpu_complete_record(
+                            core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
+                            static_cast<uint64_t>(prev_running_id), prev_running_task->func_id, h->core_type
+                        );
+                    }
+#endif
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
@@ -895,6 +937,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
                     cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
+
+#if PTO2_PROFILING
+                if (get_enable_pmu()) {
+                    pmu_aicpu_complete_record(
+                        core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
+                        static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
+                    );
+                }
+#endif
 
                 made_progress = true;
 
@@ -1052,6 +1103,13 @@ int AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO("Thread %d: Runtime has %d tasks", thread_idx, runtime->get_task_count());
     int completed = resolve_and_dispatch(*runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     LOG_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+
+#if PTO2_PROFILING
+    // Restore PMU CTRL registers for this thread's cores before AICore shutdown
+    if (get_enable_pmu()) {
+        pmu_aicpu_finalize(cur_thread_cores, thread_cores_num_[thread_idx]);
+    }
+#endif
 
     int rc = shutdown_aicore(runtime, thread_idx, cur_thread_cores);
     if (rc != 0) {

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -105,7 +105,7 @@
  * is the umbrella, each bit is a parallel diagnostics sub-feature):
  * - bit0: tensor dump enabled
  * - bit1: L2 swimlane enabled
- * - bit2: PMU enabled (reserved on a5; a2a3 wires through device_runner)
+ * - bit2: PMU enabled
  *
  * Field Access Patterns:
  * - aicpu_ready: Written by AICPU, read by AICore
@@ -118,6 +118,8 @@
  * - l2_perf_buffer_status: Written by both (AICPU=1 on buffer full, AICore=0 on buffer empty)
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
+ * - pmu_buffer_addr: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
+ * - pmu_reg_base: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
  */
 struct Handshake {
     volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
@@ -132,7 +134,9 @@ struct Handshake {
     volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
     volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
-        enable_profiling_flag;  // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+        enable_profiling_flag;          // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+    volatile uint64_t pmu_buffer_addr;  // Per-core PmuBuffer device address (for AICore-side PMU record)
+    volatile uint64_t pmu_reg_base;     // Per-core PMU MMIO base (for AICore-side PMU register reads)
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -11,8 +11,10 @@
 
 #include "aicore/aicore.h"
 #include "aicore/l2_perf_collector_aicore.h"
+#include "aicore/pmu_collector_aicore.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"  // Register-based communication
+#include "common/pmu_profiling.h"
 #include "pto2_dispatch_payload.h"
 #include "runtime.h"
 
@@ -90,6 +92,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     bool l2_perf_enabled = runtime->enable_l2_swimlane;
     bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
     // Register encoding: AICPU_IDLE_TASK_ID=idle, task_id=task, AICORE_EXIT_SIGNAL=exit
@@ -124,8 +127,21 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // Performance profiling: record start time
             uint64_t start_time = get_sys_cnt_aicore();
 
+            if (pmu_enabled) {
+                pmu_aicore_begin();
+            }
+
             // Execute the task
             execute_task(exec_payload);
+
+            if (pmu_enabled) {
+                pmu_aicore_end();
+                // Read pmu_buffer_addr / pmu_reg_base per-task (mirrors how
+                // perf_records_addr is read below): by the time AICPU dispatches
+                // a real task_id, pmu_aicpu_init has already published these.
+                __gm__ PmuBuffer *pmu_buf = reinterpret_cast<__gm__ PmuBuffer *>(my_hank->pmu_buffer_addr);
+                pmu_aicore_record_task(pmu_buf, my_hank->pmu_reg_base, task_id);
+            }
 
             if (dump_tensor_enabled) {
                 pipe_barrier(PIPE_ALL);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -97,6 +97,8 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
+ * - pmu_buffer_addr: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
+ * - pmu_reg_base: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
  */
 struct Handshake {
     volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
@@ -111,7 +113,9 @@ struct Handshake {
     volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
     volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
-        enable_profiling_flag;  // Generic profiling-related flags; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+        enable_profiling_flag;          // Generic profiling-related flags; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+    volatile uint64_t pmu_buffer_addr;  // Per-core PmuBuffer device address (for AICore-side PMU record)
+    volatile uint64_t pmu_reg_base;     // Per-core PMU MMIO base (for AICore-side PMU register reads)
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -16,6 +16,7 @@
 #include "aicpu/device_time.h"
 #include "aicpu/l2_perf_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "common/memory_barrier.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
@@ -349,6 +350,13 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
     int32_t core_num = core_trackers_[thread_idx].core_num();
     if (core_num == 0) return 0;
 
+#if PTO2_PROFILING
+    // Restore PMU CTRL registers for this thread's cores before AICore shutdown
+    if (get_enable_pmu()) {
+        pmu_aicpu_finalize(cores, core_num);
+    }
+#endif
+
     DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cores[i];
@@ -427,6 +435,10 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
         CoreType type = hank->core_type;
 
         core_exec_states_[i].reg_addr = reg_addr;
+
+#if PTO2_PROFILING
+        physical_core_ids_[i] = physical_core_id;
+#endif
 
 #if !PTO2_PROFILING
         core_exec_states_[i].worker_id = i;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -20,6 +20,7 @@
 
 // Performance profiling headers
 #include "aicpu/l2_perf_collector_aicpu.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 
 // =============================================================================
@@ -151,6 +152,20 @@ void SchedulerContext::complete_slot_task(
 #if PTO2_SCHED_PROFILING
         l2_perf.sched_complete_perf_cycle += (get_sys_cnt_aicpu() - t_perf_start);
 #endif
+    }
+#endif
+
+#if PTO2_PROFILING
+    if (get_enable_pmu()) {
+        // Slot key must be the 32-bit register token AICore wrote into
+        // dual_issue_slots[task_id & 1].task_id (= DATA_MAIN_BASE value).
+        // task_id.raw is the full PTO2 (ring_id<<32|local_id) encoding —
+        // matching on that would never hit. Pass the PTO2 id separately
+        // for the PmuRecord.
+        pmu_aicpu_complete_record(
+            core_id, thread_idx, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+            slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
+        );
     }
 #endif
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -153,6 +153,15 @@ private:
     int32_t aic_count_{0};
     int32_t aiv_count_{0};
 
+#if PTO2_PROFILING
+    // Physical core ids keyed by logical worker id. Populated by
+    // handshake_all_cores() and handed to pmu_aicpu_init() so the platform
+    // can resolve per-core PMU MMIO bases. Only needed when PTO2_PROFILING=1
+    // — without it, PMU is compiled out and core_exec_states_ already
+    // carries the field.
+    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER]{};
+#endif
+
     // Platform AICore-register base array (set by AicpuExecutor before init()).
     uint64_t regs_{0};
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -23,6 +23,7 @@
 
 // Performance profiling headers
 #include "aicpu/l2_perf_collector_aicpu.h"
+#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 
 // =============================================================================
@@ -328,6 +329,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
         if (get_enable_dump_tensor()) {
             dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
+        }
+        if (get_enable_pmu()) {
+            pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
+            DEV_INFO("PMU profiling started on %d cores", cores_total_num_);
         }
 #endif
 


### PR DESCRIPTION
## Summary

- Add a5 (DAV_3510) host/AICPU/AICore PMU collection flow for onboard and sim builds, exporting LuoPan-compatible CSV files under `outputs/`. Mirrors the a2a3 PMU front-end (already platform-agnostic: `--enable-pmu`, ChipCallConfig, worker mailbox).
- Wire DAV_3510 PMU MMIO into `RegId` / `platform_config.h` (10 counters + dual `PMU_CTRL_0/1`, offsets `0x2400-0x2524` / `0x4200-0x42AC`); extend a5sim's sparse register layout to a third page covering the PMU range.
- Replace a2a3's halHostRegister + SPSC + background-thread streaming model with the **memcpy collector pattern** already used by `PerformanceCollector` / `TensorDumpCollector` (halHostRegister is unsupported on DAV_3510): one `PmuBuffer` per AICore on device, drained via `rtMemcpy` after `rtStreamSynchronize`.
- AICore-side per-task PMU snapshot uses the `ld_dev` MMIO load intrinsic (with sim stub) and writes into `dual_issue_slots[task_id & 1]`; AICPU validates the slot via the 32-bit `DATA_MAIN_BASE` register token (not the PTO2 `(ring_id<<32)|local_id` logical id) and commits into `PmuBuffer::records[]`.
- Per-core register base is shared between CTRL and PMU on DAV_3510 (`halResMap(RES_AICORE)` returns one 3 MB page covering both) — no separate `pmu_reg_addrs` table needed; PMU helpers reuse `get_platform_regs()`.
- Add cross-check at finalize: `PmuBufferState::total_record_count` (AICPU attempted commits) vs `collected + dropped` (host CSV) — silent slot-mismatch loss is reported.
- Instrument both runtimes (`host_build_graph` + `tensormap_and_ringbuffer`); the latter's PMU hooks live in the new `runtime/scheduler/` files post-`SchedulerContext` refactor.
- Add an a5 PMU guide ([src/a5/docs/pmu-profiling.md](src/a5/docs/pmu-profiling.md)) covering design, usage, output schema, and the `PTO2_DISABLE_DUAL_ISSUE` limitation.

## Test plan

- [x] a5sim and a5 (onboard) build clean
- [x] a5sim + \`--enable-pmu 2\` (PIPE_UTILIZATION) on \`bgemm\` (tensormap_and_ringbuffer): 384 records, 0 dropped, device_total matches
- [x] a5sim + \`--enable-pmu 2\` on \`paged_attention\` (host_build_graph): 4 records, 0 dropped, device_total matches
- [x] a5sim + \`--enable-pmu 4\` (MEMORY): variable-width CSV header matches pypto \`tilefwk_pmu_to_csv.py\` table_pmu_header_3510
- [x] a5sim regression without \`--enable-pmu\` still PASSES
- [ ] a5 hardware smoke test \`--enable-pmu 2\` — counters non-zero, CSV loads in LuoPan
- [ ] Full a5sim CI: \`./ci.sh -p a5sim -c <commit>\`