### PR TITLE
[WIP] Add: host-side stream sync timeout via aclrtSynchronizeStreamWithTimeout

### DIFF
--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -59,6 +59,12 @@ constexpr int PLATFORM_MAX_AICPU_THREADS = 4;
  */
 constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 6;
 
+/**
+ * Host-side stream synchronization timeout (milliseconds)
+ * Passed to aclrtSynchronizeStreamWithTimeout to detect stream sync hangs.
+ */
+constexpr int PLATFORM_STREAM_SYNC_TIMEOUT_MS = 1000;
+
 // =============================================================================
 // Derived Platform Limits
 // =============================================================================

--- a/src/a2a3/platform/include/host/l2_perf_collector.h
+++ b/src/a2a3/platform/include/host/l2_perf_collector.h
@@ -158,8 +158,10 @@ public:
     /**
      * Stop the memory management thread
      * Blocks until the thread exits.
+     *
+     * @param free_buffers If false, skip freeing device buffers (use after device reset).
      */
-    void stop();
+    void stop(bool free_buffers = true);
 
     /**
      * Try to pop a ready buffer info (non-blocking)
@@ -315,8 +317,10 @@ public:
      * Stop the memory management thread and clean up remaining data
      *
      * Must be called after device execution completes.
+     *
+     * @param free_buffers If false, skip freeing device buffers (use after device reset).
      */
-    void stop_memory_manager();
+    void stop_memory_manager(bool free_buffers = true);
 
     /**
      * Cleanup all resources

--- a/src/a2a3/platform/include/host/memory_allocator.h
+++ b/src/a2a3/platform/include/host/memory_allocator.h
@@ -92,6 +92,14 @@ public:
     int finalize();
 
     /**
+     * Drop all tracked pointers without calling rtFree.
+     *
+     * Use after a device reset (aclrtResetDevice) that reclaims all device
+     * memory, so individual rtFree calls are unnecessary and may block.
+     */
+    void abandon();
+
+    /**
      * Get number of tracked allocations
      *
      * @return Number of currently tracked pointers

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -433,10 +433,33 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
+int DeviceRunner::synchronize_stream_with_timeout(rtStream_t stream, const char *stream_name, int timeout_ms) {
+    if (stream == nullptr) {
+        LOG_ERROR("synchronize_stream_with_timeout: stream %s is null", stream_name);
+        return -1;
+    }
+
+    int rc = aclrtSynchronizeStreamWithTimeout(stream, timeout_ms);
+    if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
+        LOG_ERROR(
+            "Stream sync timeout: stream=%s timeout_ms=%d device_id=%d block_dim=%d "
+            "worker_count=%d binaries_loaded=%d",
+            stream_name, timeout_ms, device_id_, block_dim_, worker_count_, binaries_loaded_ ? 1 : 0
+        );
+        last_run_timed_out_ = true;
+        return rc;
+    }
+    if (rc != 0) {
+        LOG_ERROR("aclrtSynchronizeStreamWithTimeout (%s) failed: %d", stream_name, rc);
+    }
+    return rc;
+}
+
 int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
     const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
 ) {
+    last_run_timed_out_ = false;
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -554,6 +577,7 @@ int DeviceRunner::run(
 
     // Scope guards for cleanup on all exit paths
     auto regs_cleanup = RAIIScopeGuard([this]() {
+        if (last_run_timed_out_) return;
         if (kernel_args_.args.regs != 0) {
             mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.regs));
             kernel_args_.args.regs = 0;
@@ -561,6 +585,7 @@ int DeviceRunner::run(
     });
 
     auto pmu_regs_cleanup = RAIIScopeGuard([this]() {
+        if (last_run_timed_out_) return;
         if (kernel_args_.args.pmu_reg_addrs != 0) {
             mem_alloc_.free(reinterpret_cast<void *>(kernel_args_.args.pmu_reg_addrs));
             kernel_args_.args.pmu_reg_addrs = 0;
@@ -568,6 +593,7 @@ int DeviceRunner::run(
     });
 
     auto runtime_args_cleanup = RAIIScopeGuard([this]() {
+        if (last_run_timed_out_) return;
         kernel_args_.finalize_device_kernel_args();
         kernel_args_.finalize_runtime_args();
     });
@@ -607,9 +633,8 @@ int DeviceRunner::run(
     }
 
     auto perf_cleanup = RAIIScopeGuard([this]() {
-        bool was_initialized = l2_perf_collector_.is_initialized();
-        if (was_initialized) {
-            l2_perf_collector_.stop_memory_manager();
+        if (l2_perf_collector_.is_initialized()) {
+            l2_perf_collector_.stop_memory_manager(/*free_buffers=*/!last_run_timed_out_);
         }
     });
 
@@ -721,17 +746,14 @@ int DeviceRunner::run(
         });
 
         LOG_INFO("=== rtStreamSynchronize stream_aicpu_ ===");
-        // Synchronize streams
-        rc = rtStreamSynchronize(stream_aicpu_);
+        rc = synchronize_stream_with_timeout(stream_aicpu_, "AICPU", PLATFORM_STREAM_SYNC_TIMEOUT_MS);
         if (rc != 0) {
-            LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
             return rc;
         }
 
         LOG_INFO("=== rtStreamSynchronize stream_aicore_ ===");
-        rc = rtStreamSynchronize(stream_aicore_);
+        rc = synchronize_stream_with_timeout(stream_aicore_, "AICore", PLATFORM_STREAM_SYNC_TIMEOUT_MS);
         if (rc != 0) {
-            LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
             return rc;
         }
     }
@@ -851,6 +873,50 @@ int DeviceRunner::finalize() {
         return rc;
     }
 
+    if (last_run_timed_out_) {
+        // Device is unresponsive — skip all rt* cleanup (rtFree, rtStreamDestroy,
+        // halHostUnregister) which would block. Go directly to aclrtResetDevice.
+        // Device reset reclaims all device memory, so skipped frees are safe.
+        // Every cached device pointer must be nulled to prevent stale reuse.
+        LOG_ERROR("finalize: timeout recovery — skipping rt* cleanup, resetting device directly");
+        stream_aicpu_ = nullptr;
+        stream_aicore_ = nullptr;
+        kernel_args_.abandon();
+        so_info_.abandon();
+        func_id_to_addr_.clear();
+        binaries_loaded_ = false;
+        dev_orch_so_buffer_ = nullptr;
+        dev_orch_so_capacity_ = 0;
+        cached_orch_so_hash_ = 0;
+        host_orch_so_copy_.clear();
+        host_orch_so_copy_.shrink_to_fit();
+        mem_alloc_.abandon();
+
+        // aclrtResetDevice must execute unconditionally here — the run() path
+        // uses rtSetDevice (not aclInit), so acl_ready_ is false, but the
+        // device still needs resetting.  reset_device_and_acl() gates on
+        // acl_ready_ and would skip the reset entirely.
+        if (device_id_ >= 0) {
+            int reset_rc = aclrtResetDevice(device_id_);
+            if (reset_rc != 0) {
+                LOG_ERROR("aclrtResetDevice(%d) failed during timeout recovery: %d", device_id_, reset_rc);
+            }
+        }
+        if (acl_ready_) {
+            int fin_rc = aclFinalize();
+            if (fin_rc != 0) {
+                LOG_ERROR("aclFinalize failed during timeout recovery: %d", fin_rc);
+            }
+            acl_ready_ = false;
+        }
+        device_id_ = -1;
+        block_dim_ = 0;
+        worker_count_ = 0;
+        aicore_kernel_binary_.clear();
+        LOG_INFO("DeviceRunner finalized (timeout recovery)");
+        return 0;
+    }
+
     release_run_context();
 
     // Cleanup kernel args (deviceArgs)
@@ -938,7 +1004,11 @@ int DeviceRunner::finalize() {
     // Free all remaining allocations (including handshake buffer and binGmAddr)
     mem_alloc_.finalize();
 
-    // Reset device and finalize ACL AFTER all device memory is freed.
+    return reset_device_and_acl();
+}
+
+int DeviceRunner::reset_device_and_acl() {
+    int rc = 0;
     // Gated on acl_ready_ so rt-only runtimes that never called
     // ensure_acl_ready() do not try to aclFinalize an un-init'd ACL state.
     if (acl_ready_ && device_id_ >= 0) {

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -132,6 +132,19 @@ struct KernelArgsHelper {
      */
     int finalize_device_kernel_args();
 
+    /** Null out all device pointers without calling rtFree (for use after device reset). */
+    void abandon() {
+        args.device_args = nullptr;
+        args.runtime_args = nullptr;
+        args.regs = 0;
+        args.ffts_base_addr = 0;
+        args.dump_data_base = 0;
+        args.l2_perf_data_base = 0;
+        args.pmu_data_base = 0;
+        args.pmu_reg_addrs = 0;
+        device_k_args_ = nullptr;
+    }
+
     /**
      * Implicit conversion operators for seamless use with runtime APIs
      *
@@ -169,6 +182,12 @@ struct AicpuSoInfo {
      * @return 0 on success, error code on failure
      */
     int finalize();
+
+    /** Null out device pointer without calling rtFree (for use after device reset). */
+    void abandon() {
+        aicpu_so_bin = 0;
+        aicpu_so_len = 0;
+    }
 };
 
 /**
@@ -290,6 +309,11 @@ public:
      * @return 0 on success, error code on failure
      */
     int finalize();
+
+    /**
+     * Whether the most recent run() exited due to stream sync timeout.
+     */
+    bool last_run_timed_out() const { return last_run_timed_out_; }
 
     /**
      * Launch an AICPU kernel
@@ -422,6 +446,7 @@ private:
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results in destructor
     std::vector<uint8_t> aicore_kernel_binary_;
+    bool last_run_timed_out_{false};
 
     // Memory management
     MemoryAllocator mem_alloc_;
@@ -506,6 +531,20 @@ private:
      * @return 0 on success, non-zero on failure.
      */
     int prepare_orch_so(Runtime &runtime);
+
+    /**
+     * Synchronize stream with a host-side timeout via aclrtSynchronizeStreamWithTimeout.
+     * Sets last_run_timed_out_ on ACL_ERROR_RT_STREAM_SYNC_TIMEOUT.
+     *
+     * @param stream Stream to synchronize
+     * @param stream_name Stream label for logs
+     * @param timeout_ms Timeout threshold in milliseconds
+     * @return 0 on success, error code on failure/timeout
+     */
+    int synchronize_stream_with_timeout(rtStream_t stream, const char *stream_name, int timeout_ms);
+
+    /** Execute aclrtResetDevice + aclFinalize and clear runner state. */
+    int reset_device_and_acl();
 
     /**
      * Initialize performance profiling shared memory

--- a/src/a2a3/platform/onboard/host/memory_allocator.cpp
+++ b/src/a2a3/platform/onboard/host/memory_allocator.cpp
@@ -70,3 +70,8 @@ int MemoryAllocator::finalize() {
     ptr_set_.clear();
     return last_error;
 }
+
+void MemoryAllocator::abandon() {
+    std::lock_guard<std::mutex> lk(mu_);
+    ptr_set_.clear();
+}

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -238,8 +238,20 @@ int run_runtime(
         std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
         rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
         if (rc != 0) {
-            validate_runtime_impl(r);
-            r->~Runtime();
+            if (runner->last_run_timed_out()) {
+                // Skip validate_runtime_impl: device state is unreliable after
+                // stream sync timeout — copy_from_device / device_free may block
+                // or fault on already-reset resources.
+                LOG_ERROR("run_runtime: stream sync timeout detected, skipping validation, triggering full reset");
+                r->~Runtime();
+                int reset_rc = runner->finalize();
+                if (reset_rc != 0) {
+                    LOG_ERROR("run_runtime: DeviceRunner finalize after timeout failed: %d", reset_rc);
+                }
+            } else {
+                validate_runtime_impl(r);
+                r->~Runtime();
+            }
             return rc;
         }
 

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -68,10 +68,21 @@ void ProfMemoryManager::start(
     LOG_INFO("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
 }
 
-void ProfMemoryManager::stop() {
+void ProfMemoryManager::stop(bool free_buffers) {
     running_.store(false);
     if (mgmt_thread_.joinable()) {
         mgmt_thread_.join();
+    }
+
+    if (!free_buffers) {
+        // After device reset, device memory is already reclaimed.
+        // Just clear host-side tracking without calling rtFree.
+        std::scoped_lock<std::mutex> lock(done_mutex_);
+        std::queue<CopyDoneInfo>().swap(done_queue_);
+        recycled_perf_buffers_.clear();
+        recycled_phase_buffers_.clear();
+        LOG_INFO("ProfMemoryManager stopped (buffers abandoned after device reset)");
+        return;
     }
 
     // Drain remaining done_queue and free buffers
@@ -710,9 +721,9 @@ void L2PerfCollector::start_memory_manager(const ThreadFactory &thread_factory) 
     );
 }
 
-void L2PerfCollector::stop_memory_manager() {
+void L2PerfCollector::stop_memory_manager(bool free_buffers) {
     if (memory_manager_.is_running()) {
-        memory_manager_.stop();
+        memory_manager_.stop(free_buffers);
     }
 }
 


### PR DESCRIPTION
Replace bare rtStreamSynchronize with aclrtSynchronizeStreamWithTimeout
(1 s deadline) so the host process no longer hangs indefinitely when device
tasks stall. On timeout, skip validate_runtime_impl (its device I/O could
block again) and finalize the DeviceRunner directly.
