### PR TITLE
Refactor: rename ChipCallConfig -> CallConfig

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -126,13 +126,13 @@ destroy_device_context(ctx);
 ### Layer 3: Python API (`python/bindings/task_interface.cpp` via nanobind)
 
 ```python
-from simpler.task_interface import ChipWorker, ChipCallable, ChipStorageTaskArgs, ChipCallConfig
+from simpler.task_interface import ChipWorker, ChipCallable, ChipStorageTaskArgs, CallConfig
 
 worker = ChipWorker()
 worker.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path="")
 worker.set_device(device_id)
 
-config = ChipCallConfig()
+config = CallConfig()
 config.block_dim = 24
 config.aicpu_thread_num = 3
 config.enable_pmu = 0
@@ -150,10 +150,12 @@ level model (see [hierarchical_level_runtime.md](hierarchical_level_runtime.md))
 | Worker | `ChipWorker` | `Worker` | `Worker(level=N)` |
 | Callable | `ChipCallable` | *(planned)* | — |
 | TaskArgs | `ChipStorageTaskArgs` | *(planned)* | — |
-| Config | `ChipCallConfig` | *(planned)* | — |
+| Config | `CallConfig` | `CallConfig` | — |
 
+`CallConfig` is the exception — same type used at every level, with no
+`Chip*` / unprefixed split (see [task-flow.md](task-flow.md) for details).
 The unified `Worker(level=N)` factory already routes to the correct backend.
-When new level-specific types are added (e.g. `CallConfig`), each concept
+When new level-specific types are added (e.g. `ChipCallable`), each concept
 should follow the same pattern: a `Chip*` concrete type for L2, a prefix-less
 concrete type for L3+, and optionally a factory function that routes by level.
 
@@ -187,7 +189,7 @@ worker.set_device(device_id)
 ### 3. Execution Phase
 
 ```text
-worker.run(callable, args, ChipCallConfig(block_dim, aicpu_thread_num))
+worker.run(callable, args, CallConfig(block_dim, aicpu_thread_num))
   │
   └─→ run_runtime(ctx, runtime, callable, args, ...)
        │

--- a/docs/hierarchical_level_runtime.md
+++ b/docs/hierarchical_level_runtime.md
@@ -184,7 +184,7 @@ w4.add_worker(l3)
 w4.init()
 
 def my_l4_orch(orch, args, config):
-    orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+    orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
 w4.run(my_l4_orch)
 w4.close()

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -21,10 +21,10 @@ public:
     // --- User-facing submit API (tags inside TaskArgs drive deps) ---
     SubmitResult submit_next_level(uint64_t callable,
                                     const TaskArgs &args,
-                                    const ChipCallConfig &config);
+                                    const CallConfig &config);
     SubmitResult submit_next_level_group(uint64_t callable,
                                           const std::vector<TaskArgs> &args_list,
-                                          const ChipCallConfig &config);
+                                          const CallConfig &config);
     SubmitResult submit_sub(int32_t callable_id, const TaskArgs &args);
     SubmitResult submit_sub_group(int32_t callable_id,
                                    const std::vector<TaskArgs> &args_list);

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -201,8 +201,7 @@ Propagated by value throughout:
 5. `IWorker::run` receives `const CallConfig&`; passed on to `pto2_run_runtime`
    at the L2 edge
 
-Same type at every level. `ChipCallConfig` is an alias for `CallConfig` at the
-L2 runtime ABI (they must have identical layout).
+Same type at every level. Used directly at the L2 runtime ABI.
 
 ---
 
@@ -425,7 +424,7 @@ w4.add_worker(l3)                   # add un-init'd L3 Worker as child
 w4.init()
 
 def my_l4_orch(orch, args):
-    orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+    orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
 w4.run(Task(orch=my_l4_orch))
 w4.close()

--- a/docs/tensor-dump.md
+++ b/docs/tensor-dump.md
@@ -279,12 +279,12 @@ execution is never affected.
 ### 3.1 Enable at runtime
 
 The user-facing switch is still
-`ChipCallConfig::enable_dump_tensor`, but the runtime no longer relies
+`CallConfig::enable_dump_tensor`, but the runtime no longer relies
 on `dump_data_base` as the enable signal.
 
 Current propagation chain:
 
-1. Python / test harness sets `ChipCallConfig::enable_dump_tensor`.
+1. Python / test harness sets `CallConfig::enable_dump_tensor`.
 2. Host `DeviceRunner` allocates dump storage and publishes its base
    address via `kernel_args.dump_data_base`.
 3. Host also sets `PROFILING_FLAG_DUMP_TENSOR` in each worker

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -18,10 +18,10 @@ import tempfile
 import torch
 from simpler.task_interface import (
     ArgDirection,
+    CallConfig,
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCallConfig,
     ChipCommBootstrapConfig,
     ChipContext,
     ContinuousTensor,
@@ -159,7 +159,7 @@ def run(
                 args.add_scalar(ctx.device_ctx)
                 orch.submit_next_level(chip_callable, args, cfg, worker=rank)
 
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         ok = True
         for rank in range(nranks):

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -19,10 +19,10 @@ from multiprocessing.shared_memory import SharedMemory
 import torch
 from simpler.task_interface import (
     ArgDirection,
+    CallConfig,
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCallConfig,
     ChipCommBootstrapConfig,
     ChipContext,
     ContinuousTensor,
@@ -189,7 +189,7 @@ def run(
                 args.add_scalar(ctx.device_ctx)
                 orch.submit_next_level(chip_callable, args, cfg, worker=rank)
 
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         ok = True
         for rank in range(nranks):

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -18,10 +18,10 @@ import tempfile
 import torch
 from simpler.task_interface import (
     ArgDirection,
+    CallConfig,
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCallConfig,
     ChipCommBootstrapConfig,
     ChipContext,
     ContinuousTensor,
@@ -153,7 +153,7 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
                 args.add_scalar(ctx.device_ctx)
                 orch.submit_next_level(chip_callable, args, cfg, worker=rank)
 
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         ok = True
         for rank in range(nranks):

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -19,10 +19,10 @@ from multiprocessing.shared_memory import SharedMemory
 import torch
 from simpler.task_interface import (
     ArgDirection,
+    CallConfig,
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCallConfig,
     ChipCommBootstrapConfig,
     ChipContext,
     ContinuousTensor,
@@ -189,7 +189,7 @@ def run(
                 args.add_scalar(ctx.device_ctx)
                 orch.submit_next_level(chip_callable, args, cfg, worker=rank)
 
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         ok = True
         for rank in range(nranks):

--- a/examples/workers/l2/README.md
+++ b/examples/workers/l2/README.md
@@ -24,7 +24,7 @@ worker = Worker(
 worker.init()             # load host.so + aicpu.so + aicore.o, set device
 try:
     # ... allocate device buffers, build ChipCallable, run ...
-    worker.run(chip_callable, task_args, chip_call_config)
+    worker.run(chip_callable, task_args, call_config)
 finally:
     worker.close()        # release ACL resources and device
 ```

--- a/examples/workers/l2/vector_add/README.md
+++ b/examples/workers/l2/vector_add/README.md
@@ -96,7 +96,7 @@ args.add_tensor(ContinuousTensor.make(dev_a,   shape, DataType.FLOAT32))
 args.add_tensor(ContinuousTensor.make(dev_b,   shape, DataType.FLOAT32))
 args.add_tensor(ContinuousTensor.make(dev_out, shape, DataType.FLOAT32))
 
-worker.run(chip_callable, args, ChipCallConfig())
+worker.run(chip_callable, args, CallConfig())
 ```
 
 The tensor order must match `signature` order on the `ChipCallable`. `run()`

--- a/examples/workers/l2/vector_add/main.py
+++ b/examples/workers/l2/vector_add/main.py
@@ -39,8 +39,8 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import torch  # noqa: E402
 from simpler.task_interface import (
     ArgDirection,
+    CallConfig,
     ChipCallable,
-    ChipCallConfig,
     ChipStorageTaskArgs,
     ContinuousTensor,
     CoreCallable,
@@ -151,8 +151,8 @@ def _run(worker: Worker, chip_callable: ChipCallable) -> None:
     args.add_tensor(ContinuousTensor.make(dev_b, (N_ROWS, N_COLS), DataType.FLOAT32))
     args.add_tensor(ContinuousTensor.make(dev_out, (N_ROWS, N_COLS), DataType.FLOAT32))
 
-    # --- 4. Run. ChipCallConfig() defaults are fine for this kernel. ---
-    config = ChipCallConfig()
+    # --- 4. Run. CallConfig() defaults are fine for this kernel. ---
+    config = CallConfig()
     print("[vector_add] running on device...")
     worker.run(chip_callable, args, config)
 

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -45,10 +45,10 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
+    CallConfig,
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCallConfig,
     ChipCommBootstrapConfig,
     ChipContext,
     ContinuousTensor,
@@ -230,7 +230,7 @@ def run(device_ids: list[int]) -> int:
                 orch.submit_next_level(chip_callable, chip_args, cfg, worker=i)
 
         print("[allreduce] running 2-chip allreduce DAG...")
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         expected = torch.tensor(expected_output(nranks), dtype=torch.float32)
         ok = True

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -39,10 +39,10 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
+    CallConfig,
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCallConfig,
     ChipCommBootstrapConfig,
     ChipContext,
     ContinuousTensor,
@@ -253,7 +253,7 @@ def run(device_ids: list[int]) -> int:
                 orch.submit_next_level(allreduce_cc, a2, cfg, worker=i)
 
         print("[ffn_tp_parallel] running 2-chip 2-stage DAG...")
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         # Golden: every rank's y should equal sum over r of x_shard[r] @ w_shard[r].
         expected = torch.zeros(M, N, dtype=torch.float32)

--- a/examples/workers/l3/multi_chip_dispatch/README.md
+++ b/examples/workers/l3/multi_chip_dispatch/README.md
@@ -110,7 +110,7 @@ the DAG before returning.
 ### 4. `Worker.run(orch_fn, ...)` — blocks until DAG drains
 
 ```python
-worker.run(orch_fn, args=None, config=ChipCallConfig())
+worker.run(orch_fn, args=None, config=CallConfig())
 ```
 
 After this returns, all tags on `host_out` are satisfied: chip tasks have

--- a/examples/workers/l3/multi_chip_dispatch/main.py
+++ b/examples/workers/l3/multi_chip_dispatch/main.py
@@ -37,8 +37,8 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import torch  # noqa: E402
 from simpler.task_interface import (
     ArgDirection,
+    CallConfig,
     ChipCallable,
-    ChipCallConfig,
     CoreCallable,
     TaskArgs,
     TensorArgType,
@@ -178,7 +178,7 @@ def run(platform: str, device_ids: list[int]) -> int:
         # --- 7. Run the DAG. Worker.run() opens a scope, invokes orch_fn,
         # drains the DAG to completion, then closes the scope.
         print("[multi_chip_dispatch] running DAG (2 chip tasks + 1 sub)...")
-        worker.run(orch_fn, args=None, config=ChipCallConfig())
+        worker.run(orch_fn, args=None, config=CallConfig())
 
         # --- 8. Verify outputs. ``host_out`` was written in-place by the
         # chip processes via shared memory; no explicit copy needed.

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -551,17 +551,17 @@ NB_MODULE(_task_interface, m) {
             return os.str();
         });
 
-    // --- ChipCallConfig ---
-    nb::class_<ChipCallConfig>(m, "ChipCallConfig")
+    // --- CallConfig ---
+    nb::class_<CallConfig>(m, "CallConfig")
         .def(nb::init<>())
-        .def_rw("block_dim", &ChipCallConfig::block_dim)
-        .def_rw("aicpu_thread_num", &ChipCallConfig::aicpu_thread_num)
-        .def_rw("enable_l2_swimlane", &ChipCallConfig::enable_l2_swimlane)
-        .def_rw("enable_dump_tensor", &ChipCallConfig::enable_dump_tensor)
-        .def_rw("enable_pmu", &ChipCallConfig::enable_pmu)
-        .def("__repr__", [](const ChipCallConfig &self) -> std::string {
+        .def_rw("block_dim", &CallConfig::block_dim)
+        .def_rw("aicpu_thread_num", &CallConfig::aicpu_thread_num)
+        .def_rw("enable_l2_swimlane", &CallConfig::enable_l2_swimlane)
+        .def_rw("enable_dump_tensor", &CallConfig::enable_dump_tensor)
+        .def_rw("enable_pmu", &CallConfig::enable_pmu)
+        .def("__repr__", [](const CallConfig &self) -> std::string {
             std::ostringstream os;
-            os << "ChipCallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
+            os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
                << ", enable_l2_swimlane=" << (self.enable_l2_swimlane ? "True" : "False")
                << ", enable_dump_tensor=" << (self.enable_dump_tensor ? "True" : "False")
                << ", enable_pmu=" << self.enable_pmu << ")";
@@ -580,8 +580,7 @@ NB_MODULE(_task_interface, m) {
         .def("finalize", &ChipWorker::finalize)
         .def(
             "run",
-            [](ChipWorker &self, const PyChipCallable &callable, ChipStorageTaskArgs &args,
-               const ChipCallConfig &config) {
+            [](ChipWorker &self, const PyChipCallable &callable, ChipStorageTaskArgs &args, const CallConfig &config) {
                 self.run(callable.buffer_.data(), &args, config);
             },
             nb::arg("callable"), nb::arg("args"), nb::arg("config")
@@ -590,7 +589,7 @@ NB_MODULE(_task_interface, m) {
             "run_raw",
             [](ChipWorker &self, uint64_t callable, uint64_t args, int block_dim, int aicpu_thread_num,
                bool enable_l2_swimlane, bool enable_dump_tensor, int enable_pmu) {
-                ChipCallConfig config;
+                CallConfig config;
                 config.block_dim = block_dim;
                 config.aicpu_thread_num = aicpu_thread_num;
                 config.enable_l2_swimlane = enable_l2_swimlane;
@@ -606,7 +605,7 @@ NB_MODULE(_task_interface, m) {
             "run_from_blob",
             [](ChipWorker &self, uint64_t callable, uint64_t blob_ptr, int block_dim, int aicpu_thread_num,
                bool enable_l2_swimlane, bool enable_dump_tensor, int enable_pmu) {
-                ChipCallConfig config;
+                CallConfig config;
                 config.block_dim = block_dim;
                 config.aicpu_thread_num = aicpu_thread_num;
                 config.enable_l2_swimlane = enable_l2_swimlane;

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -100,8 +100,7 @@ inline void bind_worker(nb::module_ &m) {
     nb::class_<Orchestrator>(m, "_Orchestrator")
         .def(
             "submit_next_level",
-            [](Orchestrator &self, uint64_t callable, const TaskArgs &args, const ChipCallConfig &config,
-               int8_t worker) {
+            [](Orchestrator &self, uint64_t callable, const TaskArgs &args, const CallConfig &config, int8_t worker) {
                 return self.submit_next_level(callable, args, config, worker);
             },
             nb::arg("callable"), nb::arg("args"), nb::arg("config"), nb::arg("worker") = int8_t(-1),
@@ -109,8 +108,8 @@ inline void bind_worker(nb::module_ &m) {
         )
         .def(
             "submit_next_level_group",
-            [](Orchestrator &self, uint64_t callable, const std::vector<TaskArgs> &args_list,
-               const ChipCallConfig &config, const std::vector<int8_t> &workers) {
+            [](Orchestrator &self, uint64_t callable, const std::vector<TaskArgs> &args_list, const CallConfig &config,
+               const std::vector<int8_t> &workers) {
                 return self.submit_next_level_group(callable, args_list, config, workers);
             },
             nb::arg("callable"), nb::arg("args_list"), nb::arg("config"), nb::arg("workers") = std::vector<int8_t>{},
@@ -245,7 +244,7 @@ inline void bind_worker(nb::module_ &m) {
             "set_run_callback",
             [](Worker &self, nb::object cb) {
                 self.set_run_callback(
-                    [cb_stored = nb::object(cb)](uint64_t callable, TaskArgsView view, const ChipCallConfig &config) {
+                    [cb_stored = nb::object(cb)](uint64_t callable, TaskArgsView view, const CallConfig &config) {
                         nb::gil_scoped_acquire gil;
                         TaskArgs args;
                         for (int32_t i = 0; i < view.tensor_count; i++) {
@@ -260,7 +259,7 @@ inline void bind_worker(nb::module_ &m) {
             },
             nb::arg("callback"),
             "Set the Python callback for THREAD-mode L4+ dispatch. The callback "
-            "receives (callable_id, TaskArgs, ChipCallConfig) with the GIL held."
+            "receives (callable_id, TaskArgs, CallConfig) with the GIL held."
         )
 
         .def(

--- a/python/simpler/orchestrator.py
+++ b/python/simpler/orchestrator.py
@@ -34,7 +34,7 @@ from collections.abc import Iterator, Sequence
 from typing import Any, Optional
 
 from .task_interface import (
-    ChipCallConfig,
+    CallConfig,
     ContinuousTensor,
     DataType,
     TaskArgs,
@@ -68,20 +68,20 @@ class Orchestrator:
     # ------------------------------------------------------------------
 
     def submit_next_level(
-        self, callable_: Any, args: TaskArgs, config: Optional[ChipCallConfig] = None, *, worker: int = -1
+        self, callable_: Any, args: TaskArgs, config: Optional[CallConfig] = None, *, worker: int = -1
     ):
         """Submit a NEXT_LEVEL (chip) task. Tags inside ``args`` drive deps.
 
         ``worker``: logical worker id for affinity (-1 = unconstrained).
         """
-        cfg = config if config is not None else ChipCallConfig()
+        cfg = config if config is not None else CallConfig()
         return self._o.submit_next_level(_resolve_callable_ptr(callable_), args, cfg, int(worker))
 
     def submit_next_level_group(
         self,
         callable_: Any,
         args_list: list,
-        config: Optional[ChipCallConfig] = None,
+        config: Optional[CallConfig] = None,
         *,
         workers: Optional[list] = None,
     ):
@@ -89,7 +89,7 @@ class Orchestrator:
 
         ``workers``: per-args affinity list (None/empty = all unconstrained).
         """
-        cfg = config if config is not None else ChipCallConfig()
+        cfg = config if config is not None else CallConfig()
         w = [int(x) for x in workers] if workers else []
         return self._o.submit_next_level_group(_resolve_callable_ptr(callable_), args_list, cfg, w)
 

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -31,10 +31,10 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
     ArgDirection,
+    CallConfig,
     ChipBootstrapChannel,
     ChipBootstrapMailboxState,
     ChipCallable,
-    ChipCallConfig,
     ChipStorageTaskArgs,
     ContinuousTensor,
     CoreCallable,
@@ -65,7 +65,7 @@ __all__ = [
     "ArgDirection",
     "CoreCallable",
     "ChipCallable",
-    "ChipCallConfig",
+    "CallConfig",
     "ChipWorker",
     "arg_direction_name",
     "scalar_to_uint64",
@@ -288,11 +288,11 @@ class ChipWorker:
         Args:
             callable: ChipCallable built from orchestration + kernel binaries.
             args: ChipStorageTaskArgs for this invocation.
-            config: Optional ChipCallConfig. If None, a default is created.
+            config: Optional CallConfig. If None, a default is created.
             **kwargs: Overrides applied to config (e.g. block_dim=24).
         """
         if config is None:
-            config = ChipCallConfig()
+            config = CallConfig()
         for k, v in kwargs.items():
             setattr(config, k, v)
         self._impl.run(callable, args, config)

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -69,8 +69,8 @@ from .task_interface import (
     MAILBOX_ERROR_MSG_SIZE,
     MAILBOX_OFF_ERROR_MSG,
     MAILBOX_SIZE,
+    CallConfig,
     ChipBootstrapConfig,
-    ChipCallConfig,
     ChipContext,
     ChipWorker,
     ContinuousTensor,
@@ -490,9 +490,9 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
             cw.finalize()
 
 
-def _read_config_from_mailbox(buf: memoryview) -> "ChipCallConfig":
-    """Reconstruct a ChipCallConfig from the unified mailbox layout."""
-    cfg = ChipCallConfig()
+def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
+    """Reconstruct a CallConfig from the unified mailbox layout."""
+    cfg = CallConfig()
     cfg.block_dim = struct.unpack_from("i", buf, _OFF_BLOCK_DIM)[0]
     cfg.aicpu_thread_num = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
     cfg.enable_l2_swimlane = bool(struct.unpack_from("i", buf, _OFF_ENABLE_L2_SWIMLANE)[0])
@@ -1049,10 +1049,10 @@ class Worker:
 
         callable: ChipCallable (L2) or Python orch fn (L3+)
         args:     TaskArgs (optional)
-        config:   ChipCallConfig (optional, default-constructed if None)
+        config:   CallConfig (optional, default-constructed if None)
         """
         assert self._initialized, "Worker not initialized; call init() first"
-        cfg = config if config is not None else ChipCallConfig()
+        cfg = config if config is not None else CallConfig()
 
         if self.level == 2:
             assert self._chip_worker is not None

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -857,9 +857,9 @@ class SceneTestCase:
         raise ValueError(f"Unsupported level: {self._st_level}")
 
     def _build_config(self, config_dict, enable_l2_swimlane=False, enable_dump_tensor=False, enable_pmu=0):
-        from simpler.task_interface import ChipCallConfig  # noqa: PLC0415
+        from simpler.task_interface import CallConfig  # noqa: PLC0415
 
-        config = ChipCallConfig()
+        config = CallConfig()
         config.block_dim = config_dict.get("block_dim", 1)
         config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 3)
         config.enable_l2_swimlane = enable_l2_swimlane

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -137,25 +137,25 @@ ContinuousTensor Orchestrator::alloc(const std::vector<uint32_t> &shape, DataTyp
 // =============================================================================
 
 SubmitResult
-Orchestrator::submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config, int8_t worker) {
+Orchestrator::submit_next_level(uint64_t callable, const TaskArgs &args, const CallConfig &config, int8_t worker) {
     std::vector<int8_t> affinities;
     if (worker >= 0) affinities = {worker};
     return submit_impl(WorkerType::NEXT_LEVEL, callable, /*callable_id=*/-1, config, {args}, std::move(affinities));
 }
 
 SubmitResult Orchestrator::submit_next_level_group(
-    uint64_t callable, const std::vector<TaskArgs> &args_list, const ChipCallConfig &config,
+    uint64_t callable, const std::vector<TaskArgs> &args_list, const CallConfig &config,
     const std::vector<int8_t> &workers
 ) {
     return submit_impl(WorkerType::NEXT_LEVEL, callable, /*callable_id=*/-1, config, args_list, workers);
 }
 
 SubmitResult Orchestrator::submit_sub(int32_t callable_id, const TaskArgs &args) {
-    return submit_impl(WorkerType::SUB, /*callable_ptr=*/0, callable_id, ChipCallConfig{}, {args});
+    return submit_impl(WorkerType::SUB, /*callable_ptr=*/0, callable_id, CallConfig{}, {args});
 }
 
 SubmitResult Orchestrator::submit_sub_group(int32_t callable_id, const std::vector<TaskArgs> &args_list) {
-    return submit_impl(WorkerType::SUB, /*callable_ptr=*/0, callable_id, ChipCallConfig{}, args_list);
+    return submit_impl(WorkerType::SUB, /*callable_ptr=*/0, callable_id, CallConfig{}, args_list);
 }
 
 // =============================================================================
@@ -163,7 +163,7 @@ SubmitResult Orchestrator::submit_sub_group(int32_t callable_id, const std::vect
 // =============================================================================
 
 SubmitResult Orchestrator::submit_impl(
-    WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const ChipCallConfig &config,
+    WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const CallConfig &config,
     std::vector<TaskArgs> args_list, std::vector<int8_t> affinities
 ) {
     if (args_list.empty()) throw std::invalid_argument("Orchestrator: args_list must not be empty");

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -13,8 +13,8 @@
  * Orchestrator — DAG builder.
  *
  * Public API (called by the user's orch fn during Worker::run):
- *   - submit_next_level(callable, TaskArgs, ChipCallConfig)
- *   - submit_next_level_group(callable, vector<TaskArgs>, ChipCallConfig)
+ *   - submit_next_level(callable, TaskArgs, CallConfig)
+ *   - submit_next_level_group(callable, vector<TaskArgs>, CallConfig)
  *   - submit_sub(callable_id, TaskArgs)
  *   - submit_sub_group(callable_id, vector<TaskArgs>)
  *   - alloc(shape, dtype) — runtime-owned intermediate buffer
@@ -37,7 +37,7 @@
 #include <mutex>
 #include <vector>
 
-#include "../task_interface/chip_call_config.h"
+#include "../task_interface/call_config.h"
 #include "../task_interface/data_type.h"
 #include "../task_interface/task_args.h"
 #include "../task_interface/tensor_arg.h"
@@ -98,12 +98,12 @@ public:
     // data are auto-allocated from the HeapRing.
     // `worker`: logical worker id for affinity (-1 = unconstrained).
     SubmitResult
-    submit_next_level(uint64_t callable, const TaskArgs &args, const ChipCallConfig &config, int8_t worker = -1);
+    submit_next_level(uint64_t callable, const TaskArgs &args, const CallConfig &config, int8_t worker = -1);
 
     // Submit a group of NEXT_LEVEL tasks: N args -> N workers, 1 DAG node.
     // `workers`: per-args affinity (empty = all unconstrained).
     SubmitResult submit_next_level_group(
-        uint64_t callable, const std::vector<TaskArgs> &args_list, const ChipCallConfig &config,
+        uint64_t callable, const std::vector<TaskArgs> &args_list, const CallConfig &config,
         const std::vector<int8_t> &workers = {}
     );
 
@@ -178,7 +178,7 @@ private:
     // Shared submit machinery. Takes `args_list` by value so the Orchestrator
     // can patch `tensor.data` on OUTPUT tensors flagged for auto-allocation.
     SubmitResult submit_impl(
-        WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const ChipCallConfig &config,
+        WorkerType worker_type, uint64_t callable_ptr, int32_t callable_id, const CallConfig &config,
         std::vector<TaskArgs> args_list, std::vector<int8_t> affinities = {}
     );
 

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -30,7 +30,7 @@ void TaskSlotState::reset() {
     worker_type = WorkerType::NEXT_LEVEL;
     callable = 0;
     callable_id = -1;
-    config = ChipCallConfig{};
+    config = CallConfig{};
     task_args.clear();
     task_args_list.clear();
     is_group_ = false;

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -21,7 +21,7 @@
  *   - IWorker: abstract interface implemented by ChipWorker, SubWorker,
  *              and Worker itself (recursive composition)
  *
- * IWorker::run takes (callable, TaskArgsView, ChipCallConfig) directly.
+ * IWorker::run takes (callable, TaskArgsView, CallConfig) directly.
  * THREAD-mode dispatch builds the view via `slot.args_view(i)` from the
  * slot's stored TaskArgs; PROCESS-mode dispatch encodes the TaskArgs into
  * the per-WorkerThread shm mailbox via write_blob() and the child rebuilds
@@ -38,7 +38,7 @@
 #include <queue>
 #include <vector>
 
-#include "../task_interface/chip_call_config.h"
+#include "../task_interface/call_config.h"
 #include "../task_interface/task_args.h"
 
 // =============================================================================
@@ -148,7 +148,7 @@ struct TaskSlotState {
     WorkerType worker_type{WorkerType::NEXT_LEVEL};
     uint64_t callable{0};     // NEXT_LEVEL: ChipCallable buffer ptr; SUB: unused
     int32_t callable_id{-1};  // SUB: registered callable id
-    ChipCallConfig config{};  // NEXT_LEVEL config (block_dim, aicpu_thread_num, diagnostics sub-features)
+    CallConfig config{};      // NEXT_LEVEL config (block_dim, aicpu_thread_num, diagnostics sub-features)
 
     // Unified task-args storage: `task_args` is the single-task builder;
     // when `is_group_` is true, `task_args_list` carries one TaskArgs per
@@ -236,5 +236,5 @@ public:
     //
     // slot_id is not a parameter — completion routing is owned by
     // WorkerThread / Scheduler at a higher layer.
-    virtual void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) = 0;
+    virtual void run(uint64_t callable, TaskArgsView args, const CallConfig &config) = 0;
 };

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -167,7 +167,7 @@ void Worker::close() {
 // IWorker::run() — Worker as sub-worker of a higher level (THREAD mode)
 // =============================================================================
 
-void Worker::run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) {
+void Worker::run(uint64_t callable, TaskArgsView args, const CallConfig &config) {
     if (run_callback_) {
         run_callback_(callable, args, config);
     }

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -90,9 +90,9 @@ public:
     // run() invokes run_callback_ which acquires the GIL and delegates
     // to the Python Worker._run_as_child method (approach (b): Python
     // callback — simpler than full C++ registry lookup).
-    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) override;
+    void run(uint64_t callable, TaskArgsView args, const CallConfig &config) override;
 
-    using RunCallback = std::function<void(uint64_t, TaskArgsView, const ChipCallConfig &)>;
+    using RunCallback = std::function<void(uint64_t, TaskArgsView, const CallConfig &)>;
     void set_run_callback(RunCallback cb) { run_callback_ = std::move(cb); }
 
 private:

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * ChipCallConfig — per-NEXT_LEVEL-task config. Carries execution knobs
+ * CallConfig — per-NEXT_LEVEL-task config. Carries execution knobs
  * (block_dim, aicpu_thread_num) plus the three parallel diagnostics
  * sub-features under the profiling umbrella: `enable_l2_swimlane` (swimlane),
  * `enable_dump_tensor`, and `enable_pmu`.
@@ -22,7 +22,7 @@
 
 #pragma once
 
-struct ChipCallConfig {
+struct CallConfig {
     int block_dim = 24;
     int aicpu_thread_num = 3;
     bool enable_l2_swimlane = false;

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -226,7 +226,7 @@ void ChipWorker::finalize() {
     finalized_ = true;
 }
 
-void ChipWorker::run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) {
+void ChipWorker::run(uint64_t callable, TaskArgsView args, const CallConfig &config) {
     // L2 ABI edge: assemble the fixed-size ChipStorageTaskArgs POD from the
     // view and hand it to the runtime. This conversion used to happen at
     // submit time (stored on the slot); it now runs lazily in the worker so
@@ -235,7 +235,7 @@ void ChipWorker::run(uint64_t callable, TaskArgsView args, const ChipCallConfig 
     run(reinterpret_cast<const void *>(callable), &chip_storage, config);
 }
 
-void ChipWorker::run(const void *callable, const void *args, const ChipCallConfig &config) {
+void ChipWorker::run(const void *callable, const void *args, const CallConfig &config) {
     if (!device_set_) {
         throw std::runtime_error("ChipWorker device not set; call set_device() first");
     }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -16,7 +16,7 @@
 #include <string>
 #include <vector>
 
-#include "../task_interface/chip_call_config.h"
+#include "../task_interface/call_config.h"
 #include "../task_interface/task_args.h"
 #include "types.h"
 
@@ -50,11 +50,11 @@ public:
     // IWorker: build a ChipStorageTaskArgs POD from `args` and execute the
     // runtime synchronously. `callable` is a ChipCallable buffer pointer
     // cast to uint64.
-    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig &config) override;
+    void run(uint64_t callable, TaskArgsView args, const CallConfig &config) override;
 
     // Direct invocation (used by Python wrapper and internal tests) — bypasses
     // the TaskArgsView path and takes a ready-made ChipStorageTaskArgs POD.
-    void run(const void *callable, const void *args, const ChipCallConfig &config);
+    void run(const void *callable, const void *args, const CallConfig &config);
 
     uint64_t malloc(size_t size);
     void free(uint64_t ptr);

--- a/tests/st/explicit_fatal/test_explicit_fatal.py
+++ b/tests/st/explicit_fatal/test_explicit_fatal.py
@@ -12,7 +12,7 @@
 import os
 
 import pytest
-from simpler.task_interface import ChipCallable, ChipCallConfig, ChipStorageTaskArgs
+from simpler.task_interface import CallConfig, ChipCallable, ChipStorageTaskArgs
 from simpler.worker import Worker
 
 from simpler_setup.kernel_compiler import KernelCompiler
@@ -43,7 +43,7 @@ def test_explicit_fatal_reports(st_platform, st_device_ids, monkeypatch):
     worker = Worker(level=2, platform=st_platform, runtime=RUNTIME, device_id=int(st_device_ids[0]))
     worker.init()
     try:
-        config = ChipCallConfig()
+        config = CallConfig()
         config.block_dim = 24
         config.aicpu_thread_num = 4
         with pytest.raises(RuntimeError, match=r"run_runtime failed with code -9"):

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -13,7 +13,7 @@
 
 #include <atomic>
 
-#include "chip_call_config.h"
+#include "call_config.h"
 #include "ring.h"
 #include "orchestrator.h"
 #include "scope.h"
@@ -33,7 +33,7 @@ struct OrchestratorFixture : public ::testing::Test {
     ReadyQueue rq_next_level;
     ReadyQueue rq_sub;
     Orchestrator orch;
-    ChipCallConfig cfg;
+    CallConfig cfg;
 
     // Tests in this file only submit NEXT_LEVEL tasks, so `rq` is a
     // convenience alias for the next-level queue. Kept public so existing

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -19,7 +19,7 @@
 #include <thread>
 #include <vector>
 
-#include "chip_call_config.h"
+#include "call_config.h"
 #include "orchestrator.h"
 #include "ring.h"
 #include "scheduler.h"
@@ -48,7 +48,7 @@ struct MockWorker : public IWorker {
     std::atomic<bool> should_complete{false};
     std::atomic<bool> is_running{false};
 
-    void run(uint64_t callable, TaskArgsView args, const ChipCallConfig & /*cfg*/) override {
+    void run(uint64_t callable, TaskArgsView args, const CallConfig & /*cfg*/) override {
         {
             std::lock_guard<std::mutex> lk(dispatched_mu);
             uint64_t key = (args.tensor_count > 0) ? args.tensors[0].data : 0;
@@ -113,7 +113,7 @@ struct SchedulerFixture : public ::testing::Test {
     MockWorker mock_worker;
     WorkerManager manager;
     Scheduler sched;
-    ChipCallConfig cfg;
+    CallConfig cfg;
 
     std::vector<TaskSlot> consumed_slots;
     std::mutex consumed_mu;
@@ -220,7 +220,7 @@ struct GroupSchedulerFixture : public ::testing::Test {
     MockWorker worker_b;
     WorkerManager manager;
     Scheduler sched;
-    ChipCallConfig cfg;
+    CallConfig cfg;
 
     std::vector<TaskSlot> consumed_slots;
     std::mutex consumed_mu;
@@ -331,7 +331,7 @@ struct MixedTypeSchedulerFixture : public ::testing::Test {
     MockWorker sub_worker;
     WorkerManager manager;
     Scheduler sched;
-    ChipCallConfig cfg;
+    CallConfig cfg;
 
     std::vector<TaskSlot> consumed_slots;
     std::mutex consumed_mu;

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -6,19 +6,19 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Tests for ChipCallConfig and ChipWorker state machine."""
+"""Tests for CallConfig and ChipWorker state machine."""
 
 import pytest
-from _task_interface import ChipCallConfig, _ChipWorker  # pyright: ignore[reportMissingImports]
+from _task_interface import CallConfig, _ChipWorker  # pyright: ignore[reportMissingImports]
 
 # ============================================================================
-# ChipCallConfig tests
+# CallConfig tests
 # ============================================================================
 
 
-class TestChipCallConfig:
+class TestCallConfig:
     def test_defaults(self):
-        config = ChipCallConfig()
+        config = CallConfig()
         assert config.block_dim == 24
         assert config.aicpu_thread_num == 3
         assert config.enable_l2_swimlane is False
@@ -26,7 +26,7 @@ class TestChipCallConfig:
         assert config.enable_pmu == 0
 
     def test_setters(self):
-        config = ChipCallConfig()
+        config = CallConfig()
         config.block_dim = 32
         config.aicpu_thread_num = 4
         config.enable_l2_swimlane = True
@@ -37,7 +37,7 @@ class TestChipCallConfig:
     def test_diagnostics_subfeatures_are_parallel(self):
         # Guard against drift: the three diagnostics sub-features under the
         # profiling umbrella must all round-trip through the nanobind surface.
-        config = ChipCallConfig()
+        config = CallConfig()
         config.enable_l2_swimlane = True
         config.enable_dump_tensor = True
         config.enable_pmu = 2
@@ -50,7 +50,7 @@ class TestChipCallConfig:
         assert "enable_pmu=2" in r
 
     def test_repr(self):
-        config = ChipCallConfig()
+        config = CallConfig()
         r = repr(config)
         assert "block_dim=24" in r
         assert "enable_l2_swimlane=False" in r
@@ -72,7 +72,7 @@ class TestChipWorkerStateMachine:
         from _task_interface import ChipCallable, ChipStorageTaskArgs  # noqa: PLC0415
 
         worker = _ChipWorker()
-        config = ChipCallConfig()
+        config = CallConfig()
         args = ChipStorageTaskArgs()
 
         # Build a minimal ChipCallable for the test
@@ -119,11 +119,11 @@ class TestChipWorkerStateMachine:
 class TestChipWorkerPython:
     def test_import(self):
         from simpler.task_interface import (  # noqa: PLC0415
-            ChipCallConfig as PyChipCallConfig,  # pyright: ignore[reportAttributeAccessIssue]
+            CallConfig as PyCallConfig,  # pyright: ignore[reportAttributeAccessIssue]
         )
         from simpler.task_interface import ChipWorker  # noqa: PLC0415  # pyright: ignore[reportAttributeAccessIssue]
 
         worker = ChipWorker()
         assert worker.initialized is False
         assert worker.device_set is False
-        assert isinstance(PyChipCallConfig(), ChipCallConfig)
+        assert isinstance(PyCallConfig(), CallConfig)

--- a/tests/ut/py/test_worker/test_error_propagation.py
+++ b/tests/ut/py/test_worker/test_error_propagation.py
@@ -27,7 +27,7 @@ import time
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
-from simpler.task_interface import ChipCallConfig, TaskArgs
+from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import Worker
 
 # ---------------------------------------------------------------------------
@@ -220,7 +220,7 @@ class TestL4ChainedFailure:
         try:
 
             def l4_orch(orch, args, config):
-                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
             with pytest.raises(RuntimeError) as info:
                 w4.run(l4_orch)

--- a/tests/ut/py/test_worker/test_l4_recursive.py
+++ b/tests/ut/py/test_worker/test_l4_recursive.py
@@ -19,7 +19,7 @@ import struct
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
-from simpler.task_interface import ChipCallConfig, TaskArgs
+from simpler.task_interface import CallConfig, TaskArgs
 from simpler.worker import Worker
 
 # ---------------------------------------------------------------------------
@@ -134,7 +134,7 @@ class TestL4ToL3SingleDispatch:
             w4.init()
 
             def l4_orch(orch, args, config):
-                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
             w4.run(l4_orch)
             w4.close()
@@ -169,7 +169,7 @@ class TestL4ToL3MultipleDispatches:
 
             def l4_orch(orch, args, config):
                 for _ in range(3):
-                    orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                    orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
             w4.run(l4_orch)
             w4.close()
@@ -210,7 +210,7 @@ class TestL4WithOwnSubs:
             w4.init()
 
             def l4_orch(orch, args, config):
-                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
                 orch.submit_sub(l4_verify_cid)
 
             w4.run(l4_orch)
@@ -246,7 +246,7 @@ class TestL4MultipleRuns:
             w4.init()
 
             def l4_orch(orch, args, config):
-                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
             for _ in range(5):
                 w4.run(l4_orch)
@@ -287,7 +287,7 @@ class TestL4L3WithMultipleSubs:
             w4.init()
 
             def l4_orch(orch, args, config):
-                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
             w4.run(l4_orch)
             w4.close()
@@ -323,7 +323,7 @@ class TestL3OwnOrchestrator:
             w4.init()
 
             def l4_orch(orch, args, config):
-                orch.submit_next_level(l3_cid, TaskArgs(), ChipCallConfig())
+                orch.submit_next_level(l3_cid, TaskArgs(), CallConfig())
 
             w4.run(l4_orch)
             w4.close()


### PR DESCRIPTION
## Summary

Pure mechanical rename. The `Chip` prefix on `ChipCallConfig` was redundant — "CallConfig" already implies it's config for a chip-level call from surrounding context. Drops it everywhere:

- C++ struct in `src/common/task_interface/call_config.h` (file renamed from `chip_call_config.h`)
- C++ usages in `src/common/{hierarchical,worker}/`, `python/bindings/`, C++ unit tests
- Python class name in nanobind binding (`"CallConfig"`)
- Python imports in `python/simpler/`, `simpler_setup/`, `tests/`, `examples/`
- Doc references in `docs/`

No behavior change.

## Why now

This is the first of three follow-up PRs that supersede #685 (env-var rename). The architectural plan is to pass the per-task output path via a new `CallConfig.output_prefix` field and drop `SIMPLER_OUTPUT_DIR` entirely. This rename PR is the prep step:

1. **This PR — rename** `ChipCallConfig` → `CallConfig`
2. Pack mailbox config fields into a single POD block (refactor, no functional change)
3. Add `output_prefix` to `CallConfig`, drop env var + perf-record subdir scoping

## Test plan

- [ ] CI: lint + tests pass
- [ ] `rg ChipCallConfig` returns no matches (verified locally — 0 leftovers across `src/`, `python/`, `tests/`, `examples/`, `docs/`)
- [ ] `rg chip_call_config` returns no matches (verified locally — 0 leftovers; include path also updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)