### PR TITLE
Fix: remove 16-dep truncation in TensorMap lookup (a2a3 + a5)

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -33,7 +33,7 @@ addr null-check → TensorMap lookup → spin-wait producer COMPLETED → comput
 - **addr null-check**: `buffer.addr == 0` means unallocated — log error, return 0
 - **TensorMap lookup**: find producer task by `buffer.addr`
 - **spin-wait**: wait until producer `task_state >= PTO2_TASK_COMPLETED`
-- **No producer** (`lookup_result.count == 0`): skip waiting, read immediately
+- **No producer** (lookup callback never fires): skip waiting, read immediately
 
 ### 3.2 set_tensor_data Flow
 
@@ -116,7 +116,7 @@ Three actors:
 
 **Scenario #3 is the only case requiring special attention**:
 
-TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` sees `lookup_result.count == 0` and returns immediately — but the kernel may still be reading → **WAR data race**.
+TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` finds no matching producer (the lookup callback never fires) and returns immediately — but the kernel may still be reading → **WAR data race**.
 
 **Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through `fanout_refcount`.
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -614,21 +614,22 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
             continue;
         }
 
-        PTO2LookupResult lookup_result;
-        orch->tensor_map.lookup(*tensor, lookup_result);
-
-        for (int r = 0; r < lookup_result.count; r++) {
-            PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
-            auto overlap_status = lookup_result.entries[r].overlap_status;
+        bool lookup_fatal = false;
+        orch->tensor_map.lookup(*tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus overlap_status) -> bool {
             auto prod_ring = entry.producer_task_id.ring();
             auto prod_local = entry.producer_task_id.local();
             PTO2TaskSlotState *prod_state = &orch->sm_header->rings[prod_ring].get_slot_state_by_task_id(prod_local);
             if (!pto2_append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
-                return result;
+                lookup_fatal = true;
+                return false;
             }
             if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
                 orch->tensor_map.remove_entry(entry);
             }
+            return true;
+        });
+        if (lookup_fatal) {
+            return result;
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -79,90 +79,106 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     PTO2TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = rt->orchestrator;
 
-    // Collect producer slot states from both maps, deduplicated by pointer.
-    // +1: one creator slot + up to PTO2_LOOKUP_MAX_RESULTS modifier slots.
-    constexpr int kMaxWait = PTO2_LOOKUP_MAX_RESULTS + 1;
-    PTO2TaskSlotState *slots[kMaxWait];
-    int slot_count = 0;
+    // Segmented wait: collect up to kSegmentCap producer slots, then flush by
+    // spinning on each. When the segment fills, we wait for the accumulated
+    // batch before continuing to gather more. Dedup is per-segment only; a
+    // producer that appears in two segments is waited on twice, which is
+    // idempotent (task_state is monotonic) and only adds one atomic load on
+    // the second encounter.
+    constexpr int kSegmentCap = 64;
+    const PTO2TaskSlotState *seg[kSegmentCap];
+    int seg_count = 0;
+    bool signaled = false;
+    bool failed = false;
 
-    // Step A: creator retention — read owner directly from tensor metadata
-    if (owner.is_valid()) {
-        slots[slot_count++] = &orch.sm_header->rings[owner.ring()].get_slot_state_by_task_id(owner.local());
-    }
-
-    // Step B: modifier writer lookup (OverlapMap)
-    PTO2LookupResult lookup_result;
-    orch.tensor_map.lookup(tensor, lookup_result);
-    for (int r = 0; r < lookup_result.count; r++) {
-        PTO2TaskId pid = lookup_result.entries[r].entry->producer_task_id;
-        PTO2TaskSlotState *s = &orch.sm_header->rings[pid.ring()].get_slot_state_by_task_id(pid.local());
-        bool already = false;
-        for (int j = 0; j < slot_count; j++) {
-            if (slots[j] == s) {
-                already = true;
-                break;
-            }
-        }
-        if (!already && slot_count < kMaxWait) {
-            slots[slot_count++] = s;
-        }
-    }
-
-    // Signal scheduler: orchestrator is about to block, bypass wiring backoff
-    bool signaled = slot_count > 0 && orch.scheduler;
-    if (signaled) {
-        orch.scheduler->wiring.orch_needs_drain.store(true, std::memory_order_release);
-    }
-
-    // Wait for each producer
-    for (int p = 0; p < slot_count; p++) {
-        PTO2TaskSlotState &slot = *slots[p];
+    auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
-
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                if (signaled) {
-                    orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
-                }
                 pto2_orch_report_fatal(
                     &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
                 );
-                return false;
+                failed = true;
+                return;
             }
         }
+    };
 
-        if (wait_for_consumers) {
-            t0 = get_sys_cnt_aicpu();
-            spin_count = 0;
-            while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
-                SPIN_WAIT_HINT();
-                if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                    if (signaled) {
-                        orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
-                    }
-                    pto2_orch_report_fatal(
-                        &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
-                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
-                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
-                    );
-                    return false;
-                }
+    auto wait_one_consumers = [&](const PTO2TaskSlotState &slot) {
+        uint8_t ring_id = slot.ring_id;
+        int32_t local_id = slot.task->task_id.local();
+        uint64_t t0 = get_sys_cnt_aicpu();
+        int32_t spin_count = 0;
+        while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
+            SPIN_WAIT_HINT();
+            if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                pto2_orch_report_fatal(
+                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                    "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
+                );
+                failed = true;
+                return;
             }
         }
-    }
+    };
 
-    // Clear urgency flag: orchestrator no longer blocking
+    auto flush_segment = [&]() {
+        for (int i = 0; i < seg_count; i++) {
+            wait_one_producer(*seg[i]);
+            if (failed) return;
+            if (!wait_for_consumers) continue;
+            wait_one_consumers(*seg[i]);
+            if (failed) return;
+        }
+        seg_count = 0;
+    };
+
+    auto try_push = [&](const PTO2TaskSlotState &s) {
+        for (int j = 0; j < seg_count; j++) {
+            if (seg[j] == &s) return;  // per-segment dedup
+        }
+        if (seg_count == kSegmentCap) {
+            flush_segment();
+            if (failed) return;
+        }
+        seg[seg_count++] = &s;
+        if (!signaled) {
+            orch.scheduler->wiring.orch_needs_drain.store(true, std::memory_order_release);
+            signaled = true;
+        }
+    };
+
+    auto do_wait = [&]() {
+        // Step A: creator retention — read owner directly from tensor metadata
+        if (owner.is_valid()) {
+            auto &s = orch.sm_header->rings[owner.ring()].get_slot_state_by_task_id(owner.local());
+            try_push(s);
+            if (failed) return;
+        }
+
+        // Step B: modifier writer lookup (OverlapMap), direct callback
+        orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
+            PTO2TaskId pid = entry.producer_task_id;
+            auto &s = orch.sm_header->rings[pid.ring()].get_slot_state_by_task_id(pid.local());
+            try_push(s);
+            return !failed;
+        });
+        if (failed) return;
+        flush_segment();
+    };
+
+    do_wait();
     if (signaled) {
         orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
     }
-
-    return true;
+    return !failed;
 }
 MAYBE_UNINITIALIZED_END
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -128,7 +128,7 @@
 #define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 // Fanin storage
-#define PTO2_FANIN_INLINE_CAP 16
+#define PTO2_FANIN_INLINE_CAP 64
 
 // TensorMap cleanup interval
 #define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
@@ -294,9 +294,9 @@ struct PTO2TaskPayload {
 static_assert(
     offsetof(PTO2TaskPayload, fanin_inline_slot_states) == 24, "inline fanin array must follow spill metadata"
 );
-static_assert(offsetof(PTO2TaskPayload, tensors) == 192, "tensors must start at byte 192 (cache line 3)");
+static_assert(offsetof(PTO2TaskPayload, tensors) == 576, "tensors must start at byte 192 (cache line 3)");
 static_assert(
-    offsetof(PTO2TaskPayload, scalars) == 192 + MAX_TENSOR_ARGS * sizeof(Tensor),
+    offsetof(PTO2TaskPayload, scalars) == 576 + MAX_TENSOR_ARGS * sizeof(Tensor),
     "scalars must immediately follow tensors"
 );
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -169,27 +169,9 @@ static_assert(
     offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)"
 );
 
-/**
- * Stack-allocated lookup result (avoids heap allocation per lookup)
- */
-#define PTO2_LOOKUP_MAX_RESULTS 16
 // =============================================================================
 // TensorMap Lookup Chain Length Statistics (compile-time toggle)
 // =============================================================================
-struct PTO2LookupResult {
-    struct Entry {
-        PTO2TensorMapEntry *entry;
-        OverlapStatus overlap_status;
-    };
-    Entry entries[PTO2_LOOKUP_MAX_RESULTS];
-    int32_t count{0};
-
-    void push(PTO2TensorMapEntry *entry, OverlapStatus s) {
-        if (count < PTO2_LOOKUP_MAX_RESULTS) {
-            entries[count++] = {entry, s};
-        }
-    }
-};
 
 /**
  * TensorMap structure
@@ -297,18 +279,23 @@ struct PTO2TensorMap {
     /**
      * Lookup producer for a tensor region
      *
-     * Searches the hash table for a matching region.
-     * Returns producer entry if found and valid.
+     * Searches the hash table for matching regions and invokes the callback
+     * for each overlapping valid entry.
      * Stale entries from different rings are skipped (not truncated).
      *
-     * @param tensor  Tensor to look up
-     * @param result  Output: stack-allocated result buffer
+     * The callback receives (PTO2TensorMapEntry &, OverlapStatus) and should
+     * return true to continue iteration, false to stop early. It is safe for
+     * the callback to call remove_entry() on the current entry: next_in_bucket
+     * is latched before invocation.
+     *
+     * @param tensor    Tensor to look up
+     * @param on_match  Callback invoked for each overlapping entry
      */
-    void lookup(const Tensor &tensor, PTO2LookupResult &result) {
+    template <typename Fn>
+    void lookup(const Tensor &tensor, Fn &&on_match) {
         uint32_t bucket_index = hash(tensor.buffer.addr);
         PTO2TensorMapEntry *cur_entry = buckets[bucket_index];
 
-        result.count = 0;
 #if PTO2_TENSORMAP_PROFILING
         g_lookup_count++;
         int32_t chain_len = 0;
@@ -337,10 +324,16 @@ struct PTO2TensorMap {
 #endif
                 auto overlap_status = cur_entry->check_overlap(tensor);
                 if (overlap_status != OverlapStatus::NO_OVERLAP) {
-                    result.push(cur_entry, overlap_status);
 #if PTO2_TENSORMAP_PROFILING
                     g_lookup_overlap_hits++;
 #endif
+                    if (!on_match(*cur_entry, overlap_status)) {
+#if PTO2_TENSORMAP_PROFILING
+                        g_lookup_chain_total += chain_len;
+                        if (chain_len > g_lookup_chain_max) g_lookup_chain_max = chain_len;
+#endif
+                        return;
+                    }
                 }
             }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -33,7 +33,7 @@ addr null-check → TensorMap lookup → spin-wait producer COMPLETED → comput
 - **addr null-check**: `buffer.addr == 0` means unallocated — log error, return 0
 - **TensorMap lookup**: find producer task by `buffer.addr`
 - **spin-wait**: wait until producer `task_state >= PTO2_TASK_COMPLETED`
-- **No producer** (`lookup_result.count == 0`): skip waiting, read immediately
+- **No producer** (lookup callback never fires): skip waiting, read immediately
 
 ### 3.2 set_tensor_data Flow
 
@@ -116,7 +116,7 @@ Three actors:
 
 **Scenario #3 is the only case requiring special attention**:
 
-TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` sees `lookup_result.count == 0` and returns immediately — but the kernel may still be reading → **WAR data race**.
+TensorMap tracks only producers (OUTPUT/INOUT), not pure INPUT consumers. If a tensor is only registered via `add_input()`, TensorMap has no producer entry for it. `set_tensor_data`'s `wait_for_tensor_ready()` finds no matching producer (the lookup callback never fires) and returns immediately — but the kernel may still be reading → **WAR data race**.
 
 **Solution**: For tensors that may later be written via `set_tensor_data`, use `add_inout()` instead of `add_input()`. INOUT registers a producer entry in TensorMap, enabling `set_tensor_data` to track all consumers through `fanout_refcount`.
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -615,21 +615,22 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
             continue;
         }
 
-        PTO2LookupResult lookup_result;
-        orch->tensor_map.lookup(*tensor, lookup_result);
-
-        for (int r = 0; r < lookup_result.count; r++) {
-            PTO2TensorMapEntry &entry = *lookup_result.entries[r].entry;
-            auto overlap_status = lookup_result.entries[r].overlap_status;
+        bool lookup_fatal = false;
+        orch->tensor_map.lookup(*tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus overlap_status) -> bool {
             auto prod_ring = entry.producer_task_id.ring();
             auto prod_local = entry.producer_task_id.local();
             PTO2TaskSlotState *prod_state = &orch->sm_header->rings[prod_ring].get_slot_state_by_task_id(prod_local);
             if (!pto2_append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
-                return result;
+                lookup_fatal = true;
+                return false;
             }
             if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
                 orch->tensor_map.remove_entry(entry);
             }
+            return true;
+        });
+        if (lookup_fatal) {
+            return result;
         }
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -79,90 +79,106 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
     PTO2TaskId owner = tensor.owner_task_id;
     PTO2OrchestratorState &orch = rt->orchestrator;
 
-    // Collect producer slot states from both maps, deduplicated by pointer.
-    // +1: one creator slot + up to PTO2_LOOKUP_MAX_RESULTS modifier slots.
-    constexpr int kMaxWait = PTO2_LOOKUP_MAX_RESULTS + 1;
-    PTO2TaskSlotState *slots[kMaxWait];
-    int slot_count = 0;
+    // Segmented wait: collect up to kSegmentCap producer slots, then flush by
+    // spinning on each. When the segment fills, we wait for the accumulated
+    // batch before continuing to gather more. Dedup is per-segment only; a
+    // producer that appears in two segments is waited on twice, which is
+    // idempotent (task_state is monotonic) and only adds one atomic load on
+    // the second encounter.
+    constexpr int kSegmentCap = 64;
+    const PTO2TaskSlotState *seg[kSegmentCap];
+    int seg_count = 0;
+    bool signaled = false;
+    bool failed = false;
 
-    // Step A: creator retention — read owner directly from tensor metadata
-    if (owner.is_valid()) {
-        slots[slot_count++] = &orch.sm_header->rings[owner.ring()].get_slot_state_by_task_id(owner.local());
-    }
-
-    // Step B: modifier writer lookup (OverlapMap)
-    PTO2LookupResult lookup_result;
-    orch.tensor_map.lookup(tensor, lookup_result);
-    for (int r = 0; r < lookup_result.count; r++) {
-        PTO2TaskId pid = lookup_result.entries[r].entry->producer_task_id;
-        PTO2TaskSlotState *s = &orch.sm_header->rings[pid.ring()].get_slot_state_by_task_id(pid.local());
-        bool already = false;
-        for (int j = 0; j < slot_count; j++) {
-            if (slots[j] == s) {
-                already = true;
-                break;
-            }
-        }
-        if (!already && slot_count < kMaxWait) {
-            slots[slot_count++] = s;
-        }
-    }
-
-    // Signal scheduler: orchestrator is about to block, bypass wiring backoff
-    bool signaled = slot_count > 0 && orch.scheduler;
-    if (signaled) {
-        orch.scheduler->wiring.orch_needs_drain.store(true, std::memory_order_release);
-    }
-
-    // Wait for each producer
-    for (int p = 0; p < slot_count; p++) {
-        PTO2TaskSlotState &slot = *slots[p];
+    auto wait_one_producer = [&](const PTO2TaskSlotState &slot) {
         uint8_t ring_id = slot.ring_id;
         int32_t local_id = static_cast<int32_t>(slot.task->task_id.local());
-
         uint64_t t0 = get_sys_cnt_aicpu();
         int32_t spin_count = 0;
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                if (signaled) {
-                    orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
-                }
                 pto2_orch_report_fatal(
                     &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
                 );
-                return false;
+                failed = true;
+                return;
             }
         }
+    };
 
-        if (wait_for_consumers) {
-            t0 = get_sys_cnt_aicpu();
-            spin_count = 0;
-            while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
-                SPIN_WAIT_HINT();
-                if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                    if (signaled) {
-                        orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
-                    }
-                    pto2_orch_report_fatal(
-                        &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
-                        "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
-                        (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
-                    );
-                    return false;
-                }
+    auto wait_one_consumers = [&](const PTO2TaskSlotState &slot) {
+        uint8_t ring_id = slot.ring_id;
+        int32_t local_id = slot.task->task_id.local();
+        uint64_t t0 = get_sys_cnt_aicpu();
+        int32_t spin_count = 0;
+        while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
+            SPIN_WAIT_HINT();
+            if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
+                pto2_orch_report_fatal(
+                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                    "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
+                    (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
+                );
+                failed = true;
+                return;
             }
         }
-    }
+    };
 
-    // Clear urgency flag: orchestrator no longer blocking
+    auto flush_segment = [&]() {
+        for (int i = 0; i < seg_count; i++) {
+            wait_one_producer(*seg[i]);
+            if (failed) return;
+            if (!wait_for_consumers) continue;
+            wait_one_consumers(*seg[i]);
+            if (failed) return;
+        }
+        seg_count = 0;
+    };
+
+    auto try_push = [&](const PTO2TaskSlotState &s) {
+        for (int j = 0; j < seg_count; j++) {
+            if (seg[j] == &s) return;  // per-segment dedup
+        }
+        if (seg_count == kSegmentCap) {
+            flush_segment();
+            if (failed) return;
+        }
+        seg[seg_count++] = &s;
+        if (!signaled) {
+            orch.scheduler->wiring.orch_needs_drain.store(true, std::memory_order_release);
+            signaled = true;
+        }
+    };
+
+    auto do_wait = [&]() {
+        // Step A: creator retention — read owner directly from tensor metadata
+        if (owner.is_valid()) {
+            auto &s = orch.sm_header->rings[owner.ring()].get_slot_state_by_task_id(owner.local());
+            try_push(s);
+            if (failed) return;
+        }
+
+        // Step B: modifier writer lookup (OverlapMap), direct callback
+        orch.tensor_map.lookup(tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus) -> bool {
+            PTO2TaskId pid = entry.producer_task_id;
+            auto &s = orch.sm_header->rings[pid.ring()].get_slot_state_by_task_id(pid.local());
+            try_push(s);
+            return !failed;
+        });
+        if (failed) return;
+        flush_segment();
+    };
+
+    do_wait();
     if (signaled) {
         orch.scheduler->wiring.orch_needs_drain.store(false, std::memory_order_release);
     }
-
-    return true;
+    return !failed;
 }
 MAYBE_UNINITIALIZED_END
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -169,27 +169,9 @@ static_assert(
     offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)"
 );
 
-/**
- * Stack-allocated lookup result (avoids heap allocation per lookup)
- */
-#define PTO2_LOOKUP_MAX_RESULTS 16
 // =============================================================================
 // TensorMap Lookup Chain Length Statistics (compile-time toggle)
 // =============================================================================
-struct PTO2LookupResult {
-    struct Entry {
-        PTO2TensorMapEntry *entry;
-        OverlapStatus overlap_status;
-    };
-    Entry entries[PTO2_LOOKUP_MAX_RESULTS];
-    int32_t count{0};
-
-    void push(PTO2TensorMapEntry *entry, OverlapStatus s) {
-        if (count < PTO2_LOOKUP_MAX_RESULTS) {
-            entries[count++] = {entry, s};
-        }
-    }
-};
 
 /**
  * TensorMap structure
@@ -297,18 +279,23 @@ struct PTO2TensorMap {
     /**
      * Lookup producer for a tensor region
      *
-     * Searches the hash table for a matching region.
-     * Returns producer entry if found and valid.
+     * Searches the hash table for matching regions and invokes the callback
+     * for each overlapping valid entry.
      * Stale entries from different rings are skipped (not truncated).
      *
-     * @param tensor  Tensor to look up
-     * @param result  Output: stack-allocated result buffer
+     * The callback receives (PTO2TensorMapEntry &, OverlapStatus) and should
+     * return true to continue iteration, false to stop early. It is safe for
+     * the callback to call remove_entry() on the current entry: next_in_bucket
+     * is latched before invocation.
+     *
+     * @param tensor    Tensor to look up
+     * @param on_match  Callback invoked for each overlapping entry
      */
-    void lookup(const Tensor &tensor, PTO2LookupResult &result) {
+    template <typename Fn>
+    void lookup(const Tensor &tensor, Fn &&on_match) {
         uint32_t bucket_index = hash(tensor.buffer.addr);
         PTO2TensorMapEntry *cur_entry = buckets[bucket_index];
 
-        result.count = 0;
 #if PTO2_TENSORMAP_PROFILING
         g_lookup_count++;
         int32_t chain_len = 0;
@@ -337,10 +324,16 @@ struct PTO2TensorMap {
 #endif
                 auto overlap_status = cur_entry->check_overlap(tensor);
                 if (overlap_status != OverlapStatus::NO_OVERLAP) {
-                    result.push(cur_entry, overlap_status);
 #if PTO2_TENSORMAP_PROFILING
                     g_lookup_overlap_hits++;
 #endif
+                    if (!on_match(*cur_entry, overlap_status)) {
+#if PTO2_TENSORMAP_PROFILING
+                        g_lookup_chain_total += chain_len;
+                        if (chain_len > g_lookup_chain_max) g_lookup_chain_max = chain_len;
+#endif
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
PTO2LookupResult was a stack-allocated 16-slot buffer; tensors with more than 16 overlapping producers silently lost the tail. Replace it with a template lookup(tensor, on_match) that invokes a callback per matching entry, eliminating the fixed cap.

- pto_tensormap.h: lookup becomes a template; drop PTO2LookupResult and PTO2_LOOKUP_MAX_RESULTS
- pto_orchestrator.cpp (submit_mixed_task): write directly into PTO2FaninBuilder from the callback; spill pool absorbs any count
- pto_runtime2.cpp (wait_for_tensor_ready): segmented wait with a 64-slot stack buffer, flushing by spin-waiting when full; dedup within a segment (cross-segment duplicates are idempotent since task_state is monotonic)
- SCALAR_DATA_ACCESS.md: reword stale "lookup_result.count == 0" phrasing to "lookup callback never fires"
- PTO2_FANIN_INLINE_CAP 16 -> 64 (a2a3) to keep the common path inline and avoid spill-pool pressure for mid-sized fanin