### PR TITLE
Add: PTO_LOG_LEVEL=off to fully mute host/python/sim-aicpu logs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -114,7 +114,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--build` | | false | Compile runtime from source (not pre-built) |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
-| `--log-level LEVEL` | | (none) | Set `PTO_LOG_LEVEL` env var (`error`/`warn`/`info`/`debug`) |
+| `--log-level LEVEL` | | (none) | Set `PTO_LOG_LEVEL` env var (`off`/`error`/`warn`/`info`/`debug`). `off` suppresses all Host/Python/sim-device logs including `ALWAYS`; onboard AICPU logs are managed by CANN and must be controlled via CANN env vars (e.g. `ASCEND_GLOBAL_LOG_LEVEL`) |
 
 Profiling is enabled only on the first round to avoid overhead on subsequent iterations. Output tensors are reset to their initial values between rounds.
 

--- a/simpler_setup/log_config.py
+++ b/simpler_setup/log_config.py
@@ -20,10 +20,11 @@ pyproject `log_cli_level` knobs.
 import logging
 import os
 
-LOG_LEVEL_CHOICES = ["error", "warn", "info", "debug"]
+LOG_LEVEL_CHOICES = ["off", "error", "warn", "info", "debug"]
 DEFAULT_LOG_LEVEL = "info"
 
 _LEVEL_MAP = {
+    "off": logging.CRITICAL + 1,
     "error": logging.ERROR,
     "warn": logging.WARNING,
     "info": logging.INFO,
@@ -35,14 +36,15 @@ def configure_logging(log_level: str = DEFAULT_LOG_LEVEL) -> None:
     """Configure root logger for a CLI entry point.
 
     Args:
-        log_level: one of "error" / "warn" / "info" / "debug" (case-insensitive).
-            Unknown values fall back to INFO.
+        log_level: one of "off" / "error" / "warn" / "info" / "debug"
+            (case-insensitive). Unknown values fall back to INFO.
     """
     log_level = log_level.lower()
     level = _LEVEL_MAP.get(log_level, logging.INFO)
-    logging.basicConfig(
-        level=level,
-        format="[%(levelname)s] %(message)s",
-        force=True,
-    )
+    root = logging.getLogger()
+    root.setLevel(level)
+    if not root.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+        root.addHandler(handler)
     os.environ["PTO_LOG_LEVEL"] = log_level

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1209,8 +1209,8 @@ class SceneTestCase:
         parser.add_argument(
             "--log-level",
             choices=LOG_LEVEL_CHOICES,
-            default=DEFAULT_LOG_LEVEL,
-            help=f"Root logger level (default: {DEFAULT_LOG_LEVEL})",
+            default=os.environ.get("PTO_LOG_LEVEL", DEFAULT_LOG_LEVEL),
+            help=f"Root logger level (default: $PTO_LOG_LEVEL or {DEFAULT_LOG_LEVEL})",
         )
         args = parser.parse_args()
         configure_logging(args.log_level)

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -616,7 +616,7 @@ int DeviceRunner::run(
         }
     });
 
-    std::cout << "\n=== Initialize runtime args ===" << '\n';
+    LOG_INFO("=== Initialize runtime args ===");
     // Resolve the orchestration SO into a device-resident buffer and refresh
     // runtime metadata before the Runtime struct is uploaded to device.
     rc = prepare_orch_so(runtime);
@@ -645,7 +645,7 @@ int DeviceRunner::run(
         return rc;
     }
 
-    std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServerInit===" << '\n';
+    LOG_INFO("=== launch_aicpu_kernel DynTileFwkKernelServerInit ===");
     // Launch AICPU init kernel
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
@@ -653,7 +653,7 @@ int DeviceRunner::run(
         return rc;
     }
 
-    std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
+    LOG_INFO("=== launch_aicpu_kernel DynTileFwkKernelServer ===");
     // Launch AICPU main kernel (over-launch for affinity gate)
     rc = launch_aicpu_kernel(
         stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
@@ -663,7 +663,7 @@ int DeviceRunner::run(
         return rc;
     }
 
-    std::cout << "\n=== launch_aicore_kernel===" << '\n';
+    LOG_INFO("=== launch_aicore_kernel ===");
     // Launch AICore kernel (pass device copy of KernelArgs)
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
     if (rc != 0) {
@@ -723,7 +723,7 @@ int DeviceRunner::run(
             }
         });
 
-        std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
+        LOG_INFO("=== rtStreamSynchronize stream_aicpu_ ===");
         // Synchronize streams
         rc = rtStreamSynchronize(stream_aicpu_);
         if (rc != 0) {
@@ -731,7 +731,7 @@ int DeviceRunner::run(
             return rc;
         }
 
-        std::cout << "\n=== rtStreamSynchronize stream_aicore_===" << '\n';
+        LOG_INFO("=== rtStreamSynchronize stream_aicore_ ===");
         rc = rtStreamSynchronize(stream_aicore_);
         if (rc != 0) {
             LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);

--- a/src/a2a3/platform/sim/aicpu/device_log.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_log.cpp
@@ -57,8 +57,14 @@ void init_log_switch() {
         }
 
         // Parse log level
-        if (strcmp(level, "silent") == 0 || strcmp(level, "error") == 0) {
-            // Silent/Error: only errors
+        if (strcmp(level, "off") == 0) {
+            // Off: suppress everything
+            g_is_log_enable_debug = false;
+            g_is_log_enable_info = false;
+            g_is_log_enable_warn = false;
+            g_is_log_enable_error = false;
+        } else if (strcmp(level, "error") == 0) {
+            // Error: only errors
             g_is_log_enable_debug = false;
             g_is_log_enable_info = false;
             g_is_log_enable_warn = false;

--- a/src/a2a3/platform/src/host/host_log.cpp
+++ b/src/a2a3/platform/src/host/host_log.cpp
@@ -58,7 +58,9 @@ void HostLogger::init_from_env() {
         }
 
         // Map log level strings to enum values (1-to-1 mapping)
-        if (level == "error") {
+        if (level == "off") {
+            current_level_ = HostLogLevel::OFF;
+        } else if (level == "error") {
             current_level_ = HostLogLevel::ERROR;
         } else if (level == "warn") {
             current_level_ = HostLogLevel::WARN;
@@ -119,6 +121,8 @@ const char *HostLogger::get_level_name(HostLogLevel level) const {
         return "DEBUG";
     case HostLogLevel::ALWAYS:
         return "ALWAYS";
+    case HostLogLevel::OFF:
+        return "OFF";
     default:
         return "UNKNOWN";
     }
@@ -139,6 +143,10 @@ FILE *HostLogger::get_output_file(HostLogLevel level) {
 }
 
 void HostLogger::log(HostLogLevel level, const char *format, ...) {
+    // Hard mute: OFF suppresses everything including ALWAYS
+    if (current_level_ == HostLogLevel::OFF) {
+        return;
+    }
     // Check if this level is enabled
     if (!is_enabled(level)) {
         return;

--- a/src/a2a3/platform/src/host/host_log.h
+++ b/src/a2a3/platform/src/host/host_log.h
@@ -16,10 +16,11 @@
  * Integrates with Python logging system via environment variables.
  *
  * Environment Variables:
- * - PTO_LOG_LEVEL: error/warn/info/debug (default: info)
+ * - PTO_LOG_LEVEL: off/error/warn/info/debug (default: info)
  * - PTO_LOG_FILE: Optional log file path (default: stdout/stderr)
  *
  * Log Levels (1-to-1 mapping with Python logging):
+ * - OFF: Suppress everything, including ALWAYS
  * - ERROR: Only errors and failures
  * - WARN: Warnings and above
  * - INFO: Key progress steps and above (default)
@@ -40,6 +41,7 @@
 // =============================================================================
 
 enum class HostLogLevel {
+    OFF = -2,     // suppress everything (including ALWAYS)
     ALWAYS = -1,  // always logging
     ERROR = 0,    // error level only
     WARN = 1,     // warn level and above

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -436,7 +436,7 @@ int DeviceRunner::run(
         }
     }
 
-    std::cout << "\n=== Initialize runtime args ===" << '\n';
+    LOG_INFO("=== Initialize runtime args ===");
     rc = prepare_orch_so(runtime);
     if (rc != 0) {
         LOG_ERROR("prepare_orch_so failed: %d", rc);
@@ -449,7 +449,7 @@ int DeviceRunner::run(
         return rc;
     }
 
-    std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServerInit===" << '\n';
+    LOG_INFO("=== launch_aicpu_kernel DynTileFwkKernelServerInit ===");
     // Launch AICPU init kernel
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
@@ -457,7 +457,7 @@ int DeviceRunner::run(
         return rc;
     }
 
-    std::cout << "\n=== launch_aicpu_kernel DynTileFwkKernelServer===" << '\n';
+    LOG_INFO("=== launch_aicpu_kernel DynTileFwkKernelServer ===");
     // Launch AICPU main kernel (over-launch for affinity gate)
     rc = launch_aicpu_kernel(
         stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
@@ -467,7 +467,7 @@ int DeviceRunner::run(
         return rc;
     }
 
-    std::cout << "\n=== launch_aicore_kernel===" << '\n';
+    LOG_INFO("=== launch_aicore_kernel ===");
     // Launch AICore kernel
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
     if (rc != 0) {
@@ -476,7 +476,7 @@ int DeviceRunner::run(
     }
 
     {
-        std::cout << "\n=== rtStreamSynchronize stream_aicpu_===" << '\n';
+        LOG_INFO("=== rtStreamSynchronize stream_aicpu_ ===");
         // Synchronize streams
         rc = rtStreamSynchronize(stream_aicpu_);
         if (rc != 0) {
@@ -484,7 +484,7 @@ int DeviceRunner::run(
             return rc;
         }
 
-        std::cout << "\n=== rtStreamSynchronize stream_aicore_===" << '\n';
+        LOG_INFO("=== rtStreamSynchronize stream_aicore_ ===");
         rc = rtStreamSynchronize(stream_aicore_);
         if (rc != 0) {
             LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);

--- a/src/a5/platform/sim/aicpu/device_log.cpp
+++ b/src/a5/platform/sim/aicpu/device_log.cpp
@@ -57,8 +57,14 @@ void init_log_switch() {
         }
 
         // Parse log level
-        if (strcmp(level, "silent") == 0 || strcmp(level, "error") == 0) {
-            // Silent/Error: only errors
+        if (strcmp(level, "off") == 0) {
+            // Off: suppress everything
+            g_is_log_enable_debug = false;
+            g_is_log_enable_info = false;
+            g_is_log_enable_warn = false;
+            g_is_log_enable_error = false;
+        } else if (strcmp(level, "error") == 0) {
+            // Error: only errors
             g_is_log_enable_debug = false;
             g_is_log_enable_info = false;
             g_is_log_enable_warn = false;

--- a/src/a5/platform/src/host/host_log.cpp
+++ b/src/a5/platform/src/host/host_log.cpp
@@ -58,7 +58,9 @@ void HostLogger::init_from_env() {
         }
 
         // Map log level strings to enum values (1-to-1 mapping)
-        if (level == "error") {
+        if (level == "off") {
+            current_level_ = HostLogLevel::OFF;
+        } else if (level == "error") {
             current_level_ = HostLogLevel::ERROR;
         } else if (level == "warn") {
             current_level_ = HostLogLevel::WARN;
@@ -119,6 +121,8 @@ const char *HostLogger::get_level_name(HostLogLevel level) const {
         return "DEBUG";
     case HostLogLevel::ALWAYS:
         return "ALWAYS";
+    case HostLogLevel::OFF:
+        return "OFF";
     default:
         return "UNKNOWN";
     }
@@ -139,6 +143,10 @@ FILE *HostLogger::get_output_file(HostLogLevel level) {
 }
 
 void HostLogger::log(HostLogLevel level, const char *format, ...) {
+    // Hard mute: OFF suppresses everything including ALWAYS
+    if (current_level_ == HostLogLevel::OFF) {
+        return;
+    }
     // Check if this level is enabled
     if (!is_enabled(level)) {
         return;

--- a/src/a5/platform/src/host/host_log.h
+++ b/src/a5/platform/src/host/host_log.h
@@ -16,10 +16,11 @@
  * Integrates with Python logging system via environment variables.
  *
  * Environment Variables:
- * - PTO_LOG_LEVEL: error/warn/info/debug (default: info)
+ * - PTO_LOG_LEVEL: off/error/warn/info/debug (default: info)
  * - PTO_LOG_FILE: Optional log file path (default: stdout/stderr)
  *
  * Log Levels (1-to-1 mapping with Python logging):
+ * - OFF: Suppress everything, including ALWAYS
  * - ERROR: Only errors and failures
  * - WARN: Warnings and above
  * - INFO: Key progress steps and above (default)
@@ -40,6 +41,7 @@
 // =============================================================================
 
 enum class HostLogLevel {
+    OFF = -2,     // suppress everything (including ALWAYS)
     ALWAYS = -1,  // always logging
     ERROR = 0,    // error level only
     WARN = 1,     // warn level and above

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -258,6 +258,25 @@ add_a2a3_test(test_a2a3_fatal a2a3/test_a2a3_fatal.cpp)
 # ---------------------------------------------------------------------------
 add_a5_test(test_a5_fatal a5/test_a5_fatal.cpp)
 
+# Host logger silent/off behavior — no runtime deps, just compile host_log.cpp
+# alongside the test.
+set(A5_HOST_LOG_DIR ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/src/host)
+add_executable(test_host_log_off
+    a5/test_host_log_off.cpp
+    ${A5_HOST_LOG_DIR}/host_log.cpp
+)
+target_include_directories(test_host_log_off PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${A5_HOST_LOG_DIR}
+)
+target_compile_options(test_host_log_off PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0)
+target_link_libraries(test_host_log_off PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_host_log_off COMMAND test_host_log_off)
+
 # Hardware-gated tests.  Block is only entered when the project is configured
 # with -DSIMPLER_ENABLE_HARDWARE_TESTS=ON.  CI's no-hw `ut` job does not pass
 # this flag, so nothing here is compiled there — this is the structural

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Covers PTO_LOG_LEVEL=off: when set, every level including ALWAYS
+// must be fully muted. Regression guard for the bug where invalid level
+// strings were silently mapped to INFO in the host path and ALWAYS
+// bypassed the filter.
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "host_log.h"
+
+namespace {
+
+struct CapturedStdio {
+    std::string out;
+    std::string err;
+};
+
+CapturedStdio run_with_level(const char *level_value, void (*fn)()) {
+    // Redirect stdout/stderr to temp files so we can read the bytes back.
+    fflush(stdout);
+    fflush(stderr);
+    FILE *out_tmp = tmpfile();
+    FILE *err_tmp = tmpfile();
+    int saved_out = dup(fileno(stdout));
+    int saved_err = dup(fileno(stderr));
+    dup2(fileno(out_tmp), fileno(stdout));
+    dup2(fileno(err_tmp), fileno(stderr));
+
+    if (level_value != nullptr) {
+        setenv("PTO_LOG_LEVEL", level_value, 1);
+    } else {
+        unsetenv("PTO_LOG_LEVEL");
+    }
+    HostLogger::get_instance().reinitialize();
+
+    fn();
+
+    fflush(stdout);
+    fflush(stderr);
+    dup2(saved_out, fileno(stdout));
+    dup2(saved_err, fileno(stderr));
+    close(saved_out);
+    close(saved_err);
+
+    auto slurp = [](FILE *f) {
+        std::string s;
+        rewind(f);
+        char buf[512];
+        size_t n;
+        while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+            s.append(buf, n);
+        }
+        fclose(f);
+        return s;
+    };
+    return {slurp(out_tmp), slurp(err_tmp)};
+}
+
+}  // namespace
+
+TEST(HostLogOffTest, OffMutesEverythingIncludingAlways) {
+    auto captured = run_with_level("off", [] {
+        HostLogger::get_instance().log(HostLogLevel::ERROR, "err-msg");
+        HostLogger::get_instance().log(HostLogLevel::WARN, "warn-msg");
+        HostLogger::get_instance().log(HostLogLevel::INFO, "info-msg");
+        HostLogger::get_instance().log(HostLogLevel::DEBUG, "dbg-msg");
+        HostLogger::get_instance().log(HostLogLevel::ALWAYS, "always-msg");
+    });
+    EXPECT_EQ(captured.out, "");
+    EXPECT_EQ(captured.err, "");
+}
+
+TEST(HostLogOffTest, ErrorLevelStillEmitsErrorAndAlways) {
+    auto captured = run_with_level("error", [] {
+        HostLogger::get_instance().log(HostLogLevel::ERROR, "err-msg");
+        HostLogger::get_instance().log(HostLogLevel::INFO, "info-msg");
+        HostLogger::get_instance().log(HostLogLevel::ALWAYS, "always-msg");
+    });
+    EXPECT_NE(captured.err.find("err-msg"), std::string::npos);
+    EXPECT_EQ(captured.out.find("info-msg"), std::string::npos);
+    EXPECT_NE((captured.out + captured.err).find("always-msg"), std::string::npos);
+}

--- a/tests/ut/py/test_log_config.py
+++ b/tests/ut/py/test_log_config.py
@@ -1,0 +1,42 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Tests for simpler_setup.log_config — off must mute everything."""
+
+import logging
+import os
+
+from simpler_setup.log_config import (
+    DEFAULT_LOG_LEVEL,
+    LOG_LEVEL_CHOICES,
+    configure_logging,
+)
+
+
+def test_off_mutes_all_records(caplog):
+    configure_logging("off")
+    logger = logging.getLogger("simpler.test.log_config")
+    with caplog.at_level(logging.NOTSET, logger=logger.name):
+        logger.error("err-should-be-muted")
+        logger.critical("crit-should-be-muted")
+    assert caplog.records == []
+    assert os.environ["PTO_LOG_LEVEL"] == "off"
+
+
+def test_error_level_still_emits_error(caplog):
+    configure_logging("error")
+    logger = logging.getLogger("simpler.test.log_config")
+    with caplog.at_level(logging.ERROR, logger=logger.name):
+        logger.error("err-must-show")
+    assert any("err-must-show" in r.message for r in caplog.records)
+
+
+def test_choices_contains_off_only():
+    assert "off" in LOG_LEVEL_CHOICES
+    assert "silent" not in LOG_LEVEL_CHOICES
+    assert DEFAULT_LOG_LEVEL == "info"


### PR DESCRIPTION
## Summary
- Adds an explicit `off` level to `PTO_LOG_LEVEL` across the Python CLI, the host C++ logger, and the sim AICPU logger. `off` suppresses every level including `ALWAYS` — used to silence noisy `device_runner` banners during benchmark/CI runs without recompiling.
- Replaces a handful of stray `std::cout` banners in `device_runner` (a2a3 + a5) with `LOG_INFO` so they respect the level.
- Drops the legacy `silent` alias from the sim AICPU logger; only `off` mutes all channels.
- `scene_test --log-level` now defaults to `$PTO_LOG_LEVEL` instead of hard-coded `info`, so the env var actually wins when not overridden on the CLI.

## Implementation notes
- Python: `configure_logging("off")` maps to `logging.CRITICAL + 1` and exports `PTO_LOG_LEVEL=off` so subprocesses inherit the mute.
- Host logger: new `HostLogLevel::OFF` short-circuits `log()` before any formatting, including `ALWAYS`.
- Onboard AICPU logs are not affected — those are managed by CANN and must be controlled via CANN env vars (e.g. `ASCEND_GLOBAL_LOG_LEVEL`). Documented in `docs/testing.md`.

## Testing
- [x] `tests/ut/py/test_log_config.py` — Python `off` mutes all records; `error` still emits errors; `silent` no longer in choices.
- [x] `tests/ut/cpp/a5/test_host_log_off.cpp` — host logger `off` mutes everything including `ALWAYS`; `error` still emits `ERROR` and `ALWAYS`.
- [x] Simulation tests pass
- [x] Hardware tests pass (if applicable)