### PR TITLE
Fix: package tools directory for wheel assets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,4 +43,6 @@ if(SKBUILD_MODE)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/build/lib/
             DESTINATION simpler_setup/_assets/build/lib
             OPTIONAL)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}/tools/
+            DESTINATION simpler_setup/_assets/tools)
 endif()


### PR DESCRIPTION
## Summary

Automatic swimlane conversion in device profiling depends on
`tools/swimlane_converter.py` at runtime. The current wheel packaging can miss
this script.

## Root Cause

In `SKBUILD_MODE`, [CMakeLists.txt](cci:7://file:///Users/wzr/ForPR/pypto/CMakeLists.txt:0:0-0:0) installs only [src/](cci:9://file:///Users/wzr/ForPR/pypto/src:0:0-0:0) and `build/lib/` into
`simpler_setup/_assets/`, but does not install [tools/](cci:9://file:///Users/wzr/ForPR/pypto/runtime/tools:0:0-0:0).

## Changes

- Update [CMakeLists.txt](cci:7://file:///Users/wzr/ForPR/pypto/CMakeLists.txt:0:0-0:0) to install [tools/](cci:9://file:///Users/wzr/ForPR/pypto/runtime/tools:0:0-0:0) under `SKBUILD_MODE`:
  - `install(DIRECTORY ${CMAKE_SOURCE_DIR}/tools/ DESTINATION simpler_setup/_assets/tools)`

## Impact

- Ensures `swimlane_converter.py` is available in wheel assets.
- Restores required runtime assets for upstream auto-conversion.
- No change to core runtime execution semantics.

## Validation

- Built and installed the runtime package.
- Verified `simpler_setup/_assets/tools/swimlane_converter.py` exists after install.