### PR TITLE
Add: support deferred completion in a2a3/a5 PTO runtime

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_consumer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_consumer.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "pto/common/pto_tile.hpp"
+
+#include "tensor.h"
+
+using namespace pto;
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *result_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ int32_t *notify_counter = reinterpret_cast<__gm__ int32_t *>(args[3]);
+
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    constexpr int kRows = 128;
+    constexpr int kCols = 128;
+    using DynShapeDim5 = Shape<1, 1, 1, kRows, kCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kCols, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
+
+    TileData src_tile(kRows, kCols);
+    TileData dst_tile(kRows, kCols);
+    TASSIGN(src_tile, 0x0);
+    TASSIGN(dst_tile, 0x10000);
+
+    GlobalData src_global(src);
+    GlobalData dst_global(result);
+    TLOAD(src_tile, src_global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADDS(dst_tile, src_tile, static_cast<float>(*notify_counter));
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dst_global, dst_tile);
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "pto_async_kernel_api.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    uint64_t notify_counter_addr = static_cast<uint64_t>(args[1]);
+    uint32_t expected_value = static_cast<uint32_t>(args[2]);
+    PTO2AsyncCtx ctx = pto2_async_ctx(args);
+    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(notify_counter_addr), expected_value);
+    pto2_defer_flush(ctx);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
+#include <pto/pto-inst.hpp>
+#include "pto/common/pto_tile.hpp"
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+using namespace pto;
+
+template <typename T>
+static inline __aicore__ __gm__ T *comm_remote_ptr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *in_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ int32_t *local_counter = reinterpret_cast<__gm__ int32_t *>(args[2]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
+
+    __gm__ float *in_data = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *out_data = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int my_rank = static_cast<int>(comm_ctx->rankId);
+    int peer_rank = 1 - my_rank;
+
+    constexpr int kRows = 128;
+    constexpr int kCols = 128;
+    using DynShapeDim5 = Shape<1, 1, 1, kRows, kCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kCols, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
+
+    TileData in_tile(kRows, kCols);
+    TileData out_tile(kRows, kCols);
+    TASSIGN(in_tile, 0x0);
+    TASSIGN(out_tile, 0x10000);
+
+    GlobalData in_global(in_data);
+    GlobalData out_global(out_data);
+    TLOAD(in_tile, in_global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(out_tile, in_tile, in_tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(out_global, out_tile);
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+
+    if (my_rank == 1) {
+        for (volatile int i = 0; i < 2000000; ++i) {}
+    }
+
+    __gm__ int32_t *remote_counter = comm_remote_ptr(comm_ctx, local_counter, peer_rank);
+    pto::comm::Signal remote_signal(remote_counter);
+    pto::comm::TNOTIFY(remote_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -18,10 +18,9 @@
 #define __aicore__ [aicore]
 #endif
 
+#include <pto/pto-inst.hpp>
 #include <pto/comm/comm_types.hpp>
 #include <pto/comm/pto_comm_inst.hpp>
-#include <pto/pto-inst.hpp>
-#include "pto/common/pto_tile.hpp"
 
 #include "platform_comm/comm_context.h"
 #include "tensor.h"

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "platform_comm/comm_context.h"
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+async_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+}
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    return async_notify_orchestration_config(orch_args);
+}
+
+__attribute__((visibility("default"))) void async_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+    if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
+        LOG_ERROR("async_notify_demo: expected 5 args");
+        return;
+    }
+
+    Tensor input = from_tensor_arg(orch_args.tensor(0));
+    Tensor output = from_tensor_arg(orch_args.tensor(1));
+    Tensor result = from_tensor_arg(orch_args.tensor(2));
+    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+
+    Arg params_producer;
+    params_producer.add_input(input);
+    params_producer.add_output(output);
+    params_producer.add_scalar(notify_counter.buffer.addr);
+    params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    pto2_rt_submit_aiv_task(0, params_producer);
+
+    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+
+    Arg params_consumer;
+    params_consumer.add_input(notify_token);
+    params_consumer.add_input(output);
+    params_consumer.add_output(result);
+    params_consumer.add_scalar(notify_counter.buffer.addr);
+    pto2_rt_submit_aiv_task(1, params_consumer);
+}
+
+}  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -46,7 +46,14 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
     pto2_rt_submit_aiv_task(0, params_producer);
 
-    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+    uint32_t notify_token_shape[1] = {1};
+    TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
+    Arg params_notify;
+    params_notify.add_output(notify_token_info);
+    params_notify.add_scalar(notify_counter.buffer.addr);
+    params_notify.add_scalar(static_cast<uint64_t>(1));
+    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
     params_consumer.add_input(notify_token);

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""TNOTIFY + deferred completion smoke test for onboard a2a3."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    ChipBootstrapConfig,
+    ChipBufferSpec,
+    ChipCallable,
+    ChipCallConfig,
+    ChipCommBootstrapConfig,
+    ChipContext,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+N = 128 * 128
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x]
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        return list(range(lo, hi + 1))
+    return [int(spec)]
+
+
+def build_chip_callable(platform: str, pto_isa_commit: str | None, clone_protocol: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol=clone_protocol)
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+
+    children = []
+    for func_id, rel in [
+        (0, "kernels/aiv/kernel_producer_notify.cpp"),
+        (1, "kernels/aiv/kernel_consumer.cpp"),
+        (2, "kernels/aiv/kernel_notify_wait.cpp"),
+    ]:
+        kernel = kc.compile_incore(
+            source_path=os.path.join(HERE, rel),
+            core_type="aiv",
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=extra_includes,
+        )
+        if not platform.endswith("sim"):
+            kernel = extract_text_section(kernel)
+        children.append(
+            (
+                func_id,
+                CoreCallable.build(
+                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
+                    binary=kernel,
+                ),
+            )
+        )
+
+    orch = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/async_notify_orchestration.cpp"),
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
+        func_name="async_notify_orchestration",
+        binary=orch,
+        children=children,
+    )
+
+
+def run(
+    platform: str = "a2a3",
+    device_ids: list[int] | None = None,
+    pto_isa_commit: str | None = None,
+    build: bool = False,
+) -> int:
+    if device_ids is None:
+        device_ids = [0, 1]
+    nranks = len(device_ids)
+    if nranks != 2:
+        raise ValueError(f"async_notify_demo needs exactly 2 devices, got {device_ids}")
+
+    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_async_notify_rootinfo_{os.getpid()}.bin")
+    try:
+        os.unlink(rootinfo_path)
+    except FileNotFoundError:
+        pass
+
+    inp = [
+        torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
+        for _ in range(nranks)
+    ]
+    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+
+    cfgs = [
+        ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4 * 1024),
+            buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+        )
+        for rank in range(nranks)
+    ]
+
+    chip_callable = build_chip_callable(platform, pto_isa_commit, "https")
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        chip_bootstrap_configs=cfgs,
+        build=build,
+    )
+    try:
+        worker.init()
+        contexts: list[ChipContext] = worker.chip_contexts
+
+        def orch_fn(orch, _args, cfg):
+            for rank, ctx in enumerate(contexts):
+                args = TaskArgs()
+                args.add_tensor(make_tensor_arg(inp[rank]), TensorArgType.INPUT)
+                args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_tensor(
+                    ContinuousTensor.make(
+                        data=ctx.buffer_ptrs["notify_counter"],
+                        shapes=(1,),
+                        dtype=DataType.INT32,
+                        child_memory=True,
+                    ),
+                    TensorArgType.INPUT,
+                )
+                args.add_scalar(ctx.device_ctx)
+                orch.submit_next_level(chip_callable, args, cfg, worker=rank)
+
+        worker.run(orch_fn, args=None, config=ChipCallConfig())
+
+        ok = True
+        for rank in range(nranks):
+            expected_out = inp[rank] * 2.0
+            expected_result = expected_out + 1.0
+            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
+            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
+            print(f"[async_notify_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
+            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
+        return 0 if ok else 1
+    finally:
+        worker.close()
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_async_notify_demo() -> None:
+    assert run("a2a3", [0, 1]) == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a2a3")
+    parser.add_argument("-d", "--device", default="0-1")
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--pto-isa-commit", default=None)
+    args = parser.parse_args()
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_consumer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_consumer.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "tensor.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mailbox_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *result_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *mailbox =
+        reinterpret_cast<__gm__ float *>(mailbox_tensor->buffer.addr) + mailbox_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    uint32_t n = static_cast<uint32_t>(result_tensor->shapes[0]);
+    for (uint32_t i = 0; i < n; ++i) {
+        result[i] = mailbox[i];
+    }
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "pto_async_kernel_api.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    uint64_t counter_addr = static_cast<uint64_t>(args[1]);
+    uint32_t expected_value = static_cast<uint32_t>(args[2]);
+    PTO2AsyncCtx ctx = pto2_async_ctx(args);
+    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(counter_addr), expected_value);
+    pto2_defer_flush(ctx);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -12,6 +12,8 @@
 #include <cstdint>
 
 #include <pto/pto-inst.hpp>
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
 
 #ifndef __gm__
 #define __gm__
@@ -49,5 +51,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
-    __atomic_add_fetch(reinterpret_cast<int32_t *>(peer_counter), 1, __ATOMIC_RELEASE);
+    pto::comm::Signal peer_signal(peer_counter);
+    pto::comm::TNOTIFY(peer_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+template <typename T>
+static inline __aicore__ __gm__ T *comm_remote_ptr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *partial_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *mailbox_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ int32_t *local_counter = reinterpret_cast<__gm__ int32_t *>(args[3]);
+    __gm__ CommContext *ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+
+    __gm__ float *partial =
+        reinterpret_cast<__gm__ float *>(partial_tensor->buffer.addr) + partial_tensor->start_offset;
+    __gm__ float *mailbox =
+        reinterpret_cast<__gm__ float *>(mailbox_tensor->buffer.addr) + mailbox_tensor->start_offset;
+
+    int peer_rank = (static_cast<int>(ctx->rankId) + 1) % static_cast<int>(ctx->rankNum);
+    __gm__ float *peer_mailbox = comm_remote_ptr(ctx, mailbox, peer_rank);
+    uint32_t n = static_cast<uint32_t>(partial_tensor->shapes[0]);
+    for (uint32_t i = 0; i < n; ++i) {
+        peer_mailbox[i] = partial[i];
+    }
+
+    __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
+    __atomic_add_fetch(reinterpret_cast<int32_t *>(peer_counter), 1, __ATOMIC_RELEASE);
+}

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -49,6 +49,15 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (uint32_t i = 0; i < n; ++i) {
         peer_mailbox[i] = partial[i];
     }
+#if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
+    dcci((__gm__ int32_t *)peer_mailbox, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+#if defined(__CPU_SIM)
+    dsb(0);
+#else
+    dsb(DSB_DDR);
+#endif
+    pipe_barrier(PIPE_ALL);
+#endif
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
     pto::comm::Signal peer_signal(peer_counter);

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -49,7 +49,14 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
     pto2_rt_submit_aiv_task(0, params_producer);
 
-    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+    uint32_t notify_token_shape[1] = {1};
+    TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
+    Arg params_notify;
+    params_notify.add_output(notify_token_info);
+    params_notify.add_scalar(notify_counter.buffer.addr);
+    params_notify.add_scalar(static_cast<uint64_t>(1));
+    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
     params_consumer.add_input(notify_token);

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "platform_comm/comm_context.h"
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+deferred_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+}
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    return deferred_notify_orchestration_config(orch_args);
+}
+
+__attribute__((visibility("default"))) void deferred_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+    if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
+        LOG_ERROR("deferred_notify_demo: expected 5 args");
+        return;
+    }
+
+    Tensor partial = from_tensor_arg(orch_args.tensor(0));
+    Tensor mailbox = from_tensor_arg(orch_args.tensor(1));
+    Tensor result = from_tensor_arg(orch_args.tensor(2));
+    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+
+    uint32_t shapes[1] = {128 * 128};
+    TensorCreateInfo producer_output_info(shapes, 1, DataType::FLOAT32);
+    Arg params_producer;
+    params_producer.add_input(partial);
+    params_producer.add_inout(mailbox);
+    params_producer.add_output(producer_output_info);
+    params_producer.add_scalar(notify_counter.buffer.addr);
+    params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    pto2_rt_submit_aiv_task(0, params_producer);
+
+    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+
+    Arg params_consumer;
+    params_consumer.add_input(notify_token);
+    params_consumer.add_input(mailbox);
+    params_consumer.add_output(result);
+    params_consumer.add_scalar(notify_counter.buffer.addr);
+    pto2_rt_submit_aiv_task(1, params_consumer);
+}
+
+}  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L2 deferred completion + two-chip comm smoke test for a2a3sim."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    ChipBootstrapConfig,
+    ChipBufferSpec,
+    ChipCallable,
+    ChipCallConfig,
+    ChipCommBootstrapConfig,
+    ChipContext,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+N = 128 * 128
+DTYPE_NBYTES = 4
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x]
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        return list(range(lo, hi + 1))
+    return [int(spec)]
+
+
+def build_chip_callable(platform: str, pto_isa_commit: str | None, clone_protocol: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol=clone_protocol)
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+
+    children = []
+    for func_id, rel in [
+        (0, "kernels/aiv/kernel_producer.cpp"),
+        (1, "kernels/aiv/kernel_consumer.cpp"),
+        (2, "kernels/aiv/kernel_notify_wait.cpp"),
+    ]:
+        kernel = kc.compile_incore(
+            source_path=os.path.join(HERE, rel),
+            core_type="aiv",
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=extra_includes,
+        )
+        if not platform.endswith("sim"):
+            kernel = extract_text_section(kernel)
+        children.append(
+            (
+                func_id,
+                CoreCallable.build(
+                    signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
+                    binary=kernel,
+                ),
+            )
+        )
+
+    orch = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/deferred_notify_orch.cpp"),
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
+        func_name="deferred_notify_orchestration",
+        binary=orch,
+        children=children,
+    )
+
+
+def run(
+    platform: str = "a2a3sim",
+    device_ids: list[int] | None = None,
+    pto_isa_commit: str | None = None,
+    build: bool = False,
+) -> int:
+    if device_ids is None:
+        device_ids = [0, 1]
+    nranks = len(device_ids)
+    if nranks != 2:
+        raise ValueError(f"deferred_notify_demo needs exactly 2 devices, got {device_ids}")
+
+    mailbox_nbytes = N * DTYPE_NBYTES
+    counter_nbytes = 4
+    window_size = max(mailbox_nbytes + counter_nbytes, 4 * 1024)
+    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_deferred_notify_rootinfo_{os.getpid()}.bin")
+    try:
+        os.unlink(rootinfo_path)
+    except FileNotFoundError:
+        pass
+
+    partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
+    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+
+    cfgs = [
+        ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(
+                rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=window_size
+            ),
+            buffers=[
+                ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+                ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=counter_nbytes),
+            ],
+        )
+        for rank in range(nranks)
+    ]
+
+    chip_callable = build_chip_callable(platform, pto_isa_commit, "https")
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        chip_bootstrap_configs=cfgs,
+        build=build,
+    )
+    try:
+        worker.init()
+        contexts: list[ChipContext] = worker.chip_contexts
+
+        def orch_fn(orch, _args, cfg):
+            for rank, ctx in enumerate(contexts):
+                args = TaskArgs()
+                args.add_tensor(make_tensor_arg(partial[rank]), TensorArgType.INPUT)
+                args.add_tensor(
+                    ContinuousTensor.make(
+                        data=ctx.buffer_ptrs["mailbox"],
+                        shapes=(N,),
+                        dtype=DataType.FLOAT32,
+                        child_memory=True,
+                    ),
+                    TensorArgType.INOUT,
+                )
+                args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_tensor(
+                    ContinuousTensor.make(
+                        data=ctx.buffer_ptrs["notify_counter"],
+                        shapes=(1,),
+                        dtype=DataType.INT32,
+                        child_memory=True,
+                    ),
+                    TensorArgType.INPUT,
+                )
+                args.add_scalar(ctx.device_ctx)
+                orch.submit_next_level(chip_callable, args, cfg, worker=rank)
+
+        worker.run(orch_fn, args=None, config=ChipCallConfig())
+
+        ok = True
+        for rank in range(nranks):
+            expected = partial[(rank + 1) % nranks]
+            max_diff = float(torch.max(torch.abs(result[rank] - expected)))
+            print(f"[deferred_notify_demo] rank {rank}: max_diff={max_diff:.3e}")
+            ok = ok and max_diff <= 1e-6
+        return 0 if ok else 1
+    finally:
+        worker.close()
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_deferred_notify_demo() -> None:
+    assert run("a2a3sim", [0, 1]) == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a2a3sim")
+    parser.add_argument("-d", "--device", default="0-1")
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--pto-isa-commit", default=None)
+    args = parser.parse_args()
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import os
 import tempfile
+from multiprocessing.shared_memory import SharedMemory
 
 import torch
 from simpler.task_interface import (
@@ -27,6 +28,7 @@ from simpler.task_interface import (
     ContinuousTensor,
     CoreCallable,
     DataType,
+    HostBufferStaging,
     TaskArgs,
     TensorArgType,
 )
@@ -118,6 +120,12 @@ def run(
 
     partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
     result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+    counter_init_shms = [SharedMemory(create=True, size=counter_nbytes) for _ in range(nranks)]
+    for shm in counter_init_shms:
+        buf = shm.buf
+        if buf is None:
+            raise RuntimeError("SharedMemory buffer is unavailable")
+        buf[:counter_nbytes] = b"\x00" * counter_nbytes
 
     cfgs = [
         ChipBootstrapConfig(
@@ -126,7 +134,16 @@ def run(
             ),
             buffers=[
                 ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=counter_nbytes),
+                ChipBufferSpec(
+                    name="notify_counter",
+                    dtype="int32",
+                    count=1,
+                    nbytes=counter_nbytes,
+                    load_from_host=True,
+                ),
+            ],
+            host_inputs=[
+                HostBufferStaging(name="notify_counter", shm_name=counter_init_shms[rank].name, size=counter_nbytes)
             ],
         )
         for rank in range(nranks)
@@ -187,6 +204,9 @@ def run(
             os.unlink(rootinfo_path)
         except FileNotFoundError:
             pass
+        for shm in counter_init_shms:
+            shm.close()
+            shm.unlink()
 
 
 def test_deferred_notify_demo() -> None:

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_consumer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_consumer.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "pto/common/pto_tile.hpp"
+
+#include "tensor.h"
+
+using namespace pto;
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *result_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ int32_t *notify_counter = reinterpret_cast<__gm__ int32_t *>(args[3]);
+
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    constexpr int kRows = 128;
+    constexpr int kCols = 128;
+    using DynShapeDim5 = Shape<1, 1, 1, kRows, kCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kCols, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
+
+    TileData src_tile(kRows, kCols);
+    TileData dst_tile(kRows, kCols);
+    TASSIGN(src_tile, 0x0);
+    TASSIGN(dst_tile, 0x10000);
+
+    GlobalData src_global(src);
+    GlobalData dst_global(result);
+    TLOAD(src_tile, src_global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADDS(dst_tile, src_tile, static_cast<float>(*notify_counter));
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dst_global, dst_tile);
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+}

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/pto-inst.hpp>
+#include "pto_async_kernel_api.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    uint64_t notify_counter_addr = static_cast<uint64_t>(args[1]);
+    uint32_t expected_value = static_cast<uint32_t>(args[2]);
+    PTO2AsyncCtx ctx = pto2_async_ctx(args);
+    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(notify_counter_addr), expected_value);
+    pto2_defer_flush(ctx);
+}

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
+#include <pto/pto-inst.hpp>
+#include "pto/common/pto_tile.hpp"
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+using namespace pto;
+
+template <typename T>
+static inline __aicore__ __gm__ T *comm_remote_ptr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *in_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ int32_t *local_counter = reinterpret_cast<__gm__ int32_t *>(args[2]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[3]);
+
+    __gm__ float *in_data = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *out_data = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int my_rank = static_cast<int>(comm_ctx->rankId);
+    int peer_rank = 1 - my_rank;
+
+    constexpr int kRows = 128;
+    constexpr int kCols = 128;
+    using DynShapeDim5 = Shape<1, 1, 1, kRows, kCols>;
+    using DynStridDim5 = Stride<1, 1, 1, kCols, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
+    using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
+
+    TileData in_tile(kRows, kCols);
+    TileData out_tile(kRows, kCols);
+    TASSIGN(in_tile, 0x0);
+    TASSIGN(out_tile, 0x10000);
+
+    GlobalData in_global(in_data);
+    GlobalData out_global(out_data);
+    TLOAD(in_tile, in_global);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    TADD(out_tile, in_tile, in_tile);
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(out_global, out_tile);
+    set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+
+    if (my_rank == 1) {
+        for (volatile int i = 0; i < 2000000; ++i) {}
+    }
+
+    __gm__ int32_t *remote_counter = comm_remote_ptr(comm_ctx, local_counter, peer_rank);
+    pto::comm::Signal remote_signal(remote_counter);
+    pto::comm::TNOTIFY(remote_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -18,10 +18,9 @@
 #define __aicore__ [aicore]
 #endif
 
+#include <pto/pto-inst.hpp>
 #include <pto/comm/comm_types.hpp>
 #include <pto/comm/pto_comm_inst.hpp>
-#include <pto/pto-inst.hpp>
-#include "pto/common/pto_tile.hpp"
 
 #include "platform_comm/comm_context.h"
 #include "tensor.h"

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "platform_comm/comm_context.h"
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+async_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+}
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    return async_notify_orchestration_config(orch_args);
+}
+
+__attribute__((visibility("default"))) void async_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+    if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
+        LOG_ERROR("async_notify_demo: expected 5 args");
+        return;
+    }
+
+    Tensor input = from_tensor_arg(orch_args.tensor(0));
+    Tensor output = from_tensor_arg(orch_args.tensor(1));
+    Tensor result = from_tensor_arg(orch_args.tensor(2));
+    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+
+    Arg params_producer;
+    params_producer.add_input(input);
+    params_producer.add_output(output);
+    params_producer.add_scalar(notify_counter.buffer.addr);
+    params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    pto2_rt_submit_aiv_task(0, params_producer);
+
+    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+
+    Arg params_consumer;
+    params_consumer.add_input(notify_token);
+    params_consumer.add_input(output);
+    params_consumer.add_output(result);
+    params_consumer.add_scalar(notify_counter.buffer.addr);
+    pto2_rt_submit_aiv_task(1, params_consumer);
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -46,7 +46,14 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
     pto2_rt_submit_aiv_task(0, params_producer);
 
-    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+    uint32_t notify_token_shape[1] = {1};
+    TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
+    Arg params_notify;
+    params_notify.add_output(notify_token_info);
+    params_notify.add_scalar(notify_counter.buffer.addr);
+    params_notify.add_scalar(static_cast<uint64_t>(1));
+    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
     params_consumer.add_input(notify_token);

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""TNOTIFY + deferred completion smoke test for onboard a5."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    ChipBootstrapConfig,
+    ChipBufferSpec,
+    ChipCallable,
+    ChipCallConfig,
+    ChipCommBootstrapConfig,
+    ChipContext,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+N = 128 * 128
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x]
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        return list(range(lo, hi + 1))
+    return [int(spec)]
+
+
+def build_chip_callable(platform: str, pto_isa_commit: str | None, clone_protocol: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol=clone_protocol)
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+
+    children = []
+    for func_id, rel in [
+        (0, "kernels/aiv/kernel_producer_notify.cpp"),
+        (1, "kernels/aiv/kernel_consumer.cpp"),
+        (2, "kernels/aiv/kernel_notify_wait.cpp"),
+    ]:
+        kernel = kc.compile_incore(
+            source_path=os.path.join(HERE, rel),
+            core_type="aiv",
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=extra_includes,
+        )
+        if not platform.endswith("sim"):
+            kernel = extract_text_section(kernel)
+        children.append(
+            (
+                func_id,
+                CoreCallable.build(
+                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
+                    binary=kernel,
+                ),
+            )
+        )
+
+    orch = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/async_notify_orchestration.cpp"),
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
+        func_name="async_notify_orchestration",
+        binary=orch,
+        children=children,
+    )
+
+
+def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commit: str | None = None) -> int:
+    if device_ids is None:
+        device_ids = [0, 1]
+    nranks = len(device_ids)
+    if nranks != 2:
+        raise ValueError(f"async_notify_demo needs exactly 2 devices, got {device_ids}")
+
+    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_async_notify_rootinfo_{os.getpid()}.bin")
+    try:
+        os.unlink(rootinfo_path)
+    except FileNotFoundError:
+        pass
+
+    inp = [
+        torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
+        for _ in range(nranks)
+    ]
+    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+
+    cfgs = [
+        ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4 * 1024),
+            buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+        )
+        for rank in range(nranks)
+    ]
+
+    chip_callable = build_chip_callable(platform, pto_isa_commit, "https")
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        chip_bootstrap_configs=cfgs,
+    )
+    try:
+        worker.init()
+        contexts: list[ChipContext] = worker.chip_contexts
+
+        def orch_fn(orch, _args, cfg):
+            for rank, ctx in enumerate(contexts):
+                args = TaskArgs()
+                args.add_tensor(make_tensor_arg(inp[rank]), TensorArgType.INPUT)
+                args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_tensor(
+                    ContinuousTensor.make(
+                        data=ctx.buffer_ptrs["notify_counter"],
+                        shapes=(1,),
+                        dtype=DataType.INT32,
+                        child_memory=True,
+                    ),
+                    TensorArgType.INPUT,
+                )
+                args.add_scalar(ctx.device_ctx)
+                orch.submit_next_level(chip_callable, args, cfg, worker=rank)
+
+        worker.run(orch_fn, args=None, config=ChipCallConfig())
+
+        ok = True
+        for rank in range(nranks):
+            expected_out = inp[rank] * 2.0
+            expected_result = expected_out + 1.0
+            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
+            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
+            print(f"[async_notify_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
+            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
+        return 0 if ok else 1
+    finally:
+        worker.close()
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_async_notify_demo() -> None:
+    assert run("a5", [0, 1]) == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a5")
+    parser.add_argument("-d", "--device", default="0-1")
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--pto-isa-commit", default=None)
+    args = parser.parse_args()
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_consumer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_consumer.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "tensor.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *mailbox_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *result_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *mailbox =
+        reinterpret_cast<__gm__ float *>(mailbox_tensor->buffer.addr) + mailbox_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    uint32_t n = static_cast<uint32_t>(result_tensor->shapes[0]);
+    for (uint32_t i = 0; i < n; ++i) {
+        result[i] = mailbox[i];
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "pto_async_kernel_api.h"
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    uint64_t counter_addr = static_cast<uint64_t>(args[1]);
+    uint32_t expected_value = static_cast<uint32_t>(args[2]);
+    PTO2AsyncCtx ctx = pto2_async_ctx(args);
+    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(counter_addr), expected_value);
+    pto2_defer_flush(ctx);
+}

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -12,6 +12,8 @@
 #include <cstdint>
 
 #include <pto/pto-inst.hpp>
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
 
 #ifndef __gm__
 #define __gm__
@@ -49,5 +51,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
-    __atomic_add_fetch(reinterpret_cast<int32_t *>(peer_counter), 1, __ATOMIC_RELEASE);
+    pto::comm::Signal peer_signal(peer_counter);
+    pto::comm::TNOTIFY(peer_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
 }

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+template <typename T>
+static inline __aicore__ __gm__ T *comm_remote_ptr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *partial_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *mailbox_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ int32_t *local_counter = reinterpret_cast<__gm__ int32_t *>(args[3]);
+    __gm__ CommContext *ctx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+
+    __gm__ float *partial =
+        reinterpret_cast<__gm__ float *>(partial_tensor->buffer.addr) + partial_tensor->start_offset;
+    __gm__ float *mailbox =
+        reinterpret_cast<__gm__ float *>(mailbox_tensor->buffer.addr) + mailbox_tensor->start_offset;
+
+    int peer_rank = (static_cast<int>(ctx->rankId) + 1) % static_cast<int>(ctx->rankNum);
+    __gm__ float *peer_mailbox = comm_remote_ptr(ctx, mailbox, peer_rank);
+    uint32_t n = static_cast<uint32_t>(partial_tensor->shapes[0]);
+    for (uint32_t i = 0; i < n; ++i) {
+        peer_mailbox[i] = partial[i];
+    }
+
+    __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
+    __atomic_add_fetch(reinterpret_cast<int32_t *>(peer_counter), 1, __ATOMIC_RELEASE);
+}

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -49,6 +49,15 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (uint32_t i = 0; i < n; ++i) {
         peer_mailbox[i] = partial[i];
     }
+#if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
+    dcci((__gm__ int32_t *)peer_mailbox, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+#if defined(__CPU_SIM)
+    dsb(0);
+#else
+    dsb(DSB_DDR);
+#endif
+    pipe_barrier(PIPE_ALL);
+#endif
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
     pto::comm::Signal peer_signal(peer_counter);

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -49,7 +49,14 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
     pto2_rt_submit_aiv_task(0, params_producer);
 
-    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+    uint32_t notify_token_shape[1] = {1};
+    TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
+    Arg params_notify;
+    params_notify.add_output(notify_token_info);
+    params_notify.add_scalar(notify_counter.buffer.addr);
+    params_notify.add_scalar(static_cast<uint64_t>(1));
+    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
     params_consumer.add_input(notify_token);

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "platform_comm/comm_context.h"
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+deferred_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+}
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    return deferred_notify_orchestration_config(orch_args);
+}
+
+__attribute__((visibility("default"))) void deferred_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+    if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
+        LOG_ERROR("deferred_notify_demo: expected 5 args");
+        return;
+    }
+
+    Tensor partial = from_tensor_arg(orch_args.tensor(0));
+    Tensor mailbox = from_tensor_arg(orch_args.tensor(1));
+    Tensor result = from_tensor_arg(orch_args.tensor(2));
+    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+
+    uint32_t shapes[1] = {128 * 128};
+    TensorCreateInfo producer_output_info(shapes, 1, DataType::FLOAT32);
+    Arg params_producer;
+    params_producer.add_input(partial);
+    params_producer.add_inout(mailbox);
+    params_producer.add_output(producer_output_info);
+    params_producer.add_scalar(notify_counter.buffer.addr);
+    params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    pto2_rt_submit_aiv_task(0, params_producer);
+
+    Tensor notify_token = pto2_rt_submit_notification_wait_task(2, notify_counter.buffer.addr, 1);
+
+    Arg params_consumer;
+    params_consumer.add_input(notify_token);
+    params_consumer.add_input(mailbox);
+    params_consumer.add_output(result);
+    params_consumer.add_scalar(notify_counter.buffer.addr);
+    pto2_rt_submit_aiv_task(1, params_consumer);
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L2 deferred completion + two-chip comm smoke test for a5sim."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    ChipBootstrapConfig,
+    ChipBufferSpec,
+    ChipCallable,
+    ChipCallConfig,
+    ChipCommBootstrapConfig,
+    ChipContext,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+N = 128 * 128
+DTYPE_NBYTES = 4
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x]
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        return list(range(lo, hi + 1))
+    return [int(spec)]
+
+
+def build_chip_callable(platform: str, pto_isa_commit: str | None, clone_protocol: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol=clone_protocol)
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+
+    children = []
+    for func_id, rel in [
+        (0, "kernels/aiv/kernel_producer.cpp"),
+        (1, "kernels/aiv/kernel_consumer.cpp"),
+        (2, "kernels/aiv/kernel_notify_wait.cpp"),
+    ]:
+        kernel = kc.compile_incore(
+            source_path=os.path.join(HERE, rel),
+            core_type="aiv",
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=extra_includes,
+        )
+        if not platform.endswith("sim"):
+            kernel = extract_text_section(kernel)
+        children.append(
+            (
+                func_id,
+                CoreCallable.build(
+                    signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
+                    binary=kernel,
+                ),
+            )
+        )
+
+    orch = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/deferred_notify_orch.cpp"),
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.INOUT, ArgDirection.OUT, ArgDirection.IN],
+        func_name="deferred_notify_orchestration",
+        binary=orch,
+        children=children,
+    )
+
+
+def run(
+    platform: str = "a5sim",
+    device_ids: list[int] | None = None,
+    pto_isa_commit: str | None = None,
+    build: bool = False,
+) -> int:
+    if device_ids is None:
+        device_ids = [0, 1]
+    nranks = len(device_ids)
+    if nranks != 2:
+        raise ValueError(f"deferred_notify_demo needs exactly 2 devices, got {device_ids}")
+
+    mailbox_nbytes = N * DTYPE_NBYTES
+    counter_nbytes = 4
+    window_size = max(mailbox_nbytes + counter_nbytes, 4 * 1024)
+    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_deferred_notify_rootinfo_{os.getpid()}.bin")
+    try:
+        os.unlink(rootinfo_path)
+    except FileNotFoundError:
+        pass
+
+    partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
+    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+
+    cfgs = [
+        ChipBootstrapConfig(
+            comm=ChipCommBootstrapConfig(
+                rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=window_size
+            ),
+            buffers=[
+                ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+                ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=counter_nbytes),
+            ],
+        )
+        for rank in range(nranks)
+    ]
+
+    chip_callable = build_chip_callable(platform, pto_isa_commit, "https")
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        chip_bootstrap_configs=cfgs,
+        build=build,
+    )
+    try:
+        worker.init()
+        contexts: list[ChipContext] = worker.chip_contexts
+
+        def orch_fn(orch, _args, cfg):
+            for rank, ctx in enumerate(contexts):
+                args = TaskArgs()
+                args.add_tensor(make_tensor_arg(partial[rank]), TensorArgType.INPUT)
+                args.add_tensor(
+                    ContinuousTensor.make(
+                        data=ctx.buffer_ptrs["mailbox"],
+                        shapes=(N,),
+                        dtype=DataType.FLOAT32,
+                        child_memory=True,
+                    ),
+                    TensorArgType.INOUT,
+                )
+                args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
+                args.add_tensor(
+                    ContinuousTensor.make(
+                        data=ctx.buffer_ptrs["notify_counter"],
+                        shapes=(1,),
+                        dtype=DataType.INT32,
+                        child_memory=True,
+                    ),
+                    TensorArgType.INPUT,
+                )
+                args.add_scalar(ctx.device_ctx)
+                orch.submit_next_level(chip_callable, args, cfg, worker=rank)
+
+        worker.run(orch_fn, args=None, config=ChipCallConfig())
+
+        ok = True
+        for rank in range(nranks):
+            expected = partial[(rank + 1) % nranks]
+            max_diff = float(torch.max(torch.abs(result[rank] - expected)))
+            print(f"[deferred_notify_demo] rank {rank}: max_diff={max_diff:.3e}")
+            ok = ok and max_diff <= 1e-6
+        return 0 if ok else 1
+    finally:
+        worker.close()
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass
+
+
+def test_deferred_notify_demo() -> None:
+    assert run("a5sim", [0, 1]) == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a5sim")
+    parser.add_argument("-d", "--device", default="0-1")
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--pto-isa-commit", default=None)
+    args = parser.parse_args()
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import argparse
 import os
 import tempfile
+from multiprocessing.shared_memory import SharedMemory
 
 import torch
 from simpler.task_interface import (
@@ -27,6 +28,7 @@ from simpler.task_interface import (
     ContinuousTensor,
     CoreCallable,
     DataType,
+    HostBufferStaging,
     TaskArgs,
     TensorArgType,
 )
@@ -118,6 +120,12 @@ def run(
 
     partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
     result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+    counter_init_shms = [SharedMemory(create=True, size=counter_nbytes) for _ in range(nranks)]
+    for shm in counter_init_shms:
+        buf = shm.buf
+        if buf is None:
+            raise RuntimeError("SharedMemory buffer is unavailable")
+        buf[:counter_nbytes] = b"\x00" * counter_nbytes
 
     cfgs = [
         ChipBootstrapConfig(
@@ -126,7 +134,16 @@ def run(
             ),
             buffers=[
                 ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=counter_nbytes),
+                ChipBufferSpec(
+                    name="notify_counter",
+                    dtype="int32",
+                    count=1,
+                    nbytes=counter_nbytes,
+                    load_from_host=True,
+                ),
+            ],
+            host_inputs=[
+                HostBufferStaging(name="notify_counter", shm_name=counter_init_shms[rank].name, size=counter_nbytes)
             ],
         )
         for rank in range(nranks)
@@ -187,6 +204,9 @@ def run(
             os.unlink(rootinfo_path)
         except FileNotFoundError:
             pass
+        for shm in counter_init_shms:
+            shm.close()
+            shm.unlink()
 
 
 def test_deferred_notify_demo() -> None:

--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -134,4 +134,15 @@ uint32_t platform_get_physical_cores_count();
  */
 void cache_invalidate_range(const void *addr, size_t size);
 
+/**
+ * Clean data cache for a memory range back to global memory.
+ *
+ * On real hardware (onboard): performs DC CVAC per cache line + DSB/ISB.
+ * On simulation (sim): no-op.
+ *
+ * @param addr  Start address of the memory range
+ * @param size  Size of the memory range in bytes
+ */
+void cache_flush_range(const void *addr, size_t size);
+
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/onboard/aicpu/cache_ops.cpp
@@ -26,3 +26,17 @@ void cache_invalidate_range(const void *addr, size_t size) {
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");
 }
+
+void cache_flush_range(const void *addr, size_t size) {
+    if (size == 0) {
+        return;
+    }
+    const size_t kCacheLineSize = 64;
+    uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
+    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    for (uintptr_t p = start; p < end; p += kCacheLineSize) {
+        __asm__ __volatile__("dc cvac, %0" ::"r"(p) : "memory");
+    }
+    __asm__ __volatile__("dsb sy" ::: "memory");
+    __asm__ __volatile__("isb" ::: "memory");
+}

--- a/src/a2a3/platform/sim/aicpu/cache_ops.cpp
+++ b/src/a2a3/platform/sim/aicpu/cache_ops.cpp
@@ -15,3 +15,7 @@
 void cache_invalidate_range(const void * /* addr */, size_t /* size */) {
     // No-op on simulation: no hardware cache to invalidate
 }
+
+void cache_flush_range(const void * /* addr */, size_t /* size */) {
+    // No-op on simulation: no hardware cache to flush
+}

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -65,7 +65,7 @@
 /** Number of extra pointer slots appended to the args[] tail (LocalContext + GlobalContext). */
 static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
-struct PTO2DeferredCompletionEntry;
+struct PTO2DeferredCompletionIngressBuffer;
 
 /**
  * Args[] suffix indices for context pointers.
@@ -102,8 +102,7 @@ struct LocalContext {
                         // NOT the same as RUNTIME_CONFIG.block_dim in kernel_config.py,
                         // which controls how many physical cores the runtime launches.
     PTO2TaskId task_token;
-    volatile __gm__ PTO2DeferredCompletionEntry *deferred_completion_entries;
-    volatile __gm__ uint32_t *deferred_completion_count;
+    volatile __gm__ PTO2DeferredCompletionIngressBuffer *deferred_ingress;
     uint32_t deferred_completion_capacity;
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -52,6 +52,8 @@
 
 #include <stdint.h>
 
+#include "pto_task_id.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -63,6 +65,8 @@
 /** Number of extra pointer slots appended to the args[] tail (LocalContext + GlobalContext). */
 static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
+struct PTO2DeferredCompletionEntry;
+
 /**
  * Args[] suffix indices for context pointers.
  * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32).
@@ -70,6 +74,8 @@ static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
  */
 static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 48;
 static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 49;
+static constexpr int32_t PAYLOAD_LOCAL_CONTEXT_INDEX = SPMD_LOCAL_CONTEXT_INDEX;
+static constexpr int32_t PAYLOAD_GLOBAL_CONTEXT_INDEX = SPMD_GLOBAL_CONTEXT_INDEX;
 
 /**
  * Per-core global context, stored in PTO2DispatchPayload.
@@ -95,6 +101,10 @@ struct LocalContext {
                         // Currently fixed to 1 (block_dim > 1 not yet implemented).
                         // NOT the same as RUNTIME_CONFIG.block_dim in kernel_config.py,
                         // which controls how many physical cores the runtime launches.
+    PTO2TaskId task_token;
+    volatile __gm__ PTO2DeferredCompletionEntry *deferred_completion_entries;
+    volatile __gm__ uint32_t *deferred_completion_count;
+    uint32_t deferred_completion_capacity;
 };
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -34,6 +34,9 @@
 
 // Scheduler errors (100+): detected in scheduler threads
 #define PTO2_ERROR_SCHEDULER_TIMEOUT 100
+#define PTO2_ERROR_ASYNC_COMPLETION_INVALID 101
+#define PTO2_ERROR_ASYNC_WAIT_OVERFLOW 102
+#define PTO2_ERROR_ASYNC_REGISTRATION_FAILED 103
 
 static inline int32_t pto2_runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
     if (orch_error_code != PTO2_ERROR_NONE) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -395,7 +395,7 @@ Key members:
 | 2 | Initialize task descriptor + slot state, copy parameters |
 | 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
 | 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
-| 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >16); increment each producer's `fanout_count` (no lock needed — single writer). This step runs **before** `payload.init()`. |
+| 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >64); increment each producer's `fanout_count` (no lock needed — single writer). This step runs **before** `payload.init()`. |
 | 6 | **Push to wiring queue**: push to global `PTO2SpscQueue`; scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
 
 > **Note**: Fanout wiring (Steps 4–7 in earlier versions) has been moved from the

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -239,6 +239,23 @@ static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const
     return rt->ops->submit_task(rt, mk, args);
 }
 
+static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, Arg &args) {
+    args.complete_in_future = true;
+    return pto2_rt_submit_aiv_task(kernel_id, args);
+}
+
+static inline Tensor
+pto2_rt_submit_notification_wait_task(int32_t kernel_id, uint64_t local_counter_addr, uint32_t expected_value) {
+    uint32_t shape[1] = {1};
+    TensorCreateInfo token_info(shape, 1, DataType::INT32);
+    Arg params;
+    params.add_output(token_info);
+    params.add_scalar(local_counter_addr);
+    params.add_scalar(static_cast<uint64_t>(expected_value));
+    TaskOutputTensors outputs = pto2_rt_submit_aiv_task_deferred(kernel_id, params);
+    return outputs.get_ref(0);
+}
+
 static inline void pto2_rt_scope_begin() {
     PTO2Runtime *rt = pto2_current_runtime();
     if (rt->ops->is_fatal(rt)) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -115,7 +115,9 @@ void pto2_framework_bind_runtime(PTO2Runtime *rt);
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(
+        PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+    );
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
@@ -205,55 +207,41 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
     return alloc_tensors(args);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+static inline TaskOutputTensors
+pto2_rt_submit_task_impl(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
     PTO2Runtime *rt = pto2_current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
-    return rt->ops->submit_task(rt, mixed_kernels, args);
+    return rt->ops->submit_task(rt, mixed_kernels, args, complete_in_future);
+}
+
+static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    return pto2_rt_submit_task_impl(mixed_kernels, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
 static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
-    PTO2Runtime *rt = pto2_current_runtime();
-    if (rt->ops->is_fatal(rt)) {
-        return TaskOutputTensors{};
-    }
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
-    return rt->ops->submit_task(rt, mk, args);
+    return pto2_rt_submit_task_impl(mk, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
 static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
-    PTO2Runtime *rt = pto2_current_runtime();
-    if (rt->ops->is_fatal(rt)) {
-        return TaskOutputTensors{};
-    }
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    return rt->ops->submit_task(rt, mk, args);
+    return pto2_rt_submit_task_impl(mk, args, false);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, Arg &args) {
-    args.complete_in_future = true;
-    return pto2_rt_submit_aiv_task(kernel_id, args);
-}
-
-static inline Tensor
-pto2_rt_submit_notification_wait_task(int32_t kernel_id, uint64_t local_counter_addr, uint32_t expected_value) {
-    uint32_t shape[1] = {1};
-    TensorCreateInfo token_info(shape, 1, DataType::INT32);
-    Arg params;
-    params.add_output(token_info);
-    params.add_scalar(local_counter_addr);
-    params.add_scalar(static_cast<uint64_t>(expected_value));
-    TaskOutputTensors outputs = pto2_rt_submit_aiv_task_deferred(kernel_id, params);
-    return outputs.get_ref(0);
+static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, const Arg &args) {
+    MixedKernels mk;
+    mk.aiv0_kernel_id = kernel_id;
+    return pto2_rt_submit_task_impl(mk, args, true);
 }
 
 static inline void pto2_rt_scope_begin() {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -81,9 +81,13 @@ struct alignas(64) PTO2DispatchPayload {
      *  args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
     GlobalContext global_context;
 
+    uint8_t reserved_payload_abi_pad[8];
+
     static_assert(sizeof(args[0]) == 8);
     static_assert(
         PTO2_ALIGN_UP((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]), 64) ==
         (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0])
     );
 };
+
+static_assert(sizeof(PTO2DispatchPayload) == 512, "PTO2DispatchPayload hardware ABI size drift");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -16,6 +16,7 @@
 
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
+#include "pto_runtime_status.h"
 
 #ifndef __aicore__
 #define __aicore__
@@ -25,8 +26,7 @@
 #endif
 
 struct PTO2AsyncCtx {
-    volatile __gm__ PTO2DeferredCompletionEntry *entries;
-    volatile __gm__ uint32_t *entry_count;
+    volatile __gm__ PTO2DeferredCompletionIngressBuffer *ingress;
     uint32_t entry_capacity;
     PTO2TaskId task_token;
 };
@@ -35,8 +35,7 @@ inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
     __gm__ LocalContext *lc =
         reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
     PTO2AsyncCtx ctx;
-    ctx.entries = lc->deferred_completion_entries;
-    ctx.entry_count = lc->deferred_completion_count;
+    ctx.ingress = lc->deferred_ingress;
     ctx.entry_capacity = lc->deferred_completion_capacity;
     ctx.task_token.raw = lc->task_token.raw;
     return ctx;
@@ -45,27 +44,30 @@ inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
 inline __aicore__ bool pto2_async_ctx_is_deferred(const PTO2AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
 
 inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
-    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) {
+    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) {
         return;
     }
 
-    uint32_t idx = *ctx.entry_count;
-    if (idx >= ctx.entry_capacity) return;
+    uint32_t idx = ctx.ingress->count;
+    if (idx >= ctx.entry_capacity) {
+        ctx.ingress->error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+        return;
+    }
 
-    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.entries[idx];
+    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.ingress->entries[idx];
     slot->addr = reinterpret_cast<uint64_t>(counter_addr);
     slot->expected_value = expected;
     slot->engine = PTO2_COMPLETION_ENGINE_SDMA;
     slot->completion_type = PTO2_COMPLETION_TYPE_COUNTER;
     slot->_pad = 0;
-    *ctx.entry_count = idx + 1;
+    ctx.ingress->count = idx + 1;
 }
 
 inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
-    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) return;
+    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
-    dcci((__gm__ int32_t *)ctx.entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
-    dcci((__gm__ int32_t *)ctx.entry_count, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    dcci((__gm__ int32_t *)ctx.ingress->entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci((__gm__ int32_t *)ctx.ingress, SINGLE_CACHE_LINE, CACHELINE_OUT);
 #if defined(__CPU_SIM)
     dsb(0);
 #else
@@ -74,7 +76,7 @@ inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
     pipe_barrier(PIPE_ALL);
 #else
     (void)ctx;
-    __atomic_thread_fence(__ATOMIC_RELEASE);
+    __asm__ __volatile__("" ::: "memory");
 #endif
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PTO_ASYNC_KERNEL_API_H
+#define PTO_ASYNC_KERNEL_API_H
+
+#include <stdint.h>
+
+#include "intrinsic.h"
+#include "pto_completion_ingress.h"
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+#ifndef __gm__
+#define __gm__
+#endif
+
+struct PTO2AsyncCtx {
+    volatile __gm__ PTO2DeferredCompletionEntry *entries;
+    volatile __gm__ uint32_t *entry_count;
+    uint32_t entry_capacity;
+    PTO2TaskId task_token;
+};
+
+inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
+    __gm__ LocalContext *lc =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
+    PTO2AsyncCtx ctx;
+    ctx.entries = lc->deferred_completion_entries;
+    ctx.entry_count = lc->deferred_completion_count;
+    ctx.entry_capacity = lc->deferred_completion_capacity;
+    ctx.task_token.raw = lc->task_token.raw;
+    return ctx;
+}
+
+inline __aicore__ bool pto2_async_ctx_is_deferred(const PTO2AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
+
+inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
+    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) {
+        return;
+    }
+
+    uint32_t idx = *ctx.entry_count;
+    if (idx >= ctx.entry_capacity) return;
+
+    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.entries[idx];
+    slot->addr = reinterpret_cast<uint64_t>(counter_addr);
+    slot->expected_value = expected;
+    slot->engine = PTO2_COMPLETION_ENGINE_SDMA;
+    slot->completion_type = PTO2_COMPLETION_TYPE_COUNTER;
+    slot->_pad = 0;
+    *ctx.entry_count = idx + 1;
+}
+
+inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
+    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) return;
+#if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
+    dcci((__gm__ int32_t *)ctx.entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci((__gm__ int32_t *)ctx.entry_count, SINGLE_CACHE_LINE, CACHELINE_OUT);
+#if defined(__CPU_SIM)
+    dsb(0);
+#else
+    dsb(DSB_DDR);
+#endif
+    pipe_barrier(PIPE_ALL);
+#else
+    (void)ctx;
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+#endif
+}
+
+#endif  // PTO_ASYNC_KERNEL_API_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PTO_ASYNC_WAIT_H
+#define PTO_ASYNC_WAIT_H
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+#include "common/memory_barrier.h"
+#include "pto_completion_ingress.h"
+#include "pto_runtime2_types.h"
+
+struct PTO2SchedulerState;
+struct PTO2LocalReadyBuffer;
+struct PTO2CompletionStats;
+
+inline constexpr int32_t PTO2_MAX_ASYNC_WAITS = 64;
+inline constexpr int32_t PTO2_MAX_PENDING_COMPLETIONS = 128;
+
+inline uintptr_t pto2_completion_ingress_cache_line(const volatile void *addr) {
+    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
+}
+
+inline void pto2_completion_ingress_invalidate_entries(
+    volatile PTO2CompletionIngressQueue *completion_ingress, uint64_t tail, uint64_t head
+) {
+    uint64_t active_count = head - tail;
+    if (active_count == 0) return;
+
+    uint64_t tail_index = tail & PTO2_COMPLETION_INGRESS_MASK;
+    uint64_t first_span = active_count;
+    uint64_t contiguous_capacity = PTO2_COMPLETION_INGRESS_CAPACITY - tail_index;
+    if (first_span > contiguous_capacity) {
+        first_span = contiguous_capacity;
+    }
+
+    cache_invalidate_range(
+        const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->entries[tail_index])),
+        first_span * sizeof(PTO2CompletionIngressEntry)
+    );
+
+    uint64_t remaining = active_count - first_span;
+    if (remaining == 0) return;
+
+    cache_invalidate_range(
+        const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->entries[0])),
+        remaining * sizeof(PTO2CompletionIngressEntry)
+    );
+}
+
+inline bool pto2_completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
+    if (completion_ingress == nullptr) return false;
+    cache_invalidate_range(
+        const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
+        sizeof(completion_ingress->head)
+    );
+    uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+    uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
+    return tail < head;
+}
+
+enum class PTO2CompletionPollState : uint8_t {
+    PENDING = 0,
+    READY = 1,
+    FAILED = 2,
+};
+
+struct PTO2CompletionPollResult {
+    PTO2CompletionPollState state{PTO2CompletionPollState::PENDING};
+    int32_t error_code{PTO2_ERROR_NONE};
+};
+
+struct PTO2CompletionCondition {
+    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+    bool satisfied{false};
+    volatile uint32_t *counter_addr{nullptr};
+    uint32_t expected_value{0};
+
+    PTO2CompletionPollResult test() const {
+        if (satisfied) {
+            return {PTO2CompletionPollState::READY, PTO2_ERROR_NONE};
+        }
+        if (counter_addr == nullptr) {
+            return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+        }
+        return {
+            *counter_addr >= expected_value ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING,
+            PTO2_ERROR_NONE
+        };
+    }
+};
+
+struct PTO2AsyncWaitEntry {
+    PTO2TaskSlotState *slot_state{nullptr};
+    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    PTO2CompletionCondition conditions[PTO2_MAX_COMPLETIONS_PER_TASK];
+    int32_t condition_count{0};
+    int32_t waiting_completion_count{0};
+};
+
+struct PTO2PendingCompletion {
+    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    uint64_t addr{0};
+    uint32_t expected_value{0};
+    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+};
+
+struct PTO2AsyncPollResult {
+    int32_t completed{0};
+    int32_t error_code{PTO2_ERROR_NONE};
+    PTO2TaskSlotState *failed_slot_state{nullptr};
+};
+
+inline const char *pto2_async_engine_name(PTO2AsyncEngine engine) {
+    switch (engine) {
+    case PTO2_ASYNC_ENGINE_SDMA:
+        return "SDMA";
+    case PTO2_ASYNC_ENGINE_ROCE:
+        return "ROCE";
+    case PTO2_ASYNC_ENGINE_URMA:
+        return "URMA";
+    case PTO2_ASYNC_ENGINE_CCU:
+        return "CCU";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+struct PTO2AsyncWaitList {
+    std::atomic<int32_t> busy{0};
+    PTO2AsyncWaitEntry entries[PTO2_MAX_ASYNC_WAITS];
+    int32_t count{0};
+    PTO2PendingCompletion pending_completions[PTO2_MAX_PENDING_COMPLETIONS];
+    int32_t pending_completion_count{0};
+
+    bool try_lock() {
+        int32_t expected = 0;
+        return busy.compare_exchange_strong(expected, 1, std::memory_order_acquire, std::memory_order_relaxed);
+    }
+
+    void unlock() { busy.store(0, std::memory_order_release); }
+
+    PTO2AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+        for (int32_t i = 0; i < count; i++) {
+            if (entries[i].task_token == token) return &entries[i];
+        }
+        return nullptr;
+    }
+
+    int32_t
+    drain_completion_ingress_locked(volatile PTO2CompletionIngressQueue *completion_ingress, int32_t &error_code) {
+        error_code = PTO2_ERROR_NONE;
+        if (completion_ingress == nullptr) return 0;
+
+        int32_t drained = 0;
+        while (true) {
+            uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
+            cache_invalidate_range(
+                const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
+                sizeof(completion_ingress->head)
+            );
+            uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+            if (tail >= head) break;
+            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head);
+
+            volatile PTO2CompletionIngressEntry *slot =
+                &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
+            uint64_t expected_seq = tail + 1;
+            uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+            if (seq != expected_seq) break;
+
+            PTO2TaskId token{slot->task_token.raw};
+            uint64_t addr = slot->addr;
+            uint32_t expected_value = slot->expected_value;
+            PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
+
+            slot->seq = 0;
+            completion_ingress->tail = tail + 1;
+            OUT_OF_ORDER_STORE_BARRIER();
+            cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(slot)), sizeof(*slot));
+            cache_flush_range(
+                const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->tail)),
+                sizeof(completion_ingress->tail)
+            );
+            drained++;
+
+            PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
+            if (entry != nullptr) {
+                if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+                    error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                    return drained;
+                }
+                PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
+                cond.engine = engine;
+                cond.satisfied = false;
+                cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+                cond.expected_value = expected_value;
+                entry->waiting_completion_count++;
+                continue;
+            }
+
+            if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
+                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                return drained;
+            }
+            PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
+            pending.task_token = token;
+            pending.addr = addr;
+            pending.expected_value = expected_value;
+            pending.engine = engine;
+        }
+        return drained;
+    }
+
+    void absorb_pending_completions_locked(PTO2AsyncWaitEntry &entry) {
+        int32_t write = 0;
+        for (int32_t i = 0; i < pending_completion_count; i++) {
+            if (pending_completions[i].task_token == entry.task_token) {
+                if (entry.condition_count < PTO2_MAX_COMPLETIONS_PER_TASK) {
+                    PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+                    cond.engine = pending_completions[i].engine;
+                    cond.satisfied = false;
+                    cond.counter_addr =
+                        reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(pending_completions[i].addr));
+                    cond.expected_value = pending_completions[i].expected_value;
+                    entry.waiting_completion_count++;
+                }
+            } else {
+                if (write != i) pending_completions[write] = pending_completions[i];
+                write++;
+            }
+        }
+        pending_completion_count = write;
+    }
+
+    enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
+
+    RegisterResult register_deferred(PTO2TaskSlotState &slot_state, int32_t &error_code) {
+        error_code = PTO2_ERROR_NONE;
+        PTO2TaskPayload *payload = slot_state.payload;
+        if (payload == nullptr || !payload->complete_in_future) {
+            return RegisterResult::NotDeferred;
+        }
+
+        if (!try_lock()) return RegisterResult::Skipped;
+
+        if (count >= PTO2_MAX_ASYNC_WAITS) {
+            error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+            unlock();
+            return RegisterResult::Error;
+        }
+
+        PTO2AsyncWaitEntry &entry = entries[count++];
+        entry.slot_state = &slot_state;
+        entry.task_token = slot_state.task->task_id;
+        entry.condition_count = 0;
+        entry.waiting_completion_count = 0;
+
+        cache_invalidate_range(&payload->deferred_completion_count, sizeof(payload->deferred_completion_count));
+        uint32_t deferred_count = payload->deferred_completion_count;
+        if (deferred_count > PTO2_MAX_COMPLETIONS_PER_TASK) {
+            error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+            unlock();
+            return RegisterResult::Error;
+        }
+        if (deferred_count > 0) {
+            cache_invalidate_range(
+                payload->deferred_completion_entries, deferred_count * sizeof(PTO2DeferredCompletionEntry)
+            );
+        }
+        for (uint32_t i = 0; i < deferred_count; ++i) {
+            const PTO2DeferredCompletionEntry &deferred = payload->deferred_completion_entries[i];
+            PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+            cond.engine = static_cast<PTO2AsyncEngine>(deferred.engine);
+            cond.satisfied = false;
+            cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred.addr));
+            cond.expected_value = deferred.expected_value;
+            entry.waiting_completion_count++;
+        }
+
+        absorb_pending_completions_locked(entry);
+        unlock();
+        return RegisterResult::Registered;
+    }
+
+    template <bool Profiling>
+    PTO2AsyncPollResult poll_and_complete(
+        volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+        PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
+        int32_t &deferred_release_count, int32_t deferred_release_capacity
+#if PTO2_SCHED_PROFILING
+        ,
+        int thread_idx
+#endif
+    );
+};
+
+#endif  // PTO_ASYNC_WAIT_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -107,6 +107,7 @@ struct PTO2AsyncWaitEntry {
     PTO2CompletionCondition conditions[PTO2_MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
+    bool normal_done{false};
 };
 
 struct PTO2PendingCompletion {
@@ -249,7 +250,26 @@ struct PTO2AsyncWaitList {
 
     enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
-    RegisterResult register_deferred(PTO2TaskSlotState &slot_state, int32_t &error_code) {
+    bool append_condition_locked(
+        PTO2AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, PTO2AsyncEngine engine, int32_t &error_code
+    ) {
+        if (entry.condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+            error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+            return false;
+        }
+        PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+        cond.engine = engine;
+        cond.satisfied = false;
+        cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+        cond.expected_value = expected_value;
+        entry.waiting_completion_count++;
+        return true;
+    }
+
+    RegisterResult register_deferred(
+        PTO2TaskSlotState &slot_state, volatile PTO2DeferredCompletionIngressBuffer *ingress, bool normal_done,
+        int32_t &error_code
+    ) {
         error_code = PTO2_ERROR_NONE;
         PTO2TaskPayload *payload = slot_state.payload;
         if (payload == nullptr || !payload->complete_in_future) {
@@ -258,41 +278,67 @@ struct PTO2AsyncWaitList {
 
         if (!try_lock()) return RegisterResult::Skipped;
 
-        if (count >= PTO2_MAX_ASYNC_WAITS) {
-            error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-            unlock();
-            return RegisterResult::Error;
+        uint32_t deferred_count = 0;
+        if (ingress != nullptr) {
+            cache_invalidate_range(
+                const_cast<const void *>(reinterpret_cast<volatile void *>(ingress)), PTO2_ALIGN_SIZE
+            );
+            if (ingress->error_code != PTO2_ERROR_NONE) {
+                error_code = ingress->error_code;
+                unlock();
+                return RegisterResult::Error;
+            }
+            deferred_count = ingress->count;
         }
-
-        PTO2AsyncWaitEntry &entry = entries[count++];
-        entry.slot_state = &slot_state;
-        entry.task_token = slot_state.task->task_id;
-        entry.condition_count = 0;
-        entry.waiting_completion_count = 0;
-
-        cache_invalidate_range(&payload->deferred_completion_count, sizeof(payload->deferred_completion_count));
-        uint32_t deferred_count = payload->deferred_completion_count;
         if (deferred_count > PTO2_MAX_COMPLETIONS_PER_TASK) {
             error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
             unlock();
             return RegisterResult::Error;
         }
-        if (deferred_count > 0) {
+        if (deferred_count > 0 && ingress != nullptr) {
             cache_invalidate_range(
-                payload->deferred_completion_entries, deferred_count * sizeof(PTO2DeferredCompletionEntry)
+                const_cast<const void *>(reinterpret_cast<volatile void *>(ingress->entries)),
+                deferred_count * sizeof(PTO2DeferredCompletionEntry)
             );
         }
-        for (uint32_t i = 0; i < deferred_count; ++i) {
-            const PTO2DeferredCompletionEntry &deferred = payload->deferred_completion_entries[i];
-            PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
-            cond.engine = static_cast<PTO2AsyncEngine>(deferred.engine);
-            cond.satisfied = false;
-            cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred.addr));
-            cond.expected_value = deferred.expected_value;
-            entry.waiting_completion_count++;
+        PTO2AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
+        if (entry == nullptr) {
+            if (!normal_done && deferred_count == 0) {
+                unlock();
+                return RegisterResult::Registered;
+            }
+            if (count >= PTO2_MAX_ASYNC_WAITS) {
+                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                unlock();
+                return RegisterResult::Error;
+            }
+            entry = &entries[count++];
+            entry->slot_state = &slot_state;
+            entry->task_token = slot_state.task->task_id;
+            entry->condition_count = 0;
+            entry->waiting_completion_count = 0;
+            entry->normal_done = false;
+        }
+        if (normal_done) {
+            entry->normal_done = true;
         }
 
-        absorb_pending_completions_locked(entry);
+        for (uint32_t i = 0; i < deferred_count; ++i) {
+            volatile PTO2DeferredCompletionEntry *deferred = &ingress->entries[i];
+            volatile uint32_t *counter = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
+            cache_invalidate_range(
+                reinterpret_cast<const void *>(pto2_completion_ingress_cache_line(counter)), sizeof(uint32_t)
+            );
+            if (!append_condition_locked(
+                    *entry, deferred->addr, deferred->expected_value, static_cast<PTO2AsyncEngine>(deferred->engine),
+                    error_code
+                )) {
+                unlock();
+                return RegisterResult::Error;
+            }
+        }
+
+        absorb_pending_completions_locked(*entry);
         unlock();
         return RegisterResult::Registered;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -170,55 +170,58 @@ struct PTO2AsyncWaitList {
                 const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
                 sizeof(completion_ingress->head)
             );
-            uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
-            if (tail >= head) break;
-            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head);
+            uint64_t head_snapshot = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+            if (tail >= head_snapshot) break;
+            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head_snapshot);
 
-            volatile PTO2CompletionIngressEntry *slot =
-                &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
-            uint64_t expected_seq = tail + 1;
-            uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-            if (seq != expected_seq) break;
+            while (tail < head_snapshot) {
+                volatile PTO2CompletionIngressEntry *slot =
+                    &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
+                uint64_t expected_seq = tail + 1;
+                uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+                if (seq != expected_seq) return drained;
 
-            PTO2TaskId token{slot->task_token.raw};
-            uint64_t addr = slot->addr;
-            uint32_t expected_value = slot->expected_value;
-            PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
+                PTO2TaskId token{slot->task_token.raw};
+                uint64_t addr = slot->addr;
+                uint32_t expected_value = slot->expected_value;
+                PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
 
-            slot->seq = 0;
-            completion_ingress->tail = tail + 1;
-            OUT_OF_ORDER_STORE_BARRIER();
-            cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(slot)), sizeof(*slot));
-            cache_flush_range(
-                const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->tail)),
-                sizeof(completion_ingress->tail)
-            );
-            drained++;
+                slot->seq = 0;
+                completion_ingress->tail = tail + 1;
+                OUT_OF_ORDER_STORE_BARRIER();
+                cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(slot)), sizeof(*slot));
+                cache_flush_range(
+                    const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->tail)),
+                    sizeof(completion_ingress->tail)
+                );
+                drained++;
+                tail++;
 
-            PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
-            if (entry != nullptr) {
-                if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
-                    error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
+                if (entry != nullptr) {
+                    if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+                        error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                        return drained;
+                    }
+                    PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
+                    cond.engine = engine;
+                    cond.satisfied = false;
+                    cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+                    cond.expected_value = expected_value;
+                    entry->waiting_completion_count++;
+                    continue;
+                }
+
+                if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
+                    error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                     return drained;
                 }
-                PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
-                cond.engine = engine;
-                cond.satisfied = false;
-                cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
-                cond.expected_value = expected_value;
-                entry->waiting_completion_count++;
-                continue;
+                PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
+                pending.task_token = token;
+                pending.addr = addr;
+                pending.expected_value = expected_value;
+                pending.engine = engine;
             }
-
-            if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
-                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-                return drained;
-            }
-            PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
-            pending.task_token = token;
-            pending.addr = addr;
-            pending.expected_value = expected_value;
-            pending.engine = engine;
         }
         return drained;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+
+#include <stdint.h>
+
+#include "pto_constants.h"
+#include "pto_task_id.h"
+
+#define PTO2_COMPLETION_INGRESS_CAPACITY 4096u
+#define PTO2_COMPLETION_INGRESS_MASK (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)
+
+static_assert(
+    (PTO2_COMPLETION_INGRESS_CAPACITY & (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
+    "PTO2_COMPLETION_INGRESS_CAPACITY must be a power of two"
+);
+
+inline constexpr int32_t PTO2_MAX_COMPLETIONS_PER_TASK = 64;
+
+#define PTO2_COMPLETION_ENGINE_SDMA 0u
+#define PTO2_COMPLETION_ENGINE_ROCE 1u
+#define PTO2_COMPLETION_ENGINE_URMA 2u
+#define PTO2_COMPLETION_ENGINE_CCU 3u
+
+#define PTO2_COMPLETION_TYPE_COUNTER 0
+
+struct PTO2CompletionIngressEntry {
+    volatile uint64_t seq;
+    PTO2TaskId task_token;
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint32_t _pad[6];
+};
+
+static_assert(sizeof(PTO2CompletionIngressEntry) == PTO2_ALIGN_SIZE, "PTO2CompletionIngressEntry layout drift");
+
+struct PTO2DeferredCompletionEntry {
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint32_t _pad;
+};
+
+static_assert(sizeof(PTO2DeferredCompletionEntry) == 24, "PTO2DeferredCompletionEntry layout drift");
+
+struct PTO2CompletionIngressQueue {
+    alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
+    uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
+    alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
+    uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
+    alignas(PTO2_ALIGN_SIZE) PTO2CompletionIngressEntry entries[PTO2_COMPLETION_INGRESS_CAPACITY];
+};
+
+static_assert(
+    sizeof(PTO2CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
+    "PTO2CompletionIngressQueue size must be cache-line aligned"
+);
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
@@ -56,6 +56,18 @@ struct PTO2DeferredCompletionEntry {
 
 static_assert(sizeof(PTO2DeferredCompletionEntry) == 24, "PTO2DeferredCompletionEntry layout drift");
 
+struct PTO2DeferredCompletionIngressBuffer {
+    alignas(PTO2_ALIGN_SIZE) volatile uint32_t count;
+    volatile int32_t error_code;
+    uint8_t _header_pad[PTO2_ALIGN_SIZE - sizeof(uint32_t) - sizeof(int32_t)];
+    alignas(PTO2_ALIGN_SIZE) PTO2DeferredCompletionEntry entries[PTO2_MAX_COMPLETIONS_PER_TASK];
+};
+
+static_assert(
+    sizeof(PTO2DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
+    "PTO2DeferredCompletionIngressBuffer size must be cache-line aligned"
+);
+
 struct PTO2CompletionIngressQueue {
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_constants.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_constants.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_CONSTANTS_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_CONSTANTS_H_
+
+#define PTO2_ALIGN_SIZE 64             // Cache line alignment
+#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_CONSTANTS_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -489,8 +489,9 @@ void pto2_scope_end(PTO2OrchestratorState *orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors
-pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args) {
+TaskOutputTensors pto2_submit_mixed_task(
+    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+) {
     CYCLE_COUNT_START();
 
     TaskOutputTensors result;
@@ -678,7 +679,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         payload.fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
     }
 
-    payload.init(args, result, prepared.alloc_result, layout);
+    payload.init(args, result, prepared.alloc_result, layout, complete_in_future);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
@@ -771,7 +772,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 
     TaskOutputTensors outputs;
     outputs.set_task_id(prepared.task_id);
-    payload.init(args, outputs, prepared.alloc_result, layout);
+    payload.init(args, outputs, prepared.alloc_result, layout, false);
     payload.fanin_actual_count = 0;
     payload.fanin_spill_start = 0;
     payload.fanin_spill_pool = &orch->rings[prepared.task_id.ring()].fanin_pool;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -186,8 +186,9 @@ void pto2_scope_end(PTO2OrchestratorState *orch);
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
  * @param args      Aggregated tensor and scalar parameters
  */
-TaskOutputTensors
-pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args);
+TaskOutputTensors pto2_submit_mixed_task(
+    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+);
 
 /**
  * Allocate fresh tensors by creating one hidden runtime-owned output task.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -306,6 +306,16 @@ PTO2Runtime *pto2_runtime_create_custom(
     // Connect orchestrator to scheduler (for simulated mode)
     pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
+    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    if (!rt->completion_ingress) {
+        pto2_scheduler_destroy(&rt->scheduler);
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt->gm_heap);
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+
     return rt;
 }
 
@@ -339,6 +349,14 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 
     pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
+    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    if (!rt->completion_ingress) {
+        pto2_scheduler_destroy(&rt->scheduler);
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt);
+        return NULL;
+    }
+
     return rt;
 }
 
@@ -347,6 +365,8 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
 
     pto2_scheduler_destroy(&rt->scheduler);
     pto2_orchestrator_destroy(&rt->orchestrator);
+
+    free(rt->completion_ingress);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -38,8 +38,9 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args);
+static TaskOutputTensors
+submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
+    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args, complete_in_future);
 }
 
 static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -67,7 +67,9 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(
+        PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+    );
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -42,6 +42,7 @@
 #include "pto_tensormap.h"
 #include "scheduler/pto_scheduler.h"
 #include "pto_orchestrator.h"
+#include "pto_completion_ingress.h"
 
 // =============================================================================
 // Runtime Context
@@ -103,6 +104,7 @@ struct PTO2Runtime {
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
+    PTO2CompletionIngressQueue *completion_ingress;
 
     // GM Heap for output buffers
     void *gm_heap;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -232,25 +232,23 @@ struct PTO2TaskDescriptor {
 /**
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
- * Layout: metadata + inline fanin packed in the first 3 cache lines, followed
+ * Layout: metadata + inline fanin packed in the first 9 cache lines, followed
  * by bulk tensor and scalar data. Small fanins stay fully inline; larger
  * fanins spill into a per-ring ring buffer slice.
  */
 struct PTO2TaskPayload {
-    // === Cache lines 0-2 (192B) — metadata ===
+    // === Cache lines 0-8 (576B) — metadata + inline fanin ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t fanin_spill_start{0};   // Linear start index in fanin spill pool (0 = no spill)
+    bool complete_in_future{false};
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
-    // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 9-40 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 35-38 (256B) — scalars ===
+    // === Cache lines 41-44 (256B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
-    bool complete_in_future{false};
-    uint32_t deferred_completion_count{0};
-    PTO2DeferredCompletionEntry deferred_completion_entries[PTO2_MAX_COMPLETIONS_PER_TASK];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
@@ -292,18 +290,23 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
         complete_in_future = complete_in_future_flag;
-        deferred_completion_count = 0;
     }
 };
 
 // PTO2TaskPayload layout verification (offsetof requires complete type).
+static_assert(offsetof(PTO2TaskPayload, complete_in_future) == 16, "deferred flag must stay in the first cache line");
+static_assert(offsetof(PTO2TaskPayload, fanin_spill_pool) == 24, "spill pool pointer layout drift");
 static_assert(
-    offsetof(PTO2TaskPayload, fanin_inline_slot_states) == 24, "inline fanin array must follow spill metadata"
+    offsetof(PTO2TaskPayload, fanin_inline_slot_states) == 32, "inline fanin array must follow spill metadata"
 );
-static_assert(offsetof(PTO2TaskPayload, tensors) == 576, "tensors must start at byte 192 (cache line 3)");
+static_assert(offsetof(PTO2TaskPayload, tensors) == 576, "tensors must start at byte 576 (cache line 9)");
 static_assert(
     offsetof(PTO2TaskPayload, scalars) == 576 + MAX_TENSOR_ARGS * sizeof(Tensor),
     "scalars must immediately follow tensors"
+);
+static_assert(
+    sizeof(PTO2TaskPayload) == 576 + MAX_TENSOR_ARGS * sizeof(Tensor) + MAX_SCALAR_ARGS * sizeof(uint64_t),
+    "PTO2TaskPayload size must stay on the baseline cache-line footprint"
 );
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -266,7 +266,10 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param result  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout) {
+    void init(
+        const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout,
+        bool complete_in_future_flag
+    ) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
@@ -288,7 +291,7 @@ struct PTO2TaskPayload {
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
-        complete_in_future = args.complete_in_future;
+        complete_in_future = complete_in_future_flag;
         deferred_completion_count = 0;
     }
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -31,7 +31,10 @@
 
 #include <atomic>
 
+#include "pto_constants.h"
 #include "pto_runtime_status.h"
+#include "pto2_dispatch_payload.h"
+#include "pto_completion_ingress.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
@@ -121,11 +124,6 @@
 
 // Wiring queue
 #define PTO2_WRIRING_QUEUE_SIZE 1024  // Per-shape queue size
-
-// Memory alignment
-#define PTO2_ALIGN_SIZE 64             // Cache line alignment
-#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
-#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 64
@@ -250,6 +248,9 @@ struct PTO2TaskPayload {
     Tensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 35-38 (256B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
+    bool complete_in_future{false};
+    uint32_t deferred_completion_count{0};
+    PTO2DeferredCompletionEntry deferred_completion_entries[PTO2_MAX_COMPLETIONS_PER_TASK];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
@@ -287,6 +288,8 @@ struct PTO2TaskPayload {
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
+        complete_in_future = args.complete_in_future;
+        deferred_completion_count = 0;
     }
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -150,13 +150,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     bool has_error{false};
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
-    bool complete_in_future{false};
 
     void reset() {
         clear();
         has_error = false;
         error_msg = nullptr;
-        complete_in_future = false;
     }
 
     void set_error(const char *msg) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -46,6 +46,18 @@
 #define PTO2_MAX_INPUTS 16   // Maximum inputs per task
 #define PTO2_MAX_INOUTS 8    // Maximum in-out args per task
 
+typedef enum {
+    PTO2_ASYNC_ENGINE_SDMA = 0,
+    PTO2_ASYNC_ENGINE_ROCE = 1,
+    PTO2_ASYNC_ENGINE_URMA = 2,
+    PTO2_ASYNC_ENGINE_CCU = 3,
+    PTO2_NUM_ASYNC_ENGINES = 4,
+} PTO2AsyncEngine;
+
+enum class PTO2CompletionType : int32_t {
+    COUNTER = 0,
+};
+
 // =============================================================================
 // Task Output Tensors (return value from submit)
 // =============================================================================
@@ -138,11 +150,13 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     bool has_error{false};
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
+    bool complete_in_future{false};
 
     void reset() {
         clear();
         has_error = false;
         error_msg = nullptr;
+        complete_in_future = false;
     }
 
     void set_error(const char *msg) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1041,7 +1041,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
             }
         }
 
-        if (entry.waiting_completion_count <= 0) {
+        if (entry.normal_done && entry.waiting_completion_count <= 0) {
             if (deferred_release_count >= deferred_release_capacity) {
                 result.error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                 result.failed_slot_state = entry.slot_state;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -32,6 +32,7 @@
 #include <atomic>
 
 #include "common/core_type.h"
+#include "pto_async_wait.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
@@ -590,6 +591,8 @@ struct PTO2SchedulerState {
     );
     static_assert(sizeof(WiringState) == 576, "WiringState must be exactly 9 cache lines (576B)");
 
+    alignas(64) PTO2AsyncWaitList async_wait_list;
+
     // Statistics (cold path, isolated from hot-path fields)
 #if PTO2_SCHED_PROFILING
     alignas(64) std::atomic<int64_t> tasks_completed;
@@ -990,6 +993,78 @@ bool pto2_scheduler_init(
     PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 void pto2_scheduler_destroy(PTO2SchedulerState *sched);
+
+template <bool Profiling>
+inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
+    volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+    PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
+    int32_t deferred_release_capacity
+#if PTO2_SCHED_PROFILING
+    ,
+    int thread_idx
+#endif
+) {
+    PTO2AsyncPollResult result;
+    if (!try_lock()) return result;
+
+    int32_t drain_err = PTO2_ERROR_NONE;
+    drain_completion_ingress_locked(completion_ingress, drain_err);
+    if (drain_err != PTO2_ERROR_NONE) {
+        result.error_code = drain_err;
+        unlock();
+        return result;
+    }
+
+    for (int32_t i = count - 1; i >= 0; --i) {
+        PTO2AsyncWaitEntry &entry = entries[i];
+        uintptr_t last_invalidated_counter_line = static_cast<uintptr_t>(-1);
+        for (int32_t c = 0; c < entry.condition_count; c++) {
+            PTO2CompletionCondition &cond = entry.conditions[c];
+            if (cond.satisfied) continue;
+            if (cond.counter_addr) {
+                uintptr_t counter_line = pto2_completion_ingress_cache_line(cond.counter_addr);
+                if (counter_line != last_invalidated_counter_line) {
+                    cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
+                    last_invalidated_counter_line = counter_line;
+                }
+            }
+            PTO2CompletionPollResult poll = cond.test();
+            if (poll.state == PTO2CompletionPollState::FAILED) {
+                result.error_code = poll.error_code;
+                result.failed_slot_state = entry.slot_state;
+                unlock();
+                return result;
+            }
+            if (poll.state == PTO2CompletionPollState::READY) {
+                cond.satisfied = true;
+                entry.waiting_completion_count--;
+            }
+        }
+
+        if (entry.waiting_completion_count <= 0) {
+            if (deferred_release_count >= deferred_release_capacity) {
+                result.error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                result.failed_slot_state = entry.slot_state;
+                unlock();
+                return result;
+            }
+#if PTO2_SCHED_PROFILING
+            sched->on_mixed_task_complete(*entry.slot_state, thread_idx, local_bufs);
+#else
+            sched->on_mixed_task_complete(*entry.slot_state, local_bufs);
+#endif
+            deferred_release_slot_states[deferred_release_count++] = entry.slot_state;
+            result.completed++;
+
+            int32_t last = count - 1;
+            if (i != last) entries[i] = entries[last];
+            count = last;
+        }
+    }
+
+    unlock();
+    return result;
+}
 
 // =============================================================================
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -657,6 +657,7 @@ int32_t SchedulerContext::init(
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
+    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
 
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
@@ -688,6 +689,7 @@ void SchedulerContext::deinit() {
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
+    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
 
     // Reset sync-start drain coordination — a previous run that aborted mid-drain
     // would otherwise leave dirty pending/elected/ack state for the next reuse.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -723,6 +723,7 @@ void SchedulerContext::deinit() {
 
     regs_ = 0;
     sched_ = nullptr;
+    rt_ = nullptr;
     func_id_to_addr_ = nullptr;
 }
 
@@ -732,7 +733,10 @@ void SchedulerContext::wait_pto2_init_complete() const {
     }
 }
 
-void SchedulerContext::bind_runtime(PTO2Runtime *rt) { sched_ = &rt->scheduler; }
+void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
+    rt_ = rt;
+    sched_ = &rt->scheduler;
+}
 
 // =============================================================================
 // Post-orchestration bookkeeping. Runs on the orchestrator thread once the

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -15,6 +15,7 @@
 #include "aicpu/platform_regs.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
@@ -90,6 +91,25 @@ void SchedulerContext::complete_slot_task(
             );
         }
 #endif
+        int32_t reg_err = PTO2_ERROR_NONE;
+        PTO2AsyncWaitList::RegisterResult reg_result;
+        do {
+            reg_result = sched_->async_wait_list.register_deferred(slot_state, reg_err);
+        } while (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped);
+
+        if (reg_result == PTO2AsyncWaitList::RegisterResult::Error) {
+            int32_t expected = PTO2_ERROR_NONE;
+            sched_->sm_header->sched_error_code.compare_exchange_strong(
+                expected, reg_err, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+            completed_.store(true, std::memory_order_release);
+            return;
+        }
+
+        if (reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
+            return;
+        }
+
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
         l2_perf.notify_edges_total += cstats.fanout_edges;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -28,6 +28,10 @@
 // Dual-slot state machine helpers
 // =============================================================================
 
+namespace {
+inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
+}
+
 // Pure function: read register result -> SlotTransition (no side effects).
 SlotTransition SchedulerContext::decide_slot_transition(
     int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id
@@ -95,6 +99,9 @@ void SchedulerContext::complete_slot_task(
         PTO2AsyncWaitList::RegisterResult reg_result;
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, reg_err);
+            if (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped) {
+                SPIN_WAIT_HINT();
+            }
         } while (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped);
 
         if (reg_result == PTO2AsyncWaitList::RegisterResult::Error) {
@@ -122,7 +129,7 @@ void SchedulerContext::complete_slot_task(
         l2_perf.phase_complete_count++;
 #endif
 #endif
-        if (deferred_release_count < 256) {
+        if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
             deferred_release_slot_states[deferred_release_count++] = &slot_state;
         } else {
             DEV_ALWAYS("Thread %d: release", thread_idx);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -81,24 +81,14 @@ void SchedulerContext::complete_slot_task(
     (void)hank;
 #endif
     bool mixed_complete = sched_->on_subtask_complete(slot_state);
-    if (mixed_complete) {
-#if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
-            dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
-                thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
-                [](uint8_t active_mask, uint8_t raw_subtask_id) {
-                    return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
-                },
-                [this](int32_t func_id) {
-                    return get_function_bin_addr(func_id);
-                }
-            );
-        }
-#endif
+    if (slot_state.payload != nullptr && slot_state.payload->complete_in_future) {
         int32_t reg_err = PTO2_ERROR_NONE;
         PTO2AsyncWaitList::RegisterResult reg_result;
+        volatile PTO2DeferredCompletionIngressBuffer *deferred_ingress =
+            &deferred_ingress_per_core_[core_id][expected_reg_task_id & 1];
         do {
-            reg_result = sched_->async_wait_list.register_deferred(slot_state, reg_err);
+            reg_result =
+                sched_->async_wait_list.register_deferred(slot_state, deferred_ingress, mixed_complete, reg_err);
             if (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped) {
                 SPIN_WAIT_HINT();
             }
@@ -113,10 +103,24 @@ void SchedulerContext::complete_slot_task(
             return;
         }
 
-        if (reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
+        if (mixed_complete && reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
             return;
         }
-
+    }
+    if (mixed_complete) {
+#if PTO2_PROFILING
+        if (get_enable_dump_tensor()) {
+            dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
+                thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
+                [](uint8_t active_mask, uint8_t raw_subtask_id) {
+                    return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+                },
+                [this](int32_t func_id) {
+                    return get_function_bin_addr(func_id);
+                }
+            );
+        }
+#endif
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
         l2_perf.notify_edges_total += cstats.fanout_edges;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -110,6 +110,7 @@ private:
 
     // --- Scheduler binding & per-core runtime state ---
     alignas(64) PTO2SchedulerState *sched_{nullptr};
+    PTO2Runtime *rt_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -15,6 +15,7 @@
 
 #include "scheduler/pto_scheduler.h"
 
+#include "pto_completion_ingress.h"
 #include "pto2_dispatch_payload.h"
 
 // These macros are defined in runtime.h, but we cannot include it here
@@ -122,6 +123,11 @@ private:
     // buf_idx = reg_task_id & 1; adjacent dispatches alternate automatically.
     PTO2DispatchPayload payload_per_core_[RUNTIME_MAX_WORKER][2];
 
+    // Per-core deferred-completion ingress storage.  This has the same runtime
+    // lifetime as payload_per_core_, but is kept out of the dispatch payload so
+    // normal task dispatch layout and cache footprint stay unchanged.
+    PTO2DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
+
     // sync_start drain coordination
     SyncStartDrainState drain_state_;
 
@@ -199,7 +205,10 @@ private:
         int max_count
     );
 
-    void build_payload(PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot);
+    void build_payload(
+        PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        PTO2DeferredCompletionIngressBuffer *deferred_ingress
+    );
 
     void dispatch_subtask_to_core(
         Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -31,6 +31,10 @@
 // Dispatch helpers
 // =============================================================================
 
+namespace {
+inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
+}
+
 const char *SchedulerContext::shape_name(PTO2ResourceShape shape) {
     switch (shape) {
     case PTO2ResourceShape::AIC:
@@ -382,7 +386,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     for (int32_t i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         local_bufs[i].reset(local_ptrs[i], LOCAL_READY_CAP_PER_TYPE);
     }
-    PTO2TaskSlotState *deferred_release_slot_states[256];
+    PTO2TaskSlotState *deferred_release_slot_states[PTO2_DEFERRED_RELEASE_CAP];
     int32_t deferred_release_count = 0;
 
     bool cores_released = false;
@@ -445,7 +449,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0 ||
              pto2_completion_ingress_has_pending(rt_->completion_ingress))) {
             PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
-                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count, 256
+                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
+                PTO2_DEFERRED_RELEASE_CAP
 #if PTO2_SCHED_PROFILING
                 ,
                 thread_idx

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -18,6 +18,7 @@
 #include "callable.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
@@ -97,8 +98,16 @@ void SchedulerContext::build_payload(
     }
     dispatch_payload.local_context.block_idx = slot_state.next_block_idx;
     dispatch_payload.local_context.block_num = slot_state.logical_block_num;
-    dispatch_payload.args[SPMD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
-    dispatch_payload.args[SPMD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
+    dispatch_payload.local_context.task_token =
+        payload.complete_in_future ? slot_state.task->task_id : PTO2TaskId::invalid();
+    dispatch_payload.local_context.deferred_completion_entries =
+        payload.complete_in_future ? payload.deferred_completion_entries : nullptr;
+    dispatch_payload.local_context.deferred_completion_count =
+        payload.complete_in_future ? &payload.deferred_completion_count : nullptr;
+    dispatch_payload.local_context.deferred_completion_capacity =
+        payload.complete_in_future ? PTO2_MAX_COMPLETIONS_PER_TASK : 0;
+    dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
+    dispatch_payload.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
 }
 
 void SchedulerContext::dispatch_subtask_to_core(
@@ -429,6 +438,35 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                         100.0 * new_total / task_count
                     );
                 }
+            }
+        }
+
+        if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
+            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0 ||
+             pto2_completion_ingress_has_pending(rt_->completion_ingress))) {
+            PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
+                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count, 256
+#if PTO2_SCHED_PROFILING
+                ,
+                thread_idx
+#endif
+            );
+            if (poll_result.error_code != PTO2_ERROR_NONE) {
+                int32_t expected = PTO2_ERROR_NONE;
+                header->sched_error_code.compare_exchange_strong(
+                    expected, poll_result.error_code, std::memory_order_acq_rel, std::memory_order_acquire
+                );
+                completed_.store(true, std::memory_order_release);
+                break;
+            }
+            if (poll_result.completed > 0) {
+#if PTO2_SCHED_PROFILING
+                sched_->tasks_completed.fetch_add(poll_result.completed, std::memory_order_relaxed);
+#endif
+                int32_t prev = completed_tasks_.fetch_add(poll_result.completed, std::memory_order_relaxed);
+                int32_t new_total = prev + poll_result.completed;
+                last_progress_count = new_total;
+                made_progress = true;
             }
         }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -17,6 +17,7 @@
 #include "aicpu/platform_regs.h"
 #include "callable.h"
 #include "common/l2_perf_profiling.h"
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
@@ -86,7 +87,8 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot
+    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+    PTO2DeferredCompletionIngressBuffer *deferred_ingress
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
     uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
@@ -104,10 +106,7 @@ void SchedulerContext::build_payload(
     dispatch_payload.local_context.block_num = slot_state.logical_block_num;
     dispatch_payload.local_context.task_token =
         payload.complete_in_future ? slot_state.task->task_id : PTO2TaskId::invalid();
-    dispatch_payload.local_context.deferred_completion_entries =
-        payload.complete_in_future ? payload.deferred_completion_entries : nullptr;
-    dispatch_payload.local_context.deferred_completion_count =
-        payload.complete_in_future ? &payload.deferred_completion_count : nullptr;
+    dispatch_payload.local_context.deferred_ingress = payload.complete_in_future ? deferred_ingress : nullptr;
     dispatch_payload.local_context.deferred_completion_capacity =
         payload.complete_in_future ? PTO2_MAX_COMPLETIONS_PER_TASK : 0;
     dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
@@ -138,7 +137,15 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    build_payload(payload, slot_state, subslot);
+    PTO2DeferredCompletionIngressBuffer *deferred_ingress = nullptr;
+    if (slot_state.payload != nullptr && slot_state.payload->complete_in_future) {
+        deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
+        deferred_ingress->count = 0;
+        deferred_ingress->error_code = PTO2_ERROR_NONE;
+        OUT_OF_ORDER_STORE_BARRIER();
+        cache_flush_range(deferred_ingress, PTO2_ALIGN_SIZE);
+    }
+    build_payload(payload, slot_state, subslot, deferred_ingress);
 
     if (to_pending) {
         core_exec_state.pending_subslot = subslot;
@@ -446,8 +453,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
 
         if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
-            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0 ||
-             pto2_completion_ingress_has_pending(rt_->completion_ingress))) {
+            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
             PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
                 rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -125,4 +125,15 @@ uint32_t platform_get_physical_cores_count();
  */
 void cache_invalidate_range(const void *addr, size_t size);
 
+/**
+ * Clean data cache for a memory range back to global memory.
+ *
+ * On real hardware (onboard): performs DC CVAC per cache line + DSB/ISB.
+ * On simulation (sim): no-op.
+ *
+ * @param addr  Start address of the memory range
+ * @param size  Size of the memory range in bytes
+ */
+void cache_flush_range(const void *addr, size_t size);
+
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a5/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/a5/platform/onboard/aicpu/cache_ops.cpp
@@ -26,3 +26,17 @@ void cache_invalidate_range(const void *addr, size_t size) {
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");
 }
+
+void cache_flush_range(const void *addr, size_t size) {
+    if (size == 0) {
+        return;
+    }
+    const size_t kCacheLineSize = 64;
+    uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
+    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    for (uintptr_t p = start; p < end; p += kCacheLineSize) {
+        __asm__ __volatile__("dc cvac, %0" ::"r"(p) : "memory");
+    }
+    __asm__ __volatile__("dsb sy" ::: "memory");
+    __asm__ __volatile__("isb" ::: "memory");
+}

--- a/src/a5/platform/sim/aicpu/cache_ops.cpp
+++ b/src/a5/platform/sim/aicpu/cache_ops.cpp
@@ -15,3 +15,7 @@
 void cache_invalidate_range(const void * /* addr */, size_t /* size */) {
     // No-op on simulation: no hardware cache to invalidate
 }
+
+void cache_flush_range(const void * /* addr */, size_t /* size */) {
+    // No-op on simulation: no hardware cache to flush
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -52,6 +52,8 @@
 
 #include <stdint.h>
 
+#include "pto_task_id.h"
+
 #ifndef __gm__
 #define __gm__
 #endif
@@ -63,6 +65,8 @@
 /** Number of extra pointer slots appended to the args[] tail (LocalContext + GlobalContext). */
 static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
+struct PTO2DeferredCompletionEntry;
+
 /**
  * Args[] suffix indices for context pointers.
  * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32).
@@ -70,6 +74,8 @@ static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
  */
 static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 48;
 static constexpr int32_t SPMD_GLOBAL_CONTEXT_INDEX = 49;
+static constexpr int32_t PAYLOAD_LOCAL_CONTEXT_INDEX = SPMD_LOCAL_CONTEXT_INDEX;
+static constexpr int32_t PAYLOAD_GLOBAL_CONTEXT_INDEX = SPMD_GLOBAL_CONTEXT_INDEX;
 
 /**
  * Per-core global context, stored in PTO2DispatchPayload.
@@ -98,6 +104,10 @@ struct LocalContext {
                           // Currently fixed to 1 (block_dim > 1 not yet implemented).
                           // NOT the same as RUNTIME_CONFIG.block_dim in kernel_config.py,
                           // which controls how many physical cores the runtime launches.
+    PTO2TaskId task_token;
+    volatile __gm__ PTO2DeferredCompletionEntry *deferred_completion_entries;
+    volatile __gm__ uint32_t *deferred_completion_count;
+    uint32_t deferred_completion_capacity;
 };
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -65,7 +65,7 @@
 /** Number of extra pointer slots appended to the args[] tail (LocalContext + GlobalContext). */
 static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
-struct PTO2DeferredCompletionEntry;
+struct PTO2DeferredCompletionIngressBuffer;
 
 /**
  * Args[] suffix indices for context pointers.
@@ -105,8 +105,7 @@ struct LocalContext {
                           // NOT the same as RUNTIME_CONFIG.block_dim in kernel_config.py,
                           // which controls how many physical cores the runtime launches.
     PTO2TaskId task_token;
-    volatile __gm__ PTO2DeferredCompletionEntry *deferred_completion_entries;
-    volatile __gm__ uint32_t *deferred_completion_count;
+    volatile __gm__ PTO2DeferredCompletionIngressBuffer *deferred_ingress;
     uint32_t deferred_completion_capacity;
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -34,6 +34,9 @@
 
 // Scheduler errors (100+): detected in scheduler threads
 #define PTO2_ERROR_SCHEDULER_TIMEOUT 100
+#define PTO2_ERROR_ASYNC_COMPLETION_INVALID 101
+#define PTO2_ERROR_ASYNC_WAIT_OVERFLOW 102
+#define PTO2_ERROR_ASYNC_REGISTRATION_FAILED 103
 
 static inline int32_t pto2_runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
     if (orch_error_code != PTO2_ERROR_NONE) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -395,7 +395,7 @@ Key members:
 | 2 | Initialize task descriptor + slot state, copy parameters |
 | 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
 | 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |
-| 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >16); increment each producer's `fanout_count` (no lock needed — single writer). This step runs **before** `payload.init()`. |
+| 5 | **Record fanin metadata**: store producer pointers in `payload->fanin_inline_slot_states[]` (+ spill pool if >64); increment each producer's `fanout_count` (no lock needed — single writer). This step runs **before** `payload.init()`. |
 | 6 | **Push to wiring queue**: push to global `PTO2SpscQueue`; scheduler thread 0 asynchronously wires fanout edges (lock + dep_pool + early_finished check + ready push) |
 
 > **Note**: Fanout wiring (Steps 4–7 in earlier versions) has been moved from the

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -239,6 +239,23 @@ static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const
     return rt->ops->submit_task(rt, mk, args);
 }
 
+static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, Arg &args) {
+    args.complete_in_future = true;
+    return pto2_rt_submit_aiv_task(kernel_id, args);
+}
+
+static inline Tensor
+pto2_rt_submit_notification_wait_task(int32_t kernel_id, uint64_t local_counter_addr, uint32_t expected_value) {
+    uint32_t shape[1] = {1};
+    TensorCreateInfo token_info(shape, 1, DataType::INT32);
+    Arg params;
+    params.add_output(token_info);
+    params.add_scalar(local_counter_addr);
+    params.add_scalar(static_cast<uint64_t>(expected_value));
+    TaskOutputTensors outputs = pto2_rt_submit_aiv_task_deferred(kernel_id, params);
+    return outputs.get_ref(0);
+}
+
 static inline void pto2_rt_scope_begin() {
     PTO2Runtime *rt = pto2_current_runtime();
     if (rt->ops->is_fatal(rt)) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -115,7 +115,9 @@ void pto2_framework_bind_runtime(PTO2Runtime *rt);
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(
+        PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+    );
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
@@ -205,55 +207,41 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
     return alloc_tensors(args);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+static inline TaskOutputTensors
+pto2_rt_submit_task_impl(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
     PTO2Runtime *rt = pto2_current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
-    return rt->ops->submit_task(rt, mixed_kernels, args);
+    return rt->ops->submit_task(rt, mixed_kernels, args, complete_in_future);
+}
+
+static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    return pto2_rt_submit_task_impl(mixed_kernels, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
 static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
-    PTO2Runtime *rt = pto2_current_runtime();
-    if (rt->ops->is_fatal(rt)) {
-        return TaskOutputTensors{};
-    }
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
-    return rt->ops->submit_task(rt, mk, args);
+    return pto2_rt_submit_task_impl(mk, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
 static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
-    PTO2Runtime *rt = pto2_current_runtime();
-    if (rt->ops->is_fatal(rt)) {
-        return TaskOutputTensors{};
-    }
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    return rt->ops->submit_task(rt, mk, args);
+    return pto2_rt_submit_task_impl(mk, args, false);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, Arg &args) {
-    args.complete_in_future = true;
-    return pto2_rt_submit_aiv_task(kernel_id, args);
-}
-
-static inline Tensor
-pto2_rt_submit_notification_wait_task(int32_t kernel_id, uint64_t local_counter_addr, uint32_t expected_value) {
-    uint32_t shape[1] = {1};
-    TensorCreateInfo token_info(shape, 1, DataType::INT32);
-    Arg params;
-    params.add_output(token_info);
-    params.add_scalar(local_counter_addr);
-    params.add_scalar(static_cast<uint64_t>(expected_value));
-    TaskOutputTensors outputs = pto2_rt_submit_aiv_task_deferred(kernel_id, params);
-    return outputs.get_ref(0);
+static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, const Arg &args) {
+    MixedKernels mk;
+    mk.aiv0_kernel_id = kernel_id;
+    return pto2_rt_submit_task_impl(mk, args, true);
 }
 
 static inline void pto2_rt_scope_begin() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -81,9 +81,13 @@ struct alignas(64) PTO2DispatchPayload {
      *  args[SPMD_GLOBAL_CONTEXT_INDEX] points here. */
     GlobalContext global_context;
 
+    uint8_t reserved_payload_abi_pad[8];
+
     static_assert(sizeof(args[0]) == 8);
     static_assert(
         PTO2_ALIGN_UP((MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0]), 64) ==
         (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS) * sizeof(args[0])
     );
 };
+
+static_assert(sizeof(PTO2DispatchPayload) == 512, "PTO2DispatchPayload hardware ABI size drift");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -16,6 +16,7 @@
 
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
+#include "pto_runtime_status.h"
 
 #ifndef __aicore__
 #define __aicore__
@@ -25,8 +26,7 @@
 #endif
 
 struct PTO2AsyncCtx {
-    volatile __gm__ PTO2DeferredCompletionEntry *entries;
-    volatile __gm__ uint32_t *entry_count;
+    volatile __gm__ PTO2DeferredCompletionIngressBuffer *ingress;
     uint32_t entry_capacity;
     PTO2TaskId task_token;
 };
@@ -35,8 +35,7 @@ inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
     __gm__ LocalContext *lc =
         reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
     PTO2AsyncCtx ctx;
-    ctx.entries = lc->deferred_completion_entries;
-    ctx.entry_count = lc->deferred_completion_count;
+    ctx.ingress = lc->deferred_ingress;
     ctx.entry_capacity = lc->deferred_completion_capacity;
     ctx.task_token.raw = lc->task_token.raw;
     return ctx;
@@ -45,27 +44,30 @@ inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
 inline __aicore__ bool pto2_async_ctx_is_deferred(const PTO2AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
 
 inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
-    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) {
+    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) {
         return;
     }
 
-    uint32_t idx = *ctx.entry_count;
-    if (idx >= ctx.entry_capacity) return;
+    uint32_t idx = ctx.ingress->count;
+    if (idx >= ctx.entry_capacity) {
+        ctx.ingress->error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+        return;
+    }
 
-    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.entries[idx];
+    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.ingress->entries[idx];
     slot->addr = reinterpret_cast<uint64_t>(counter_addr);
     slot->expected_value = expected;
     slot->engine = PTO2_COMPLETION_ENGINE_SDMA;
     slot->completion_type = PTO2_COMPLETION_TYPE_COUNTER;
     slot->_pad = 0;
-    *ctx.entry_count = idx + 1;
+    ctx.ingress->count = idx + 1;
 }
 
 inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
-    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) return;
+    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
-    dcci((__gm__ int32_t *)ctx.entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
-    dcci((__gm__ int32_t *)ctx.entry_count, SINGLE_CACHE_LINE, CACHELINE_OUT);
+    dcci((__gm__ int32_t *)ctx.ingress->entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci((__gm__ int32_t *)ctx.ingress, SINGLE_CACHE_LINE, CACHELINE_OUT);
 #if defined(__CPU_SIM)
     dsb(0);
 #else
@@ -74,7 +76,7 @@ inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
     pipe_barrier(PIPE_ALL);
 #else
     (void)ctx;
-    __atomic_thread_fence(__ATOMIC_RELEASE);
+    __asm__ __volatile__("" ::: "memory");
 #endif
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PTO_ASYNC_KERNEL_API_H
+#define PTO_ASYNC_KERNEL_API_H
+
+#include <stdint.h>
+
+#include "intrinsic.h"
+#include "pto_completion_ingress.h"
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+#ifndef __gm__
+#define __gm__
+#endif
+
+struct PTO2AsyncCtx {
+    volatile __gm__ PTO2DeferredCompletionEntry *entries;
+    volatile __gm__ uint32_t *entry_count;
+    uint32_t entry_capacity;
+    PTO2TaskId task_token;
+};
+
+inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
+    __gm__ LocalContext *lc =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
+    PTO2AsyncCtx ctx;
+    ctx.entries = lc->deferred_completion_entries;
+    ctx.entry_count = lc->deferred_completion_count;
+    ctx.entry_capacity = lc->deferred_completion_capacity;
+    ctx.task_token.raw = lc->task_token.raw;
+    return ctx;
+}
+
+inline __aicore__ bool pto2_async_ctx_is_deferred(const PTO2AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
+
+inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
+    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) {
+        return;
+    }
+
+    uint32_t idx = *ctx.entry_count;
+    if (idx >= ctx.entry_capacity) return;
+
+    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.entries[idx];
+    slot->addr = reinterpret_cast<uint64_t>(counter_addr);
+    slot->expected_value = expected;
+    slot->engine = PTO2_COMPLETION_ENGINE_SDMA;
+    slot->completion_type = PTO2_COMPLETION_TYPE_COUNTER;
+    slot->_pad = 0;
+    *ctx.entry_count = idx + 1;
+}
+
+inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
+    if (!ctx.task_token.is_valid() || ctx.entries == nullptr || ctx.entry_count == nullptr) return;
+#if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
+    dcci((__gm__ int32_t *)ctx.entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
+    dcci((__gm__ int32_t *)ctx.entry_count, SINGLE_CACHE_LINE, CACHELINE_OUT);
+#if defined(__CPU_SIM)
+    dsb(0);
+#else
+    dsb(DSB_DDR);
+#endif
+    pipe_barrier(PIPE_ALL);
+#else
+    (void)ctx;
+    __atomic_thread_fence(__ATOMIC_RELEASE);
+#endif
+}
+
+#endif  // PTO_ASYNC_KERNEL_API_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef PTO_ASYNC_WAIT_H
+#define PTO_ASYNC_WAIT_H
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+#include "common/memory_barrier.h"
+#include "pto_completion_ingress.h"
+#include "pto_runtime2_types.h"
+
+struct PTO2SchedulerState;
+struct PTO2LocalReadyBuffer;
+struct PTO2CompletionStats;
+
+inline constexpr int32_t PTO2_MAX_ASYNC_WAITS = 64;
+inline constexpr int32_t PTO2_MAX_PENDING_COMPLETIONS = 128;
+
+inline uintptr_t pto2_completion_ingress_cache_line(const volatile void *addr) {
+    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
+}
+
+inline void pto2_completion_ingress_invalidate_entries(
+    volatile PTO2CompletionIngressQueue *completion_ingress, uint64_t tail, uint64_t head
+) {
+    uint64_t active_count = head - tail;
+    if (active_count == 0) return;
+
+    uint64_t tail_index = tail & PTO2_COMPLETION_INGRESS_MASK;
+    uint64_t first_span = active_count;
+    uint64_t contiguous_capacity = PTO2_COMPLETION_INGRESS_CAPACITY - tail_index;
+    if (first_span > contiguous_capacity) {
+        first_span = contiguous_capacity;
+    }
+
+    cache_invalidate_range(
+        const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->entries[tail_index])),
+        first_span * sizeof(PTO2CompletionIngressEntry)
+    );
+
+    uint64_t remaining = active_count - first_span;
+    if (remaining == 0) return;
+
+    cache_invalidate_range(
+        const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->entries[0])),
+        remaining * sizeof(PTO2CompletionIngressEntry)
+    );
+}
+
+inline bool pto2_completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
+    if (completion_ingress == nullptr) return false;
+    cache_invalidate_range(
+        const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
+        sizeof(completion_ingress->head)
+    );
+    uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+    uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
+    return tail < head;
+}
+
+enum class PTO2CompletionPollState : uint8_t {
+    PENDING = 0,
+    READY = 1,
+    FAILED = 2,
+};
+
+struct PTO2CompletionPollResult {
+    PTO2CompletionPollState state{PTO2CompletionPollState::PENDING};
+    int32_t error_code{PTO2_ERROR_NONE};
+};
+
+struct PTO2CompletionCondition {
+    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+    bool satisfied{false};
+    volatile uint32_t *counter_addr{nullptr};
+    uint32_t expected_value{0};
+
+    PTO2CompletionPollResult test() const {
+        if (satisfied) {
+            return {PTO2CompletionPollState::READY, PTO2_ERROR_NONE};
+        }
+        if (counter_addr == nullptr) {
+            return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+        }
+        return {
+            *counter_addr >= expected_value ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING,
+            PTO2_ERROR_NONE
+        };
+    }
+};
+
+struct PTO2AsyncWaitEntry {
+    PTO2TaskSlotState *slot_state{nullptr};
+    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    PTO2CompletionCondition conditions[PTO2_MAX_COMPLETIONS_PER_TASK];
+    int32_t condition_count{0};
+    int32_t waiting_completion_count{0};
+};
+
+struct PTO2PendingCompletion {
+    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    uint64_t addr{0};
+    uint32_t expected_value{0};
+    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+};
+
+struct PTO2AsyncPollResult {
+    int32_t completed{0};
+    int32_t error_code{PTO2_ERROR_NONE};
+    PTO2TaskSlotState *failed_slot_state{nullptr};
+};
+
+inline const char *pto2_async_engine_name(PTO2AsyncEngine engine) {
+    switch (engine) {
+    case PTO2_ASYNC_ENGINE_SDMA:
+        return "SDMA";
+    case PTO2_ASYNC_ENGINE_ROCE:
+        return "ROCE";
+    case PTO2_ASYNC_ENGINE_URMA:
+        return "URMA";
+    case PTO2_ASYNC_ENGINE_CCU:
+        return "CCU";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+struct PTO2AsyncWaitList {
+    std::atomic<int32_t> busy{0};
+    PTO2AsyncWaitEntry entries[PTO2_MAX_ASYNC_WAITS];
+    int32_t count{0};
+    PTO2PendingCompletion pending_completions[PTO2_MAX_PENDING_COMPLETIONS];
+    int32_t pending_completion_count{0};
+
+    bool try_lock() {
+        int32_t expected = 0;
+        return busy.compare_exchange_strong(expected, 1, std::memory_order_acquire, std::memory_order_relaxed);
+    }
+
+    void unlock() { busy.store(0, std::memory_order_release); }
+
+    PTO2AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+        for (int32_t i = 0; i < count; i++) {
+            if (entries[i].task_token == token) return &entries[i];
+        }
+        return nullptr;
+    }
+
+    int32_t
+    drain_completion_ingress_locked(volatile PTO2CompletionIngressQueue *completion_ingress, int32_t &error_code) {
+        error_code = PTO2_ERROR_NONE;
+        if (completion_ingress == nullptr) return 0;
+
+        int32_t drained = 0;
+        while (true) {
+            uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
+            cache_invalidate_range(
+                const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
+                sizeof(completion_ingress->head)
+            );
+            uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+            if (tail >= head) break;
+            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head);
+
+            volatile PTO2CompletionIngressEntry *slot =
+                &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
+            uint64_t expected_seq = tail + 1;
+            uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+            if (seq != expected_seq) break;
+
+            PTO2TaskId token{slot->task_token.raw};
+            uint64_t addr = slot->addr;
+            uint32_t expected_value = slot->expected_value;
+            PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
+
+            slot->seq = 0;
+            completion_ingress->tail = tail + 1;
+            OUT_OF_ORDER_STORE_BARRIER();
+            cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(slot)), sizeof(*slot));
+            cache_flush_range(
+                const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->tail)),
+                sizeof(completion_ingress->tail)
+            );
+            drained++;
+
+            PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
+            if (entry != nullptr) {
+                if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+                    error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                    return drained;
+                }
+                PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
+                cond.engine = engine;
+                cond.satisfied = false;
+                cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+                cond.expected_value = expected_value;
+                entry->waiting_completion_count++;
+                continue;
+            }
+
+            if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
+                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                return drained;
+            }
+            PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
+            pending.task_token = token;
+            pending.addr = addr;
+            pending.expected_value = expected_value;
+            pending.engine = engine;
+        }
+        return drained;
+    }
+
+    void absorb_pending_completions_locked(PTO2AsyncWaitEntry &entry) {
+        int32_t write = 0;
+        for (int32_t i = 0; i < pending_completion_count; i++) {
+            if (pending_completions[i].task_token == entry.task_token) {
+                if (entry.condition_count < PTO2_MAX_COMPLETIONS_PER_TASK) {
+                    PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+                    cond.engine = pending_completions[i].engine;
+                    cond.satisfied = false;
+                    cond.counter_addr =
+                        reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(pending_completions[i].addr));
+                    cond.expected_value = pending_completions[i].expected_value;
+                    entry.waiting_completion_count++;
+                }
+            } else {
+                if (write != i) pending_completions[write] = pending_completions[i];
+                write++;
+            }
+        }
+        pending_completion_count = write;
+    }
+
+    enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
+
+    RegisterResult register_deferred(PTO2TaskSlotState &slot_state, int32_t &error_code) {
+        error_code = PTO2_ERROR_NONE;
+        PTO2TaskPayload *payload = slot_state.payload;
+        if (payload == nullptr || !payload->complete_in_future) {
+            return RegisterResult::NotDeferred;
+        }
+
+        if (!try_lock()) return RegisterResult::Skipped;
+
+        if (count >= PTO2_MAX_ASYNC_WAITS) {
+            error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+            unlock();
+            return RegisterResult::Error;
+        }
+
+        PTO2AsyncWaitEntry &entry = entries[count++];
+        entry.slot_state = &slot_state;
+        entry.task_token = slot_state.task->task_id;
+        entry.condition_count = 0;
+        entry.waiting_completion_count = 0;
+
+        cache_invalidate_range(&payload->deferred_completion_count, sizeof(payload->deferred_completion_count));
+        uint32_t deferred_count = payload->deferred_completion_count;
+        if (deferred_count > PTO2_MAX_COMPLETIONS_PER_TASK) {
+            error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+            unlock();
+            return RegisterResult::Error;
+        }
+        if (deferred_count > 0) {
+            cache_invalidate_range(
+                payload->deferred_completion_entries, deferred_count * sizeof(PTO2DeferredCompletionEntry)
+            );
+        }
+        for (uint32_t i = 0; i < deferred_count; ++i) {
+            const PTO2DeferredCompletionEntry &deferred = payload->deferred_completion_entries[i];
+            PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+            cond.engine = static_cast<PTO2AsyncEngine>(deferred.engine);
+            cond.satisfied = false;
+            cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred.addr));
+            cond.expected_value = deferred.expected_value;
+            entry.waiting_completion_count++;
+        }
+
+        absorb_pending_completions_locked(entry);
+        unlock();
+        return RegisterResult::Registered;
+    }
+
+    template <bool Profiling>
+    PTO2AsyncPollResult poll_and_complete(
+        volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+        PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
+        int32_t &deferred_release_count, int32_t deferred_release_capacity
+#if PTO2_SCHED_PROFILING
+        ,
+        int thread_idx
+#endif
+    );
+};
+
+#endif  // PTO_ASYNC_WAIT_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -107,6 +107,7 @@ struct PTO2AsyncWaitEntry {
     PTO2CompletionCondition conditions[PTO2_MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
+    bool normal_done{false};
 };
 
 struct PTO2PendingCompletion {
@@ -249,7 +250,26 @@ struct PTO2AsyncWaitList {
 
     enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
-    RegisterResult register_deferred(PTO2TaskSlotState &slot_state, int32_t &error_code) {
+    bool append_condition_locked(
+        PTO2AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, PTO2AsyncEngine engine, int32_t &error_code
+    ) {
+        if (entry.condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+            error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+            return false;
+        }
+        PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+        cond.engine = engine;
+        cond.satisfied = false;
+        cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+        cond.expected_value = expected_value;
+        entry.waiting_completion_count++;
+        return true;
+    }
+
+    RegisterResult register_deferred(
+        PTO2TaskSlotState &slot_state, volatile PTO2DeferredCompletionIngressBuffer *ingress, bool normal_done,
+        int32_t &error_code
+    ) {
         error_code = PTO2_ERROR_NONE;
         PTO2TaskPayload *payload = slot_state.payload;
         if (payload == nullptr || !payload->complete_in_future) {
@@ -258,41 +278,67 @@ struct PTO2AsyncWaitList {
 
         if (!try_lock()) return RegisterResult::Skipped;
 
-        if (count >= PTO2_MAX_ASYNC_WAITS) {
-            error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-            unlock();
-            return RegisterResult::Error;
+        uint32_t deferred_count = 0;
+        if (ingress != nullptr) {
+            cache_invalidate_range(
+                const_cast<const void *>(reinterpret_cast<volatile void *>(ingress)), PTO2_ALIGN_SIZE
+            );
+            if (ingress->error_code != PTO2_ERROR_NONE) {
+                error_code = ingress->error_code;
+                unlock();
+                return RegisterResult::Error;
+            }
+            deferred_count = ingress->count;
         }
-
-        PTO2AsyncWaitEntry &entry = entries[count++];
-        entry.slot_state = &slot_state;
-        entry.task_token = slot_state.task->task_id;
-        entry.condition_count = 0;
-        entry.waiting_completion_count = 0;
-
-        cache_invalidate_range(&payload->deferred_completion_count, sizeof(payload->deferred_completion_count));
-        uint32_t deferred_count = payload->deferred_completion_count;
         if (deferred_count > PTO2_MAX_COMPLETIONS_PER_TASK) {
             error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
             unlock();
             return RegisterResult::Error;
         }
-        if (deferred_count > 0) {
+        if (deferred_count > 0 && ingress != nullptr) {
             cache_invalidate_range(
-                payload->deferred_completion_entries, deferred_count * sizeof(PTO2DeferredCompletionEntry)
+                const_cast<const void *>(reinterpret_cast<volatile void *>(ingress->entries)),
+                deferred_count * sizeof(PTO2DeferredCompletionEntry)
             );
         }
-        for (uint32_t i = 0; i < deferred_count; ++i) {
-            const PTO2DeferredCompletionEntry &deferred = payload->deferred_completion_entries[i];
-            PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
-            cond.engine = static_cast<PTO2AsyncEngine>(deferred.engine);
-            cond.satisfied = false;
-            cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred.addr));
-            cond.expected_value = deferred.expected_value;
-            entry.waiting_completion_count++;
+        PTO2AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
+        if (entry == nullptr) {
+            if (!normal_done && deferred_count == 0) {
+                unlock();
+                return RegisterResult::Registered;
+            }
+            if (count >= PTO2_MAX_ASYNC_WAITS) {
+                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                unlock();
+                return RegisterResult::Error;
+            }
+            entry = &entries[count++];
+            entry->slot_state = &slot_state;
+            entry->task_token = slot_state.task->task_id;
+            entry->condition_count = 0;
+            entry->waiting_completion_count = 0;
+            entry->normal_done = false;
+        }
+        if (normal_done) {
+            entry->normal_done = true;
         }
 
-        absorb_pending_completions_locked(entry);
+        for (uint32_t i = 0; i < deferred_count; ++i) {
+            volatile PTO2DeferredCompletionEntry *deferred = &ingress->entries[i];
+            volatile uint32_t *counter = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
+            cache_invalidate_range(
+                reinterpret_cast<const void *>(pto2_completion_ingress_cache_line(counter)), sizeof(uint32_t)
+            );
+            if (!append_condition_locked(
+                    *entry, deferred->addr, deferred->expected_value, static_cast<PTO2AsyncEngine>(deferred->engine),
+                    error_code
+                )) {
+                unlock();
+                return RegisterResult::Error;
+            }
+        }
+
+        absorb_pending_completions_locked(*entry);
         unlock();
         return RegisterResult::Registered;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -170,55 +170,58 @@ struct PTO2AsyncWaitList {
                 const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
                 sizeof(completion_ingress->head)
             );
-            uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
-            if (tail >= head) break;
-            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head);
+            uint64_t head_snapshot = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+            if (tail >= head_snapshot) break;
+            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head_snapshot);
 
-            volatile PTO2CompletionIngressEntry *slot =
-                &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
-            uint64_t expected_seq = tail + 1;
-            uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-            if (seq != expected_seq) break;
+            while (tail < head_snapshot) {
+                volatile PTO2CompletionIngressEntry *slot =
+                    &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
+                uint64_t expected_seq = tail + 1;
+                uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
+                if (seq != expected_seq) return drained;
 
-            PTO2TaskId token{slot->task_token.raw};
-            uint64_t addr = slot->addr;
-            uint32_t expected_value = slot->expected_value;
-            PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
+                PTO2TaskId token{slot->task_token.raw};
+                uint64_t addr = slot->addr;
+                uint32_t expected_value = slot->expected_value;
+                PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
 
-            slot->seq = 0;
-            completion_ingress->tail = tail + 1;
-            OUT_OF_ORDER_STORE_BARRIER();
-            cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(slot)), sizeof(*slot));
-            cache_flush_range(
-                const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->tail)),
-                sizeof(completion_ingress->tail)
-            );
-            drained++;
+                slot->seq = 0;
+                completion_ingress->tail = tail + 1;
+                OUT_OF_ORDER_STORE_BARRIER();
+                cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(slot)), sizeof(*slot));
+                cache_flush_range(
+                    const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->tail)),
+                    sizeof(completion_ingress->tail)
+                );
+                drained++;
+                tail++;
 
-            PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
-            if (entry != nullptr) {
-                if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
-                    error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
+                if (entry != nullptr) {
+                    if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+                        error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                        return drained;
+                    }
+                    PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
+                    cond.engine = engine;
+                    cond.satisfied = false;
+                    cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
+                    cond.expected_value = expected_value;
+                    entry->waiting_completion_count++;
+                    continue;
+                }
+
+                if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
+                    error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                     return drained;
                 }
-                PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
-                cond.engine = engine;
-                cond.satisfied = false;
-                cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
-                cond.expected_value = expected_value;
-                entry->waiting_completion_count++;
-                continue;
+                PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
+                pending.task_token = token;
+                pending.addr = addr;
+                pending.expected_value = expected_value;
+                pending.engine = engine;
             }
-
-            if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
-                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-                return drained;
-            }
-            PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
-            pending.task_token = token;
-            pending.addr = addr;
-            pending.expected_value = expected_value;
-            pending.engine = engine;
         }
         return drained;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
@@ -56,6 +56,18 @@ struct PTO2DeferredCompletionEntry {
 
 static_assert(sizeof(PTO2DeferredCompletionEntry) == 24, "PTO2DeferredCompletionEntry layout drift");
 
+struct PTO2DeferredCompletionIngressBuffer {
+    alignas(PTO2_ALIGN_SIZE) volatile uint32_t count;
+    volatile int32_t error_code;
+    uint8_t _header_pad[PTO2_ALIGN_SIZE - sizeof(uint32_t) - sizeof(int32_t)];
+    alignas(PTO2_ALIGN_SIZE) PTO2DeferredCompletionEntry entries[PTO2_MAX_COMPLETIONS_PER_TASK];
+};
+
+static_assert(
+    sizeof(PTO2DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
+    "PTO2DeferredCompletionIngressBuffer size must be cache-line aligned"
+);
+
 struct PTO2CompletionIngressQueue {
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+
+#include <stdint.h>
+
+#include "pto_constants.h"
+#include "pto_task_id.h"
+
+#define PTO2_COMPLETION_INGRESS_CAPACITY 4096u
+#define PTO2_COMPLETION_INGRESS_MASK (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)
+
+static_assert(
+    (PTO2_COMPLETION_INGRESS_CAPACITY & (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
+    "PTO2_COMPLETION_INGRESS_CAPACITY must be a power of two"
+);
+
+inline constexpr int32_t PTO2_MAX_COMPLETIONS_PER_TASK = 64;
+
+#define PTO2_COMPLETION_ENGINE_SDMA 0u
+#define PTO2_COMPLETION_ENGINE_ROCE 1u
+#define PTO2_COMPLETION_ENGINE_URMA 2u
+#define PTO2_COMPLETION_ENGINE_CCU 3u
+
+#define PTO2_COMPLETION_TYPE_COUNTER 0
+
+struct PTO2CompletionIngressEntry {
+    volatile uint64_t seq;
+    PTO2TaskId task_token;
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint32_t _pad[6];
+};
+
+static_assert(sizeof(PTO2CompletionIngressEntry) == PTO2_ALIGN_SIZE, "PTO2CompletionIngressEntry layout drift");
+
+struct PTO2DeferredCompletionEntry {
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint32_t _pad;
+};
+
+static_assert(sizeof(PTO2DeferredCompletionEntry) == 24, "PTO2DeferredCompletionEntry layout drift");
+
+struct PTO2CompletionIngressQueue {
+    alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
+    uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
+    alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
+    uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
+    alignas(PTO2_ALIGN_SIZE) PTO2CompletionIngressEntry entries[PTO2_COMPLETION_INGRESS_CAPACITY];
+};
+
+static_assert(
+    sizeof(PTO2CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
+    "PTO2CompletionIngressQueue size must be cache-line aligned"
+);
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_constants.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_constants.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_CONSTANTS_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_CONSTANTS_H_
+
+#define PTO2_ALIGN_SIZE 64             // Cache line alignment
+#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
+#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_CONSTANTS_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -489,8 +489,9 @@ void pto2_scope_end(PTO2OrchestratorState *orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors
-pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args) {
+TaskOutputTensors pto2_submit_mixed_task(
+    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+) {
     CYCLE_COUNT_START();
 
     TaskOutputTensors result;
@@ -679,7 +680,7 @@ pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_ke
         payload.fanin_inline_slot_states[i] = fanin_builder.inline_slots[i];
     }
 
-    payload.init(args, result, prepared.alloc_result, layout);
+    payload.init(args, result, prepared.alloc_result, layout, complete_in_future);
 
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, task_id.raw);
 #if PTO2_ORCH_PROFILING
@@ -770,7 +771,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 
     TaskOutputTensors outputs;
     outputs.set_task_id(prepared.task_id);
-    payload.init(args, outputs, prepared.alloc_result, layout);
+    payload.init(args, outputs, prepared.alloc_result, layout, false);
     payload.fanin_actual_count = 0;
     payload.fanin_spill_start = 0;
     payload.fanin_spill_pool = &orch->rings[prepared.task_id.ring()].fanin_pool;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -186,8 +186,9 @@ void pto2_scope_end(PTO2OrchestratorState *orch);
  * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
  * @param args      Aggregated tensor and scalar parameters
  */
-TaskOutputTensors
-pto2_submit_mixed_task(PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args);
+TaskOutputTensors pto2_submit_mixed_task(
+    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+);
 
 /**
  * Allocate fresh tensors by creating one hidden runtime-owned output task.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -306,6 +306,16 @@ PTO2Runtime *pto2_runtime_create_custom(
     // Connect orchestrator to scheduler (for simulated mode)
     pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
+    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    if (!rt->completion_ingress) {
+        pto2_scheduler_destroy(&rt->scheduler);
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt->gm_heap);
+        pto2_sm_destroy(rt->sm_handle);
+        free(rt);
+        return NULL;
+    }
+
     return rt;
 }
 
@@ -339,6 +349,14 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 
     pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
 
+    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    if (!rt->completion_ingress) {
+        pto2_scheduler_destroy(&rt->scheduler);
+        pto2_orchestrator_destroy(&rt->orchestrator);
+        free(rt);
+        return NULL;
+    }
+
     return rt;
 }
 
@@ -347,6 +365,8 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
 
     pto2_scheduler_destroy(&rt->scheduler);
     pto2_orchestrator_destroy(&rt->orchestrator);
+
+    free(rt->completion_ingress);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -38,8 +38,9 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args);
+static TaskOutputTensors
+submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
+    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args, complete_in_future);
 }
 
 static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -67,7 +67,9 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(
+        PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
+    );
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -42,6 +42,7 @@
 #include "pto_tensormap.h"
 #include "scheduler/pto_scheduler.h"
 #include "pto_orchestrator.h"
+#include "pto_completion_ingress.h"
 
 // =============================================================================
 // Runtime Context
@@ -103,6 +104,7 @@ struct PTO2Runtime {
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
+    PTO2CompletionIngressQueue *completion_ingress;
 
     // GM Heap for output buffers
     void *gm_heap;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -253,7 +253,10 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout) {
+    void init(
+        const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout,
+        bool complete_in_future_flag
+    ) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
@@ -275,7 +278,7 @@ struct PTO2TaskPayload {
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
-        complete_in_future = args.complete_in_future;
+        complete_in_future = complete_in_future_flag;
         deferred_completion_count = 0;
     }
 };

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -31,7 +31,10 @@
 
 #include <atomic>
 
+#include "pto_constants.h"
 #include "pto_runtime_status.h"
+#include "pto2_dispatch_payload.h"
+#include "pto_completion_ingress.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"
@@ -112,11 +115,6 @@
 
 // Wiring queue
 #define PTO2_WRIRING_QUEUE_SIZE 1024  // Per-shape queue size
-
-// Memory alignment
-#define PTO2_ALIGN_SIZE 64             // Cache line alignment
-#define PTO2_PACKED_OUTPUT_ALIGN 1024  // Each output in packed buffer aligned to 1024B; gap is padding
-#define PTO2_ALIGN_UP(x, align) (((x) + (align) - 1) & ~((align) - 1))
 
 // Fanin storage
 #define PTO2_FANIN_INLINE_CAP 16
@@ -237,6 +235,9 @@ struct PTO2TaskPayload {
     Tensor tensors[MAX_TENSOR_ARGS];
     // === Cache lines 35-38 (256B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
+    bool complete_in_future{false};
+    uint32_t deferred_completion_count{0};
+    PTO2DeferredCompletionEntry deferred_completion_entries[PTO2_MAX_COMPLETIONS_PER_TASK];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
@@ -274,6 +275,8 @@ struct PTO2TaskPayload {
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
+        complete_in_future = args.complete_in_future;
+        deferred_completion_count = 0;
     }
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -117,7 +117,7 @@
 #define PTO2_WRIRING_QUEUE_SIZE 1024  // Per-shape queue size
 
 // Fanin storage
-#define PTO2_FANIN_INLINE_CAP 16
+#define PTO2_FANIN_INLINE_CAP 64
 
 // TensorMap cleanup interval
 #define PTO2_TENSORMAP_CLEANUP_INTERVAL 64  // Cleanup every N retired tasks
@@ -219,25 +219,23 @@ struct PTO2TaskDescriptor {
 /**
  * Task payload data (cold path - only accessed during orchestration and dispatch)
  *
- * Layout: metadata + inline fanin packed in the first 3 cache lines, followed
+ * Layout: metadata + inline fanin packed in the first 9 cache lines, followed
  * by bulk tensor and scalar data. Small fanins stay fully inline; larger
  * fanins spill into a per-ring ring buffer slice.
  */
 struct PTO2TaskPayload {
-    // === Cache lines 0-2 (192B) — metadata ===
+    // === Cache lines 0-8 (576B) — metadata + inline fanin ===
     int32_t tensor_count{0};
     int32_t scalar_count{0};
     int32_t fanin_actual_count{0};  // Actual fanin count (without the +1 redundance)
     int32_t fanin_spill_start{0};   // Linear start index in fanin spill pool (0 = no spill)
+    bool complete_in_future{false};
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
-    // === Cache lines 3-34 (2048B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 9-40 (2048B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 35-38 (256B) — scalars ===
+    // === Cache lines 41-44 (256B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
-    bool complete_in_future{false};
-    uint32_t deferred_completion_count{0};
-    PTO2DeferredCompletionEntry deferred_completion_entries[PTO2_MAX_COMPLETIONS_PER_TASK];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
@@ -279,18 +277,23 @@ struct PTO2TaskPayload {
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
         complete_in_future = complete_in_future_flag;
-        deferred_completion_count = 0;
     }
 };
 
 // PTO2TaskPayload layout verification (offsetof requires complete type).
+static_assert(offsetof(PTO2TaskPayload, complete_in_future) == 16, "deferred flag must stay in the first cache line");
+static_assert(offsetof(PTO2TaskPayload, fanin_spill_pool) == 24, "spill pool pointer layout drift");
 static_assert(
-    offsetof(PTO2TaskPayload, fanin_inline_slot_states) == 24, "inline fanin array must follow spill metadata"
+    offsetof(PTO2TaskPayload, fanin_inline_slot_states) == 32, "inline fanin array must follow spill metadata"
 );
-static_assert(offsetof(PTO2TaskPayload, tensors) == 192, "tensors must start at byte 192 (cache line 3)");
+static_assert(offsetof(PTO2TaskPayload, tensors) == 576, "tensors must start at byte 576 (cache line 9)");
 static_assert(
-    offsetof(PTO2TaskPayload, scalars) == 192 + MAX_TENSOR_ARGS * sizeof(Tensor),
+    offsetof(PTO2TaskPayload, scalars) == 576 + MAX_TENSOR_ARGS * sizeof(Tensor),
     "scalars must immediately follow tensors"
+);
+static_assert(
+    sizeof(PTO2TaskPayload) == 576 + MAX_TENSOR_ARGS * sizeof(Tensor) + MAX_SCALAR_ARGS * sizeof(uint64_t),
+    "PTO2TaskPayload size must stay on the baseline cache-line footprint"
 );
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -150,13 +150,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     bool has_error{false};
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
-    bool complete_in_future{false};
 
     void reset() {
         clear();
         has_error = false;
         error_msg = nullptr;
-        complete_in_future = false;
     }
 
     void set_error(const char *msg) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -46,6 +46,18 @@
 #define PTO2_MAX_INPUTS 16   // Maximum inputs per task
 #define PTO2_MAX_INOUTS 8    // Maximum in-out args per task
 
+typedef enum {
+    PTO2_ASYNC_ENGINE_SDMA = 0,
+    PTO2_ASYNC_ENGINE_ROCE = 1,
+    PTO2_ASYNC_ENGINE_URMA = 2,
+    PTO2_ASYNC_ENGINE_CCU = 3,
+    PTO2_NUM_ASYNC_ENGINES = 4,
+} PTO2AsyncEngine;
+
+enum class PTO2CompletionType : int32_t {
+    COUNTER = 0,
+};
+
 // =============================================================================
 // Task Output Tensors (return value from submit)
 // =============================================================================
@@ -138,11 +150,13 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     bool has_error{false};
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
+    bool complete_in_future{false};
 
     void reset() {
         clear();
         has_error = false;
         error_msg = nullptr;
+        complete_in_future = false;
     }
 
     void set_error(const char *msg) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -32,6 +32,7 @@
 #include <atomic>
 
 #include "common/core_type.h"
+#include "pto_async_wait.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
@@ -593,6 +594,8 @@ struct PTO2SchedulerState {
     );
     static_assert(sizeof(WiringState) == 576, "WiringState must be exactly 9 cache lines (576B)");
 
+    alignas(64) PTO2AsyncWaitList async_wait_list;
+
     // Statistics (cold path, isolated from hot-path fields)
 #if PTO2_SCHED_PROFILING
     alignas(64) std::atomic<int64_t> tasks_completed;
@@ -993,6 +996,78 @@ bool pto2_scheduler_init(
     PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
 void pto2_scheduler_destroy(PTO2SchedulerState *sched);
+
+template <bool Profiling>
+inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
+    volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+    PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
+    int32_t deferred_release_capacity
+#if PTO2_SCHED_PROFILING
+    ,
+    int thread_idx
+#endif
+) {
+    PTO2AsyncPollResult result;
+    if (!try_lock()) return result;
+
+    int32_t drain_err = PTO2_ERROR_NONE;
+    drain_completion_ingress_locked(completion_ingress, drain_err);
+    if (drain_err != PTO2_ERROR_NONE) {
+        result.error_code = drain_err;
+        unlock();
+        return result;
+    }
+
+    for (int32_t i = count - 1; i >= 0; --i) {
+        PTO2AsyncWaitEntry &entry = entries[i];
+        uintptr_t last_invalidated_counter_line = static_cast<uintptr_t>(-1);
+        for (int32_t c = 0; c < entry.condition_count; c++) {
+            PTO2CompletionCondition &cond = entry.conditions[c];
+            if (cond.satisfied) continue;
+            if (cond.counter_addr) {
+                uintptr_t counter_line = pto2_completion_ingress_cache_line(cond.counter_addr);
+                if (counter_line != last_invalidated_counter_line) {
+                    cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
+                    last_invalidated_counter_line = counter_line;
+                }
+            }
+            PTO2CompletionPollResult poll = cond.test();
+            if (poll.state == PTO2CompletionPollState::FAILED) {
+                result.error_code = poll.error_code;
+                result.failed_slot_state = entry.slot_state;
+                unlock();
+                return result;
+            }
+            if (poll.state == PTO2CompletionPollState::READY) {
+                cond.satisfied = true;
+                entry.waiting_completion_count--;
+            }
+        }
+
+        if (entry.waiting_completion_count <= 0) {
+            if (deferred_release_count >= deferred_release_capacity) {
+                result.error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                result.failed_slot_state = entry.slot_state;
+                unlock();
+                return result;
+            }
+#if PTO2_SCHED_PROFILING
+            sched->on_mixed_task_complete(*entry.slot_state, thread_idx, local_bufs);
+#else
+            sched->on_mixed_task_complete(*entry.slot_state, local_bufs);
+#endif
+            deferred_release_slot_states[deferred_release_count++] = entry.slot_state;
+            result.completed++;
+
+            int32_t last = count - 1;
+            if (i != last) entries[i] = entries[last];
+            count = last;
+        }
+    }
+
+    unlock();
+    return result;
+}
 
 // =============================================================================
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1044,7 +1044,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
             }
         }
 
-        if (entry.waiting_completion_count <= 0) {
+        if (entry.normal_done && entry.waiting_completion_count <= 0) {
             if (deferred_release_count >= deferred_release_capacity) {
                 result.error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                 result.failed_slot_state = entry.slot_state;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -657,6 +657,7 @@ int32_t SchedulerContext::init(
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
+    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
 
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
@@ -688,6 +689,7 @@ void SchedulerContext::deinit() {
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
+    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
 
     // Reset sync-start drain coordination — a previous run that aborted mid-drain
     // would otherwise leave dirty pending/elected/ack state for the next reuse.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -723,6 +723,7 @@ void SchedulerContext::deinit() {
 
     regs_ = 0;
     sched_ = nullptr;
+    rt_ = nullptr;
     func_id_to_addr_ = nullptr;
 }
 
@@ -732,7 +733,10 @@ void SchedulerContext::wait_pto2_init_complete() const {
     }
 }
 
-void SchedulerContext::bind_runtime(PTO2Runtime *rt) { sched_ = &rt->scheduler; }
+void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
+    rt_ = rt;
+    sched_ = &rt->scheduler;
+}
 
 // =============================================================================
 // Post-orchestration bookkeeping. Runs on the orchestrator thread once the

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -15,6 +15,7 @@
 #include "aicpu/platform_regs.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
@@ -90,6 +91,25 @@ void SchedulerContext::complete_slot_task(
             );
         }
 #endif
+        int32_t reg_err = PTO2_ERROR_NONE;
+        PTO2AsyncWaitList::RegisterResult reg_result;
+        do {
+            reg_result = sched_->async_wait_list.register_deferred(slot_state, reg_err);
+        } while (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped);
+
+        if (reg_result == PTO2AsyncWaitList::RegisterResult::Error) {
+            int32_t expected = PTO2_ERROR_NONE;
+            sched_->sm_header->sched_error_code.compare_exchange_strong(
+                expected, reg_err, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+            completed_.store(true, std::memory_order_release);
+            return;
+        }
+
+        if (reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
+            return;
+        }
+
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
         l2_perf.notify_edges_total += cstats.fanout_edges;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -28,6 +28,10 @@
 // Dual-slot state machine helpers
 // =============================================================================
 
+namespace {
+inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
+}
+
 // Pure function: read register result -> SlotTransition (no side effects).
 SlotTransition SchedulerContext::decide_slot_transition(
     int32_t reg_task_id, int32_t reg_state, int32_t running_id, int32_t pending_id
@@ -95,6 +99,9 @@ void SchedulerContext::complete_slot_task(
         PTO2AsyncWaitList::RegisterResult reg_result;
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, reg_err);
+            if (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped) {
+                SPIN_WAIT_HINT();
+            }
         } while (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped);
 
         if (reg_result == PTO2AsyncWaitList::RegisterResult::Error) {
@@ -122,7 +129,7 @@ void SchedulerContext::complete_slot_task(
         l2_perf.phase_complete_count++;
 #endif
 #endif
-        if (deferred_release_count < 256) {
+        if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
             deferred_release_slot_states[deferred_release_count++] = &slot_state;
         } else {
             DEV_ALWAYS("Thread %d: release", thread_idx);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -81,24 +81,14 @@ void SchedulerContext::complete_slot_task(
     (void)hank;
 #endif
     bool mixed_complete = sched_->on_subtask_complete(slot_state);
-    if (mixed_complete) {
-#if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
-            dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
-                thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
-                [](uint8_t active_mask, uint8_t raw_subtask_id) {
-                    return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
-                },
-                [this](int32_t func_id) {
-                    return get_function_bin_addr(func_id);
-                }
-            );
-        }
-#endif
+    if (slot_state.payload != nullptr && slot_state.payload->complete_in_future) {
         int32_t reg_err = PTO2_ERROR_NONE;
         PTO2AsyncWaitList::RegisterResult reg_result;
+        volatile PTO2DeferredCompletionIngressBuffer *deferred_ingress =
+            &deferred_ingress_per_core_[core_id][expected_reg_task_id & 1];
         do {
-            reg_result = sched_->async_wait_list.register_deferred(slot_state, reg_err);
+            reg_result =
+                sched_->async_wait_list.register_deferred(slot_state, deferred_ingress, mixed_complete, reg_err);
             if (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped) {
                 SPIN_WAIT_HINT();
             }
@@ -113,10 +103,24 @@ void SchedulerContext::complete_slot_task(
             return;
         }
 
-        if (reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
+        if (mixed_complete && reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
             return;
         }
-
+    }
+    if (mixed_complete) {
+#if PTO2_PROFILING
+        if (get_enable_dump_tensor()) {
+            dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
+                thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
+                [](uint8_t active_mask, uint8_t raw_subtask_id) {
+                    return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+                },
+                [this](int32_t func_id) {
+                    return get_function_bin_addr(func_id);
+                }
+            );
+        }
+#endif
 #if PTO2_SCHED_PROFILING
         PTO2CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
         l2_perf.notify_edges_total += cstats.fanout_edges;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -15,6 +15,8 @@
 
 #include "scheduler/pto_scheduler.h"
 
+#include "pto_completion_ingress.h"
+
 // These macros are defined in runtime.h, but we cannot include it here
 // (it pulls in Handshake which we only forward-declare).  Mirror the
 // authoritative values so the class layout compiles standalone.
@@ -120,6 +122,11 @@ private:
     // buf_idx = reg_task_id & 1; adjacent dispatches alternate automatically.
     PTO2DispatchPayload payload_per_core_[RUNTIME_MAX_WORKER][2];
 
+    // Per-core deferred-completion ingress storage.  This has the same runtime
+    // lifetime as payload_per_core_, but is kept out of the dispatch payload so
+    // normal task dispatch layout and cache footprint stay unchanged.
+    PTO2DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
+
     // sync_start drain coordination
     SyncStartDrainState drain_state_;
 
@@ -199,7 +206,10 @@ private:
         int max_count
     );
 
-    void build_payload(PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot);
+    void build_payload(
+        PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+        PTO2DeferredCompletionIngressBuffer *deferred_ingress
+    );
 
     void dispatch_subtask_to_core(
         Runtime *runtime, int32_t thread_idx, int32_t core_offset, PTO2TaskSlotState &slot_state,

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -108,6 +108,7 @@ private:
 
     // --- Scheduler binding & per-core runtime state ---
     alignas(64) PTO2SchedulerState *sched_{nullptr};
+    PTO2Runtime *rt_{nullptr};
 
     // Per-core execution state, indexed by core_id (= worker_id)
     CoreExecState core_exec_states_[RUNTIME_MAX_WORKER];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -18,6 +18,7 @@
 #include "callable.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
+#include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
 
@@ -97,8 +98,16 @@ void SchedulerContext::build_payload(
     }
     dispatch_payload.local_context.s_block_idx = slot_state.next_block_idx;
     dispatch_payload.local_context.s_block_num = slot_state.logical_block_num;
-    dispatch_payload.args[SPMD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
-    dispatch_payload.args[SPMD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
+    dispatch_payload.local_context.task_token =
+        payload.complete_in_future ? slot_state.task->task_id : PTO2TaskId::invalid();
+    dispatch_payload.local_context.deferred_completion_entries =
+        payload.complete_in_future ? payload.deferred_completion_entries : nullptr;
+    dispatch_payload.local_context.deferred_completion_count =
+        payload.complete_in_future ? &payload.deferred_completion_count : nullptr;
+    dispatch_payload.local_context.deferred_completion_capacity =
+        payload.complete_in_future ? PTO2_MAX_COMPLETIONS_PER_TASK : 0;
+    dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
+    dispatch_payload.args[PAYLOAD_GLOBAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.global_context);
 }
 
 void SchedulerContext::dispatch_subtask_to_core(
@@ -416,6 +425,35 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                         100.0 * new_total / task_count
                     );
                 }
+            }
+        }
+
+        if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
+            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0 ||
+             pto2_completion_ingress_has_pending(rt_->completion_ingress))) {
+            PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
+                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count, 256
+#if PTO2_SCHED_PROFILING
+                ,
+                thread_idx
+#endif
+            );
+            if (poll_result.error_code != PTO2_ERROR_NONE) {
+                int32_t expected = PTO2_ERROR_NONE;
+                header->sched_error_code.compare_exchange_strong(
+                    expected, poll_result.error_code, std::memory_order_acq_rel, std::memory_order_acquire
+                );
+                completed_.store(true, std::memory_order_release);
+                break;
+            }
+            if (poll_result.completed > 0) {
+#if PTO2_SCHED_PROFILING
+                sched_->tasks_completed.fetch_add(poll_result.completed, std::memory_order_relaxed);
+#endif
+                int32_t prev = completed_tasks_.fetch_add(poll_result.completed, std::memory_order_relaxed);
+                int32_t new_total = prev + poll_result.completed;
+                last_progress_count = new_total;
+                made_progress = true;
             }
         }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -31,6 +31,10 @@
 // Dispatch helpers
 // =============================================================================
 
+namespace {
+inline constexpr int32_t PTO2_DEFERRED_RELEASE_CAP = 256;
+}
+
 const char *SchedulerContext::shape_name(PTO2ResourceShape shape) {
     switch (shape) {
     case PTO2ResourceShape::AIC:
@@ -369,7 +373,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     for (int32_t i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         local_bufs[i].reset(local_ptrs[i], LOCAL_READY_CAP_PER_TYPE);
     }
-    PTO2TaskSlotState *deferred_release_slot_states[256];
+    PTO2TaskSlotState *deferred_release_slot_states[PTO2_DEFERRED_RELEASE_CAP];
     int32_t deferred_release_count = 0;
 
     bool cores_released = false;
@@ -432,7 +436,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0 ||
              pto2_completion_ingress_has_pending(rt_->completion_ingress))) {
             PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
-                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count, 256
+                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
+                PTO2_DEFERRED_RELEASE_CAP
 #if PTO2_SCHED_PROFILING
                 ,
                 thread_idx

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -17,6 +17,7 @@
 #include "aicpu/platform_regs.h"
 #include "callable.h"
 #include "common/l2_perf_profiling.h"
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
@@ -86,7 +87,8 @@ int SchedulerContext::pop_ready_tasks_batch(
 }
 
 void SchedulerContext::build_payload(
-    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot
+    PTO2DispatchPayload &dispatch_payload, PTO2TaskSlotState &slot_state, PTO2SubtaskSlot subslot,
+    PTO2DeferredCompletionIngressBuffer *deferred_ingress
 ) {
     int32_t slot_idx = static_cast<int32_t>(subslot);
     uint64_t callable_addr = get_function_bin_addr(slot_state.task->kernel_id[slot_idx]);
@@ -104,10 +106,7 @@ void SchedulerContext::build_payload(
     dispatch_payload.local_context.s_block_num = slot_state.logical_block_num;
     dispatch_payload.local_context.task_token =
         payload.complete_in_future ? slot_state.task->task_id : PTO2TaskId::invalid();
-    dispatch_payload.local_context.deferred_completion_entries =
-        payload.complete_in_future ? payload.deferred_completion_entries : nullptr;
-    dispatch_payload.local_context.deferred_completion_count =
-        payload.complete_in_future ? &payload.deferred_completion_count : nullptr;
+    dispatch_payload.local_context.deferred_ingress = payload.complete_in_future ? deferred_ingress : nullptr;
     dispatch_payload.local_context.deferred_completion_capacity =
         payload.complete_in_future ? PTO2_MAX_COMPLETIONS_PER_TASK : 0;
     dispatch_payload.args[PAYLOAD_LOCAL_CONTEXT_INDEX] = reinterpret_cast<uint64_t>(&dispatch_payload.local_context);
@@ -139,7 +138,15 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    build_payload(payload, slot_state, subslot);
+    PTO2DeferredCompletionIngressBuffer *deferred_ingress = nullptr;
+    if (slot_state.payload != nullptr && slot_state.payload->complete_in_future) {
+        deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
+        deferred_ingress->count = 0;
+        deferred_ingress->error_code = PTO2_ERROR_NONE;
+        OUT_OF_ORDER_STORE_BARRIER();
+        cache_flush_range(deferred_ingress, PTO2_ALIGN_SIZE);
+    }
+    build_payload(payload, slot_state, subslot, deferred_ingress);
 
     if (to_pending) {
         core_exec_state.pending_subslot = subslot;
@@ -433,8 +440,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
 
         if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
-            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0 ||
-             pto2_completion_ingress_has_pending(rt_->completion_ingress))) {
+            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
             PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
                 rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -51,7 +51,7 @@ static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast belo
 
 FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &) {
+TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &, bool) {
     as_fake(rt)->submit_calls++;
     return TaskOutputTensors{};
 }

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -45,7 +45,7 @@ static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast belo
 
 FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &) {
+TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &, bool) {
     as_fake(rt)->submit_calls++;
     return TaskOutputTensors{};
 }


### PR DESCRIPTION
- Add kernel and orchestration APIs for tasks that complete after their kernel returns
- Track deferred counter waits in task payloads and scheduler wait state, then complete tasks once registered conditions are ready
- Allocate runtime-owned completion ingress state for future async completion producers
- Add sim and onboard demos that exercise comm-triggered deferred completion through ChipBootstrapConfig and ChipContext
- Use the mainline comm/bootstrap path instead of restoring the old branch-local distributed bootstrap surface