### PR TITLE
Fix(host_build_graph): empty swimlane due to stale l2_perf_records_addr (AICore)

### DIFF
--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -95,6 +95,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             }
 
             if (l2_perf_enabled) {
+                dcci(my_hank, SINGLE_CACHE_LINE);
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ L2PerfBuffer *l2_perf_buf = (__gm__ L2PerfBuffer *)my_hank->l2_perf_records_addr;
                 l2_perf_aicore_record_task(l2_perf_buf, actual_task_id, start_time, end_time);

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -85,6 +85,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             }
 
             if (l2_perf_enabled) {
+                dcci(my_hank, SINGLE_CACHE_LINE);
                 uint64_t end_time = get_sys_cnt_aicore();
                 __gm__ L2PerfBuffer *l2_perf_buf = (__gm__ L2PerfBuffer *)my_hank->l2_perf_records_addr;
                 l2_perf_aicore_record_task(l2_perf_buf, actual_task_id, start_time, end_time);


### PR DESCRIPTION
Add dcci(my_hank, SINGLE_CACHE_LINE) after execute_task() in host_build_graph AICore (a2a3 and a5). AICPU fills l2_perf_records_addr on the same 64B handshake line as enable_profiling_flag; without reloading that line after execute_task(), AICore reads a stale l2_perf_records_addr (often zero), so l2_perf_aicore_record_task writes to an invalid address and swimlane export sees no task records.