### PR TITLE
Refactor: drop unused code and replace redundant core arrays with CoreTracker accessors

### DIFF
--- a/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/performance_collector_aicpu.h
@@ -164,20 +164,14 @@ void perf_aicpu_record_orch_phase(
 );
 
 /**
- * Write core-to-thread assignment mapping to shared memory
+ * Write core-to-thread assignment mapping to shared memory.
  *
- * Records which scheduler thread manages each core_id.
- * Called once after orchestration completes (not on the scheduler hot path).
- *
- * @param core_assignments 2D array [thread_idx][i] = core_id
- * @param core_counts Per-thread core count array
- * @param num_threads Number of scheduler threads
- * @param total_cores Total number of cores
+ * Callers invoke `perf_aicpu_init_core_assignments(total_cores)` once, then
+ * `perf_aicpu_write_core_assignments_for_thread(t, ids, n)` for every
+ * scheduler thread.
  */
-void perf_aicpu_write_core_assignments(
-    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
-    int total_cores
-);
+void perf_aicpu_init_core_assignments(int total_cores);
+void perf_aicpu_write_core_assignments_for_thread(int thread_idx, const int *core_ids, int core_num);
 
 /**
  * Flush remaining phase records for a thread

--- a/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -532,27 +532,25 @@ void perf_aicpu_flush_phase_buffers(int thread_idx) {
     wmb();
 }
 
-void perf_aicpu_write_core_assignments(
-    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
-    int total_cores
-) {
+void perf_aicpu_init_core_assignments(int total_cores) {
     if (s_phase_header == nullptr) {
         return;
     }
-
     memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
     s_phase_header->num_cores = static_cast<uint32_t>(total_cores);
+    wmb();
+    LOG_INFO("Core-to-thread mapping init: %d cores", total_cores);
+}
 
-    for (int t = 0; t < num_threads; t++) {
-        for (int i = 0; i < core_counts[t]; i++) {
-            int core_id = core_assignments[t][i];
-            if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
-                s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
-            }
+void perf_aicpu_write_core_assignments_for_thread(int thread_idx, const int *core_ids, int core_num) {
+    if (s_phase_header == nullptr) {
+        return;
+    }
+    for (int i = 0; i < core_num; i++) {
+        int core_id = core_ids[i];
+        if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
+            s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(thread_idx);
         }
     }
-
     wmb();
-
-    LOG_INFO("Core-to-thread mapping written: %d cores, %d threads", total_cores, num_threads);
 }

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1947,9 +1947,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if PTO2_PROFILING
             // Write core-to-thread mapping (one-time, after orchestration)
             if (runtime->enable_profiling) {
-                perf_aicpu_write_core_assignments(
-                    core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
-                );
+                perf_aicpu_init_core_assignments(cores_total_num_);
+                for (int32_t t = 0; t < sched_thread_num_; t++) {
+                    perf_aicpu_write_core_assignments_for_thread(t, core_assignments_[t], core_count_per_thread_[t]);
+                }
                 // Flush orchestrator's phase record buffer
                 perf_aicpu_flush_phase_buffers(thread_idx);
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -509,13 +509,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
-
-#if PTO2_ORCH_PROFILING
-            uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-            DEV_ALWAYS(
-                "Thread %d: reassign, cost %.3fus", thread_idx, cycles_to_us(reassign_cycle_end - reassign_cycle_start)
-            );
-#endif
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
@@ -549,7 +542,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
-    // core_count_per_thread_ == 0 so they skip the loop harmlessly.
+    // core_trackers_[thread_idx].core_num() == 0 so they skip the loop harmlessly.
     auto rc = sched_ctx_.shutdown(thread_idx);
     if (rc != 0) {
         return rc;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -334,7 +334,7 @@ When `pto2_submit_task` processes parameters:
 | `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 \| local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
-| `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
+| `completed_subtasks` | Atomic counter; each subtask increments on completion. Trigger condition: `completed_subtasks == total_required_subtasks` |
 | `fanin_count` | Number of producer dependencies (set by scheduler during wiring) |
 | `fanout_lock` | Per-task spinlock for concurrent fanout modification (used by scheduler wiring + completion) |
 | `fanout_head` | Head of fanout consumer list (pointer, protected by `fanout_lock`) |
@@ -464,7 +464,7 @@ Each scheduler thread runs a tight loop with two main phases:
 **Phase 1 — Completion Handling**:
 
 - Poll register `COND` on each managed core
-- When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
+- When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to increment the completion counter; when `completed_subtasks == total_required_subtasks`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
 
 **Phase 2 — Dispatch**:
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -90,7 +90,7 @@ Rules:
 
 1. `task_id`
 2. `active_mask`
-3. `subtask_done_mask`
+3. `completed_subtasks` (atomic counter, incremented per subtask completion)
 4. `kernel_id[3]` for `(AIC, AIV0, AIV1)`
 5. dependency heads/counters and packed-buffer metadata
 
@@ -128,7 +128,7 @@ Queueing key is normalized resource shape (not raw slot label).
 1. Fanin release/readiness remains dependency-correct and graph-level.
 2. Two-stage completion:
    - `on_subtask_complete(task_id, subslot)`
-   - `on_mixed_task_complete(task_id)` only when `subtask_done_mask == active_mask`
+   - `on_mixed_task_complete(task_id)` only when `completed_subtasks == total_required_subtasks`
 3. Downstream release is triggered once per mixed task completion, not once per subslot.
 
 ## 9. Executor Ownership and Numbering

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -110,7 +110,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 
 | Phase | What it does | Inline stats |
 | ----- | ------------ | ------------ |
-| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
+| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to increment the completion counter; when `completed_subtasks == total_required_subtasks`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
 | **scan** | Updates the perf profiling header with latest scheduler state | — |
 | **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
 | **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -827,48 +827,6 @@ void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
 #endif
 }
 
-// =============================================================================
-// Debug Utilities
-// =============================================================================
-
-void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
-    LOG_INFO("=== Orchestrator Statistics ===");
-#if PTO2_PROFILING
-    LOG_INFO("Tasks submitted:     %" PRId64, orch->tasks_submitted);
-    LOG_INFO("Buffers allocated:   %" PRId64, orch->buffers_allocated);
-    LOG_INFO("Bytes allocated:     %" PRId64, orch->bytes_allocated);
-#endif
-    LOG_INFO("Current scope depth: %d", orch->scope_stack_top + 1);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        int32_t active = orch->rings[r].task_allocator.active_count();
-        if (active > 0) {
-            LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO(
-                "Ring %d heap used:    %" PRIu64 " / %" PRIu64, r, orch->rings[r].task_allocator.heap_top(),
-                orch->rings[r].task_allocator.heap_capacity()
-            );
-            LOG_INFO(
-                "Ring %d fanin pool:   %d / %d", r, orch->rings[r].fanin_pool.used(), orch->rings[r].fanin_pool.capacity
-            );
-        }
-    }
-    LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());
-    LOG_INFO("===============================");
-}
-
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch) {
-    LOG_INFO("=== Scope Stack ===");
-    LOG_INFO("Depth: %d", orch->scope_stack_top + 1);
-
-    for (int i = 0; i <= orch->scope_stack_top; i++) {
-        int32_t begin = orch->scope_begins[i];
-        int32_t end = (i < orch->scope_stack_top) ? orch->scope_begins[i + 1] : orch->scope_tasks_size;
-        LOG_INFO("  [%d] tasks_owned = %d", i, end - begin);
-    }
-
-    LOG_INFO("==================");
-}
-
 #if PTO2_ORCH_PROFILING
 PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     PTO2OrchProfilingData d;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -209,20 +209,6 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
-// Debug Utilities
-// =============================================================================
-
-/**
- * Print orchestrator statistics
- */
-void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch);
-
-/**
- * Print scope stack state
- */
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch);
-
-// =============================================================================
 // Orchestrator Profiling Data
 // =============================================================================
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -32,10 +32,24 @@
 #include <atomic>
 
 #include "pto_runtime_status.h"
-#include "pto2_dispatch_payload.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
+#endif
+
+// Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
+// ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
+// all threads share host CPU cores, so we yield to prevent starvation.
+// This header is also compiled into the Host .so (for struct definitions only),
+// where the hint is never called — the fallback no-op keeps Host builds clean.
+#if __has_include("spin_hint.h")
+#include "spin_hint.h"
+#else
+#define SPIN_WAIT_HINT() ((void)0)
+#endif
 
 // =============================================================================
 // Profiling Configuration
@@ -125,30 +139,6 @@
 constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
 
 // =============================================================================
-// Multi-Ring task_id Encoding
-// =============================================================================
-
-/**
- * TaskId: defined in pto_task_id.h (included above).
- */
-
-// =============================================================================
-// Worker Types
-// =============================================================================
-
-/**
- * Worker type enumeration
- * Each worker type has its own ready queue for load balancing
- */
-typedef enum {
-    PTO2_WORKER_CUBE = 0,         // AICore CUBE unit (matrix ops)
-    PTO2_WORKER_VECTOR = 1,       // AICore VECTOR unit (element-wise ops)
-    PTO2_WORKER_AI_CPU = 2,       // AI_CPU (scalar ops, control flow)
-    PTO2_WORKER_ACCELERATOR = 3,  // Fixed-function accelerators (DMA, etc.)
-    PTO2_NUM_WORKER_TYPES = 4
-} PTO2WorkerType;
-
-// =============================================================================
 // Task States
 // =============================================================================
 
@@ -170,21 +160,6 @@ typedef enum {
     PTO2_TASK_CONSUMED = 4    // Output fully consumed, buffers can be released
 } PTO2TaskState;
 
-// =============================================================================
-// Logical Tensor (for view/reshape/transpose operations)
-// =============================================================================
-
-/**
- * Maximum dimensions supported for logical tensors
- */
-#define PTO2_MAX_TENSOR_DIM 8
-
-/**
- * Maximum depth of layout history for HBB overlap detection
- * Simple (contiguous) tensor has depth=1, non-contiguous has depth>1
- */
-#define PTO2_MAX_LAYOUT_DEPTH 8
-
 /**
  * Result of a unified task allocation.
  */
@@ -202,113 +177,6 @@ struct PTO2OutputLayout {
     uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
     int32_t total_output_size = 0;
 };
-
-/**
- * Layout operation type for HBB
- */
-typedef enum {
-    PTO2_LAYOUT_VIEW = 0,      // View/slice: records bounding box
-    PTO2_LAYOUT_RESHAPE = 1,   // Reshape: records new shape
-    PTO2_LAYOUT_TRANSPOSE = 2  // Transpose: records permutation
-} PTO2LayoutOpType;
-
-/**
- * Layout operation entry for HBB
- * Each entry records one derivation step from the parent tensor.
- */
-typedef struct {
-    PTO2LayoutOpType type;
-    union {
-        struct {               // PTO2_LAYOUT_VIEW
-            int64_t bbox_min;  // First byte accessed
-            int64_t bbox_max;  // Last byte accessed
-        } view;
-        struct {  // PTO2_LAYOUT_RESHAPE
-            int32_t ndim;
-            int64_t shape[PTO2_MAX_TENSOR_DIM];
-        } reshape;
-        struct {  // PTO2_LAYOUT_TRANSPOSE
-            int32_t ndim;
-            int32_t perm[PTO2_MAX_TENSOR_DIM];
-        } transpose;
-    };
-} PTO2LayoutOp;
-
-/**
- * Tensor extraction type (for tracking how tensor was created)
- */
-typedef enum {
-    PTO2_TENSOR_RAW = 0,            // Original raw tensor (owns storage)
-    PTO2_TENSOR_VIEW = 1,           // view() - subset selection, shared storage
-    PTO2_TENSOR_RESHAPE = 2,        // reshape() - shape change, shared storage
-    PTO2_TENSOR_TRANSPOSE = 3,      // transpose() - dimension permute, shared storage
-    PTO2_TENSOR_DEEP_VIEW = 4,      // deep_view() - copied subset, new storage
-    PTO2_TENSOR_DEEP_RESHAPE = 5,   // deep_reshape() - copied reshape, new storage
-    PTO2_TENSOR_DEEP_TRANSPOSE = 6  // deep_transpose() - copied transpose, new storage
-} PTO2TensorExtractionType;
-
-/**
- * Raw tensor (storage provider)
- *
- * The raw tensor owns the actual memory allocation.
- * Multiple logical tensors can share the same raw tensor (aliasing).
- */
-typedef struct {
-    void *base_ptr;      // Base pointer of allocated memory
-    int64_t total_size;  // Total size in bytes
-    int32_t refcount;    // Number of logical tensors referencing this storage
-                         // (for memory management, 0 = can be freed)
-} PTO2RawTensor;
-
-/**
- * Logical tensor structure
- *
- * A "view" into raw tensor storage with specific layout.
- * Supports multi-dimensional tensors with strides (for view/reshape/transpose).
- *
- * Memory footprint is determined by:
- *   - storage_offset: byte offset from raw_base to first element
- *   - shape[d]: number of elements in dimension d
- *   - strides[d]: byte offset between consecutive elements in dimension d
- *
- * For element at indices [i0, i1, ..., i_{n-1}]:
- *   byte_offset = storage_offset + sum(i_d * strides[d])
- *
- * Examples:
- *   - Contiguous row-major (3,4): shape=[3,4], strides=[4*elem_size, elem_size]
- *   - Transposed (4,3): shape=[4,3], strides=[elem_size, 4*elem_size]
- *   - Sliced [1:3, 1:3]: offset adjusted, shape=[2,2], strides unchanged
- */
-typedef struct {
-    // === Raw tensor reference (shared storage) ===
-    void *raw_base;          // Pointer to raw tensor's base (for aliasing check)
-    int64_t raw_total_size;  // Total size of raw tensor in bytes
-
-    // === Storage offset ===
-    int64_t storage_offset;  // Byte offset from raw_base to first element
-
-    // === Shape and strides ===
-    int64_t shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
-    int64_t strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
-    int32_t ndim;                          // Number of dimensions (0 = scalar)
-
-    // === Precomputed bounding box (for fast overlap detection) ===
-    int64_t min_byte_offset;  // First byte accessed (relative to raw_base)
-    int64_t max_byte_offset;  // Last byte accessed (relative to raw_base)
-
-    // === Element info ===
-    int64_t elem_size;  // Size of each element in bytes
-    int64_t numel;      // Total number of elements
-
-    // === Extraction tracking ===
-    PTO2TensorExtractionType extraction_type;  // How this tensor was created
-    bool is_contiguous;                        // True if memory is contiguous (no gaps)
-                                               // Equivalent to layout_depth == 1
-
-    // === Layout history for HBB overlap detection ===
-    int32_t layout_depth;                            // Number of layout ops (1=simple)
-    PTO2LayoutOp layout_ops[PTO2_MAX_LAYOUT_DEPTH];  // Derivation history
-} PTO2LogicalTensor;
 
 // =============================================================================
 // Dependency List Entry
@@ -466,10 +334,9 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor *task;
 
     // --- Set per-submit (depend on task inputs) ---
-    uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;  // Deprecated: superseded by completed_subtasks
-    uint8_t ring_id;                         // Ring layer (immutable after init)
-    int32_t dep_pool_mark{0};                // Dep pool top after wiring (thread-0-only)
+    uint8_t active_mask;       // Bitmask of active subtask slots (set once)
+    uint8_t ring_id;           // Ring layer (immutable after init)
+    int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
     int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
@@ -512,52 +379,6 @@ struct alignas(64) PTO2TaskSlotState {
 static_assert(sizeof(PTO2TaskSlotState) == 64);
 
 // =============================================================================
-// Cycle Cost Function Type
-// =============================================================================
-
-/**
- * Cycle cost function pointer type
- * Returns estimated cycle count for the InCore function
- */
-typedef int64_t (*PTO2CycleCostFunc)(void **args, int32_t num_args);
-
-// =============================================================================
-// InCore Function Type
-// =============================================================================
-
-/**
- * InCore function signature
- * All InCore functions must match this signature
- */
-typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
-
-// =============================================================================
-// Utility Macros
-// =============================================================================
-
-/**
- * Memory barrier macros for different architectures
- */
-#if defined(__aarch64__)
-#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("dmb sy" ::: "memory")
-#elif defined(__x86_64__)
-#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("mfence" ::: "memory")
-#else
-#define PTO2_MEMORY_BARRIER() __sync_synchronize()
-#endif
-
-// Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
-// ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
-// all threads share host CPU cores, so we yield to prevent starvation.
-// This header is also compiled into the Host .so (for struct definitions only),
-// where the hint is never called — the fallback no-op keeps Host builds clean.
-#if __has_include("spin_hint.h")
-#include "spin_hint.h"
-#else
-#define SPIN_WAIT_HINT() ((void)0)
-#endif
-
-// =============================================================================
 // Per-task fanout spinlock helpers
 //
 // Used by BOTH the orchestrator (pto_orchestrator.cpp) and the scheduler
@@ -568,10 +389,6 @@ typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
 // fanout_count, because the orchestrator adds consumers concurrently with the
 // scheduler traversing the list after task completion.
 // =============================================================================
-
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-#include "aicpu/device_time.h"
-#endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
 static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -37,7 +37,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 };
 
 /**
- * Subtask mask bits (for active_mask / subtask_done_mask)
+ * Subtask mask bits (for active_mask)
  */
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);         // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);        // 0x2

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -284,12 +284,6 @@ public:
     /** @deprecated RT2 uses PTO2DispatchPayload, not Task. Always returns nullptr. */
     Task *get_task(int) { return nullptr; }
 
-    /** @deprecated Use PTO2 dispatch mode */
-    bool get_use_pto2_dispatch() const { return true; }
-
-    /** @deprecated Use PTO2 dispatch mode */
-    void set_use_pto2_dispatch(bool) {}
-
     // =========================================================================
     // Host API (host-only, not copied to device)
     // =========================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -131,7 +131,6 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHeader *sm_header,
         ring->slot_states[i].reset_for_reuse();
         ring->slot_states[i].fanin_count = 0;
         ring->slot_states[i].active_mask = 0;
-        ring->slot_states[i].subtask_done_mask.store(0, std::memory_order_relaxed);
     }
 
     return true;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -133,10 +133,9 @@ void SchedulerContext::log_stall_diagnostics(
     int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
     int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
     int32_t total_running = aic_running + aiv_running;
-    int32_t core_num = core_count_per_thread_[thread_idx];
     DEV_ALWAYS(
         "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running, aiv_running,
-        core_num
+        core_trackers_[thread_idx].core_num()
     );
     auto all_running = tracker.get_all_running_cores();
     int32_t dump_count = 0;
@@ -342,12 +341,12 @@ void SchedulerContext::log_profiling_summary(int32_t thread_idx, int32_t cur_thr
 
 // =============================================================================
 // Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
-// Orchestrator threads have core_count_per_thread_[thread_idx] == 0 -> no-op.
+// Orchestrator threads have core_trackers_[thread_idx].core_num() == 0 -> no-op.
 // platform_deinit_aicore_regs is idempotent; safe to call after early completion.
 // =============================================================================
 int32_t SchedulerContext::shutdown(int32_t thread_idx) {
-    const int32_t *cores = core_assignments_[thread_idx];
-    int32_t core_num = core_count_per_thread_[thread_idx];
+    const int32_t *cores = core_trackers_[thread_idx].core_ids();
+    int32_t core_num = core_trackers_[thread_idx].core_num();
     if (core_num == 0) return 0;
 
 #if PTO2_PROFILING
@@ -499,15 +498,12 @@ bool SchedulerContext::assign_cores_to_threads() {
     }
     for (int32_t i = 0; i < active_sched_threads_; i++) {
         core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
     }
 
-    int32_t core_idx[MAX_AICPU_THREADS] = {};
     int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
 
     for (int32_t ci = 0; ci < cluster_count; ci++) {
         int32_t t = ci % active_sched_threads_;
-        int32_t &idx = core_idx[t];
 
         int32_t aic_wid = aic_worker_ids_[ci];
         int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
@@ -515,16 +511,14 @@ bool SchedulerContext::assign_cores_to_threads() {
 
         core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
 
-        core_assignments_[t][idx++] = aic_wid;
-        core_assignments_[t][idx++] = aiv0_wid;
-        core_assignments_[t][idx++] = aiv1_wid;
-
         DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < thread_num_; t++) {
-        core_count_per_thread_[t] = core_idx[t];
-        DEV_INFO("Thread %d: total %d cores (%d clusters)", t, core_idx[t], core_trackers_[t].get_cluster_count());
+        DEV_INFO(
+            "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
+            core_trackers_[t].get_cluster_count()
+        );
     }
 
     DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
@@ -557,7 +551,6 @@ void SchedulerContext::reassign_cores_for_all_threads() {
     // Re-init all trackers and reset core counts
     for (int32_t i = 0; i < thread_num_; i++) {
         core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
     }
 
     // Assign clusters round-robin and restore running state
@@ -585,10 +578,6 @@ void SchedulerContext::reassign_cores_for_all_threads() {
             core_trackers_[t].change_core_state(cl_idx * 3 + 2);
             core_trackers_[t].set_pending_occupied(cl_idx * 3 + 2);
         }
-
-        core_assignments_[t][core_count_per_thread_[t]++] = aic_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv0_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv1_wid;
     }
 
     // Log final distribution
@@ -597,7 +586,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
         DEV_INFO(
-            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count(), aic_running, aiv_running
         );
     }
@@ -730,8 +719,6 @@ void SchedulerContext::deinit() {
     for (int32_t t = 0; t < MAX_AICPU_THREADS; t++) {
         core_trackers_[t] = CoreTracker{};
     }
-    memset(core_assignments_, 0, sizeof(core_assignments_));
-    memset(core_count_per_thread_, 0, sizeof(core_count_per_thread_));
 
     regs_ = 0;
     sched_ = nullptr;
@@ -755,16 +742,10 @@ void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
 ) {
 #if PTO2_PROFILING
-    // Write core-to-thread mapping (one-time, after orchestration)
     if (runtime->enable_profiling) {
-        perf_aicpu_write_core_assignments(
-            core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
-        );
         // Flush orchestrator's phase record buffer
         perf_aicpu_flush_phase_buffers(thread_idx);
     }
-#else
-    (void)thread_idx;
 #endif
 
     total_tasks_ = total_tasks;
@@ -810,4 +791,16 @@ void SchedulerContext::on_orchestration_done(
             reassigned_.store(true, std::memory_order_release);
         }
     }
+
+#if PTO2_PROFILING
+    // Write core-to-thread mapping AFTER reassignment so the profiling data
+    // reflects the final distribution (all active_sched_threads_, including
+    // former orchestrator threads when orch_to_sched_ is enabled).
+    if (runtime->enable_profiling) {
+        perf_aicpu_init_core_assignments(cores_total_num_);
+        for (int32_t t = 0; t < active_sched_threads_; t++) {
+            perf_aicpu_write_core_assignments_for_thread(t, core_trackers_[t].core_ids(), core_trackers_[t].core_num());
+        }
+    }
+#endif
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -15,6 +15,8 @@
 
 #include "scheduler/pto_scheduler.h"
 
+#include "pto2_dispatch_payload.h"
+
 // These macros are defined in runtime.h, but we cannot include it here
 // (it pulls in Handshake which we only forward-declare).  Mirror the
 // authoritative values so the class layout compiles standalone.
@@ -71,7 +73,7 @@ public:
 
     // Shutdown AICore registers for this thread's assigned cores.
     // Also runs PMU finalize (PTO2_PROFILING) before deinit when enabled.
-    // Orchestrator threads (core_count_per_thread_[thread_idx] == 0) are a no-op.
+    // Orchestrator threads (core_trackers_[thread_idx].core_num() == 0) are a no-op.
     int32_t shutdown(int32_t thread_idx);
 
     // Run all post-orchestration scheduler bookkeeping:
@@ -146,8 +148,6 @@ private:
     bool orch_to_sched_{false};
     int32_t thread_num_{0};
     int32_t cores_total_num_{0};
-    int32_t core_count_per_thread_[MAX_AICPU_THREADS]{};
-    int32_t core_assignments_[MAX_AICPU_THREADS][RUNTIME_MAX_WORKER]{};
 
     // Cluster-ordered worker_id lists, populated by handshake_all_cores().
     int32_t aic_worker_ids_[RUNTIME_MAX_WORKER]{};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -304,7 +304,6 @@ void SchedulerContext::dispatch_shape(
 
 int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
     always_assert(sched_ != nullptr);
-    int32_t &core_num = core_count_per_thread_[thread_idx];
     CoreTracker &tracker = core_trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch entry", thread_idx);
 
@@ -358,7 +357,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
     }
 
-    DEV_INFO("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_num);
+    DEV_INFO("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
     int32_t cur_thread_completed = 0;
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
@@ -576,7 +575,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
 #if PTO2_PROFILING
     if (perf.profiling_enabled) {
-        perf_aicpu_flush_buffers(runtime, thread_idx, core_assignments_[thread_idx], core_num);
+        perf_aicpu_flush_buffers(
+            runtime, thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
+        );
         perf_aicpu_flush_phase_buffers(thread_idx);
     }
 #endif
@@ -587,7 +588,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 #if PTO2_PROFILING
     if (get_enable_pmu()) {
-        pmu_aicpu_flush_buffers(thread_idx, core_assignments_[thread_idx], core_num);
+        pmu_aicpu_flush_buffers(
+            thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
+        );
     }
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -16,7 +16,6 @@
 
 #include "common/core_type.h"
 #include "common/platform_config.h"
-#include "pto2_dispatch_payload.h"
 #include "pto_runtime2_types.h"
 
 // =============================================================================
@@ -303,6 +302,9 @@ public:
     // --- Bit offset <-> worker_id mapping ---
 
     int32_t get_core_id_by_offset(int32_t offset) const { return core_id_map_[offset]; }
+
+    const int32_t *core_ids() const { return core_id_map_; }
+    int32_t core_num() const { return cluster_count_ * 3; }
 
 private:
     int32_t cluster_count_;

--- a/src/a5/platform/include/aicpu/performance_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/performance_collector_aicpu.h
@@ -146,19 +146,13 @@ void perf_aicpu_record_orch_phase(
 );
 
 /**
- * Write core-to-thread assignment mapping to shared memory
+ * Write core-to-thread assignment mapping to shared memory.
  *
- * Records which scheduler thread manages each core_id.
- * Called once after orchestration completes (not on the scheduler hot path).
- *
- * @param core_assignments 2D array [thread_idx][i] = core_id
- * @param core_counts Per-thread core count array
- * @param num_threads Number of scheduler threads
- * @param total_cores Total number of cores
+ * Callers invoke `perf_aicpu_init_core_assignments(total_cores)` once, then
+ * `perf_aicpu_write_core_assignments_for_thread(t, ids, n)` for every
+ * scheduler thread.
  */
-void perf_aicpu_write_core_assignments(
-    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
-    int total_cores
-);
+void perf_aicpu_init_core_assignments(int total_cores);
+void perf_aicpu_write_core_assignments_for_thread(int thread_idx, const int *core_ids, int core_num);
 
 #endif  // PLATFORM_AICPU_PERFORMANCE_COLLECTOR_AICPU_H_

--- a/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/performance_collector_aicpu.cpp
@@ -236,28 +236,27 @@ void perf_aicpu_record_orch_phase(
     perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
 
-void perf_aicpu_write_core_assignments(
-    const int core_assignments[][PLATFORM_MAX_CORES_PER_THREAD], const int *core_counts, int num_threads,
-    int total_cores
-) {
+void perf_aicpu_init_core_assignments(int total_cores) {
     if (s_setup_header == nullptr) {
         return;
     }
-
     AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
     memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
     phase_header->num_cores = static_cast<uint32_t>(total_cores);
+    wmb();
+    LOG_INFO("Core-to-thread mapping init: %d cores", total_cores);
+}
 
-    for (int t = 0; t < num_threads; t++) {
-        for (int i = 0; i < core_counts[t]; i++) {
-            int core_id = core_assignments[t][i];
-            if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
-                phase_header->core_to_thread[core_id] = static_cast<int8_t>(t);
-            }
+void perf_aicpu_write_core_assignments_for_thread(int thread_idx, const int *core_ids, int core_num) {
+    if (s_setup_header == nullptr) {
+        return;
+    }
+    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
+    for (int i = 0; i < core_num; i++) {
+        int core_id = core_ids[i];
+        if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
+            phase_header->core_to_thread[core_id] = static_cast<int8_t>(thread_idx);
         }
     }
-
     wmb();
-
-    LOG_INFO("Core-to-thread mapping written: %d cores, %d threads", total_cores, num_threads);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -509,13 +509,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
-
-#if PTO2_ORCH_PROFILING
-            uint64_t reassign_cycle_end = get_sys_cnt_aicpu();
-            DEV_ALWAYS(
-                "Thread %d: reassign, cost %.3fus", thread_idx, cycles_to_us(reassign_cycle_end - reassign_cycle_start)
-            );
-#endif
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
@@ -549,7 +542,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
-    // core_count_per_thread_ == 0 so they skip the loop harmlessly.
+    // core_trackers_[thread_idx].core_num() == 0 so they skip the loop harmlessly.
     auto rc = sched_ctx_.shutdown(thread_idx);
     if (rc != 0) {
         return rc;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -334,7 +334,7 @@ When `pto2_submit_task` processes parameters:
 | `task_id` | Canonical mixed-task ID (64-bit: `ring_id << 32 \| local_id`). See [MULTI_RING.md §3](MULTI_RING.md). |
 | `kernel_id[3]` | Per-slot kernel IDs: `[AIC, AIV0, AIV1]`; `INVALID_KERNEL_ID` = inactive |
 | `active_mask` | Bitmask of active subtask slots: `bit0=AIC`, `bit1=AIV0`, `bit2=AIV1` |
-| `subtask_done_mask` | Atomic bitmask; each subtask sets its done bit on completion |
+| `completed_subtasks` | Atomic counter; each subtask increments on completion. Trigger condition: `completed_subtasks == total_required_subtasks` |
 | `fanin_count` | Number of producer dependencies (set by scheduler during wiring) |
 | `fanout_lock` | Per-task spinlock for concurrent fanout modification (used by scheduler wiring + completion) |
 | `fanout_head` | Head of fanout consumer list (pointer, protected by `fanout_lock`) |
@@ -464,7 +464,7 @@ Each scheduler thread runs a tight loop with two main phases:
 **Phase 1 — Completion Handling**:
 
 - Poll register `COND` on each managed core
-- When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
+- When `TASK_FIN_STATE` detected: record completion timestamps, call `on_subtask_complete(task_id, subslot)` to increment the completion counter; when `completed_subtasks == total_required_subtasks`, trigger `on_mixed_task_complete(task_id)` which marks `task_state[slot] = COMPLETED`, acquires fanout lock, traverses fanout list (incrementing consumers' `fanin_refcount`), marks `task_state[slot] = CONSUMED`, and advances `last_task_alive` watermark
 
 **Phase 2 — Dispatch**:
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -90,7 +90,7 @@ Rules:
 
 1. `task_id`
 2. `active_mask`
-3. `subtask_done_mask`
+3. `completed_subtasks` (atomic counter, incremented per subtask completion)
 4. `kernel_id[3]` for `(AIC, AIV0, AIV1)`
 5. dependency heads/counters and packed-buffer metadata
 
@@ -128,7 +128,7 @@ Queueing key is normalized resource shape (not raw slot label).
 1. Fanin release/readiness remains dependency-correct and graph-level.
 2. Two-stage completion:
    - `on_subtask_complete(task_id, subslot)`
-   - `on_mixed_task_complete(task_id)` only when `subtask_done_mask == active_mask`
+   - `on_mixed_task_complete(task_id)` only when `completed_subtasks == total_required_subtasks`
 3. Downstream release is triggered once per mixed task completion, not once per subslot.
 
 ## 9. Executor Ownership and Numbering

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -110,7 +110,7 @@ The scheduler loop runs four phases each iteration. Each phase's time is accumul
 
 | Phase | What it does | Inline stats |
 | ----- | ------------ | ------------ |
-| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to set the done bit; when `subtask_done_mask == active_mask`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
+| **complete** | Polls handshake on each managed core; when a core completes, calls `on_subtask_complete(task_id, subslot)` to increment the completion counter; when `completed_subtasks == total_required_subtasks`, triggers `on_mixed_task_complete` which traverses fanout list (notify consumers) and fanin list (release producers) | `fanout`: edges/max_degree/avg for consumer notification; `fanin`: edges/max_degree/avg for producer release |
 | **scan** | Updates the perf profiling header with latest scheduler state | — |
 | **dispatch** | For each idle core, pops a task from the shape-based ready queue via `get_ready_task(shape)`, builds the dispatch payload, and writes the task to the core's handshake register | `pop`: `hit` = successful pops (task dispatched), `miss` = empty queue pops, `hit_rate` = hit/(hit+miss) |
 | **idle** | Scheduler loop iteration where no progress was made (no completions, no dispatches) | — |

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -826,48 +826,6 @@ void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
 #endif
 }
 
-// =============================================================================
-// Debug Utilities
-// =============================================================================
-
-void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch) {
-    LOG_INFO("=== Orchestrator Statistics ===");
-#if PTO2_PROFILING
-    LOG_INFO("Tasks submitted:     %" PRId64, orch->tasks_submitted);
-    LOG_INFO("Buffers allocated:   %" PRId64, orch->buffers_allocated);
-    LOG_INFO("Bytes allocated:     %" PRId64, orch->bytes_allocated);
-#endif
-    LOG_INFO("Current scope depth: %d", orch->scope_stack_top + 1);
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        int32_t active = orch->rings[r].task_allocator.active_count();
-        if (active > 0) {
-            LOG_INFO("Ring %d task active:  %d", r, active);
-            LOG_INFO(
-                "Ring %d heap used:    %" PRIu64 " / %" PRIu64, r, orch->rings[r].task_allocator.heap_top(),
-                orch->rings[r].task_allocator.heap_capacity()
-            );
-            LOG_INFO(
-                "Ring %d fanin pool:   %d / %d", r, orch->rings[r].fanin_pool.used(), orch->rings[r].fanin_pool.capacity
-            );
-        }
-    }
-    LOG_INFO("TensorMap valid:     %d", orch->tensor_map.valid_count());
-    LOG_INFO("===============================");
-}
-
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch) {
-    LOG_INFO("=== Scope Stack ===");
-    LOG_INFO("Depth: %d", orch->scope_stack_top + 1);
-
-    for (int i = 0; i <= orch->scope_stack_top; i++) {
-        int32_t begin = orch->scope_begins[i];
-        int32_t end = (i < orch->scope_stack_top) ? orch->scope_begins[i + 1] : orch->scope_tasks_size;
-        LOG_INFO("  [%d] tasks_owned = %d", i, end - begin);
-    }
-
-    LOG_INFO("==================");
-}
-
 #if PTO2_ORCH_PROFILING
 PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
     PTO2OrchProfilingData d;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -209,20 +209,6 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
-// Debug Utilities
-// =============================================================================
-
-/**
- * Print orchestrator statistics
- */
-void pto2_orchestrator_print_stats(PTO2OrchestratorState *orch);
-
-/**
- * Print scope stack state
- */
-void pto2_orchestrator_print_scope_stack(PTO2OrchestratorState *orch);
-
-// =============================================================================
 // Orchestrator Profiling Data
 // =============================================================================
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -32,10 +32,24 @@
 #include <atomic>
 
 #include "pto_runtime_status.h"
-#include "pto2_dispatch_payload.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
+#endif
+
+// Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
+// ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
+// all threads share host CPU cores, so we yield to prevent starvation.
+// This header is also compiled into the Host .so (for struct definitions only),
+// where the hint is never called — the fallback no-op keeps Host builds clean.
+#if __has_include("spin_hint.h")
+#include "spin_hint.h"
+#else
+#define SPIN_WAIT_HINT() ((void)0)
+#endif
 
 // =============================================================================
 // Profiling Configuration
@@ -116,30 +130,6 @@
 constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
 
 // =============================================================================
-// Multi-Ring task_id Encoding
-// =============================================================================
-
-/**
- * TaskId: defined in pto_task_id.h (included above).
- */
-
-// =============================================================================
-// Worker Types
-// =============================================================================
-
-/**
- * Worker type enumeration
- * Each worker type has its own ready queue for load balancing
- */
-typedef enum {
-    PTO2_WORKER_CUBE = 0,         // AICore CUBE unit (matrix ops)
-    PTO2_WORKER_VECTOR = 1,       // AICore VECTOR unit (element-wise ops)
-    PTO2_WORKER_AI_CPU = 2,       // AI_CPU (scalar ops, control flow)
-    PTO2_WORKER_ACCELERATOR = 3,  // Fixed-function accelerators (DMA, etc.)
-    PTO2_NUM_WORKER_TYPES = 4
-} PTO2WorkerType;
-
-// =============================================================================
 // Task States
 // =============================================================================
 
@@ -161,21 +151,6 @@ typedef enum {
     PTO2_TASK_CONSUMED = 4    // Output fully consumed, buffers can be released
 } PTO2TaskState;
 
-// =============================================================================
-// Logical Tensor (for view/reshape/transpose operations)
-// =============================================================================
-
-/**
- * Maximum dimensions supported for logical tensors
- */
-#define PTO2_MAX_TENSOR_DIM 8
-
-/**
- * Maximum depth of layout history for HBB overlap detection
- * Simple (contiguous) tensor has depth=1, non-contiguous has depth>1
- */
-#define PTO2_MAX_LAYOUT_DEPTH 8
-
 /**
  * Result of a unified task allocation.
  */
@@ -193,113 +168,6 @@ struct PTO2OutputLayout {
     uint64_t buffer_sizes[MAX_TENSOR_ARGS] = {};
     int32_t total_output_size = 0;
 };
-
-/**
- * Layout operation type for HBB
- */
-typedef enum {
-    PTO2_LAYOUT_VIEW = 0,      // View/slice: records bounding box
-    PTO2_LAYOUT_RESHAPE = 1,   // Reshape: records new shape
-    PTO2_LAYOUT_TRANSPOSE = 2  // Transpose: records permutation
-} PTO2LayoutOpType;
-
-/**
- * Layout operation entry for HBB
- * Each entry records one derivation step from the parent tensor.
- */
-typedef struct {
-    PTO2LayoutOpType type;
-    union {
-        struct {               // PTO2_LAYOUT_VIEW
-            int64_t bbox_min;  // First byte accessed
-            int64_t bbox_max;  // Last byte accessed
-        } view;
-        struct {  // PTO2_LAYOUT_RESHAPE
-            int32_t ndim;
-            int64_t shape[PTO2_MAX_TENSOR_DIM];
-        } reshape;
-        struct {  // PTO2_LAYOUT_TRANSPOSE
-            int32_t ndim;
-            int32_t perm[PTO2_MAX_TENSOR_DIM];
-        } transpose;
-    };
-} PTO2LayoutOp;
-
-/**
- * Tensor extraction type (for tracking how tensor was created)
- */
-typedef enum {
-    PTO2_TENSOR_RAW = 0,            // Original raw tensor (owns storage)
-    PTO2_TENSOR_VIEW = 1,           // view() - subset selection, shared storage
-    PTO2_TENSOR_RESHAPE = 2,        // reshape() - shape change, shared storage
-    PTO2_TENSOR_TRANSPOSE = 3,      // transpose() - dimension permute, shared storage
-    PTO2_TENSOR_DEEP_VIEW = 4,      // deep_view() - copied subset, new storage
-    PTO2_TENSOR_DEEP_RESHAPE = 5,   // deep_reshape() - copied reshape, new storage
-    PTO2_TENSOR_DEEP_TRANSPOSE = 6  // deep_transpose() - copied transpose, new storage
-} PTO2TensorExtractionType;
-
-/**
- * Raw tensor (storage provider)
- *
- * The raw tensor owns the actual memory allocation.
- * Multiple logical tensors can share the same raw tensor (aliasing).
- */
-typedef struct {
-    void *base_ptr;      // Base pointer of allocated memory
-    int64_t total_size;  // Total size in bytes
-    int32_t refcount;    // Number of logical tensors referencing this storage
-                         // (for memory management, 0 = can be freed)
-} PTO2RawTensor;
-
-/**
- * Logical tensor structure
- *
- * A "view" into raw tensor storage with specific layout.
- * Supports multi-dimensional tensors with strides (for view/reshape/transpose).
- *
- * Memory footprint is determined by:
- *   - storage_offset: byte offset from raw_base to first element
- *   - shape[d]: number of elements in dimension d
- *   - strides[d]: byte offset between consecutive elements in dimension d
- *
- * For element at indices [i0, i1, ..., i_{n-1}]:
- *   byte_offset = storage_offset + sum(i_d * strides[d])
- *
- * Examples:
- *   - Contiguous row-major (3,4): shape=[3,4], strides=[4*elem_size, elem_size]
- *   - Transposed (4,3): shape=[4,3], strides=[elem_size, 4*elem_size]
- *   - Sliced [1:3, 1:3]: offset adjusted, shape=[2,2], strides unchanged
- */
-typedef struct {
-    // === Raw tensor reference (shared storage) ===
-    void *raw_base;          // Pointer to raw tensor's base (for aliasing check)
-    int64_t raw_total_size;  // Total size of raw tensor in bytes
-
-    // === Storage offset ===
-    int64_t storage_offset;  // Byte offset from raw_base to first element
-
-    // === Shape and strides ===
-    int64_t shape[PTO2_MAX_TENSOR_DIM];    // Size in each dimension
-    int64_t strides[PTO2_MAX_TENSOR_DIM];  // Byte stride in each dimension
-    int32_t ndim;                          // Number of dimensions (0 = scalar)
-
-    // === Precomputed bounding box (for fast overlap detection) ===
-    int64_t min_byte_offset;  // First byte accessed (relative to raw_base)
-    int64_t max_byte_offset;  // Last byte accessed (relative to raw_base)
-
-    // === Element info ===
-    int64_t elem_size;  // Size of each element in bytes
-    int64_t numel;      // Total number of elements
-
-    // === Extraction tracking ===
-    PTO2TensorExtractionType extraction_type;  // How this tensor was created
-    bool is_contiguous;                        // True if memory is contiguous (no gaps)
-                                               // Equivalent to layout_depth == 1
-
-    // === Layout history for HBB overlap detection ===
-    int32_t layout_depth;                            // Number of layout ops (1=simple)
-    PTO2LayoutOp layout_ops[PTO2_MAX_LAYOUT_DEPTH];  // Derivation history
-} PTO2LogicalTensor;
 
 // =============================================================================
 // Dependency List Entry
@@ -453,10 +321,9 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor *task;
 
     // --- Set per-submit (depend on task inputs) ---
-    uint8_t active_mask;                     // Bitmask of active subtask slots (set once)
-    std::atomic<uint8_t> subtask_done_mask;  // Deprecated: superseded by completed_subtasks
-    uint8_t ring_id;                         // Ring layer (immutable after init)
-    int32_t dep_pool_mark{0};                // Dep pool top after wiring (thread-0-only)
+    uint8_t active_mask;       // Bitmask of active subtask slots (set once)
+    uint8_t ring_id;           // Ring layer (immutable after init)
+    int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
     int16_t total_required_subtasks{0};          // = logical_block_num * popcount(active_mask)
@@ -499,52 +366,6 @@ struct alignas(64) PTO2TaskSlotState {
 static_assert(sizeof(PTO2TaskSlotState) == 64);
 
 // =============================================================================
-// Cycle Cost Function Type
-// =============================================================================
-
-/**
- * Cycle cost function pointer type
- * Returns estimated cycle count for the InCore function
- */
-typedef int64_t (*PTO2CycleCostFunc)(void **args, int32_t num_args);
-
-// =============================================================================
-// InCore Function Type
-// =============================================================================
-
-/**
- * InCore function signature
- * All InCore functions must match this signature
- */
-typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
-
-// =============================================================================
-// Utility Macros
-// =============================================================================
-
-/**
- * Memory barrier macros for different architectures
- */
-#if defined(__aarch64__)
-#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("dmb sy" ::: "memory")
-#elif defined(__x86_64__)
-#define PTO2_MEMORY_BARRIER() __asm__ __volatile__("mfence" ::: "memory")
-#else
-#define PTO2_MEMORY_BARRIER() __sync_synchronize()
-#endif
-
-// Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
-// ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
-// all threads share host CPU cores, so we yield to prevent starvation.
-// This header is also compiled into the Host .so (for struct definitions only),
-// where the hint is never called — the fallback no-op keeps Host builds clean.
-#if __has_include("spin_hint.h")
-#include "spin_hint.h"
-#else
-#define SPIN_WAIT_HINT() ((void)0)
-#endif
-
-// =============================================================================
 // Per-task fanout spinlock helpers
 //
 // Used by BOTH the orchestrator (pto_orchestrator.cpp) and the scheduler
@@ -555,10 +376,6 @@ typedef void (*PTO2InCoreFunc)(void **args, int32_t num_args);
 // fanout_count, because the orchestrator adds consumers concurrently with the
 // scheduler traversing the list after task completion.
 // =============================================================================
-
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-#include "aicpu/device_time.h"
-#endif
 
 #if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
 static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -37,7 +37,7 @@ enum class PTO2SubtaskSlot : uint8_t {
 };
 
 /**
- * Subtask mask bits (for active_mask / subtask_done_mask)
+ * Subtask mask bits (for active_mask)
  */
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);         // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);        // 0x2

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -284,12 +284,6 @@ public:
     /** @deprecated RT2 uses PTO2DispatchPayload, not Task. Always returns nullptr. */
     Task *get_task(int) { return nullptr; }
 
-    /** @deprecated Use PTO2 dispatch mode */
-    bool get_use_pto2_dispatch() const { return true; }
-
-    /** @deprecated Use PTO2 dispatch mode */
-    void set_use_pto2_dispatch(bool) {}
-
     // =========================================================================
     // Host API (host-only, not copied to device)
     // =========================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -131,7 +131,6 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHeader *sm_header,
         ring->slot_states[i].reset_for_reuse();
         ring->slot_states[i].fanin_count = 0;
         ring->slot_states[i].active_mask = 0;
-        ring->slot_states[i].subtask_done_mask.store(0, std::memory_order_relaxed);
     }
 
     return true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -132,10 +132,9 @@ void SchedulerContext::log_stall_diagnostics(
     int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
     int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
     int32_t total_running = aic_running + aiv_running;
-    int32_t core_num = core_count_per_thread_[thread_idx];
     DEV_ALWAYS(
         "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running, aiv_running,
-        core_num
+        core_trackers_[thread_idx].core_num()
     );
     auto all_running = tracker.get_all_running_cores();
     int32_t dump_count = 0;
@@ -340,13 +339,13 @@ void SchedulerContext::log_profiling_summary(int32_t thread_idx, int32_t cur_thr
 #endif
 
 // =============================================================================
-// Shutdown: deinit AICore regs for this thread's cores (and PMU finalize if enabled).
-// Orchestrator threads have core_count_per_thread_[thread_idx] == 0 -> no-op.
+// Shutdown: deinit AICore regs for this thread's cores.
+// Orchestrator threads have core_trackers_[thread_idx].core_num() == 0 -> no-op.
 // platform_deinit_aicore_regs is idempotent; safe to call after early completion.
 // =============================================================================
 int32_t SchedulerContext::shutdown(int32_t thread_idx) {
-    const int32_t *cores = core_assignments_[thread_idx];
-    int32_t core_num = core_count_per_thread_[thread_idx];
+    const int32_t *cores = core_trackers_[thread_idx].core_ids();
+    int32_t core_num = core_trackers_[thread_idx].core_num();
     if (core_num == 0) return 0;
 
     DEV_INFO("Thread %d: Shutting down %d cores", thread_idx, core_num);
@@ -487,15 +486,12 @@ bool SchedulerContext::assign_cores_to_threads() {
     }
     for (int32_t i = 0; i < active_sched_threads_; i++) {
         core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
     }
 
-    int32_t core_idx[MAX_AICPU_THREADS] = {};
     int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
 
     for (int32_t ci = 0; ci < cluster_count; ci++) {
         int32_t t = ci % active_sched_threads_;
-        int32_t &idx = core_idx[t];
 
         int32_t aic_wid = aic_worker_ids_[ci];
         int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
@@ -503,16 +499,14 @@ bool SchedulerContext::assign_cores_to_threads() {
 
         core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
 
-        core_assignments_[t][idx++] = aic_wid;
-        core_assignments_[t][idx++] = aiv0_wid;
-        core_assignments_[t][idx++] = aiv1_wid;
-
         DEV_INFO("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < thread_num_; t++) {
-        core_count_per_thread_[t] = core_idx[t];
-        DEV_INFO("Thread %d: total %d cores (%d clusters)", t, core_idx[t], core_trackers_[t].get_cluster_count());
+        DEV_INFO(
+            "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
+            core_trackers_[t].get_cluster_count()
+        );
     }
 
     DEV_INFO("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
@@ -545,7 +539,6 @@ void SchedulerContext::reassign_cores_for_all_threads() {
     // Re-init all trackers and reset core counts
     for (int32_t i = 0; i < thread_num_; i++) {
         core_trackers_[i].init(clusters_per_thread[i]);
-        core_count_per_thread_[i] = 0;
     }
 
     // Assign clusters round-robin and restore running state
@@ -573,10 +566,6 @@ void SchedulerContext::reassign_cores_for_all_threads() {
             core_trackers_[t].change_core_state(cl_idx * 3 + 2);
             core_trackers_[t].set_pending_occupied(cl_idx * 3 + 2);
         }
-
-        core_assignments_[t][core_count_per_thread_[t]++] = aic_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv0_wid;
-        core_assignments_[t][core_count_per_thread_[t]++] = aiv1_wid;
     }
 
     // Log final distribution
@@ -585,7 +574,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
         DEV_INFO(
-            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_count_per_thread_[t],
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count(), aic_running, aiv_running
         );
     }
@@ -718,8 +707,6 @@ void SchedulerContext::deinit() {
     for (int32_t t = 0; t < MAX_AICPU_THREADS; t++) {
         core_trackers_[t] = CoreTracker{};
     }
-    memset(core_assignments_, 0, sizeof(core_assignments_));
-    memset(core_count_per_thread_, 0, sizeof(core_count_per_thread_));
 
     regs_ = 0;
     sched_ = nullptr;
@@ -742,17 +729,6 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) { sched_ = &rt->scheduler; 
 void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
 ) {
-#if PTO2_PROFILING
-    // Write core-to-thread mapping (one-time, after orchestration)
-    if (runtime->enable_profiling) {
-        perf_aicpu_write_core_assignments(
-            core_assignments_, core_count_per_thread_, sched_thread_num_, cores_total_num_
-        );
-    }
-#else
-    (void)thread_idx;
-#endif
-
     total_tasks_ = total_tasks;
 
     // Fold tasks completed inline during orchestration
@@ -796,4 +772,16 @@ void SchedulerContext::on_orchestration_done(
             reassigned_.store(true, std::memory_order_release);
         }
     }
+
+#if PTO2_PROFILING
+    // Write core-to-thread mapping AFTER reassignment so the profiling data
+    // reflects the final distribution (all active_sched_threads_, including
+    // former orchestrator threads when orch_to_sched_ is enabled).
+    if (runtime->enable_profiling) {
+        perf_aicpu_init_core_assignments(cores_total_num_);
+        for (int32_t t = 0; t < active_sched_threads_; t++) {
+            perf_aicpu_write_core_assignments_for_thread(t, core_trackers_[t].core_ids(), core_trackers_[t].core_num());
+        }
+    }
+#endif
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -71,7 +71,7 @@ public:
 
     // Shutdown AICore registers for this thread's assigned cores.
     // Also runs PMU finalize (PTO2_PROFILING) before deinit when enabled.
-    // Orchestrator threads (core_count_per_thread_[thread_idx] == 0) are a no-op.
+    // Orchestrator threads (core_trackers_[thread_idx].core_num() == 0) are a no-op.
     int32_t shutdown(int32_t thread_idx);
 
     // Run all post-orchestration scheduler bookkeeping:
@@ -146,8 +146,6 @@ private:
     bool orch_to_sched_{false};
     int32_t thread_num_{0};
     int32_t cores_total_num_{0};
-    int32_t core_count_per_thread_[MAX_AICPU_THREADS]{};
-    int32_t core_assignments_[MAX_AICPU_THREADS][RUNTIME_MAX_WORKER]{};
 
     // Cluster-ordered worker_id lists, populated by handshake_all_cores().
     int32_t aic_worker_ids_[RUNTIME_MAX_WORKER]{};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -294,7 +294,6 @@ void SchedulerContext::dispatch_shape(
 // =============================================================================
 
 int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
-    int32_t &core_num = core_count_per_thread_[thread_idx];
     CoreTracker &tracker = core_trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch entry", thread_idx);
 
@@ -340,7 +339,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
     }
 
-    DEV_INFO("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_num);
+    DEV_INFO("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, tracker.core_num());
     int32_t cur_thread_completed = 0;
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -303,6 +303,9 @@ public:
 
     int32_t get_core_id_by_offset(int32_t offset) const { return core_id_map_[offset]; }
 
+    const int32_t *core_ids() const { return core_id_map_; }
+    int32_t core_num() const { return cluster_count_ * 3; }
+
 private:
     int32_t cluster_count_;
     BitStates aic_mask_;


### PR DESCRIPTION
Dead code removal (identified by audit):
- PTO2TaskSlotState::subtask_done_mask — superseded by completed_subtasks
- Runtime::get_use_pto2_dispatch / set_use_pto2_dispatch — zero callers
- pto2_orchestrator_print_stats / print_scope_stack — zero callers
- PTO2_MAX_TENSOR_DIM / PTO2_MAX_LAYOUT_DEPTH — zero references
- Dead PTO2_ORCH_PROFILING block with undefined reassign_cycle_start

Redundant array elimination:
- core_assignments_[t][i] duplicated core_trackers_[t].core_ids()[i]
- core_count_per_thread_[t] duplicated core_trackers_[t].core_num()
- Remove both arrays, add CoreTracker::core_ids() / core_num() accessors
- Refactor perf_aicpu_write_core_assignments into two-step API (init + per-thread) so callers pass CoreTracker data directly

Fix running_cores buffer: use RUNTIME_MAX_WORKER (worker_id range) instead of MAX_CORES_PER_THREAD (per-thread capacity).

Update docs: subtask_done_mask → completed_subtasks throughout. Applied symmetrically to a2a3 and a5.