### PR TITLE
Refactor: pack mailbox config fields into a single POD block

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -552,12 +552,30 @@ NB_MODULE(_task_interface, m) {
         });
 
     // --- CallConfig ---
+    // The two enable_* fields are stored as int32 on the wire (see call_config.h).
+    // Expose them as Python `bool` via def_property so user-facing API is unchanged.
     nb::class_<CallConfig>(m, "CallConfig")
         .def(nb::init<>())
         .def_rw("block_dim", &CallConfig::block_dim)
         .def_rw("aicpu_thread_num", &CallConfig::aicpu_thread_num)
-        .def_rw("enable_l2_swimlane", &CallConfig::enable_l2_swimlane)
-        .def_rw("enable_dump_tensor", &CallConfig::enable_dump_tensor)
+        .def_prop_rw(
+            "enable_l2_swimlane",
+            [](const CallConfig &c) {
+                return static_cast<bool>(c.enable_l2_swimlane);
+            },
+            [](CallConfig &c, bool v) {
+                c.enable_l2_swimlane = v ? 1 : 0;
+            }
+        )
+        .def_prop_rw(
+            "enable_dump_tensor",
+            [](const CallConfig &c) {
+                return static_cast<bool>(c.enable_dump_tensor);
+            },
+            [](CallConfig &c, bool v) {
+                c.enable_dump_tensor = v ? 1 : 0;
+            }
+        )
         .def_rw("enable_pmu", &CallConfig::enable_pmu)
         .def("__repr__", [](const CallConfig &self) -> std::string {
             std::ostringstream os;

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -97,12 +97,17 @@ _BOOTSTRAP_POLL_INTERVAL_S = 0.001
 _OFF_STATE = 0
 _OFF_ERROR = 4
 _OFF_CALLABLE = 8
-_OFF_BLOCK_DIM = 16
-_OFF_AICPU_THREAD_NUM = 20
-_OFF_ENABLE_L2_SWIMLANE = 24
-_OFF_ENABLE_DUMP_TENSOR = 28
-_OFF_ENABLE_PMU = 32
+_OFF_CONFIG = 16
+# Packed CallConfig wire layout (5 int32s in declaration order, see call_config.h).
+# struct.calcsize("=iiiii") == 20.
+_CFG_FMT = struct.Struct("=iiiii")
+# Held at 64 (not packed flush against CONFIG) so the args blob's first
+# ContinuousTensor.data (uint64_t at OFF_ARGS+8) is 8-byte aligned, avoiding
+# SIGBUS on strict-alignment platforms. Also keeps clear of the control
+# region (offsets 16–47, mutually exclusive with task dispatch).
 _OFF_ARGS = 64
+assert _OFF_CONFIG + _CFG_FMT.size <= _OFF_ARGS, "CallConfig overflows config region"
+assert _OFF_ARGS % 8 == 0, "_OFF_ARGS must be 8-aligned for ContinuousTensor.data"
 # MAILBOX_OFF_ERROR_MSG / MAILBOX_ERROR_MSG_SIZE come from the C++
 # nanobind module so the two sides cannot drift.
 
@@ -277,11 +282,7 @@ def _chip_process_loop(
         state = _mailbox_load_i32(state_addr)
         if state == _TASK_READY:
             callable_ptr = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
-            block_dim = struct.unpack_from("i", buf, _OFF_BLOCK_DIM)[0]
-            aicpu_tn = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
-            enable_l2_swimlane = struct.unpack_from("i", buf, _OFF_ENABLE_L2_SWIMLANE)[0]
-            dump_tensor = struct.unpack_from("i", buf, _OFF_ENABLE_DUMP_TENSOR)[0]
-            enable_pmu = struct.unpack_from("i", buf, _OFF_ENABLE_PMU)[0]
+            block_dim, aicpu_tn, enable_l2_swimlane, dump_tensor, enable_pmu = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
 
             code = 0
             msg = ""
@@ -397,11 +398,9 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
             state = _mailbox_load_i32(state_addr)
             if state == _TASK_READY:
                 callable_ptr = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
-                block_dim = struct.unpack_from("i", buf, _OFF_BLOCK_DIM)[0]
-                aicpu_tn = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
-                enable_l2_swimlane = struct.unpack_from("i", buf, _OFF_ENABLE_L2_SWIMLANE)[0]
-                dump_tensor = struct.unpack_from("i", buf, _OFF_ENABLE_DUMP_TENSOR)[0]
-                enable_pmu = struct.unpack_from("i", buf, _OFF_ENABLE_PMU)[0]
+                block_dim, aicpu_tn, enable_l2_swimlane, dump_tensor, enable_pmu = _CFG_FMT.unpack_from(
+                    buf, _OFF_CONFIG
+                )
 
                 code = 0
                 msg = ""
@@ -492,12 +491,13 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
 
 def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     """Reconstruct a CallConfig from the unified mailbox layout."""
+    block_dim, aicpu_tn, swl, dt, pmu = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
     cfg = CallConfig()
-    cfg.block_dim = struct.unpack_from("i", buf, _OFF_BLOCK_DIM)[0]
-    cfg.aicpu_thread_num = struct.unpack_from("i", buf, _OFF_AICPU_THREAD_NUM)[0]
-    cfg.enable_l2_swimlane = bool(struct.unpack_from("i", buf, _OFF_ENABLE_L2_SWIMLANE)[0])
-    cfg.enable_dump_tensor = bool(struct.unpack_from("i", buf, _OFF_ENABLE_DUMP_TENSOR)[0])
-    cfg.enable_pmu = struct.unpack_from("i", buf, _OFF_ENABLE_PMU)[0]
+    cfg.block_dim = block_dim
+    cfg.aicpu_thread_num = aicpu_tn
+    cfg.enable_l2_swimlane = bool(swl)
+    cfg.enable_dump_tensor = bool(dt)
+    cfg.enable_pmu = pmu
     return cfg
 
 

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -165,17 +165,8 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     // Write callable.
     std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &callable, sizeof(uint64_t));
 
-    // Write config fields individually to avoid struct-layout portability issues.
-    int32_t block_dim = s.config.block_dim;
-    int32_t aicpu_tn = s.config.aicpu_thread_num;
-    int32_t perf = s.config.enable_l2_swimlane ? 1 : 0;
-    int32_t dump_tensor = s.config.enable_dump_tensor ? 1 : 0;
-    int32_t enable_pmu = s.config.enable_pmu;
-    std::memcpy(mbox() + MAILBOX_OFF_BLOCK_DIM, &block_dim, sizeof(int32_t));
-    std::memcpy(mbox() + MAILBOX_OFF_AICPU_THREAD_NUM, &aicpu_tn, sizeof(int32_t));
-    std::memcpy(mbox() + MAILBOX_OFF_ENABLE_L2_SWIMLANE, &perf, sizeof(int32_t));
-    std::memcpy(mbox() + MAILBOX_OFF_ENABLE_DUMP_TENSOR, &dump_tensor, sizeof(int32_t));
-    std::memcpy(mbox() + MAILBOX_OFF_ENABLE_PMU, &enable_pmu, sizeof(int32_t));
+    // Write config as a single packed POD block (see call_config.h).
+    std::memcpy(mbox() + MAILBOX_OFF_CONFIG, &s.config, sizeof(CallConfig));
 
     // Write length-prefixed TaskArgs blob: [T][S][tensors][scalars].
     size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ContinuousTensor) +

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -45,6 +45,7 @@
 #include <thread>
 #include <vector>
 
+#include "../task_interface/call_config.h"
 #include "types.h"
 
 class Ring;  // forward decl — owns the slot state pool
@@ -70,21 +71,31 @@ enum class MailboxState : int32_t {
 
 static constexpr size_t MAILBOX_SIZE = 4096;
 
-// Error message region lives at the mailbox tail so OFF_ARGS and all earlier
-// offsets stay byte-compatible with the pre-L4 layout. 256 B of headroom is
+// Error message region lives at the mailbox tail. 256 B of headroom is
 // enough for `<ExceptionType>: <short message>` produced by the child-side
 // Python loops; anything longer is truncated + NUL-terminated.
 static constexpr size_t MAILBOX_ERROR_MSG_SIZE = 256;
 
+// CallConfig is written/read as a single packed POD block (see call_config.h).
+// Both ends transfer it with one memcpy — no per-field offsets to keep in sync.
+//
+// MAILBOX_OFF_ARGS is held at 64 (rather than packed flush against CONFIG) for
+// two reasons: (a) the args blob is `[T:i32][S:i32][ContinuousTensor[T]][u64[S]]`,
+// so the first ContinuousTensor's `uint64_t data` field lands at OFF_ARGS+8 —
+// it must be 8-byte aligned to avoid SIGBUS on strict-alignment platforms
+// (aarch64 atomics, some ARM cores); (b) the control region (CTRL_OFF_ARG0..
+// CTRL_OFF_RESULT) overlaps offsets 16–47 and is mutually exclusive with task
+// dispatch, but using offset 64 keeps the two regions visually disjoint.
 static constexpr ptrdiff_t MAILBOX_OFF_STATE = 0;
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR = 4;
 static constexpr ptrdiff_t MAILBOX_OFF_CALLABLE = 8;  // also: control sub-command (uint64)
-static constexpr ptrdiff_t MAILBOX_OFF_BLOCK_DIM = 16;
-static constexpr ptrdiff_t MAILBOX_OFF_AICPU_THREAD_NUM = 20;
-static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_L2_SWIMLANE = 24;
-static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_DUMP_TENSOR = 28;
-static constexpr ptrdiff_t MAILBOX_OFF_ENABLE_PMU = 32;
+static constexpr ptrdiff_t MAILBOX_OFF_CONFIG = 16;
 static constexpr ptrdiff_t MAILBOX_OFF_ARGS = 64;
+static_assert(
+    MAILBOX_OFF_CONFIG + static_cast<ptrdiff_t>(sizeof(CallConfig)) <= MAILBOX_OFF_ARGS,
+    "CallConfig overflows reserved config region"
+);
+static_assert(MAILBOX_OFF_ARGS % 8 == 0, "MAILBOX_OFF_ARGS must be 8-aligned for ContinuousTensor.data");
 static constexpr ptrdiff_t MAILBOX_OFF_ERROR_MSG =
     static_cast<ptrdiff_t>(MAILBOX_SIZE) - static_cast<ptrdiff_t>(MAILBOX_ERROR_MSG_SIZE);
 static constexpr size_t MAILBOX_ARGS_CAPACITY =

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -18,14 +18,24 @@
  * Lives here (rather than chip_worker.h) so distributed task slot state
  * can store it directly without pulling in the full ChipWorker header
  * (which depends on types.h).
+ *
+ * Wire-compatible POD — packed and laid out so that one memcpy moves the
+ * whole struct between the parent and the forked child via the shared-memory
+ * mailbox. `bool` fields are stored as int32 to keep the layout deterministic
+ * across compilers (sizeof(bool) is implementation-defined).
  */
 
 #pragma once
 
+#include <cstdint>
+
+#pragma pack(push, 1)
 struct CallConfig {
-    int block_dim = 24;
-    int aicpu_thread_num = 3;
-    bool enable_l2_swimlane = false;
-    bool enable_dump_tensor = false;
-    int enable_pmu = 0;  // 0 = disabled; >0 = enabled, value selects event type
+    int32_t block_dim = 24;
+    int32_t aicpu_thread_num = 3;
+    int32_t enable_l2_swimlane = 0;
+    int32_t enable_dump_tensor = 0;
+    int32_t enable_pmu = 0;  // 0 = disabled; >0 = enabled, value selects event type
 };
+#pragma pack(pop)
+static_assert(sizeof(CallConfig) == 5 * sizeof(int32_t), "CallConfig wire layout drift");

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -244,8 +244,8 @@ void ChipWorker::run(const void *callable, const void *args, const CallConfig &c
 
     int rc = run_runtime_fn_(
         device_ctx_, rt, callable, args, config.block_dim, config.aicpu_thread_num, device_id_, aicpu_binary_.data(),
-        aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(), config.enable_l2_swimlane ? 1 : 0,
-        config.enable_dump_tensor ? 1 : 0, config.enable_pmu
+        aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(), config.enable_l2_swimlane,
+        config.enable_dump_tensor, config.enable_pmu
     );
     if (rc != 0) {
         throw std::runtime_error("run_runtime failed with code " + std::to_string(rc));


### PR DESCRIPTION
## Summary

Currently the parent → forked-child mailbox transfer uses **5 individual offsets** for the `CallConfig` fields (`MAILBOX_OFF_BLOCK_DIM`, `_AICPU_THREAD_NUM`, `_ENABLE_L2_SWIMLANE`, `_ENABLE_DUMP_TENSOR`, `_ENABLE_PMU`), with matching per-field `memcpy` / `struct.unpack_from` calls on both ends. Adding any new config field forces a 6-touch change (struct + C++ offsets + Python offsets + writer + reader + nanobind).

Pack `CallConfig` as a packed POD wire struct so the whole thing moves with **one `memcpy` / one `struct.unpack`**.

### Changes

- `call_config.h` — `#pragma pack(1)`, `bool` → `int32_t` for layout determinism (`sizeof(bool)` is implementation-defined), `static_assert(sizeof == 20)` to catch drift.
- `worker_manager.h` — 5 scattered `MAILBOX_OFF_*` → 1 `MAILBOX_OFF_CONFIG`. `MAILBOX_OFF_ARGS` stays at 64 (with `static_assert` guarding 8-byte alignment for `ContinuousTensor.data` and inline comment explaining the constraint vs the control region).
- `worker_manager.cpp` — 5 `memcpy`s → 1 `memcpy(&s.config, sizeof(CallConfig))`.
- `python/simpler/worker.py` — 3 dispatch-loop sites × 5 `struct.unpack_from` → 1 `_CFG_FMT.unpack_from` per site.
- `python/bindings/task_interface.cpp` — `enable_l2_swimlane` / `enable_dump_tensor` exposed via `def_prop_rw` so Python users still see `bool` despite `int32` storage. `__repr__` unchanged.
- `chip_worker.cpp` — drop now-redundant `? 1 : 0` ternaries on the int32 fields when forwarding to the C ABI.

### Net effect

Adding a new config field now requires only:
1. Add the field to the C++ struct in `call_config.h`
2. Extend the Python `_CFG_FMT` format string

No more per-field offsets to keep in sync between two languages.

`MAILBOX_OFF_ARGS` and `MAILBOX_ARGS_CAPACITY` are unchanged from main (64 / 3776 bytes). The 28-byte gap between the CallConfig block and ARGS is required to keep the args blob's first `ContinuousTensor.data` (uint64_t at OFF_ARGS+8) on an 8-byte boundary — `static_assert` catches any future regression.

## Why now

This is the second of three follow-up PRs that supersede #685. The architectural plan is to add a per-task `output_prefix` field to `CallConfig` (instead of using `SIMPLER_OUTPUT_DIR` env var), and consolidating the mailbox layout first makes that addition a one-line struct extension instead of touching N places.

1. ~~Rename `ChipCallConfig` → `CallConfig`~~ (#687, merged)
2. **This PR — pack mailbox config fields**
3. Add `output_prefix` to `CallConfig`, drop `SIMPLER_OUTPUT_DIR` env var + perf-record subdir scoping

## Test plan

- [ ] CI: lint + tests pass (mailbox parent/child layout has to stay byte-compatible — the `static_assert`s + Python `_CFG_FMT.size` derivation catch drift, but real validation is round-trip dispatch tests in CI)
- [ ] Verify `bool` semantics preserved on Python side: `cfg.enable_l2_swimlane` returns `True`/`False`, not `1`/`0` (handled by `def_prop_rw` bridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)