### PR TITLE
Refactor: profiling and handshake API cleanup (post-#658)

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -237,20 +237,17 @@ AICPU and AICore cores coordinate via **handshake buffers** (one per core):
 struct Handshake {
     volatile uint32_t aicpu_ready;   // AICPU→AICore: scheduler ready
     volatile uint32_t aicore_done;   // AICore→AICPU: core ready
-    volatile uint64_t task;          // AICPU→AICore: task pointer
-    volatile int32_t task_status;    // Task state: 1=busy, 0=done
-    volatile int32_t control;        // AICPU→AICore: 1=quit
+    volatile uint64_t task;          // AICPU→AICore: task pointer (init only; runtime uses DATA_MAIN_BASE)
 };
 ```
 
 **Flow:**
 
 1. AICPU finds a ready task
-2. AICPU writes task pointer to handshake buffer and sets `aicpu_ready`
-3. AICore polls buffer, sees task, reads from device memory
-4. AICore sets `task_status = 1` (busy) and executes
-5. AICore sets `task_status = 0` (done) and `aicore_done`
-6. AICPU reads result and continues
+2. AICPU writes task pointer to handshake buffer and signals via DATA_MAIN_BASE register
+3. AICore polls DATA_MAIN_BASE, reads the task, executes
+4. AICore writes FIN to COND; AICPU observes completion
+5. AICPU reads result and continues
 
 ## Platform Backends
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -602,7 +602,7 @@ def _convert_case_swimlane(
     the runtime's second-precision filename collisions), then invoke the converter.
 
     The ``l2_perf_records_`` prefix is preserved so the converter's stem-based output
-    naming still strips it and produces ``merged_swimlane_<ts>_<case_label>.json``.
+    naming still strips it and produces ``merged_swimlane_<case_label>_<ts>.json``.
 
     When ``callable_spec`` is provided and contains ``"name"`` entries on incores,
     a ``func_id_names_<label>.json`` sidecar is written and passed to the converter
@@ -616,12 +616,12 @@ def _convert_case_swimlane(
         logger.warning(f"[{case_label}] No new l2_perf_records_*.json produced; skipping conversion")
         return
     safe_label = _sanitize_for_filename(case_label)
-    suffix = (
+    timestamp = (
         l2_perf_records_file.stem[len("l2_perf_records_") :]
         if l2_perf_records_file.stem.startswith("l2_perf_records_")
         else l2_perf_records_file.stem
     )
-    renamed = l2_perf_records_file.with_name(f"l2_perf_records_{suffix}_{safe_label}.json")
+    renamed = l2_perf_records_file.with_name(f"l2_perf_records_{safe_label}_{timestamp}.json")
     if renamed.exists():
         logger.warning(f"[{case_label}] target {renamed.name} already exists; overwriting")
         renamed.unlink()

--- a/simpler_setup/tools/device_log_resolver.py
+++ b/simpler_setup/tools/device_log_resolver.py
@@ -51,7 +51,7 @@ def _extract_l2_perf_records_timestamp(l2_perf_records_path: Path | None) -> dat
     if l2_perf_records_path is None:
         return None
 
-    filename_match = re.search(r"l2_perf_records_(\d{8}_\d{6})", l2_perf_records_path.name)
+    filename_match = re.search(r"(\d{8}_\d{6})\.json$", l2_perf_records_path.name)
     if filename_match:
         try:
             return datetime.strptime(filename_match.group(1), "%Y%m%d_%H%M%S")

--- a/simpler_setup/tools/perf_to_mermaid.py
+++ b/simpler_setup/tools/perf_to_mermaid.py
@@ -293,13 +293,13 @@ def _resolve_output_path(args, input_path):
 
     input_stem = input_path.stem
     if input_stem.startswith("l2_perf_records_"):
-        timestamp_part = input_stem[len("l2_perf_records_") :]
+        suffix_part = input_stem[len("l2_perf_records_") :]
     else:
-        timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
+        suffix_part = datetime.now().strftime("%Y%m%d_%H%M%S")
 
     outputs_dir = Path.cwd() / "outputs"
     outputs_dir.mkdir(exist_ok=True)
-    return outputs_dir / f"mermaid_diagram_{timestamp_part}.md"
+    return outputs_dir / f"mermaid_diagram_{suffix_part}.md"
 
 
 def main():

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -1165,13 +1165,13 @@ def _resolve_output_path(args, input_path):
 
     input_stem = input_path.stem
     if input_stem.startswith("l2_perf_records_"):
-        timestamp_part = input_stem[len("l2_perf_records_") :]
+        suffix_part = input_stem[len("l2_perf_records_") :]
     else:
-        timestamp_part = datetime.now().strftime("%Y%m%d_%H%M%S")
+        suffix_part = datetime.now().strftime("%Y%m%d_%H%M%S")
 
     outputs_dir = Path.cwd() / "outputs"
     outputs_dir.mkdir(exist_ok=True)
-    return outputs_dir / f"merged_swimlane_{timestamp_part}.json"
+    return outputs_dir / f"merged_swimlane_{suffix_part}.json"
 
 
 def _print_verbose_data_info(data, verbose):

--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -33,13 +33,11 @@
  * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
  * entry (onboard) before `l2_perf_aicpu_init_profiling()` so AICPU code can
  * read perf state without reaching into the generic `Runtime` struct.
- * Mirrors the `set_platform_dump_base` / `set_enable_dump_tensor` pattern
- * used by tensor dump and PMU.
  */
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
 extern "C" uint64_t get_platform_l2_perf_base();
-extern "C" void set_enable_l2_swimlane(bool enable);
-extern "C" bool get_enable_l2_swimlane();
+extern "C" void set_l2_swimlane_enabled(bool enable);
+extern "C" bool is_l2_swimlane_enabled();
 
 /**
  * Initialize performance profiling

--- a/src/a2a3/platform/include/aicpu/pmu_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/pmu_collector_aicpu.h
@@ -21,7 +21,7 @@
  *   [task loop]
  *     pmu_aicpu_record_task()   — read counters, write one PmuRecord; switch buffer when full
  *   pmu_aicpu_flush_buffers()   — per-thread: flush each of this thread's non-empty
- *                                 PmuBuffers to the ready_queue (mirrors l2_perf_aicpu_flush_buffers)
+ *                                 PmuBuffers to the ready_queue
  *   pmu_aicpu_finalize()        — per-thread: restore CTRL registers on shutdown
  */
 
@@ -35,8 +35,8 @@
 
 extern "C" void set_platform_pmu_base(uint64_t pmu_data_base);
 extern "C" uint64_t get_platform_pmu_base();
-extern "C" void set_enable_pmu(bool enable);
-extern "C" bool get_enable_pmu();
+extern "C" void set_pmu_enabled(bool enable);
+extern "C" bool is_pmu_enabled();
 
 /**
  * Initialize PMU for all cores.
@@ -77,7 +77,7 @@ void pmu_aicpu_init(const uint32_t *physical_core_ids, int num_cores);
 void pmu_aicpu_record_task(int core_id, int thread_idx, uint64_t task_id, uint32_t func_id, CoreType core_type);
 
 /**
- * Per-thread PMU buffer flush. Mirrors l2_perf_aicpu_flush_buffers().
+ * Per-thread PMU buffer flush.
  *
  * For each core in cur_thread_cores, enqueue its non-empty PmuBuffer into the
  * thread's ready_queue so the host collector can pick it up.

--- a/src/a2a3/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/tensor_dump_aicpu.h
@@ -56,14 +56,14 @@ uint64_t get_platform_dump_base();
  *
  * @param enable true to enable tensor dump, false to disable
  */
-void set_enable_dump_tensor(bool enable);
+void set_dump_tensor_enabled(bool enable);
 
 /**
  * Get whether tensor dump is enabled for this execution.
  *
  * @return true if tensor dump is enabled
  */
-bool get_enable_dump_tensor();
+bool is_dump_tensor_enabled();
 
 #ifdef __cplusplus
 }

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -79,8 +79,8 @@ struct L2PerfRecord {
     uint64_t duration;    // Execution duration (end - start)
 
     // AICPU-side timestamps (written by AICPU, not AICore)
-    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
-    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
+    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore
+    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion
 
     // AICore writes the register dispatch token (low 32 bits only) zero-extended into task_id.
     // For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites

--- a/src/a2a3/platform/include/common/pmu_profiling.h
+++ b/src/a2a3/platform/include/common/pmu_profiling.h
@@ -105,8 +105,8 @@ constexpr PmuEventConfig PMU_EVENTS_A2A3_L2_CACHE = {
  * Resolve an event type to the DAV_2201 event table. Returns nullptr for
  * unknown values (caller falls back to PIPE_UTILIZATION).
  */
-inline const PmuEventConfig *pmu_resolve_event_config_a2a3(uint32_t event_type) {
-    switch (static_cast<PmuEventType>(event_type)) {
+inline const PmuEventConfig *pmu_resolve_event_config_a2a3(PmuEventType event_type) {
+    switch (event_type) {
     case PmuEventType::ARITHMETIC_UTILIZATION:
         return &PMU_EVENTS_A2A3_ARITHMETIC;
     case PmuEventType::PIPE_UTILIZATION:

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -196,7 +196,7 @@ struct DumpReadyQueueEntry {
  * 1. Per-thread ready queues (circular FIFOs) — one per AICPU thread
  * 2. Metadata (thread count, config)
  *
- * Ready queue design mirrors L2PerfDataHeader but is independent:
+ * Ready queue design:
  * - Per-thread queues avoid lock contention
  * - Producer: AICPU thread (adds full DumpMetaBuffers)
  * - Consumer: Host DumpMemoryManager thread

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -104,7 +104,7 @@ public:
      */
     int init(
         int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
-        uint32_t event_type, PmuAllocCallback alloc_cb, PmuRegisterCallback register_cb, PmuFreeCallback free_cb,
+        PmuEventType event_type, PmuAllocCallback alloc_cb, PmuRegisterCallback register_cb, PmuFreeCallback free_cb,
         void *user_data, int device_id
     );
 
@@ -140,7 +140,7 @@ private:
     int num_cores_ = 0;
     int num_threads_ = 0;
     int device_id_ = -1;
-    uint32_t event_type_ = 0;
+    PmuEventType event_type_{PmuEventType::PIPE_UTILIZATION};
 
     // Shared memory region (PmuDataHeader + PmuBufferState[])
     void *shm_dev_ = nullptr;
@@ -196,7 +196,7 @@ private:
 inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
     PmuEventType resolved = PmuEventType::PIPE_UTILIZATION;
     if (requested_event_type > 0 &&
-        pmu_resolve_event_config_a2a3(static_cast<uint32_t>(requested_event_type)) != nullptr) {
+        pmu_resolve_event_config_a2a3(static_cast<PmuEventType>(requested_event_type)) != nullptr) {
         resolved = static_cast<PmuEventType>(requested_event_type);
     } else if (requested_event_type != 0) {
         // 0 means PMU disabled (enable_pmu == 0), not an invalid type — only warn for nonzero
@@ -210,7 +210,7 @@ inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
         return resolved;
     }
     int val = std::atoi(pmu_env);
-    if (val > 0 && pmu_resolve_event_config_a2a3(static_cast<uint32_t>(val)) != nullptr) {
+    if (val > 0 && pmu_resolve_event_config_a2a3(static_cast<PmuEventType>(val)) != nullptr) {
         resolved = static_cast<PmuEventType>(val);
         LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", static_cast<uint32_t>(resolved));
         return resolved;

--- a/src/a2a3/platform/include/host/tensor_dump_collector.h
+++ b/src/a2a3/platform/include/host/tensor_dump_collector.h
@@ -16,7 +16,7 @@
  * Fully decoupled from profiling: uses its own shared memory region,
  * ready queues, and memory manager thread.
  *
- * Mirrors L2PerfCollector architecture:
+ * Architecture:
  * - DumpMemoryManager: Background thread that polls dump ready queues,
  *   recycles metadata buffers, and hands off full buffers to the main thread.
  * - TensorDumpCollector: Main thread copies tensor data from arenas,

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -86,12 +86,12 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     // The dump base address is only the backing storage location.
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
-    set_enable_dump_tensor(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_dump_tensor_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_perf_base(k_args->l2_perf_data_base);
-    set_enable_l2_swimlane(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
+    set_l2_swimlane_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
     set_platform_pmu_reg_addrs(k_args->pmu_reg_addrs);
-    set_enable_pmu(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
+    set_pmu_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
     if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -532,14 +532,11 @@ int DeviceRunner::run(
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
-        runtime.workers[i].task_status = 0;
         // Set core type: first 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
         runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
         runtime.workers[i].l2_perf_records_addr = static_cast<uint64_t>(0);
-        runtime.workers[i].l2_perf_buffer_status = 0;
     }
 
     // Set function_bin_addr for all tasks: func_id_to_addr_[] stores CoreCallable
@@ -599,9 +596,7 @@ int DeviceRunner::run(
     }
 
     if (enable_pmu_) {
-        rc = init_pmu_buffers(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(), static_cast<uint32_t>(pmu_event_type_), device_id
-        );
+        rc = init_pmu_buffers(num_aicore, launch_aicpu_num, make_pmu_csv_path(), pmu_event_type_, device_id);
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.args.pmu_data_base = 0;
@@ -778,8 +773,8 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG(
-            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, workers[i].aicore_done,
-            workers[i].aicpu_ready, workers[i].control, workers[i].task
+            "  Core %d: aicore_done=%d aicpu_ready=%d task=%d", i, workers[i].aicore_done, workers[i].aicpu_ready,
+            workers[i].task
         );
     }
 }
@@ -1180,7 +1175,7 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
 }
 
 int DeviceRunner::init_pmu_buffers(
-    int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
 ) {
     auto alloc_cb = [](size_t size, void *user_data) -> void * {
         auto *allocator = static_cast<MemoryAllocator *>(user_data);

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -261,9 +261,9 @@ public:
      * corresponding `enable_*_` members directly. Moved off the generic
      * Runtime struct / run() arg list so all three travel the same way.
      */
-    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
-    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
-    void set_enable_pmu(int enable_pmu) {
+    void set_l2_swimlane_enabled(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
+    void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
@@ -542,8 +542,9 @@ private:
      * @param device_id  Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int
-    init_pmu_buffers(int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id);
+    int init_pmu_buffers(
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+    );
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -551,7 +552,7 @@ private:
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
-    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -229,9 +229,9 @@ int run_runtime(
             return rc;
         }
 
-        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
-        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
-        runner->set_enable_pmu(enable_pmu);
+        runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
+        runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
+        runner->set_pmu_enabled(enable_pmu);
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -46,9 +46,9 @@ typedef void (*aicore_execute_func_t)(
 );
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 typedef void (*set_platform_dump_base_func_t)(uint64_t dump_data_base);
-typedef void (*set_enable_dump_tensor_func_t)(bool enable);
+typedef void (*set_dump_tensor_enabled_func_t)(bool enable);
 typedef void (*set_platform_pmu_base_func_t)(uint64_t pmu_data_base);
-typedef void (*set_enable_pmu_func_t)(bool enable);
+typedef void (*set_pmu_enabled_func_t)(bool enable);
 
 namespace {
 
@@ -154,10 +154,10 @@ int DeviceRunner::ensure_binaries_loaded(
             LOG_ERROR("dlsym failed for set_platform_dump_base: %s", dlerror());
             return -1;
         }
-        set_enable_dump_tensor_func_ =
-            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_dump_tensor"));
-        if (set_enable_dump_tensor_func_ == nullptr) {
-            LOG_ERROR("dlsym failed for set_enable_dump_tensor: %s", dlerror());
+        set_dump_tensor_enabled_func_ =
+            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_dump_tensor_enabled"));
+        if (set_dump_tensor_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_dump_tensor_enabled: %s", dlerror());
             return -1;
         }
 
@@ -168,10 +168,10 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        set_enable_l2_swimlane_func_ =
-            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_l2_swimlane"));
-        if (set_enable_l2_swimlane_func_ == nullptr) {
-            LOG_ERROR("dlsym failed for set_enable_l2_swimlane: %s", dlerror());
+        set_l2_swimlane_enabled_func_ =
+            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_l2_swimlane_enabled"));
+        if (set_l2_swimlane_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_l2_swimlane_enabled: %s", dlerror());
             return -1;
         }
 
@@ -189,9 +189,9 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        set_enable_pmu_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_pmu"));
-        if (set_enable_pmu_func_ == nullptr) {
-            LOG_ERROR("dlsym failed for set_enable_pmu: %s", dlerror());
+        set_pmu_enabled_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_pmu_enabled"));
+        if (set_pmu_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_pmu_enabled: %s", dlerror());
             return -1;
         }
 
@@ -348,9 +348,7 @@ int DeviceRunner::run(
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
-        runtime.workers[i].task_status = 0;
         // First 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
         runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
@@ -402,9 +400,7 @@ int DeviceRunner::run(
     }
 
     if (enable_pmu_) {
-        rc = init_pmu_buffers(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(), static_cast<uint32_t>(pmu_event_type_), device_id
-        );
+        rc = init_pmu_buffers(num_aicore, launch_aicpu_num, make_pmu_csv_path(), pmu_event_type_, device_id);
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.pmu_data_base = 0;
@@ -455,21 +451,21 @@ int DeviceRunner::run(
 
     // Check if executors are loaded
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
-        set_platform_dump_base_func_ == nullptr || set_enable_dump_tensor_func_ == nullptr ||
+        set_platform_dump_base_func_ == nullptr || set_dump_tensor_enabled_func_ == nullptr ||
         set_platform_pmu_base_func_ == nullptr || set_platform_pmu_reg_addrs_func_ == nullptr ||
-        set_enable_pmu_func_ == nullptr) {
+        set_pmu_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
 
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_enable_dump_tensor_func_(enable_dump_tensor_);
+    set_dump_tensor_enabled_func_(enable_dump_tensor_);
     set_platform_l2_perf_base_func_(kernel_args_.l2_perf_data_base);
-    set_enable_l2_swimlane_func_(enable_l2_swimlane_);
+    set_l2_swimlane_enabled_func_(enable_l2_swimlane_);
     set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
     set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);  // 0 on sim (no PMU hardware)
-    set_enable_pmu_func_(enable_pmu_);
+    set_pmu_enabled_func_(enable_pmu_);
 
     // Launch AICPU threads (over-launch for affinity gate)
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
@@ -610,8 +606,8 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG(
-            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, last_runtime_->workers[i].aicore_done,
-            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].control, last_runtime_->workers[i].task
+            "  Core %d: aicore_done=%d aicpu_ready=%d task=%d", i, last_runtime_->workers[i].aicore_done,
+            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].task
         );
     }
 }
@@ -623,12 +619,12 @@ void DeviceRunner::unload_executor_binaries() {
         aicpu_execute_func_ = nullptr;
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
-        set_enable_dump_tensor_func_ = nullptr;
+        set_dump_tensor_enabled_func_ = nullptr;
         set_platform_l2_perf_base_func_ = nullptr;
-        set_enable_l2_swimlane_func_ = nullptr;
+        set_l2_swimlane_enabled_func_ = nullptr;
         set_platform_pmu_base_func_ = nullptr;
         set_platform_pmu_reg_addrs_func_ = nullptr;
-        set_enable_pmu_func_ = nullptr;
+        set_pmu_enabled_func_ = nullptr;
         aicpu_so_loaded_ = false;
     }
     if (!aicpu_so_path_.empty()) {
@@ -918,7 +914,7 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
 }
 
 int DeviceRunner::init_pmu_buffers(
-    int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int /*device_id*/
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
 ) {
     auto alloc_cb = [](size_t size, void * /*user_data*/) -> void * {
         return malloc(size);

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -152,9 +152,9 @@ public:
      * corresponding `enable_*_` members directly. Moved off the generic
      * Runtime struct / run() arg list so all three travel the same way.
      */
-    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
-    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
-    void set_enable_pmu(int enable_pmu) {
+    void set_l2_swimlane_enabled(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
+    void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
@@ -237,12 +237,12 @@ private:
     void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
-    void (*set_enable_dump_tensor_func_)(bool){nullptr};
+    void (*set_dump_tensor_enabled_func_)(bool){nullptr};
     void (*set_platform_l2_perf_base_func_)(uint64_t){nullptr};
-    void (*set_enable_l2_swimlane_func_)(bool){nullptr};
+    void (*set_l2_swimlane_enabled_func_)(bool){nullptr};
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_reg_addrs_func_)(uint64_t){nullptr};
-    void (*set_enable_pmu_func_)(bool){nullptr};
+    void (*set_pmu_enabled_func_)(bool){nullptr};
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
 
@@ -286,8 +286,9 @@ private:
 
     int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
 
-    int
-    init_pmu_buffers(int num_cores, int num_threads, const std::string &csv_path, uint32_t event_type, int device_id);
+    int init_pmu_buffers(
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+    );
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -295,7 +296,7 @@ private:
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
-    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
 };
 
 #endif  // SRC_A2A3_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -190,9 +190,9 @@ int run_runtime(
         // Phase 2: publish diagnostics enablement to the DeviceRunner so run()
         // and its helpers can read the three sub-features uniformly (via
         // members, not Runtime / run() args).
-        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
-        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
-        runner->set_enable_pmu(enable_pmu);
+        runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
+        runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
+        runner->set_pmu_enabled(enable_pmu);
 
         // Phase 3: launch
         std::vector<uint8_t> aicpu_vec;

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -44,15 +44,14 @@ static int s_orch_thread_idx = -1;
 // L2 perf platform state. Published by the host (via dlsym'd setters on sim)
 // or by the AICPU kernel entry (onboard) before perf init runs, so downstream
 // perf code can discover enablement + device-base without reading the generic
-// Runtime struct. Mirrors the g_platform_dump_base / g_enable_dump_tensor pair
-// in tensor_dump_aicpu.cpp and the PMU equivalents in pmu_collector_aicpu.cpp.
+// Runtime struct.
 static uint64_t g_platform_l2_perf_base = 0;
 static bool g_enable_l2_swimlane = false;
 
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base) { g_platform_l2_perf_base = l2_perf_data_base; }
 extern "C" uint64_t get_platform_l2_perf_base() { return g_platform_l2_perf_base; }
-extern "C" void set_enable_l2_swimlane(bool enable) { g_enable_l2_swimlane = enable; }
-extern "C" bool get_enable_l2_swimlane() { return g_enable_l2_swimlane; }
+extern "C" void set_l2_swimlane_enabled(bool enable) { g_enable_l2_swimlane = enable; }
+extern "C" bool is_l2_swimlane_enabled() { return g_enable_l2_swimlane; }
 
 /**
  * Enqueue ready buffer to per-thread queue

--- a/src/a2a3/platform/src/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/pmu_collector_aicpu.cpp
@@ -16,11 +16,11 @@
  * Uses read_reg/write_reg from platform_regs for MMIO register access,
  * consistent with the rest of the platform layer.
  *
- * Buffer switching mirrors l2_perf_collector_aicpu.cpp:
+ * Buffer switching:
  *   - SPSC free_queue: Host pushes free PmuBuffers, AICPU pops when switching.
  *   - Per-thread ready_queue: AICPU enqueues full buffers for host collection.
  *   - On free_queue empty or ready_queue full: overwrite current buffer (data lost,
- *     same policy as perf profiling — avoids blocking the AICPU dispatch loop).
+ *     avoids blocking the AICPU dispatch loop).
  */
 
 #include "aicpu/pmu_collector_aicpu.h"
@@ -51,9 +51,9 @@ extern "C" void set_platform_pmu_base(uint64_t pmu_data_base) { g_platform_pmu_b
 
 extern "C" uint64_t get_platform_pmu_base() { return g_platform_pmu_base; }
 
-extern "C" void set_enable_pmu(bool enable) { g_enable_pmu = enable; }
+extern "C" void set_pmu_enabled(bool enable) { g_enable_pmu = enable; }
 
-extern "C" bool get_enable_pmu() { return g_enable_pmu; }
+extern "C" bool is_pmu_enabled() { return g_enable_pmu; }
 
 // ---------------------------------------------------------------------------
 // Low-level MMIO helpers (internal use only)
@@ -201,7 +201,7 @@ void pmu_aicpu_init(const uint32_t *physical_core_ids, int num_cores) {
     }
 
     // Program event selectors and start PMU counters on all cores
-    const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(pmu_event_type);
+    const PmuEventConfig *evt = pmu_resolve_event_config_a2a3(static_cast<PmuEventType>(pmu_event_type));
     if (evt == nullptr) {
         evt = &PMU_EVENTS_A2A3_PIPE_UTIL;
     }

--- a/src/a2a3/platform/src/aicpu/tensor_dump_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/tensor_dump_aicpu.cpp
@@ -13,7 +13,6 @@
  * @file tensor_dump_aicpu.cpp
  * @brief AICPU tensor dump collection implementation
  *
- * Mirrors l2_perf_collector_aicpu.cpp patterns:
  * - Per-thread DumpBufferState with SPSC free queues
  * - Per-thread ready queue for handing off full metadata buffers
  * - Per-thread circular arena for tensor payload data
@@ -55,9 +54,9 @@ extern "C" uint64_t get_platform_dump_base() { return g_platform_dump_base; }
 
 static bool g_enable_dump_tensor = false;
 
-extern "C" void set_enable_dump_tensor(bool enable) { g_enable_dump_tensor = enable; }
+extern "C" void set_dump_tensor_enabled(bool enable) { g_enable_dump_tensor = enable; }
 
-extern "C" bool get_enable_dump_tensor() { return g_enable_dump_tensor; }
+extern "C" bool is_dump_tensor_enabled() { return g_enable_dump_tensor; }
 
 bool get_tensor_dump_role_from_direction(ArgDirection dir, TensorDumpRole *role) {
     switch (dir) {

--- a/src/a2a3/platform/src/host/pmu_collector.cpp
+++ b/src/a2a3/platform/src/host/pmu_collector.cpp
@@ -32,7 +32,7 @@ PmuCollectorHost::~PmuCollectorHost() = default;
 
 int PmuCollectorHost::init(
     int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
-    uint32_t event_type, PmuAllocCallback alloc_cb, PmuRegisterCallback register_cb, PmuFreeCallback free_cb,
+    PmuEventType event_type, PmuAllocCallback alloc_cb, PmuRegisterCallback register_cb, PmuFreeCallback free_cb,
     void *user_data, int device_id
 ) {
     if (num_cores <= 0 || num_threads <= 0 || kernel_args_pmu_data_base == nullptr || alloc_cb == nullptr ||
@@ -87,7 +87,7 @@ int PmuCollectorHost::init(
     std::memset(shm_host_, 0, shm_size_);
 
     // Write event_type into header so AICPU can read it from SHM
-    get_pmu_header(shm_host_)->event_type = event_type;
+    get_pmu_header(shm_host_)->event_type = static_cast<uint32_t>(event_type);
 
     // Publish device address to KernelArgs
     *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(shm_dev_);
@@ -224,7 +224,7 @@ void PmuCollectorHost::write_buffer_to_csv(int core_id, int thread_idx, const vo
             }
             csv_file_ << ',' << r.pmu_counters[k];
         }
-        csv_file_ << ',' << event_type_ << '\n';
+        csv_file_ << ',' << static_cast<uint32_t>(event_type_) << '\n';
     }
     csv_file_.flush();
 }

--- a/src/a2a3/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a2a3/platform/src/host/tensor_dump_collector.cpp
@@ -13,7 +13,6 @@
  * @file tensor_dump_collector.cpp
  * @brief Host-side tensor dump collector implementation
  *
- * Mirrors l2_perf_collector.cpp patterns:
  * - DumpMemoryManager: background thread polling dump ready queues
  * - TensorDumpCollector: lifecycle management, arena reads, file export
  */

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -409,7 +409,7 @@ struct AicpuExecutor {
 #endif
 
 #if PTO2_PROFILING
-                if (get_enable_pmu()) {
+                if (is_pmu_enabled()) {
                     pmu_aicpu_record_task(
                         core_id, thread_idx, slot_state.task->task_id.raw,
                         slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type
@@ -424,7 +424,7 @@ struct AicpuExecutor {
                 cur_thread_completed++;
                 if (mixed_complete) {
 #if PTO2_PROFILING
-                    if (get_enable_dump_tensor()) {
+                    if (is_dump_tensor_enabled()) {
                         dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                             thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
                             [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -957,7 +957,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #if PTO2_PROFILING
         // Assign perf buffers to cores early so profiling captures all tasks
         // (total_tasks written to header later when orchestrator completes)
-        if (get_enable_l2_swimlane()) {
+        if (is_l2_swimlane_enabled()) {
             l2_perf_aicpu_init_profiling(runtime);
             // Initialize phase profiling for scheduler threads + orchestrator threads
             l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
@@ -965,14 +965,14 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         }
 #endif
 #if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
+        if (is_dump_tensor_enabled()) {
             dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
         }
 #endif
 
 #if PTO2_PROFILING
         // Initialize PMU: program events, start counters, and pop initial buffers
-        if (get_enable_pmu()) {
+        if (is_pmu_enabled()) {
             pmu_aicpu_init(physical_core_ids_, cores_total_num_);
             DEV_INFO("PMU profiling started on %d cores", cores_total_num_);
         }
@@ -991,7 +991,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
 #if PTO2_PROFILING
-    bool l2_perf_enabled = get_enable_l2_swimlane();
+    bool l2_perf_enabled = is_l2_swimlane_enabled();
 #endif
 
     // Scheduler profiling counters
@@ -1192,7 +1192,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
 #endif
                     ResourceCount rc = shape_resource_count(shape);
 #if PTO2_PROFILING
-                    if (get_enable_dump_tensor()) {
+                    if (is_dump_tensor_enabled()) {
                         dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                             thread_idx, *slot_state, TensorDumpStage::BEFORE_DISPATCH,
                             [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -1301,7 +1301,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
                 Cluster &c = tracker.clusters[ci];
                 ResourceCount rc = shape_resource_count(shape);
 #if PTO2_PROFILING
-                if (get_enable_dump_tensor()) {
+                if (is_dump_tensor_enabled()) {
                     dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                         thread_idx, *slot_state, TensorDumpStage::BEFORE_DISPATCH,
                         [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -1679,12 +1679,12 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
         l2_perf_aicpu_flush_buffers(thread_idx, core_assignments_[thread_idx], core_num);
         l2_perf_aicpu_flush_phase_buffers(thread_idx);
     }
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_flush_buffers(thread_idx, core_assignments_[thread_idx], core_num);
     }
 #endif
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_flush(thread_idx);
     }
 #endif
@@ -1866,7 +1866,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = get_enable_l2_swimlane();
+            rt->orchestrator.enable_l2_swimlane = is_l2_swimlane_enabled();
 #endif
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
@@ -1887,7 +1887,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Each orchestrator thread sets its own phase buffer index (thread-local)
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif
@@ -1944,7 +1944,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -1964,7 +1964,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write core-to-thread mapping (one-time, after orchestration)
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 l2_perf_aicpu_init_core_assignments(cores_total_num_);
                 for (int32_t t = 0; t < sched_thread_num_; t++) {
                     l2_perf_aicpu_write_core_assignments_for_thread(t, core_assignments_[t], core_count_per_thread_[t]);
@@ -1992,7 +1992,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             );
 #endif
             total_tasks_ = pto2_task_count;
-            if (get_enable_l2_swimlane() && pto2_task_count > 0) {
+            if (is_l2_swimlane_enabled() && pto2_task_count > 0) {
                 l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(pto2_task_count));
             }
             orchestrator_done_ = true;
@@ -2090,7 +2090,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         if (shutdown_count > 0) {
 #if PTO2_PROFILING
             // Restore PMU CTRL registers for this thread's cores before AICore shutdown
-            if (get_enable_pmu()) {
+            if (is_pmu_enabled()) {
                 pmu_aicpu_finalize(shutdown_cores, shutdown_count);
             }
 #endif

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -63,9 +63,9 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * Protocol State Machine:
  * 1. Initialization: AICPU sets aicpu_ready=1
  * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU assigns task pointer and sets task_status=1
- * 4. Task Execution: AICore reads task, executes, sets task_status=0
- * 5. Task Completion: AICPU reads task_status=0, clears task=0
+ * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE after updating the per-core task pointer
+ * 4. Task Execution: AICore reads the dispatched task and executes
+ * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
  * 6. Shutdown: AICPU sets control=1, AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
@@ -89,23 +89,18 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = no task, non-zero = PTO2DispatchPayload*)
- * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
- * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;            // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                   // Task pointer: 0=no task, non-zero=PTO2DispatchPayload*
-    volatile int32_t task_status;             // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;                 // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;              // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;   // Performance records address
-    volatile uint32_t l2_perf_buffer_status;  // 0 = not full, 1 == full
-    volatile uint32_t physical_core_id;       // Physical core ID
-    volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                  // Task pointer: 0=no task, non-zero=PTO2DispatchPayload*
+    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t l2_perf_records_addr;  // Performance records address
+    volatile uint32_t physical_core_id;      // Physical core ID
+    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
         enable_profiling_flag;  // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
 } __attribute__((aligned(64)));

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -123,9 +123,16 @@ struct AicpuExecutor {
     diagnose_stuck_state(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num, Handshake *hank);
 
     // Helper functions (inline to avoid linker issues, not always_inline to preserve barriers)
+    //
+    // resolve_task_dependencies also handles post-completion profiling hooks
+    // (AFTER_COMPLETION tensor dump + per-task PMU record) so that callers
+    // walk one boundary instead of sprinkling three #if PTO2_PROFILING blocks
+    // after every resolve site. core_id / core_type are only read when the
+    // relevant profiling flag is enabled.
     inline void resolve_task_dependencies(
-        Task *task, Runtime &runtime, int thread_idx, int *cur_ready_queue_aic, int &cur_aic_tail,
-        int &cur_aic_ready_count, int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+        Task *task, Runtime &runtime, int thread_idx, int core_id, CoreType core_type, int *cur_ready_queue_aic,
+        int &cur_aic_tail, int &cur_aic_ready_count, int *cur_ready_queue_aiv, int &cur_aiv_tail,
+        int &cur_aiv_ready_count
     );
 
     inline bool try_dispatch_task(
@@ -156,17 +163,19 @@ collect_task_tensor_buffer_addrs(const Runtime &runtime, const Task &task, uint6
 
 // ===== Helper Function Implementations =====
 
-// Resolve dependencies: decrement fanin and enqueue newly ready tasks
+// Resolve dependencies: decrement fanin and enqueue newly ready tasks.
+// Also handles post-completion profiling hooks (AFTER_COMPLETION tensor dump
+// + per-task PMU record) so callers don't need to re-check profiling flags.
 inline void AicpuExecutor::resolve_task_dependencies(
-    Task *task, Runtime &runtime, int thread_idx, int *cur_ready_queue_aic, int &cur_aic_tail, int &cur_aic_ready_count,
-    int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+    Task *task, Runtime &runtime, int thread_idx, int core_id, CoreType core_type, int *cur_ready_queue_aic,
+    int &cur_aic_tail, int &cur_aic_ready_count, int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
 ) {
     if (task == nullptr) {
         return;
     }
 
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
         if (callable_addr != 0) {
             const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
@@ -182,8 +191,13 @@ inline void AicpuExecutor::resolve_task_dependencies(
             );
         }
     }
+    if (is_pmu_enabled()) {
+        pmu_aicpu_record_task(core_id, thread_idx, static_cast<uint64_t>(task->task_id), task->func_id, core_type);
+    }
 #else
     (void)thread_idx;
+    (void)core_id;
+    (void)core_type;
 #endif
 
     for (int j = 0; j < task->fanout_count; j++) {
@@ -250,7 +264,7 @@ inline bool AicpuExecutor::try_dispatch_task(
     );
 
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         Task *task = runtime.get_task(task_id);
         if (task != nullptr) {
             uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
@@ -337,14 +351,14 @@ int AicpuExecutor::init(Runtime *runtime) {
         dispatch_timestamps_[i] = 0;
         core_dispatch_counts_[i] = 0;
     }
-    if (get_enable_l2_swimlane()) {
+    if (is_l2_swimlane_enabled()) {
         l2_perf_aicpu_init_profiling(runtime);
     }
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_init(thread_num_);
     }
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
         LOG_INFO("PMU profiling started on %d cores", cores_total_num_);
     }
@@ -661,7 +675,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
     int verification_warning_count = 0;
     const int MAX_VERIFICATION_WARNINGS = 10;
-    bool l2_perf_enabled = get_enable_l2_swimlane();
+    bool l2_perf_enabled = is_l2_swimlane_enabled();
 
     // Extract array pointers as local variables for better readability and performance
     int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
@@ -785,35 +799,18 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                     Task *prev_running_task = runtime.get_task(prev_running_id);
                     resolve_task_dependencies(
-                        prev_running_task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                        prev_running_task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic,
+                        cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
-
-#if PTO2_PROFILING
-                    if (get_enable_pmu()) {
-                        pmu_aicpu_record_task(
-                            core_id, thread_idx, static_cast<uint64_t>(prev_running_id), prev_running_task->func_id,
-                            h->core_type
-                        );
-                    }
-#endif
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 Task *task = runtime.get_task(completed_task_id);
                 resolve_task_dependencies(
-                    task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                    cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic, cur_aic_tail,
+                    cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
-
-#if PTO2_PROFILING
-                if (get_enable_pmu()) {
-                    pmu_aicpu_record_task(
-                        core_id, thread_idx, static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
-                    );
-                }
-#endif
 
                 made_progress = true;
 
@@ -866,18 +863,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                     Task *prev_running_task = runtime.get_task(prev_running_id);
                     resolve_task_dependencies(
-                        prev_running_task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                        prev_running_task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic,
+                        cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
-
-#if PTO2_PROFILING
-                    if (get_enable_pmu()) {
-                        pmu_aicpu_record_task(
-                            core_id, thread_idx, static_cast<uint64_t>(prev_running_id), prev_running_task->func_id,
-                            h->core_type
-                        );
-                    }
-#endif
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
@@ -935,17 +923,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                 Task *task = runtime.get_task(completed_task_id);
                 resolve_task_dependencies(
-                    task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                    cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic, cur_aic_tail,
+                    cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
-
-#if PTO2_PROFILING
-                if (get_enable_pmu()) {
-                    pmu_aicpu_record_task(
-                        core_id, thread_idx, static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
-                    );
-                }
-#endif
 
                 made_progress = true;
 
@@ -1111,21 +1091,21 @@ int AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
 
     // Flush performance buffers for cores managed by this thread
-    if (get_enable_l2_swimlane()) {
+    if (is_l2_swimlane_enabled()) {
         l2_perf_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
 #if PTO2_PROFILING
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_flush(thread_idx);
     }
 #endif
 
 #if PTO2_PROFILING
     // Restore PMU CTRL registers for this thread's cores before AICore shutdown
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_finalize(cur_thread_cores, thread_cores_num_[thread_idx]);
     }
 #endif

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -21,8 +21,8 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 ## Execution Flow (Device)
 
 1. `aicpu_executor.cpp` performs core discovery, handshake initialization, and ready-queue seeding using `Runtime::get_initial_ready_tasks`.
-2. Scheduler threads maintain per-core and global ready queues. When a task is ready, the scheduler writes its pointer to the core's `Handshake` and sets `task_status=1`.
-3. AICore reads the handshake, executes the kernel at `Task::function_bin_addr`, and writes `task_status=0` on completion.
+2. Scheduler threads maintain per-core and global ready queues. When a task is ready, the scheduler publishes the task pointer and signals the core via `DATA_MAIN_BASE`.
+3. AICore reads the task_id from `DATA_MAIN_BASE`, executes the kernel at `Task::function_bin_addr`, and writes FIN to `COND` on completion.
 4. AICPU observes completion, resolves dependencies by decrementing fanin, and enqueues newly-ready tasks.
 5. The executor shuts down cores by setting `Handshake::control=1` after all tasks complete.
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -86,9 +86,9 @@
  * Protocol State Machine:
  * 1. Initialization: AICPU sets aicpu_ready=1
  * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU assigns task pointer and sets task_status=1
- * 4. Task Execution: AICore reads task, executes, sets task_status=0
- * 5. Task Completion: AICPU reads task_status=0, clears task=0
+ * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE with the task_id after publishing Task*
+ * 4. Task Execution: AICore reads the task and executes
+ * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
  * 6. Shutdown: AICPU sets control=1, AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
@@ -112,26 +112,20 @@
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = no task assigned)
- * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
- * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  * - l2_perf_records_addr: Written by AICPU, read by AICore (performance records address)
- * - l2_perf_buffer_status: Written by both (AICPU=1 on buffer full, AICore=0 on buffer empty)
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;            // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                   // Task pointer: 0=no task, non-zero=Task* address
-    volatile int32_t task_status;             // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;                 // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;              // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;   // Performance records address
-    volatile uint32_t l2_perf_buffer_status;  // 0 = not full, 1 = full
-    volatile uint32_t physical_core_id;       // Physical core ID
-    volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                  // Task pointer: 0=no task, non-zero=Task* address
+    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t l2_perf_records_addr;  // Performance records address
+    volatile uint32_t physical_core_id;      // Physical core ID
+    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
         enable_profiling_flag;  // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
 } __attribute__((aligned(64)));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -445,7 +445,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = get_enable_l2_swimlane();
+            rt->orchestrator.enable_l2_swimlane = is_l2_swimlane_enabled();
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
@@ -467,7 +467,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif
@@ -552,7 +552,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -585,7 +585,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             pto2_submitted_tasks = total_tasks;
 #endif
 
-            if (get_enable_l2_swimlane() && total_tasks > 0) {
+            if (is_l2_swimlane_enabled() && total_tasks > 0) {
                 l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(total_tasks));
             }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -539,7 +539,7 @@ Each AICore worker has a `Handshake` struct in shared memory:
 
 ### 9.2 Register-Based Dispatch
 
-Instead of polling `Handshake.task_status`, the production protocol uses hardware registers.
+Instead of polling a shared-memory status flag, the production protocol uses hardware registers.
 
 > **Multi-ring note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions. See [MULTI_RING.md §6](MULTI_RING.md).
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -231,7 +231,7 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 L2 swimlane enablement is published through the handshake
 `enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
-AICPU code reads it via `get_enable_l2_swimlane()` (set at launch time
+AICPU code reads it via `is_l2_swimlane_enabled()` (set at launch time
 by the platform from `kernel_args.l2_perf_data_base` + the bitmask). It
 controls **data collection**, NOT log output.
 
@@ -252,7 +252,7 @@ controls **data collection**, NOT log output.
 
 ```cpp
 // AICPU path — read enablement from the platform accessor, not the Runtime struct.
-if (get_enable_l2_swimlane()) {
+if (is_l2_swimlane_enabled()) {
     // ... perf-collection code ...
 }
 ```

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -93,23 +93,18 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
- * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
- * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;            // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                   // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
-    volatile int32_t task_status;             // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;                 // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;              // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;   // Performance records address
-    volatile uint32_t l2_perf_buffer_status;  // 0 = not full, 1 == full
-    volatile uint32_t physical_core_id;       // Physical core ID
-    volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                  // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t l2_perf_records_addr;  // Performance records address
+    volatile uint32_t physical_core_id;      // Physical core ID
+    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
         enable_profiling_flag;  // Generic profiling-related flags; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
 } __attribute__((aligned(64)));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -351,7 +351,7 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
     if (core_num == 0) return 0;
 
 #if PTO2_PROFILING
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_finalize(cores, core_num);
     }
 #endif
@@ -743,7 +743,7 @@ void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
 ) {
 #if PTO2_PROFILING
-    if (get_enable_l2_swimlane()) {
+    if (is_l2_swimlane_enabled()) {
         // Flush orchestrator's phase record buffer
         l2_perf_aicpu_flush_phase_buffers(thread_idx);
     }
@@ -797,7 +797,7 @@ void SchedulerContext::on_orchestration_done(
     // Write core-to-thread mapping AFTER reassignment so the profiling data
     // reflects the final distribution (all active_sched_threads_, including
     // former orchestrator threads when orch_to_sched_ is enabled).
-    if (get_enable_l2_swimlane()) {
+    if (is_l2_swimlane_enabled()) {
         l2_perf_aicpu_init_core_assignments(cores_total_num_);
         for (int32_t t = 0; t < active_sched_threads_; t++) {
             l2_perf_aicpu_write_core_assignments_for_thread(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -78,7 +78,7 @@ void SchedulerContext::complete_slot_task(
     bool mixed_complete = sched_->on_subtask_complete(slot_state);
     if (mixed_complete) {
 #if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
+        if (is_dump_tensor_enabled()) {
             dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                 thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
                 [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -156,7 +156,7 @@ void SchedulerContext::complete_slot_task(
 #endif
 
 #if PTO2_PROFILING
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_record_task(
             core_id, thread_idx, slot_state.task->task_id.raw,
             slot_state.task->kernel_id[static_cast<int32_t>(subslot)], hank[core_id].core_type

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -194,7 +194,7 @@ void SchedulerContext::dispatch_block(
     bool to_pending
 ) {
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
             thread_idx, slot_state, TensorDumpStage::BEFORE_DISPATCH,
             [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -329,21 +329,21 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         DEV_INFO("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
-        if (get_enable_l2_swimlane()) {
+        if (is_l2_swimlane_enabled()) {
             l2_perf_aicpu_init_profiling(runtime);
             l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
             l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
 #if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
+        if (is_dump_tensor_enabled()) {
             dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
         }
 #endif
 
 #if PTO2_PROFILING
         // Initialize PMU: program events, start counters, and pop initial buffers
-        if (get_enable_pmu()) {
+        if (is_pmu_enabled()) {
             pmu_aicpu_init(physical_core_ids_, cores_total_num_);
             DEV_INFO("PMU profiling started on %d cores", cores_total_num_);
         }
@@ -364,7 +364,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
     l2_perf.reset();
-    l2_perf.l2_perf_enabled = get_enable_l2_swimlane();
+    l2_perf.l2_perf_enabled = is_l2_swimlane_enabled();
 #endif
 
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
@@ -582,12 +582,12 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 #endif
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_flush(thread_idx);
     }
 #endif
 #if PTO2_PROFILING
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_flush_buffers(
             thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
         );

--- a/src/a5/platform/include/aicore/pmu_collector_aicore.h
+++ b/src/a5/platform/include/aicore/pmu_collector_aicore.h
@@ -12,7 +12,7 @@
  * @file pmu_collector_aicore.h
  * @brief AICore-side PMU gate + per-task MMIO record (a5)
  *
- * Split of duties (mirrors a2a3 perf):
+ * Split of duties:
  *   - AICPU programs event selectors + starts PMU_CTRL_0/1 once at init,
  *     and restores them at finalize.
  *   - AICore gates counting around each kernel execution via CTRL SPR bit 0
@@ -25,8 +25,7 @@
  *
  * The two dual_issue_slots exist because AICore's dual-issue dispatch
  * can have up to two tasks in flight per core — the parity task_id & 1
- * keeps N and N+1 from colliding. This is the same reason a2a3 perf
- * uses wip[2].
+ * keeps N and N+1 from colliding.
  */
 
 #ifndef PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_
@@ -60,8 +59,7 @@ __aicore__ __attribute__((always_inline)) static inline void pmu_aicore_end() {
  * Must be called after pmu_aicore_end() has frozen the counters.
  * AICPU picks up the slot and commits it via pmu_aicpu_complete_record.
  *
- * Leaves func_id and core_type untouched — those are AICPU-owned fields,
- * mirroring the a2a3 perf producer/consumer split.
+ * Leaves func_id and core_type untouched — those are AICPU-owned fields.
  *
  * @param buf       Per-core PmuBuffer (from Handshake.pmu_buffer_addr)
  * @param reg_base  Per-core PMU MMIO base (from Handshake.pmu_reg_base)

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -36,13 +36,11 @@
  * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
  * entry (onboard) before `l2_perf_aicpu_init_profiling()` so AICPU code can
  * read perf state without reaching into the generic `Runtime` struct.
- * Mirrors the `set_platform_dump_base` / `set_enable_dump_tensor` pattern
- * used by tensor dump and PMU.
  */
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
 extern "C" uint64_t get_platform_l2_perf_base();
-extern "C" void set_enable_l2_swimlane(bool enable);
-extern "C" bool get_enable_l2_swimlane();
+extern "C" void set_l2_swimlane_enabled(bool enable);
+extern "C" bool is_l2_swimlane_enabled();
 
 /**
  * Initialize performance profiling

--- a/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
@@ -13,7 +13,7 @@
  * @file pmu_collector_aicpu.h
  * @brief AICPU-side PMU collection interface (a5)
  *
- * Split of duties (mirrors a2a3 perf):
+ * Split of duties:
  *   - AICPU owns init (event selectors, PMU_CTRL_0/1 start) and finalize
  *     (CTRL restore). It also publishes per-core pmu_buffer_addr /
  *     pmu_reg_base into Handshake at init time so AICore can do the
@@ -51,8 +51,8 @@
 
 extern "C" void set_platform_pmu_base(uint64_t pmu_data_base);
 extern "C" uint64_t get_platform_pmu_base();
-extern "C" void set_enable_pmu(bool enable);
-extern "C" bool get_enable_pmu();
+extern "C" void set_pmu_enabled(bool enable);
+extern "C" bool is_pmu_enabled();
 
 /**
  * Initialize PMU for all cores.
@@ -95,8 +95,6 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
  * Every call bumps PmuBufferState::total_record_count so host can cross-check
  * collected + dropped against the AICPU's attempted-commit count.
  * No-op if PMU is not enabled or the core has no PMU buffer bound.
- *
- * Mirrors a2a3's perf_aicpu_complete_record.
  *
  * @param core_id     Logical core index
  * @param thread_idx  AICPU thread index (reserved; not used on a5 memcpy path)

--- a/src/a5/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/a5/platform/include/aicpu/tensor_dump_aicpu.h
@@ -56,14 +56,14 @@ uint64_t get_platform_dump_base();
  *
  * @param enable true to enable tensor dump, false to disable
  */
-void set_enable_dump_tensor(bool enable);
+void set_dump_tensor_enabled(bool enable);
 
 /**
  * Get whether tensor dump is enabled for this execution.
  *
  * @return true if tensor dump is enabled
  */
-bool get_enable_dump_tensor();
+bool is_dump_tensor_enabled();
 
 #ifdef __cplusplus
 }

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -57,8 +57,8 @@ struct L2PerfRecord {
     uint64_t duration;    // Execution duration (end - start)
 
     // AICPU-side timestamps (written by AICPU, not AICore)
-    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore (task_status set to 1)
-    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion (task_status back to 0)
+    uint64_t dispatch_time;  // AICPU timestamp: when task was dispatched to AICore
+    uint64_t finish_time;    // AICPU timestamp: when AICPU observed task completion
 
     // AICore writes the register dispatch token (low 32 bits only) zero-extended into task_id.
     // For multi-ring runtimes (tensormap_and_ringbuffer, aicpu_build_graph), AICPU overwrites

--- a/src/a5/platform/include/common/pmu_profiling.h
+++ b/src/a5/platform/include/common/pmu_profiling.h
@@ -109,8 +109,8 @@ constexpr PmuEventConfig PMU_EVENTS_A5_L2_CACHE = {
  * Resolve an event type to the DAV_3510 event table. Returns nullptr for
  * unknown values (caller falls back to PIPE_UTILIZATION).
  */
-inline const PmuEventConfig *pmu_resolve_event_config_a5(uint32_t event_type) {
-    switch (static_cast<PmuEventType>(event_type)) {
+inline const PmuEventConfig *pmu_resolve_event_config_a5(PmuEventType event_type) {
+    switch (event_type) {
     case PmuEventType::ARITHMETIC_UTILIZATION:
         return &PMU_EVENTS_A5_ARITHMETIC;
     case PmuEventType::PIPE_UTILIZATION:

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -14,8 +14,7 @@
  * @brief Tensor dump data structures for device-to-host tensor collection (memcpy-based)
  *
  * A5 simplified design: pre-allocated buffers + direct write + memcpy collect-after-sync.
- * Mirrors L2PerfCollector pattern — no shared memory, no background threads,
- * no SPSC queues.
+ * No shared memory, no background threads, no SPSC queues.
  *
  * Memory layout (allocated only when enable_dump_tensor=true):
  *

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -81,7 +81,7 @@ public:
      * @return 0 on success
      */
     int initialize(
-        int num_cores, uint32_t event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
+        int num_cores, PmuEventType event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
         PmuFreeCallback free_cb, PmuCopyToDeviceCallback copy_to_dev_cb, PmuCopyFromDeviceCallback copy_from_dev_cb
     );
 
@@ -110,7 +110,7 @@ private:
     std::vector<void *> core_buffers_dev_;  // PmuBuffer* per core (device)
 
     int num_cores_{0};
-    uint32_t event_type_{0};
+    PmuEventType event_type_{PmuEventType::PIPE_UTILIZATION};
     size_t pmu_buffer_bytes_{0};
     size_t setup_region_bytes_{0};
 
@@ -133,7 +133,7 @@ private:
 inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
     PmuEventType resolved = PmuEventType::PIPE_UTILIZATION;
     if (requested_event_type > 0 &&
-        pmu_resolve_event_config_a5(static_cast<uint32_t>(requested_event_type)) != nullptr) {
+        pmu_resolve_event_config_a5(static_cast<PmuEventType>(requested_event_type)) != nullptr) {
         resolved = static_cast<PmuEventType>(requested_event_type);
     } else if (requested_event_type != 0) {
         LOG_WARN(
@@ -146,7 +146,7 @@ inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
         return resolved;
     }
     int val = std::atoi(pmu_env);
-    if (val > 0 && pmu_resolve_event_config_a5(static_cast<uint32_t>(val)) != nullptr) {
+    if (val > 0 && pmu_resolve_event_config_a5(static_cast<PmuEventType>(val)) != nullptr) {
         resolved = static_cast<PmuEventType>(val);
         LOG_INFO("PMU event type set to %u from SIMPLER_PMU_EVENT_TYPE", static_cast<uint32_t>(resolved));
         return resolved;

--- a/src/a5/platform/include/host/tensor_dump_collector.h
+++ b/src/a5/platform/include/host/tensor_dump_collector.h
@@ -13,7 +13,6 @@
  * @file tensor_dump_collector.h
  * @brief Host-side tensor dump collector (memcpy-based)
  *
- * Mirrors L2PerfCollector architecture:
  * - Host allocates per-thread DumpBuffers + arenas on device
  * - AICPU writes records and payload during execution
  * - After stream sync, host copies everything back via rtMemcpy/memcpy
@@ -87,7 +86,7 @@ struct DumpedTensor {
 /**
  * Host-side tensor dump collector.
  *
- * Lifecycle (mirrors L2PerfCollector):
+ * Lifecycle:
  *   1. initialize() — allocate DumpSetupHeader + per-thread DumpBuffers + arenas,
  *      caller reads get_dump_setup_device_ptr() and sets kernel_args.dump_data_base
  *   2. (AICPU execution writes records and payload data)

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -86,11 +86,11 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     // The dump base address is only the backing storage location.
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
-    set_enable_dump_tensor(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_dump_tensor_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_perf_base(k_args->l2_perf_data_base);
-    set_enable_l2_swimlane(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
+    set_l2_swimlane_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
-    set_enable_pmu(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
+    set_pmu_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
     if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -372,14 +372,11 @@ int DeviceRunner::run(
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
-        runtime.workers[i].task_status = 0;
         // Set core type: first 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
         runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
         runtime.workers[i].l2_perf_records_addr = static_cast<uint64_t>(0);
-        runtime.workers[i].l2_perf_buffer_status = 0;
     }
 
     // Set function_bin_addr for all tasks: func_id_to_addr_[] stores CoreCallable
@@ -427,7 +424,7 @@ int DeviceRunner::run(
 
     // Initialize PMU profiling if enabled
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, static_cast<uint32_t>(pmu_event_type_));
+        rc = init_pmu(num_aicore, pmu_event_type_);
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -528,8 +525,8 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG(
-            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, workers[i].aicore_done,
-            workers[i].aicpu_ready, workers[i].control, workers[i].task
+            "  Core %d: aicore_done=%d aicpu_ready=%d task=%d", i, workers[i].aicore_done, workers[i].aicpu_ready,
+            workers[i].task
         );
     }
 }
@@ -860,7 +857,7 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
     return 0;
 }
 
-int DeviceRunner::init_pmu(int num_aicore, uint32_t event_type) {
+int DeviceRunner::init_pmu(int num_aicore, PmuEventType event_type) {
     auto alloc_cb = [](size_t size) -> void * {
         void *ptr = nullptr;
         int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -236,9 +236,9 @@ public:
      * corresponding `enable_*_` members directly. Moved off the generic
      * Runtime struct / run() arg list so all three travel the same way.
      */
-    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
-    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
-    void set_enable_pmu(int enable_pmu) {
+    void set_l2_swimlane_enabled(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
+    void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
@@ -459,7 +459,7 @@ private:
      * @param event_type   Resolved PmuEventType value
      * @return 0 on success, error code on failure
      */
-    int init_pmu(int num_aicore, uint32_t event_type);
+    int init_pmu(int num_aicore, PmuEventType event_type);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -467,7 +467,7 @@ private:
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
-    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -196,9 +196,9 @@ int run_runtime(
             return rc;
         }
 
-        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
-        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
-        runner->set_enable_pmu(enable_pmu);
+        runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
+        runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
+        runner->set_pmu_enabled(enable_pmu);
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -152,10 +152,10 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        set_enable_dump_tensor_func_ =
-            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_dump_tensor"));
-        if (set_enable_dump_tensor_func_ == nullptr) {
-            LOG_ERROR("dlsym failed for set_enable_dump_tensor: %s", dlerror());
+        set_dump_tensor_enabled_func_ =
+            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_dump_tensor_enabled"));
+        if (set_dump_tensor_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_dump_tensor_enabled: %s", dlerror());
             return -1;
         }
 
@@ -166,19 +166,19 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        set_enable_l2_swimlane_func_ =
-            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_l2_swimlane"));
-        if (set_enable_l2_swimlane_func_ == nullptr) {
-            LOG_ERROR("dlsym failed for set_enable_l2_swimlane: %s", dlerror());
+        set_l2_swimlane_enabled_func_ =
+            reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_l2_swimlane_enabled"));
+        if (set_l2_swimlane_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_l2_swimlane_enabled: %s", dlerror());
             return -1;
         }
 
         // PMU bindings — tolerated as optional so a5sim keeps building against
         // pre-PMU AICPU SOs during the transition. Missing symbols mean PMU
-        // is unavailable on this build and set_enable_pmu_func_ stays null.
+        // is unavailable on this build and set_pmu_enabled_func_ stays null.
         set_platform_pmu_base_func_ =
             reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_pmu_base"));
-        set_enable_pmu_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_enable_pmu"));
+        set_pmu_enabled_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_pmu_enabled"));
 
         aicpu_so_loaded_ = true;
         LOG_INFO("DeviceRunner(sim): Loaded aicpu_execute from %s", aicpu_so_path_.c_str());
@@ -332,9 +332,7 @@ int DeviceRunner::run(
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
         runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].control = 0;
         runtime.workers[i].task = 0;
-        runtime.workers[i].task_status = 0;
         // First 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
         runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
@@ -382,7 +380,7 @@ int DeviceRunner::run(
 
     // Initialize PMU profiling if enabled
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, static_cast<uint32_t>(pmu_event_type_));
+        rc = init_pmu(num_aicore, pmu_event_type_);
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -434,9 +432,9 @@ int DeviceRunner::run(
     // Set platform regs in the AICPU .so before launching threads
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_enable_dump_tensor_func_(enable_dump_tensor_);
+    set_dump_tensor_enabled_func_(enable_dump_tensor_);
     set_platform_l2_perf_base_func_(kernel_args_.l2_perf_data_base);
-    set_enable_l2_swimlane_func_(enable_l2_swimlane_);
+    set_l2_swimlane_enabled_func_(enable_l2_swimlane_);
 
     // Publish PMU session state to the AICPU SO (dlsym symbols are optional —
     // older SOs without PMU support leave these nullptr, which simply turns
@@ -444,8 +442,8 @@ int DeviceRunner::run(
     if (set_platform_pmu_base_func_ != nullptr) {
         set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
     }
-    if (set_enable_pmu_func_ != nullptr) {
-        set_enable_pmu_func_(enable_pmu_);
+    if (set_pmu_enabled_func_ != nullptr) {
+        set_pmu_enabled_func_(enable_pmu_);
     }
 
     // Launch AICPU threads (over-launch for affinity gate)
@@ -530,8 +528,8 @@ void DeviceRunner::print_handshake_results() {
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG(
-            "  Core %d: aicore_done=%d aicpu_ready=%d control=%d task=%d", i, last_runtime_->workers[i].aicore_done,
-            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].control, last_runtime_->workers[i].task
+            "  Core %d: aicore_done=%d aicpu_ready=%d task=%d", i, last_runtime_->workers[i].aicore_done,
+            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].task
         );
     }
 }
@@ -543,11 +541,11 @@ void DeviceRunner::unload_executor_binaries() {
         aicpu_execute_func_ = nullptr;
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
-        set_enable_dump_tensor_func_ = nullptr;
+        set_dump_tensor_enabled_func_ = nullptr;
         set_platform_l2_perf_base_func_ = nullptr;
-        set_enable_l2_swimlane_func_ = nullptr;
+        set_l2_swimlane_enabled_func_ = nullptr;
         set_platform_pmu_base_func_ = nullptr;
-        set_enable_pmu_func_ = nullptr;
+        set_pmu_enabled_func_ = nullptr;
         aicpu_so_loaded_ = false;
     }
     if (!aicpu_so_path_.empty()) {
@@ -836,7 +834,7 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
     return 0;
 }
 
-int DeviceRunner::init_pmu(int num_aicore, uint32_t event_type) {
+int DeviceRunner::init_pmu(int num_aicore, PmuEventType event_type) {
     auto alloc_cb = [](size_t size) -> void * {
         return malloc(size);
     };

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -150,9 +150,9 @@ public:
      * corresponding `enable_*_` members directly. Moved off the generic
      * Runtime struct / run() arg list so all three travel the same way.
      */
-    void set_enable_l2_swimlane(bool enable) { enable_l2_swimlane_ = enable; }
-    void set_enable_dump_tensor(bool enable) { enable_dump_tensor_ = enable; }
-    void set_enable_pmu(int enable_pmu) {
+    void set_l2_swimlane_enabled(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
+    void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
@@ -232,10 +232,10 @@ private:
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
-    void (*set_enable_dump_tensor_func_)(bool){nullptr};
+    void (*set_dump_tensor_enabled_func_)(bool){nullptr};
     void (*set_platform_l2_perf_base_func_)(uint64_t){nullptr};
-    void (*set_enable_l2_swimlane_func_)(bool){nullptr};
-    void (*set_enable_pmu_func_)(bool){nullptr};
+    void (*set_l2_swimlane_enabled_func_)(bool){nullptr};
+    void (*set_pmu_enabled_func_)(bool){nullptr};
     std::string aicpu_so_path_;
     std::string aicore_so_path_;
 
@@ -287,7 +287,7 @@ private:
      * the setup-header pointer into kernel_args.pmu_data_base. pmu_reg_addrs
      * stays 0 on sim (no hardware PMU model).
      */
-    int init_pmu(int num_aicore, uint32_t event_type);
+    int init_pmu(int num_aicore, PmuEventType event_type);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -295,7 +295,7 @@ private:
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
-    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_enable_pmu()
+    PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -190,9 +190,9 @@ int run_runtime(
         // Phase 2: publish diagnostics enablement to the DeviceRunner so run()
         // and its helpers can read the three sub-features uniformly (via
         // members, not Runtime / run() args).
-        runner->set_enable_l2_swimlane(enable_l2_swimlane != 0);
-        runner->set_enable_dump_tensor(enable_dump_tensor != 0);
-        runner->set_enable_pmu(enable_pmu);
+        runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
+        runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
+        runner->set_pmu_enabled(enable_pmu);
 
         // Phase 3: launch
         std::vector<uint8_t> aicpu_vec;

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -40,15 +40,14 @@ static int s_orch_thread_idx = -1;
 // L2 perf platform state. Published by the host (via dlsym'd setters on sim)
 // or by the AICPU kernel entry (onboard) before perf init runs, so downstream
 // perf code can discover enablement + device-base without reading the generic
-// Runtime struct. Mirrors the g_platform_dump_base / g_enable_dump_tensor pair
-// in tensor_dump_aicpu.cpp and the PMU equivalents in pmu_collector_aicpu.cpp.
+// Runtime struct.
 static uint64_t g_platform_l2_perf_base = 0;
 static bool g_enable_l2_swimlane = false;
 
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base) { g_platform_l2_perf_base = l2_perf_data_base; }
 extern "C" uint64_t get_platform_l2_perf_base() { return g_platform_l2_perf_base; }
-extern "C" void set_enable_l2_swimlane(bool enable) { g_enable_l2_swimlane = enable; }
-extern "C" bool get_enable_l2_swimlane() { return g_enable_l2_swimlane; }
+extern "C" void set_l2_swimlane_enabled(bool enable) { g_enable_l2_swimlane = enable; }
+extern "C" bool is_l2_swimlane_enabled() { return g_enable_l2_swimlane; }
 
 void l2_perf_aicpu_init_profiling(Runtime *runtime) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);

--- a/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
@@ -54,9 +54,9 @@ extern "C" void set_platform_pmu_base(uint64_t pmu_data_base) { g_platform_pmu_b
 
 extern "C" uint64_t get_platform_pmu_base() { return g_platform_pmu_base; }
 
-extern "C" void set_enable_pmu(bool enable) { g_enable_pmu = enable; }
+extern "C" void set_pmu_enabled(bool enable) { g_enable_pmu = enable; }
 
-extern "C" bool get_enable_pmu() { return g_enable_pmu; }
+extern "C" bool is_pmu_enabled() { return g_enable_pmu; }
 
 // ---------------------------------------------------------------------------
 // Low-level MMIO helpers (internal use only)
@@ -128,7 +128,7 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
 
     // Program event selectors and start PMU counters on all cores with a valid
     // PMU reg base.
-    const PmuEventConfig *evt = pmu_resolve_event_config_a5(pmu_event_type);
+    const PmuEventConfig *evt = pmu_resolve_event_config_a5(static_cast<PmuEventType>(pmu_event_type));
     if (evt == nullptr) {
         evt = &PMU_EVENTS_A5_PIPE_UTIL;
     }
@@ -168,8 +168,7 @@ void pmu_aicpu_complete_record(
 
     // Stamp thread ownership on every commit. a5 binds each core to a fixed
     // AICPU scheduler thread at init time, so this value is stable — host
-    // reads it at collect time to emit the CSV thread_id column (mirrors
-    // a2a3's per-queue thread association).
+    // reads it at collect time to emit the CSV thread_id column.
     state->owning_thread_id = static_cast<uint32_t>(thread_idx);
 
     // Account for every commit attempt so host can detect silent slot loss.

--- a/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
@@ -52,9 +52,9 @@ extern "C" void set_platform_dump_base(uint64_t dump_data_base) { g_platform_dum
 
 extern "C" uint64_t get_platform_dump_base() { return g_platform_dump_base; }
 
-extern "C" void set_enable_dump_tensor(bool enable) { g_enable_dump_tensor = enable; }
+extern "C" void set_dump_tensor_enabled(bool enable) { g_enable_dump_tensor = enable; }
 
-extern "C" bool get_enable_dump_tensor() { return g_enable_dump_tensor; }
+extern "C" bool is_dump_tensor_enabled() { return g_enable_dump_tensor; }
 
 // =============================================================================
 // Helper Functions (same as A2A3)

--- a/src/a5/platform/src/host/pmu_collector.cpp
+++ b/src/a5/platform/src/host/pmu_collector.cpp
@@ -23,7 +23,7 @@ PmuCollector::~PmuCollector() {
 }
 
 int PmuCollector::initialize(
-    int num_cores, uint32_t event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
+    int num_cores, PmuEventType event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
     PmuFreeCallback free_cb, PmuCopyToDeviceCallback copy_to_dev_cb, PmuCopyFromDeviceCallback copy_from_dev_cb
 ) {
     if (num_cores <= 0 || num_cores > PLATFORM_MAX_CORES || kernel_args_pmu_data_base == nullptr ||
@@ -42,7 +42,7 @@ int PmuCollector::initialize(
     setup_region_bytes_ = calc_pmu_setup_size(num_cores_);
 
     // Allocate the [PmuSetupHeader][PmuBufferState[num_cores]] shared region
-    // on device, mirroring a2a3's single-allocation layout.
+    // on device in a single allocation.
     setup_header_dev_ = alloc_cb_(setup_region_bytes_);
     if (setup_header_dev_ == nullptr) {
         LOG_ERROR("PmuCollector::initialize: failed to alloc PMU setup region (%zu bytes)", setup_region_bytes_);
@@ -54,7 +54,7 @@ int PmuCollector::initialize(
     std::vector<uint8_t> host_setup(setup_region_bytes_, 0);
     PmuSetupHeader *host_header = get_pmu_setup_header(host_setup.data());
     host_header->num_cores = static_cast<uint32_t>(num_cores_);
-    host_header->event_type = event_type_;
+    host_header->event_type = static_cast<uint32_t>(event_type_);
     for (int i = 0; i < num_cores_; ++i) {
         void *buf_dev = alloc_cb_(pmu_buffer_bytes_);
         if (buf_dev == nullptr) {
@@ -86,8 +86,8 @@ int PmuCollector::initialize(
 
     *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(setup_header_dev_);
     LOG_INFO(
-        "PMU collector initialized: %d cores, event_type=%u, setup_header=0x%lx", num_cores_, event_type_,
-        static_cast<unsigned long>(*kernel_args_pmu_data_base)
+        "PMU collector initialized: %d cores, event_type=%u, setup_header=0x%lx", num_cores_,
+        static_cast<uint32_t>(event_type_), static_cast<unsigned long>(*kernel_args_pmu_data_base)
     );
     return 0;
 }
@@ -209,7 +209,7 @@ int PmuCollector::export_csv(const std::string &output_dir) {
             for (int i = 0; i < named_count; ++i) {
                 csv << "," << rec.pmu_counters[i];
             }
-            csv << "," << event_type_ << "\n";
+            csv << "," << static_cast<uint32_t>(event_type_) << "\n";
             ++total_rows;
         }
         total_dropped += dropped_counts_[core_id];
@@ -218,8 +218,7 @@ int PmuCollector::export_csv(const std::string &output_dir) {
     csv.flush();
     LOG_INFO("PMU CSV written to %s", csv_path.c_str());
 
-    // Cross-check device-side totals against what we wrote to CSV. Mirrors
-    // the a2a3 host collector. Invariant:
+    // Cross-check device-side totals against what we wrote to CSV. Invariant:
     //   device_total == collected + dropped (buffer-full) + slot-mismatch
     // collected + dropped should account for every commit attempt; any
     // remainder is silent slot-mismatch loss (AICore not yet published).
@@ -270,7 +269,7 @@ int PmuCollector::finalize() {
     setup_header_dev_ = nullptr;
 
     num_cores_ = 0;
-    event_type_ = 0;
+    event_type_ = PmuEventType::PIPE_UTILIZATION;
     pmu_buffer_bytes_ = 0;
     setup_region_bytes_ = 0;
     collected_records_.clear();

--- a/src/a5/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a5/platform/src/host/tensor_dump_collector.cpp
@@ -13,7 +13,6 @@
  * @file tensor_dump_collector.cpp
  * @brief Host-side tensor dump collector implementation (memcpy-based)
  *
- * Mirrors l2_perf_collector.cpp patterns:
  * - Allocate device buffers, copy header to device
  * - After stream sync, two-step copy (header then data)
  * - Export to JSON manifest + binary payload

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -89,6 +89,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             if (pmu_enabled) {
                 pmu_aicore_end();
+                dcci(my_hank, SINGLE_CACHE_LINE);
                 // Read pmu_buffer_addr / pmu_reg_base per-task (mirrors how
                 // perf_records_addr is read below): by the time AICPU dispatches
                 // a real task_id, pmu_aicpu_init has already published these.

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -127,9 +127,16 @@ struct AicpuExecutor {
     diagnose_stuck_state(Runtime &runtime, int thread_idx, const int *cur_thread_cores, int core_num, Handshake *hank);
 
     // Helper functions (inline to avoid linker issues, not always_inline to preserve barriers)
+    //
+    // resolve_task_dependencies also handles post-completion profiling hooks
+    // (AFTER_COMPLETION tensor dump + per-task PMU record) so that callers
+    // walk one boundary instead of sprinkling three #if PTO2_PROFILING blocks
+    // after every resolve site. core_id / core_type are only read when the
+    // relevant profiling flag is enabled.
     inline void resolve_task_dependencies(
-        Task *task, Runtime &runtime, int thread_idx, int *cur_ready_queue_aic, int &cur_aic_tail,
-        int &cur_aic_ready_count, int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+        Task *task, Runtime &runtime, int thread_idx, int core_id, CoreType core_type, int *cur_ready_queue_aic,
+        int &cur_aic_tail, int &cur_aic_ready_count, int *cur_ready_queue_aiv, int &cur_aiv_tail,
+        int &cur_aiv_ready_count
     );
 
     inline bool try_dispatch_task(
@@ -160,17 +167,19 @@ collect_task_tensor_buffer_addrs(const Runtime &runtime, const Task &task, uint6
 
 // ===== Helper Function Implementations =====
 
-// Resolve dependencies: decrement fanin and enqueue newly ready tasks
+// Resolve dependencies: decrement fanin and enqueue newly ready tasks.
+// Also handles post-completion profiling hooks (AFTER_COMPLETION tensor dump
+// + per-task PMU record) so callers don't need to re-check profiling flags.
 inline void AicpuExecutor::resolve_task_dependencies(
-    Task *task, Runtime &runtime, int thread_idx, int *cur_ready_queue_aic, int &cur_aic_tail, int &cur_aic_ready_count,
-    int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
+    Task *task, Runtime &runtime, int thread_idx, int core_id, CoreType core_type, int *cur_ready_queue_aic,
+    int &cur_aic_tail, int &cur_aic_ready_count, int *cur_ready_queue_aiv, int &cur_aiv_tail, int &cur_aiv_ready_count
 ) {
     if (task == nullptr) {
         return;
     }
 
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
         if (callable_addr != 0) {
             const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
@@ -186,8 +195,16 @@ inline void AicpuExecutor::resolve_task_dependencies(
             );
         }
     }
+    if (is_pmu_enabled()) {
+        pmu_aicpu_complete_record(
+            core_id, thread_idx, static_cast<uint32_t>(task->task_id), static_cast<uint64_t>(task->task_id),
+            task->func_id, core_type
+        );
+    }
 #else
     (void)thread_idx;
+    (void)core_id;
+    (void)core_type;
 #endif
 
     for (int j = 0; j < task->fanout_count; j++) {
@@ -244,7 +261,7 @@ inline bool AicpuExecutor::try_dispatch_task(
     );
 
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         Task *task = runtime_->get_task(task_id);
         if (task != nullptr) {
             uint64_t callable_addr = runtime_->get_function_bin_addr(task->func_id);
@@ -336,14 +353,14 @@ int AicpuExecutor::init(Runtime *runtime) {
     for (int i = 0; i < RUNTIME_MAX_WORKER; i++) {
         dispatch_timestamps_[i] = 0;
     }
-    if (get_enable_l2_swimlane()) {
+    if (is_l2_swimlane_enabled()) {
         l2_perf_aicpu_init_profiling(runtime);
     }
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_init(thread_num_);
     }
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
         LOG_INFO("PMU profiling started on %d cores", cores_total_num_);
     }
@@ -659,7 +676,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
     int verification_warning_count = 0;
     const int MAX_VERIFICATION_WARNINGS = 10;
-    bool l2_perf_enabled = get_enable_l2_swimlane();
+    bool l2_perf_enabled = is_l2_swimlane_enabled();
 
     // Extract array pointers as local variables for better readability and performance
     int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
@@ -783,36 +800,18 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                     Task *prev_running_task = runtime.get_task(prev_running_id);
                     resolve_task_dependencies(
-                        prev_running_task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                        prev_running_task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic,
+                        cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
-
-#if PTO2_PROFILING
-                    if (get_enable_pmu()) {
-                        pmu_aicpu_complete_record(
-                            core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
-                            static_cast<uint64_t>(prev_running_id), prev_running_task->func_id, h->core_type
-                        );
-                    }
-#endif
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
 
                 Task *task = runtime.get_task(completed_task_id);
                 resolve_task_dependencies(
-                    task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                    cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic, cur_aic_tail,
+                    cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
-
-#if PTO2_PROFILING
-                if (get_enable_pmu()) {
-                    pmu_aicpu_complete_record(
-                        core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
-                        static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
-                    );
-                }
-#endif
 
                 made_progress = true;
 
@@ -865,18 +864,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                     Task *prev_running_task = runtime.get_task(prev_running_id);
                     resolve_task_dependencies(
-                        prev_running_task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                        cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                        prev_running_task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic,
+                        cur_aic_tail, cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                     );
-
-#if PTO2_PROFILING
-                    if (get_enable_pmu()) {
-                        pmu_aicpu_complete_record(
-                            core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
-                            static_cast<uint64_t>(prev_running_id), prev_running_task->func_id, h->core_type
-                        );
-                    }
-#endif
 
                     LOG_INFO("Thread %d: Core %d resolved old running task %d", thread_idx, core_id, prev_running_id);
                 }
@@ -934,18 +924,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                 Task *task = runtime.get_task(completed_task_id);
                 resolve_task_dependencies(
-                    task, runtime, thread_idx, cur_ready_queue_aic, cur_aic_tail, cur_aic_ready_count,
-                    cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
+                    task, runtime, thread_idx, core_id, h->core_type, cur_ready_queue_aic, cur_aic_tail,
+                    cur_aic_ready_count, cur_ready_queue_aiv, cur_aiv_tail, cur_aiv_ready_count
                 );
-
-#if PTO2_PROFILING
-                if (get_enable_pmu()) {
-                    pmu_aicpu_complete_record(
-                        core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
-                        static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type
-                    );
-                }
-#endif
 
                 made_progress = true;
 
@@ -1106,7 +1087,7 @@ int AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
     // Restore PMU CTRL registers for this thread's cores before AICore shutdown
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_finalize(cur_thread_cores, thread_cores_num_[thread_idx]);
     }
 #endif
@@ -1117,7 +1098,7 @@ int AicpuExecutor::run(Runtime *runtime) {
     }
 
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_flush(thread_idx);
     }
 #endif

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -21,8 +21,8 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 ## Execution Flow (Device)
 
 1. `aicpu_executor.cpp` performs core discovery, handshake initialization, and ready-queue seeding using `Runtime::get_initial_ready_tasks`.
-2. Scheduler threads maintain per-core and global ready queues. When a task is ready, the scheduler writes its pointer to the core's `Handshake` and sets `task_status=1`.
-3. AICore reads the handshake, executes the kernel at `Task::function_bin_addr`, and writes `task_status=0` on completion.
+2. Scheduler threads maintain per-core and global ready queues. When a task is ready, the scheduler publishes the task pointer and signals the core via `DATA_MAIN_BASE`.
+3. AICore reads the task_id from `DATA_MAIN_BASE`, executes the kernel at `Task::function_bin_addr`, and writes FIN to `COND` on completion.
 4. AICPU observes completion, resolves dependencies by decrementing fanin, and enqueues newly-ready tasks.
 5. The executor shuts down cores by setting `Handshake::control=1` after all tasks complete.
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -85,9 +85,9 @@
  * Protocol State Machine:
  * 1. Initialization: AICPU sets aicpu_ready=1
  * 2. Acknowledgment: AICore sets aicore_done=core_id+1
- * 3. Task Dispatch: AICPU assigns task pointer and sets task_status=1
- * 4. Task Execution: AICore reads task, executes, sets task_status=0
- * 5. Task Completion: AICPU reads task_status=0, clears task=0
+ * 3. Task Dispatch: AICPU writes DATA_MAIN_BASE with the task_id after publishing Task*
+ * 4. Task Execution: AICore reads the task and executes
+ * 5. Task Completion: AICore writes FIN to COND; AICPU observes completion
  * 6. Shutdown: AICPU sets control=1, AICore exits
  *
  * Each AICore instance has its own handshake buffer to enable concurrent
@@ -111,28 +111,22 @@
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = no task assigned)
- * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
- * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  * - l2_perf_records_addr: Written by AICPU, read by AICore (performance records address)
- * - l2_perf_buffer_status: Written by both (AICPU=1 on buffer full, AICore=0 on buffer empty)
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  * - pmu_buffer_addr: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
  * - pmu_reg_base: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;            // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                   // Task pointer: 0=no task, non-zero=Task* address
-    volatile int32_t task_status;             // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;                 // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;              // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;   // Performance records address
-    volatile uint32_t l2_perf_buffer_status;  // 0 = not full, 1 = full
-    volatile uint32_t physical_core_id;       // Physical core ID
-    volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                  // Task pointer: 0=no task, non-zero=Task* address
+    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t l2_perf_records_addr;  // Performance records address
+    volatile uint32_t physical_core_id;      // Physical core ID
+    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
         enable_profiling_flag;          // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
     volatile uint64_t pmu_buffer_addr;  // Per-core PmuBuffer device address (for AICore-side PMU record)

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -445,7 +445,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = get_enable_l2_swimlane();
+            rt->orchestrator.enable_l2_swimlane = is_l2_swimlane_enabled();
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
@@ -467,7 +467,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif
@@ -552,7 +552,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (get_enable_l2_swimlane()) {
+            if (is_l2_swimlane_enabled()) {
                 AicpuOrchSummary orch_summary = {};
                 orch_summary.start_time = orch_cycle_start;
                 orch_summary.end_time = orch_cycle_end;
@@ -585,7 +585,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             pto2_submitted_tasks = total_tasks;
 #endif
 
-            if (get_enable_l2_swimlane() && total_tasks > 0) {
+            if (is_l2_swimlane_enabled() && total_tasks > 0) {
                 l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(total_tasks));
             }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -539,7 +539,7 @@ Each AICore worker has a `Handshake` struct in shared memory:
 
 ### 9.2 Register-Based Dispatch
 
-Instead of polling `Handshake.task_status`, the production protocol uses hardware registers.
+Instead of polling a shared-memory status flag, the production protocol uses hardware registers.
 
 > **Multi-ring note**: `task_id` is 64-bit but registers are 32-bit. A per-core monotonic dispatch counter (`s_dispatch_seq`) replaces `task_id` in register writes to prevent collisions. See [MULTI_RING.md §6](MULTI_RING.md).
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -231,7 +231,7 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 L2 swimlane enablement is published through the handshake
 `enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
-AICPU code reads it via `get_enable_l2_swimlane()` (set at launch time
+AICPU code reads it via `is_l2_swimlane_enabled()` (set at launch time
 by the platform from `kernel_args.l2_perf_data_base` + the bitmask). It
 controls **data collection**, NOT log output.
 
@@ -252,7 +252,7 @@ controls **data collection**, NOT log output.
 
 ```cpp
 // AICPU path — read enablement from the platform accessor, not the Runtime struct.
-if (get_enable_l2_swimlane()) {
+if (is_l2_swimlane_enabled()) {
     // ... perf-collection code ...
 }
 ```

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -93,25 +93,20 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
- * - task_status: Written by both (AICPU=1 on dispatch, AICore=0 on completion)
- * - control: Written by AICPU, read by AICore (0 = continue, 1 = quit)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
  * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  * - pmu_buffer_addr: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
  * - pmu_reg_base: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;            // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;            // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                   // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
-    volatile int32_t task_status;             // Task execution status: 0=idle, 1=busy
-    volatile int32_t control;                 // Control signal: 0=execute, 1=quit
-    volatile CoreType core_type;              // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;   // Performance records address
-    volatile uint32_t l2_perf_buffer_status;  // 0 = not full, 1 == full
-    volatile uint32_t physical_core_id;       // Physical core ID
-    volatile uint32_t aicpu_regs_ready;       // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;      // AICore ID reported: 0=pending, 1=done
+    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;                  // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint64_t l2_perf_records_addr;  // Performance records address
+    volatile uint32_t physical_core_id;      // Physical core ID
+    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
     volatile uint32_t
         enable_profiling_flag;          // Generic profiling-related flags; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
     volatile uint64_t pmu_buffer_addr;  // Per-core PmuBuffer device address (for AICore-side PMU record)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -352,7 +352,7 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 
 #if PTO2_PROFILING
     // Restore PMU CTRL registers for this thread's cores before AICore shutdown
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         pmu_aicpu_finalize(cores, core_num);
     }
 #endif
@@ -790,7 +790,7 @@ void SchedulerContext::on_orchestration_done(
     // Write core-to-thread mapping AFTER reassignment so the profiling data
     // reflects the final distribution (all active_sched_threads_, including
     // former orchestrator threads when orch_to_sched_ is enabled).
-    if (get_enable_l2_swimlane()) {
+    if (is_l2_swimlane_enabled()) {
         l2_perf_aicpu_init_core_assignments(cores_total_num_);
         for (int32_t t = 0; t < active_sched_threads_; t++) {
             l2_perf_aicpu_write_core_assignments_for_thread(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -78,7 +78,7 @@ void SchedulerContext::complete_slot_task(
     bool mixed_complete = sched_->on_subtask_complete(slot_state);
     if (mixed_complete) {
 #if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
+        if (is_dump_tensor_enabled()) {
             dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                 thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
                 [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -156,7 +156,7 @@ void SchedulerContext::complete_slot_task(
 #endif
 
 #if PTO2_PROFILING
-    if (get_enable_pmu()) {
+    if (is_pmu_enabled()) {
         // Slot key must be the 32-bit register token AICore wrote into
         // dual_issue_slots[task_id & 1].task_id (= DATA_MAIN_BASE value).
         // task_id.raw is the full PTO2 (ring_id<<32|local_id) encoding —

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -186,7 +186,7 @@ void SchedulerContext::dispatch_block(
     bool to_pending
 ) {
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
             thread_idx, slot_state, TensorDumpStage::BEFORE_DISPATCH,
             [](uint8_t active_mask, uint8_t raw_subtask_id) {
@@ -320,17 +320,17 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         DEV_INFO("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
-        if (get_enable_l2_swimlane()) {
+        if (is_l2_swimlane_enabled()) {
             l2_perf_aicpu_init_profiling(runtime);
             l2_perf_aicpu_init_phase_profiling(sched_thread_num_);
             l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
 #if PTO2_PROFILING
-        if (get_enable_dump_tensor()) {
+        if (is_dump_tensor_enabled()) {
             dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
         }
-        if (get_enable_pmu()) {
+        if (is_pmu_enabled()) {
             pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
             DEV_INFO("PMU profiling started on %d cores", cores_total_num_);
         }
@@ -351,7 +351,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
     l2_perf.reset();
-    l2_perf.l2_perf_enabled = get_enable_l2_swimlane();
+    l2_perf.l2_perf_enabled = is_l2_swimlane_enabled();
 #endif
 
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
@@ -557,7 +557,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 
 #if PTO2_PROFILING
-    if (get_enable_dump_tensor()) {
+    if (is_dump_tensor_enabled()) {
         dump_tensor_flush(thread_idx);
     }
 #endif


### PR DESCRIPTION
## Summary

Stacked on top of #658 (`fix/issue-641-pr2-remove-perf-from-runtime`). **Please merge #658 first.** Seven small post-#658 cleanups bundled into one commit:

1. **Drop unused Handshake fields** — `task_status`, `l2_perf_buffer_status`, and `control` had no readers anywhere; only init-zero writes in device_runner and a debug log line. Updated all four runtime variants (a2a3/a5 × tensormap_and_ringbuffer/host_build_graph + a2a3 aicpu_build_graph), comment blocks, and `docs/chip-level-arch.md`.

2. **perf filename layout** — `l2_perf_records_<label>_<ts>.json` so the timestamp is the trailing field, matching tensor_dump and pmu. Updated `device_log_resolver` regex and tooling locals.

3. **`get_enable_*` → `is_*_enabled` / `set_enable_*` → `set_*_enabled`** for pmu, dump_tensor, l2_swimlane. Predicate naming for boolean returns; getter/setter pairs now symmetric.

4. **host_build_graph profiling consolidation** — collapse the three scattered hooks in `aicpu_executor.cpp` (dispatch + dep-resolve + post-completion) into one PMU record write inside `resolve_task_dependencies`.

5. **Drop \"mirrors <other>.cpp\" prose** from perf / dump-tensor / pmu module comments — mirroring is enforced by review, not by the comment.

6. **Thread `PmuEventType` through the PMU init path** (device_runner → PmuCollectorHost::init → pmu_resolve_event_config_*) instead of `uint32_t` with manual casts at every layer. Cast to `uint32_t` only at the SHM / CSV boundary where the wire format is fixed.

7. **a5 host_build_graph aicore_executor PMU cache fix** — `dcci(my_hank, SINGLE_CACHE_LINE)` before reading `pmu_buffer_addr` / `pmu_reg_base`. Without it, AICore observed stale handshake fields when PMU is enabled.

## Test plan

- [ ] sim CI: \`./ci.sh -p a2a3sim\` and \`./ci.sh -p a5sim\`
- [ ] Hardware CI on a2a3 and a5
- [ ] Verify perf JSON / tensor_dump / pmu CSV filenames and contents on a representative example with each diagnostic enabled