### PR TITLE
Add validation and logs for kernel func_id out-of-range

### DIFF
--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
@@ -97,6 +97,10 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
+            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+                return -1;
+            }
             const auto &kernel = callable->child(i);
             uint64_t addr = runtime->host_api.upload_kernel_binary(
                 func_id, reinterpret_cast<const uint8_t *>(&kernel),

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -119,12 +119,21 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
 }
 
 void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
-        func_id_to_addr_[func_id] = addr;
-        if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+        return;
+    }
+    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
             registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        } else {
+            LOG_ERROR(
+                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
+                func_id
+            );
         }
     }
+    func_id_to_addr_[func_id] = addr;
 }
 
 int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -303,6 +303,10 @@ int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const Chip
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
+            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+                return -1;
+            }
             const auto &kernel = callable->child(i);
             uint64_t addr = runtime->host_api.upload_kernel_binary(
                 func_id, reinterpret_cast<const uint8_t *>(&kernel),

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -230,3 +230,25 @@ TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
 void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
+
+// =============================================================================
+// Kernel Binary Address Management
+// =============================================================================
+
+void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
+    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+        return;
+    }
+    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        } else {
+            LOG_ERROR(
+                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
+                func_id
+            );
+        }
+    }
+    func_id_to_addr_[func_id] = addr;
+}

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -449,14 +449,7 @@ public:
      * Set function binary address for a func_id.
      * Called by platform layer after kernel registration.
      */
-    void set_function_bin_addr(int func_id, uint64_t addr) {
-        if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
-            func_id_to_addr_[func_id] = addr;
-            if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-                registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-            }
-        }
-    }
+    void set_function_bin_addr(int func_id, uint64_t addr);
 
     int get_registered_kernel_count() const { return registered_kernel_count_; }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -119,6 +119,10 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
+            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+                return -1;
+            }
             const auto &kernel = callable->child(i);
             uint64_t addr = runtime->host_api.upload_kernel_binary(
                 func_id, reinterpret_cast<const uint8_t *>(&kernel),

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -11,6 +11,7 @@
 #ifndef SCHEDULER_CONTEXT_H
 #define SCHEDULER_CONTEXT_H
 
+#include "aicpu/device_log.h"
 #include "scheduler_types.h"
 
 #include "scheduler/pto_scheduler.h"
@@ -284,7 +285,10 @@ private:
     // =========================================================================
 
     uint64_t get_function_bin_addr(int func_id) const {
-        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
+        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+            DEV_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
+            return 0;
+        }
         return func_id_to_addr_[func_id];
     }
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -143,12 +143,21 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
 }
 
 void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
-        func_id_to_addr_[func_id] = addr;
-        if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+        return;
+    }
+    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
             registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        } else {
+            LOG_ERROR(
+                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
+                func_id
+            );
         }
     }
+    func_id_to_addr_[func_id] = addr;
 }
 
 int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -303,6 +303,10 @@ int init_runtime_impl(Runtime *runtime, const ChipCallable *callable, const Chip
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
+            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+                return -1;
+            }
             const auto &kernel = callable->child(i);
             uint64_t addr = runtime->host_api.upload_kernel_binary(
                 func_id, reinterpret_cast<const uint8_t *>(&kernel),

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -230,3 +230,25 @@ TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
 int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
 
 void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
+
+// =============================================================================
+// Kernel Binary Address Management
+// =============================================================================
+
+void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
+    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+        return;
+    }
+    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        } else {
+            LOG_ERROR(
+                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
+                func_id
+            );
+        }
+    }
+    func_id_to_addr_[func_id] = addr;
+}

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -452,14 +452,7 @@ public:
      * Set function binary address for a func_id.
      * Called by platform layer after kernel registration.
      */
-    void set_function_bin_addr(int func_id, uint64_t addr) {
-        if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
-            func_id_to_addr_[func_id] = addr;
-            if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-                registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-            }
-        }
-    }
+    void set_function_bin_addr(int func_id, uint64_t addr);
 
     int get_registered_kernel_count() const { return registered_kernel_count_; }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -119,6 +119,10 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         LOG_INFO("Registering %d kernel(s) in init_runtime_impl", callable->child_count());
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
+            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+                return -1;
+            }
             const auto &kernel = callable->child(i);
             uint64_t addr = runtime->host_api.upload_kernel_binary(
                 func_id, reinterpret_cast<const uint8_t *>(&kernel),

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -11,6 +11,7 @@
 #ifndef SCHEDULER_CONTEXT_H
 #define SCHEDULER_CONTEXT_H
 
+#include "aicpu/device_log.h"
 #include "scheduler_types.h"
 
 #include "scheduler/pto_scheduler.h"
@@ -284,7 +285,10 @@ private:
     // =========================================================================
 
     uint64_t get_function_bin_addr(int func_id) const {
-        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
+        if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+            DEV_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
+            return 0;
+        }
         return func_id_to_addr_[func_id];
     }
 };

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -145,12 +145,21 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
 }
 
 void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id >= 0 && func_id < RUNTIME_MAX_FUNC_ID) {
-        func_id_to_addr_[func_id] = addr;
-        if (addr != 0 && registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
+    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
+        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
+        return;
+    }
+    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
             registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
+        } else {
+            LOG_ERROR(
+                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
+                func_id
+            );
         }
     }
+    func_id_to_addr_[func_id] = addr;
 }
 
 int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }


### PR DESCRIPTION
## Summary

When `func_id` is outside `[0, RUNTIME_MAX_FUNC_ID)`, the runtime previously
silently dropped the registration in `set_function_bin_addr`. The host-side
`init_runtime_impl` continued and returned success, so the caller believed all
kernels were registered. Later, on the device side, `get_function_bin_addr`
returned `0`, causing an AICore null-pointer dereference with no logs at any
layer.

This PR adds three layers of defense:

1. **Host initialization** (`init_runtime_impl`, all 5 variants): validate
   `func_id` before upload and return `-1` if out of range, so initialization
   fails early with a clear `LOG_ERROR`.
2. **Runtime API** (`Runtime::set_function_bin_addr`, all runtimes): add
   `LOG_ERROR` on out-of-range `func_id` instead of silently ignoring it.
3. **AICPU scheduler** (`SchedulerContext::get_function_bin_addr`, a2a3/a5 TRB):
   add `DEV_ERROR` so device-side logs also capture the fault.

Also moves `set_function_bin_addr` implementation out of `runtime.h` headers
into `.cpp` files so `LOG_ERROR` is available.

## Test plan

- [x] `tests/ut/py/test_task_interface.py` passes (97 tests)
- [x] Full editable build (`pip install -e .`) passes
- [ ] Simulation CI pipeline
- [ ] Hardware CI pipeline

Fixes #680