### PR TITLE
Fix A5 multi-chip dispatch kernel compile ambiguity

### DIFF
--- a/examples/workers/l3/multi_chip_dispatch/kernels/aiv/vector_add_kernel.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/aiv/vector_add_kernel.cpp
@@ -42,7 +42,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     constexpr int vCols = 128;
 
     using DynShapeDim5 = Shape<1, 1, 1, vRows, vCols>;
-    using DynStridDim5 = Stride<1, 1, 1, kTCols_, 1>;
+    using DynStridDim5 = pto::Stride<1, 1, 1, kTCols_, 1>;
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStridDim5>;
     using TileData = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 


### PR DESCRIPTION
Qualify  as  in the L3  AIV kernel to avoid symbol ambiguity with CCEC intrinsic headers. This keeps the example compatible with newer toolchains without modifying pto-isa.