### PR TITLE
Refactor: collapse AicpuExecutor into SchedulerContext-owned lifecycle

### DIFF
--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -196,18 +196,30 @@ Applied to all sim compilation paths:
 Additionally, `data_type.h::get_element_size()` uses `constexpr static`
 instead of `static` to avoid generating UNIQUE symbols at the source level.
 
-## AicpuExecutor::deinit()
+## AicpuExecutor::deinit() and SchedulerContext::deinit()
 
 The AICPU SO contains a file-scope static `AicpuExecutor g_aicpu_executor`,
-which in turn holds a `SchedulerContext sched_ctx_` member owning all
-scheduler dispatch state (core trackers, dispatch payloads, drain state).
+which holds a `SchedulerContext sched_ctx_` member owning all scheduler
+state (core trackers, dispatch payloads, drain state, task counters,
+core-transition flags, one-time init coordination, etc.).
+
 When the AICPU SO is dlclosed and re-dlopen'd between tasks, the static is
 reconstructed. But when the AICPU SO is **reused** (same runtime, consecutive
-tasks), `deinit()` must reset all fields. Previously missing resets:
+tasks), `deinit()` must reset all fields. Responsibilities are split so that
+SchedulerContext owns its own teardown:
 
-- `cores_total_num_`, `thread_num_`, `sched_thread_num_`
-- `trackers_` / `sched_ctx_.core_trackers_`, `core_assignments_`, `core_count_per_thread_`
-- `orch_func_`, `orch_args_cached_`, `orch_so_handle_`, `orch_so_path_`
+- `SchedulerContext::deinit()` resets every scheduler-owned field —
+  per-core states, payloads, sync-start drain coordination
+  (`sync_start_pending` / `drain_worker_elected` / `drain_ack_mask` /
+  `pending_task`), task counters, transition flags, worker-id lists,
+  core trackers, `cores_total_num_` / `aic_count_` / `aiv_count_`,
+  `regs_`, `sched_`, `func_id_to_addr_`, and the `pto2_init_*` flags.
+- `AicpuExecutor::deinit()` calls `sched_ctx_.deinit()` first, then resets
+  only its own fields: `thread_num_`, `sched_thread_num_`, `orch_to_sched_`,
+  `orch_func_`, `orch_args_cached_`, `orch_so_handle_`, `orch_so_path_`,
+  `runtime_init_ready_`, and the lifecycle atomics
+  (`initialized_`, `init_done_`, `init_failed_`, `finished_`, `thread_idx_`,
+  `finished_count_`).
 
 Applies to all 5 runtime executors: a2a3 (abg, hbg, tmr), a5 (hbg, tmr).
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -36,9 +36,7 @@
 
 // Performance profiling headers
 #include "aicpu/performance_collector_aicpu.h"
-#include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
-#include "common/memory_barrier.h"
 #include "common/perf_profiling.h"
 #include "common/unified_log.h"
 
@@ -94,8 +92,6 @@ static PTO2Runtime *rt{nullptr};
 
 struct AicpuExecutor {
     int32_t sched_thread_num_;
-    int32_t active_sched_threads_{0};  // Threads currently in dispatch loop (initially sched_thread_num_, becomes
-                                       // thread_num_ after orch→sched transition)
     bool orch_to_sched_{false};
 
     // ===== Thread management state =====
@@ -106,44 +102,11 @@ struct AicpuExecutor {
     std::atomic<bool> finished_{false};
 
     int32_t thread_num_{0};
-    int32_t cores_total_num_{0};
-    int32_t thread_cores_num_{0};  // Cores per scheduler thread (0 for orchestrator when thread_num_==4)
-    int32_t core_count_per_thread_[MAX_AICPU_THREADS];  // Actual core count per thread
-    int32_t core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
-
-    // Cluster-ordered worker_id lists for core assignment (init-only)
-    int32_t aic_worker_ids_[MAX_CORES_PER_THREAD];
-    int32_t aiv_worker_ids_[MAX_CORES_PER_THREAD];
-    int32_t aic_count_{0};
-    int32_t aiv_count_{0};
-
-#if PTO2_PROFILING
-    // Logical core_id -> hardware physical core id, collected during handshake.
-    // Handed to pmu_aicpu_init() so the platform can resolve per-core PMU MMIO
-    // bases. Separate storage is required because CoreExecState's 64-byte
-    // cache-line budget has no room for physical_core_id when PTO2_PROFILING=1.
-    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER];
-#endif
-
-    // Platform register base address array (set via get_platform_regs())
-    uint64_t regs_{0};
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
-    // Task execution tracking
-    std::atomic<int32_t> completed_tasks_{0};
-    int32_t total_tasks_{0};
     std::atomic<int32_t> finished_count_{0};
-    // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
-    // volatile prevents the compiler from hoisting the load out of spin loops.
-    volatile bool orchestrator_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
-
-    // ===== Dynamic core transition state =====
-    std::atomic<bool> transition_requested_{false};
-    std::atomic<int32_t> wait_reassign_{0};
-    std::atomic<bool> reassigned_{false};
-    std::atomic<bool> completed_{false};
 
     // Orchestration SO handle - defer dlclose until all tasks complete
     void *orch_so_handle_{nullptr};
@@ -154,277 +117,18 @@ struct AicpuExecutor {
     DeviceOrchestrationBindRuntimeFunc orch_bind_runtime_{nullptr};
     const ChipStorageTaskArgs *orch_args_cached_{nullptr};
 
-    uint64_t *func_id_to_addr_;
-    uint64_t get_function_bin_addr(int func_id) const {
-        if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
-        return func_id_to_addr_[func_id];
-    }
-
     // ===== Scheduler context (owns all dispatch/completion/drain state) =====
     SchedulerContext sched_ctx_;
 
     // ===== Methods =====
     int32_t init(Runtime *runtime);
-    int32_t handshake_all_cores(Runtime *runtime);
-    bool assign_cores_to_threads();
-    void reassign_cores_for_all_threads();
-    int32_t shutdown_aicore(Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num);
     int32_t run(Runtime *runtime);
     void deinit(Runtime *runtime);
-    void emergency_shutdown(Runtime *runtime);
-    void diagnose_stuck_state(
-        Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
-    );
 };
 
 static AicpuExecutor g_aicpu_executor;
 
-static void emergency_shutdown_callback(Runtime *runtime) { g_aicpu_executor.emergency_shutdown(runtime); }
-
 // ===== AicpuExecutor Method Implementations =====
-
-/**
- * Handshake with all cores and discover their types
- * Sets up register addresses for fast dispatch.
- */
-int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
-    cores_total_num_ = runtime->worker_count;
-
-    // Validate cores_total_num_ before using as array index
-    if (cores_total_num_ == 0 || cores_total_num_ > MAX_CORES_PER_THREAD) {
-        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, MAX_CORES_PER_THREAD);
-        return -1;
-    }
-
-    aic_count_ = 0;
-    aiv_count_ = 0;
-
-    DEV_INFO("Handshaking with %d cores", cores_total_num_);
-
-    // Step 1: Write per-core payload addresses and send handshake signal
-    // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
-    // aicpu_ready=1, so AICore reads the correct payload pointer after waking up.
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        all_handshakes[i].task = reinterpret_cast<uint64_t>(&sched_ctx_.payload_per_core_[i][0]);
-        OUT_OF_ORDER_STORE_BARRIER();
-        all_handshakes[i].aicpu_ready = 1;
-    }
-    OUT_OF_ORDER_STORE_BARRIER();
-
-    // Get platform physical cores count for validation
-    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
-
-    // Step 2: Wait for all cores to respond, collect core type and register addresses
-    bool handshake_failed = false;
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake *hank = &all_handshakes[i];
-
-        while (hank->aicore_regs_ready == 0) {}
-
-        uint32_t physical_core_id = hank->physical_core_id;
-
-        // Validate physical_core_id before using as array index
-        if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR(
-                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
-                max_physical_cores_count
-            );
-            handshake_failed = true;
-            continue;
-        }
-
-        // Get register address using physical_core_id
-        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
-        uint64_t reg_addr = regs[physical_core_id];
-
-        // Initialize AICore registers after discovery (first round)
-        platform_init_aicore_regs(reg_addr);
-        OUT_OF_ORDER_STORE_BARRIER();
-        hank->aicpu_regs_ready = 1;
-
-        OUT_OF_ORDER_STORE_BARRIER();
-
-        while (hank->aicore_done == 0) {}
-
-        CoreType type = hank->core_type;
-
-        sched_ctx_.core_exec_states_[i].reg_addr = reg_addr;
-
-#if PTO2_PROFILING
-        // Record physical_core_id for PMU init later (CoreExecState has no room
-        // for this field under PTO2_PROFILING).
-        physical_core_ids_[i] = physical_core_id;
-#endif
-#if !PTO2_PROFILING
-        sched_ctx_.core_exec_states_[i].worker_id = i;
-        sched_ctx_.core_exec_states_[i].physical_core_id = physical_core_id;
-        sched_ctx_.core_exec_states_[i].core_type = type;
-#endif
-
-        if (type == CoreType::AIC) {
-            aic_worker_ids_[aic_count_++] = i;
-            DEV_INFO("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
-        } else {
-            aiv_worker_ids_[aiv_count_++] = i;
-            DEV_INFO("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
-        }
-    }
-
-    if (handshake_failed) {
-        emergency_shutdown(runtime);
-        return -1;
-    }
-
-    DEV_INFO("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
-    return 0;
-}
-
-/**
- * Assign discovered cores to scheduler threads
- * (Aligned with host_build_graph mechanism)
- */
-bool AicpuExecutor::assign_cores_to_threads() {
-    // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
-    // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
-    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
-    int32_t cluster_count = aic_count_;
-
-    // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
-    int32_t max_clusters_per_thread = (cluster_count + active_sched_threads_ - 1) / active_sched_threads_;
-    thread_cores_num_ = max_clusters_per_thread * 3;
-
-    if (thread_cores_num_ > CoreTracker::MAX_CORE_PER_THREAD) {
-        DEV_ERROR("Can't assign more then 64 cores in per scheduler");
-        return false;
-    }
-
-    DEV_INFO(
-        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
-        active_sched_threads_, aic_count_, aiv_count_
-    );
-
-    for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
-        sched_ctx_.core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
-        sched_ctx_.core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
-    }
-
-    // Count clusters per thread first (round-robin may distribute unevenly)
-    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % active_sched_threads_]++;
-    }
-    for (int32_t i = 0; i < active_sched_threads_; i++) {
-        sched_ctx_.core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
-    }
-
-    // Per-sched-thread running core index used while filling core_assignments_.
-    int32_t core_idx[MAX_AICPU_THREADS] = {};
-    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
-
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % active_sched_threads_;
-        int32_t &idx = core_idx[t];
-
-        int32_t aic_wid = aic_worker_ids_[ci];
-        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
-        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
-
-        sched_ctx_.core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
-
-        core_assignments_[t][idx++] = aic_wid;
-        core_assignments_[t][idx++] = aiv0_wid;
-        core_assignments_[t][idx++] = aiv1_wid;
-
-        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
-    }
-
-    for (int32_t t = 0; t < thread_num_; t++) {
-        core_count_per_thread_[t] = core_idx[t];
-        DEV_INFO(
-            "Thread %d: total %d cores (%d clusters)", t, core_idx[t], sched_ctx_.core_trackers_[t].get_cluster_count()
-        );
-    }
-
-    return true;
-}
-
-/**
- * Reassign all cores evenly across all threads (schedulers + orchestrators).
- * Called by the last orchestrator thread when orchestration completes.
- * Writes into new_core_assignments_ / new_core_count_per_thread_.
- */
-void AicpuExecutor::reassign_cores_for_all_threads() {
-    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
-
-    // Collect running worker_ids from all current trackers
-    bool running_cores[MAX_CORES_PER_THREAD] = {};
-    for (int32_t i = 0; i < thread_num_; i++) {
-        auto all_running = sched_ctx_.core_trackers_[i].get_all_running_cores();
-        int32_t bp;
-        while ((bp = all_running.pop_first()) >= 0) {
-            running_cores[sched_ctx_.core_trackers_[i].get_core_id_by_offset(bp)] = true;
-        }
-    }
-
-    // Count clusters per thread (round-robin across all threads)
-    int32_t cluster_count = aic_count_;
-    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % thread_num_]++;
-    }
-
-    // Re-init all trackers and reset core counts
-    for (int32_t i = 0; i < thread_num_; i++) {
-        sched_ctx_.core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
-    }
-
-    // Assign clusters round-robin and restore running state
-    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % thread_num_;
-
-        int32_t aic_wid = aic_worker_ids_[ci];
-        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
-        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
-
-        int32_t cl_idx = cluster_idx_per_thread[t]++;
-        sched_ctx_.core_trackers_[t].set_cluster(cl_idx, aic_wid, aiv0_wid, aiv1_wid);
-
-        // init() marks all idle; toggle cores that were running and restore pending_occupied
-        if (running_cores[aic_wid]) {
-            sched_ctx_.core_trackers_[t].change_core_state(cl_idx * 3);
-            sched_ctx_.core_trackers_[t].set_pending_occupied(cl_idx * 3);
-        }
-        if (running_cores[aiv0_wid]) {
-            sched_ctx_.core_trackers_[t].change_core_state(cl_idx * 3 + 1);
-            sched_ctx_.core_trackers_[t].set_pending_occupied(cl_idx * 3 + 1);
-        }
-        if (running_cores[aiv1_wid]) {
-            sched_ctx_.core_trackers_[t].change_core_state(cl_idx * 3 + 2);
-            sched_ctx_.core_trackers_[t].set_pending_occupied(cl_idx * 3 + 2);
-        }
-
-        core_assignments_[t][core_count_per_thread_[t]++] = aic_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv0_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv1_wid;
-    }
-
-    // Log final distribution
-    DEV_INFO("Core reassignment complete:");
-    for (int32_t t = 0; t < thread_num_; t++) {
-        int32_t aic_running = sched_ctx_.core_trackers_[t].get_running_count<CoreType::AIC>();
-        int32_t aiv_running = sched_ctx_.core_trackers_[t].get_running_count<CoreType::AIV>();
-        DEV_INFO(
-            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
-            sched_ctx_.core_trackers_[t].get_cluster_count(), aic_running, aiv_running
-        );
-    }
-    active_sched_threads_ = thread_num_;
-    sched_ctx_.active_sched_threads_ = thread_num_;
-}
 
 int32_t AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
@@ -440,8 +144,6 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    func_id_to_addr_ = runtime->func_id_to_addr_;
-
     // Read execution parameters from runtime
     thread_num_ = runtime->sche_cpu_num;
     sched_thread_num_ = thread_num_ - 1;
@@ -454,90 +156,12 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    // Zero all per-core execution state before handshake
-    memset(sched_ctx_.core_exec_states_, 0, sizeof(sched_ctx_.core_exec_states_));
-
-    // Use handshake mechanism to discover cores (aligned with host_build_graph)
-    int32_t rc = handshake_all_cores(runtime);
-    if (rc != 0) {
-        DEV_ERROR("handshake_all_cores failed");
+    if (sched_ctx_.init(runtime, thread_num_, sched_thread_num_, orch_to_sched_, get_platform_regs()) != 0) {
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
 
-    // Dynamically assign cores to threads
-    if (!assign_cores_to_threads()) {
-        return -1;
-    }
-
-    DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num_);
-
-    // Initialize runtime execution state
-    // Task count comes from PTO2 shared memory
-    if (runtime->get_pto2_gm_sm_ptr()) {
-        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
-        int32_t pto2_count = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-        }
-        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
-    } else {
-        total_tasks_ = 0;
-    }
-    completed_tasks_.store(0, std::memory_order_release);
-    // Host orchestration: graph already built, no wait needed. Device orch: Thread 3 will set this.
-    bool orch_on_host = runtime->get_orch_built_on_host();
-    DEV_INFO("Init: orch_built_on_host=%d", orch_on_host ? 1 : 0);
-    orchestrator_done_ = orch_on_host;
-
-    // Initial ready tasks will be populated via scheduler ready queues
-
-    // Clear per-core dispatch payloads
-    memset(sched_ctx_.payload_per_core_, 0, sizeof(sched_ctx_.payload_per_core_));
-
-    // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
-    // This is done once at startup and never modified afterwards.
-    for (int32_t t = 0; t < sched_thread_num_; t++) {
-        CoreTracker &tracker = sched_ctx_.core_trackers_[t];
-        for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
-            auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
-            auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
-            sched_ctx_.payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;
-            sched_ctx_.payload_per_core_[aiv0_id][1].global_context.sub_block_id = 0;
-            sched_ctx_.payload_per_core_[aiv1_id][0].global_context.sub_block_id = 1;
-            sched_ctx_.payload_per_core_[aiv1_id][1].global_context.sub_block_id = 1;
-        }
-    }
-
-    DEV_INFO("Init: PTO2 mode, task count from shared memory");
-
     finished_count_.store(0, std::memory_order_release);
-
-    // Initialize SchedulerContext: wire pointers to shared AicpuExecutor state
-    // Note: sched_ is set later in run() after rt is created (device orch) or below (host orch)
-    if (rt) {
-        sched_ctx_.sched_ = &rt->scheduler;
-    }
-    sched_ctx_.completed_tasks_ptr_ = &completed_tasks_;
-    sched_ctx_.total_tasks_ptr_ = &total_tasks_;
-    sched_ctx_.orchestrator_done_ptr_ = &orchestrator_done_;
-    sched_ctx_.completed_ptr_ = &completed_;
-    sched_ctx_.func_id_to_addr_ = func_id_to_addr_;
-    sched_ctx_.transition_requested_ptr_ = &transition_requested_;
-    sched_ctx_.wait_reassign_ptr_ = &wait_reassign_;
-    sched_ctx_.reassigned_ptr_ = &reassigned_;
-    sched_ctx_.active_sched_threads_ = active_sched_threads_;
-    sched_ctx_.sched_thread_num_ = sched_thread_num_;
-    sched_ctx_.orch_to_sched_ = orch_to_sched_;
-    sched_ctx_.thread_num_ = thread_num_;
-    sched_ctx_.core_count_per_thread_ = core_count_per_thread_;
-    sched_ctx_.core_assignments_ = core_assignments_;
-#if PTO2_PROFILING
-    sched_ctx_.physical_core_ids_ = physical_core_ids_;
-    sched_ctx_.cores_total_num_ = cores_total_num_;
-#endif
-    sched_ctx_.emergency_shutdown_fn_ = emergency_shutdown_callback;
 
     init_done_.store(true, std::memory_order_release);
     DEV_INFO("AicpuExecutor: Init complete");
@@ -547,27 +171,6 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::shutdown_aicore(
-    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num
-) {
-    (void)runtime;
-    if (core_num == 0) return 0;
-
-    DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
-
-    for (int32_t i = 0; i < core_num; i++) {
-        int32_t core_id = cur_thread_cores[i];
-        uint64_t reg_addr = sched_ctx_.core_exec_states_[core_id].reg_addr;
-        if (reg_addr != 0) {
-            platform_deinit_aicore_regs(reg_addr);
-        } else {
-            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
-        }
-    }
-    DEV_INFO("Thread %d: Shutdown complete", thread_idx);
-    return 0;
-}
-
 int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
     DEV_INFO("Thread %d: Start", thread_idx);
@@ -761,8 +364,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
-            rt->orchestrator.total_cluster_count = aic_count_;
-            rt->orchestrator.total_aiv_count = aiv_count_;
+            rt->orchestrator.total_cluster_count = sched_ctx_.aic_count();
+            rt->orchestrator.total_aiv_count = sched_ctx_.aiv_count();
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
             runtime->set_pto2_slot_states_ptr(nullptr);
@@ -773,15 +376,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             orch_so_handle_ = handle;
             snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
 
-            // Wire scheduler context to the newly created PTO2Runtime
-            sched_ctx_.sched_ = &rt->scheduler;
+            // Wire scheduler context to the newly created PTO2Runtime before
+            // releasing scheduler threads from runtime_init_ready_.
+            sched_ctx_.bind_runtime(rt);
 
             runtime_init_ready_.store(true, std::memory_order_release);
 
             // Wait for scheduler's one-time init to complete
-            while (!sched_ctx_.pto2_init_complete_.load(std::memory_order_acquire)) {
-                SPIN_WAIT_HINT();
-            }
+            sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
             if (runtime->enable_profiling) {
@@ -887,92 +489,26 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 #endif
 
-#if PTO2_PROFILING
-            // Write core-to-thread mapping (one-time, after orchestration)
-            if (runtime->enable_profiling) {
-                perf_aicpu_write_core_assignments(
-                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
-                );
-                // Flush orchestrator's phase record buffer
-                perf_aicpu_flush_phase_buffers(thread_idx);
-            }
-#endif
-
-            // Signal completion and trigger core transition
+            // Signal completion to the orchestrator state machine
             pto2_rt_orchestration_done(rt);
 
-            void *sm = runtime->get_pto2_gm_sm_ptr();
-            PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
-            int32_t pto2_task_count = 0;
-            if (sm_header) {
+            // Latch task count from PTO2 shared memory
+            int32_t total_tasks = 0;
+            if (rt->orchestrator.sm_header) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                    pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+                    total_tasks +=
+                        rt->orchestrator.sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }
             }
 #if PTO2_PROFILING
-            pto2_submitted_tasks = pto2_task_count;
-#endif
-            total_tasks_ = pto2_task_count;
-            if (runtime->enable_profiling && pto2_task_count > 0) {
-                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
-            }
-            int32_t inline_completed = static_cast<int32_t>(rt->orchestrator.inline_completed_tasks);
-            if (inline_completed > 0) {
-                completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
-#if PTO2_SCHED_PROFILING
-                rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
-#endif
-            }
-            orchestrator_done_ = true;
-            {
-                int32_t orch_err = 0;
-                void *sm = runtime->get_pto2_gm_sm_ptr();
-                if (sm) {
-                    orch_err =
-                        static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
-                }
-
-                // Fatal error: shutdown AICore immediately before core transition.
-                if (orch_err != PTO2_ERROR_NONE) {
-                    emergency_shutdown(runtime);
-                    completed_.store(true, std::memory_order_release);
-                }
-            }
-
-#if PTO2_ORCH_PROFILING
-            uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
+            pto2_submitted_tasks = total_tasks;
 #endif
 
-            // Skip core transition on fatal error — cores already shut down above
-            if (completed_.load(std::memory_order_acquire)) {
-                // Signal transition to unblock scheduler threads waiting at core transition
-                transition_requested_.store(true, std::memory_order_release);
-                reassigned_.store(true, std::memory_order_release);
-            } else if (orch_to_sched_) {
-                // Compute new core assignments for all threads and initialize donated slots
-                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
-#if PTO2_PROFILING
-                uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
-#endif
-                transition_requested_.store(true, std::memory_order_release);
-#if PTO2_PROFILING
-                DEV_ALWAYS(
-                    "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
-                );
-#endif
-
-                // Wait for scheduler threads to acknowledge transition request
-                while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
-                    if (completed_.load(std::memory_order_acquire)) {
-                        break;
-                    }
-                    SPIN_WAIT_HINT();
-                }
-                if (!completed_.load(std::memory_order_acquire)) {
-                    reassign_cores_for_all_threads();
-                    reassigned_.store(true, std::memory_order_release);
-                }
+            if (runtime->enable_profiling && total_tasks > 0) {
+                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(total_tasks));
             }
+
+            sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
 
 #if PTO2_ORCH_PROFILING
             uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
@@ -991,7 +527,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         if (pto2_submitted_tasks >= 0) {
             DEV_ALWAYS(
                 "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
-                completed_tasks_.load(std::memory_order_acquire)
+                sched_ctx_.completed_tasks_count()
             );
         }
 #endif
@@ -999,37 +535,24 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
-    if (!completed_.load(std::memory_order_acquire) && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
+    if (!sched_ctx_.is_completed() && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
             while (!runtime_init_ready_.load(std::memory_order_acquire)) {
                 SPIN_WAIT_HINT();
             }
         }
-        always_assert(rt != nullptr);
-        sched_ctx_.sched_ = &rt->scheduler;
+        sched_ctx_.bind_runtime(rt);
         int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
         DEV_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
     }
 
-    // Always shutdown AICore — even if completed_ was already true.
+    // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_count_per_thread_ == 0 so they skip the loop harmlessly.
-    {
-        const int32_t *shutdown_cores = core_assignments_[thread_idx];
-        int32_t shutdown_count = core_count_per_thread_[thread_idx];
-        if (shutdown_count > 0) {
-#if PTO2_PROFILING
-            // Restore PMU CTRL registers for this thread's cores before AICore shutdown
-            if (get_enable_pmu()) {
-                pmu_aicpu_finalize(shutdown_cores, shutdown_count);
-            }
-#endif
-            auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
-            if (rc != 0) {
-                return rc;
-            }
-        }
+    auto rc = sched_ctx_.shutdown(thread_idx);
+    if (rc != 0) {
+        return rc;
     }
 
     DEV_INFO("Thread %d: Completed", thread_idx);
@@ -1058,44 +581,16 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
     cache_invalidate_range(runtime, sizeof(Runtime));
 
-    // Reset all per-core execution state
-    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
-        sched_ctx_.core_exec_states_[i] = {};
-        sched_ctx_.core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
-        sched_ctx_.core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
-    }
+    // Reset all SchedulerContext-owned state in one place.
+    sched_ctx_.deinit();
 
-    // Clear per-core dispatch payloads
-    memset(sched_ctx_.payload_per_core_, 0, sizeof(sched_ctx_.payload_per_core_));
-
-    completed_tasks_.store(0, std::memory_order_release);
-    total_tasks_ = 0;
     finished_count_.store(0, std::memory_order_release);
-    orchestrator_done_ = false;
-    sched_ctx_.pto2_init_done_.store(false, std::memory_order_release);
-    sched_ctx_.pto2_init_complete_.store(false, std::memory_order_release);
     runtime_init_ready_.store(false, std::memory_order_release);
 
-    // Reset core transition state
-    transition_requested_.store(false, std::memory_order_release);
-    wait_reassign_.store(0, std::memory_order_release);
-    reassigned_.store(false, std::memory_order_release);
-    completed_.store(false, std::memory_order_release);
-
-    // Reset core discovery and assignment state
-    aic_count_ = 0;
-    aiv_count_ = 0;
-    cores_total_num_ = 0;
     thread_num_ = 0;
     sched_thread_num_ = 0;
-    thread_cores_num_ = 0;
     orch_to_sched_ = false;
-    active_sched_threads_ = 0;
-    memset(sched_ctx_.core_trackers_, 0, sizeof(sched_ctx_.core_trackers_));
-    memset(core_assignments_, 0, sizeof(core_assignments_));
-    memset(core_count_per_thread_, 0, sizeof(core_count_per_thread_));
 
-    regs_ = 0;
     orch_func_ = nullptr;
     orch_bind_runtime_ = nullptr;
     orch_args_cached_ = nullptr;
@@ -1122,95 +617,6 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
-    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake *hank = &all_handshakes[i];
-        OUT_OF_ORDER_STORE_BARRIER();
-        hank->aicpu_regs_ready = 1;
-        if (sched_ctx_.core_exec_states_[i].reg_addr != 0) {
-            platform_deinit_aicore_regs(sched_ctx_.core_exec_states_[i].reg_addr);
-        }
-    }
-
-    DEV_WARN("Emergency shutdown complete");
-}
-
-void AicpuExecutor::diagnose_stuck_state(
-    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
-) {
-    (void)runtime;
-    PTO2SchedulerState *sched = &rt->scheduler;
-    DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
-
-    int32_t completed = completed_tasks_.load(std::memory_order_acquire);
-    int32_t total = total_tasks_;
-    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)", completed, total, total > 0 ? completed * 100.0 / total : 0.0);
-
-    uint64_t aic_ready = 0, aiv_ready = 0, mix_ready = 0;
-    if (rt) {
-        aic_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].size();
-        aiv_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIV)].size();
-        mix_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size();
-    }
-    DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, MIX=%lu", aic_ready, aiv_ready, mix_ready);
-
-    int32_t busy_cores = 0;
-    int32_t idle_cores = 0;
-
-    DEV_ALWAYS("Core Status:");
-    for (int32_t i = 0; i < core_num; i++) {
-        int32_t core_id = cur_thread_cores[i];
-        Handshake *h = &hank[core_id];
-        const char *core_type_str = core_type_to_string(h->core_type);
-
-        uint64_t reg_addr = sched_ctx_.core_exec_states_[core_id].reg_addr;
-        uint64_t reg_val = read_reg(reg_addr, RegId::COND);
-        int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
-        int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
-        int32_t task_id = sched_ctx_.core_exec_states_[core_id].running_reg_task_id;
-
-        if (reg_state != TASK_FIN_STATE || task_id >= 0) {
-            busy_cores++;
-            if (task_id >= 0) {
-                int32_t kernel_id = -1;
-                if (rt && rt->sm_handle && sched_ctx_.core_exec_states_[core_id].running_slot_state) {
-                    int32_t diag_slot = static_cast<int32_t>(sched_ctx_.core_exec_states_[core_id].running_subslot);
-                    kernel_id = sched_ctx_.core_exec_states_[core_id].running_slot_state->task->kernel_id[diag_slot];
-                }
-                DEV_ALWAYS(
-                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), running_reg_task_id=%d, "
-                    "kernel_id=%d",
-                    core_id, core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK", task_id,
-                    kernel_id
-                );
-            } else {
-                DEV_ALWAYS(
-                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked", core_id,
-                    core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK"
-                );
-            }
-        } else {
-            idle_cores++;
-        }
-    }
-
-    DEV_ALWAYS("Summary: %d busy, %d idle", busy_cores, idle_cores);
-
-    // Diagnose deadlock vs livelock
-    if (busy_cores == 0 && aic_ready == 0 && aiv_ready == 0 && completed < total) {
-        DEV_ALWAYS("*** DEADLOCK DETECTED ***");
-        DEV_ALWAYS("All cores idle, no ready tasks, but %d tasks incomplete", total - completed);
-        DEV_ALWAYS("Check PTO2 shared memory for task dependency state");
-    } else if (busy_cores > 0) {
-        DEV_ALWAYS("*** LIVELOCK / HUNG TASK ***");
-        DEV_ALWAYS("%d cores executing but no progress", busy_cores);
-    }
-
-    DEV_ALWAYS("========== END DIAGNOSTIC ==========");
-}
-
 // ===== Public Entry Point =====
 
 /**
@@ -1233,9 +639,6 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     }
 
     DEV_INFO("%s", "aicpu_execute: Starting AICPU kernel execution");
-
-    // Get platform register addresses from platform-level global
-    g_aicpu_executor.regs_ = get_platform_regs();
 
     g_aicpu_executor.init(runtime);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -499,6 +499,30 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
 
 This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time.
 
+### 8.5 SchedulerContext
+
+All scheduler-side state and methods live in `SchedulerContext` (`runtime/scheduler/scheduler_context.h`). It is held as a `sched_ctx_` member of `AicpuExecutor`; `AicpuExecutor` is a thin wrapper that owns the lifecycle atomics and the orchestration SO handle, and delegates everything else to `SchedulerContext`.
+
+Public surface (called from `AicpuExecutor::init/run/deinit`):
+
+| Method | Phase | Purpose |
+| ------ | ----- | ------- |
+| `init(runtime, thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
+| `bind_runtime(rt)` | device-orch only | Wire `sched_` to `rt->scheduler` once the orchestrator thread creates `rt` |
+| `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
+| `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled |
+| `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | orchestrator thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_`, drive orch→sched core transition (or `emergency_shutdown` on fatal) |
+| `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
+| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` / `wait_pto2_init_complete()` |
+
+Private internals are split across three .cpp files by responsibility:
+
+- `scheduler_completion.cpp` — completion polling, drain protocol
+- `scheduler_dispatch.cpp` — task dispatch loop and helpers
+- `scheduler_cold_path.cpp` — exit checks, stall diagnostics, profiling, lifecycle (`init/deinit`), core management (`handshake_all_cores` / `assign_cores_to_threads` / `reassign_cores_for_all_threads` / `emergency_shutdown`), and `on_orchestration_done`
+
+`AicpuExecutor` calls neither `handshake_*`, `assign_*`, `reassign_*`, nor `emergency_shutdown` directly — they are private, invoked only by `init` and `on_orchestration_done`.
+
 ---
 
 ## 9. AICore Worker Interaction

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -14,9 +14,14 @@
 
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
+#include "aicpu/performance_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
+#include "aicpu/pmu_collector_aicpu.h"
+#include "common/memory_barrier.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2.h"
+#include "pto_shared_memory.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
@@ -27,7 +32,7 @@
 LoopAction SchedulerContext::handle_orchestrator_exit(
     int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count
 ) {
-    bool orch_done = *orchestrator_done_ptr_;
+    bool orch_done = orchestrator_done_;
     if (!orch_done) return LoopAction::NONE;
 
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
@@ -35,18 +40,18 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
         DEV_ERROR(
             "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
             "completed_tasks=%d, total_tasks=%d",
-            thread_idx, orch_err, completed_tasks_ptr_->load(std::memory_order_relaxed), *total_tasks_ptr_
+            thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
         );
-        emergency_shutdown_fn_(runtime);
-        completed_ptr_->store(true, std::memory_order_release);
+        emergency_shutdown(runtime);
+        completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
 
-    task_count = *total_tasks_ptr_;
-    if (task_count > 0 && completed_tasks_ptr_->load(std::memory_order_relaxed) >= task_count) {
-        completed_ptr_->store(true, std::memory_order_release);
+    task_count = total_tasks_;
+    if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
+        completed_.store(true, std::memory_order_release);
         DEV_INFO(
-            "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_ptr_->load(std::memory_order_relaxed),
+            "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
             task_count
         );
         return LoopAction::BREAK_LOOP;
@@ -55,11 +60,11 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
 }
 
 LoopAction SchedulerContext::handle_core_transition(bool &cores_released) {
-    if (!transition_requested_ptr_->load(std::memory_order_acquire)) return LoopAction::NONE;
-    if (!reassigned_ptr_->load(std::memory_order_acquire)) {
-        wait_reassign_ptr_->fetch_add(1, std::memory_order_release);
-        while (!reassigned_ptr_->load(std::memory_order_acquire)) {
-            if (completed_ptr_->load(std::memory_order_acquire)) {
+    if (!transition_requested_.load(std::memory_order_acquire)) return LoopAction::NONE;
+    if (!reassigned_.load(std::memory_order_acquire)) {
+        wait_reassign_.fetch_add(1, std::memory_order_release);
+        while (!reassigned_.load(std::memory_order_acquire)) {
+            if (completed_.load(std::memory_order_acquire)) {
                 return LoopAction::BREAK_LOOP;
             }
             SPIN_WAIT_HINT();
@@ -74,8 +79,8 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
         DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
-        emergency_shutdown_fn_(runtime);
-        completed_ptr_->store(true, std::memory_order_release);
+        emergency_shutdown(runtime);
+        completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
     return LoopAction::NONE;
@@ -84,7 +89,7 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
 void SchedulerContext::log_stall_diagnostics(
     int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count
 ) {
-    int32_t c = completed_tasks_ptr_->load(std::memory_order_relaxed);
+    int32_t c = completed_tasks_.load(std::memory_order_relaxed);
     DEV_ALWAYS(
         "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
         task_count, last_progress_count
@@ -334,3 +339,475 @@ void SchedulerContext::log_profiling_summary(int32_t thread_idx, int32_t cur_thr
     );
 }
 #endif
+
+// =============================================================================
+// Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
+// Orchestrator threads have core_count_per_thread_[thread_idx] == 0 -> no-op.
+// platform_deinit_aicore_regs is idempotent; safe to call after early completion.
+// =============================================================================
+int32_t SchedulerContext::shutdown(int32_t thread_idx) {
+    const int32_t *cores = core_assignments_[thread_idx];
+    int32_t core_num = core_count_per_thread_[thread_idx];
+    if (core_num == 0) return 0;
+
+#if PTO2_PROFILING
+    if (get_enable_pmu()) {
+        pmu_aicpu_finalize(cores, core_num);
+    }
+#endif
+
+    DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
+    for (int32_t i = 0; i < core_num; i++) {
+        int32_t core_id = cores[i];
+        uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
+        if (reg_addr != 0) {
+            platform_deinit_aicore_regs(reg_addr);
+        } else {
+            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+        }
+    }
+    DEV_INFO("Thread %d: Shutdown complete", thread_idx);
+    return 0;
+}
+
+// =============================================================================
+// Handshake with all AICore workers; discover core type and reg address.
+// =============================================================================
+int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    cores_total_num_ = runtime->worker_count;
+
+    // Validate cores_total_num_ before using as array index
+    if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
+        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
+        return -1;
+    }
+
+    aic_count_ = 0;
+    aiv_count_ = 0;
+
+    DEV_INFO("Handshaking with %d cores", cores_total_num_);
+
+    // Step 1: Write per-core payload addresses and send handshake signal.
+    // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
+    // aicpu_ready=1, so AICore reads the correct payload pointer after waking up.
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        all_handshakes[i].task = reinterpret_cast<uint64_t>(&payload_per_core_[i][0]);
+        OUT_OF_ORDER_STORE_BARRIER();
+        all_handshakes[i].aicpu_ready = 1;
+    }
+    OUT_OF_ORDER_STORE_BARRIER();
+
+    // Get platform physical cores count for validation
+    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
+
+    // Step 2: Wait for all cores to respond, collect core type and register addresses
+    bool handshake_failed = false;
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake *hank = &all_handshakes[i];
+
+        while (hank->aicore_regs_ready == 0) {}
+
+        uint32_t physical_core_id = hank->physical_core_id;
+
+        if (physical_core_id >= max_physical_cores_count) {
+            DEV_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
+            handshake_failed = true;
+            continue;
+        }
+
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
+        uint64_t reg_addr = regs[physical_core_id];
+
+        // Initialize AICore registers after discovery (first round)
+        platform_init_aicore_regs(reg_addr);
+        OUT_OF_ORDER_STORE_BARRIER();
+        hank->aicpu_regs_ready = 1;
+
+        OUT_OF_ORDER_STORE_BARRIER();
+
+        while (hank->aicore_done == 0) {}
+
+        CoreType type = hank->core_type;
+
+        core_exec_states_[i].reg_addr = reg_addr;
+
+#if PTO2_PROFILING
+        // Record physical_core_id for PMU init later (CoreExecState has no room
+        // for this field under PTO2_PROFILING).
+        physical_core_ids_[i] = physical_core_id;
+#endif
+#if !PTO2_PROFILING
+        core_exec_states_[i].worker_id = i;
+        core_exec_states_[i].physical_core_id = physical_core_id;
+        core_exec_states_[i].core_type = type;
+#endif
+
+        if (type == CoreType::AIC) {
+            aic_worker_ids_[aic_count_++] = i;
+            DEV_INFO("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        } else {
+            aiv_worker_ids_[aiv_count_++] = i;
+            DEV_INFO("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        }
+    }
+
+    if (handshake_failed) {
+        emergency_shutdown(runtime);
+        return -1;
+    }
+
+    DEV_INFO("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
+    return 0;
+}
+
+// =============================================================================
+// Assign discovered cores to scheduler threads (cluster-aligned round-robin).
+// =============================================================================
+bool SchedulerContext::assign_cores_to_threads() {
+    // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
+    // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
+    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
+    int32_t cluster_count = aic_count_;
+
+    // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
+    int32_t max_clusters_per_thread = (cluster_count + active_sched_threads_ - 1) / active_sched_threads_;
+    int32_t thread_cores_num = max_clusters_per_thread * 3;
+
+    if (thread_cores_num > CoreTracker::MAX_CORE_PER_THREAD) {
+        DEV_ERROR("Can't assign more then 64 cores in per scheduler");
+        return false;
+    }
+
+    DEV_INFO(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
+        active_sched_threads_, aic_count_, aiv_count_
+    );
+
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
+        core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
+    }
+
+    // Count clusters per thread first (round-robin may distribute unevenly)
+    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        clusters_per_thread[ci % active_sched_threads_]++;
+    }
+    for (int32_t i = 0; i < active_sched_threads_; i++) {
+        core_trackers_[i].init(clusters_per_thread[i]);
+        core_count_per_thread_[i] = 0;
+    }
+
+    int32_t core_idx[MAX_AICPU_THREADS] = {};
+    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
+
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        int32_t t = ci % active_sched_threads_;
+        int32_t &idx = core_idx[t];
+
+        int32_t aic_wid = aic_worker_ids_[ci];
+        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
+        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
+
+        core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
+
+        core_assignments_[t][idx++] = aic_wid;
+        core_assignments_[t][idx++] = aiv0_wid;
+        core_assignments_[t][idx++] = aiv1_wid;
+
+        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+    }
+
+    for (int32_t t = 0; t < thread_num_; t++) {
+        core_count_per_thread_[t] = core_idx[t];
+        DEV_INFO("Thread %d: total %d cores (%d clusters)", t, core_idx[t], core_trackers_[t].get_cluster_count());
+    }
+
+    DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
+    return true;
+}
+
+// =============================================================================
+// Reassign all cores across all threads (sched + orchestrator) after orchestration.
+// =============================================================================
+void SchedulerContext::reassign_cores_for_all_threads() {
+    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
+
+    // Collect running worker_ids from all current trackers
+    bool running_cores[RUNTIME_MAX_WORKER] = {};
+    for (int32_t i = 0; i < thread_num_; i++) {
+        auto all_running = core_trackers_[i].get_all_running_cores();
+        int32_t bp;
+        while ((bp = all_running.pop_first()) >= 0) {
+            running_cores[core_trackers_[i].get_core_id_by_offset(bp)] = true;
+        }
+    }
+
+    // Count clusters per thread (round-robin across all threads)
+    int32_t cluster_count = aic_count_;
+    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        clusters_per_thread[ci % thread_num_]++;
+    }
+
+    // Re-init all trackers and reset core counts
+    for (int32_t i = 0; i < thread_num_; i++) {
+        core_trackers_[i].init(clusters_per_thread[i]);
+        core_count_per_thread_[i] = 0;
+    }
+
+    // Assign clusters round-robin and restore running state
+    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        int32_t t = ci % thread_num_;
+
+        int32_t aic_wid = aic_worker_ids_[ci];
+        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
+        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
+
+        int32_t cl_idx = cluster_idx_per_thread[t]++;
+        core_trackers_[t].set_cluster(cl_idx, aic_wid, aiv0_wid, aiv1_wid);
+
+        // init() marks all idle; toggle cores that were running and restore pending_occupied
+        if (running_cores[aic_wid]) {
+            core_trackers_[t].change_core_state(cl_idx * 3);
+            core_trackers_[t].set_pending_occupied(cl_idx * 3);
+        }
+        if (running_cores[aiv0_wid]) {
+            core_trackers_[t].change_core_state(cl_idx * 3 + 1);
+            core_trackers_[t].set_pending_occupied(cl_idx * 3 + 1);
+        }
+        if (running_cores[aiv1_wid]) {
+            core_trackers_[t].change_core_state(cl_idx * 3 + 2);
+            core_trackers_[t].set_pending_occupied(cl_idx * 3 + 2);
+        }
+
+        core_assignments_[t][core_count_per_thread_[t]++] = aic_wid;
+        core_assignments_[t][core_count_per_thread_[t]++] = aiv0_wid;
+        core_assignments_[t][core_count_per_thread_[t]++] = aiv1_wid;
+    }
+
+    // Log final distribution
+    DEV_INFO("Core reassignment complete:");
+    for (int32_t t = 0; t < thread_num_; t++) {
+        int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
+        int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
+        DEV_INFO(
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
+            core_trackers_[t].get_cluster_count(), aic_running, aiv_running
+        );
+    }
+    active_sched_threads_ = thread_num_;
+}
+
+// =============================================================================
+// Emergency shutdown: broadcast exit signal to every handshake'd core and
+// deinit their AICore register blocks. Idempotent.
+// =============================================================================
+void SchedulerContext::emergency_shutdown(Runtime *runtime) {
+    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake *hank = &all_handshakes[i];
+        OUT_OF_ORDER_STORE_BARRIER();
+        hank->aicpu_regs_ready = 1;
+        if (core_exec_states_[i].reg_addr != 0) {
+            platform_deinit_aicore_regs(core_exec_states_[i].reg_addr);
+        }
+    }
+    DEV_WARN("Emergency shutdown complete");
+}
+
+// =============================================================================
+// Lifecycle: init / deinit
+// =============================================================================
+int32_t SchedulerContext::init(
+    Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base
+) {
+    always_assert(runtime != nullptr);
+
+    // Zero all per-core execution state before handshake
+    memset(core_exec_states_, 0, sizeof(core_exec_states_));
+
+    // Wire thread/transition configuration that handshake/assign need to read.
+    thread_num_ = thread_num;
+    sched_thread_num_ = sched_thread_num;
+    orch_to_sched_ = orch_to_sched;
+    regs_ = regs_base;
+
+    // Discover cores and assign to scheduler threads.
+    int32_t rc = handshake_all_cores(runtime);
+    if (rc != 0) {
+        DEV_ERROR("handshake_all_cores failed");
+        return rc;
+    }
+    if (!assign_cores_to_threads()) {
+        return -1;
+    }
+
+    // Initialize task counters. Task count comes from PTO2 shared memory.
+    if (runtime->get_pto2_gm_sm_ptr()) {
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
+        int32_t pto2_count = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+        }
+        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
+    } else {
+        total_tasks_ = 0;
+    }
+    completed_tasks_.store(0, std::memory_order_release);
+
+    // Host orchestration: graph already built; device orch: orchestrator sets it.
+    orchestrator_done_ = runtime->get_orch_built_on_host();
+
+    // Clear per-core dispatch payloads
+    memset(payload_per_core_, 0, sizeof(payload_per_core_));
+
+    // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
+    // This is done once at startup and never modified afterwards.
+    for (int32_t t = 0; t < sched_thread_num_; t++) {
+        CoreTracker &tracker = core_trackers_[t];
+        for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
+            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
+            auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
+            auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
+            payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;
+            payload_per_core_[aiv0_id][1].global_context.sub_block_id = 0;
+            payload_per_core_[aiv1_id][0].global_context.sub_block_id = 1;
+            payload_per_core_[aiv1_id][1].global_context.sub_block_id = 1;
+        }
+    }
+
+    func_id_to_addr_ = runtime->func_id_to_addr_;
+
+    return 0;
+}
+
+void SchedulerContext::deinit() {
+    // Reset all per-core execution state
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        core_exec_states_[i] = {};
+        core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
+        core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
+    }
+
+    // Clear per-core dispatch payloads
+    memset(payload_per_core_, 0, sizeof(payload_per_core_));
+
+    // Reset sync-start drain coordination — a previous run that aborted mid-drain
+    // would otherwise leave dirty pending/elected/ack state for the next reuse.
+    drain_state_.sync_start_pending.store(0, std::memory_order_release);
+    drain_state_.drain_worker_elected.store(0, std::memory_order_release);
+    drain_state_.drain_ack_mask.store(0, std::memory_order_release);
+    drain_state_.pending_task = nullptr;
+
+    // Reset task counters and orchestrator state
+    completed_tasks_.store(0, std::memory_order_release);
+    total_tasks_ = 0;
+    orchestrator_done_ = false;
+    pto2_init_done_.store(false, std::memory_order_release);
+    pto2_init_complete_.store(false, std::memory_order_release);
+
+    // Reset core transition state
+    transition_requested_.store(false, std::memory_order_release);
+    wait_reassign_.store(0, std::memory_order_release);
+    reassigned_.store(false, std::memory_order_release);
+    completed_.store(false, std::memory_order_release);
+
+    // Reset core discovery and assignment state
+    aic_count_ = 0;
+    aiv_count_ = 0;
+    cores_total_num_ = 0;
+    thread_num_ = 0;
+    sched_thread_num_ = 0;
+    orch_to_sched_ = false;
+    active_sched_threads_ = 0;
+    for (int32_t t = 0; t < MAX_AICPU_THREADS; t++) {
+        core_trackers_[t] = CoreTracker{};
+    }
+    memset(core_assignments_, 0, sizeof(core_assignments_));
+    memset(core_count_per_thread_, 0, sizeof(core_count_per_thread_));
+
+    regs_ = 0;
+    sched_ = nullptr;
+    func_id_to_addr_ = nullptr;
+}
+
+void SchedulerContext::wait_pto2_init_complete() const {
+    while (!pto2_init_complete_.load(std::memory_order_acquire)) {
+        SPIN_WAIT_HINT();
+    }
+}
+
+void SchedulerContext::bind_runtime(PTO2Runtime *rt) { sched_ = &rt->scheduler; }
+
+// =============================================================================
+// Post-orchestration bookkeeping. Runs on the orchestrator thread once the
+// build phase finishes; folds inline-completed tasks, flips orchestrator_done_,
+// and drives the orchestrator → scheduler core transition (or fatal shutdown).
+// =============================================================================
+void SchedulerContext::on_orchestration_done(
+    Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
+) {
+#if PTO2_PROFILING
+    // Write core-to-thread mapping (one-time, after orchestration)
+    if (runtime->enable_profiling) {
+        perf_aicpu_write_core_assignments(
+            core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
+        );
+        // Flush orchestrator's phase record buffer
+        perf_aicpu_flush_phase_buffers(thread_idx);
+    }
+#else
+    (void)thread_idx;
+#endif
+
+    total_tasks_ = total_tasks;
+
+    // Fold tasks completed inline during orchestration
+    int32_t inline_completed = static_cast<int32_t>(rt->orchestrator.inline_completed_tasks);
+    if (inline_completed > 0) {
+        completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
+#if PTO2_SCHED_PROFILING
+        rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
+#endif
+    }
+    orchestrator_done_ = true;
+
+    // Check for fatal error from orchestration; if so, shut down immediately.
+    int32_t orch_err = 0;
+    if (sched_->sm_header) {
+        orch_err = sched_->sm_header->orch_error_code.load(std::memory_order_relaxed);
+    }
+    if (orch_err != PTO2_ERROR_NONE) {
+        emergency_shutdown(runtime);
+        completed_.store(true, std::memory_order_release);
+    }
+
+    // Skip core transition on fatal error — cores already shut down above.
+    if (completed_.load(std::memory_order_acquire)) {
+        // Signal transition to unblock scheduler threads waiting at core transition
+        transition_requested_.store(true, std::memory_order_release);
+        reassigned_.store(true, std::memory_order_release);
+    } else if (orch_to_sched_) {
+        DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+        transition_requested_.store(true, std::memory_order_release);
+
+        // Wait for scheduler threads to acknowledge transition request
+        while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
+            if (completed_.load(std::memory_order_acquire)) {
+                break;
+            }
+            SPIN_WAIT_HINT();
+        }
+        if (!completed_.load(std::memory_order_acquire)) {
+            reassign_cores_for_all_threads();
+            reassigned_.store(true, std::memory_order_release);
+        }
+    }
+}

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -28,6 +28,7 @@
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
 class Runtime;
 struct Handshake;
+struct PTO2Runtime;
 
 /**
  * SchedulerContext: owns all scheduler-side state and methods.
@@ -43,12 +44,70 @@ struct Handshake;
  */
 class SchedulerContext {
 public:
-    // === Public entry point ===
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    // Initialize scheduler state from the given runtime and thread layout.
+    // - Discovers cores via handshake_all_cores()
+    // - Assigns cores to scheduler threads
+    // - Resets task counters, payloads, per-core GlobalContext
+    // - Binds func_id_to_addr_ / initial sched_ (if rt is already known)
+    // - Captures AICore-register base (consumed by handshake_all_cores())
+    // Returns 0 on success, negative on failure (handshake / assignment error).
+    int32_t
+    init(Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base);
+
+    // Reset all SchedulerContext-owned state to its post-construction defaults.
+    // Called by AicpuExecutor::deinit() during per-run teardown.
+    void deinit();
+
+    // =========================================================================
+    // Per-thread execution entry points (called by AicpuExecutor::run)
+    // =========================================================================
+
+    // Main scheduler thread entry: poll completion + dispatch ready tasks.
     int32_t resolve_and_dispatch(Runtime *runtime, int32_t thread_idx);
 
-    // === State (public for AicpuExecutor init/handshake access during transition) ===
+    // Shutdown AICore registers for this thread's assigned cores.
+    // Also runs PMU finalize (PTO2_PROFILING) before deinit when enabled.
+    // Orchestrator threads (core_count_per_thread_[thread_idx] == 0) are a no-op.
+    int32_t shutdown(int32_t thread_idx);
 
-    PTO2SchedulerState *sched_{nullptr};
+    // Run all post-orchestration scheduler bookkeeping:
+    //  - publishes core assignments to the perf collector (PTO2_PROFILING)
+    //  - latches submitted task count from PTO2 shared memory
+    //  - folds inline_completed_tasks into completed_tasks_
+    //  - flips orchestrator_done_ and triggers core transition
+    //    (skipped on fatal error — emergency_shutdown runs instead)
+    // Callers must invoke pto2_rt_orchestration_done(rt) before this — that
+    // step belongs to the orchestrator lifecycle, not the scheduler.
+    void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
+
+    // Bind the PTO2Runtime scheduler pointer. Required in device-orchestration
+    // mode where rt is created by the orchestrator thread after init().
+    void bind_runtime(PTO2Runtime *rt);
+
+    // =========================================================================
+    // State queries / external synchronization points
+    // =========================================================================
+
+    int32_t aic_count() const { return aic_count_; }
+    int32_t aiv_count() const { return aiv_count_; }
+    bool is_completed() const { return completed_.load(std::memory_order_acquire); }
+    int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+
+    // Block until the first scheduler thread has finished one-time PTO2 init.
+    // Called by the orchestrator thread in device-orch mode.
+    void wait_pto2_init_complete() const;
+
+private:
+    // =========================================================================
+    // State
+    // =========================================================================
+
+    // --- Scheduler binding & per-core runtime state ---
+    alignas(64) PTO2SchedulerState *sched_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];
@@ -67,101 +126,69 @@ public:
     SchedProfilingCounters sched_perf_[MAX_AICPU_THREADS];
 #endif
 
-    // Shared state pointers (set during init, point into AicpuExecutor)
-    std::atomic<int32_t> *completed_tasks_ptr_{nullptr};
-    int32_t *total_tasks_ptr_{nullptr};
-    volatile bool *orchestrator_done_ptr_{nullptr};
-    std::atomic<bool> *completed_ptr_{nullptr};
+    // --- Task-execution tracking ---
+    std::atomic<int32_t> completed_tasks_{0};
+    int32_t total_tasks_{0};
+    // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
+    // volatile prevents the compiler from hoisting the load out of spin loops.
+    volatile bool orchestrator_done_{false};
+    std::atomic<bool> completed_{false};
     uint64_t *func_id_to_addr_{nullptr};
 
-    // Core transition state pointers (set during init, point into AicpuExecutor)
-    std::atomic<bool> *transition_requested_ptr_{nullptr};
-    std::atomic<int32_t> *wait_reassign_ptr_{nullptr};
-    std::atomic<bool> *reassigned_ptr_{nullptr};
+    // --- Core-transition coordination ---
+    std::atomic<bool> transition_requested_{false};
+    std::atomic<int32_t> wait_reassign_{0};
+    std::atomic<bool> reassigned_{false};
 
-    // Thread/core configuration
+    // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};
     int32_t sched_thread_num_{0};
     bool orch_to_sched_{false};
     int32_t thread_num_{0};
-    int32_t *core_count_per_thread_{nullptr};
-    int32_t (*core_assignments_)[MAX_CORES_PER_THREAD]{nullptr};
+    int32_t cores_total_num_{0};
+    int32_t core_count_per_thread_[MAX_AICPU_THREADS]{};
+    int32_t core_assignments_[MAX_AICPU_THREADS][RUNTIME_MAX_WORKER]{};
+
+    // Cluster-ordered worker_id lists, populated by handshake_all_cores().
+    int32_t aic_worker_ids_[RUNTIME_MAX_WORKER]{};
+    int32_t aiv_worker_ids_[RUNTIME_MAX_WORKER]{};
+    int32_t aic_count_{0};
+    int32_t aiv_count_{0};
+
+    // Platform AICore-register base array (set by AicpuExecutor before init()).
+    uint64_t regs_{0};
 
 #if PTO2_PROFILING
-    // PMU profiling: physical core IDs for PMU MMIO base resolution
-    uint32_t *physical_core_ids_{nullptr};
-    int32_t cores_total_num_{0};
+    // PMU profiling: physical core IDs for PMU MMIO base resolution.
+    // Separate storage because CoreExecState's 64-byte budget has no room for
+    // physical_core_id when PTO2_PROFILING=1.
+    uint32_t physical_core_ids_[RUNTIME_MAX_WORKER]{};
 #endif
 
-    // One-time init coordination
+    // --- One-time init coordination ---
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> pto2_init_complete_{false};
 
-    // Emergency shutdown callback (calls AicpuExecutor::emergency_shutdown)
-    void (*emergency_shutdown_fn_)(Runtime *runtime){nullptr};
+    // =========================================================================
+    // Core management (scheduler_cold_path.cpp)
+    // =========================================================================
 
-    uint64_t get_function_bin_addr(int func_id) const {
-        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
-        return func_id_to_addr_[func_id];
-    }
+    // Handshake with all AICore workers; populates core_exec_states_, worker id lists.
+    int32_t handshake_all_cores(Runtime *runtime);
 
-private:
-    // === Completion & drain (scheduler_completion.cpp) ===
+    // Assign discovered cores (cluster = 1 AIC + 2 AIV) round-robin across scheduler threads.
+    bool assign_cores_to_threads();
 
-    static SlotTransition
-    decide_slot_transition(int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id);
+    // Re-distribute all cores across all threads after orchestration completes.
+    void reassign_cores_for_all_threads();
 
-    void complete_slot_task(
-        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
-        int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
-        PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
-        PTO2LocalReadyBuffer *local_bufs
-#if PTO2_PROFILING
-        ,
-        uint64_t dispatch_ts
-#endif
-    );
+    // Emergency shutdown: broadcast exit signal to every handshake'd core and
+    // deinit their AICore register blocks. Idempotent.
+    void emergency_shutdown(Runtime *runtime);
 
-    static void promote_pending_to_running(CoreExecState &core);
-    static void clear_running_slot(CoreExecState &core);
-
-    void check_running_cores_for_completion(
-        int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
-        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
-        PTO2LocalReadyBuffer *local_bufs
-    );
-
-    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
-    int32_t count_global_available(PTO2ResourceShape shape);
-    void drain_worker_dispatch(Runtime *runtime, int32_t block_num);
-    void handle_drain_mode(Runtime *runtime, int32_t thread_idx);
-
-    // === Cold path (scheduler_cold_path.cpp) ===
-
-    __attribute__((noinline, cold)) LoopAction
-    handle_orchestrator_exit(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count);
-
-    __attribute__((noinline, cold)) LoopAction handle_core_transition(bool &cores_released);
-
-    __attribute__((noinline, cold)) LoopAction
-    check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime);
-
-    __attribute__((noinline, cold)) void
-    log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
-
-    __attribute__((noinline, cold)) int32_t handle_timeout_exit(
-        int32_t thread_idx, int32_t idle_iterations
-#if PTO2_PROFILING
-        ,
-        uint64_t sched_start_ts
-#endif
-    );
-
-#if PTO2_PROFILING
-    __attribute__((noinline, cold)) void log_profiling_summary(int32_t thread_idx, int32_t cur_thread_completed);
-#endif
-
-    // === Dispatch (scheduler_dispatch.cpp) ===
+    // =========================================================================
+    // Dispatch (scheduler_dispatch.cpp)
+    // =========================================================================
 
     static const char *shape_name(PTO2ResourceShape shape);
     static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx);
@@ -192,6 +219,74 @@ private:
         PTO2LocalReadyBuffer &local_buf, CoreTracker &tracker, bool &entered_drain, bool &made_progress,
         bool &try_pushed
     );
+
+    // =========================================================================
+    // Completion & drain (scheduler_completion.cpp)
+    // =========================================================================
+
+    static SlotTransition
+    decide_slot_transition(int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id);
+
+    void complete_slot_task(
+        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
+        int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
+        PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
+        PTO2LocalReadyBuffer *local_bufs
+#if PTO2_PROFILING
+        ,
+        uint64_t dispatch_ts
+#endif
+    );
+
+    static void promote_pending_to_running(CoreExecState &core);
+    static void clear_running_slot(CoreExecState &core);
+
+    void check_running_cores_for_completion(
+        int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
+        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
+        PTO2LocalReadyBuffer *local_bufs
+    );
+
+    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
+    int32_t count_global_available(PTO2ResourceShape shape);
+    void drain_worker_dispatch(Runtime *runtime, int32_t block_num);
+    void handle_drain_mode(Runtime *runtime, int32_t thread_idx);
+
+    // =========================================================================
+    // Cold path: exit checks, stall diagnostics, profiling (scheduler_cold_path.cpp)
+    // =========================================================================
+
+    __attribute__((noinline, cold)) LoopAction
+    handle_orchestrator_exit(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count);
+
+    __attribute__((noinline, cold)) LoopAction handle_core_transition(bool &cores_released);
+
+    __attribute__((noinline, cold)) LoopAction
+    check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime);
+
+    __attribute__((noinline, cold)) void
+    log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
+
+    __attribute__((noinline, cold)) int32_t handle_timeout_exit(
+        int32_t thread_idx, int32_t idle_iterations
+#if PTO2_PROFILING
+        ,
+        uint64_t sched_start_ts
+#endif
+    );
+
+#if PTO2_PROFILING
+    __attribute__((noinline, cold)) void log_profiling_summary(int32_t thread_idx, int32_t cur_thread_completed);
+#endif
+
+    // =========================================================================
+    // Small inline helpers
+    // =========================================================================
+
+    uint64_t get_function_bin_addr(int func_id) const {
+        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
+        return func_id_to_addr_[func_id];
+    }
 };
 
 #endif  // SCHEDULER_CONTEXT_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -303,6 +303,7 @@ void SchedulerContext::dispatch_shape(
 // =============================================================================
 
 int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
+    always_assert(sched_ != nullptr);
     int32_t &core_num = core_count_per_thread_[thread_idx];
     CoreTracker &tracker = core_trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch entry", thread_idx);
@@ -418,7 +419,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_SCHED_PROFILING
             sched_->tasks_completed.fetch_add(completed_this_turn, std::memory_order_relaxed);
 #endif
-            int32_t prev = completed_tasks_ptr_->fetch_add(completed_this_turn, std::memory_order_relaxed);
+            int32_t prev = completed_tasks_.fetch_add(completed_this_turn, std::memory_order_relaxed);
             int32_t new_total = prev + completed_this_turn;
             last_progress_count = new_total;
             if (thread_idx == 0 && task_count > 0) {
@@ -458,7 +459,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Phase 3: Drain wiring queue (thread 0 only)
         if (thread_idx == 0) {
-            int wired = sched_->drain_wiring_queue(*orchestrator_done_ptr_);
+            int wired = sched_->drain_wiring_queue(orchestrator_done_);
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -43,7 +43,6 @@
 // =============================================================================
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
-constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
 constexpr int32_t STALL_LOG_INTERVAL = 50000;         // DEV_ALWAYS every N idle iters to debug hang

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -37,7 +37,6 @@
 // Performance profiling headers
 #include "aicpu/performance_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
-#include "common/memory_barrier.h"
 #include "common/perf_profiling.h"
 #include "common/unified_log.h"
 
@@ -93,8 +92,6 @@ static PTO2Runtime *rt{nullptr};
 
 struct AicpuExecutor {
     int32_t sched_thread_num_;
-    int32_t active_sched_threads_{0};  // Threads currently in dispatch loop (initially sched_thread_num_, becomes
-                                       // thread_num_ after orch→sched transition)
     bool orch_to_sched_{false};
 
     // ===== Thread management state =====
@@ -105,36 +102,11 @@ struct AicpuExecutor {
     std::atomic<bool> finished_{false};
 
     int32_t thread_num_{0};
-    int32_t cores_total_num_{0};
-    int32_t thread_cores_num_{0};  // Cores per scheduler thread (0 for orchestrator when thread_num_==4)
-    int32_t core_count_per_thread_[MAX_AICPU_THREADS];  // Actual core count per thread
-    int32_t core_assignments_[MAX_AICPU_THREADS][MAX_CORES_PER_THREAD];
-
-    // Cluster-ordered worker_id lists for core assignment (init-only)
-    int32_t aic_worker_ids_[MAX_CORES_PER_THREAD];
-    int32_t aiv_worker_ids_[MAX_CORES_PER_THREAD];
-    int32_t aic_count_{0};
-    int32_t aiv_count_{0};
-
-    // Platform register base address array (set via get_platform_regs())
-    uint64_t regs_{0};
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
-    // Task execution tracking
-    std::atomic<int32_t> completed_tasks_{0};
-    int32_t total_tasks_{0};
     std::atomic<int32_t> finished_count_{0};
-    // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
-    // volatile prevents the compiler from hoisting the load out of spin loops.
-    volatile bool orchestrator_done_{false};
     std::atomic<bool> runtime_init_ready_{false};
-
-    // ===== Dynamic core transition state =====
-    std::atomic<bool> transition_requested_{false};
-    std::atomic<int32_t> wait_reassign_{0};
-    std::atomic<bool> reassigned_{false};
-    std::atomic<bool> completed_{false};
 
     // Orchestration SO handle - defer dlclose until all tasks complete
     void *orch_so_handle_{nullptr};
@@ -145,271 +117,18 @@ struct AicpuExecutor {
     DeviceOrchestrationBindRuntimeFunc orch_bind_runtime_{nullptr};
     const ChipStorageTaskArgs *orch_args_cached_{nullptr};
 
-    uint64_t *func_id_to_addr_;
-    uint64_t get_function_bin_addr(int func_id) const {
-        if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
-        return func_id_to_addr_[func_id];
-    }
-
     // ===== Scheduler context (owns all dispatch/completion/drain state) =====
     SchedulerContext sched_ctx_;
 
     // ===== Methods =====
     int32_t init(Runtime *runtime);
-    int32_t handshake_all_cores(Runtime *runtime);
-    bool assign_cores_to_threads();
-    void reassign_cores_for_all_threads();
-    int32_t shutdown_aicore(Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num);
     int32_t run(Runtime *runtime);
     void deinit(Runtime *runtime);
-    void emergency_shutdown(Runtime *runtime);
-    void diagnose_stuck_state(
-        Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
-    );
 };
 
 static AicpuExecutor g_aicpu_executor;
 
-static void emergency_shutdown_callback(Runtime *runtime) { g_aicpu_executor.emergency_shutdown(runtime); }
-
 // ===== AicpuExecutor Method Implementations =====
-
-/**
- * Handshake with all cores and discover their types
- * Sets up register addresses for fast dispatch.
- */
-int32_t AicpuExecutor::handshake_all_cores(Runtime *runtime) {
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
-    cores_total_num_ = runtime->worker_count;
-
-    // Validate cores_total_num_ before using as array index
-    if (cores_total_num_ == 0 || cores_total_num_ > MAX_CORES_PER_THREAD) {
-        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, MAX_CORES_PER_THREAD);
-        return -1;
-    }
-
-    aic_count_ = 0;
-    aiv_count_ = 0;
-
-    DEV_INFO("Handshaking with %d cores", cores_total_num_);
-
-    // Step 1: Write per-core payload addresses and send handshake signal
-    // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
-    // aicpu_ready=1, so AICore reads the correct payload pointer after waking up.
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        all_handshakes[i].task = reinterpret_cast<uint64_t>(&sched_ctx_.payload_per_core_[i][0]);
-        OUT_OF_ORDER_STORE_BARRIER();
-        all_handshakes[i].aicpu_ready = 1;
-    }
-    OUT_OF_ORDER_STORE_BARRIER();
-
-    // Get platform physical cores count for validation
-    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
-
-    // Step 2: Wait for all cores to respond, collect core type and register addresses
-    bool handshake_failed = false;
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake *hank = &all_handshakes[i];
-
-        while (hank->aicore_regs_ready == 0) {}
-
-        uint32_t physical_core_id = hank->physical_core_id;
-
-        // Validate physical_core_id before using as array index
-        if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR(
-                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
-                max_physical_cores_count
-            );
-            handshake_failed = true;
-            continue;
-        }
-
-        // Get register address using physical_core_id
-        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
-        uint64_t reg_addr = regs[physical_core_id];
-
-        // Initialize AICore registers after discovery (first round)
-        platform_init_aicore_regs(reg_addr);
-        OUT_OF_ORDER_STORE_BARRIER();
-        hank->aicpu_regs_ready = 1;
-
-        OUT_OF_ORDER_STORE_BARRIER();
-
-        while (hank->aicore_done == 0) {}
-
-        CoreType type = hank->core_type;
-
-        sched_ctx_.core_exec_states_[i].reg_addr = reg_addr;
-#if !PTO2_PROFILING
-        sched_ctx_.core_exec_states_[i].worker_id = i;
-        sched_ctx_.core_exec_states_[i].physical_core_id = physical_core_id;
-        sched_ctx_.core_exec_states_[i].core_type = type;
-#endif
-
-        if (type == CoreType::AIC) {
-            aic_worker_ids_[aic_count_++] = i;
-            DEV_INFO("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
-        } else {
-            aiv_worker_ids_[aiv_count_++] = i;
-            DEV_INFO("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
-        }
-    }
-
-    if (handshake_failed) {
-        emergency_shutdown(runtime);
-        return -1;
-    }
-
-    DEV_INFO("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
-    return 0;
-}
-
-/**
- * Assign discovered cores to scheduler threads
- * (Aligned with host_build_graph mechanism)
- */
-bool AicpuExecutor::assign_cores_to_threads() {
-    // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
-    // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
-    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
-    int32_t cluster_count = aic_count_;
-
-    // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
-    int32_t max_clusters_per_thread = (cluster_count + active_sched_threads_ - 1) / active_sched_threads_;
-    thread_cores_num_ = max_clusters_per_thread * 3;
-
-    if (thread_cores_num_ > CoreTracker::MAX_CORE_PER_THREAD) {
-        DEV_ERROR("Can't assign more then 64 cores in per scheduler");
-        return false;
-    }
-
-    DEV_INFO(
-        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
-        active_sched_threads_, aic_count_, aiv_count_
-    );
-
-    for (int32_t i = 0; i < MAX_CORES_PER_THREAD; i++) {
-        sched_ctx_.core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
-        sched_ctx_.core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
-    }
-
-    // Count clusters per thread first (round-robin may distribute unevenly)
-    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % active_sched_threads_]++;
-    }
-    for (int32_t i = 0; i < active_sched_threads_; i++) {
-        sched_ctx_.core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
-    }
-
-    // Per-sched-thread running core index used while filling core_assignments_.
-    int32_t core_idx[MAX_AICPU_THREADS] = {};
-    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
-
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % active_sched_threads_;
-        int32_t &idx = core_idx[t];
-
-        int32_t aic_wid = aic_worker_ids_[ci];
-        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
-        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
-
-        sched_ctx_.core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
-
-        core_assignments_[t][idx++] = aic_wid;
-        core_assignments_[t][idx++] = aiv0_wid;
-        core_assignments_[t][idx++] = aiv1_wid;
-
-        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
-    }
-
-    for (int32_t t = 0; t < thread_num_; t++) {
-        core_count_per_thread_[t] = core_idx[t];
-        DEV_INFO(
-            "Thread %d: total %d cores (%d clusters)", t, core_idx[t], sched_ctx_.core_trackers_[t].get_cluster_count()
-        );
-    }
-
-    return true;
-}
-
-/**
- * Reassign all cores evenly across all threads (schedulers + orchestrators).
- * Called by the last orchestrator thread when orchestration completes.
- * Writes into new_core_assignments_ / new_core_count_per_thread_.
- */
-void AicpuExecutor::reassign_cores_for_all_threads() {
-    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
-
-    // Collect running worker_ids from all current trackers
-    bool running_cores[MAX_CORES_PER_THREAD] = {};
-    for (int32_t i = 0; i < thread_num_; i++) {
-        auto all_running = sched_ctx_.core_trackers_[i].get_all_running_cores();
-        int32_t bp;
-        while ((bp = all_running.pop_first()) >= 0) {
-            running_cores[sched_ctx_.core_trackers_[i].get_core_id_by_offset(bp)] = true;
-        }
-    }
-
-    // Count clusters per thread (round-robin across all threads)
-    int32_t cluster_count = aic_count_;
-    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % thread_num_]++;
-    }
-
-    // Re-init all trackers and reset core counts
-    for (int32_t i = 0; i < thread_num_; i++) {
-        sched_ctx_.core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
-    }
-
-    // Assign clusters round-robin and restore running state
-    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
-    for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % thread_num_;
-
-        int32_t aic_wid = aic_worker_ids_[ci];
-        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
-        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
-
-        int32_t cl_idx = cluster_idx_per_thread[t]++;
-        sched_ctx_.core_trackers_[t].set_cluster(cl_idx, aic_wid, aiv0_wid, aiv1_wid);
-
-        // init() marks all idle; toggle cores that were running and restore pending_occupied
-        if (running_cores[aic_wid]) {
-            sched_ctx_.core_trackers_[t].change_core_state(cl_idx * 3);
-            sched_ctx_.core_trackers_[t].set_pending_occupied(cl_idx * 3);
-        }
-        if (running_cores[aiv0_wid]) {
-            sched_ctx_.core_trackers_[t].change_core_state(cl_idx * 3 + 1);
-            sched_ctx_.core_trackers_[t].set_pending_occupied(cl_idx * 3 + 1);
-        }
-        if (running_cores[aiv1_wid]) {
-            sched_ctx_.core_trackers_[t].change_core_state(cl_idx * 3 + 2);
-            sched_ctx_.core_trackers_[t].set_pending_occupied(cl_idx * 3 + 2);
-        }
-
-        core_assignments_[t][core_count_per_thread_[t]++] = aic_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv0_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv1_wid;
-    }
-
-    // Log final distribution
-    DEV_INFO("Core reassignment complete:");
-    for (int32_t t = 0; t < thread_num_; t++) {
-        int32_t aic_running = sched_ctx_.core_trackers_[t].get_running_count<CoreType::AIC>();
-        int32_t aiv_running = sched_ctx_.core_trackers_[t].get_running_count<CoreType::AIV>();
-        DEV_INFO(
-            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
-            sched_ctx_.core_trackers_[t].get_cluster_count(), aic_running, aiv_running
-        );
-    }
-    active_sched_threads_ = thread_num_;
-    sched_ctx_.active_sched_threads_ = thread_num_;
-}
 
 int32_t AicpuExecutor::init(Runtime *runtime) {
     bool expected = false;
@@ -425,8 +144,6 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    func_id_to_addr_ = runtime->func_id_to_addr_;
-
     // Read execution parameters from runtime
     thread_num_ = runtime->sche_cpu_num;
     sched_thread_num_ = thread_num_ - 1;
@@ -439,86 +156,12 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    // Zero all per-core execution state before handshake
-    memset(sched_ctx_.core_exec_states_, 0, sizeof(sched_ctx_.core_exec_states_));
-
-    // Use handshake mechanism to discover cores (aligned with host_build_graph)
-    int32_t rc = handshake_all_cores(runtime);
-    if (rc != 0) {
-        DEV_ERROR("handshake_all_cores failed");
+    if (sched_ctx_.init(runtime, thread_num_, sched_thread_num_, orch_to_sched_, get_platform_regs()) != 0) {
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
 
-    // Dynamically assign cores to threads
-    if (!assign_cores_to_threads()) {
-        return -1;
-    }
-
-    DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num_);
-
-    // Initialize runtime execution state
-    // Task count comes from PTO2 shared memory
-    if (runtime->get_pto2_gm_sm_ptr()) {
-        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
-        int32_t pto2_count = 0;
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
-        }
-        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
-    } else {
-        total_tasks_ = 0;
-    }
-    completed_tasks_.store(0, std::memory_order_release);
-    // Host orchestration: graph already built, no wait needed. Device orch: Thread 3 will set this.
-    bool orch_on_host = runtime->get_orch_built_on_host();
-    DEV_INFO("Init: orch_built_on_host=%d", orch_on_host ? 1 : 0);
-    orchestrator_done_ = orch_on_host;
-
-    // Initial ready tasks will be populated via scheduler ready queues
-
-    // Clear per-core dispatch payloads
-    memset(sched_ctx_.payload_per_core_, 0, sizeof(sched_ctx_.payload_per_core_));
-
-    // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
-    // This is done once at startup and never modified afterwards.
-    for (int32_t t = 0; t < sched_thread_num_; t++) {
-        CoreTracker &tracker = sched_ctx_.core_trackers_[t];
-        for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
-            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
-            auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
-            auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
-            sched_ctx_.payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;
-            sched_ctx_.payload_per_core_[aiv0_id][1].global_context.sub_block_id = 0;
-            sched_ctx_.payload_per_core_[aiv1_id][0].global_context.sub_block_id = 1;
-            sched_ctx_.payload_per_core_[aiv1_id][1].global_context.sub_block_id = 1;
-        }
-    }
-
-    DEV_INFO("Init: PTO2 mode, task count from shared memory");
-
     finished_count_.store(0, std::memory_order_release);
-
-    // Initialize SchedulerContext: wire pointers to shared AicpuExecutor state
-    // Note: sched_ is set later in run() after rt is created (device orch) or below (host orch)
-    if (rt) {
-        sched_ctx_.sched_ = &rt->scheduler;
-    }
-    sched_ctx_.completed_tasks_ptr_ = &completed_tasks_;
-    sched_ctx_.total_tasks_ptr_ = &total_tasks_;
-    sched_ctx_.orchestrator_done_ptr_ = &orchestrator_done_;
-    sched_ctx_.completed_ptr_ = &completed_;
-    sched_ctx_.func_id_to_addr_ = func_id_to_addr_;
-    sched_ctx_.transition_requested_ptr_ = &transition_requested_;
-    sched_ctx_.wait_reassign_ptr_ = &wait_reassign_;
-    sched_ctx_.reassigned_ptr_ = &reassigned_;
-    sched_ctx_.active_sched_threads_ = active_sched_threads_;
-    sched_ctx_.sched_thread_num_ = sched_thread_num_;
-    sched_ctx_.orch_to_sched_ = orch_to_sched_;
-    sched_ctx_.thread_num_ = thread_num_;
-    sched_ctx_.core_count_per_thread_ = core_count_per_thread_;
-    sched_ctx_.core_assignments_ = core_assignments_;
-    sched_ctx_.emergency_shutdown_fn_ = emergency_shutdown_callback;
 
     init_done_.store(true, std::memory_order_release);
     DEV_INFO("AicpuExecutor: Init complete");
@@ -528,27 +171,6 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 /**
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
-int32_t AicpuExecutor::shutdown_aicore(
-    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num
-) {
-    (void)runtime;
-    if (core_num == 0) return 0;
-
-    DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
-
-    for (int32_t i = 0; i < core_num; i++) {
-        int32_t core_id = cur_thread_cores[i];
-        uint64_t reg_addr = sched_ctx_.core_exec_states_[core_id].reg_addr;
-        if (reg_addr != 0) {
-            platform_deinit_aicore_regs(reg_addr);
-        } else {
-            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
-        }
-    }
-    DEV_INFO("Thread %d: Shutdown complete", thread_idx);
-    return 0;
-}
-
 int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
     DEV_INFO("Thread %d: Start", thread_idx);
@@ -742,8 +364,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
-            rt->orchestrator.total_cluster_count = aic_count_;
-            rt->orchestrator.total_aiv_count = aiv_count_;
+            rt->orchestrator.total_cluster_count = sched_ctx_.aic_count();
+            rt->orchestrator.total_aiv_count = sched_ctx_.aiv_count();
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
             runtime->set_pto2_slot_states_ptr(nullptr);
@@ -754,15 +376,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             orch_so_handle_ = handle;
             snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
 
-            // Wire scheduler context to the newly created PTO2Runtime
-            sched_ctx_.sched_ = &rt->scheduler;
+            // Wire scheduler context to the newly created PTO2Runtime before
+            // releasing scheduler threads from runtime_init_ready_.
+            sched_ctx_.bind_runtime(rt);
 
             runtime_init_ready_.store(true, std::memory_order_release);
 
             // Wait for scheduler's one-time init to complete
-            while (!sched_ctx_.pto2_init_complete_.load(std::memory_order_acquire)) {
-                SPIN_WAIT_HINT();
-            }
+            sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
             if (runtime->enable_profiling) {
@@ -868,90 +489,26 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 #endif
 
-#if PTO2_PROFILING
-            // Write core-to-thread mapping (one-time, after orchestration)
-            if (runtime->enable_profiling) {
-                perf_aicpu_write_core_assignments(
-                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
-                );
-            }
-#endif
-
-            // Signal completion and trigger core transition
+            // Signal completion to the orchestrator state machine
             pto2_rt_orchestration_done(rt);
 
-            void *sm = runtime->get_pto2_gm_sm_ptr();
-            PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
-            int32_t pto2_task_count = 0;
-            if (sm_header) {
+            // Latch task count from PTO2 shared memory
+            int32_t total_tasks = 0;
+            if (rt->orchestrator.sm_header) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                    pto2_task_count += sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+                    total_tasks +=
+                        rt->orchestrator.sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }
             }
 #if PTO2_PROFILING
-            pto2_submitted_tasks = pto2_task_count;
-#endif
-            total_tasks_ = pto2_task_count;
-            if (runtime->enable_profiling && pto2_task_count > 0) {
-                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(pto2_task_count));
-            }
-            int32_t inline_completed = static_cast<int32_t>(rt->orchestrator.inline_completed_tasks);
-            if (inline_completed > 0) {
-                completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
-#if PTO2_SCHED_PROFILING
-                rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
-#endif
-            }
-            orchestrator_done_ = true;
-            {
-                int32_t orch_err = 0;
-                void *sm = runtime->get_pto2_gm_sm_ptr();
-                if (sm) {
-                    orch_err =
-                        static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);
-                }
-
-                // Fatal error: shutdown AICore immediately before core transition.
-                if (orch_err != PTO2_ERROR_NONE) {
-                    emergency_shutdown(runtime);
-                    completed_.store(true, std::memory_order_release);
-                }
-            }
-
-#if PTO2_ORCH_PROFILING
-            uint64_t reassign_cycle_start = get_sys_cnt_aicpu();
+            pto2_submitted_tasks = total_tasks;
 #endif
 
-            // Skip core transition on fatal error — cores already shut down above
-            if (completed_.load(std::memory_order_acquire)) {
-                // Signal transition to unblock scheduler threads waiting at core transition
-                transition_requested_.store(true, std::memory_order_release);
-                reassigned_.store(true, std::memory_order_release);
-            } else if (orch_to_sched_) {
-                // Compute new core assignments for all threads and initialize donated slots
-                DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
-#if PTO2_PROFILING
-                uint64_t orch_stage_end_ts = get_sys_cnt_aicpu();
-#endif
-                transition_requested_.store(true, std::memory_order_release);
-#if PTO2_PROFILING
-                DEV_ALWAYS(
-                    "Thread %d: orch_stage_end=%" PRIu64 "", thread_idx, static_cast<uint64_t>(orch_stage_end_ts)
-                );
-#endif
-
-                // Wait for scheduler threads to acknowledge transition request
-                while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
-                    if (completed_.load(std::memory_order_acquire)) {
-                        break;
-                    }
-                    SPIN_WAIT_HINT();
-                }
-                if (!completed_.load(std::memory_order_acquire)) {
-                    reassign_cores_for_all_threads();
-                    reassigned_.store(true, std::memory_order_release);
-                }
+            if (runtime->enable_profiling && total_tasks > 0) {
+                perf_aicpu_update_total_tasks(runtime, static_cast<uint32_t>(total_tasks));
             }
+
+            sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
 
 #if PTO2_ORCH_PROFILING
             uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
@@ -970,7 +527,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         if (pto2_submitted_tasks >= 0) {
             DEV_ALWAYS(
                 "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
-                completed_tasks_.load(std::memory_order_acquire)
+                sched_ctx_.completed_tasks_count()
             );
         }
 #endif
@@ -978,31 +535,24 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
-    if (!completed_.load(std::memory_order_acquire) && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
+    if (!sched_ctx_.is_completed() && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
         // Device orchestration: wait for primary orchestrator to initialize SM header
         if (!runtime->get_orch_built_on_host()) {
             while (!runtime_init_ready_.load(std::memory_order_acquire)) {
                 SPIN_WAIT_HINT();
             }
         }
-        always_assert(rt != nullptr);
-        sched_ctx_.sched_ = &rt->scheduler;
+        sched_ctx_.bind_runtime(rt);
         int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
         DEV_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
     }
 
-    // Always shutdown AICore — even if completed_ was already true.
+    // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_count_per_thread_ == 0 so they skip the loop harmlessly.
-    {
-        const int32_t *shutdown_cores = core_assignments_[thread_idx];
-        int32_t shutdown_count = core_count_per_thread_[thread_idx];
-        if (shutdown_count > 0) {
-            auto rc = shutdown_aicore(runtime, thread_idx, shutdown_cores, shutdown_count);
-            if (rc != 0) {
-                return rc;
-            }
-        }
+    auto rc = sched_ctx_.shutdown(thread_idx);
+    if (rc != 0) {
+        return rc;
     }
 
     DEV_INFO("Thread %d: Completed", thread_idx);
@@ -1031,44 +581,16 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
     cache_invalidate_range(runtime, sizeof(Runtime));
 
-    // Reset all per-core execution state
-    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
-        sched_ctx_.core_exec_states_[i] = {};
-        sched_ctx_.core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
-        sched_ctx_.core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
-    }
+    // Reset all SchedulerContext-owned state in one place.
+    sched_ctx_.deinit();
 
-    // Clear per-core dispatch payloads
-    memset(sched_ctx_.payload_per_core_, 0, sizeof(sched_ctx_.payload_per_core_));
-
-    completed_tasks_.store(0, std::memory_order_release);
-    total_tasks_ = 0;
     finished_count_.store(0, std::memory_order_release);
-    orchestrator_done_ = false;
-    sched_ctx_.pto2_init_done_.store(false, std::memory_order_release);
-    sched_ctx_.pto2_init_complete_.store(false, std::memory_order_release);
     runtime_init_ready_.store(false, std::memory_order_release);
 
-    // Reset core transition state
-    transition_requested_.store(false, std::memory_order_release);
-    wait_reassign_.store(0, std::memory_order_release);
-    reassigned_.store(false, std::memory_order_release);
-    completed_.store(false, std::memory_order_release);
-
-    // Reset core discovery and assignment state
-    aic_count_ = 0;
-    aiv_count_ = 0;
-    cores_total_num_ = 0;
     thread_num_ = 0;
     sched_thread_num_ = 0;
-    thread_cores_num_ = 0;
     orch_to_sched_ = false;
-    active_sched_threads_ = 0;
-    memset(sched_ctx_.core_trackers_, 0, sizeof(sched_ctx_.core_trackers_));
-    memset(core_assignments_, 0, sizeof(core_assignments_));
-    memset(core_count_per_thread_, 0, sizeof(core_count_per_thread_));
 
-    regs_ = 0;
     orch_func_ = nullptr;
     orch_bind_runtime_ = nullptr;
     orch_args_cached_ = nullptr;
@@ -1095,95 +617,6 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     DEV_INFO("DeInit: AicpuExecutor reset complete");
 }
 
-void AicpuExecutor::emergency_shutdown(Runtime *runtime) {
-    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
-    for (int32_t i = 0; i < cores_total_num_; i++) {
-        Handshake *hank = &all_handshakes[i];
-        OUT_OF_ORDER_STORE_BARRIER();
-        hank->aicpu_regs_ready = 1;
-        if (sched_ctx_.core_exec_states_[i].reg_addr != 0) {
-            platform_deinit_aicore_regs(sched_ctx_.core_exec_states_[i].reg_addr);
-        }
-    }
-
-    DEV_WARN("Emergency shutdown complete");
-}
-
-void AicpuExecutor::diagnose_stuck_state(
-    Runtime *runtime, int32_t thread_idx, const int32_t *cur_thread_cores, int32_t core_num, Handshake *hank
-) {
-    (void)runtime;
-    PTO2SchedulerState *sched = &rt->scheduler;
-    DEV_ALWAYS("========== DIAGNOSTIC REPORT: Thread %d ==========", thread_idx);
-
-    int32_t completed = completed_tasks_.load(std::memory_order_acquire);
-    int32_t total = total_tasks_;
-    DEV_ALWAYS("Progress: %d/%d tasks (%.1f%%)", completed, total, total > 0 ? completed * 100.0 / total : 0.0);
-
-    uint64_t aic_ready = 0, aiv_ready = 0, mix_ready = 0;
-    if (rt) {
-        aic_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIC)].size();
-        aiv_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::AIV)].size();
-        mix_ready = sched->ready_queues[static_cast<int32_t>(PTO2ResourceShape::MIX)].size();
-    }
-    DEV_ALWAYS("Ready Queues: AIC=%lu, AIV=%lu, MIX=%lu", aic_ready, aiv_ready, mix_ready);
-
-    int32_t busy_cores = 0;
-    int32_t idle_cores = 0;
-
-    DEV_ALWAYS("Core Status:");
-    for (int32_t i = 0; i < core_num; i++) {
-        int32_t core_id = cur_thread_cores[i];
-        Handshake *h = &hank[core_id];
-        const char *core_type_str = core_type_to_string(h->core_type);
-
-        uint64_t reg_addr = sched_ctx_.core_exec_states_[core_id].reg_addr;
-        uint64_t reg_val = read_reg(reg_addr, RegId::COND);
-        int32_t reg_task_id = EXTRACT_TASK_ID(reg_val);
-        int32_t reg_state = EXTRACT_TASK_STATE(reg_val);
-        int32_t task_id = sched_ctx_.core_exec_states_[core_id].running_reg_task_id;
-
-        if (reg_state != TASK_FIN_STATE || task_id >= 0) {
-            busy_cores++;
-            if (task_id >= 0) {
-                int32_t kernel_id = -1;
-                if (rt && rt->sm_handle && sched_ctx_.core_exec_states_[core_id].running_slot_state) {
-                    int32_t diag_slot = static_cast<int32_t>(sched_ctx_.core_exec_states_[core_id].running_subslot);
-                    kernel_id = sched_ctx_.core_exec_states_[core_id].running_slot_state->task->kernel_id[diag_slot];
-                }
-                DEV_ALWAYS(
-                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s), running_reg_task_id=%d, "
-                    "kernel_id=%d",
-                    core_id, core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK", task_id,
-                    kernel_id
-                );
-            } else {
-                DEV_ALWAYS(
-                    "  Core %d [%s, BUSY]: COND=0x%lx (reg_task_id=%d, reg_state=%s) but task_id not tracked", core_id,
-                    core_type_str, reg_val, reg_task_id, reg_state == TASK_FIN_STATE ? "FIN" : "ACK"
-                );
-            }
-        } else {
-            idle_cores++;
-        }
-    }
-
-    DEV_ALWAYS("Summary: %d busy, %d idle", busy_cores, idle_cores);
-
-    // Diagnose deadlock vs livelock
-    if (busy_cores == 0 && aic_ready == 0 && aiv_ready == 0 && completed < total) {
-        DEV_ALWAYS("*** DEADLOCK DETECTED ***");
-        DEV_ALWAYS("All cores idle, no ready tasks, but %d tasks incomplete", total - completed);
-        DEV_ALWAYS("Check PTO2 shared memory for task dependency state");
-    } else if (busy_cores > 0) {
-        DEV_ALWAYS("*** LIVELOCK / HUNG TASK ***");
-        DEV_ALWAYS("%d cores executing but no progress", busy_cores);
-    }
-
-    DEV_ALWAYS("========== END DIAGNOSTIC ==========");
-}
-
 // ===== Public Entry Point =====
 
 /**
@@ -1206,9 +639,6 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     }
 
     DEV_INFO("%s", "aicpu_execute: Starting AICPU kernel execution");
-
-    // Get platform register addresses from platform-level global
-    g_aicpu_executor.regs_ = get_platform_regs();
 
     g_aicpu_executor.init(runtime);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -499,6 +499,30 @@ advance_ring_pointers(ring_id):  // protected by per-ring advance_lock
 
 This is protected by a per-ring try-lock (`advance_lock`) in `RingSchedState`, ensuring only one scheduler thread advances a given ring's watermark at a time.
 
+### 8.5 SchedulerContext
+
+All scheduler-side state and methods live in `SchedulerContext` (`runtime/scheduler/scheduler_context.h`). It is held as a `sched_ctx_` member of `AicpuExecutor`; `AicpuExecutor` is a thin wrapper that owns the lifecycle atomics and the orchestration SO handle, and delegates everything else to `SchedulerContext`.
+
+Public surface (called from `AicpuExecutor::init/run/deinit`):
+
+| Method | Phase | Purpose |
+| ------ | ----- | ------- |
+| `init(runtime, thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
+| `bind_runtime(rt)` | device-orch only | Wire `sched_` to `rt->scheduler` once the orchestrator thread creates `rt` |
+| `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
+| `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores |
+| `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | orchestrator thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_`, drive orch→sched core transition (or `emergency_shutdown` on fatal) |
+| `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
+| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` / `wait_pto2_init_complete()` |
+
+Private internals are split across three .cpp files by responsibility:
+
+- `scheduler_completion.cpp` — completion polling, drain protocol
+- `scheduler_dispatch.cpp` — task dispatch loop and helpers
+- `scheduler_cold_path.cpp` — exit checks, stall diagnostics, profiling, lifecycle (`init/deinit`), core management (`handshake_all_cores` / `assign_cores_to_threads` / `reassign_cores_for_all_threads` / `emergency_shutdown`), and `on_orchestration_done`
+
+`AicpuExecutor` calls neither `handshake_*`, `assign_*`, `reassign_*`, nor `emergency_shutdown` directly — they are private, invoked only by `init` and `on_orchestration_done`.
+
 ---
 
 ## 9. AICore Worker Interaction

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -14,9 +14,13 @@
 
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
+#include "aicpu/performance_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
+#include "common/memory_barrier.h"
 #include "common/perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2.h"
+#include "pto_shared_memory.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
@@ -27,7 +31,7 @@
 LoopAction SchedulerContext::handle_orchestrator_exit(
     int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count
 ) {
-    bool orch_done = *orchestrator_done_ptr_;
+    bool orch_done = orchestrator_done_;
     if (!orch_done) return LoopAction::NONE;
 
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
@@ -35,18 +39,18 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
         DEV_ERROR(
             "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
             "completed_tasks=%d, total_tasks=%d",
-            thread_idx, orch_err, completed_tasks_ptr_->load(std::memory_order_relaxed), *total_tasks_ptr_
+            thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
         );
-        emergency_shutdown_fn_(runtime);
-        completed_ptr_->store(true, std::memory_order_release);
+        emergency_shutdown(runtime);
+        completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
 
-    task_count = *total_tasks_ptr_;
-    if (task_count > 0 && completed_tasks_ptr_->load(std::memory_order_relaxed) >= task_count) {
-        completed_ptr_->store(true, std::memory_order_release);
+    task_count = total_tasks_;
+    if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
+        completed_.store(true, std::memory_order_release);
         DEV_INFO(
-            "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_ptr_->load(std::memory_order_relaxed),
+            "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
             task_count
         );
         return LoopAction::BREAK_LOOP;
@@ -55,11 +59,11 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
 }
 
 LoopAction SchedulerContext::handle_core_transition(bool &cores_released) {
-    if (!transition_requested_ptr_->load(std::memory_order_acquire)) return LoopAction::NONE;
-    if (!reassigned_ptr_->load(std::memory_order_acquire)) {
-        wait_reassign_ptr_->fetch_add(1, std::memory_order_release);
-        while (!reassigned_ptr_->load(std::memory_order_acquire)) {
-            if (completed_ptr_->load(std::memory_order_acquire)) {
+    if (!transition_requested_.load(std::memory_order_acquire)) return LoopAction::NONE;
+    if (!reassigned_.load(std::memory_order_acquire)) {
+        wait_reassign_.fetch_add(1, std::memory_order_release);
+        while (!reassigned_.load(std::memory_order_acquire)) {
+            if (completed_.load(std::memory_order_acquire)) {
                 return LoopAction::BREAK_LOOP;
             }
             SPIN_WAIT_HINT();
@@ -74,8 +78,8 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
         DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
-        emergency_shutdown_fn_(runtime);
-        completed_ptr_->store(true, std::memory_order_release);
+        emergency_shutdown(runtime);
+        completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
     return LoopAction::NONE;
@@ -84,7 +88,7 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
 void SchedulerContext::log_stall_diagnostics(
     int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count
 ) {
-    int32_t c = completed_tasks_ptr_->load(std::memory_order_relaxed);
+    int32_t c = completed_tasks_.load(std::memory_order_relaxed);
     DEV_ALWAYS(
         "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
         task_count, last_progress_count
@@ -334,3 +338,462 @@ void SchedulerContext::log_profiling_summary(int32_t thread_idx, int32_t cur_thr
     );
 }
 #endif
+
+// =============================================================================
+// Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
+// Orchestrator threads have core_count_per_thread_[thread_idx] == 0 -> no-op.
+// platform_deinit_aicore_regs is idempotent; safe to call after early completion.
+// =============================================================================
+int32_t SchedulerContext::shutdown(int32_t thread_idx) {
+    const int32_t *cores = core_assignments_[thread_idx];
+    int32_t core_num = core_count_per_thread_[thread_idx];
+    if (core_num == 0) return 0;
+
+    DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
+    for (int32_t i = 0; i < core_num; i++) {
+        int32_t core_id = cores[i];
+        uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
+        if (reg_addr != 0) {
+            platform_deinit_aicore_regs(reg_addr);
+        } else {
+            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+        }
+    }
+    DEV_INFO("Thread %d: Shutdown complete", thread_idx);
+    return 0;
+}
+
+// =============================================================================
+// Handshake with all AICore workers; discover core type and reg address.
+// =============================================================================
+int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    cores_total_num_ = runtime->worker_count;
+
+    // Validate cores_total_num_ before using as array index
+    if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
+        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
+        return -1;
+    }
+
+    aic_count_ = 0;
+    aiv_count_ = 0;
+
+    DEV_INFO("Handshaking with %d cores", cores_total_num_);
+
+    // Step 1: Write per-core payload addresses and send handshake signal.
+    // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
+    // aicpu_ready=1, so AICore reads the correct payload pointer after waking up.
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        all_handshakes[i].task = reinterpret_cast<uint64_t>(&payload_per_core_[i][0]);
+        OUT_OF_ORDER_STORE_BARRIER();
+        all_handshakes[i].aicpu_ready = 1;
+    }
+    OUT_OF_ORDER_STORE_BARRIER();
+
+    // Get platform physical cores count for validation
+    uint32_t max_physical_cores_count = platform_get_physical_cores_count();
+
+    // Step 2: Wait for all cores to respond, collect core type and register addresses
+    bool handshake_failed = false;
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake *hank = &all_handshakes[i];
+
+        while (hank->aicore_regs_ready == 0) {}
+
+        uint32_t physical_core_id = hank->physical_core_id;
+
+        if (physical_core_id >= max_physical_cores_count) {
+            DEV_ERROR(
+                "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
+                max_physical_cores_count
+            );
+            handshake_failed = true;
+            continue;
+        }
+
+        uint64_t *regs = reinterpret_cast<uint64_t *>(regs_);
+        uint64_t reg_addr = regs[physical_core_id];
+
+        // Initialize AICore registers after discovery (first round)
+        platform_init_aicore_regs(reg_addr);
+        OUT_OF_ORDER_STORE_BARRIER();
+        hank->aicpu_regs_ready = 1;
+
+        OUT_OF_ORDER_STORE_BARRIER();
+
+        while (hank->aicore_done == 0) {}
+
+        CoreType type = hank->core_type;
+
+        core_exec_states_[i].reg_addr = reg_addr;
+
+#if !PTO2_PROFILING
+        core_exec_states_[i].worker_id = i;
+        core_exec_states_[i].physical_core_id = physical_core_id;
+        core_exec_states_[i].core_type = type;
+#endif
+
+        if (type == CoreType::AIC) {
+            aic_worker_ids_[aic_count_++] = i;
+            DEV_INFO("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        } else {
+            aiv_worker_ids_[aiv_count_++] = i;
+            DEV_INFO("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+        }
+    }
+
+    if (handshake_failed) {
+        emergency_shutdown(runtime);
+        return -1;
+    }
+
+    DEV_INFO("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
+    return 0;
+}
+
+// =============================================================================
+// Assign discovered cores to scheduler threads (cluster-aligned round-robin).
+// =============================================================================
+bool SchedulerContext::assign_cores_to_threads() {
+    // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
+    // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
+    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
+    int32_t cluster_count = aic_count_;
+
+    // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
+    int32_t max_clusters_per_thread = (cluster_count + active_sched_threads_ - 1) / active_sched_threads_;
+    int32_t thread_cores_num = max_clusters_per_thread * 3;
+
+    if (thread_cores_num > CoreTracker::MAX_CORE_PER_THREAD) {
+        DEV_ERROR("Can't assign more then 64 cores in per scheduler");
+        return false;
+    }
+
+    DEV_INFO(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
+        active_sched_threads_, aic_count_, aiv_count_
+    );
+
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
+        core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
+    }
+
+    // Count clusters per thread first (round-robin may distribute unevenly)
+    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        clusters_per_thread[ci % active_sched_threads_]++;
+    }
+    for (int32_t i = 0; i < active_sched_threads_; i++) {
+        core_trackers_[i].init(clusters_per_thread[i]);
+        core_count_per_thread_[i] = 0;
+    }
+
+    int32_t core_idx[MAX_AICPU_THREADS] = {};
+    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
+
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        int32_t t = ci % active_sched_threads_;
+        int32_t &idx = core_idx[t];
+
+        int32_t aic_wid = aic_worker_ids_[ci];
+        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
+        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
+
+        core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
+
+        core_assignments_[t][idx++] = aic_wid;
+        core_assignments_[t][idx++] = aiv0_wid;
+        core_assignments_[t][idx++] = aiv1_wid;
+
+        DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+    }
+
+    for (int32_t t = 0; t < thread_num_; t++) {
+        core_count_per_thread_[t] = core_idx[t];
+        DEV_INFO("Thread %d: total %d cores (%d clusters)", t, core_idx[t], core_trackers_[t].get_cluster_count());
+    }
+
+    DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
+    return true;
+}
+
+// =============================================================================
+// Reassign all cores across all threads (sched + orchestrator) after orchestration.
+// =============================================================================
+void SchedulerContext::reassign_cores_for_all_threads() {
+    DEV_INFO("Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_);
+
+    // Collect running worker_ids from all current trackers
+    bool running_cores[RUNTIME_MAX_WORKER] = {};
+    for (int32_t i = 0; i < thread_num_; i++) {
+        auto all_running = core_trackers_[i].get_all_running_cores();
+        int32_t bp;
+        while ((bp = all_running.pop_first()) >= 0) {
+            running_cores[core_trackers_[i].get_core_id_by_offset(bp)] = true;
+        }
+    }
+
+    // Count clusters per thread (round-robin across all threads)
+    int32_t cluster_count = aic_count_;
+    int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        clusters_per_thread[ci % thread_num_]++;
+    }
+
+    // Re-init all trackers and reset core counts
+    for (int32_t i = 0; i < thread_num_; i++) {
+        core_trackers_[i].init(clusters_per_thread[i]);
+        core_count_per_thread_[i] = 0;
+    }
+
+    // Assign clusters round-robin and restore running state
+    int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
+    for (int32_t ci = 0; ci < cluster_count; ci++) {
+        int32_t t = ci % thread_num_;
+
+        int32_t aic_wid = aic_worker_ids_[ci];
+        int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
+        int32_t aiv1_wid = aiv_worker_ids_[2 * ci + 1];
+
+        int32_t cl_idx = cluster_idx_per_thread[t]++;
+        core_trackers_[t].set_cluster(cl_idx, aic_wid, aiv0_wid, aiv1_wid);
+
+        // init() marks all idle; toggle cores that were running and restore pending_occupied
+        if (running_cores[aic_wid]) {
+            core_trackers_[t].change_core_state(cl_idx * 3);
+            core_trackers_[t].set_pending_occupied(cl_idx * 3);
+        }
+        if (running_cores[aiv0_wid]) {
+            core_trackers_[t].change_core_state(cl_idx * 3 + 1);
+            core_trackers_[t].set_pending_occupied(cl_idx * 3 + 1);
+        }
+        if (running_cores[aiv1_wid]) {
+            core_trackers_[t].change_core_state(cl_idx * 3 + 2);
+            core_trackers_[t].set_pending_occupied(cl_idx * 3 + 2);
+        }
+
+        core_assignments_[t][core_count_per_thread_[t]++] = aic_wid;
+        core_assignments_[t][core_count_per_thread_[t]++] = aiv0_wid;
+        core_assignments_[t][core_count_per_thread_[t]++] = aiv1_wid;
+    }
+
+    // Log final distribution
+    DEV_INFO("Core reassignment complete:");
+    for (int32_t t = 0; t < thread_num_; t++) {
+        int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
+        int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
+        DEV_INFO(
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
+            core_trackers_[t].get_cluster_count(), aic_running, aiv_running
+        );
+    }
+    active_sched_threads_ = thread_num_;
+}
+
+// =============================================================================
+// Emergency shutdown: broadcast exit signal to every handshake'd core and
+// deinit their AICore register blocks. Idempotent.
+// =============================================================================
+void SchedulerContext::emergency_shutdown(Runtime *runtime) {
+    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    for (int32_t i = 0; i < cores_total_num_; i++) {
+        Handshake *hank = &all_handshakes[i];
+        OUT_OF_ORDER_STORE_BARRIER();
+        hank->aicpu_regs_ready = 1;
+        if (core_exec_states_[i].reg_addr != 0) {
+            platform_deinit_aicore_regs(core_exec_states_[i].reg_addr);
+        }
+    }
+    DEV_WARN("Emergency shutdown complete");
+}
+
+// =============================================================================
+// Lifecycle: init / deinit
+// =============================================================================
+int32_t SchedulerContext::init(
+    Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base
+) {
+    always_assert(runtime != nullptr);
+
+    // Zero all per-core execution state before handshake
+    memset(core_exec_states_, 0, sizeof(core_exec_states_));
+
+    // Wire thread/transition configuration that handshake/assign need to read.
+    thread_num_ = thread_num;
+    sched_thread_num_ = sched_thread_num;
+    orch_to_sched_ = orch_to_sched;
+    regs_ = regs_base;
+
+    // Discover cores and assign to scheduler threads.
+    int32_t rc = handshake_all_cores(runtime);
+    if (rc != 0) {
+        DEV_ERROR("handshake_all_cores failed");
+        return rc;
+    }
+    if (!assign_cores_to_threads()) {
+        return -1;
+    }
+
+    // Initialize task counters. Task count comes from PTO2 shared memory.
+    if (runtime->get_pto2_gm_sm_ptr()) {
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
+        int32_t pto2_count = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+        }
+        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
+    } else {
+        total_tasks_ = 0;
+    }
+    completed_tasks_.store(0, std::memory_order_release);
+
+    // Host orchestration: graph already built; device orch: orchestrator sets it.
+    orchestrator_done_ = runtime->get_orch_built_on_host();
+
+    // Clear per-core dispatch payloads
+    memset(payload_per_core_, 0, sizeof(payload_per_core_));
+
+    // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
+    // This is done once at startup and never modified afterwards.
+    for (int32_t t = 0; t < sched_thread_num_; t++) {
+        CoreTracker &tracker = core_trackers_[t];
+        for (int32_t c = 0; c < tracker.get_cluster_count(); c++) {
+            int32_t cluster_offset = c * 3;  // Each cluster = 1 AIC + 2 AIV
+            auto aiv0_id = tracker.get_core_id_by_offset(tracker.get_aiv0_core_offset(cluster_offset));
+            auto aiv1_id = tracker.get_core_id_by_offset(tracker.get_aiv1_core_offset(cluster_offset));
+            payload_per_core_[aiv0_id][0].global_context.sub_block_id = 0;
+            payload_per_core_[aiv0_id][1].global_context.sub_block_id = 0;
+            payload_per_core_[aiv1_id][0].global_context.sub_block_id = 1;
+            payload_per_core_[aiv1_id][1].global_context.sub_block_id = 1;
+        }
+    }
+
+    func_id_to_addr_ = runtime->func_id_to_addr_;
+
+    return 0;
+}
+
+void SchedulerContext::deinit() {
+    // Reset all per-core execution state
+    for (int32_t i = 0; i < RUNTIME_MAX_WORKER; i++) {
+        core_exec_states_[i] = {};
+        core_exec_states_[i].running_reg_task_id = AICPU_TASK_INVALID;
+        core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
+    }
+
+    // Clear per-core dispatch payloads
+    memset(payload_per_core_, 0, sizeof(payload_per_core_));
+
+    // Reset sync-start drain coordination — a previous run that aborted mid-drain
+    // would otherwise leave dirty pending/elected/ack state for the next reuse.
+    drain_state_.sync_start_pending.store(0, std::memory_order_release);
+    drain_state_.drain_worker_elected.store(0, std::memory_order_release);
+    drain_state_.drain_ack_mask.store(0, std::memory_order_release);
+    drain_state_.pending_task = nullptr;
+
+    // Reset task counters and orchestrator state
+    completed_tasks_.store(0, std::memory_order_release);
+    total_tasks_ = 0;
+    orchestrator_done_ = false;
+    pto2_init_done_.store(false, std::memory_order_release);
+    pto2_init_complete_.store(false, std::memory_order_release);
+
+    // Reset core transition state
+    transition_requested_.store(false, std::memory_order_release);
+    wait_reassign_.store(0, std::memory_order_release);
+    reassigned_.store(false, std::memory_order_release);
+    completed_.store(false, std::memory_order_release);
+
+    // Reset core discovery and assignment state
+    aic_count_ = 0;
+    aiv_count_ = 0;
+    cores_total_num_ = 0;
+    thread_num_ = 0;
+    sched_thread_num_ = 0;
+    orch_to_sched_ = false;
+    active_sched_threads_ = 0;
+    for (int32_t t = 0; t < MAX_AICPU_THREADS; t++) {
+        core_trackers_[t] = CoreTracker{};
+    }
+    memset(core_assignments_, 0, sizeof(core_assignments_));
+    memset(core_count_per_thread_, 0, sizeof(core_count_per_thread_));
+
+    regs_ = 0;
+    sched_ = nullptr;
+    func_id_to_addr_ = nullptr;
+}
+
+void SchedulerContext::wait_pto2_init_complete() const {
+    while (!pto2_init_complete_.load(std::memory_order_acquire)) {
+        SPIN_WAIT_HINT();
+    }
+}
+
+void SchedulerContext::bind_runtime(PTO2Runtime *rt) { sched_ = &rt->scheduler; }
+
+// =============================================================================
+// Post-orchestration bookkeeping. Runs on the orchestrator thread once the
+// build phase finishes; folds inline-completed tasks, flips orchestrator_done_,
+// and drives the orchestrator → scheduler core transition (or fatal shutdown).
+// =============================================================================
+void SchedulerContext::on_orchestration_done(
+    Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
+) {
+#if PTO2_PROFILING
+    // Write core-to-thread mapping (one-time, after orchestration)
+    if (runtime->enable_profiling) {
+        perf_aicpu_write_core_assignments(
+            core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
+        );
+    }
+#else
+    (void)thread_idx;
+#endif
+
+    total_tasks_ = total_tasks;
+
+    // Fold tasks completed inline during orchestration
+    int32_t inline_completed = static_cast<int32_t>(rt->orchestrator.inline_completed_tasks);
+    if (inline_completed > 0) {
+        completed_tasks_.fetch_add(inline_completed, std::memory_order_relaxed);
+#if PTO2_SCHED_PROFILING
+        rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
+#endif
+    }
+    orchestrator_done_ = true;
+
+    // Check for fatal error from orchestration; if so, shut down immediately.
+    int32_t orch_err = 0;
+    if (sched_->sm_header) {
+        orch_err = sched_->sm_header->orch_error_code.load(std::memory_order_relaxed);
+    }
+    if (orch_err != PTO2_ERROR_NONE) {
+        emergency_shutdown(runtime);
+        completed_.store(true, std::memory_order_release);
+    }
+
+    // Skip core transition on fatal error — cores already shut down above.
+    if (completed_.load(std::memory_order_acquire)) {
+        // Signal transition to unblock scheduler threads waiting at core transition
+        transition_requested_.store(true, std::memory_order_release);
+        reassigned_.store(true, std::memory_order_release);
+    } else if (orch_to_sched_) {
+        DEV_INFO("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+        transition_requested_.store(true, std::memory_order_release);
+
+        // Wait for scheduler threads to acknowledge transition request
+        while (wait_reassign_.load(std::memory_order_acquire) != sched_thread_num_) {
+            if (completed_.load(std::memory_order_acquire)) {
+                break;
+            }
+            SPIN_WAIT_HINT();
+        }
+        if (!completed_.load(std::memory_order_acquire)) {
+            reassign_cores_for_all_threads();
+            reassigned_.store(true, std::memory_order_release);
+        }
+    }
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -28,6 +28,7 @@
 // Forward declarations — avoid pulling in full headers for pointer/reference params.
 class Runtime;
 struct Handshake;
+struct PTO2Runtime;
 
 /**
  * SchedulerContext: owns all scheduler-side state and methods.
@@ -43,12 +44,70 @@ struct Handshake;
  */
 class SchedulerContext {
 public:
-    // === Public entry point ===
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    // Initialize scheduler state from the given runtime and thread layout.
+    // - Discovers cores via handshake_all_cores()
+    // - Assigns cores to scheduler threads
+    // - Resets task counters, payloads, per-core GlobalContext
+    // - Binds func_id_to_addr_ / initial sched_ (if rt is already known)
+    // - Captures AICore-register base (consumed by handshake_all_cores())
+    // Returns 0 on success, negative on failure (handshake / assignment error).
+    int32_t
+    init(Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base);
+
+    // Reset all SchedulerContext-owned state to its post-construction defaults.
+    // Called by AicpuExecutor::deinit() during per-run teardown.
+    void deinit();
+
+    // =========================================================================
+    // Per-thread execution entry points (called by AicpuExecutor::run)
+    // =========================================================================
+
+    // Main scheduler thread entry: poll completion + dispatch ready tasks.
     int32_t resolve_and_dispatch(Runtime *runtime, int32_t thread_idx);
 
-    // === State (public for AicpuExecutor init/handshake access during transition) ===
+    // Shutdown AICore registers for this thread's assigned cores.
+    // Also runs PMU finalize (PTO2_PROFILING) before deinit when enabled.
+    // Orchestrator threads (core_count_per_thread_[thread_idx] == 0) are a no-op.
+    int32_t shutdown(int32_t thread_idx);
 
-    PTO2SchedulerState *sched_{nullptr};
+    // Run all post-orchestration scheduler bookkeeping:
+    //  - publishes core assignments to the perf collector (PTO2_PROFILING)
+    //  - latches submitted task count from PTO2 shared memory
+    //  - folds inline_completed_tasks into completed_tasks_
+    //  - flips orchestrator_done_ and triggers core transition
+    //    (skipped on fatal error — emergency_shutdown runs instead)
+    // Callers must invoke pto2_rt_orchestration_done(rt) before this — that
+    // step belongs to the orchestrator lifecycle, not the scheduler.
+    void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
+
+    // Bind the PTO2Runtime scheduler pointer. Required in device-orchestration
+    // mode where rt is created by the orchestrator thread after init().
+    void bind_runtime(PTO2Runtime *rt);
+
+    // =========================================================================
+    // State queries / external synchronization points
+    // =========================================================================
+
+    int32_t aic_count() const { return aic_count_; }
+    int32_t aiv_count() const { return aiv_count_; }
+    bool is_completed() const { return completed_.load(std::memory_order_acquire); }
+    int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+
+    // Block until the first scheduler thread has finished one-time PTO2 init.
+    // Called by the orchestrator thread in device-orch mode.
+    void wait_pto2_init_complete() const;
+
+private:
+    // =========================================================================
+    // State
+    // =========================================================================
+
+    // --- Scheduler binding & per-core runtime state ---
+    alignas(64) PTO2SchedulerState *sched_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];
@@ -67,95 +126,62 @@ public:
     SchedProfilingCounters sched_perf_[MAX_AICPU_THREADS];
 #endif
 
-    // Shared state pointers (set during init, point into AicpuExecutor)
-    std::atomic<int32_t> *completed_tasks_ptr_{nullptr};
-    int32_t *total_tasks_ptr_{nullptr};
-    volatile bool *orchestrator_done_ptr_{nullptr};
-    std::atomic<bool> *completed_ptr_{nullptr};
+    // --- Task-execution tracking ---
+    std::atomic<int32_t> completed_tasks_{0};
+    int32_t total_tasks_{0};
+    // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
+    // volatile prevents the compiler from hoisting the load out of spin loops.
+    volatile bool orchestrator_done_{false};
+    std::atomic<bool> completed_{false};
     uint64_t *func_id_to_addr_{nullptr};
 
-    // Core transition state pointers (set during init, point into AicpuExecutor)
-    std::atomic<bool> *transition_requested_ptr_{nullptr};
-    std::atomic<int32_t> *wait_reassign_ptr_{nullptr};
-    std::atomic<bool> *reassigned_ptr_{nullptr};
+    // --- Core-transition coordination ---
+    std::atomic<bool> transition_requested_{false};
+    std::atomic<int32_t> wait_reassign_{0};
+    std::atomic<bool> reassigned_{false};
 
-    // Thread/core configuration
+    // --- Thread/core configuration ---
     int32_t active_sched_threads_{0};
     int32_t sched_thread_num_{0};
     bool orch_to_sched_{false};
     int32_t thread_num_{0};
-    int32_t *core_count_per_thread_{nullptr};
-    int32_t (*core_assignments_)[MAX_CORES_PER_THREAD]{nullptr};
+    int32_t cores_total_num_{0};
+    int32_t core_count_per_thread_[MAX_AICPU_THREADS]{};
+    int32_t core_assignments_[MAX_AICPU_THREADS][RUNTIME_MAX_WORKER]{};
 
-    // One-time init coordination
+    // Cluster-ordered worker_id lists, populated by handshake_all_cores().
+    int32_t aic_worker_ids_[RUNTIME_MAX_WORKER]{};
+    int32_t aiv_worker_ids_[RUNTIME_MAX_WORKER]{};
+    int32_t aic_count_{0};
+    int32_t aiv_count_{0};
+
+    // Platform AICore-register base array (set by AicpuExecutor before init()).
+    uint64_t regs_{0};
+
+    // --- One-time init coordination ---
     std::atomic<bool> pto2_init_done_{false};
     std::atomic<bool> pto2_init_complete_{false};
 
-    // Emergency shutdown callback (calls AicpuExecutor::emergency_shutdown)
-    void (*emergency_shutdown_fn_)(Runtime *runtime){nullptr};
+    // =========================================================================
+    // Core management (scheduler_cold_path.cpp)
+    // =========================================================================
 
-    uint64_t get_function_bin_addr(int func_id) const {
-        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
-        return func_id_to_addr_[func_id];
-    }
+    // Handshake with all AICore workers; populates core_exec_states_, worker id lists.
+    int32_t handshake_all_cores(Runtime *runtime);
 
-private:
-    // === Completion & drain (scheduler_completion.cpp) ===
+    // Assign discovered cores (cluster = 1 AIC + 2 AIV) round-robin across scheduler threads.
+    bool assign_cores_to_threads();
 
-    static SlotTransition
-    decide_slot_transition(int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id);
+    // Re-distribute all cores across all threads after orchestration completes.
+    void reassign_cores_for_all_threads();
 
-    void complete_slot_task(
-        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
-        int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
-        PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
-        PTO2LocalReadyBuffer *local_bufs
-#if PTO2_PROFILING
-        ,
-        uint64_t dispatch_ts
-#endif
-    );
+    // Emergency shutdown: broadcast exit signal to every handshake'd core and
+    // deinit their AICore register blocks. Idempotent.
+    void emergency_shutdown(Runtime *runtime);
 
-    static void promote_pending_to_running(CoreExecState &core);
-    static void clear_running_slot(CoreExecState &core);
-
-    void check_running_cores_for_completion(
-        int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
-        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
-        PTO2LocalReadyBuffer *local_bufs
-    );
-
-    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
-    int32_t count_global_available(PTO2ResourceShape shape);
-    void drain_worker_dispatch(Runtime *runtime, int32_t block_num);
-    void handle_drain_mode(Runtime *runtime, int32_t thread_idx);
-
-    // === Cold path (scheduler_cold_path.cpp) ===
-
-    __attribute__((noinline, cold)) LoopAction
-    handle_orchestrator_exit(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count);
-
-    __attribute__((noinline, cold)) LoopAction handle_core_transition(bool &cores_released);
-
-    __attribute__((noinline, cold)) LoopAction
-    check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime);
-
-    __attribute__((noinline, cold)) void
-    log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
-
-    __attribute__((noinline, cold)) int32_t handle_timeout_exit(
-        int32_t thread_idx, int32_t idle_iterations
-#if PTO2_PROFILING
-        ,
-        uint64_t sched_start_ts
-#endif
-    );
-
-#if PTO2_PROFILING
-    __attribute__((noinline, cold)) void log_profiling_summary(int32_t thread_idx, int32_t cur_thread_completed);
-#endif
-
-    // === Dispatch (scheduler_dispatch.cpp) ===
+    // =========================================================================
+    // Dispatch (scheduler_dispatch.cpp)
+    // =========================================================================
 
     static const char *shape_name(PTO2ResourceShape shape);
     static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx);
@@ -186,6 +212,74 @@ private:
         PTO2LocalReadyBuffer &local_buf, CoreTracker &tracker, bool &entered_drain, bool &made_progress,
         bool &try_pushed
     );
+
+    // =========================================================================
+    // Completion & drain (scheduler_completion.cpp)
+    // =========================================================================
+
+    static SlotTransition
+    decide_slot_transition(int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id);
+
+    void complete_slot_task(
+        PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
+        int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
+        PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
+        PTO2LocalReadyBuffer *local_bufs
+#if PTO2_PROFILING
+        ,
+        uint64_t dispatch_ts
+#endif
+    );
+
+    static void promote_pending_to_running(CoreExecState &core);
+    static void clear_running_slot(CoreExecState &core);
+
+    void check_running_cores_for_completion(
+        int32_t thread_idx, Handshake *hank, int32_t &completed_this_turn, int32_t &cur_thread_completed,
+        bool &made_progress, PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count,
+        PTO2LocalReadyBuffer *local_bufs
+    );
+
+    bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
+    int32_t count_global_available(PTO2ResourceShape shape);
+    void drain_worker_dispatch(Runtime *runtime, int32_t block_num);
+    void handle_drain_mode(Runtime *runtime, int32_t thread_idx);
+
+    // =========================================================================
+    // Cold path: exit checks, stall diagnostics, profiling (scheduler_cold_path.cpp)
+    // =========================================================================
+
+    __attribute__((noinline, cold)) LoopAction
+    handle_orchestrator_exit(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count);
+
+    __attribute__((noinline, cold)) LoopAction handle_core_transition(bool &cores_released);
+
+    __attribute__((noinline, cold)) LoopAction
+    check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime);
+
+    __attribute__((noinline, cold)) void
+    log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
+
+    __attribute__((noinline, cold)) int32_t handle_timeout_exit(
+        int32_t thread_idx, int32_t idle_iterations
+#if PTO2_PROFILING
+        ,
+        uint64_t sched_start_ts
+#endif
+    );
+
+#if PTO2_PROFILING
+    __attribute__((noinline, cold)) void log_profiling_summary(int32_t thread_idx, int32_t cur_thread_completed);
+#endif
+
+    // =========================================================================
+    // Small inline helpers
+    // =========================================================================
+
+    uint64_t get_function_bin_addr(int func_id) const {
+        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
+        return func_id_to_addr_[func_id];
+    }
 };
 
 #endif  // SCHEDULER_CONTEXT_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -401,7 +401,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_SCHED_PROFILING
             sched_->tasks_completed.fetch_add(completed_this_turn, std::memory_order_relaxed);
 #endif
-            int32_t prev = completed_tasks_ptr_->fetch_add(completed_this_turn, std::memory_order_relaxed);
+            int32_t prev = completed_tasks_.fetch_add(completed_this_turn, std::memory_order_relaxed);
             int32_t new_total = prev + completed_this_turn;
             last_progress_count = new_total;
             if (thread_idx == 0 && task_count > 0) {
@@ -441,7 +441,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Phase 3: Drain wiring queue (thread 0 only)
         if (thread_idx == 0) {
-            int wired = sched_->drain_wiring_queue(*orchestrator_done_ptr_);
+            int wired = sched_->drain_wiring_queue(orchestrator_done_);
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -43,7 +43,6 @@
 // =============================================================================
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
-constexpr int32_t MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
 constexpr int32_t STALL_LOG_INTERVAL = 50000;         // DEV_ALWAYS every N idle iters to debug hang


### PR DESCRIPTION
Move all scheduler-side state and orchestration handoff out of AicpuExecutor and into SchedulerContext, so AicpuExecutor becomes a thin wrapper that owns only lifecycle atomics and the orchestration SO handle. Why: prior split duplicated counters/flags across both layers and required ptr-indirection from SchedulerContext back into the executor for every load/store.

SchedulerContext now exposes a tight public API — init / deinit / resolve_and_dispatch / shutdown / on_orchestration_done / bind_runtime plus read-only accessors — and keeps handshake / assign / reassign / emergency_shutdown private. Members are grouped by responsibility (scheduler binding, task tracking, core-transition, thread/core config, init coordination) with private state declared before private methods, matching the rest of the codebase.

Applied to both a2a3 and a5; a5 omits the PMU paths it does not implement. Verified a5sim full ST suite (9 passed) and a2a3 device ST (paged_attention_unroll passed).