### PR TITLE
Refactor: align a5 profiling collectors with a2a3 streaming buffer arch

### DIFF
--- a/docs/pmu-profiling.md
+++ b/docs/pmu-profiling.md
@@ -300,46 +300,48 @@ buffer pooling, and `Module` trait pattern are shared with TensorDump
 and L2Perf — see [profiling-framework.md](profiling-framework.md) for
 the framework reference.
 
-### 5.3 a5 — bulk rtMemcpy after stream sync (DAV_3510, 10 counters)
+### 5.3 a5 — streaming with host shadow buffers (DAV_3510, 10 counters)
 
 AICore reads the 10 PMU counters via the `ld_dev` MMIO load intrinsic
 into a per-core dual-issue staging slot indexed by `reg_task_id & 1`.
 AICPU, on observing FIN, validates the slot's recorded `task_id`
 against the register token, copies the record into
 `PmuBuffer::records[count]`, fills `func_id` / `core_type`, and
-advances `count`. After `rtStreamSynchronize` the host pulls the
-per-core `PmuBuffer`s back via `rtMemcpy` and writes the CSV.
+advances `count`. When a buffer is full, AICPU switches to a new
+buffer via the SPSC free queue / ready queue protocol (identical to
+a2a3). At shutdown, AICPU flushes any partially-filled buffers via
+`pmu_aicpu_flush_buffers()`. The host runs a dedicated collector
+thread that polls ready queues via `rtMemcpy`, writes records to CSV,
+and recycles buffers back into SPSC free queues.
 
 ```text
         HOST                                         DEVICE
 ┌──────────────────────────┐               ┌──────────────────────────┐
 │ PmuCollector             │               │ AICore                   │
 │                          │               │                          │
-│ initialize()             │  alloc +      │ per-task end:            │
-│   rtMalloc setup region  │──copy────────>│   ld_dev 10 PMU_CNTs +   │
-│   one PmuBuffer per core │               │     PMU_CNT_TOTAL        │
-│   build PmuSetupHeader   │               │   write into             │
+│ init()                   │  alloc +      │ per-task end:            │
+│   rtMalloc data region   │──copy────────>│   ld_dev 10 PMU_CNTs +   │
+│   pre-fill free queues   │               │     PMU_CNT_TOTAL        │
+│   build PmuDataHeader    │               │   write into             │
 │                          │               │   dual_issue_slots[      │
-│ ── kernel execution ──   │               │     reg_task_id & 1]     │
-│                          │               │                          │
-│                          │               │ AICPU thread             │
-│                          │               │ on FIN:                  │
-│                          │               │   match slot's task_id   │
-│                          │               │     vs reg_task_id       │
-│                          │               │   copy into              │
-│                          │               │     records[count]       │
-│                          │               │   fill func_id/core_type │
+│ start(tf)                │               │     reg_task_id & 1]     │
+│   ┌────────────────────┐ │               │                          │
+│   │ collector thread   │ │               │ AICPU thread             │
+│   │ poll_and_collect() │ │               │ on FIN:                  │
+│   │  poll ready queues │ │  rtMemcpy     │   match slot's task_id   │
+│   │  via copy hooks    │<┼──(shadow)────<│     vs reg_task_id       │
+│   │  write CSV         │ │               │   copy into              │
+│   │  recycle → free_q  │─┼──copy hook──>│     records[count]       │
+│   └────────────────────┘ │               │   fill func_id/core_type │
 │                          │               │   ++count                │
+│                          │               │   if buffer full:        │
+│                          │  SPSC ready   │     push ready entry,    │
+│                          │<──queues─────<│     pop next from free_q │
 │                          │               │                          │
-│ rtStreamSynchronize      │               │                          │
-│ collect_all()            │  batch        │                          │
-│   memcpy setup region    │<──memcpy─────<│                          │
-│     (PmuBufferState[])   │               │                          │
-│   per core:              │               │                          │
-│     copy PmuBuffer hdr → │               │                          │
-│     read count           │               │                          │
-│     copy count*PmuRecord │               │                          │
-│   write CSV              │               │                          │
+│ rtStreamSynchronize      │               │ pmu_aicpu_flush():       │
+│ drain_remaining_buffers()│               │   push remaining full    │
+│   final sync + drain     │               │   buffers to ready_q     │
+│ reconcile_counters()     │               │                          │
 │ finalize(free)           │               │                          │
 └──────────────────────────┘               └──────────────────────────┘
 ```
@@ -347,21 +349,30 @@ per-core `PmuBuffer`s back via `rtMemcpy` and writes the CSV.
 Device memory layout:
 
 ```text
-[PmuSetupHeader]                        (kernel_args.pmu_data_base)
+[PmuDataHeader]                         (kernel_args.pmu_data_base)
+├── queues  [MAX_AICPU_THREADS][READYQUEUE_SIZE]
+├── queue_heads / queue_tails (per-thread)
 ├── num_cores
-├── event_type
-└── buffer_ptrs[num_cores]              ──> per-core PmuBuffer
+└── event_type
 
-[PmuBufferState[num_cores]]             (immediately after header)
-├── owning_thread_id
+[PmuBufferState[num_cores]]             (per-core state)
+├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
+├── current_buf_ptr          (AICPU active buffer)
+├── current_buf_seq
 ├── dropped_record_count
-└── total_record_count
+├── total_record_count
+└── owning_thread_id
 
-PmuBuffer (one per core, separate alloc)
+PmuBuffer pool (rotated)                (BUFFERS_PER_CORE per core)
 ├── count                 (header, 64 B)
 ├── dual_issue_slots[2]   (AICore staging, indexed task_id & 1)
 └── records[RECORDS_PER_BUFFER]
 ```
+
+`halHostRegister` is not supported on DAV_3510, so the a5 collector
+maintains separate host shadow buffers and synchronizes via `rtMemcpy`
+(onboard) or `memcpy` (sim). The platform copy hooks
+`pmu_platform_copy_to/from_device` abstract this difference.
 
 Each `Handshake` carries `pmu_buffer_addr` and `pmu_reg_base` so each
 AICore worker locates its `PmuBuffer` and the PMU MMIO register block.
@@ -369,20 +380,23 @@ AICore worker locates its `PmuBuffer` and the PMU MMIO register block.
 **Lifecycle** (`device_runner.cpp`):
 
 ```text
-initialize()
-  pmu_collector_.initialize(num_aicore, ..., output_prefix_, event_type)
-  kernel_args_.args.pmu_data_base = pmu_collector_.get_pmu_setup_device_ptr()
+init()
+  pmu_collector_.init(num_aicore, num_threads, csv_path, event_type, ...)
+  kernel_args_.args.pmu_data_base = pmu_collector_.get_pmu_shm_device_ptr()
                                       → AICPU programs PMU event group,
                                         publishes (pmu_buffer_addr,
                                         pmu_reg_base) into Handshakes
+start(tf)                       ← spawn collector thread
+                                  (poll_and_collect: drain AICPU ready
+                                  queues via copy hooks, write CSV,
+                                  recycle buffers into free queues)
 launch AICPU / AICore
 rtStreamSynchronize
-collect_all()                   ← rtMemcpy [PmuSetupHeader+PmuBufferState[]]
-                                  back, then per-core PmuBuffer headers,
-                                  then count*PmuRecord per core
-  emit cross-check log:
-    PMU collector: record counts match
-      (collected=N, dropped=K, device_total=N+K)
+stop()                          ← signal_execution_complete, join thread
+drain_remaining_buffers()       ← final sync: drain remaining ready
+                                  queue entries + scan current_buf_ptr
+                                  for partially-filled buffers
+reconcile_counters()            ← assert collected + dropped == total
 finalize(free)
 ```
 
@@ -400,10 +414,12 @@ adjacent dispatches from colliding (the runtime's `dispatch_seq++`
 guarantees neighboring register tokens differ by 1 → different slots).
 
 [`PmuCollector`](../src/a5/platform/include/host/pmu_collector.h) on
-a5 is self-contained — `initialize` / `collect_all` / `export_csv` /
-`finalize`. `collect_all()` is the synchronous batch drain after
-stream sync; there are no helper threads to coordinate, so the a5
-collector does not derive from `ProfilerBase`.
+a5 uses the same streaming lifecycle as a2a3 — `init` / `start` /
+`stop` / `drain_remaining_buffers` / `reconcile_counters` / `finalize`.
+The collector thread runs `poll_and_collect()` concurrently with kernel
+execution. The only architectural difference from a2a3 is the memory
+transport: host shadow buffers + `rtMemcpy` copy hooks instead of
+`halHostRegister` shared memory.
 
 ### 5.4 a2a3 vs a5 at a glance
 
@@ -412,11 +428,11 @@ collector does not derive from `ProfilerBase`.
 | HW counter slots | 8 (DAV_2201) | 10 (DAV_3510) |
 | Counter readout | AICPU MMIO `read_reg` | AICore MMIO `ld_dev` |
 | Per-core staging | direct write into `records[count]` | dual-issue slots, AICPU commits on FIN |
-| Host transport | `halHostRegister` shared memory | `rtMemcpy` after `rtStreamSynchronize` |
-| Buffer model | rotating pool (free + ready queues) | single per-core `PmuBuffer` |
-| Host threads | mgmt + poll, streams during execution | drain after sync |
-| Host-class shape | `ProfilerBase` subclass (mgmt + poll thread + `BufferPoolManager<PmuModule>`) | self-contained `initialize`/`collect_all`/`finalize` |
-| Lifecycle | `init` → `start` → `stop` → `reconcile_counters` → `finalize` | `initialize` → `collect_all` → `finalize` |
+| Host transport | `halHostRegister` shared memory | host shadow buffers + `rtMemcpy` copy hooks |
+| Buffer model | rotating pool (free + ready queues) | rotating pool (free + ready queues, same SPSC protocol) |
+| Host threads | mgmt + poll, streams during execution | collector thread, streams during execution |
+| Host-class shape | `ProfilerBase` subclass (mgmt + poll thread + `BufferPoolManager<PmuModule>`) | streaming `init`/`start`/`stop`/`drain`/`finalize` |
+| Lifecycle | `init` → `start` → `stop` → `reconcile_counters` → `finalize` | `init` → `start` → `stop` → `drain_remaining_buffers` → `reconcile_counters` → `finalize` |
 
 ## 6. Overhead
 
@@ -425,10 +441,11 @@ PMU profiling is opt-in and zero-overhead when disabled — without
 counter-read code paths are skipped.
 
 When enabled, the dominant per-task overhead is the MMIO counter read
-(8 reads on a2a3, 10 on a5) plus a single record copy. Streaming
-(a2a3) keeps it off the critical path because the host mgmt thread
-drains buffers concurrently with kernel execution. Bulk drain (a5)
-defers the host-side cost entirely to after `rtStreamSynchronize`.
+(8 reads on a2a3, 10 on a5) plus a single record copy. On both
+architectures, streaming keeps host-side work off the critical path —
+the collector thread drains buffers concurrently with kernel execution.
+On a5 the copy hooks add `rtMemcpy` round-trips that a2a3's shared
+memory avoids, but these overlap with device execution.
 
 For meaningful per-task numbers on a2a3, also rebuild the runtime with
 `PTO2_DISABLE_DUAL_ISSUE=1` (see §7.1) — this serialization itself
@@ -466,12 +483,13 @@ Notes on this constraint:
   register block does not model AICore execution, so counter values
   are 0. The CSV still carries one row per task with a zero counter
   tuple — useful for validating the end-to-end data flow.
-- The per-core on-device `PmuBuffer` is fixed-size
-  (`PLATFORM_PMU_RECORDS_PER_BUFFER = 4096`). Tasks past that count
-  are accounted in `PmuBufferState::dropped_record_count` and surfaced
-  in the finalize log line; raise the constant in
+- The per-core on-device `PmuBuffer` capacity is controlled by
+  `PLATFORM_PMU_RECORDS_PER_BUFFER` (default 512). When full, AICPU
+  switches to a new buffer via the free queue. If no free buffer is
+  available, records are dropped. Increase `PLATFORM_PMU_BUFFERS_PER_CORE`
+  (default 4) in
   [platform_config.h](../src/a5/platform/include/common/platform_config.h)
-  for workloads that exceed it.
+  if your workload produces bursts that exhaust the buffer pool.
 - A non-zero `diff` in the host's `record count mismatch` warning
   means AICPU attempted to commit `diff` records whose dual-issue
   slot still carried an older `task_id`. With AICore's slot-write
@@ -526,14 +544,15 @@ nonzero means the AICPU could not get a free buffer in time
 (`free_queue` empty). Increase `PLATFORM_PMU_BUFFERS_PER_CORE` so the
 mgmt thread has more headroom to recycle buffers.
 
-**Dropped records on a5.** Per-core record cap reached
-(`PLATFORM_PMU_RECORDS_PER_BUFFER = 4096`). Raise the constant in
-`platform_config.h` for workloads that exceed it.
+**Dropped records on a5.** `PmuBufferState::dropped_record_count`
+nonzero means the AICPU could not get a free buffer in time
+(`free_queue` empty). Increase `PLATFORM_PMU_BUFFERS_PER_CORE` so the
+collector thread has more headroom to recycle buffers.
 
 ## 9. Related docs
 
 - [profiling-framework.md](profiling-framework.md) — shared host-side
-  collector framework (a2a3 only).
+  collector framework.
 - [chip-level-arch.md](chip-level-arch.md) — host / AICPU / AICore
   program boundaries the PMU path spans.
 - [task-flow.md](task-flow.md) — where AICPU dispatch and completion

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -13,10 +13,7 @@
  * @brief AICPU performance data collection interface
  *
  * Provides performance profiling management interface for AICPU side.
- * Handles buffer initialization and per-record completion. In the memcpy-based
- * collection design, Host pre-allocates one L2PerfBuffer per core and one
- * PhaseBuffer per thread; AICPU writes directly into them until full, after
- * which further records are silently dropped.
+ * Handles buffer initialization, switching, and flushing.
  */
 
 #ifndef PLATFORM_AICPU_L2_PERF_COLLECTOR_AICPU_H_
@@ -56,12 +53,10 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime);
  * Complete a L2PerfRecord with AICPU-side metadata after AICore task completion
  *
  * Reads l2_perf_buf->count, validates task_id match against the latest record,
- * and fills all AICPU-side fields. Returns -1 and silently drops the record
- * when the buffer is full (count >= PLATFORM_PROF_BUFFER_SIZE). Callers must
- * pre-extract fanout into a plain uint64_t array (platform layer cannot depend
- * on runtime linked-list types).
+ * and fills all AICPU-side fields. Callers must pre-extract fanout into a
+ * plain uint64_t array (platform layer cannot depend on runtime linked-list types).
  *
- * @param l2_perf_buf              L2PerfBuffer pointer (from handshake l2_perf_records_addr)
+ * @param l2_perf_buf           L2PerfBuffer pointer (from handshake l2_perf_records_addr)
  * @param expected_reg_task_id  Register dispatch token (low 32 bits) to validate
  * @param task_id               Task identifier to write (PTO2 encoding or plain id)
  * @param func_id               Kernel function identifier
@@ -75,6 +70,30 @@ int l2_perf_aicpu_complete_record(
     L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
     uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
 );
+
+/**
+ * Switch performance buffer when current buffer is full
+ *
+ * Enqueues the full buffer to ReadyQueue, pops a new buffer from FreeQueue,
+ * and updates the handshake l2_perf_records_addr. If FreeQueue is empty,
+ * overwrites the current buffer (lossy fallback).
+ *
+ * @param runtime Runtime instance pointer
+ * @param core_id Core ID
+ * @param thread_idx Thread index
+ */
+void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
+
+/**
+ * Flush remaining performance data
+ *
+ * Marks non-empty buffers as ready and enqueues them for host collection.
+ *
+ * @param thread_idx Thread index
+ * @param cur_thread_cores Array of core IDs managed by this thread
+ * @param core_num Number of cores managed by this thread
+ */
+void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Update total task count in performance header
@@ -92,15 +111,16 @@ void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks);
  * Sets up AicpuPhaseHeader and clears per-thread phase record buffers.
  * Must be called once from thread 0 after l2_perf_aicpu_init_profiling().
  *
+ * @param runtime Runtime instance pointer
  * @param num_sched_threads Number of scheduler threads
  */
-void l2_perf_aicpu_init_phase_profiling(int num_sched_threads);
+void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
 
 /**
  * Record a single scheduler phase
  *
  * Appends an AicpuPhaseRecord to the specified thread's buffer.
- * Silently drops records when the buffer is full.
+ * When the buffer is full, switches to a new buffer via FreeQueue.
  *
  * @param thread_idx Scheduler thread index
  * @param phase_id Phase identifier
@@ -162,5 +182,15 @@ void l2_perf_aicpu_record_orch_phase(
  */
 void l2_perf_aicpu_init_core_assignments(int total_cores);
 void l2_perf_aicpu_write_core_assignments_for_thread(int thread_idx, const int *core_ids, int core_num);
+
+/**
+ * Flush remaining phase records for a thread
+ *
+ * Marks the current WRITING phase buffer as READY and enqueues it
+ * for host collection. Called at thread exit (analogous to l2_perf_aicpu_flush_buffers).
+ *
+ * @param thread_idx Thread index (scheduler thread or orchestrator)
+ */
+void l2_perf_aicpu_flush_phase_buffers(int thread_idx);
 
 #endif  // PLATFORM_AICPU_L2_PERF_COLLECTOR_AICPU_H_

--- a/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
@@ -13,31 +13,21 @@
  * @file pmu_collector_aicpu.h
  * @brief AICPU-side PMU collection interface (a5)
  *
- * Split of duties:
- *   - AICPU owns init (event selectors, PMU_CTRL_0/1 start) and finalize
- *     (CTRL restore). It also publishes per-core pmu_buffer_addr /
- *     pmu_reg_base into Handshake at init time so AICore can do the
- *     MMIO read itself.
- *   - AICore reads PMU counters + PMU_CNT_TOTAL via MMIO after each task
- *     (pmu_aicore_record_task), writing into PmuBuffer::dual_issue_slots.
- *   - AICPU, on COND FIN, validates the slot and commits a full PmuRecord
- *     into PmuBuffer::records[] (pmu_aicpu_complete_record).
- *
  * Lifecycle (called from aicpu_executor.cpp):
  *   pmu_aicpu_init()              — resolve per-core PMU MMIO bases + buffer
  *                                   pointers, program events, start counters,
+ *                                   pop initial PmuBuffers from free_queues,
  *                                   publish (pmu_buffer_addr, pmu_reg_base)
  *                                   to each Handshake.
  *   [task loop]
- *     pmu_aicpu_complete_record() — copy the dual-issue slot AICore wrote
+ *     pmu_aicpu_complete_record()     — copy the dual-issue slot AICore wrote
  *                                   into PmuBuffer::records[count], filling
- *                                   func_id + core_type. Drops the record
- *                                   silently if the buffer is full.
+ *                                   func_id + core_type. Switches buffer
+ *                                   when full.
+ *   pmu_aicpu_flush_buffers()     — per-thread: flush each of this thread's
+ *                                   non-empty PmuBuffers to the ready_queue
+ *                                   (mirrors a2a3 pmu_aicpu_flush_buffers)
  *   pmu_aicpu_finalize()          — per-thread: restore CTRL registers.
- *
- * a5 uses a single pre-allocated PmuBuffer per core; the host drains it via
- * rtMemcpy after stream sync (see src/a5/platform/src/host/pmu_collector.cpp).
- * There is no SPSC queue and no per-thread flush step.
  */
 
 #ifndef PLATFORM_AICPU_PMU_COLLECTOR_AICPU_H_
@@ -62,6 +52,7 @@ extern "C" bool is_pmu_enabled();
  *     PMU reg-addr table.
  *   - Program event selectors (PMU_CNT0_IDX..CNT9_IDX).
  *   - Start counters (set PMU_CTRL_0 and PMU_CTRL_1).
+ *   - Pop an initial PmuBuffer from the per-core free_queue.
  *   - Publish (pmu_buffer_addr, pmu_reg_base) into handshakes[i] so the
  *     matching AICore can read PMU MMIO and write the dual-issue slot.
  *
@@ -73,44 +64,40 @@ extern "C" bool is_pmu_enabled();
  * Must be called after the host has published pmu_data_base (via
  * set_platform_pmu_base) and after every active core has reported its
  * physical_core_id via handshake. Must be called BEFORE the caller
- * sets aicpu_regs_ready=1 on each handshake, so AICore observes the
- * new fields via the same release/acquire boundary.
+ * sets aicpu_regs_ready=1 on each handshake.
  *
- * @param handshakes         Handshake array (one per core). This function
- *                           writes pmu_buffer_addr and pmu_reg_base into
- *                           handshakes[0..num_cores). Caller owns lifetime.
- * @param physical_core_ids  Array of hardware physical core ids, indexed by
- *                           logical core_id. Caller owns the memory; this
- *                           function does not retain the pointer.
- * @param num_cores          Number of active cores (logical core_id range is [0, num_cores))
+ * @param handshakes         Handshake array (one per core)
+ * @param physical_core_ids  Array of hardware physical core ids
+ * @param num_cores          Number of active cores
  */
 void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, int num_cores);
 
 /**
- * Commit one PmuRecord from the dual-issue staging slot that AICore wrote
- * into PmuBuffer::dual_issue_slots[task_id & 1]. Copies register state
- * (pmu_counters + pmu_total_cycles) and fills AICPU-owned metadata
- * (task_id, func_id, core_type). When the buffer is full the record is
- * dropped and the core's PmuBufferState::dropped_record_count is incremented.
- * Every call bumps PmuBufferState::total_record_count so host can cross-check
- * collected + dropped against the AICPU's attempted-commit count.
- * No-op if PMU is not enabled or the core has no PMU buffer bound.
+ * Commit one PmuRecord from the dual-issue staging slot.
+ * Switches buffer via SPSC free_queue/ready_queue when full.
  *
  * @param core_id     Logical core index
- * @param thread_idx  AICPU thread index (reserved; not used on a5 memcpy path)
- * @param reg_task_id Register dispatch token (DATA_MAIN_BASE value). AICore
- *                    wrote this 32-bit value into dual_issue_slots[...].task_id,
- *                    so AICPU uses it to locate the slot and validate its
- *                    freshness. Callers should pass the same register token
- *                    they observed on COND / wrote via DATA_MAIN_BASE.
- * @param task_id     Full task_id to store in the PmuRecord (e.g. PTO2's
- *                    (ring_id<<32)|local_id). May differ from reg_task_id.
+ * @param thread_idx  AICPU thread index (selects ready_queue)
+ * @param reg_task_id Register dispatch token (slot match key)
+ * @param task_id     Full task_id to store in the PmuRecord
  * @param func_id     kernel_id from the completed task slot
  * @param core_type   AIC or AIV
  */
 void pmu_aicpu_complete_record(
     int core_id, int thread_idx, uint32_t reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type
 );
+
+/**
+ * Per-thread PMU buffer flush. Mirrors a2a3 pmu_aicpu_flush_buffers().
+ *
+ * For each core in cur_thread_cores, enqueue its non-empty PmuBuffer into the
+ * thread's ready_queue so the host collector can pick it up.
+ *
+ * @param thread_idx        AICPU thread index (selects ready_queue)
+ * @param cur_thread_cores  Array of logical core ids owned by this thread
+ * @param core_num          Entries in cur_thread_cores
+ */
+void pmu_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
  * Per-thread PMU finalize: restore CTRL registers for this thread's cores.

--- a/src/a5/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/a5/platform/include/aicpu/tensor_dump_aicpu.h
@@ -10,11 +10,11 @@
  */
 /**
  * @file tensor_dump_aicpu.h
- * @brief AICPU tensor dump collection interface (memcpy-based)
+ * @brief AICPU tensor dump collection interface
  *
  * Provides tensor dump management for AICPU side.
- * Same public API as A2A3 for future migration compatibility.
- * Simplified internals: direct buffer writes, no SPSC queues.
+ * Handles dump shared-memory base propagation plus buffer initialization,
+ * tensor data copying to arenas, metadata recording, and flushing.
  */
 
 #ifndef SRC_A5_PLATFORM_AICPU_TENSOR_DUMP_AICPU_H_
@@ -36,17 +36,17 @@ extern "C" {
 #endif
 
 /**
- * Set the tensor dump base address.
+ * Set the tensor dump shared-memory base address.
  * Called by the platform layer before AICPU execution starts.
  *
- * @param dump_data_base Device pointer (as uint64_t) to DumpSetupHeader
+ * @param dump_data_base Device pointer (as uint64_t) to dump shared memory
  */
 void set_platform_dump_base(uint64_t dump_data_base);
 
 /**
- * Get the tensor dump base address.
+ * Get the tensor dump shared-memory base address.
  *
- * @return Device pointer (as uint64_t) to DumpSetupHeader
+ * @return Device pointer (as uint64_t) to dump shared memory
  */
 uint64_t get_platform_dump_base();
 
@@ -238,8 +238,8 @@ inline void dump_tensors_for_task(
 /**
  * Initialize tensor dump.
  *
- * Reads DumpSetupHeader from dump_data_base and caches per-thread
- * DumpBuffer and arena pointers.
+ * Sets up per-thread DumpBufferState pointers and pops initial
+ * metadata buffers from each thread's free_queue.
  *
  * @param num_dump_threads Number of scheduling threads that will dump tensors
  */
@@ -248,8 +248,12 @@ void dump_tensor_init(int num_dump_threads);
 /**
  * Record a single tensor dump.
  *
- * Copies tensor data to the thread's arena, appends a TensorDumpRecord
- * to the thread's DumpBuffer. Silently drops when buffer is full.
+ * Copies tensor data from GM to the thread's arena, appends a
+ * TensorDumpRecord to the current metadata buffer. Switches
+ * buffers when full via the SPSC free_queue.
+ *
+ * When metadata buffers are temporarily exhausted, old dump metadata may be
+ * overwritten so execution can continue without losing the active buffer.
  *
  * @param thread_idx Scheduling thread index
  * @param info Tensor metadata and identification
@@ -260,8 +264,8 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info);
 /**
  * Flush remaining tensor dump data for a thread.
  *
- * In the memcpy design this is a no-op for data (host reads after sync).
- * Logs per-thread dump statistics.
+ * Marks non-empty metadata buffers as ready and enqueues them
+ * for host collection.
  *
  * @param thread_idx Thread index
  */

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -13,20 +13,42 @@
  * @file l2_perf_profiling.h
  * @brief Performance profiling data structures
  *
- * Architecture: per-core L2PerfBuffer + per-thread PhaseBuffer + a single
- * L2PerfSetupHeader, all allocated on device by Host.
+ * Architecture: Fixed header + per-core/thread buffer states + optional phase profiling region
  *
- * Layout (count-first + flexible array):
- *   L2PerfBuffer  = 64B header (count + padding) + records[capacity]
- *   PhaseBuffer = 64B header (count + padding) + records[capacity]
+ * Memory layout (shared memory between Host and Device):
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │ L2PerfDataHeader (fixed header)                             │
+ * │  - ReadyQueue (FIFO, capacity=PLATFORM_PROF_READYQUEUE_SIZE)│
+ * │  - Metadata (num_cores, flags)                              │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ L2PerfBufferState[0] (Core 0)                               │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ L2PerfBufferState[1] (Core 1)                               │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ ...                                                         │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ L2PerfBufferState[num_cores-1]                              │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ AicpuPhaseHeader (optional, present when phase profiling)   │
+ * │  - magic, num_sched_threads, records_per_thread             │
+ * │  - orch_summary                                             │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PhaseBufferState[thread0]                                   │
+ * │  - free_queue: SPSC queue of available buffer pointers      │
+ * │  - current_buf_ptr, current_buf_seq                         │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ PhaseBufferState[thread1]                                   │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ ...                                                         │
+ * └─────────────────────────────────────────────────────────────┘
  *
- * Buffer device pointers + total_tasks + AicpuPhaseHeader (with orch_summary
- * and core_to_thread) are consolidated in L2PerfSetupHeader. Host copies
- * L2PerfSetupHeader to device once before execution; AICPU reads pointers in
- * its profiling init. After execution, Host copies L2PerfSetupHeader back, then
- * does a two-step memcpy (header → count → records) on each L2PerfBuffer /
- * PhaseBuffer to reduce transfer to "actual records" instead of full
- * capacity.
+ * Actual L2PerfBuffer / PhaseBuffer are allocated dynamically by Host
+ * and pushed into the per-core/thread free_queue.
+ *
+ * Base size = sizeof(L2PerfDataHeader) + num_cores * sizeof(L2PerfBufferState)
+ * With phases = Base + sizeof(AicpuPhaseHeader) + num_threads * sizeof(PhaseBufferState)
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_L2_PERF_PROFILING_H_
@@ -76,27 +98,138 @@ struct L2PerfRecord {
 static_assert(sizeof(L2PerfRecord) % 64 == 0, "L2PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
-// L2PerfBuffer - Record Buffer with Count-First Layout and WIP Staging Slots
+// L2PerfBuffer - Fixed-Size Record Buffer with WIP Staging Slots
 // =============================================================================
 
 /**
- * Performance record buffer (count-first + flexible array)
+ * Fixed-size performance record buffer
  *
- * Layout: 64B header (count + padding), then wip[2] staging slots,
- * then records[].
- * Actual allocation: sizeof(L2PerfBuffer) + capacity * sizeof(L2PerfRecord).
- *
- * Count-first enables two-step collection: Host copies sizeof(L2PerfBuffer) to
- * read count, then copies only count * sizeof(L2PerfRecord) of actual data.
+ * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
+ * Allocated dynamically by Host, pushed into per-core free_queue.
  *
  * WIP protocol: AICore writes timing to wip[reg_task_id & 1], AICPU copies
  * it into records[count] at completion. Dual-slot parity ensures no overlap.
  */
 struct L2PerfBuffer {
-    volatile uint32_t count;  // Current committed record count (at offset 0 for cache-line read)
-    uint32_t pad[15];         // Pad to 64B cache line boundary
-    L2PerfRecord wip[2];      // AICore WIP staging slots (index = reg_task_id & 1)
-    L2PerfRecord records[];   // Flexible array member (not counted in sizeof)
+    L2PerfRecord wip[2];                              // AICore WIP staging slots (index = reg_task_id & 1)
+    L2PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Committed records (AICPU writes)
+    volatile uint32_t count;                          // Current committed record count
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// L2PerfFreeQueue - SPSC Lock-Free Queue for Free Buffers
+// =============================================================================
+
+/**
+ * Single Producer Single Consumer (SPSC) lock-free queue for free buffer management
+ *
+ * Producer: Host (ProfMemoryManager thread) pushes newly allocated buffers
+ * Consumer: Device (AICPU thread) pops buffers when switching
+ *
+ * Queue semantics:
+ * - Empty: head == tail
+ * - Full: (tail - head) >= PLATFORM_PROF_SLOT_COUNT
+ * - Capacity: PLATFORM_PROF_SLOT_COUNT buffers
+ *
+ * Memory ordering:
+ * - Device pop: rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
+ * - Host push: write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
+ */
+struct L2PerfFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_PROF_SLOT_COUNT];  // Free buffer addresses
+    volatile uint32_t head;                                   // Consumer read position (Device increments)
+    volatile uint32_t tail;                                   // Producer write position (Host increments)
+    uint32_t pad[22];                                         // Pad to 128 bytes (aligned to cache line)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(L2PerfFreeQueue) == 128, "L2PerfFreeQueue must be 128 bytes for cache alignment");
+
+// =============================================================================
+// L2PerfBufferState - Per-Core/Thread Buffer State (Unified for L2PerfRecord and Phase)
+// =============================================================================
+
+/**
+ * Per-core or per-thread buffer state for dynamic profiling
+ *
+ * Contains:
+ * - free_queue: SPSC queue of available buffer addresses
+ * - current_buf_ptr: Currently active buffer being written (0 = no active buffer)
+ * - current_buf_seq: Monotonic sequence number for ordering
+ *
+ * Used in two contexts:
+ * - Per-core L2PerfRecord profiling (current_buf_ptr → L2PerfBuffer)
+ * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer)
+ *
+ * Writers:
+ * - free_queue.tail: Host writes (pushes new buffers)
+ * - free_queue.head: Device writes (pops buffers)
+ * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
+ * - current_buf_seq: Device writes (monotonic counter)
+ */
+struct L2PerfBufferState {
+    L2PerfFreeQueue free_queue;         // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
+    volatile uint32_t current_buf_seq;  // Sequence number for ordering
+    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(L2PerfBufferState) == 192, "L2PerfBufferState must be 192 bytes for cache alignment");
+
+// Type alias for semantic clarity in Phase profiling context
+using PhaseBufferState = L2PerfBufferState;  // Per-thread Phase profiling
+
+// =============================================================================
+// ReadyQueueEntry - Queue Entry for Ready Buffers
+// =============================================================================
+
+/**
+ * Ready queue entry
+ *
+ * When a buffer on a core/thread is full, AICPU adds this entry to the queue.
+ * Host memory manager retrieves entries from the queue.
+ *
+ * Entry types (distinguished by is_phase flag):
+ * - L2PerfRecord entry: core_index = core ID, is_phase = 0
+ * - Phase entry:      core_index = thread_idx, is_phase = 1
+ */
+struct ReadyQueueEntry {
+    uint32_t core_index;  // Core index (0 ~ num_cores-1), or thread_idx for phase entries
+    uint32_t is_phase;    // 0 = L2PerfRecord, 1 = Phase
+    uint64_t buffer_ptr;  // Device pointer to the full buffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad;         // Alignment padding
+} __attribute__((aligned(32)));
+
+// =============================================================================
+// L2PerfDataHeader - Fixed Header
+// =============================================================================
+
+/**
+ * Performance data fixed header
+ *
+ * Located at the start of shared memory, contains:
+ * 1. Per-thread ready queues (FIFO Circular Buffers)
+ * 2. Metadata (core count)
+ *
+ * Ready queue design:
+ * - Per-thread queues: Avoid lock contention between AICPU threads
+ * - Capacity per queue: PLATFORM_PROF_READYQUEUE_SIZE (full capacity for each thread)
+ * - Implementation: Circular Buffer
+ * - Producer: AICPU thread (adds full buffers to its own queue)
+ * - Consumer: Host memory manager thread (reads from all queues)
+ * - Queue empty: head == tail
+ * - Queue full: (tail + 1) % capacity == head
+ */
+struct L2PerfDataHeader {
+    // Per-thread ready queues (FIFO Circular Buffers)
+    // Each AICPU thread has its own queue to avoid lock contention
+    ReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_PROF_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Consumer read positions (Host modifies)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
+
+    // Metadata (Host initializes, Device read-only)
+    uint32_t num_cores;             // Actual number of cores launched
+    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -171,23 +304,21 @@ struct AicpuOrchSummary {
 constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
 
 /**
- * Phase record buffer (count-first + flexible array)
+ * Fixed-size phase record buffer (analogous to L2PerfBuffer)
  *
  * Capacity: PLATFORM_PHASE_RECORDS_PER_THREAD
- * Actual allocation: 64 + capacity * sizeof(AicpuPhaseRecord).
+ * Allocated dynamically by Host, pushed into per-thread free_queue.
  */
 struct PhaseBuffer {
-    volatile uint32_t count;     // Current record count (at offset 0 for cache-line read)
-    uint32_t pad[15];            // Pad to 64B cache line boundary
-    AicpuPhaseRecord records[];  // Flexible array member
+    AicpuPhaseRecord records[PLATFORM_PHASE_RECORDS_PER_THREAD];
+    volatile uint32_t count;
 } __attribute__((aligned(64)));
 
 /**
  * AICPU phase profiling header
  *
- * Embedded in L2PerfSetupHeader. Contains the magic, per-thread metadata, the
- * core_id → scheduler thread mapping, and the orchestrator's cumulative
- * cycle summary.
+ * Located after the L2PerfBufferState array in shared memory.
+ * Contains metadata and per-thread tracking.
  */
 struct AicpuPhaseHeader {
     uint32_t magic;                             // Validation magic (AICPU_PHASE_MAGIC)
@@ -199,39 +330,6 @@ struct AicpuPhaseHeader {
 } __attribute__((aligned(64)));
 
 // =============================================================================
-// L2PerfSetupHeader - Host/Device Metadata Exchange
-// =============================================================================
-
-/**
- * Performance setup header
- *
- * Allocated on device by Host. Host writes buffer pointers and metadata,
- * then copies this struct to device once before execution. AICPU reads
- * buffer pointers during init. After execution completes, Host copies
- * this struct back to read total_tasks and phase_header.
- *
- * Memory layout: kernel_args.l2_perf_data_base points to this struct on
- * device (read by AICPU via get_platform_l2_perf_base()).
- */
-struct L2PerfSetupHeader {
-    // Host writes, AICPU reads (init)
-    uint32_t num_cores;          // Number of AICore instances
-    uint32_t num_phase_threads;  // Number of phase profiling threads
-    uint32_t pad0[14];           // Pad to 64B
-
-    // Host writes, AICPU reads: per-core / per-thread buffer device pointers
-    uint64_t core_buffer_ptrs[PLATFORM_MAX_CORES];           // L2PerfBuffer* on device
-    uint64_t phase_buffer_ptrs[PLATFORM_MAX_AICPU_THREADS];  // PhaseBuffer* on device
-
-    // AICPU writes, host reads back
-    volatile uint32_t total_tasks;  // Updated by orchestrator
-    uint32_t pad1[15];              // Pad to 64B
-
-    // AICPU writes, host reads back (via collect_all)
-    AicpuPhaseHeader phase_header;  // Contains orch_summary and core_to_thread
-} __attribute__((aligned(64)));
-
-// =============================================================================
 // Helper Functions - Memory Layout
 // =============================================================================
 
@@ -240,38 +338,92 @@ extern "C" {
 #endif
 
 /**
- * Get L2PerfSetupHeader pointer from base address
+ * Calculate total memory size for performance data (buffer states only, no buffers)
  *
- * @param base_ptr Device base address (kernel_args.l2_perf_data_base)
- * @return L2PerfSetupHeader pointer
+ * Formula: Total size = Fixed header + Dynamic tail
+ *                     = sizeof(L2PerfDataHeader) + num_cores × sizeof(L2PerfBufferState)
+ *
+ * @param num_cores Number of cores (block_dim × PLATFORM_CORES_PER_BLOCKDIM)
+ * @return Total bytes for header + buffer states
  */
-inline L2PerfSetupHeader *get_perf_setup_header(void *base_ptr) {
-    return reinterpret_cast<L2PerfSetupHeader *>(base_ptr);
+inline size_t calc_perf_data_size(int num_cores) {
+    return sizeof(L2PerfDataHeader) + num_cores * sizeof(L2PerfBufferState);
 }
 
 /**
- * Calculate L2PerfSetupHeader allocation size
+ * Get header pointer
+ *
+ * @param base_ptr Shared memory base address (device_ptr or host_ptr)
+ * @return L2PerfDataHeader pointer
  */
-inline size_t calc_l2_perf_setup_size() { return sizeof(L2PerfSetupHeader); }
+inline L2PerfDataHeader *get_l2_perf_header(void *base_ptr) { return reinterpret_cast<L2PerfDataHeader *>(base_ptr); }
 
 /**
- * Calculate total bytes for a L2PerfBuffer with the given capacity
+ * Get L2PerfBufferState array start address
  *
- * @param capacity Number of L2PerfRecord slots (e.g. PLATFORM_PROF_BUFFER_SIZE)
- * @return 64B header + capacity * sizeof(L2PerfRecord)
+ * @param base_ptr Shared memory base address
+ * @return L2PerfBufferState array pointer
  */
-inline size_t calc_l2_perf_buffer_size(int capacity) {
-    return sizeof(L2PerfBuffer) + static_cast<size_t>(capacity) * sizeof(L2PerfRecord);
+inline L2PerfBufferState *get_perf_buffer_states(void *base_ptr) {
+    return reinterpret_cast<L2PerfBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(L2PerfDataHeader));
 }
 
 /**
- * Calculate total bytes for a PhaseBuffer with the given capacity
+ * Get L2PerfBufferState for specified core
  *
- * @param capacity Number of AicpuPhaseRecord slots (e.g. PLATFORM_PHASE_RECORDS_PER_THREAD)
- * @return 64B header + capacity * sizeof(AicpuPhaseRecord)
+ * @param base_ptr Shared memory base address
+ * @param core_index Core index (0 ~ num_cores-1)
+ * @return L2PerfBufferState pointer
  */
-inline size_t calc_phase_buffer_size(int capacity) {
-    return sizeof(PhaseBuffer) + static_cast<size_t>(capacity) * sizeof(AicpuPhaseRecord);
+inline L2PerfBufferState *get_perf_buffer_state(void *base_ptr, int core_index) {
+    return &get_perf_buffer_states(base_ptr)[core_index];
+}
+
+/**
+ * Calculate total memory size including phase profiling region (buffer states only)
+ *
+ * @param num_cores Number of AICore instances
+ * @param num_sched_threads Number of phase profiling threads (scheduler + orchestrator)
+ * @return Total bytes needed for header + all buffer states
+ */
+inline size_t calc_perf_data_size_with_phases(int num_cores, int num_sched_threads) {
+    return calc_perf_data_size(num_cores) + sizeof(AicpuPhaseHeader) + num_sched_threads * sizeof(PhaseBufferState);
+}
+
+/**
+ * Get AicpuPhaseHeader pointer (located after L2PerfBufferState array)
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @return AicpuPhaseHeader pointer
+ */
+inline AicpuPhaseHeader *get_phase_header(void *base_ptr, int num_cores) {
+    return reinterpret_cast<AicpuPhaseHeader *>(reinterpret_cast<char *>(base_ptr) + calc_perf_data_size(num_cores));
+}
+
+/**
+ * Get PhaseBufferState array start address (located after AicpuPhaseHeader)
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @return PhaseBufferState array pointer
+ */
+inline PhaseBufferState *get_phase_buffer_states(void *base_ptr, int num_cores) {
+    return reinterpret_cast<PhaseBufferState *>(
+        reinterpret_cast<char *>(get_phase_header(base_ptr, num_cores)) + sizeof(AicpuPhaseHeader)
+    );
+}
+
+/**
+ * Get PhaseBufferState for specified thread
+ *
+ * @param base_ptr Shared memory base address
+ * @param num_cores Number of AICore instances
+ * @param thread_idx Thread index
+ * @return PhaseBufferState pointer
+ */
+inline PhaseBufferState *get_phase_buffer_state(void *base_ptr, int num_cores, int thread_idx) {
+    return &get_phase_buffer_states(base_ptr, num_cores)[thread_idx];
 }
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -88,16 +88,43 @@ constexpr int PLATFORM_MAX_CORES_PER_THREAD = PLATFORM_MAX_AIC_PER_THREAD + PLAT
 constexpr int PLATFORM_MAX_CORES = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM;  // 108
 
 /**
- * Performance buffer capacity per core
- * Maximum number of L2PerfRecord entries per L2PerfBuffer.
- * Each core gets one L2PerfBuffer; when full, AICPU silently stops recording.
+ * Performance buffer capacity per buffer
+ * Number of L2PerfRecord entries per dynamically allocated L2PerfBuffer
  */
-constexpr int PLATFORM_PROF_BUFFER_SIZE = 10000;
+constexpr int PLATFORM_PROF_BUFFER_SIZE = 1000;
+
+/**
+ * Number of buffer slots per core/thread for dynamic profiling
+ * Host dynamically allocates buffers and writes addresses into these slots.
+ * Device reads slot addresses when switching buffers.
+ * Using slots: provides full pipeline depth for buffer recycling.
+ * No runtime rtMalloc — all buffers are pre-allocated and recycled in a closed loop.
+ */
+constexpr int PLATFORM_PROF_SLOT_COUNT = 4;
+
+/**
+ * L2PerfBuffer pre-allocation count per AICore.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_CORE = 8;
+
+/**
+ * PhaseBuffer pre-allocation count per AICPU thread.
+ * 1 goes into the free_queue at init, the rest into the recycled pool.
+ */
+constexpr int PLATFORM_PROF_BUFFERS_PER_THREAD = 16;
+
+/**
+ * Ready queue capacity for performance data collection
+ * Queue holds ReadyQueueEntry structs for buffers ready to be read by Host.
+ * Sized to match pre-allocation total across all cores and threads.
+ */
+constexpr int PLATFORM_PROF_READYQUEUE_SIZE =
+    PLATFORM_MAX_CORES * PLATFORM_PROF_BUFFERS_PER_CORE + PLATFORM_MAX_AICPU_THREADS * PLATFORM_PROF_BUFFERS_PER_THREAD;
 
 /**
  * Performance buffer capacity per AICPU thread
  * Maximum number of AicpuPhaseRecord entries per PhaseBuffer.
- * Each thread gets one PhaseBuffer; when full, records are silently dropped.
  */
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 500000;
 
@@ -106,6 +133,16 @@ constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 500000;
  * Used to convert timestamps to microseconds.
  */
 constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 1000000000;  // 1000 MHz
+
+/**
+ * Timeout duration for performance data collection (seconds)
+ */
+constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 30;
+
+/**
+ * Number of empty polling iterations before checking timeout
+ */
+constexpr int PLATFORM_PROF_EMPTY_POLLS_CHECK_NUM = 1000;
 
 inline double cycles_to_us(uint64_t cycles) {
     return (static_cast<double>(cycles) / PLATFORM_PROF_SYS_CNT_FREQ) * 1000000.0;
@@ -126,21 +163,19 @@ inline double cycles_to_us(uint64_t cycles) {
 // =============================================================================
 
 /**
- * Number of TensorDumpRecord entries per DumpBuffer.
+ * Number of TensorDumpRecord entries per DumpMetaBuffer.
  * Each record is 128 bytes, so one buffer = RECORDS * 128 bytes.
  */
 constexpr int PLATFORM_DUMP_RECORDS_PER_BUFFER = 256;
 
 /**
- * Pre-allocated DumpBuffer count per AICPU scheduling thread.
- * Retained for configuration parity with A2A3; in the memcpy design
- * this controls arena sizing only (no SPSC free queues).
+ * Pre-allocated DumpMetaBuffer count per AICPU scheduling thread.
+ * Controls initial buffer supply and arena sizing.
  */
 constexpr int PLATFORM_DUMP_BUFFERS_PER_THREAD = 8;
 
 /**
  * SPSC free_queue slot count for dump metadata buffers.
- * Retained for configuration parity with A2A3.
  */
 constexpr int PLATFORM_DUMP_SLOT_COUNT = 4;
 
@@ -149,7 +184,7 @@ constexpr int PLATFORM_DUMP_SLOT_COUNT = 4;
  * Used together with BUFFERS_PER_THREAD and RECORDS_PER_BUFFER to compute
  * per-thread arena size:
  *   arena = BUFFERS_PER_THREAD * RECORDS_PER_BUFFER * AVG_TENSOR_BYTES
- * Default: 4 * 256 * 65536 = 64 MB per thread.
+ * Default: 8 * 256 * 65536 = 128 MB per thread.
  */
 constexpr uint64_t PLATFORM_DUMP_AVG_TENSOR_BYTES = 65536;
 
@@ -159,14 +194,12 @@ constexpr uint64_t PLATFORM_DUMP_AVG_TENSOR_BYTES = 65536;
 constexpr int PLATFORM_DUMP_MAX_DIMS = 5;
 
 /**
- * Ready queue capacity for dump data.
- * Retained for configuration parity with A2A3.
+ * Ready queue capacity for dump data per AICPU thread.
  */
 constexpr int PLATFORM_DUMP_READYQUEUE_SIZE = PLATFORM_MAX_AICPU_THREADS * PLATFORM_DUMP_BUFFERS_PER_THREAD * 2;
 
 /**
- * Idle timeout duration for tensor dump collection (seconds)
- * Retained for configuration parity with A2A3.
+ * Idle timeout duration for tensor dump collection (seconds).
  */
 constexpr int PLATFORM_DUMP_TIMEOUT_SECONDS = 30;
 
@@ -176,14 +209,26 @@ constexpr int PLATFORM_DUMP_TIMEOUT_SECONDS = 30;
 
 /**
  * Number of PmuRecord entries per PmuBuffer.
- * A5 uses a single pre-allocated PmuBuffer per core (no SPSC free-queue
- * streaming — device memory is drained via rtMemcpy after stream sync).
- * Tasks past this count are dropped and counted in the buffer header.
  */
-constexpr int PLATFORM_PMU_RECORDS_PER_BUFFER = 4096;
+constexpr int PLATFORM_PMU_RECORDS_PER_BUFFER = 512;
 
 /**
- * Idle timeout duration for PMU collection (seconds)
+ * SPSC free-queue slot count per core (Host pushes, AICPU pops).
+ */
+constexpr int PLATFORM_PMU_SLOT_COUNT = 4;
+
+/**
+ * Number of PmuBuffers pre-allocated per core (initial pool size).
+ */
+constexpr int PLATFORM_PMU_BUFFERS_PER_CORE = 4;
+
+/**
+ * Ready queue capacity for PMU data per AICPU thread.
+ */
+constexpr int PLATFORM_PMU_READYQUEUE_SIZE = PLATFORM_MAX_CORES * PLATFORM_PMU_BUFFERS_PER_CORE;
+
+/**
+ * Idle timeout duration for PMU collection (seconds).
  */
 constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
 
@@ -201,9 +246,6 @@ constexpr uint32_t AICORE_EXIT_SIGNAL = 0x7FFFFFF0;
 
 // Physical core ID mask for get_coreid()
 constexpr uint32_t AICORE_COREID_MASK = 0x0FFF;
-
-// DAV_3510 hardware counter count.
-constexpr int PMU_COUNTER_COUNT_A5 = 10;
 
 // PMU MMIO register offsets (DAV_3510 / a5). Values ported from pypto
 // aicore_prof_dav3510_pmu.h. Accessed by AICPU through the per-core PMU

--- a/src/a5/platform/include/common/pmu_profiling.h
+++ b/src/a5/platform/include/common/pmu_profiling.h
@@ -17,11 +17,15 @@
  * CANN Open Software License 2.0). Register offsets live in platform_config.h
  * and are accessed via RegId / reg_index().
  *
- * a5 has no shared-memory transport (halHostRegister is not supported on
- * DAV_3510). The PMU buffer is a single per-core PmuBuffer allocated on
- * device at init time, written to by AICPU during task execution, and
- * drained to the host via rtMemcpy after stream sync. This mirrors the
- * memcpy pattern already used by PerformanceCollector and TensorDumpCollector.
+ * Streaming buffer design (mirrors a2a3 pmu_profiling.h):
+ *   PmuFreeQueue       — SPSC queue: Host pushes free PmuBuffers, AICPU pops them.
+ *   PmuBufferState     — Per-core state: current active buffer pointer + free_queue.
+ *   PmuDataHeader      — Fixed shared-memory header: per-thread ready queues.
+ *   PmuBuffer          — Fixed-capacity record buffer (PLATFORM_PMU_RECORDS_PER_BUFFER).
+ *
+ * a5 has no halHostRegister (DAV_3510), so host↔device SPSC fields are
+ * read/written via rtMemcpy (onboard) or memcpy (sim), using host shadow
+ * buffers — same pattern as a5 l2_perf_collector and tensor_dump_collector.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_
@@ -49,6 +53,7 @@ enum class PmuEventType : uint32_t {
 };
 
 constexpr uint32_t PMU_EVENT_TYPE_DEFAULT = static_cast<uint32_t>(PmuEventType::PIPE_UTILIZATION);
+constexpr int PMU_COUNTER_COUNT_A5 = 10;
 
 /**
  * Event ID table for a single event type.
@@ -130,20 +135,14 @@ inline const PmuEventConfig *pmu_resolve_event_config_a5(PmuEventType event_type
 }
 
 // =============================================================================
-// PMU Record + Buffer
+// PMU Record
 // =============================================================================
 
 /**
  * Per-task PMU snapshot written by AICPU after each AICore task FIN.
  *
  * AICore writes task_id / pmu_total_cycles / pmu_counters[] into the
- * dual-issue staging slot. AICPU fills func_id / core_type on commit —
- * those are consumer-owned and AICore never touches them.
- *
- * Thread ownership is tracked per-core in PmuBufferState::owning_thread_id,
- * not per-record — it's a buffer-level attribute (same core is always
- * driven by the same AICPU scheduler thread). Mirrors a2a3's per-queue
- * thread association.
+ * dual-issue staging slot. AICPU fills func_id / core_type on commit.
  */
 struct PmuRecord {
     uint64_t task_id;                             // Runtime task id
@@ -153,32 +152,24 @@ struct PmuRecord {
     uint32_t pmu_counters[PMU_COUNTER_COUNT_A5];  // PMU_CNT0..CNT9
 } __attribute__((aligned(64)));
 
+// =============================================================================
+// PMU Streaming Buffer Structures (mirrors a2a3 pmu_profiling.h)
+// =============================================================================
+
 /**
- * Fixed-capacity per-core PMU record buffer.
+ * Fixed-capacity PMU record buffer.
+ * Allocated by Host, pushed into per-core free_queue.
  *
- * Layout:
- *   [0,64)              — header: count + padding (host reads this 64-byte
- *                         header first to learn how many records to drain)
- *   [64, 64+2*PmuRecord) — dual_issue_slots: AICore writes a PmuRecord
- *                         here after each task, indexed by task_id & 1
- *   [...)                — records: AICPU commits finished PmuRecords here
- *
- * The two dual_issue_slots exist because AICore's dual-issue dispatch
- * can have up to two tasks in flight per core (task N+1 can begin
- * before AICPU has committed the record for N). Parity `task_id & 1`
- * picks the slot so N and N+1 never collide — this is exactly the
- * reason a2a3 perf uses `wip[2]` on PerfBuffer.
- *
- * dropped_record_count / total_record_count live on PmuBufferState (mirrors
- * a2a3) so cross-checking is centralized in a single per-core state region.
- *
- * Written by AICore (dual_issue_slots) + AICPU (records/count); drained
- * to host via rtMemcpy after stream sync.
+ * a5-specific: dual_issue_slots[2] exist because AICore reads PMU MMIO
+ * itself (via ld_dev) and writes the snapshot here. AICPU validates and
+ * commits into records[] on COND FIN. Parity task_id & 1 picks the slot
+ * so adjacent dual-issue dispatches never collide.
  */
 struct PmuBuffer {
     // Header (first 64 bytes) — host copies this alone first to learn count.
     volatile uint32_t count;  // Number of valid records
-    uint32_t pad[15];         // Pad header to 64 bytes
+    uint32_t pad[15];         // Pad count to 64 bytes; isolates count's cache line from
+                              // dual_issue_slots (AICore writer) to avoid false sharing.
 
     // Dual-issue staging slots — AICore writes a PmuRecord here after
     // each task, then AICPU copies it into records[count] and fills
@@ -198,72 +189,94 @@ static_assert(
 );
 
 /**
- * Per-core PMU buffer state. Mirrors a2a3 PmuBufferState (minus the
- * free_queue / current_buf_ptr fields, which a5 doesn't need because it
- * uses a single pre-allocated PmuBuffer per core).
+ * SPSC lock-free queue for free PmuBuffer management.
  *
- * Writers (AICPU only):
- *   owning_thread_id:     AICPU scheduler thread that drives this core.
- *                         Stamped on first PMU commit and stable thereafter
- *                         (a5 binds core→thread at scheduler init).
- *   dropped_record_count: Tasks whose record was dropped on device
- *                         (PmuBuffer full).
- *   total_record_count:   Monotonic count of every task the AICPU attempted
- *                         to record (success + dropped + slot-mismatch).
+ * Producer: Host (PmuCollector thread) pushes recycled/new buffers.
+ * Consumer: Device (AICPU thread) pops buffers when switching.
+ *
+ * Memory ordering:
+ *   Device pop:  rmb() → read tail → read buffer_ptrs[head % COUNT] → rmb() → write head → wmb()
+ *   Host push:   write buffer_ptrs[tail % COUNT] → wmb() → write tail → wmb()
+ */
+struct PmuFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_PMU_SLOT_COUNT];  // 4 * 8 = 32 bytes
+    volatile uint32_t head;                                  // Consumer read position (Device increments)
+    volatile uint32_t tail;                                  // Producer write position (Host increments)
+    uint32_t pad[22];                                        // Pad 40 + 88 -> 128 bytes
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(PmuFreeQueue) == 128, "PmuFreeQueue must be 128 bytes");
+
+/**
+ * Per-core PMU buffer state.
+ *
+ * Writers:
+ *   free_queue.tail:        Host writes (pushes new/recycled buffers)
+ *   free_queue.head:        Device writes (pops buffers)
+ *   current_buf_ptr:        Device writes (after pop), Host reads (for collect/drain)
+ *   current_buf_seq:        Device writes (monotonic counter)
+ *   dropped_record_count:   Device writes (tasks whose PmuRecord was never handed
+ *                           to the host, e.g. free_queue empty, ready_queue full,
+ *                           no active buffer)
+ *   total_record_count:     Device writes — monotonic count of every task the
+ *                           AICPU attempted to record (success + dropped)
  *
  * Host reads dropped / total at finalize time to cross-check:
- *   collected_on_host + dropped == total
- * Any shortfall is silent slot-mismatch loss (AICore hadn't yet published
- * its dual-issue slot when AICPU tried to commit).
+ *   collected_on_host + sum(dropped) == sum(total)
  */
 struct PmuBufferState {
-    volatile uint32_t owning_thread_id;
-    volatile uint32_t dropped_record_count;
-    volatile uint32_t total_record_count;
-    uint32_t pad[13];
+    PmuFreeQueue free_queue;                 // SPSC queue of free PmuBuffer addresses
+    volatile uint64_t current_buf_ptr;       // Current active PmuBuffer (0 = none)
+    volatile uint32_t current_buf_seq;       // Sequence number for ordering
+    volatile uint32_t dropped_record_count;  // Tasks whose record was dropped on device
+    volatile uint32_t total_record_count;    // Total tasks the AICPU attempted to record
+    uint32_t pad[11];                        // Pad to 192 bytes
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(PmuBufferState) == 64, "PmuBufferState must be 64 bytes");
+static_assert(sizeof(PmuBufferState) == 192, "PmuBufferState must be 192 bytes");
 
 /**
- * PMU setup header, allocated once on device and published into
- * kernel_args.pmu_data_base.
- *
- * The on-device shared region layout is:
- *   [PmuSetupHeader] [PmuBufferState[num_cores]]
- *
- * a5 uses one rtMemcpy at finalize to bring all PmuBufferState back to
- * host (mirrors a2a3's get_pmu_buffer_state offset math).
+ * Ready queue entry.
+ * When a PmuBuffer is full, AICPU adds this entry to the thread's ready queue.
  */
-struct PmuSetupHeader {
+struct PmuReadyQueueEntry {
+    uint32_t core_index;  // Core index (0 ~ num_cores-1)
+    uint32_t pad0;
+    uint64_t buffer_ptr;  // Device pointer to the full PmuBuffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad1;
+} __attribute__((aligned(32)));
+
+static_assert(sizeof(PmuReadyQueueEntry) == 32, "PmuReadyQueueEntry must be 32 bytes");
+
+/**
+ * PMU data fixed header, located at the start of PMU shared memory.
+ *
+ * Per-thread ready queues (one per AICPU scheduling thread):
+ *   Producer: AICPU thread (adds full PmuBuffers)
+ *   Consumer: Host PmuCollector thread
+ */
+struct PmuDataHeader {
+    PmuReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_PMU_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Host reads (consumer)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // AICPU writes (producer)
     uint32_t num_cores;
-    uint32_t event_type;  // PmuEventType value
-    uint32_t pad[14];     // Pad header to 64 bytes
-    // Device pointers to the per-core PmuBuffer, one entry per core.
-    // AICPU reads buffer_ptrs[core_id] to get its PmuBuffer.
-    uint64_t buffer_ptrs[PLATFORM_MAX_CORES];
+    uint32_t event_type;  // PmuEventType value, written by host at init
+    uint32_t pad[2];
 } __attribute__((aligned(64)));
 
-static_assert(offsetof(PmuSetupHeader, buffer_ptrs) == 64, "PmuSetupHeader header must be exactly 64 bytes");
-
 // =============================================================================
-// Helpers
+// Helper Functions
 // =============================================================================
 
-constexpr size_t PMU_BUFFER_HEADER_BYTES = 64;
-constexpr size_t PMU_SETUP_HEADER_BYTES = 64;
-
-/**
- * Total bytes of the [PmuSetupHeader][PmuBufferState[num_cores]] shared region.
- */
-inline size_t calc_pmu_setup_size(int num_cores) {
-    return sizeof(PmuSetupHeader) + static_cast<size_t>(num_cores) * sizeof(PmuBufferState);
+inline size_t calc_pmu_data_size(int num_cores) {
+    return sizeof(PmuDataHeader) + static_cast<size_t>(num_cores) * sizeof(PmuBufferState);
 }
 
-inline PmuSetupHeader *get_pmu_setup_header(void *base_ptr) { return reinterpret_cast<PmuSetupHeader *>(base_ptr); }
+inline PmuDataHeader *get_pmu_header(void *base_ptr) { return reinterpret_cast<PmuDataHeader *>(base_ptr); }
 
 inline PmuBufferState *get_pmu_buffer_state(void *base_ptr, int core_id) {
-    return reinterpret_cast<PmuBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PmuSetupHeader)) + core_id;
+    return reinterpret_cast<PmuBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(PmuDataHeader)) + core_id;
 }
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_COMMON_PMU_PROFILING_H_

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -11,19 +11,34 @@
 
 /**
  * @file tensor_dump.h
- * @brief Tensor dump data structures for device-to-host tensor collection (memcpy-based)
+ * @brief Tensor dump data structures for device-to-host tensor collection
  *
- * A5 simplified design: pre-allocated buffers + direct write + memcpy collect-after-sync.
- * No shared memory, no background threads, no SPSC queues.
+ * Independent shared memory region for capturing per-task tensor I/O.
+ * Fully decoupled from profiling — uses its own ready queues, buffer states,
+ * and memory manager thread.
  *
  * Memory layout (allocated only when enable_dump_tensor=true):
+ * ┌─────────────────────────────────────────────────────────────┐
+ * │ DumpDataHeader (fixed header)                               │
+ * │  - Per-thread ready queues (circular FIFOs)                 │
+ * │  - Metadata (num_dump_threads, config)                      │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ DumpBufferState[0] (Thread 0)                               │
+ * │  - free_queue: SPSC queue of DumpMetaBuffer addresses       │
+ * │  - current_buf_ptr, arena_base, arena_write_offset          │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ DumpBufferState[1] (Thread 1)                               │
+ * ├─────────────────────────────────────────────────────────────┤
+ * │ ...                                                         │
+ * └─────────────────────────────────────────────────────────────┘
  *
- *   DumpSetupHeader (single, published via kernel_args.dump_data_base)
- *   ├── dump_buffer_ptrs[]   → per-thread DumpBuffer (count + records[])
- *   ├── arena_header_ptrs[]  → per-thread DumpArenaHeader (write_offset)
- *   └── arena_data_ptrs[]    → per-thread arena data region
+ * Per-thread payload arenas are separate allocations.
+ * DumpMetaBuffers are allocated by the host and pushed
+ * into per-thread free_queues.
  *
- * After stream sync, host copies everything back via rtMemcpy / memcpy.
+ * A5 specifics: memory access uses host-shadow copies + explicit memcpy
+ * instead of halHostRegister/SVM. Data structures and interaction logic
+ * are identical to A2A3.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_TENSOR_DUMP_H_
@@ -65,7 +80,6 @@ enum class TensorDumpStage : uint8_t {
 
 /**
  * Per-tensor metadata + payload reference.
- * Identical layout to A2A3 for binary compatibility.
  *
  * Cache line 1 (64B): identifiers, payload location, compact scalar metadata
  * Cache line 2 (64B): logical/source layout arrays
@@ -97,60 +111,114 @@ struct alignas(64) TensorDumpRecord {
 static_assert(sizeof(TensorDumpRecord) == 128, "TensorDumpRecord must be 128 bytes (2 cache lines)");
 
 // =============================================================================
-// DumpBuffer - Per-Thread Record Buffer (count-first, like L2PerfBuffer)
+// DumpMetaBuffer - Fixed-Size Record Buffer
 // =============================================================================
 
 /**
- * Per-thread dump record buffer. AICPU writes records sequentially;
- * when count reaches capacity, further records are silently dropped.
- * Host copies the buffer back after stream sync.
+ * Fixed-size dump record buffer.
+ * Capacity: PLATFORM_DUMP_RECORDS_PER_BUFFER
+ * Allocated by host, pushed into per-thread free_queue.
  */
-struct DumpBuffer {
-    volatile uint32_t count;          // Records written by AICPU (at offset 0)
-    uint32_t capacity;                // Max records (set by host during init)
-    volatile uint32_t dropped_count;  // Records dropped (buffer or arena full)
-    uint32_t pad[13];                 // Pad header to 64B cache line
-    // TensorDumpRecord records[] follows (flexible array member)
-    // Access via: reinterpret_cast<TensorDumpRecord *>(this + 1)
+struct DumpMetaBuffer {
+    TensorDumpRecord records[PLATFORM_DUMP_RECORDS_PER_BUFFER];
+    volatile uint32_t count;  // Current record count
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(DumpBuffer) == 64, "DumpBuffer header must be 64 bytes");
-
 // =============================================================================
-// DumpArenaHeader - Per-Thread Arena Metadata
+// DumpFreeQueue - SPSC Lock-Free Queue for Free Buffers
 // =============================================================================
 
 /**
- * Per-thread arena metadata. Separate from the arena data region
- * so host can read just the header to determine how much data was written.
+ * Single Producer Single Consumer (SPSC) lock-free queue.
+ * Same layout and semantics as PerfFreeQueue, separate type for decoupling.
+ *
+ * Producer: Host (DumpMemoryManager thread) pushes recycled/new buffers
+ * Consumer: Device (AICPU thread) pops buffers when switching
  */
-struct DumpArenaHeader {
-    volatile uint64_t write_offset;  // Monotonic write cursor (AICPU increments)
-    uint64_t arena_size;             // Total arena bytes (set by host)
-    uint32_t pad[12];                // Pad to 64B
+struct DumpFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_DUMP_SLOT_COUNT];
+    volatile uint32_t head;  // Consumer read position (Device increments)
+    volatile uint32_t tail;  // Producer write position (Host increments)
+    uint32_t pad[22];        // Pad to 128 bytes (40 + 88 = 128)
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(DumpArenaHeader) == 64, "DumpArenaHeader must be 64 bytes");
+static_assert(sizeof(DumpFreeQueue) == 128, "DumpFreeQueue must be 128 bytes");
 
 // =============================================================================
-// DumpSetupHeader - Host-Initialized, AICPU Reads
+// DumpBufferState - Per-Thread Buffer State
 // =============================================================================
 
 /**
- * Setup header published via kernel_args.dump_data_base.
- * Host initializes all fields and copies to device before execution.
- * AICPU reads pointers during dump_tensor_init().
+ * Per-thread buffer management state.
+ *
+ * Writers:
+ * - free_queue.tail: Host writes (pushes new buffers)
+ * - free_queue.head: Device writes (pops buffers)
+ * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
+ * - current_buf_seq: Device writes (monotonic counter)
+ * - arena_write_offset: Device writes (monotonic), Host reads (for overwrite detection)
+ * - dropped_record_count: Device writes (records lost before host export)
  */
-struct DumpSetupHeader {
+struct DumpBufferState {
+    DumpFreeQueue free_queue;                // SPSC queue of free DumpMetaBuffer addresses
+    volatile uint64_t current_buf_ptr;       // Current active DumpMetaBuffer (0 = none)
+    volatile uint32_t current_buf_seq;       // Sequence number for ordering
+    uint32_t pad0;                           // Alignment
+    volatile uint64_t arena_base;            // Device pointer to this thread's arena
+    volatile uint64_t arena_size;            // Arena size in bytes
+    volatile uint64_t arena_write_offset;    // Monotonic write cursor (host computes % arena_size)
+    volatile uint32_t dropped_record_count;  // Records dropped before host export
+    uint8_t pad1[84];                        // Pad to 256 bytes (172 + 84 = 256)
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DumpBufferState) == 256, "DumpBufferState must be 256 bytes");
+
+// =============================================================================
+// DumpReadyQueueEntry - Ready Queue Entry
+// =============================================================================
+
+/**
+ * When a DumpMetaBuffer is full, AICPU adds this entry to the thread's ready queue.
+ * Host memory manager retrieves entries and processes them.
+ */
+struct DumpReadyQueueEntry {
+    uint32_t thread_index;  // Thread index (0 ~ num_dump_threads-1)
+    uint32_t pad0;
+    uint64_t buffer_ptr;  // Device pointer to the full DumpMetaBuffer
+    uint32_t buffer_seq;  // Sequence number for ordering
+    uint32_t pad1;
+} __attribute__((aligned(32)));
+
+// =============================================================================
+// DumpDataHeader - Fixed Header
+// =============================================================================
+
+/**
+ * Dump data fixed header, located at the start of dump shared memory.
+ *
+ * Contains:
+ * 1. Per-thread ready queues (circular FIFOs) — one per AICPU thread
+ * 2. Metadata (thread count, config)
+ *
+ * Ready queue design mirrors PerfDataHeader but is independent:
+ * - Per-thread queues avoid lock contention
+ * - Producer: AICPU thread (adds full DumpMetaBuffers)
+ * - Consumer: Host DumpMemoryManager thread
+ * - Queue empty: head == tail
+ * - Queue full: (tail + 1) % capacity == head
+ */
+struct DumpDataHeader {
+    // Per-thread ready queues
+    DumpReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_DUMP_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Host reads (consumer)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // AICPU writes (producer)
+
+    // Metadata (Host initializes, Device reads)
     uint32_t num_dump_threads;
     uint32_t records_per_buffer;
+    uint64_t arena_size_per_thread;
     uint32_t magic;
-    uint32_t pad0;
-    // Per-thread device pointers
-    uint64_t dump_buffer_ptrs[PLATFORM_MAX_AICPU_THREADS];   // -> DumpBuffer
-    uint64_t arena_header_ptrs[PLATFORM_MAX_AICPU_THREADS];  // -> DumpArenaHeader
-    uint64_t arena_data_ptrs[PLATFORM_MAX_AICPU_THREADS];    // -> arena data region
-    uint64_t arena_sizes[PLATFORM_MAX_AICPU_THREADS];
+    uint32_t pad;
 } __attribute__((aligned(64)));
 
 // =============================================================================
@@ -160,7 +228,6 @@ struct DumpSetupHeader {
 /**
  * Caller fills this struct from runtime-specific tensor types.
  * Platform layer is agnostic to runtime-specific types (Tensor, PTO2TaskPayload, etc.).
- * Identical to A2A3 TensorDumpInfo for API compatibility.
  */
 struct TensorDumpInfo {
     uint64_t task_id;
@@ -186,13 +253,13 @@ extern "C" {
 #endif
 
 /**
- * Calculate DumpBuffer allocation size (header + records array).
+ * Calculate total memory size for dump header + buffer states.
  *
- * @param capacity Number of TensorDumpRecord entries
- * @return Total bytes to allocate for one DumpBuffer
+ * @param num_dump_threads Number of AICPU scheduling threads
+ * @return Total bytes for DumpDataHeader + DumpBufferState array
  */
-inline size_t calc_dump_buffer_size(int capacity) {
-    return sizeof(DumpBuffer) + static_cast<size_t>(capacity) * sizeof(TensorDumpRecord);
+inline size_t calc_dump_data_size(int num_dump_threads) {
+    return sizeof(DumpDataHeader) + num_dump_threads * sizeof(DumpBufferState);
 }
 
 /**
@@ -206,21 +273,32 @@ inline uint64_t calc_dump_arena_size() {
 }
 
 /**
- * Get DumpSetupHeader pointer from dump base address.
+ * Get DumpDataHeader pointer.
  *
- * @param base_ptr Dump shared memory base address (kernel_args.dump_data_base)
- * @return DumpSetupHeader pointer
+ * @param base_ptr Dump shared memory base address
+ * @return DumpDataHeader pointer
  */
-inline DumpSetupHeader *get_dump_setup_header(void *base_ptr) { return reinterpret_cast<DumpSetupHeader *>(base_ptr); }
+inline DumpDataHeader *get_dump_header(void *base_ptr) { return reinterpret_cast<DumpDataHeader *>(base_ptr); }
 
 /**
- * Get pointer to the records array of a DumpBuffer.
+ * Get DumpBufferState array start address (after DumpDataHeader).
  *
- * @param buf DumpBuffer pointer
- * @return Pointer to the first TensorDumpRecord
+ * @param base_ptr Dump shared memory base address
+ * @return DumpBufferState array pointer
  */
-inline TensorDumpRecord *get_dump_buffer_records(DumpBuffer *buf) {
-    return reinterpret_cast<TensorDumpRecord *>(buf + 1);
+inline DumpBufferState *get_dump_buffer_states(void *base_ptr) {
+    return reinterpret_cast<DumpBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(DumpDataHeader));
+}
+
+/**
+ * Get DumpBufferState for specified thread.
+ *
+ * @param base_ptr Dump shared memory base address
+ * @param thread_idx Thread index (0 ~ num_dump_threads-1)
+ * @return DumpBufferState pointer
+ */
+inline DumpBufferState *get_dump_buffer_state(void *base_ptr, int thread_idx) {
+    return &get_dump_buffer_states(base_ptr)[thread_idx];
 }
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/host/l2_perf_collector.h
+++ b/src/a5/platform/include/host/l2_perf_collector.h
@@ -11,185 +11,413 @@
 
 /**
  * @file l2_perf_collector.h
- * @brief Host-side performance data collector (memcpy-based)
+ * @brief Platform-agnostic performance data collector with dynamic memory management
  *
- * Design:
- *   1. Host pre-allocates one L2PerfBuffer per core and one PhaseBuffer per
- *      AICPU thread on device, plus a single L2PerfSetupHeader that stores
- *      all buffer pointers, total_tasks, and the AicpuPhaseHeader.
- *   2. During execution, AICore writes timing into L2PerfBuffers and AICPU
- *      completes records + writes phase data directly into device memory.
- *      When a buffer fills up, records are silently dropped (AICPU-side
- *      early return).
- *   3. After stream sync, Host copies L2PerfSetupHeader, each L2PerfBuffer, and
- *      each PhaseBuffer back via rtMemcpy (two-step: 64B header → read
- *      count → copy count*sizeof(record) actual data).
+ * Architecture:
+ * - ProfMemoryManager: Dedicated thread that polls ReadyQueue, allocates new
+ *   device buffers, and replaces full buffers in slot arrays.
+ * - L2PerfCollector: Main thread collects data from ProfMemoryManager's
+ *   internal queue, copies records to host vectors, and exports results.
  *
- * This replaces the previous shared-memory + ProfMemoryManager design that
- * depended on halHostRegister, which A5 hardware does not support.
+ * Design Pattern: Dependency Injection via Callbacks for memory operations.
+ *
+ * A5 specifics:
+ * - A5 does not support halHostRegister (no SVM/shared memory).
+ * - Both onboard and sim use the same host-shadow collector flow.
+ * - Platform-specific copy hooks handle the actual Host↔Device transfer
+ *   (`rtMemcpy` on onboard, `memcpy` in sim).
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_L2_PERF_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_L2_PERF_COLLECTOR_H_
 
-#include <cstddef>
+#include <atomic>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
+#include <unordered_map>
 #include <vector>
 
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
+#include "host/profiling_copy.h"
 #include "runtime.h"
 
 /**
- * Device memory allocation callback.
+ * Memory allocation callback for performance profiling
  *
- * @param size      Memory size in bytes
+ * @param size Memory size in bytes
  * @return Allocated device memory pointer, or nullptr on failure
  */
 using L2PerfAllocCallback = void *(*)(size_t size);
 
 /**
- * Device memory free callback.
+ * Memory registration callback (for Host-Device shared memory)
  *
- * @param dev_ptr   Device memory pointer
+ * Kept for interface parity with a2a3. A5 does not support host register,
+ * so callers pass nullptr and the collector ignores it.
+ */
+using L2PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
+
+/**
+ * Memory unregister callback
+ *
+ * Kept for interface parity with a2a3. A5 does not support host register,
+ * so callers pass nullptr and the collector ignores it.
+ */
+using L2PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+
+/**
+ * Memory free callback
+ *
+ * @param dev_ptr Device memory pointer
  * @return 0 on success, error code on failure
  */
 using L2PerfFreeCallback = int (*)(void *dev_ptr);
 
 /**
- * Host -> Device copy callback (rtMemcpy HOST_TO_DEVICE / memcpy in sim).
+ * Thread factory callback for creating threads with device binding
  *
- * @param dev_dst   Device destination pointer
- * @param host_src  Host source pointer
- * @param size      Number of bytes to copy
- * @return 0 on success, error code on failure
+ * Creates a std::thread that runs the given function with proper device
+ * context setup/teardown (e.g., rtSetDevice/rtDeviceReset on onboard).
+ *
+ * @param fn Function to execute in the new thread
+ * @return The newly created thread
  */
-using L2PerfCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, size_t size);
+using ThreadFactory = std::function<std::thread(std::function<void()>)>;
+
+// =============================================================================
+// ProfMemoryManager - Dynamic Buffer Memory Management Thread
+// =============================================================================
 
 /**
- * Device -> Host copy callback (rtMemcpy DEVICE_TO_HOST / memcpy in sim).
- *
- * @param host_dst  Host destination pointer
- * @param dev_src   Device source pointer
- * @param size      Number of bytes to copy
- * @return 0 on success, error code on failure
+ * Buffer type identifier for ReadyBufferInfo
  */
-using L2PerfCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src, size_t size);
+enum class ProfBufferType { PERF_RECORD, PHASE };
 
 /**
- * Host-side performance data collector.
+ * Information about a ready (full) buffer, passed from mgmt thread to main thread
+ */
+struct ReadyBufferInfo {
+    ProfBufferType type;
+    uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
+    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    void *dev_buffer_ptr;   // Device address of the full buffer
+    void *host_buffer_ptr;  // Host-side buffer (sim: same as dev; onboard: host copy)
+    uint32_t buffer_seq;    // Sequence number for ordering
+};
+
+/**
+ * Notification that a buffer has been copied and can be freed
+ */
+struct CopyDoneInfo {
+    void *dev_buffer_ptr;  // Device buffer to free
+    ProfBufferType type;   // Buffer type (for recycling)
+};
+
+/**
+ * Dynamic profiling buffer memory manager
  *
- * Lifecycle:
- *   1. initialize() — allocate L2PerfSetupHeader and all per-core/per-thread
- *      buffers on device; caller reads get_l2_perf_setup_device_ptr() and
- *      sets kernel_args.l2_perf_data_base.
- *   2. (AICore/AICPU run, writing directly into device buffers)
- *   3. collect_all() — after stream sync, copy L2PerfSetupHeader back,
- *      then copy each L2PerfBuffer / PhaseBuffer back using two-step
- *      count-first memcpy. Fills collected_*_records_ vectors.
- *   4. export_swimlane_json() — serialize collected data to Chrome Trace
- *      Event Format JSON. Logic unchanged from previous design.
- *   5. finalize() — free all device buffers.
+ * Runs a dedicated thread that:
+ * 1. Polls ReadyQueue in shared memory for full buffer entries
+ * 2. Allocates new device buffers via callback
+ * 3. Writes new buffer addresses into slots (for device to pick up)
+ * 4. Pushes old (full) buffer info to internal queue for main thread to copy
+ * 5. Frees device buffers after main thread confirms copy is done
+ *
+ * A5 specifics:
+ * - The collector always maintains host shadow copies of shared state/buffers.
+ * - Device-visible updates and reads always go through the platform copy hooks.
+ */
+class ProfMemoryManager {
+public:
+    ProfMemoryManager() = default;
+    ~ProfMemoryManager();
+
+    // Disable copy
+    ProfMemoryManager(const ProfMemoryManager &) = delete;
+    ProfMemoryManager &operator=(const ProfMemoryManager &) = delete;
+
+    // Allow L2PerfCollector to register initial buffer mappings
+    friend class L2PerfCollector;
+
+    /**
+     * Start the memory management thread
+     *
+     * @param shared_mem_host Host-side shared memory base address (shadow buffer)
+     * @param num_cores Number of AICore instances (L2PerfBufferState count)
+     * @param num_phase_threads Number of phase profiling threads (PhaseBufferState count)
+     * @param alloc_cb Device memory allocation callback
+     * @param register_cb Host-device mapping callback (nullptr for A5)
+     * @param free_cb Device memory free callback
+     * @param device_id Device ID for interface parity (unused on A5)
+     * @param thread_factory Thread factory for creating device-bound threads (empty to use std::thread)
+     */
+    void start(
+        void *shared_mem_host, int num_cores, int num_phase_threads, L2PerfAllocCallback alloc_cb,
+        L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, int device_id,
+        const ThreadFactory &thread_factory = {}
+    );
+
+    /**
+     * Stop the memory management thread
+     * Blocks until the thread exits.
+     */
+    void stop();
+
+    /**
+     * Try to pop a ready buffer info (non-blocking)
+     *
+     * @param[out] info Ready buffer info
+     * @return true if an item was available, false otherwise
+     */
+    bool try_pop_ready(ReadyBufferInfo &info);
+
+    /**
+     * Wait for a ready buffer info with timeout
+     *
+     * @param[out] info Ready buffer info
+     * @param timeout Maximum wait time
+     * @return true if an item was available, false on timeout
+     */
+    bool wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout);
+
+    /**
+     * Notify that a buffer has been copied and can be freed
+     *
+     * @param info Copy done notification
+     */
+    void notify_copy_done(const CopyDoneInfo &info);
+
+    /**
+     * Check if the manager thread is running
+     */
+    bool is_running() const { return running_.load(); }
+
+private:
+    std::thread mgmt_thread_;
+    std::atomic<bool> running_{false};
+
+    // Shared memory references
+    void *shared_mem_host_{nullptr};  // Host-side shadow buffer
+    void *shared_mem_dev_{nullptr};   // Device-side base address
+    int num_cores_{0};
+    int num_phase_threads_{0};
+
+    // Callbacks
+    L2PerfAllocCallback alloc_cb_{nullptr};
+    L2PerfRegisterCallback register_cb_{nullptr};
+    L2PerfFreeCallback free_cb_{nullptr};
+    int device_id_{-1};
+
+    // Management thread → main thread (ready buffers)
+    std::mutex ready_mutex_;
+    std::condition_variable ready_cv_;
+    std::queue<ReadyBufferInfo> ready_queue_;
+
+    // Main thread → management thread (buffers to free)
+    std::mutex done_mutex_;
+    std::queue<CopyDoneInfo> done_queue_;
+
+    // Device-to-host pointer mapping (populated during alloc_and_register)
+    std::unordered_map<void *, void *> dev_to_host_;
+
+    // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
+    std::vector<void *> recycled_perf_buffers_;
+    std::vector<void *> recycled_phase_buffers_;
+
+    // Management thread main loop
+    void mgmt_loop();
+
+    // Allocate a new device buffer and paired host shadow
+    void *alloc_and_register(size_t size, void **host_ptr_out);
+
+    // Free a previously allocated buffer and its host shadow
+    void free_buffer(void *dev_ptr);
+
+    // Resolve device pointer to host pointer
+    void *resolve_host_ptr(void *dev_ptr);
+
+    // Register an external dev→host mapping (for initial buffers)
+    void register_mapping(void *dev_ptr, void *host_ptr);
+
+    // Process one ReadyQueue entry
+    void process_ready_entry(L2PerfDataHeader *header, int thread_idx, const ReadyQueueEntry &entry);
+};
+
+// =============================================================================
+// L2PerfCollector - Main Collector
+// =============================================================================
+
+/**
+ * Performance data collector
+ *
+ * Manages performance profiling lifecycle:
+ * 1. Initialize shared memory (Header + SlotArrays) and allocate initial buffers
+ * 2. Start ProfMemoryManager thread
+ * 3. Collect records from ProfMemoryManager's queue (main thread)
+ * 4. Export swimlane visualization
+ *
+ * Platform-agnostic: Memory management delegated to callbacks
  */
 class L2PerfCollector {
 public:
     L2PerfCollector() = default;
     ~L2PerfCollector();
 
+    // Disable copy and move
     L2PerfCollector(const L2PerfCollector &) = delete;
     L2PerfCollector &operator=(const L2PerfCollector &) = delete;
 
     /**
-     * Allocate device buffers and initialize the L2PerfSetupHeader.
+     * Initialize performance profiling
      *
-     * After success, call get_l2_perf_setup_device_ptr() to get the device-side
-     * header pointer; the caller must publish this via kernel_args.l2_perf_data_base
-     * so AICPU code can discover it through get_platform_l2_perf_base().
+     * Allocates shared memory for slot arrays, allocates initial buffers,
+     * and writes buffer addresses into slots.
      *
-     * @param num_aicore       Number of AICore instances to profile
-     * @param device_id        Device ID (stored for later callbacks)
-     * @param alloc_cb         Device memory alloc
-     * @param free_cb          Device memory free
-     * @param copy_to_dev_cb   Host→device copy (used during init to publish header)
-     * @param copy_from_dev_cb Device->host copy (used during collect_all)
+     * @param num_aicore Number of AICore instances
+     * @param device_id Device ID
+     * @param alloc_cb Memory allocation callback
+     * @param register_cb Memory registration callback (ignored on A5)
+     * @param free_cb Memory free callback
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfFreeCallback free_cb,
-        L2PerfCopyToDeviceCallback copy_to_dev_cb, L2PerfCopyFromDeviceCallback copy_from_dev_cb
+        int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
+        L2PerfFreeCallback free_cb
     );
 
     /**
-     * Copy all profiling data back from device and parse it into
-     * collected_perf_records_ / collected_phase_records_ /
-     * collected_orch_summary_ / core_to_thread_.
+     * Start the memory management thread
      *
-     * Must be called after the execution stream has been fully synchronized.
+     * Must be called after initialize() and before device execution starts.
      *
-     * @return 0 on success, error code on failure
+     * @param thread_factory Thread factory for creating device-bound threads (empty to use std::thread)
      */
-    int collect_all();
+    void start_memory_manager(const ThreadFactory &thread_factory = {});
 
     /**
-     * Export collected data to Chrome Trace Event Format JSON.
+     * Poll and collect performance data from the memory manager's queue
      *
-     * @param output_path Output directory
-     * @return 0 on success, -1 on failure
+     * Runs on the main thread (or a dedicated collector thread in sim mode).
+     * Pulls ready buffers from ProfMemoryManager, copies records to host vectors,
+     * and notifies the manager to free old device buffers.
+     *
+     * @param expected_tasks Expected total number of tasks (0 = auto-detect)
+     */
+    void poll_and_collect(int expected_tasks = 0);
+
+    /**
+     * Export performance data to Chrome Trace Event Format
+     *
+     * @param output_path Output directory path
+     * @return 0 on success, error code on failure
      */
     int export_swimlane_json(const std::string &output_path);
 
     /**
-     * Free all device buffers and clear host-side state.
+     * Stop the memory management thread and clean up remaining data
      *
+     * Must be called after device execution completes.
+     */
+    void stop_memory_manager();
+
+    /**
+     * Cleanup all resources
+     *
+     * @param unregister_cb Memory unregister callback (nullptr on A5)
+     * @param free_cb Memory free callback
      * @return 0 on success, error code on failure
      */
-    int finalize();
+    int finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb);
 
     /**
-     * Check if the collector has been initialized.
+     * Check if collector is initialized
      */
-    bool is_initialized() const { return setup_header_dev_ != nullptr; }
+    bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
 
     /**
-     * Get the device pointer to the L2PerfSetupHeader.
+     * Get the device pointer to the L2PerfDataHeader.
      * Used to set kernel_args.l2_perf_data_base after initialize() succeeds.
      */
-    void *get_l2_perf_setup_device_ptr() const { return setup_header_dev_; }
+    void *get_l2_perf_setup_device_ptr() const { return perf_shared_mem_dev_; }
 
     /**
-     * Accessor used by tests.
+     * Drain remaining buffers from the memory manager's ready queue
+     *
+     * After poll_and_collect() exits (all PERF records collected) and
+     * the memory manager is stopped, Phase buffers may still be in the
+     * ready queue. This method drains them into the collected vectors.
+     *
+     * Must be called after stop_memory_manager() and before collect_phase_data().
+     */
+    void drain_remaining_buffers();
+
+    /**
+     * Collect AICPU phase profiling data from shared memory
+     *
+     * Reads scheduler phase records and orchestrator summary from the
+     * phase profiling region. Must be called after AICPU threads have joined.
+     */
+    void collect_phase_data();
+
+    /**
+     * Scan L2PerfBufferState::current_buf_ptr for all cores to recover
+     * partial records not delivered through the pipeline.
+     *
+     * Must be called after device execution completes and after
+     * stop_memory_manager(). Follows the same pattern as collect_phase_data()
+     * for PhaseBufferStates.
+     */
+    void scan_remaining_perf_buffers();
+
+    /**
+     * Signal that device execution is complete (streams synchronized).
+     * poll_and_collect() will drain remaining pipeline data and exit.
+     */
+    void signal_execution_complete();
+
+    /**
+     * Get collected records (for testing)
      */
     const std::vector<std::vector<L2PerfRecord>> &get_records() const { return collected_perf_records_; }
 
 private:
-    // Device-side allocations
-    void *setup_header_dev_{nullptr};
-    std::vector<void *> core_buffers_dev_;
-    std::vector<void *> phase_buffers_dev_;
+    // Shared memory pointers
+    void *perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
+    void *perf_shared_mem_host_{nullptr};  // Host-side shadow buffer
+    int device_id_{-1};
 
     // Configuration
     int num_aicore_{0};
-    int num_phase_threads_{0};
-    int device_id_{-1};
 
-    // Sizes (computed once in initialize)
-    size_t l2_perf_buffer_bytes_{0};
-    size_t phase_buffer_bytes_{0};
-
-    // Callbacks
+    // Callbacks (stored for memory manager and finalize)
     L2PerfAllocCallback alloc_cb_{nullptr};
+    L2PerfRegisterCallback register_cb_{nullptr};
     L2PerfFreeCallback free_cb_{nullptr};
-    L2PerfCopyToDeviceCallback copy_to_dev_cb_{nullptr};
-    L2PerfCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
 
-    // Host-side collected data (indexed by core / thread)
+    // Memory manager
+    ProfMemoryManager memory_manager_;
+
+    // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<L2PerfRecord>> collected_perf_records_;
+
+    // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
     AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
+
+    // Signal from device_runner that execution is complete
+    std::atomic<bool> execution_complete_{false};
+
+    // Allocate a single buffer (L2PerfBuffer or PhaseBuffer) and its host shadow
+    void *alloc_single_buffer(size_t size, void **host_ptr_out);
 };
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_HOST_L2_PERF_COLLECTOR_H_

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -11,50 +11,73 @@
 
 /**
  * @file pmu_collector.h
- * @brief Host-side PMU data collector (memcpy-based)
+ * @brief Host-side PMU buffer allocation, streaming collection, and CSV export.
  *
- * Design:
- *   1. Host pre-allocates one PmuBuffer per AICore on device, plus a single
- *      PmuSetupHeader that stores all buffer device pointers, core count,
- *      and the selected PMU event type.
- *   2. During execution, AICPU reads PMU MMIO counters after each task FIN
- *      and writes one PmuRecord into that core's PmuBuffer (silently
- *      incrementing PmuBufferState::dropped_record_count when the buffer is full).
- *   3. After stream sync, host copies the PmuBuffer header (to learn count)
- *      and then count*sizeof(PmuRecord) actual records back, per core.
- *   4. Host exports a LuoPan-compatible CSV under outputs/.
+ * Lifecycle mirrors a2a3 PmuCollector:
+ *   init()                    — Allocate PmuDataHeader + PmuBufferState shared memory,
+ *                               pre-allocate PmuBuffers and push into free_queues.
+ *   [start collector thread]
+ *   poll_and_collect()        — Poll ready_queues, recycle buffers, write CSV.
+ *   signal_execution_complete() — Notify collector that device is done.
+ *   [join collector thread]
+ *   drain_remaining_buffers() — Scan any buffers still held by AICPU after execution.
+ *   finalize()                — Free all device memory.
  *
- * halHostRegister is not supported on DAV_3510, so the collector uses
- * post-stream-sync memcpy rather than a shared-memory + SPSC-queue +
- * background-collector-thread streaming model.
+ * Memory model (a5-specific):
+ *   a5 has no halHostRegister, so host↔device SPSC fields are accessed
+ *   through host shadow buffers + rtMemcpy (onboard) or memcpy (sim).
+ *   Each device buffer has a paired host shadow in buf_pool_.
+ *   The shared memory region (PmuDataHeader + PmuBufferState[]) also has
+ *   separate device and host copies synchronized via copy hooks.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
 
+#include <atomic>
 #include <cerrno>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
+#include <fstream>
+#include <mutex>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
-#include "common/pmu_profiling.h"
 #include "common/platform_config.h"
+#include "common/pmu_profiling.h"
 #include "common/unified_log.h"
+#include "host/profiling_copy.h"
 
 // ---------------------------------------------------------------------------
-// Memory operation callbacks (injected by DeviceRunner)
+// Memory operation callbacks (injected by DeviceRunner, same as a2a3)
 // ---------------------------------------------------------------------------
 
-using PmuAllocCallback = void *(*)(size_t size);
-using PmuFreeCallback = int (*)(void *dev_ptr);
-using PmuCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, size_t size);
-using PmuCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src, size_t size);
+/**
+ * Allocate device memory. Returns nullptr on failure.
+ */
+using PmuAllocCallback = void *(*)(size_t size, void *user_data);
+
+/**
+ * Register device memory for host-visible access.
+ * Unused on a5 (no halHostRegister); kept for interface parity with a2a3.
+ */
+using PmuRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr);
+
+/**
+ * Unregister previously registered host-visible device memory.
+ * Unused on a5; kept for interface parity with a2a3.
+ */
+using PmuUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_data);
+
+/**
+ * Free device memory.
+ */
+using PmuFreeCallback = int (*)(void *dev_ptr, void *user_data);
 
 // ---------------------------------------------------------------------------
 // PmuCollector
@@ -69,65 +92,98 @@ public:
     PmuCollector &operator=(const PmuCollector &) = delete;
 
     /**
-     * Allocate device-side PMU buffers and publish the setup header pointer.
+     * Allocate PMU shared memory and pre-populate free_queues.
      *
-     * @param num_cores        Number of AICore instances to profile
-     * @param event_type       PmuEventType value (stored in header, used by AICPU)
-     * @param kernel_args_pmu_data_base Out: device address of PmuSetupHeader
-     * @param alloc_cb         Device memory alloc
-     * @param free_cb          Device memory free
-     * @param copy_to_dev_cb   Host→device (for publishing header)
-     * @param copy_from_dev_cb Device→host (for collect_all)
-     * @return 0 on success
+     * @param num_cores               Number of AICore instances in use
+     * @param num_threads             Number of AICPU scheduling threads
+     * @param kernel_args_pmu_data_base  Out: device address of PmuDataHeader
+     * @param csv_path                Output CSV file path
+     * @param event_type              PmuEventType value (written to CSV rows)
+     * @param alloc_cb / register_cb / free_cb  Memory operation callbacks
+     * @param user_data               Opaque pointer forwarded to callbacks
+     * @param device_id               Device ID (for interface parity)
+     * @return 0 on success, non-zero on failure
      */
-    int initialize(
-        int num_cores, PmuEventType event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
-        PmuFreeCallback free_cb, PmuCopyToDeviceCallback copy_to_dev_cb, PmuCopyFromDeviceCallback copy_from_dev_cb
+    int init(
+        int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
+        PmuEventType event_type, PmuAllocCallback alloc_cb, PmuFreeCallback free_cb, void *user_data, int device_id
     );
 
     /**
-     * Copy all PMU buffers back from device. Fills collected_records_.
-     * Must be called after the execution stream has been fully synchronized.
+     * Main body of the collector thread.
+     * Polls all per-thread ready_queues via rtMemcpy, appends records to CSV,
+     * recycles buffers back into free_queues.
      */
-    int collect_all();
+    void poll_and_collect();
 
     /**
-     * Export collected records to a LuoPan-compatible CSV under output_dir/.
+     * Signal that device execution has finished.
+     * The collector thread will drain remaining entries then exit.
      */
-    int export_csv(const std::string &output_dir);
+    void signal_execution_complete();
 
     /**
-     * Free all device buffers and reset host state.
+     * After the collector thread exits, scan PmuBufferState.current_buf_ptr for
+     * any remaining non-empty buffers that AICPU flushed but the collector
+     * thread may not have consumed yet.
      */
-    int finalize();
+    void drain_remaining_buffers();
 
-    bool is_initialized() const { return setup_header_dev_ != nullptr; }
+    /**
+     * Free all device/shared memory and unregister mapped regions.
+     */
+    void finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data);
 
-    const std::vector<std::vector<PmuRecord>> &get_records() const { return collected_records_; }
+    bool is_initialized() const { return initialized_; }
 
 private:
-    void *setup_header_dev_{nullptr};
-    std::vector<void *> core_buffers_dev_;  // PmuBuffer* per core (device)
+    bool initialized_ = false;
+    int num_cores_ = 0;
+    int num_threads_ = 0;
+    int device_id_ = -1;
+    PmuEventType event_type_ = PmuEventType::PIPE_UTILIZATION;
 
-    int num_cores_{0};
-    PmuEventType event_type_{PmuEventType::PIPE_UTILIZATION};
-    size_t pmu_buffer_bytes_{0};
-    size_t setup_region_bytes_{0};
+    // Shared memory region (PmuDataHeader + PmuBufferState[])
+    void *shm_dev_ = nullptr;   // Device address
+    void *shm_host_ = nullptr;  // Host shadow
+    size_t shm_size_ = 0;
 
-    PmuAllocCallback alloc_cb_{nullptr};
-    PmuFreeCallback free_cb_{nullptr};
-    PmuCopyToDeviceCallback copy_to_dev_cb_{nullptr};
-    PmuCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
+    // Pre-allocated PmuBuffers (one pool per core × BUFFERS_PER_CORE)
+    struct BufEntry {
+        void *dev_ptr = nullptr;
+        void *host_ptr = nullptr;
+    };
+    std::vector<BufEntry> buf_pool_;
 
-    // Host-side collected data (indexed by core id)
-    std::vector<std::vector<PmuRecord>> collected_records_;
-    std::vector<uint32_t> dropped_counts_;
-    std::vector<uint32_t> total_counts_;
-    std::vector<uint32_t> owning_thread_ids_;
+    PmuAllocCallback alloc_cb_ = nullptr;
+    PmuFreeCallback free_cb_ = nullptr;
+    void *user_data_ = nullptr;
+
+    std::string csv_path_;
+    std::string csv_header_;
+    std::ofstream csv_file_;
+    std::mutex csv_mutex_;
+
+    std::atomic<bool> execution_complete_{false};
+    uint64_t total_collected_ = 0;
+
+    std::unordered_set<uint64_t> drained_bufs_;
+
+    // Internal helpers
+    PmuDataHeader *pmu_header_host() const { return get_pmu_header(shm_host_); }
+    PmuBufferState *pmu_state_host(int core_id) const { return get_pmu_buffer_state(shm_host_, core_id); }
+    PmuDataHeader *pmu_header_dev() const { return get_pmu_header(shm_dev_); }
+    PmuBufferState *pmu_state_dev(int core_id) const { return get_pmu_buffer_state(shm_dev_, core_id); }
+
+    void write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr);
+    void push_to_free_queue(int core_id, uint64_t buf_dev_addr);
+    void ensure_csv_open_unlocked();
+
+    void *resolve_host_ptr(uint64_t dev_addr);
 };
 
 // ---------------------------------------------------------------------------
-// Utilities
+// Utility: resolve PMU event type (env-var override)
 // ---------------------------------------------------------------------------
 
 inline PmuEventType resolve_pmu_event_type(int requested_event_type) {

--- a/src/a5/platform/include/host/profiling_copy.h
+++ b/src/a5/platform/include/host/profiling_copy.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <cstddef>
+
+// Platform-specific copy hooks for profiling collectors.
+// Implemented in onboard/sim device_runner.cpp.
+int profiling_copy_to_device(volatile void *dev_dst, const void *host_src, size_t size);
+int profiling_copy_from_device(volatile void *host_dst, const volatile void *dev_src, size_t size);

--- a/src/a5/platform/include/host/tensor_dump_collector.h
+++ b/src/a5/platform/include/host/tensor_dump_collector.h
@@ -11,53 +11,167 @@
 
 /**
  * @file tensor_dump_collector.h
- * @brief Host-side tensor dump collector (memcpy-based)
+ * @brief Host-side tensor dump collector with independent shared memory
  *
- * - Host allocates per-thread DumpBuffers + arenas on device
- * - AICPU writes records and payload during execution
- * - After stream sync, host copies everything back via rtMemcpy/memcpy
- * - Export dump files (JSON manifest + binary payload)
+ * Fully decoupled from profiling: uses its own shared memory region,
+ * ready queues, and memory manager thread.
  *
- * No background threads, no SPSC queues — simple collect-after-sync.
+ * Mirrors L2PerfCollector architecture:
+ * - DumpMemoryManager: Background thread that polls dump ready queues,
+ *   recycles metadata buffers, and hands off full buffers to the main thread.
+ * - TensorDumpCollector: Main thread copies tensor data from arenas,
+ *   manages lifecycle, and exports dump files.
+ *
+ * A5 specifics: memory access uses host-shadow copies + explicit memcpy
+ * instead of halHostRegister/SVM. Data structures and interaction logic
+ * are identical to A2A3.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_TENSOR_DUMP_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_TENSOR_DUMP_COLLECTOR_H_
 
-#include <cstddef>
+#include <atomic>
+#include <condition_variable>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <queue>
 #include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common/platform_config.h"
 #include "common/tensor_dump.h"
 #include "data_type.h"
+#include "host/profiling_copy.h"
 
 /**
  * Device memory allocation callback.
+ *
+ * @param size Memory size in bytes
+ * @return Allocated device memory pointer, or nullptr on failure
  */
 using DumpAllocCallback = void *(*)(size_t size);
 
 /**
- * Device memory free callback.
+ * Memory registration callback (for Host-Device shared memory).
+ *
+ * Kept for interface parity with A2A3. A5 does not support host register,
+ * so callers pass nullptr and the collector ignores it.
+ */
+using DumpRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
+
+/**
+ * Memory unregister callback.
+ *
+ * Kept for interface parity with A2A3. A5 does not support host register,
+ * so callers pass nullptr and the collector ignores it.
+ */
+using DumpUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+
+/**
+ * Memory free callback.
+ *
+ * @param dev_ptr Device memory pointer
+ * @return 0 on success, error code on failure
  */
 using DumpFreeCallback = int (*)(void *dev_ptr);
 
 /**
- * Host -> Device copy callback.
+ * Callback for binding the memory-manager thread to a device context.
+ *
+ * Called once at the start of the management thread. On A5 onboard this
+ * wraps rtSetDevice; in simulation mode callers pass nullptr.
+ *
+ * @param device_id Device ID
+ * @return 0 on success, error code on failure
  */
-using DumpCopyToDeviceCallback = int (*)(void *dev_dst, const void *host_src, size_t size);
-
-/**
- * Device -> Host copy callback.
- */
-using DumpCopyFromDeviceCallback = int (*)(void *host_dst, const void *dev_src, size_t size);
+using DumpSetDeviceCallback = int (*)(int device_id);
 
 // =============================================================================
-// DumpedTensor - Collected tensor metadata + payload bytes
+// DumpMemoryManager - Background Thread
 // =============================================================================
 
 /**
- * Collected tensor metadata + payload bytes (identical to A2A3 DumpedTensor).
+ * Information about a ready (full) dump metadata buffer
+ */
+struct DumpReadyBufferInfo {
+    uint32_t thread_index;
+    void *dev_buffer_ptr;
+    void *host_buffer_ptr;
+    uint32_t buffer_seq;
+};
+
+/**
+ * Dump buffer memory manager thread.
+ *
+ * Polls per-thread ready queues in DumpDataHeader, hands off full
+ * DumpMetaBuffers to the main thread, and recycles them back into
+ * the SPSC free_queue.
+ */
+class DumpMemoryManager {
+public:
+    DumpMemoryManager() = default;
+    ~DumpMemoryManager();
+
+    DumpMemoryManager(const DumpMemoryManager &) = delete;
+    DumpMemoryManager &operator=(const DumpMemoryManager &) = delete;
+
+    friend class TensorDumpCollector;
+
+    void start(
+        void *shared_mem_host, void *shared_mem_dev, int num_dump_threads, DumpAllocCallback alloc_cb,
+        DumpRegisterCallback register_cb, DumpFreeCallback free_cb, int device_id,
+        DumpSetDeviceCallback set_device_cb = nullptr
+    );
+
+    void stop();
+
+    bool try_pop_ready(DumpReadyBufferInfo &info);
+    bool wait_pop_ready(DumpReadyBufferInfo &info, std::chrono::milliseconds timeout);
+    void notify_copy_done(void *dev_buffer_ptr);
+
+    bool is_running() const { return running_.load(); }
+
+private:
+    std::thread mgmt_thread_;
+    std::atomic<bool> running_{false};
+
+    void *shared_mem_host_{nullptr};
+    void *shared_mem_dev_{nullptr};
+    int num_dump_threads_{0};
+
+    DumpAllocCallback alloc_cb_{nullptr};
+    DumpRegisterCallback register_cb_{nullptr};
+    DumpFreeCallback free_cb_{nullptr};
+    DumpSetDeviceCallback set_device_cb_{nullptr};
+    int device_id_{-1};
+    std::mutex ready_mutex_;
+    std::condition_variable ready_cv_;
+    std::queue<DumpReadyBufferInfo> ready_queue_;
+
+    std::mutex done_mutex_;
+    std::queue<void *> done_queue_;  // Device pointers to recycle
+
+    std::unordered_map<void *, void *> dev_to_host_;
+    std::vector<void *> recycled_dump_buffers_;
+
+    void mgmt_loop();
+    void *alloc_and_register(size_t size, void **host_ptr_out);
+    void free_buffer(void *dev_ptr);
+    void *resolve_host_ptr(void *dev_ptr);
+    void register_mapping(void *dev_ptr, void *host_ptr);
+    void process_dump_entry(DumpDataHeader *header, int thread_idx, const DumpReadyQueueEntry &entry);
+};
+
+// =============================================================================
+// TensorDumpCollector - Main Collector
+// =============================================================================
+
+/**
+ * Collected tensor metadata + payload bytes
  */
 struct DumpedTensor {
     uint64_t task_id;
@@ -74,26 +188,11 @@ struct DumpedTensor {
     bool is_contiguous;
     bool truncated;
     bool overwritten;
-    uint64_t payload_size;
-    uint64_t bin_offset;
+    uint64_t payload_size;  // original payload size (bytes may be cleared after writing)
+    uint64_t bin_offset;    // byte offset into tensors.bin
     std::vector<uint8_t> bytes;
 };
 
-// =============================================================================
-// TensorDumpCollector - Main Collector
-// =============================================================================
-
-/**
- * Host-side tensor dump collector.
- *
- * Lifecycle:
- *   1. initialize() — allocate DumpSetupHeader + per-thread DumpBuffers + arenas,
- *      caller reads get_dump_setup_device_ptr() and sets kernel_args.dump_data_base
- *   2. (AICPU execution writes records and payload data)
- *   3. collect_all() — after stream sync, copy header + buffers + arenas back
- *   4. export_dump_files() — write JSON manifest + binary payload
- *   5. finalize() — free all device allocations
- */
 class TensorDumpCollector {
 public:
     TensorDumpCollector() = default;
@@ -103,80 +202,98 @@ public:
     TensorDumpCollector &operator=(const TensorDumpCollector &) = delete;
 
     /**
-     * Initialize tensor dump device buffers.
+     * Initialize tensor dump shared memory.
      *
-     * @param num_dump_threads Number of AICPU scheduling threads
-     * @param device_id        Device ID
-     * @param alloc_cb         Device memory alloc
-     * @param free_cb          Device memory free
-     * @param copy_to_dev_cb   Host->device copy
-     * @param copy_from_dev_cb Device->host copy
+     * Allocates DumpDataHeader + DumpBufferState array, per-thread arenas,
+     * and initial DumpMetaBuffers.
+     *
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpFreeCallback free_cb,
-        DumpCopyToDeviceCallback copy_to_dev_cb, DumpCopyFromDeviceCallback copy_from_dev_cb
+        int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
+        DumpFreeCallback free_cb, DumpSetDeviceCallback set_device_cb = nullptr
     );
 
-    /**
-     * Copy all dump data back from device and parse into collected_ vector.
-     * Must be called after execution stream has been fully synchronized.
-     *
-     * @return 0 on success, error code on failure
-     */
-    int collect_all();
+    void start_memory_manager();
 
     /**
-     * Export collected data to dump files (JSON manifest + binary payload).
-     *
-     * @param output_path Output directory
-     * @return 0 on success, -1 on failure
+     * Streams payloads to `<output_path>/tensor_dump/<base>.bin` while the device
+     * runs. Caller-provided directory is the per-task uniqueness boundary.
      */
-    int export_dump_files(const std::string &output_path);
+    void poll_and_collect(const std::string &output_path);
 
     /**
-     * Free all device buffers and clear host-side state.
-     *
-     * @return 0 on success, error code on failure
+     * Write JSON manifest. Bin file is already written by poll_and_collect's
+     * writer thread, so no parameter is needed (uses run_dir_).
      */
-    int finalize();
+    int export_dump_files();
+    void stop_memory_manager();
+    void drain_remaining_buffers();
+    void scan_remaining_dump_buffers();
+    void signal_execution_complete();
 
-    /**
-     * Check if the collector has been initialized.
-     */
-    bool is_initialized() const { return setup_header_dev_ != nullptr; }
+    int finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb);
 
-    /**
-     * Get the device pointer to the DumpSetupHeader.
-     * Used to set kernel_args.dump_data_base.
-     */
-    void *get_dump_setup_device_ptr() const { return setup_header_dev_; }
+    bool is_initialized() const { return dump_shared_mem_host_ != nullptr; }
+
+    void *get_dump_shm_device_ptr() const { return dump_shared_mem_dev_; }
 
 private:
-    // Device-side allocations
-    void *setup_header_dev_{nullptr};
-    std::vector<void *> dump_buffers_dev_;   // Per-thread DumpBuffer
-    std::vector<void *> arena_headers_dev_;  // Per-thread DumpArenaHeader
-    std::vector<void *> arena_data_dev_;     // Per-thread arena data
-
-    // Configuration
-    int num_dump_threads_{0};
+    void *dump_shared_mem_dev_{nullptr};
+    void *dump_shared_mem_host_{nullptr};
     int device_id_{-1};
-    size_t dump_buffer_bytes_{0};
+    int num_dump_threads_{0};
 
-    // Callbacks
     DumpAllocCallback alloc_cb_{nullptr};
+    DumpRegisterCallback register_cb_{nullptr};
     DumpFreeCallback free_cb_{nullptr};
-    DumpCopyToDeviceCallback copy_to_dev_cb_{nullptr};
-    DumpCopyFromDeviceCallback copy_from_dev_cb_{nullptr};
+    DumpSetDeviceCallback set_device_cb_{nullptr};
 
-    // Collected data
+    // Per-thread arena pointers
+    struct ArenaInfo {
+        void *dev_ptr{nullptr};
+        void *host_ptr{nullptr};
+        uint64_t size{0};
+        uint64_t high_water{0};  // For overwrite detection
+    };
+    std::vector<ArenaInfo> arenas_;
+
+    DumpMemoryManager memory_manager_;
+
+    // Collected dump tensors
     std::vector<DumpedTensor> collected_;
+    std::mutex collected_mutex_;
+
+    // Execution complete signal
+    std::atomic<bool> execution_complete_{false};
 
     // Stats
-    uint32_t total_dropped_count_{0};
+    uint32_t total_dropped_record_count_{0};
     uint32_t total_truncated_count_{0};
     uint32_t total_overwrite_count_{0};
+
+    void *alloc_single_buffer(size_t size, void **host_ptr_out);
+    void process_dump_buffer(const DumpReadyBufferInfo &info);
+
+    // Track processed buffer pointers to prevent double-processing
+    std::unordered_set<void *> processed_buffers_;
+
+    // Writer thread: streams tensor payloads to a single tensors.bin
+    std::thread writer_thread_;
+    std::mutex write_mutex_;
+    std::condition_variable write_cv_;
+    std::queue<DumpedTensor> write_queue_;
+    std::atomic<bool> writer_done_{false};
+
+    // Output directory and single binary file
+    std::filesystem::path run_dir_;
+    std::ofstream bin_file_;
+    uint64_t next_bin_offset_{0};  // only accessed by collect thread
+
+    // Writer stats
+    std::atomic<uint64_t> bytes_written_{0};
+
+    void writer_loop();
 };
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_HOST_TENSOR_DUMP_COLLECTOR_H_

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -34,6 +34,7 @@ set(HOST_RUNTIME_SOURCES "")
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/profiling_copy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -411,6 +411,10 @@ int DeviceRunner::run(
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
         }
+        // Start memory management thread (needs device context)
+        l2_perf_collector_.start_memory_manager([this](std::function<void()> fn) {
+            return create_thread(std::move(fn));
+        });
     }
 
     // Initialize tensor dump if enabled
@@ -420,14 +424,17 @@ int DeviceRunner::run(
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
         }
+        dump_collector_.start_memory_manager();
     }
 
-    // Initialize PMU profiling if enabled
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, pmu_event_type_);
+        rc = init_pmu_buffers(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id
+        );
         if (rc != 0) {
-            LOG_ERROR("init_pmu failed: %d", rc);
-            return rc;
+            LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
+            kernel_args_.args.pmu_data_base = 0;
+            enable_pmu_ = false;
         }
     }
 
@@ -474,9 +481,61 @@ int DeviceRunner::run(
         return rc;
     }
 
+    // Launch collector threads before synchronization.
+    // The enclosing scope ensures guards signal + join on any early return.
     {
+        std::thread collector_thread;
+        if (enable_l2_swimlane_) {
+            collector_thread = create_thread([this]() {
+                poll_and_collect_performance_data(0);  // auto-detect task count
+            });
+        }
+        auto perf_thread_guard = RAIIScopeGuard([&]() {
+            if (collector_thread.joinable()) {
+                collector_thread.join();
+            }
+        });
+        auto perf_signal_guard = RAIIScopeGuard([this]() {
+            if (enable_l2_swimlane_) {
+                l2_perf_collector_.signal_execution_complete();
+            }
+        });
+
+        std::thread dump_collector_thread;
+        if (enable_dump_tensor_) {
+            dump_collector_thread = create_thread([this]() {
+                dump_collector_.poll_and_collect(output_prefix_);
+            });
+        }
+        auto dump_thread_guard = RAIIScopeGuard([&]() {
+            if (dump_collector_thread.joinable()) {
+                dump_collector_thread.join();
+            }
+        });
+        auto dump_signal_guard = RAIIScopeGuard([this]() {
+            if (enable_dump_tensor_) {
+                dump_collector_.signal_execution_complete();
+            }
+        });
+
+        std::thread pmu_collector_thread;
+        if (enable_pmu_ && pmu_collector_.is_initialized()) {
+            pmu_collector_thread = create_thread([this]() {
+                pmu_collector_.poll_and_collect();
+            });
+        }
+        auto pmu_thread_guard = RAIIScopeGuard([&]() {
+            if (pmu_collector_thread.joinable()) {
+                pmu_collector_thread.join();
+            }
+        });
+        auto pmu_signal_guard = RAIIScopeGuard([&]() {
+            if (enable_pmu_ && pmu_collector_.is_initialized()) {
+                pmu_collector_.signal_execution_complete();
+            }
+        });
+
         LOG_INFO_V0("=== rtStreamSynchronize stream_aicpu_ ===");
-        // Synchronize streams
         rc = rtStreamSynchronize(stream_aicpu_);
         if (rc != 0) {
             LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
@@ -491,23 +550,27 @@ int DeviceRunner::run(
         }
     }
 
-    // After streams are synchronized, pull profiling data back in one batch
-    // (memcpy-based: two-step count-first copy per buffer). All three
-    // collectors write under `output_prefix_`, the per-task directory the
-    // user must set on CallConfig (CallConfig::validate() enforces non-empty).
+    // After streams are synchronized and guards have signal+joined all threads,
+    // stop memory managers, drain remaining buffers, and export.
+    // All three collectors write under `output_prefix_`, the per-task directory
+    // the user must set on CallConfig (CallConfig::validate() enforces non-empty).
     if (enable_l2_swimlane_) {
-        l2_perf_collector_.collect_all();
+        l2_perf_collector_.stop_memory_manager();
+        l2_perf_collector_.drain_remaining_buffers();
+        l2_perf_collector_.scan_remaining_perf_buffers();
+        l2_perf_collector_.collect_phase_data();
         l2_perf_collector_.export_swimlane_json(output_prefix_);
     }
 
     if (enable_dump_tensor_) {
-        dump_collector_.collect_all();
-        dump_collector_.export_dump_files(output_prefix_);
+        dump_collector_.stop_memory_manager();
+        dump_collector_.drain_remaining_buffers();
+        dump_collector_.scan_remaining_dump_buffers();
+        dump_collector_.export_dump_files();
     }
 
     if (enable_pmu_ && pmu_collector_.is_initialized()) {
-        pmu_collector_.collect_all();
-        pmu_collector_.export_csv(output_prefix_);
+        pmu_collector_.drain_remaining_buffers();
     }
 
     // Print handshake results (reads from device memory, must be before free)
@@ -630,17 +693,26 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling (frees L2PerfSetupHeader + all per-core/per-thread buffers)
     if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize();
+        auto free_cb = [](void *dev_ptr) -> int {
+            return rtFree(dev_ptr);
+        };
+        l2_perf_collector_.finalize(nullptr, free_cb);
     }
 
     // Cleanup tensor dump
     if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize();
+        auto free_cb = [](void *dev_ptr) -> int {
+            return rtFree(dev_ptr);
+        };
+        dump_collector_.finalize(nullptr, free_cb);
     }
 
     // Cleanup PMU profiling
     if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize();
+        auto free_cb = [](void *dev_ptr, void * /*user_data*/) -> int {
+            return rtFree(dev_ptr);
+        };
+        pmu_collector_.finalize(nullptr, free_cb, nullptr);
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
@@ -812,21 +884,16 @@ int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
         return rtFree(dev_ptr);
     };
 
-    // Host->device and device->host copies via rtMemcpy
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        return rtMemcpy(dev_dst, size, host_src, size, RT_MEMCPY_HOST_TO_DEVICE);
-    };
-
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        return rtMemcpy(host_dst, size, dev_src, size, RT_MEMCPY_DEVICE_TO_HOST);
-    };
-
-    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb);
+    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, nullptr, free_cb);
     if (rc == 0) {
         kernel_args_.args.l2_perf_data_base =
             reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
     }
     return rc;
+}
+
+void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
+    l2_perf_collector_.poll_and_collect(expected_tasks);
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {
@@ -843,42 +910,35 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
         return rtFree(dev_ptr);
     };
 
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        return rtMemcpy(dev_dst, size, host_src, size, RT_MEMCPY_HOST_TO_DEVICE);
+    auto set_device_cb = [](int dev_id) -> int {
+        return rtSetDevice(dev_id);
     };
 
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        return rtMemcpy(host_dst, size, dev_src, size, RT_MEMCPY_DEVICE_TO_HOST);
-    };
-
-    int rc =
-        dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb);
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb, set_device_cb);
     if (rc != 0) {
         return rc;
     }
 
-    kernel_args_.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_setup_device_ptr());
+    kernel_args_.args.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
     return 0;
 }
 
-int DeviceRunner::init_pmu(int num_aicore, PmuEventType event_type) {
-    auto alloc_cb = [](size_t size) -> void * {
+int DeviceRunner::init_pmu_buffers(
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+) {
+    auto alloc_cb = [](size_t size, void * /*user_data*/) -> void * {
         void *ptr = nullptr;
         int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
         return (rc == 0) ? ptr : nullptr;
     };
-    auto free_cb = [](void *dev_ptr) -> int {
+
+    auto free_cb = [](void *dev_ptr, void * /*user_data*/) -> int {
         return rtFree(dev_ptr);
     };
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        return rtMemcpy(dev_dst, size, host_src, size, RT_MEMCPY_HOST_TO_DEVICE);
-    };
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        return rtMemcpy(host_dst, size, dev_src, size, RT_MEMCPY_DEVICE_TO_HOST);
-    };
 
-    int rc = pmu_collector_.initialize(
-        num_aicore, event_type, &kernel_args_.args.pmu_data_base, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
+    int rc = pmu_collector_.init(
+        num_cores, num_threads, &kernel_args_.args.pmu_data_base, csv_path, event_type, alloc_cb, free_cb, nullptr,
+        device_id
     );
     return rc;
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -262,6 +262,17 @@ public:
     void print_handshake_results();
 
     /**
+     * Poll and collect performance data from the memory manager's queue
+     *
+     * Runs on a dedicated collector thread. Pulls ready buffers from
+     * ProfMemoryManager, copies records to host vectors, and notifies
+     * the manager to free old device buffers.
+     *
+     * @param expected_tasks Expected total number of tasks
+     */
+    void poll_and_collect_performance_data(int expected_tasks);
+
+    /**
      * Cleanup all resources
      *
      * Frees all device memory, destroys streams, and resets state.
@@ -462,14 +473,10 @@ private:
     /**
      * Initialize PMU profiling device buffers.
      *
-     * Allocates a PmuSetupHeader and one PmuBuffer per core on device, then
-     * publishes the setup-header pointer into kernel_args.pmu_data_base.
-     *
-     * @param num_aicore   Number of AICore instances to profile
-     * @param event_type   Resolved PmuEventType value
-     * @return 0 on success, error code on failure
+     * Allocates a PmuDataHeader and one PmuBuffer per core on device, then
+     * publishes the data-header pointer into kernel_args.pmu_data_base.
+     * Signature matches a2a3 for cross-platform consistency.
      */
-    int init_pmu(int num_aicore, PmuEventType event_type);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -481,6 +488,10 @@ private:
     std::string output_prefix_{};                                  // diagnostic artifact root directory
     int log_level_{1};                                             // 0=DEBUG..4=NUL; default INFO
     int log_info_v_{5};                                            // INFO verbosity threshold; default V5
+
+    int init_pmu_buffers(
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+    );
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/onboard/host/profiling_copy.cpp
+++ b/src/a5/platform/onboard/host/profiling_copy.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/profiling_copy.h"
+
+#include <runtime/rt.h>
+
+int profiling_copy_to_device(volatile void *dev_dst, const void *host_src, size_t size) {
+    return rtMemcpy(const_cast<void *>(dev_dst), size, host_src, size, RT_MEMCPY_HOST_TO_DEVICE);
+}
+
+int profiling_copy_from_device(volatile void *host_dst, const volatile void *dev_src, size_t size) {
+    return rtMemcpy(
+        const_cast<void *>(host_dst), size, const_cast<const void *>(dev_src), size, RT_MEMCPY_DEVICE_TO_HOST
+    );
+}

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -39,6 +39,7 @@ set(HOST_RUNTIME_SOURCES "")
 list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/profiling_copy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/pto_runtime_c_api.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/host_log.cpp"

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <sys/stat.h>
 
+#include <atomic>
 #include <cstdio>
 #include <string>
 #include <vector>
@@ -173,12 +174,18 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        // PMU bindings — tolerated as optional so a5sim keeps building against
-        // pre-PMU AICPU SOs during the transition. Missing symbols mean PMU
-        // is unavailable on this build and set_pmu_enabled_func_ stays null.
         set_platform_pmu_base_func_ =
             reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_pmu_base"));
+        if (set_platform_pmu_base_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_platform_pmu_base: %s", dlerror());
+            return -1;
+        }
+
         set_pmu_enabled_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_pmu_enabled"));
+        if (set_pmu_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_pmu_enabled: %s", dlerror());
+            return -1;
+        }
 
         // Log config bindings (optional; older SOs without these stay at their
         // compile-time defaults).
@@ -264,6 +271,7 @@ int DeviceRunner::run(
     Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
     const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
 ) {
+    clear_cpu_sim_shared_storage();
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -356,14 +364,14 @@ int DeviceRunner::run(
         }
     }
 
+    rc = prepare_orch_so(runtime);
+    if (rc != 0) {
+        LOG_ERROR("prepare_orch_so failed: %d", rc);
+        return rc;
+    }
+
     // Store runtime pointer for print_handshake_results
     last_runtime_ = &runtime;
-
-    int rc_orch_so = prepare_orch_so(runtime);
-    if (rc_orch_so != 0) {
-        LOG_ERROR("prepare_orch_so failed: %d", rc_orch_so);
-        return rc_orch_so;
-    }
 
     // Initialize performance profiling if enabled
     if (enable_l2_swimlane_) {
@@ -372,25 +380,39 @@ int DeviceRunner::run(
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
         }
+        // Start memory management thread
+        l2_perf_collector_.start_memory_manager([this](std::function<void()> fn) {
+            return create_thread(std::move(fn));
+        });
     }
 
-    // Initialize tensor dump if enabled
     if (enable_dump_tensor_) {
+        // Initialize tensor dump (independent from profiling)
         rc = init_tensor_dump(runtime, num_aicore, device_id);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
         }
+        dump_collector_.start_memory_manager();
     }
 
-    // Initialize PMU profiling if enabled
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, pmu_event_type_);
+        rc = init_pmu_buffers(
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id
+        );
         if (rc != 0) {
-            LOG_ERROR("init_pmu failed: %d", rc);
-            return rc;
+            LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
+            kernel_args_.pmu_data_base = 0;
+            enable_pmu_ = false;
         }
     }
+
+    auto perf_cleanup = RAIIScopeGuard([this]() {
+        bool was_initialized = l2_perf_collector_.is_initialized();
+        if (was_initialized) {
+            l2_perf_collector_.stop_memory_manager();
+        }
+    });
 
     // Allocate simulated register blocks for all AICore cores
     // Using sparse mapping: 2 x 4KB pages per core instead of 24KB contiguous block
@@ -407,7 +429,6 @@ int DeviceRunner::run(
     });
 
     // Build array of per-core register base addresses
-    // Each core gets a pointer to its 8KB region (containing two 4KB pages)
     size_t regs_array_size = num_aicore * sizeof(uint64_t);
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(mem_alloc_.alloc(regs_array_size));
     if (regs_array == nullptr) {
@@ -431,27 +452,20 @@ int DeviceRunner::run(
     );
 
     // Check if executors are loaded
-    if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr) {
+    if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
+        set_platform_dump_base_func_ == nullptr || set_dump_tensor_enabled_func_ == nullptr ||
+        set_platform_pmu_base_func_ == nullptr || set_pmu_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
 
-    // Set platform regs in the AICPU .so before launching threads
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
     set_dump_tensor_enabled_func_(enable_dump_tensor_);
     set_platform_l2_perf_base_func_(kernel_args_.l2_perf_data_base);
     set_l2_swimlane_enabled_func_(enable_l2_swimlane_);
-
-    // Publish PMU session state to the AICPU SO (dlsym symbols are optional —
-    // older SOs without PMU support leave these nullptr, which simply turns
-    // PMU into a no-op in the AICPU executors).
-    if (set_platform_pmu_base_func_ != nullptr) {
-        set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
-    }
-    if (set_pmu_enabled_func_ != nullptr) {
-        set_pmu_enabled_func_(enable_pmu_);
-    }
+    set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
+    set_pmu_enabled_func_(enable_pmu_);
 
     // Publish log config to the AICPU SO. Optional dlsym for forward
     // compatibility with pre-log-config SOs.
@@ -467,12 +481,17 @@ int DeviceRunner::run(
     LOG_INFO_V0("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
     std::vector<std::thread> aicpu_threads;
     aicpu_threads.reserve(over_launch);
+    std::atomic<int> aicpu_rc{0};
     for (int i = 0; i < over_launch; i++) {
-        aicpu_threads.push_back(create_thread([this, &runtime, launch_aicpu_num, over_launch]() {
+        aicpu_threads.push_back(create_thread([this, &runtime, launch_aicpu_num, over_launch, &aicpu_rc]() {
             if (!platform_aicpu_affinity_gate(launch_aicpu_num, over_launch)) {
                 return;
             }
-            aicpu_execute_func_(&runtime);
+            int rc = aicpu_execute_func_(&runtime);
+            if (rc != 0) {
+                int expected = 0;
+                aicpu_rc.compare_exchange_strong(expected, rc, std::memory_order_acq_rel);
+            }
         }));
     }
 
@@ -487,7 +506,29 @@ int DeviceRunner::run(
         }));
     }
 
-    // Wait for all threads to complete
+    // Poll and collect performance data during execution (if enabled)
+    std::thread collector_thread;
+    if (enable_l2_swimlane_) {
+        collector_thread = create_thread([this, &runtime]() {
+            l2_perf_collector_.poll_and_collect(runtime.get_task_count());
+        });
+    }
+
+    std::thread dump_collector_thread;
+    if (enable_dump_tensor_) {
+        dump_collector_thread = std::thread([this]() {
+            dump_collector_.poll_and_collect(output_prefix_);
+        });
+    }
+
+    std::thread pmu_collector_thread;
+    if (enable_pmu_) {
+        pmu_collector_thread = std::thread([this]() {
+            pmu_collector_.poll_and_collect();
+        });
+    }
+
+    // Wait for all AICPU and AICore threads to complete
     LOG_INFO_V0("Waiting for threads to complete");
     for (auto &t : aicpu_threads) {
         t.join();
@@ -496,24 +537,55 @@ int DeviceRunner::run(
         t.join();
     }
 
+    // Signal all collectors that device execution is complete
+    if (enable_l2_swimlane_) {
+        l2_perf_collector_.signal_execution_complete();
+    }
+    if (enable_dump_tensor_) {
+        dump_collector_.signal_execution_complete();
+    }
+    if (enable_pmu_) {
+        pmu_collector_.signal_execution_complete();
+    }
+
+    // Wait for all collector threads
+    if (collector_thread.joinable()) {
+        collector_thread.join();
+    }
+    if (dump_collector_thread.joinable()) {
+        dump_collector_thread.join();
+    }
+    if (pmu_collector_thread.joinable()) {
+        pmu_collector_thread.join();
+    }
+
     LOG_INFO_V0("All threads completed");
 
-    // Collect performance data and export. All three collectors write under
-    // `output_prefix_`, the per-task directory the user must set on CallConfig
-    // (CallConfig::validate() enforces non-empty).
+    int runtime_rc = aicpu_rc.load(std::memory_order_acquire);
+    if (runtime_rc != 0) {
+        LOG_ERROR("AICPU execution failed with rc=%d", runtime_rc);
+        return runtime_rc;
+    }
+
+    // Diagnostic exports use the per-task `output_prefix_` directory the user
+    // set on CallConfig (CallConfig::validate() enforces non-empty upstream).
     if (enable_l2_swimlane_) {
-        l2_perf_collector_.collect_all();
+        l2_perf_collector_.stop_memory_manager();
+        l2_perf_collector_.drain_remaining_buffers();
+        l2_perf_collector_.scan_remaining_perf_buffers();
+        l2_perf_collector_.collect_phase_data();
         l2_perf_collector_.export_swimlane_json(output_prefix_);
     }
 
     if (enable_dump_tensor_) {
-        dump_collector_.collect_all();
-        dump_collector_.export_dump_files(output_prefix_);
+        dump_collector_.stop_memory_manager();
+        dump_collector_.drain_remaining_buffers();
+        dump_collector_.scan_remaining_dump_buffers();
+        dump_collector_.export_dump_files();
     }
 
     if (enable_pmu_ && pmu_collector_.is_initialized()) {
-        pmu_collector_.collect_all();
-        pmu_collector_.export_csv(output_prefix_);
+        pmu_collector_.drain_remaining_buffers();
     }
 
     // Print handshake results at end of run
@@ -617,6 +689,9 @@ int DeviceRunner::prepare_orch_so(Runtime &runtime) {
     host_orch_so_copy_.assign(
         static_cast<const uint8_t *>(host_so_data), static_cast<const uint8_t *>(host_so_data) + host_so_size
     );
+    // Sim shares an address space with the device-side aicpu thread, so a
+    // plain memcpy into the cached buffer is the same as rtMemcpy on
+    // hardware.
     std::memcpy(dev_orch_so_buffer_, host_orch_so_copy_.data(), host_so_size);
 
     cached_orch_so_hash_ = new_hash;
@@ -633,17 +708,32 @@ int DeviceRunner::finalize() {
 
     // Cleanup performance profiling
     if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize();
+        auto free_cb = [](void *dev_ptr) -> int {
+            free(dev_ptr);
+            return 0;
+        };
+
+        l2_perf_collector_.finalize(nullptr, free_cb);
     }
 
     // Cleanup tensor dump
     if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize();
+        auto free_cb = [](void *dev_ptr) -> int {
+            free(dev_ptr);
+            return 0;
+        };
+
+        dump_collector_.finalize(nullptr, free_cb);
     }
 
-    // Cleanup PMU profiling
     if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize();
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+            (void)user_data;
+            free(dev_ptr);
+            return 0;
+        };
+
+        pmu_collector_.finalize(nullptr, free_cb, nullptr);
     }
 
     // Kernel binaries should have been removed by validate_runtime_impl()
@@ -661,6 +751,7 @@ int DeviceRunner::finalize() {
     }
     func_id_to_addr_.clear();
 
+    // Release cached orchestration SO buffer.
     if (dev_orch_so_buffer_ != nullptr) {
         mem_alloc_.free(dev_orch_so_buffer_);
         dev_orch_so_buffer_ = nullptr;
@@ -789,28 +880,19 @@ void DeviceRunner::remove_kernel_binary(int func_id) {
 // =============================================================================
 
 int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
-    // Simulation: "device" memory is just host memory, so use malloc/free and
-    // std::memcpy for the copy callbacks.
+    // Define allocation callback (a5sim: use malloc)
     auto alloc_cb = [](size_t size) -> void * {
         return malloc(size);
     };
 
+    // Define free callback (a5sim: use free)
     auto free_cb = [](void *dev_ptr) -> int {
         free(dev_ptr);
         return 0;
     };
 
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        std::memcpy(dev_dst, host_src, size);
-        return 0;
-    };
-
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        std::memcpy(host_dst, dev_src, size);
-        return 0;
-    };
-
-    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb);
+    // Simulation: no registration needed (pass nullptr)
+    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, nullptr, free_cb);
     if (rc == 0) {
         kernel_args_.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
     }
@@ -830,45 +912,33 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
         return 0;
     };
 
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        std::memcpy(dev_dst, host_src, size);
-        return 0;
-    };
-
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        std::memcpy(host_dst, dev_src, size);
-        return 0;
-    };
-
-    int rc =
-        dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb);
+    // Simulation: no registration needed (dev == host)
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb);
     if (rc != 0) {
         return rc;
     }
 
-    kernel_args_.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_setup_device_ptr());
+    kernel_args_.dump_data_base = reinterpret_cast<uint64_t>(dump_collector_.get_dump_shm_device_ptr());
     return 0;
 }
 
-int DeviceRunner::init_pmu(int num_aicore, PmuEventType event_type) {
-    auto alloc_cb = [](size_t size) -> void * {
+int DeviceRunner::init_pmu_buffers(
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
+) {
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
+        (void)user_data;
         return malloc(size);
     };
-    auto free_cb = [](void *dev_ptr) -> int {
+
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        (void)user_data;
         free(dev_ptr);
         return 0;
     };
-    auto copy_to_dev_cb = [](void *dev_dst, const void *host_src, size_t size) -> int {
-        std::memcpy(dev_dst, host_src, size);
-        return 0;
-    };
-    auto copy_from_dev_cb = [](void *host_dst, const void *dev_src, size_t size) -> int {
-        std::memcpy(host_dst, dev_src, size);
-        return 0;
-    };
 
-    int rc = pmu_collector_.initialize(
-        num_aicore, event_type, &kernel_args_.pmu_data_base, alloc_cb, free_cb, copy_to_dev_cb, copy_from_dev_cb
+    // Simulation: no halHostRegister needed (dev == host)
+    int rc = pmu_collector_.init(
+        num_cores, num_threads, &kernel_args_.pmu_data_base, csv_path, event_type, alloc_cb, free_cb, nullptr, -1
     );
     return rc;
 }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -295,11 +295,11 @@ private:
     /**
      * Initialize PMU profiling buffers for simulation.
      *
-     * Allocates PmuSetupHeader + per-core PmuBuffer on host memory, publishes
-     * the setup-header pointer into kernel_args.pmu_data_base. pmu_reg_addrs
+     * Allocates PmuDataHeader + per-core PmuBuffer on host memory, publishes
+     * the header pointer into kernel_args.pmu_data_base. pmu_reg_addrs
      * stays 0 on sim (no hardware PMU model).
+     * Signature matches a2a3 for cross-platform consistency.
      */
-    int init_pmu(int num_aicore, PmuEventType event_type);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -311,6 +311,10 @@ private:
     std::string output_prefix_{};                                  // diagnostic artifact root directory
     int log_level_{1};                                             // 0=DEBUG..4=NUL; default INFO
     int log_info_v_{5};                                            // INFO verbosity threshold; default V5
+
+    int init_pmu_buffers(
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
+    );
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/platform/sim/host/profiling_copy.cpp
+++ b/src/a5/platform/sim/host/profiling_copy.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/profiling_copy.h"
+
+#include <cstring>
+
+int profiling_copy_to_device(volatile void *dev_dst, const void *host_src, size_t size) {
+    std::memcpy(const_cast<void *>(dev_dst), host_src, size);
+    return 0;
+}
+
+int profiling_copy_from_device(volatile void *host_dst, const volatile void *dev_src, size_t size) {
+    std::memcpy(const_cast<void *>(host_dst), const_cast<const void *>(dev_src), size);
+    return 0;
+}

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -11,12 +11,11 @@
 
 /**
  * @file l2_perf_collector_aicpu.cpp
- * @brief AICPU performance data collection implementation (memcpy-based)
+ * @brief AICPU performance data collection implementation (SPSC free queue)
  *
- * Host pre-allocates one L2PerfBuffer per core and one PhaseBuffer per thread
- * on the device. AICPU writes records directly into them via cached pointers.
- * When a buffer fills up, subsequent records are silently dropped — there is
- * no buffer switching or flushing.
+ * Uses per-core L2PerfBufferState with SPSC free queues for O(1) buffer switching.
+ * Host memory manager dynamically allocates replacement buffers and pushes
+ * them into the free_queue. Device pops from free_queue when switching.
  */
 
 #include "aicpu/l2_perf_collector_aicpu.h"
@@ -30,9 +29,14 @@
 #include "common/unified_log.h"
 
 // Cached pointers for hot-path access (set during init)
-static L2PerfSetupHeader *s_setup_header = nullptr;
+static AicpuPhaseHeader *s_phase_header = nullptr;
+static L2PerfDataHeader *s_l2_perf_header = nullptr;
 
-// Per-thread PhaseBuffer cache
+// Per-core L2PerfBufferState cache
+static L2PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+
+// Per-thread PhaseBufferState cache
+static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
 static PhaseBuffer *s_current_phase_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static int s_orch_thread_idx = -1;
@@ -49,6 +53,40 @@ extern "C" uint64_t get_platform_l2_perf_base() { return g_platform_l2_perf_base
 extern "C" void set_l2_swimlane_enabled(bool enable) { g_enable_l2_swimlane = enable; }
 extern "C" bool is_l2_swimlane_enabled() { return g_enable_l2_swimlane; }
 
+/**
+ * Enqueue ready buffer to per-thread queue
+ *
+ * @param header L2PerfDataHeader pointer
+ * @param thread_idx Thread index
+ * @param core_index Core index (or thread_idx for phase entries)
+ * @param buffer_ptr Device pointer to the full buffer
+ * @param buffer_seq Sequence number for ordering
+ * @param is_phase 0 = L2PerfRecord, 1 = Phase
+ * @return 0 on success, -1 if queue full
+ */
+static int enqueue_ready_buffer(
+    L2PerfDataHeader *header, int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq,
+    uint32_t is_phase
+) {
+    uint32_t capacity = PLATFORM_PROF_READYQUEUE_SIZE;
+    uint32_t current_tail = header->queue_tails[thread_idx];
+    uint32_t current_head = header->queue_heads[thread_idx];
+
+    // Check if queue is full
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;
+    }
+
+    header->queues[thread_idx][current_tail].core_index = core_index;
+    header->queues[thread_idx][current_tail].is_phase = is_phase;
+    header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
+    header->queue_tails[thread_idx] = next_tail;
+
+    return 0;
+}
+
 void l2_perf_aicpu_init_profiling(Runtime *runtime) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
@@ -56,29 +94,43 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
         return;
     }
 
-    s_setup_header = get_perf_setup_header(l2_perf_base);
+    s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
     int32_t task_count = runtime->get_task_count();
-    s_setup_header->total_tasks = static_cast<uint32_t>(task_count);
+    s_l2_perf_header->total_tasks = static_cast<uint32_t>(task_count);
 
     LOG_INFO_V0("Initializing performance profiling for %d cores (memcpy-based)", runtime->worker_count);
 
-    // Initialize each core's L2PerfBuffer and publish the pointer to the handshake
+    // Pop first buffer from free_queue for each core
     for (int i = 0; i < runtime->worker_count; i++) {
         Handshake *h = &runtime->workers[i];
-        uint64_t buf_ptr = s_setup_header->core_buffer_ptrs[i];
+        L2PerfBufferState *state = get_perf_buffer_state(l2_perf_base, i);
 
-        if (buf_ptr == 0) {
-            LOG_ERROR("Core %d: core_buffer_ptrs[%d] is NULL during init!", i, i);
+        s_perf_buffer_states[i] = state;
+
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(buf_ptr);
+            buf->count = 0;
+            h->l2_perf_records_addr = buf_ptr;
+
+            LOG_DEBUG("Core %d: popped initial buffer (addr=0x%lx)", i, buf_ptr);
+        } else {
+            LOG_ERROR("Core %d: free_queue is empty during init!", i);
+            state->current_buf_ptr = 0;
             h->l2_perf_records_addr = 0;
-            continue;
         }
-
-        L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(buf_ptr);
-        buf->count = 0;
-        h->l2_perf_records_addr = buf_ptr;
-
-        LOG_DEBUG("Core %d: L2PerfBuffer at 0x%lx", i, buf_ptr);
     }
 
     wmb();
@@ -92,8 +144,6 @@ int l2_perf_aicpu_complete_record(
 ) {
     rmb();
     uint32_t count = l2_perf_buf->count;
-    // Buffer-full check lives here (AICore does not branch on capacity); return -1
-    // silently drops the record, caller ignores the failure.
     if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
 
     // Read from WIP staging slot (AICore writes here, parity = reg_task_id & 1)
@@ -130,58 +180,180 @@ int l2_perf_aicpu_complete_record(
     return 0;
 }
 
+void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
+    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
+    if (l2_perf_base == nullptr) {
+        return;
+    }
+
+    L2PerfBufferState *state = s_perf_buffer_states[core_id];
+    if (state == nullptr) {
+        return;
+    }
+
+    L2PerfBuffer *full_buf = reinterpret_cast<L2PerfBuffer *>(state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    LOG_INFO_V0("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICore alive
+        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
+        // Revert: discard data and keep writing
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+    rmb();
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
+
+    L2PerfBuffer *new_buf = reinterpret_cast<L2PerfBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+
+    // Update handshake for AICore
+    Handshake *h = &runtime->workers[core_id];
+    h->l2_perf_records_addr = new_buf_ptr;
+    wmb();
+
+    LOG_INFO_V0("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
+}
+
+void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num) {
+    if (!is_l2_swimlane_enabled()) {
+        return;
+    }
+
+    rmb();
+
+    LOG_INFO_V0("Thread %d: Flushing performance buffers for %d cores", thread_idx, core_num);
+
+    int flushed_count = 0;
+
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        L2PerfBufferState *state = s_perf_buffer_states[core_id];
+        if (state == nullptr) continue;
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            // No active buffer
+            continue;
+        }
+
+        L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(buf_ptr);
+        if (buf->count == 0) {
+            continue;
+        }
+
+        uint32_t seq = state->current_buf_seq;
+        int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, core_id, buf_ptr, seq, 0);
+        if (rc == 0) {
+            LOG_INFO_V0("Thread %d: Core %d flushed buffer with %u records", thread_idx, core_id, buf->count);
+            flushed_count++;
+            state->current_buf_ptr = 0;
+            wmb();
+        } else {
+            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
+        }
+    }
+
+    wmb();
+
+    LOG_INFO_V0("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
+}
+
 void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         return;
     }
 
-    L2PerfSetupHeader *header = get_perf_setup_header(l2_perf_base);
+    L2PerfDataHeader *header = get_l2_perf_header(l2_perf_base);
     header->total_tasks = total_tasks;
     wmb();
 }
 
-void l2_perf_aicpu_init_phase_profiling(int num_sched_threads) {
+void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize phase profiling");
         return;
     }
 
-    s_setup_header = get_perf_setup_header(l2_perf_base);
+    s_phase_header = get_phase_header(l2_perf_base, runtime->worker_count);
+    s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
-    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
-    phase_header->magic = AICPU_PHASE_MAGIC;
-    phase_header->num_sched_threads = num_sched_threads;
-    phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
-    phase_header->num_cores = 0;
+    s_phase_header->magic = AICPU_PHASE_MAGIC;
+    s_phase_header->num_sched_threads = num_sched_threads;
+    s_phase_header->records_per_thread = PLATFORM_PHASE_RECORDS_PER_THREAD;
+    s_phase_header->num_cores = 0;
 
-    memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
-    memset(&phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
+    memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
-    // Cache per-thread PhaseBuffer pointers. Include all threads: scheduler +
-    // orchestrator (orchestrator may become scheduler).
+    // Cache per-thread record pointers and clear buffers
+    // Include all threads: scheduler + orchestrator (orchestrators may become schedulers)
     int total_threads = num_sched_threads + 1;
     if (total_threads > PLATFORM_MAX_AICPU_THREADS) {
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        uint64_t buf_ptr = s_setup_header->phase_buffer_ptrs[t];
-        if (buf_ptr == 0) {
-            LOG_ERROR("Thread %d: phase_buffer_ptrs[%d] is NULL during init!", t, t);
+        PhaseBufferState *state = get_phase_buffer_state(l2_perf_base, runtime->worker_count, t);
+
+        s_phase_buffer_states[t] = state;
+
+        // Pop first buffer from free_queue
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+            buf->count = 0;
+            s_current_phase_buf[t] = buf;
+
+            LOG_DEBUG("Thread %d: popped initial phase buffer (addr=0x%lx)", t, buf_ptr);
+        } else {
+            LOG_ERROR("Thread %d: phase free_queue is empty during init!", t);
+            state->current_buf_ptr = 0;
             s_current_phase_buf[t] = nullptr;
-            continue;
         }
-
-        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
-        buf->count = 0;
-        s_current_phase_buf[t] = buf;
-
-        LOG_DEBUG("Thread %d: PhaseBuffer at 0x%lx", t, buf_ptr);
     }
 
     // Clear remaining slots
     for (int t = total_threads; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        s_phase_buffer_states[t] = nullptr;
         s_current_phase_buf[t] = nullptr;
     }
 
@@ -193,21 +365,106 @@ void l2_perf_aicpu_init_phase_profiling(int num_sched_threads) {
     );
 }
 
+/**
+ * Switch phase buffer when current buffer is full (free queue version)
+ *
+ * Enqueues the full buffer to ReadyQueue and pops the next buffer from free_queue.
+ * If no free buffer is available, sets s_current_phase_buf to nullptr so subsequent
+ * records are dropped (preserving already-enqueued data).
+ */
+static void switch_phase_buffer(int thread_idx) {
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    PhaseBuffer *full_buf = s_current_phase_buf[thread_idx];
+    if (full_buf == nullptr) return;
+
+    LOG_INFO_V0("Thread %d: phase buffer is full (count=%u)", thread_idx, full_buf->count);
+
+    // Enqueue to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head != tail) {
+        uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+        rmb();
+        state->free_queue.head = head + 1;
+        state->current_buf_ptr = new_buf_ptr;
+        state->current_buf_seq = seq + 1;
+        wmb();
+
+        PhaseBuffer *new_buf = reinterpret_cast<PhaseBuffer *>(new_buf_ptr);
+        new_buf->count = 0;
+        s_current_phase_buf[thread_idx] = new_buf;
+
+        LOG_INFO_V0("Thread %d: switched to new phase buffer", thread_idx);
+    } else {
+        // No free buffer available, drop subsequent records
+        LOG_WARN("Thread %d: no free phase buffer available, dropping records until Host catches up", thread_idx);
+        s_current_phase_buf[thread_idx] = nullptr;
+        state->current_buf_ptr = 0;
+        wmb();
+    }
+}
+
 void l2_perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
     uint64_t tasks_processed
 ) {
-    if (s_setup_header == nullptr) {
+    if (s_phase_header == nullptr) {
         return;
     }
 
     PhaseBuffer *buf = s_current_phase_buf[thread_idx];
-    if (buf == nullptr) return;
+
+    // Try to recover from nullptr (no buffer was available on previous switch)
+    if (buf == nullptr) {
+        PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+        if (state == nullptr) return;
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = state->current_buf_seq + 1;
+            wmb();
+
+            buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+            buf->count = 0;
+            s_current_phase_buf[thread_idx] = buf;
+
+            LOG_INFO_V0("Thread %d: recovered phase buffer", thread_idx);
+        }
+        if (buf == nullptr) return;  // Still no buffer available
+    }
 
     uint32_t idx = buf->count;
+
     if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
-        // Buffer full; silently drop.
-        return;
+        // Buffer full, switch to next buffer
+        switch_phase_buffer(thread_idx);
+        buf = s_current_phase_buf[thread_idx];
+        if (buf == nullptr) return;  // No buffer available
+        idx = buf->count;
+        if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
+            return;  // Switch failed; drop this record
+        }
     }
 
     AicpuPhaseRecord *record = &buf->records[idx];
@@ -221,11 +478,11 @@ void l2_perf_aicpu_record_phase(
 }
 
 void l2_perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
-    if (s_setup_header == nullptr) {
+    if (s_phase_header == nullptr) {
         return;
     }
 
-    AicpuOrchSummary *dst = &s_setup_header->phase_header.orch_summary;
+    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
 
     memcpy(dst, src, sizeof(AicpuOrchSummary));
     dst->magic = AICPU_PHASE_MAGIC;
@@ -244,30 +501,62 @@ void l2_perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thr
 void l2_perf_aicpu_record_orch_phase(
     AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t submit_idx, uint64_t task_id
 ) {
-    if (s_orch_thread_idx < 0 || s_setup_header == nullptr) return;
+    if (s_orch_thread_idx < 0 || s_phase_header == nullptr) return;
     l2_perf_aicpu_record_phase(s_orch_thread_idx, phase_id, start_time, end_time, submit_idx, task_id);
 }
 
-void l2_perf_aicpu_init_core_assignments(int total_cores) {
-    if (s_setup_header == nullptr) {
+void l2_perf_aicpu_flush_phase_buffers(int thread_idx) {
+    if (s_phase_header == nullptr || s_l2_perf_header == nullptr) {
         return;
     }
-    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
-    memset(phase_header->core_to_thread, -1, sizeof(phase_header->core_to_thread));
-    phase_header->num_cores = static_cast<uint32_t>(total_cores);
+
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    rmb();
+    uint64_t buf_ptr = state->current_buf_ptr;
+    if (buf_ptr == 0) {
+        // No active buffer
+        return;
+    }
+
+    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(buf_ptr);
+    if (buf->count == 0) {
+        return;
+    }
+
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
+    if (rc == 0) {
+        LOG_INFO_V0("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
+        state->current_buf_ptr = 0;
+        s_current_phase_buf[thread_idx] = nullptr;
+        wmb();
+    } else {
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
+    }
+
+    wmb();
+}
+
+void l2_perf_aicpu_init_core_assignments(int total_cores) {
+    if (s_phase_header == nullptr) {
+        return;
+    }
+    memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
+    s_phase_header->num_cores = static_cast<uint32_t>(total_cores);
     wmb();
     LOG_INFO_V0("Core-to-thread mapping init: %d cores", total_cores);
 }
 
 void l2_perf_aicpu_write_core_assignments_for_thread(int thread_idx, const int *core_ids, int core_num) {
-    if (s_setup_header == nullptr) {
+    if (s_phase_header == nullptr) {
         return;
     }
-    AicpuPhaseHeader *phase_header = &s_setup_header->phase_header;
     for (int i = 0; i < core_num; i++) {
         int core_id = core_ids[i];
         if (core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
-            phase_header->core_to_thread[core_id] = static_cast<int8_t>(thread_idx);
+            s_phase_header->core_to_thread[core_id] = static_cast<int8_t>(thread_idx);
         }
     }
     wmb();

--- a/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
@@ -13,16 +13,14 @@
  * @file pmu_collector_aicpu.cpp
  * @brief AICPU-side PMU init/finalize + record commit from AICore slot (a5)
  *
- * AICPU programs PMU event selectors and starts PMU_CTRL_0/1 once at init,
- * publishes (pmu_buffer_addr, pmu_reg_base) into each Handshake so AICore
- * can read PMU MMIO itself, and commits slots AICore wrote into
- * PmuBuffer::dual_issue_slots on each task FIN. At finalize it restores
- * CTRL to the pre-run state.
+ * Buffer switching mirrors a2a3 pmu_collector_aicpu.cpp:
+ *   - SPSC free_queue: Host pushes free PmuBuffers, AICPU pops when switching.
+ *   - Per-thread ready_queue: AICPU enqueues full buffers for host collection.
+ *   - On free_queue empty or ready_queue full: overwrite current buffer (data lost,
+ *     same policy as a2a3 — avoids blocking the AICPU dispatch loop).
  *
- * On DAV_3510 the halResMap mapping is a single 3 MB page per AICore that
- * covers CTRL offsets (0x0, 0x5108) and PMU offsets (0x2400-0x2524,
- * 0x4200-0x42AC), so the same per-core reg base is used for init/finalize
- * (here) and for AICore-side MMIO reads.
+ * a5-specific: AICore writes PMU counters into dual_issue_slots[] via ld_dev;
+ * AICPU validates the slot and commits into records[] on COND FIN.
  */
 
 #include "aicpu/pmu_collector_aicpu.h"
@@ -30,6 +28,7 @@
 #include <cstring>
 
 #include "aicpu/platform_regs.h"
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 
@@ -41,13 +40,12 @@ static bool g_enable_pmu = false;
 static uint32_t g_pmu_saved_ctrl0[PLATFORM_MAX_CORES];
 static uint32_t g_pmu_saved_ctrl1[PLATFORM_MAX_CORES];
 
-// Per-core cached PmuBuffer pointer.
-static PmuBuffer *s_pmu_buffers[PLATFORM_MAX_CORES];
-static PmuSetupHeader *s_pmu_header = nullptr;
+// Per-core cached PmuBufferState pointer and PMU header pointer.
+static PmuBufferState *s_pmu_buffer_states[PLATFORM_MAX_CORES];
+static PmuDataHeader *s_pmu_header = nullptr;
 
-// Per-core resolved register base address, keyed by logical core_id.
-// Populated by pmu_aicpu_init() from get_platform_regs() — the same halResMap
-// mapping used for CTRL MMIO also covers PMU MMIO on DAV_3510.
+// Per-core resolved PMU MMIO base address, keyed by logical core_id.
+// Populated by pmu_aicpu_init(); 0 means "no PMU for this core" (sim).
 static uint64_t s_pmu_reg_addrs[PLATFORM_MAX_CORES] = {0};
 
 extern "C" void set_platform_pmu_base(uint64_t pmu_data_base) { g_platform_pmu_base = pmu_data_base; }
@@ -95,6 +93,83 @@ static void pmu_stop(uint64_t reg_base, uint32_t saved_ctrl0, uint32_t saved_ctr
 }
 
 // ---------------------------------------------------------------------------
+// Internal: enqueue full buffer to per-thread ready_queue
+// ---------------------------------------------------------------------------
+
+static int enqueue_pmu_ready_buffer(int thread_idx, uint32_t core_index, uint64_t buffer_ptr, uint32_t buffer_seq) {
+    uint32_t capacity = PLATFORM_PMU_READYQUEUE_SIZE;
+    uint32_t current_tail = s_pmu_header->queue_tails[thread_idx];
+    uint32_t current_head = s_pmu_header->queue_heads[thread_idx];
+
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;  // Queue full
+    }
+
+    s_pmu_header->queues[thread_idx][current_tail].core_index = core_index;
+    s_pmu_header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    s_pmu_header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
+    s_pmu_header->queue_tails[thread_idx] = next_tail;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: switch the current buffer for one core
+// ---------------------------------------------------------------------------
+
+static void pmu_switch_buffer(int core_id, int thread_idx) {
+    PmuBufferState *state = s_pmu_buffer_states[core_id];
+    if (state == nullptr) {
+        return;
+    }
+
+    PmuBuffer *full_buf = reinterpret_cast<PmuBuffer *>(state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICPU alive
+        LOG_WARN("Thread %d: Core %d no free PMU buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ready_queue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_pmu_ready_buffer(thread_idx, static_cast<uint32_t>(core_id), state->current_buf_ptr, seq);
+    if (rc != 0) {
+        LOG_ERROR(
+            "Thread %d: Core %d failed to enqueue PMU buffer (ready_queue full), data lost!", thread_idx, core_id
+        );
+        state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PMU_SLOT_COUNT];
+    rmb();
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
+
+    PmuBuffer *new_buf = reinterpret_cast<PmuBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+
+    LOG_INFO_V0("Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
+}
+
+// ---------------------------------------------------------------------------
 // High-level interface
 // ---------------------------------------------------------------------------
 
@@ -108,12 +183,12 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
         LOG_ERROR("pmu_aicpu_init: handshakes is NULL");
         return;
     }
-    s_pmu_header = reinterpret_cast<PmuSetupHeader *>(pmu_base);
+    s_pmu_header = reinterpret_cast<PmuDataHeader *>(pmu_base);
+    // Read event_type from SHM header (written by host at init)
     uint32_t pmu_event_type = s_pmu_header->event_type;
 
-    // Resolve per-core register base from physical_core_ids. On DAV_3510 the
-    // halResMap(RES_AICORE) mapping covers CTRL + PMU in a single per-core
-    // page, so PMU helpers reuse get_platform_regs().
+    // Resolve per-core PMU MMIO base from physical_core_ids. 0 means "no PMU
+    // for this core" (sim or misconfigured) — subsequent record/stop become no-ops.
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(get_platform_regs());
     for (int i = 0; i < num_cores; i++) {
         if (i >= PLATFORM_MAX_CORES) {
@@ -121,13 +196,11 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
             break;
         }
         s_pmu_reg_addrs[i] = regs_array ? regs_array[physical_core_ids[i]] : 0;
-        s_pmu_buffers[i] = reinterpret_cast<PmuBuffer *>(s_pmu_header->buffer_ptrs[i]);
         g_pmu_saved_ctrl0[i] = 0;
         g_pmu_saved_ctrl1[i] = 0;
     }
 
-    // Program event selectors and start PMU counters on all cores with a valid
-    // PMU reg base.
+    // Program event selectors and start PMU counters
     const PmuEventConfig *evt = pmu_resolve_event_config_a5(static_cast<PmuEventType>(pmu_event_type));
     if (evt == nullptr) {
         evt = &PMU_EVENTS_A5_PIPE_UTIL;
@@ -142,12 +215,37 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
         pmu_start(reg_addr, g_pmu_saved_ctrl0[i], g_pmu_saved_ctrl1[i]);
     }
 
-    // Publish per-core (pmu_buffer_addr, pmu_reg_base) into the matching
-    // Handshake so AICore can read PMU MMIO and write the dual-issue slot.
-    // Must happen before the caller sets aicpu_regs_ready=1 — AICore spins
-    // on that and reads these fields under the same release/acquire pair.
+    // Pop initial PmuBuffer from each core's free_queue
     for (int i = 0; i < num_cores; i++) {
-        handshakes[i].pmu_buffer_addr = reinterpret_cast<uint64_t>(s_pmu_buffers[i]);
+        PmuBufferState *state = get_pmu_buffer_state(pmu_base, i);
+        s_pmu_buffer_states[i] = state;
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PMU_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+
+            PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(buf_ptr);
+            buf->count = 0;
+
+            LOG_DEBUG("Core %d: popped initial PMU buffer (addr=0x%lx)", i, buf_ptr);
+        } else {
+            LOG_ERROR("Core %d: PMU free_queue is empty during init!", i);
+            state->current_buf_ptr = 0;
+        }
+    }
+
+    // Publish per-core (pmu_buffer_addr, pmu_reg_base) into the matching Handshake
+    for (int i = 0; i < num_cores; i++) {
+        PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(s_pmu_buffer_states[i]->current_buf_ptr);
+        handshakes[i].pmu_buffer_addr = reinterpret_cast<uint64_t>(buf);
         handshakes[i].pmu_reg_base = s_pmu_reg_addrs[i];
     }
 
@@ -160,38 +258,46 @@ void pmu_aicpu_complete_record(
     if (s_pmu_header == nullptr || core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
         return;
     }
-    PmuBuffer *buf = s_pmu_buffers[core_id];
-    if (buf == nullptr) {
+
+    PmuBufferState *state = s_pmu_buffer_states[core_id];
+    if (state == nullptr) {
         return;
     }
-    PmuBufferState *state = get_pmu_buffer_state(s_pmu_header, core_id);
 
-    // Stamp thread ownership on every commit. a5 binds each core to a fixed
-    // AICPU scheduler thread at init time, so this value is stable — host
-    // reads it at collect time to emit the CSV thread_id column.
-    state->owning_thread_id = static_cast<uint32_t>(thread_idx);
-
-    // Account for every commit attempt so host can detect silent slot loss.
+    // Account the task *before* any drop path so total reflects every task the
+    // AICPU tried to record. total == collected + dropped invariant on host.
     state->total_record_count += 1;
 
-    uint32_t idx = buf->count;
-    if (idx >= static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
-        // Buffer full — drop the record. Host surfaces the total at finalize.
+    rmb();
+    uint64_t cur_ptr = state->current_buf_ptr;
+    if (cur_ptr == 0) {
         state->dropped_record_count += 1;
+        wmb();
         return;
     }
+    PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(cur_ptr);
 
-    // Fetch AICore's writes into the dual-issue slot (index = reg_task_id & 1).
-    // Match the slot on the 32-bit register token AICore wrote, not the logical
-    // task_id (which may be a 64-bit PTO2 (ring<<32|local) value).
+    // Switch buffer if full
+    if (buf->count >= static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
+        pmu_switch_buffer(core_id, thread_idx);
+        rmb();
+        cur_ptr = state->current_buf_ptr;
+        if (cur_ptr == 0) {
+            state->dropped_record_count += 1;
+            wmb();
+            return;
+        }
+        buf = reinterpret_cast<PmuBuffer *>(cur_ptr);
+    }
+
+    uint32_t idx = buf->count;
+
+    // Fetch AICore's writes into the dual-issue slot
     PmuRecord *slot = &buf->dual_issue_slots[reg_task_id & 1u];
     cache_invalidate_range(slot, sizeof(PmuRecord));
 
     if (static_cast<uint32_t>(slot->task_id) != reg_task_id) {
-        // AICore hasn't published this slot yet. Should not happen because
-        // AICore writes task_id last + dcci flush before COND FIN, but bail
-        // out defensively rather than committing stale counter values.
-        // Counted in total_record_count above so host sees the gap.
+        // AICore hasn't published this slot yet — bail out defensively
         return;
     }
 
@@ -204,6 +310,62 @@ void pmu_aicpu_complete_record(
         rec->pmu_counters[i] = slot->pmu_counters[i];
     }
     buf->count = idx + 1;
+    wmb();
+}
+
+void pmu_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num) {
+    if (s_pmu_header == nullptr) {
+        LOG_ERROR("pmu_aicpu_flush_buffers: PMU not initialized (s_pmu_header=NULL), thread %d", thread_idx);
+        return;
+    }
+
+    for (int i = 0; i < core_num; i++) {
+        int core_id = cur_thread_cores[i];
+        if (core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
+            LOG_ERROR(
+                "pmu_aicpu_flush_buffers: thread %d got invalid core_id %d (max %d)", thread_idx, core_id,
+                PLATFORM_MAX_CORES
+            );
+            continue;
+        }
+
+        PmuBufferState *state = s_pmu_buffer_states[core_id];
+        if (state == nullptr) {
+            LOG_WARN(
+                "pmu_aicpu_flush_buffers: thread %d core %d has no PmuBufferState (skipped during init?)", thread_idx,
+                core_id
+            );
+            continue;
+        }
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            // No active buffer — either never allocated or already flushed. Not an error.
+            continue;
+        }
+
+        PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(buf_ptr);
+        if (buf->count == 0) {
+            // Active buffer but empty — nothing to flush.
+            continue;
+        }
+
+        uint32_t seq = state->current_buf_seq;
+        int rc = enqueue_pmu_ready_buffer(thread_idx, static_cast<uint32_t>(core_id), buf_ptr, seq);
+        if (rc == 0) {
+            LOG_INFO_V0("Thread %d: Core %d flushed PMU buffer with %u records", thread_idx, core_id, buf->count);
+            state->current_buf_ptr = 0;
+            wmb();
+        } else {
+            LOG_ERROR(
+                "Thread %d: Core %d failed to flush PMU buffer (ready_queue full), data lost!", thread_idx, core_id
+            );
+            state->dropped_record_count += buf->count;
+            buf->count = 0;
+            wmb();
+        }
+    }
 }
 
 void pmu_aicpu_finalize(const int *cur_thread_cores, int core_num) {

--- a/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
@@ -11,14 +11,12 @@
 
 /**
  * @file tensor_dump_aicpu.cpp
- * @brief AICPU tensor dump collection implementation (memcpy-based)
+ * @brief AICPU tensor dump collection implementation
  *
- * Simplified version of A2A3's tensor_dump_aicpu.cpp:
- * - No SPSC free queues or ready queues
- * - Per-thread DumpBuffer with count-first layout (like L2PerfBuffer)
+ * Mirrors l2_perf_collector_aicpu.cpp patterns:
+ * - Per-thread DumpBufferState with SPSC free queues
+ * - Per-thread ready queue for handing off full metadata buffers
  * - Per-thread circular arena for tensor payload data
- * - Silently drops records when DumpBuffer is full
- * - Host copies everything back after stream sync
  */
 
 #include "aicpu/tensor_dump_aicpu.h"
@@ -29,36 +27,37 @@
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 
-// =============================================================================
-// Static State
-// =============================================================================
-
+// Cached pointers for hot-path access (set during init)
 static uint64_t g_platform_dump_base = 0;
-static bool g_enable_dump_tensor = false;
+static DumpDataHeader *s_dump_header = nullptr;
+static DumpBufferState *s_dump_states[PLATFORM_MAX_AICPU_THREADS] = {};
+static DumpMetaBuffer *s_current_dump_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
-static DumpSetupHeader *s_setup_header = nullptr;
-static DumpBuffer *s_dump_buffers[PLATFORM_MAX_AICPU_THREADS] = {};
-static DumpArenaHeader *s_arena_headers[PLATFORM_MAX_AICPU_THREADS] = {};
-static char *s_arena_data[PLATFORM_MAX_AICPU_THREADS] = {};
-
+static bool s_logged_ready_queue_full[PLATFORM_MAX_AICPU_THREADS] = {};
+static bool s_logged_no_free_meta_buffer[PLATFORM_MAX_AICPU_THREADS] = {};
 static bool s_logged_dump_layout_mismatch = false;
 static uint32_t s_records_written[PLATFORM_MAX_AICPU_THREADS] = {};
+static uint32_t s_buffers_switched[PLATFORM_MAX_AICPU_THREADS] = {};
+static uint32_t s_buffers_flushed[PLATFORM_MAX_AICPU_THREADS] = {};
 
-// =============================================================================
-// Extern "C" API
-// =============================================================================
+static inline void account_dropped_records(DumpBufferState *state, uint32_t dropped_records) {
+    if (state == nullptr || dropped_records == 0) {
+        return;
+    }
+    uint32_t prev = state->dropped_record_count;
+    uint32_t next = prev + dropped_records;
+    state->dropped_record_count = (next < prev) ? UINT32_MAX : next;
+}
 
 extern "C" void set_platform_dump_base(uint64_t dump_data_base) { g_platform_dump_base = dump_data_base; }
 
 extern "C" uint64_t get_platform_dump_base() { return g_platform_dump_base; }
 
+static bool g_enable_dump_tensor = false;
+
 extern "C" void set_dump_tensor_enabled(bool enable) { g_enable_dump_tensor = enable; }
 
 extern "C" bool is_dump_tensor_enabled() { return g_enable_dump_tensor; }
-
-// =============================================================================
-// Helper Functions (same as A2A3)
-// =============================================================================
 
 bool get_tensor_dump_role_from_direction(ArgDirection dir, TensorDumpRole *role) {
     switch (dir) {
@@ -107,9 +106,124 @@ bool try_log_tensor_dump_layout_mismatch() {
     return true;
 }
 
-// =============================================================================
-// Circular Arena Writer (same as A2A3)
-// =============================================================================
+/**
+ * Enqueue a full dump metadata buffer to the thread's ready queue.
+ */
+static int enqueue_dump_ready_buffer(int thread_idx, uint64_t buffer_ptr, uint32_t buffer_seq) {
+    uint32_t capacity = PLATFORM_DUMP_READYQUEUE_SIZE;
+    uint32_t current_tail = s_dump_header->queue_tails[thread_idx];
+    uint32_t current_head = s_dump_header->queue_heads[thread_idx];
+
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;  // Queue full
+    }
+
+    s_dump_header->queues[thread_idx][current_tail].thread_index = static_cast<uint32_t>(thread_idx);
+    s_dump_header->queues[thread_idx][current_tail].buffer_ptr = buffer_ptr;
+    s_dump_header->queues[thread_idx][current_tail].buffer_seq = buffer_seq;
+    wmb();
+    s_dump_header->queue_tails[thread_idx] = next_tail;
+    wmb();
+
+    return 0;
+}
+
+/**
+ * Maximum spin-wait iterations when free_queue or ready_queue is exhausted.
+ * Gives host mgmt_loop time to replenish before falling back to buffer overwrite.
+ */
+static constexpr uint32_t DUMP_SPIN_WAIT_LIMIT = 1000000;
+
+/**
+ * Switch metadata buffer: enqueue the full buffer, pop a new one.
+ * Spin-waits briefly for host to replenish before falling back to overwrite.
+ */
+static int switch_dump_meta_buffer(int thread_idx) {
+    if (thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
+        return -1;
+    }
+    DumpBufferState *state = s_dump_states[thread_idx];
+    DumpMetaBuffer *cur = s_current_dump_buf[thread_idx];
+    if (state == nullptr || cur == nullptr) {
+        return -1;
+    }
+
+    // Spin-wait for a free buffer, giving host mgmt_loop time to replenish
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+    if (head == tail) {
+        for (uint32_t spin = 0; spin < DUMP_SPIN_WAIT_LIMIT; spin++) {
+            rmb();
+            head = state->free_queue.head;
+            tail = state->free_queue.tail;
+            if (head != tail) {
+                break;
+            }
+        }
+    }
+    if (head == tail) {
+        // Still empty after spin — overwrite current buffer
+        account_dropped_records(state, cur->count);
+        cur->count = 0;
+        wmb();
+        if (!s_logged_no_free_meta_buffer[thread_idx]) {
+            s_logged_no_free_meta_buffer[thread_idx] = true;
+            LOG_WARN(
+                "Tensor dump ran out of free metadata buffers on thread %d after spin-wait, "
+                "overwriting current buffer. Increase PLATFORM_DUMP_BUFFERS_PER_THREAD.",
+                thread_idx
+            );
+        }
+        return 0;
+    }
+
+    // Enqueue the full buffer (spin-wait if ready queue is full)
+    uint64_t buf_addr = reinterpret_cast<uint64_t>(cur);
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_dump_ready_buffer(thread_idx, buf_addr, seq);
+    if (rc != 0) {
+        for (uint32_t spin = 0; spin < DUMP_SPIN_WAIT_LIMIT; spin++) {
+            rmb();
+            rc = enqueue_dump_ready_buffer(thread_idx, buf_addr, seq);
+            if (rc == 0) {
+                break;
+            }
+        }
+    }
+    if (rc != 0) {
+        // Still full after spin — overwrite current buffer
+        account_dropped_records(state, cur->count);
+        cur->count = 0;
+        wmb();
+        if (!s_logged_ready_queue_full[thread_idx]) {
+            s_logged_ready_queue_full[thread_idx] = true;
+            LOG_WARN(
+                "Tensor dump ready queue full on thread %d after spin-wait, "
+                "overwriting current buffer. Increase PLATFORM_DUMP_READYQUEUE_SIZE.",
+                thread_idx
+            );
+        }
+        return 0;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_DUMP_SLOT_COUNT];
+    rmb();
+    state->free_queue.head = head + 1;
+
+    DumpMetaBuffer *new_buf = reinterpret_cast<DumpMetaBuffer *>(new_ptr);
+    new_buf->count = 0;
+    s_current_dump_buf[thread_idx] = new_buf;
+    state->current_buf_ptr = new_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
+
+    s_buffers_switched[thread_idx]++;
+
+    return 0;
+}
 
 struct CircularArenaWriter {
     char *arena;
@@ -213,10 +327,6 @@ static inline void write_tensor_dump_logical_prefix(
     gather_tensor_dump_dim(writer, info, elem_sz, 0, 0, &remaining_bytes);
 }
 
-// =============================================================================
-// Public API Implementation
-// =============================================================================
-
 void dump_tensor_init(int num_dump_threads) {
     void *dump_base = reinterpret_cast<void *>(get_platform_dump_base());
     if (dump_base == nullptr) {
@@ -224,68 +334,72 @@ void dump_tensor_init(int num_dump_threads) {
         return;
     }
 
-    s_setup_header = get_dump_setup_header(dump_base);
+    s_dump_header = get_dump_header(dump_base);
 
     LOG_INFO_V0("Initializing tensor dump for %d threads (memcpy-based)", num_dump_threads);
 
-    for (int t = 0; t < num_dump_threads && t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        uint64_t buf_ptr = s_setup_header->dump_buffer_ptrs[t];
-        uint64_t arena_hdr_ptr = s_setup_header->arena_header_ptrs[t];
-        uint64_t arena_data_ptr = s_setup_header->arena_data_ptrs[t];
+    // Pop initial metadata buffer from free_queue for each thread
+    for (int t = 0; t < num_dump_threads; t++) {
+        DumpBufferState *state = get_dump_buffer_state(dump_base, t);
+        s_dump_states[t] = state;
 
-        if (buf_ptr == 0) {
-            LOG_ERROR("Thread %d: dump_buffer_ptrs[%d] is NULL during init!", t, t);
-            s_dump_buffers[t] = nullptr;
-            continue;
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        if (head != tail) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_DUMP_SLOT_COUNT];
+            rmb();
+            state->free_queue.head = head + 1;
+            wmb();
+
+            DumpMetaBuffer *buf = reinterpret_cast<DumpMetaBuffer *>(buf_ptr);
+            buf->count = 0;
+            s_current_dump_buf[t] = buf;
+            state->current_buf_ptr = buf_ptr;
+            state->current_buf_seq = 0;
+            wmb();
+            LOG_DEBUG("Thread %d: popped initial dump buffer (addr=0x%lx)", t, buf_ptr);
+        } else {
+            LOG_ERROR("Thread %d: dump free_queue is empty during init!", t);
+            s_current_dump_buf[t] = nullptr;
+            state->current_buf_ptr = 0;
         }
-
-        DumpBuffer *buf = reinterpret_cast<DumpBuffer *>(buf_ptr);
-        buf->count = 0;
-        buf->dropped_count = 0;
-        s_dump_buffers[t] = buf;
-
-        s_arena_headers[t] = reinterpret_cast<DumpArenaHeader *>(arena_hdr_ptr);
-        s_arena_data[t] = reinterpret_cast<char *>(arena_data_ptr);
-
-        if (s_arena_headers[t] != nullptr) {
-            s_arena_headers[t]->write_offset = 0;
-        }
-
-        LOG_DEBUG(
-            "Thread %d: DumpBuffer at 0x%lx, arena at 0x%lx (size=%lu)", t, buf_ptr, arena_data_ptr,
-            s_setup_header->arena_sizes[t]
-        );
     }
 
+    memset(s_logged_ready_queue_full, 0, sizeof(s_logged_ready_queue_full));
+    memset(s_logged_no_free_meta_buffer, 0, sizeof(s_logged_no_free_meta_buffer));
     memset(s_records_written, 0, sizeof(s_records_written));
-    s_logged_dump_layout_mismatch = false;
-
-    wmb();
-    LOG_INFO_V0("Tensor dump initialized for %d threads", num_dump_threads);
+    memset(s_buffers_switched, 0, sizeof(s_buffers_switched));
+    memset(s_buffers_flushed, 0, sizeof(s_buffers_flushed));
 }
 
 int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
-    if (s_setup_header == nullptr) {
+    if (s_dump_header == nullptr) {
+        return -1;
+    }
+    if (thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
         return -1;
     }
 
-    DumpBuffer *buf = s_dump_buffers[thread_idx];
+    DumpBufferState *state = s_dump_states[thread_idx];
+    DumpMetaBuffer *buf = s_current_dump_buf[thread_idx];
     if (buf == nullptr) {
         return -1;
     }
 
-    TensorDumpRecord *records = get_dump_buffer_records(buf);
-
-    // Check capacity — drop if full
-    uint32_t count = buf->count;
-    if (count >= buf->capacity) {
-        uint32_t prev = buf->dropped_count;
-        uint32_t next = prev + 1;
-        buf->dropped_count = (next < prev) ? UINT32_MAX : next;
-        return 0;
+    // Switch metadata buffer if full
+    if (buf->count >= PLATFORM_DUMP_RECORDS_PER_BUFFER) {
+        if (switch_dump_meta_buffer(thread_idx) != 0) {
+            return -1;  // No free buffer
+        }
+        buf = s_current_dump_buf[thread_idx];
+        if (buf == nullptr) {
+            return -1;
+        }
     }
 
-    // Compute tensor data size
+    // Reserve space in arena
+    // Compute actual tensor data size from shape (not buffer.size which may include padding)
     uint64_t actual_elements = get_tensor_dump_num_elements(info);
     uint64_t elem_sz = get_element_size(static_cast<DataType>(info.dtype));
     uint64_t bytes = actual_elements * elem_sz;
@@ -293,82 +407,83 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     bool truncated = false;
     bool is_contiguous = tensor_dump_is_contiguous(info);
 
-    DumpArenaHeader *arena_hdr = s_arena_headers[thread_idx];
-    char *arena = s_arena_data[thread_idx];
-
-    if (arena_hdr != nullptr && arena != nullptr) {
-        uint64_t arena_sz = arena_hdr->arena_size;
-        if (bytes > arena_sz) {
-            copy_bytes = arena_sz / 2;
-            truncated = true;
-        }
-
-        uint64_t offset = arena_hdr->write_offset;
-        arena_hdr->write_offset = offset + copy_bytes;
-
-        CircularArenaWriter writer = {arena, arena_sz, offset, 0};
-        write_tensor_dump_logical_prefix(&writer, info, elem_sz, copy_bytes);
-        wmb();
-
-        // Fill metadata record
-        TensorDumpRecord *rec = &records[count];
-        rec->task_id = info.task_id;
-        rec->subtask_id = info.subtask_id;
-        rec->func_id = info.func_id;
-        rec->arg_index = info.arg_index;
-        rec->is_contiguous = is_contiguous ? 1 : 0;
-        rec->role = static_cast<uint8_t>(info.role);
-        rec->stage = static_cast<uint8_t>(info.stage);
-        rec->ndims = info.ndims;
-        rec->dtype = info.dtype;
-        rec->truncated = truncated ? 1 : 0;
-        rec->payload_offset = offset;
-        rec->payload_size = copy_bytes;
-        for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-            rec->raw_shapes[d] = info.raw_shapes[d];
-            rec->shapes[d] = info.shapes[d];
-            rec->offsets[d] = info.offsets[d];
-        }
-    } else {
-        // No arena — record metadata only, no payload
-        TensorDumpRecord *rec = &records[count];
-        rec->task_id = info.task_id;
-        rec->subtask_id = info.subtask_id;
-        rec->func_id = info.func_id;
-        rec->arg_index = info.arg_index;
-        rec->is_contiguous = is_contiguous ? 1 : 0;
-        rec->role = static_cast<uint8_t>(info.role);
-        rec->stage = static_cast<uint8_t>(info.stage);
-        rec->ndims = info.ndims;
-        rec->dtype = info.dtype;
-        rec->truncated = 1;
-        rec->payload_offset = 0;
-        rec->payload_size = 0;
-        for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-            rec->raw_shapes[d] = info.raw_shapes[d];
-            rec->shapes[d] = info.shapes[d];
-            rec->offsets[d] = info.offsets[d];
-        }
+    if (bytes > state->arena_size) {
+        // Tensor larger than entire arena — copy a partial sample
+        copy_bytes = state->arena_size / 2;
+        truncated = true;
     }
 
-    buf->count = count + 1;
+    uint64_t offset = state->arena_write_offset;
+    state->arena_write_offset = offset + copy_bytes;
+
+    // Copy tensor data into arena (circular wraparound)
+    char *arena = reinterpret_cast<char *>(state->arena_base);
+    uint64_t arena_sz = state->arena_size;
+    CircularArenaWriter writer = {arena, arena_sz, offset, 0};
+    write_tensor_dump_logical_prefix(&writer, info, elem_sz, copy_bytes);
     wmb();
 
-    if (thread_idx >= 0 && thread_idx < PLATFORM_MAX_AICPU_THREADS) {
-        s_records_written[thread_idx]++;
+    // Append metadata record
+    uint32_t idx = buf->count;
+    TensorDumpRecord *rec = &buf->records[idx];
+    rec->task_id = info.task_id;
+    rec->subtask_id = info.subtask_id;
+    rec->func_id = info.func_id;
+    rec->arg_index = info.arg_index;
+    rec->is_contiguous = is_contiguous ? 1 : 0;
+    rec->role = static_cast<uint8_t>(info.role);
+    rec->stage = static_cast<uint8_t>(info.stage);
+    rec->ndims = info.ndims;
+    rec->dtype = info.dtype;
+    rec->truncated = truncated ? 1 : 0;
+    rec->payload_offset = offset;
+    rec->payload_size = copy_bytes;
+    for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
+        rec->raw_shapes[d] = info.raw_shapes[d];
+        rec->shapes[d] = info.shapes[d];
+        rec->offsets[d] = info.offsets[d];
     }
+    buf->count = idx + 1;
+    wmb();
+
+    s_records_written[thread_idx]++;
 
     return 0;
 }
 
 void dump_tensor_flush(int thread_idx) {
-    // In the memcpy design, flush is a no-op for data — host reads after sync.
-    // Log per-thread statistics for diagnostics.
-    if (thread_idx >= 0 && thread_idx < PLATFORM_MAX_AICPU_THREADS) {
-        DumpBuffer *buf = s_dump_buffers[thread_idx];
-        uint32_t dropped = (buf != nullptr) ? buf->dropped_count : 0;
-        LOG_INFO_V0(
-            "Thread %d: dump_tensor_flush (records=%u, dropped=%u)", thread_idx, s_records_written[thread_idx], dropped
-        );
+    if (s_dump_header == nullptr) {
+        return;
     }
+    if (thread_idx < 0 || thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
+        return;
+    }
+
+    DumpMetaBuffer *buf = s_current_dump_buf[thread_idx];
+    if (buf != nullptr && buf->count > 0) {
+        uint64_t buf_addr = reinterpret_cast<uint64_t>(buf);
+        uint32_t seq = s_dump_states[thread_idx]->current_buf_seq;
+        if (enqueue_dump_ready_buffer(thread_idx, buf_addr, seq) != 0) {
+            account_dropped_records(s_dump_states[thread_idx], buf->count);
+            buf->count = 0;
+            wmb();
+            if (!s_logged_ready_queue_full[thread_idx]) {
+                s_logged_ready_queue_full[thread_idx] = true;
+                LOG_WARN(
+                    "Tensor dump ready queue is full on thread %d, so the current metadata buffer will be "
+                    "overwritten. Increase PLATFORM_DUMP_READYQUEUE_SIZE.",
+                    thread_idx
+                );
+            }
+        }
+        s_current_dump_buf[thread_idx] = nullptr;
+        s_dump_states[thread_idx]->current_buf_ptr = 0;
+    }
+
+    s_buffers_flushed[thread_idx]++;
+    uint32_t dropped = s_dump_states[thread_idx] ? s_dump_states[thread_idx]->dropped_record_count : 0;
+    LOG_INFO_V0(
+        "Thread %d: dump_tensor_flush (records=%u, buf_switches=%u, flushes=%u, dropped=%u)", thread_idx,
+        s_records_written[thread_idx], s_buffers_switched[thread_idx], s_buffers_flushed[thread_idx], dropped
+    );
 }

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -11,12 +11,20 @@
 
 /**
  * @file l2_perf_collector.cpp
- * @brief Host-side performance data collector (memcpy-based) implementation
+ * @brief Platform-agnostic performance data collector implementation
+ *
+ * Implements ProfMemoryManager (dynamic buffer management thread) and
+ * L2PerfCollector (data collection and export).
+ *
+ * A5 specifics:
+ * - The collector always uses host shadow buffers and platform copy hooks.
+ * - Onboard hooks call rtMemcpy; sim hooks call memcpy.
  */
 
 #include "host/l2_perf_collector.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cinttypes>
 #include <cstdlib>
 #include <cstring>
@@ -24,13 +32,580 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "common/memory_barrier.h"
 #include "common/unified_log.h"
 
 // =============================================================================
-// Helpers
+// ProfMemoryManager Implementation
+// =============================================================================
+
+ProfMemoryManager::~ProfMemoryManager() {
+    if (running_.load()) {
+        stop();
+    }
+}
+
+void ProfMemoryManager::start(
+    void *shared_mem_host, int num_cores, int num_phase_threads, L2PerfAllocCallback alloc_cb,
+    L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, int device_id, const ThreadFactory &thread_factory
+) {
+    shared_mem_host_ = shared_mem_host;
+    num_cores_ = num_cores;
+    num_phase_threads_ = num_phase_threads;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    device_id_ = device_id;
+
+    running_.store(true);
+    if (thread_factory) {
+        mgmt_thread_ = thread_factory([this]() {
+            mgmt_loop();
+        });
+    } else {
+        mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
+    }
+
+    LOG_INFO_V0("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
+}
+
+void ProfMemoryManager::stop() {
+    running_.store(false);
+    if (mgmt_thread_.joinable()) {
+        mgmt_thread_.join();
+    }
+
+    // Drain remaining done_queue and free buffers
+    {
+        std::scoped_lock<std::mutex> lock(done_mutex_);
+        while (!done_queue_.empty()) {
+            CopyDoneInfo info = done_queue_.front();
+            done_queue_.pop();
+            free_buffer(info.dev_buffer_ptr);
+        }
+    }
+
+    // Free recycled buffers
+    for (void *ptr : recycled_perf_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_perf_buffers_.clear();
+    for (void *ptr : recycled_phase_buffers_) {
+        free_buffer(ptr);
+    }
+    recycled_phase_buffers_.clear();
+
+    LOG_INFO_V0("ProfMemoryManager stopped");
+}
+
+bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
+    std::scoped_lock<std::mutex> lock(ready_mutex_);
+    if (ready_queue_.empty()) {
+        return false;
+    }
+    info = ready_queue_.front();
+    ready_queue_.pop();
+    return true;
+}
+
+bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(ready_mutex_);
+    if (ready_cv_.wait_for(lock, timeout, [this] {
+            return !ready_queue_.empty();
+        })) {
+        info = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+    return false;
+}
+
+void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
+    std::scoped_lock<std::mutex> lock(done_mutex_);
+    done_queue_.push(info);
+}
+
+void *ProfMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size);
+    if (dev_ptr == nullptr) {
+        const char *hint = (size == sizeof(L2PerfBuffer)) ?
+                               "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss" :
+                               "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
+        LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void *host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        void *host_ptr = malloc(size);
+        if (host_ptr == nullptr) {
+            LOG_ERROR("ProfMemoryManager: host shadow alloc failed for %zu bytes", size);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        memset(host_ptr, 0, size);
+        profiling_copy_to_device(dev_ptr, host_ptr, size);
+        *host_ptr_out = host_ptr;
+    }
+
+    dev_to_host_[dev_ptr] = *host_ptr_out;
+    return dev_ptr;
+}
+
+void ProfMemoryManager::free_buffer(void *dev_ptr) {
+    if (dev_ptr == nullptr) return;
+
+    if (free_cb_ != nullptr) {
+        auto it = dev_to_host_.find(dev_ptr);
+        if (it != dev_to_host_.end()) {
+            // In non-SVM mode, free the host shadow if it differs from dev_ptr
+            if (register_cb_ == nullptr && it->second != nullptr && it->second != dev_ptr) {
+                free(it->second);
+            }
+            dev_to_host_.erase(it);
+        }
+        free_cb_(dev_ptr);
+    }
+}
+
+void *ProfMemoryManager::resolve_host_ptr(void *dev_ptr) {
+    auto it = dev_to_host_.find(dev_ptr);
+    if (it != dev_to_host_.end()) {
+        return it->second;
+    }
+    LOG_ERROR("ProfMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
+    return nullptr;
+}
+
+void ProfMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
+
+void ProfMemoryManager::process_ready_entry(
+    L2PerfDataHeader * /*header*/, int /*thread_idx*/, const ReadyQueueEntry &entry
+) {
+    bool is_phase = (entry.is_phase != 0);
+    uint64_t old_dev_ptr = entry.buffer_ptr;
+    uint32_t seq = entry.buffer_seq;
+
+    void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
+    if (old_host_ptr != nullptr) {
+        size_t buf_size = is_phase ? sizeof(PhaseBuffer) : sizeof(L2PerfBuffer);
+        profiling_copy_from_device(old_host_ptr, reinterpret_cast<void *>(old_dev_ptr), buf_size);
+    }
+
+    if (is_phase) {
+        uint32_t tidx = entry.core_index;
+        if (tidx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
+            LOG_ERROR("ProfMemoryManager: invalid phase entry: thread=%u", tidx);
+            return;
+        }
+
+        PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
+
+        PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, tidx);
+        profiling_copy_from_device(state, dev_state, sizeof(PhaseBufferState));
+
+        // Replenish free_queue
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
+
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
+
+            if (!recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                std::scoped_lock<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
+                new_dev_ptr = recycled_phase_buffers_.back();
+                recycled_phase_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
+            uint32_t zero = 0;
+            profiling_copy_to_device(
+                reinterpret_cast<char *>(new_dev_ptr) + offsetof(PhaseBuffer, count), &zero, sizeof(uint32_t)
+            );
+
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
+
+            // In memcpy mode, write the slot and tail back to device
+            PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, tidx);
+            uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev_ptr);
+            profiling_copy_to_device(
+                &dev_state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT], &slot_val, sizeof(uint64_t)
+            );
+            uint32_t new_tail = cur_tail + 1;
+            profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+        }
+
+        // Resolve host pointer of old buffer
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
+            return;
+        }
+
+        // Push old buffer to ready queue for main thread to copy
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PHASE;
+        info.index = tidx;
+        info.slot_idx = 0;  // Not used in free queue design
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+
+    } else {
+        uint32_t core_index = entry.core_index;
+        if (core_index >= static_cast<uint32_t>(num_cores_)) {
+            LOG_ERROR("ProfMemoryManager: invalid perf entry: core=%u", core_index);
+            return;
+        }
+
+        L2PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, core_index);
+
+        L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, core_index);
+        profiling_copy_from_device(state, dev_state, sizeof(L2PerfBufferState));
+
+        // Replenish free_queue
+        rmb();
+        uint32_t head_val = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t available = tail - head_val;
+
+        int to_push = PLATFORM_PROF_SLOT_COUNT;
+        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
+            void *host_ptr = nullptr;
+            void *new_dev_ptr = nullptr;
+
+            if (!recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                std::scoped_lock<std::mutex> lock(done_mutex_);
+                while (!done_queue_.empty()) {
+                    CopyDoneInfo dinfo = done_queue_.front();
+                    done_queue_.pop();
+                    if (dinfo.type == ProfBufferType::PERF_RECORD)
+                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
+                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
+                }
+            }
+            if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
+                new_dev_ptr = recycled_perf_buffers_.back();
+                recycled_perf_buffers_.pop_back();
+                host_ptr = resolve_host_ptr(new_dev_ptr);
+            }
+            if (new_dev_ptr == nullptr) {
+                new_dev_ptr = alloc_and_register(sizeof(L2PerfBuffer), &host_ptr);
+            }
+            if (new_dev_ptr == nullptr) break;
+
+            reinterpret_cast<L2PerfBuffer *>(host_ptr)->count = 0;
+            uint32_t zero = 0;
+            profiling_copy_to_device(
+                reinterpret_cast<char *>(new_dev_ptr) + offsetof(L2PerfBuffer, count), &zero, sizeof(uint32_t)
+            );
+
+            uint32_t cur_tail = tail + p;
+            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
+                reinterpret_cast<uint64_t>(new_dev_ptr);
+            wmb();
+            state->free_queue.tail = cur_tail + 1;
+            wmb();
+
+            // In memcpy mode, write the slot and tail back to device
+            L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, core_index);
+            uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev_ptr);
+            profiling_copy_to_device(
+                &dev_state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT], &slot_val, sizeof(uint64_t)
+            );
+            uint32_t new_tail = cur_tail + 1;
+            profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+        }
+
+        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
+        if (old_host_ptr == nullptr) {
+            LOG_ERROR(
+                "ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
+                reinterpret_cast<void *>(old_dev_ptr)
+            );
+            return;
+        }
+
+        ReadyBufferInfo info;
+        info.type = ProfBufferType::PERF_RECORD;
+        info.index = core_index;
+        info.slot_idx = 0;  // Not used in free queue design
+        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
+        info.host_buffer_ptr = old_host_ptr;
+        info.buffer_seq = seq;
+
+        {
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+    }
+}
+
+void ProfMemoryManager::mgmt_loop() {
+    L2PerfDataHeader *header = get_l2_perf_header(shared_mem_host_);
+
+    while (running_.load()) {
+        // 1. Recycle done queue: move completed buffers to recycled pools for reuse
+        {
+            std::scoped_lock<std::mutex> lock(done_mutex_);
+            while (!done_queue_.empty()) {
+                CopyDoneInfo info = done_queue_.front();
+                done_queue_.pop();
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    recycled_perf_buffers_.push_back(info.dev_buffer_ptr);
+                } else {
+                    recycled_phase_buffers_.push_back(info.dev_buffer_ptr);
+                }
+            }
+        }
+
+        // 2. Poll ReadyQueues from all AICPU threads
+        L2PerfDataHeader *dev_header = get_l2_perf_header(shared_mem_dev_);
+        profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
+
+        bool found_any = false;
+        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+            rmb();
+            uint32_t head = header->queue_heads[t];
+            uint32_t tail = header->queue_tails[t];
+
+            // Validate indices to prevent OOB access from corrupted shared memory
+            if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR(
+                    "mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
+                    PLATFORM_PROF_READYQUEUE_SIZE
+                );
+                continue;
+            }
+
+            while (head != tail) {
+                ReadyQueueEntry entry;
+                profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(ReadyQueueEntry));
+
+                process_ready_entry(header, t, entry);
+
+                head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+                header->queue_heads[t] = head;
+                wmb();
+
+                // In memcpy mode, write updated head back to device
+                profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
+
+                found_any = true;
+
+                // Re-read tail in case more entries arrived
+                profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
+                rmb();
+                tail = header->queue_tails[t];
+                if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                    LOG_ERROR("mgmt_loop: invalid tail for thread %d: %u", t, tail);
+                    break;
+                }
+            }
+        }
+
+        // 3. Proactive replenishment: push buffers to cores/threads whose free_queue
+        //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
+        if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
+                L2PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
+                L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                profiling_copy_from_device(state, dev_state, sizeof(L2PerfBufferState));
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void *dev_ptr = recycled_perf_buffers_.back();
+                    recycled_perf_buffers_.pop_back();
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<L2PerfBuffer *>(host_ptr)->count = 0;
+                        uint32_t zero = 0;
+                        profiling_copy_to_device(
+                            reinterpret_cast<char *>(dev_ptr) + offsetof(L2PerfBuffer, count), &zero, sizeof(uint32_t)
+                        );
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                        L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                        uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
+                        profiling_copy_to_device(
+                            &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
+                            sizeof(uint64_t)
+                        );
+                        uint32_t new_tail = t_val + 1;
+                        profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+                    }
+                }
+            }
+            for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
+                PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
+                PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, t);
+                profiling_copy_from_device(state, dev_state, sizeof(PhaseBufferState));
+                rmb();
+                uint32_t avail = state->free_queue.tail - state->free_queue.head;
+                if (avail == 0) {
+                    void *dev_ptr = recycled_phase_buffers_.back();
+                    recycled_phase_buffers_.pop_back();
+                    void *host_ptr = resolve_host_ptr(dev_ptr);
+                    if (host_ptr != nullptr) {
+                        reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
+                        uint32_t zero = 0;
+                        profiling_copy_to_device(
+                            reinterpret_cast<char *>(dev_ptr) + offsetof(PhaseBuffer, count), &zero, sizeof(uint32_t)
+                        );
+                        uint32_t t_val = state->free_queue.tail;
+                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                            reinterpret_cast<uint64_t>(dev_ptr);
+                        wmb();
+                        state->free_queue.tail = t_val + 1;
+                        wmb();
+                        PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, t);
+                        uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
+                        profiling_copy_to_device(
+                            &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
+                            sizeof(uint64_t)
+                        );
+                        uint32_t new_tail = t_val + 1;
+                        profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+                    }
+                }
+            }
+        }
+        // Alloc fallback: if recycled pools are both empty, scan for depleted cores and alloc.
+        // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
+        if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
+            for (int i = 0; i < num_cores_; i++) {
+                L2PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
+                L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                profiling_copy_from_device(state, dev_state, sizeof(L2PerfBufferState));
+                rmb();
+                if (state->free_queue.tail - state->free_queue.head == 0) {
+                    void *host_ptr = nullptr;
+                    void *dev_ptr = alloc_and_register(sizeof(L2PerfBuffer), &host_ptr);
+                    if (dev_ptr == nullptr) break;  // HBM exhausted, stop trying
+                    reinterpret_cast<L2PerfBuffer *>(host_ptr)->count = 0;
+                    uint32_t zero = 0;
+                    profiling_copy_to_device(
+                        reinterpret_cast<char *>(dev_ptr) + offsetof(L2PerfBuffer, count), &zero, sizeof(uint32_t)
+                    );
+                    uint32_t t_val = state->free_queue.tail;
+                    state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
+                        reinterpret_cast<uint64_t>(dev_ptr);
+                    wmb();
+                    state->free_queue.tail = t_val + 1;
+                    wmb();
+                    L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
+                    uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
+                    profiling_copy_to_device(
+                        &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
+                        sizeof(uint64_t)
+                    );
+                    uint32_t new_tail = t_val + 1;
+                    profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+                    break;  // One alloc per iteration to limit rtMalloc frequency
+                }
+            }
+        }
+
+        // 4. If nothing found, yield briefly to avoid busy-spinning
+        if (!found_any) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+    }
+
+    // Final drain: process any remaining entries
+    L2PerfDataHeader *dev_header = get_l2_perf_header(shared_mem_dev_);
+    profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        rmb();
+        uint32_t head = header->queue_heads[t];
+        uint32_t tail = header->queue_tails[t];
+        if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
+            continue;
+        }
+        while (head != tail) {
+            ReadyQueueEntry entry;
+            profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(ReadyQueueEntry));
+            process_ready_entry(header, t, entry);
+            head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
+            header->queue_heads[t] = head;
+            wmb();
+            profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
+            profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
+            rmb();
+            tail = header->queue_tails[t];
+            if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
+                LOG_ERROR("mgmt_loop drain: invalid tail for thread %d: %u", t, tail);
+                break;
+            }
+        }
+    }
+}
+
+// =============================================================================
+// L2PerfCollector Implementation
 // =============================================================================
 
 /**
@@ -42,279 +617,671 @@ static bool is_scheduler_phase(AicpuPhaseId id) {
     return static_cast<uint32_t>(id) < static_cast<uint32_t>(AicpuPhaseId::SCHED_PHASE_COUNT);
 }
 
-// =============================================================================
-// L2PerfCollector Implementation
-// =============================================================================
-
 L2PerfCollector::~L2PerfCollector() {
-    if (setup_header_dev_ != nullptr) {
+    if (perf_shared_mem_host_ != nullptr) {
         LOG_WARN("L2PerfCollector destroyed without finalize()");
     }
 }
 
+void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size);
+    if (dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    void *host_ptr = malloc(size);
+    if (host_ptr == nullptr) {
+        LOG_ERROR("Host shadow alloc failed for %zu bytes", size);
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+    *host_ptr_out = host_ptr;
+
+    // Register mapping so ProfMemoryManager can resolve dev→host
+    memory_manager_.register_mapping(dev_ptr, *host_ptr_out);
+    return dev_ptr;
+}
+
 int L2PerfCollector::initialize(
-    int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfFreeCallback free_cb,
-    L2PerfCopyToDeviceCallback copy_to_dev_cb, L2PerfCopyFromDeviceCallback copy_from_dev_cb
+    int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
+    L2PerfFreeCallback free_cb
 ) {
-    if (setup_header_dev_ != nullptr) {
+    if (perf_shared_mem_host_ != nullptr) {
         LOG_ERROR("L2PerfCollector already initialized");
         return -1;
     }
+
+    LOG_INFO_V0("Initializing performance profiling");
 
     if (num_aicore <= 0 || num_aicore > PLATFORM_MAX_CORES) {
         LOG_ERROR("Invalid number of AICores: %d (max=%d)", num_aicore, PLATFORM_MAX_CORES);
         return -1;
     }
-    if (alloc_cb == nullptr || free_cb == nullptr || copy_to_dev_cb == nullptr || copy_from_dev_cb == nullptr) {
-        LOG_ERROR("L2PerfCollector::initialize: null callback");
-        return -1;
-    }
-
-    LOG_INFO_V0("Initializing performance profiling (memcpy-based)");
 
     device_id_ = device_id;
     num_aicore_ = num_aicore;
-    num_phase_threads_ = PLATFORM_MAX_AICPU_THREADS;
     alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
     free_cb_ = free_cb;
-    copy_to_dev_cb_ = copy_to_dev_cb;
-    copy_from_dev_cb_ = copy_from_dev_cb;
 
-    l2_perf_buffer_bytes_ = calc_l2_perf_buffer_size(PLATFORM_PROF_BUFFER_SIZE);
-    phase_buffer_bytes_ = calc_phase_buffer_size(PLATFORM_PHASE_RECORDS_PER_THREAD);
+    // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
+    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
+    size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads);
 
-    LOG_DEBUG("  L2PerfSetupHeader size: %zu bytes", calc_l2_perf_setup_size());
-    LOG_DEBUG("  L2PerfBuffer size:      %zu bytes (capacity=%d)", l2_perf_buffer_bytes_, PLATFORM_PROF_BUFFER_SIZE);
-    LOG_DEBUG(
-        "  PhaseBuffer size:     %zu bytes (capacity=%d)", phase_buffer_bytes_, PLATFORM_PHASE_RECORDS_PER_THREAD
-    );
-    LOG_DEBUG("  num_aicore:           %d", num_aicore_);
-    LOG_DEBUG("  num_phase_threads:    %d", num_phase_threads_);
+    LOG_DEBUG("Shared memory allocation plan:");
+    LOG_DEBUG("  Number of cores:      %d", num_aicore);
+    LOG_DEBUG("  Header size:          %zu bytes", sizeof(L2PerfDataHeader));
+    LOG_DEBUG("  L2PerfBufferState size: %zu bytes each", sizeof(L2PerfBufferState));
+    LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
+    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
-    // Step 1: Allocate L2PerfSetupHeader on device
-    setup_header_dev_ = alloc_cb_(calc_l2_perf_setup_size());
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("Failed to allocate L2PerfSetupHeader (%zu bytes)", calc_l2_perf_setup_size());
+    // Step 2: Allocate shared memory for slot arrays
+    void *perf_dev_ptr = alloc_cb(total_size);
+    if (perf_dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
     }
+    LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
 
-    // Step 2: Allocate one L2PerfBuffer per core on device
-    core_buffers_dev_.assign(num_aicore_, nullptr);
-    for (int i = 0; i < num_aicore_; i++) {
-        void *buf = alloc_cb_(l2_perf_buffer_bytes_);
-        if (buf == nullptr) {
-            LOG_ERROR("Failed to allocate L2PerfBuffer for core %d (%zu bytes)", i, l2_perf_buffer_bytes_);
-            finalize();
-            return -1;
+    // Step 3: Allocate host-side shadow for the shared memory region
+    void *perf_host_ptr = malloc(total_size);
+    if (perf_host_ptr == nullptr) {
+        LOG_ERROR("Host shadow alloc failed for shared memory (%zu bytes)", total_size);
+        return -1;
+    }
+    LOG_DEBUG("Allocated host shadow: %p", perf_host_ptr);
+
+    // Step 4: Initialize header
+    L2PerfDataHeader *header = get_l2_perf_header(perf_host_ptr);
+
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        memset(header->queues[t], 0, sizeof(header->queues[t]));
+        header->queue_heads[t] = 0;
+        header->queue_tails[t] = 0;
+    }
+
+    header->num_cores = num_aicore;
+    header->total_tasks = 0;
+
+    LOG_DEBUG("Initialized L2PerfDataHeader:");
+    LOG_DEBUG("  num_cores:        %d", header->num_cores);
+    LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
+    LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
+
+    // Step 5: Initialize L2PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
+    for (int i = 0; i < num_aicore; i++) {
+        L2PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
+        memset(state, 0, sizeof(L2PerfBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(L2PerfBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate L2PerfBuffer for core %d, buffer %d", i, s);
+                return -1;
+            }
+            L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(host_buf_ptr);
+            memset(buf, 0, sizeof(L2PerfBuffer));
+            buf->count = 0;
+
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_perf_buffers_.push_back(dev_buf_ptr);
+            }
         }
-        core_buffers_dev_[i] = buf;
+        wmb();
+        state->free_queue.tail = 1;
+        wmb();
     }
+    LOG_DEBUG(
+        "Initialized %d L2PerfBufferStates: 1 buffer/core, %d in recycled pool", num_aicore,
+        num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
+    );
 
-    // Step 3: Allocate one PhaseBuffer per AICPU thread on device
-    phase_buffers_dev_.assign(num_phase_threads_, nullptr);
-    for (int t = 0; t < num_phase_threads_; t++) {
-        void *buf = alloc_cb_(phase_buffer_bytes_);
-        if (buf == nullptr) {
-            LOG_ERROR("Failed to allocate PhaseBuffer for thread %d (%zu bytes)", t, phase_buffer_bytes_);
-            finalize();
-            return -1;
+    // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        memset(state, 0, sizeof(PhaseBufferState));
+
+        state->free_queue.head = 0;
+        state->free_queue.tail = 0;
+        state->current_buf_ptr = 0;
+        state->current_buf_seq = 0;
+
+        for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
+            void *host_buf_ptr = nullptr;
+            void *dev_buf_ptr = alloc_single_buffer(sizeof(PhaseBuffer), &host_buf_ptr);
+            if (dev_buf_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
+                return -1;
+            }
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(host_buf_ptr);
+            memset(buf, 0, sizeof(PhaseBuffer));
+            buf->count = 0;
+
+            if (s == 0) {
+                state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
+            } else {
+                memory_manager_.recycled_phase_buffers_.push_back(dev_buf_ptr);
+            }
         }
-        phase_buffers_dev_[t] = buf;
+        wmb();
+        state->free_queue.tail = 1;
+        wmb();
     }
+    LOG_DEBUG(
+        "Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool", num_phase_threads,
+        num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1)
+    );
 
-    // Step 4: Build L2PerfSetupHeader on host and copy to device
-    L2PerfSetupHeader host_header;
-    memset(&host_header, 0, sizeof(host_header));
-    host_header.num_cores = static_cast<uint32_t>(num_aicore_);
-    host_header.num_phase_threads = static_cast<uint32_t>(num_phase_threads_);
-    host_header.total_tasks = 0;
-    for (int i = 0; i < num_aicore_; i++) {
-        host_header.core_buffer_ptrs[i] = reinterpret_cast<uint64_t>(core_buffers_dev_[i]);
-    }
-    for (int t = 0; t < num_phase_threads_; t++) {
-        host_header.phase_buffer_ptrs[t] = reinterpret_cast<uint64_t>(phase_buffers_dev_[t]);
-    }
-    // phase_header is zero-initialized; AICPU sets magic during init.
-
-    int rc = copy_to_dev_cb_(setup_header_dev_, &host_header, sizeof(host_header));
+    int rc = profiling_copy_to_device(perf_dev_ptr, perf_host_ptr, total_size);
     if (rc != 0) {
-        LOG_ERROR("Failed to copy L2PerfSetupHeader to device: %d", rc);
-        finalize();
+        LOG_ERROR("Failed to copy shared memory to device: %d", rc);
         return rc;
     }
+    for (int i = 0; i < num_aicore; i++) {
+        L2PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
+        void *dev_buf = reinterpret_cast<void *>(state->free_queue.buffer_ptrs[0]);
+        void *host_buf = memory_manager_.resolve_host_ptr(dev_buf);
+        if (host_buf != nullptr) {
+            profiling_copy_to_device(dev_buf, host_buf, sizeof(L2PerfBuffer));
+        }
+    }
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
+        void *dev_buf = reinterpret_cast<void *>(state->free_queue.buffer_ptrs[0]);
+        void *host_buf = memory_manager_.resolve_host_ptr(dev_buf);
+        if (host_buf != nullptr) {
+            profiling_copy_to_device(dev_buf, host_buf, sizeof(PhaseBuffer));
+        }
+    }
 
-    // Device-side header pointer is now ready. Caller reads it via
-    // get_l2_perf_setup_device_ptr() and publishes to kernel_args.l2_perf_data_base.
-    LOG_DEBUG("L2PerfSetupHeader on device at 0x%lx", reinterpret_cast<uint64_t>(setup_header_dev_));
+    wmb();
 
-    LOG_INFO_V0(
-        "Performance profiling initialized: %d cores × %zuB L2PerfBuffer, %d threads × %zuB PhaseBuffer", num_aicore_,
-        l2_perf_buffer_bytes_, num_phase_threads_, phase_buffer_bytes_
-    );
+    // Step 7: Stash device pointer for the caller to publish via
+    // kernel_args.l2_perf_data_base (read back via get_l2_perf_setup_device_ptr()).
+    LOG_DEBUG("L2 perf device base = 0x%lx", reinterpret_cast<uint64_t>(perf_dev_ptr));
+
+    perf_shared_mem_dev_ = perf_dev_ptr;
+    perf_shared_mem_host_ = perf_host_ptr;
+
+    LOG_INFO_V0("Performance profiling initialized (dynamic buffer mode)");
     return 0;
 }
 
-int L2PerfCollector::collect_all() {
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("L2PerfCollector::collect_all called before initialize");
-        return -1;
+void L2PerfCollector::start_memory_manager(const ThreadFactory &thread_factory) {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
     }
 
-    LOG_INFO_V0("Collecting performance data via device→host memcpy");
+    memory_manager_.shared_mem_dev_ = perf_shared_mem_dev_;
+    memory_manager_.start(
+        perf_shared_mem_host_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_, free_cb_, device_id_,
+        thread_factory
+    );
+}
 
-    // Step 1: Copy back L2PerfSetupHeader (contains total_tasks and phase_header)
-    L2PerfSetupHeader host_header;
-    memset(&host_header, 0, sizeof(host_header));
-    int rc = copy_from_dev_cb_(&host_header, setup_header_dev_, sizeof(host_header));
-    if (rc != 0) {
-        LOG_ERROR("Failed to copy L2PerfSetupHeader from device: %d", rc);
-        return rc;
+void L2PerfCollector::stop_memory_manager() {
+    if (memory_manager_.is_running()) {
+        memory_manager_.stop();
+    }
+}
+
+void L2PerfCollector::signal_execution_complete() { execution_complete_.store(true); }
+
+void L2PerfCollector::poll_and_collect(int expected_tasks) {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
     }
 
-    uint32_t total_tasks = host_header.total_tasks;
-    LOG_DEBUG("L2PerfSetupHeader: total_tasks=%u", total_tasks);
+    execution_complete_.store(false);
 
-    // Step 2: Prepare host-side storage
+    LOG_INFO_V0("Collecting performance data");
+
+    L2PerfDataHeader *header = get_l2_perf_header(perf_shared_mem_host_);
+
+    const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
+    std::optional<std::chrono::steady_clock::time_point> idle_start;
+
+    // Initialize collection storage before the waiting loop so buffers
+    // can be processed immediately, preventing device memory leaks.
+    int total_records_collected = 0;
+    int buffers_processed = 0;
+
     collected_perf_records_.clear();
     collected_perf_records_.resize(num_aicore_);
     collected_phase_records_.clear();
-    collected_phase_records_.resize(num_phase_threads_);
+    collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
 
-    // Step 3: Two-step copy each L2PerfBuffer back.
-    //   - First copy 64B header → read count
-    //   - Then copy count * sizeof(L2PerfRecord) of actual data
-    uint64_t total_perf_records = 0;
-    {
-        // Reusable header buffer (aligned to 64B to match L2PerfBuffer layout)
-        alignas(64) unsigned char header_buf[sizeof(L2PerfBuffer)];
-        for (int i = 0; i < num_aicore_; i++) {
-            void *dev_ptr = core_buffers_dev_[i];
-            if (dev_ptr == nullptr) continue;
+    // Helper lambda: read total_tasks from device (memcpy mode) or host shadow
+    auto read_total_tasks = [&]() -> uint32_t {
+        L2PerfDataHeader *dev_header = get_l2_perf_header(perf_shared_mem_dev_);
+        uint32_t val = 0;
+        profiling_copy_from_device(&val, &dev_header->total_tasks, sizeof(uint32_t));
+        header->total_tasks = val;
+        rmb();
+        return header->total_tasks;
+    };
 
-            rc = copy_from_dev_cb_(header_buf, dev_ptr, sizeof(L2PerfBuffer));
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy L2PerfBuffer header for core %d: %d", i, rc);
-                continue;
+    if (expected_tasks <= 0) {
+        LOG_INFO_V0("Waiting for AICPU to write total_tasks in L2PerfDataHeader...");
+        idle_start = std::chrono::steady_clock::now();
+
+        while (true) {
+            uint32_t raw_total_tasks = read_total_tasks();
+
+            if (raw_total_tasks > 0) {
+                expected_tasks = static_cast<int>(raw_total_tasks);
+                LOG_INFO_V0("AICPU reported task count: %d", expected_tasks);
+                break;
             }
 
-            uint32_t count = reinterpret_cast<L2PerfBuffer *>(header_buf)->count;
-            if (count > static_cast<uint32_t>(PLATFORM_PROF_BUFFER_SIZE)) {
-                LOG_WARN(
-                    "Core %d: L2PerfBuffer count=%u exceeds capacity=%d, clamping", i, count, PLATFORM_PROF_BUFFER_SIZE
+            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
+            if (elapsed >= timeout_duration) {
+                LOG_ERROR(
+                    "Timeout waiting for AICPU task count after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
                 );
+                return;
+            }
+
+            // Process ready buffers while waiting to free device memory
+            ReadyBufferInfo info;
+            if (memory_manager_.try_pop_ready(info)) {
+                if (info.type == ProfBufferType::PERF_RECORD) {
+                    L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                        count = PLATFORM_PROF_BUFFER_SIZE;
+                    }
+                    uint32_t core_index = info.index;
+                    if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_perf_records_[core_index].push_back(buf->records[i]);
+                        }
+                        total_records_collected += count;
+                    }
+                } else {
+                    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+                    rmb();
+                    uint32_t count = buf->count;
+                    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                    }
+                    uint32_t tidx = info.index;
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_phase_records_[tidx].push_back(buf->records[i]);
+                    }
+                }
+                memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+                idle_start = std::chrono::steady_clock::now();
+                buffers_processed++;
+            }
+        }
+    }
+
+    LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
+
+    idle_start.reset();
+    int last_logged_expected = -1;
+
+    while (total_records_collected < expected_tasks) {
+        // Check for updated expected_tasks
+        int current_expected = static_cast<int>(read_total_tasks());
+        if (current_expected > expected_tasks) {
+            expected_tasks = current_expected;
+            if (last_logged_expected < 0) {
+                LOG_INFO_V0("Updated expected_tasks to %d (orchestrator progress)", expected_tasks);
+                last_logged_expected = expected_tasks;
+            }
+        }
+
+        ReadyBufferInfo info;
+        if (memory_manager_.wait_pop_ready(info, std::chrono::milliseconds(100))) {
+            idle_start.reset();
+
+            if (info.type == ProfBufferType::PERF_RECORD) {
+                L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
+                rmb();
+                uint32_t count = buf->count;
+                if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                    count = PLATFORM_PROF_BUFFER_SIZE;
+                }
+
+                uint32_t core_index = info.index;
+                if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                    for (uint32_t i = 0; i < count; i++) {
+                        collected_perf_records_[core_index].push_back(buf->records[i]);
+                    }
+                    total_records_collected += count;
+                }
+
+                LOG_DEBUG(
+                    "Collected %u perf records from core %u (total: %d/%d)", count, core_index, total_records_collected,
+                    expected_tasks
+                );
+
+            } else {
+                PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+                rmb();
+                uint32_t count = buf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                }
+
+                uint32_t tidx = info.index;
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[tidx].push_back(buf->records[i]);
+                }
+
+                LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
+            }
+
+            // Notify memory manager to recycle old buffer
+            memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+            buffers_processed++;
+
+        } else {
+            // Timeout on wait — check for execution complete signal or overall timeout
+            if (execution_complete_.load()) {
+                // Device is done. Final non-blocking drain and exit.
+                ReadyBufferInfo drain_info;
+                while (memory_manager_.try_pop_ready(drain_info)) {
+                    if (drain_info.type == ProfBufferType::PERF_RECORD) {
+                        L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > PLATFORM_PROF_BUFFER_SIZE) {
+                            count = PLATFORM_PROF_BUFFER_SIZE;
+                        }
+                        uint32_t ci = drain_info.index;
+                        if (ci < static_cast<uint32_t>(num_aicore_)) {
+                            for (uint32_t i = 0; i < count; i++) {
+                                collected_perf_records_[ci].push_back(buf->records[i]);
+                            }
+                            total_records_collected += count;
+                        }
+                    } else {
+                        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(drain_info.host_buffer_ptr);
+                        rmb();
+                        uint32_t count = buf->count;
+                        if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                        }
+                        uint32_t tidx = drain_info.index;
+                        for (uint32_t i = 0; i < count; i++) {
+                            collected_phase_records_[tidx].push_back(buf->records[i]);
+                        }
+                    }
+                    memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
+                    buffers_processed++;
+                }
+                LOG_INFO_V0(
+                    "Execution complete signal received, exiting with %d/%d records", total_records_collected,
+                    expected_tasks
+                );
+                break;
+            }
+            if (!idle_start.has_value()) {
+                idle_start = std::chrono::steady_clock::now();
+            }
+            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
+            if (elapsed >= timeout_duration) {
+                LOG_ERROR(
+                    "Performance data collection idle timeout after %ld seconds",
+                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
+                );
+                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
+                break;
+            }
+        }
+    }
+
+    LOG_INFO_V0("Total buffers processed: %d", buffers_processed);
+    LOG_INFO_V0("Total records collected: %d", total_records_collected);
+
+    if (total_records_collected < expected_tasks) {
+        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
+    }
+
+    LOG_INFO_V0("Performance data collection complete");
+}
+
+void L2PerfCollector::drain_remaining_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    int drained_perf = 0;
+    int drained_phase = 0;
+
+    ReadyBufferInfo info;
+    while (memory_manager_.try_pop_ready(info)) {
+        if (info.type == ProfBufferType::PERF_RECORD) {
+            L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
+            rmb();
+            uint32_t count = buf->count;
+            if (count > PLATFORM_PROF_BUFFER_SIZE) {
                 count = PLATFORM_PROF_BUFFER_SIZE;
             }
-            if (count == 0) {
-                LOG_DEBUG("Core %d: empty L2PerfBuffer", i);
-                continue;
+            uint32_t core_index = info.index;
+            if (core_index < static_cast<uint32_t>(num_aicore_)) {
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_perf_records_[core_index].push_back(buf->records[i]);
+                }
+                drained_perf += count;
             }
-
-            collected_perf_records_[i].resize(count);
-            size_t records_bytes = static_cast<size_t>(count) * sizeof(L2PerfRecord);
-            void *dev_records = static_cast<unsigned char *>(dev_ptr) + sizeof(L2PerfBuffer);
-            rc = copy_from_dev_cb_(collected_perf_records_[i].data(), dev_records, records_bytes);
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy L2PerfBuffer records for core %d: %d", i, rc);
-                collected_perf_records_[i].clear();
-                continue;
-            }
-            total_perf_records += count;
-            LOG_DEBUG("Core %d: collected %u perf records", i, count);
-        }
-    }
-
-    // Step 4: Two-step copy each PhaseBuffer back.
-    uint64_t total_phase_records = 0;
-    {
-        alignas(64) unsigned char header_buf[sizeof(PhaseBuffer)];
-        for (int t = 0; t < num_phase_threads_; t++) {
-            void *dev_ptr = phase_buffers_dev_[t];
-            if (dev_ptr == nullptr) continue;
-
-            rc = copy_from_dev_cb_(header_buf, dev_ptr, sizeof(PhaseBuffer));
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy PhaseBuffer header for thread %d: %d", t, rc);
-                continue;
-            }
-
-            uint32_t count = reinterpret_cast<PhaseBuffer *>(header_buf)->count;
+        } else {
+            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+            rmb();
+            uint32_t count = buf->count;
             if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                LOG_WARN(
-                    "Thread %d: PhaseBuffer count=%u exceeds capacity=%d, clamping", t, count,
-                    PLATFORM_PHASE_RECORDS_PER_THREAD
-                );
                 count = PLATFORM_PHASE_RECORDS_PER_THREAD;
             }
-            if (count == 0) {
-                continue;
+            uint32_t tidx = info.index;
+            for (uint32_t i = 0; i < count; i++) {
+                collected_phase_records_[tidx].push_back(buf->records[i]);
             }
+            drained_phase += count;
+        }
 
-            collected_phase_records_[t].resize(count);
-            size_t records_bytes = static_cast<size_t>(count) * sizeof(AicpuPhaseRecord);
-            void *dev_records = static_cast<unsigned char *>(dev_ptr) + sizeof(PhaseBuffer);
-            rc = copy_from_dev_cb_(collected_phase_records_[t].data(), dev_records, records_bytes);
-            if (rc != 0) {
-                LOG_ERROR("Failed to copy PhaseBuffer records for thread %d: %d", t, rc);
-                collected_phase_records_[t].clear();
+        memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
+    }
+
+    if (drained_perf > 0 || drained_phase > 0) {
+        LOG_INFO_V0("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
+    }
+
+    if (drained_phase > 0) {
+        has_phase_data_ = true;
+    }
+}
+
+void L2PerfCollector::scan_remaining_perf_buffers() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    for (int i = 0; i < num_aicore_; i++) {
+        L2PerfBufferState *host_state = get_perf_buffer_state(perf_shared_mem_host_, i);
+        L2PerfBufferState *dev_state = get_perf_buffer_state(perf_shared_mem_dev_, i);
+        profiling_copy_from_device(host_state, dev_state, sizeof(L2PerfBufferState));
+    }
+    rmb();
+
+    int total_recovered = 0;
+
+    for (int core_index = 0; core_index < num_aicore_; core_index++) {
+        L2PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) {
+            continue;
+        }
+
+        void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+        if (host_ptr == nullptr) {
+            LOG_ERROR(
+                "scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
+                reinterpret_cast<void *>(buf_ptr), core_index
+            );
+            continue;
+        }
+
+        profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(L2PerfBuffer));
+
+        L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(host_ptr);
+        uint32_t count = buf->count;
+        if (count == 0) {
+            continue;
+        }
+        if (count > PLATFORM_PROF_BUFFER_SIZE) {
+            count = PLATFORM_PROF_BUFFER_SIZE;
+        }
+
+        for (uint32_t i = 0; i < count; i++) {
+            collected_perf_records_[core_index].push_back(buf->records[i]);
+        }
+        total_recovered += count;
+    }
+
+    if (total_recovered > 0) {
+        LOG_INFO_V0("scan_remaining_perf_buffers: recovered %d records from active buffers", total_recovered);
+    }
+}
+
+void L2PerfCollector::collect_phase_data() {
+    if (perf_shared_mem_host_ == nullptr) {
+        return;
+    }
+
+    AicpuPhaseHeader *host_ph = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    AicpuPhaseHeader *dev_ph = get_phase_header(perf_shared_mem_dev_, num_aicore_);
+    profiling_copy_from_device(host_ph, dev_ph, sizeof(AicpuPhaseHeader));
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        PhaseBufferState *host_state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *dev_state = get_phase_buffer_state(perf_shared_mem_dev_, num_aicore_, t);
+        profiling_copy_from_device(host_state, dev_state, sizeof(PhaseBufferState));
+    }
+    rmb();
+
+    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+
+    // Validate magic
+    if (phase_header->magic != AICPU_PHASE_MAGIC) {
+        LOG_INFO_V0(
+            "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC
+        );
+        return;
+    }
+
+    int num_sched_threads = phase_header->num_sched_threads;
+    if (num_sched_threads > PLATFORM_MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "Invalid num_sched_threads %d from shared memory (max=%d)", num_sched_threads, PLATFORM_MAX_AICPU_THREADS
+        );
+        return;
+    }
+    LOG_INFO_V0("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
+
+    int total_slots = PLATFORM_MAX_AICPU_THREADS;
+
+    // Scan remaining PhaseBufferStates for active buffers with partial data.
+    // READY buffers were already enqueued to the ReadyQueue and collected via
+    // poll_and_collect() or drain_remaining_buffers(). Only current_buf_ptr
+    // contains partial data that was never enqueued (the active buffer when execution ended).
+    int total_phase_records = 0;
+    for (int t = 0; t < total_slots; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        rmb();
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr != 0) {
+            void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+            if (host_ptr == nullptr) {
+                LOG_ERROR(
+                    "collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", reinterpret_cast<void *>(buf_ptr),
+                    t
+                );
                 continue;
             }
-            total_phase_records += count;
+            profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(PhaseBuffer));
+            PhaseBuffer *pbuf = reinterpret_cast<PhaseBuffer *>(host_ptr);
+            if (pbuf->count > 0) {
+                uint32_t count = pbuf->count;
+                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
+                }
+
+                for (uint32_t i = 0; i < count; i++) {
+                    collected_phase_records_[t].push_back(pbuf->records[i]);
+                }
+                total_phase_records += count;
+            }
         }
     }
 
-    // Step 5: Extract phase header fields (orch summary + core-to-thread mapping)
-    const AicpuPhaseHeader &phase_header = host_header.phase_header;
-    bool phase_header_valid = (phase_header.magic == AICPU_PHASE_MAGIC);
-
-    if (phase_header_valid) {
-        collected_orch_summary_ = phase_header.orch_summary;
-        int num_cores_mapping = static_cast<int>(phase_header.num_cores);
-        if (num_cores_mapping > 0 && num_cores_mapping <= PLATFORM_MAX_CORES) {
-            core_to_thread_.assign(phase_header.core_to_thread, phase_header.core_to_thread + num_cores_mapping);
-            LOG_DEBUG("Core-to-thread mapping: %d cores", num_cores_mapping);
-        }
-    } else {
-        memset(&collected_orch_summary_, 0, sizeof(collected_orch_summary_));
-    }
-
-    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
-    has_phase_data_ = (total_phase_records > 0) || orch_valid;
-
-    // Step 6: Log per-thread totals (sched vs orch breakdown)
-    if (has_phase_data_) {
-        for (size_t t = 0; t < collected_phase_records_.size(); t++) {
-            if (collected_phase_records_[t].empty()) continue;
+    // Log per-thread totals
+    for (size_t t = 0; t < collected_phase_records_.size(); t++) {
+        if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
             for (const auto &r : collected_phase_records_[t]) {
                 if (is_scheduler_phase(r.phase_id)) sched_count++;
                 else orch_count++;
             }
             LOG_INFO_V0(
-                "  Thread %zu: %zu phase records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(),
-                sched_count, orch_count
+                "  Thread %zu: %zu records (sched=%zu, orch=%zu)", t, collected_phase_records_[t].size(), sched_count,
+                orch_count
             );
         }
-        if (orch_valid) {
-            LOG_INFO_V0(
-                "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
-                cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
-            );
+    }
+
+    // Read orchestrator summary
+    collected_orch_summary_ = phase_header->orch_summary;
+    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
+
+    if (orch_valid) {
+        LOG_INFO_V0(
+            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
+            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
+        );
+    } else {
+        LOG_INFO_V0("  Orchestrator: no summary data");
+    }
+
+    // Check if drain_remaining_buffers() already accumulated some Phase records
+    bool has_accumulated = has_phase_data_;
+    if (!has_accumulated) {
+        for (const auto &v : collected_phase_records_) {
+            if (!v.empty()) {
+                has_accumulated = true;
+                break;
+            }
         }
+    }
+    has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
+
+    // Read core-to-thread mapping
+    int num_cores = static_cast<int>(phase_header->num_cores);
+    if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
+        core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
+        LOG_INFO_V0("  Core-to-thread mapping: %d cores", num_cores);
     }
 
     LOG_INFO_V0(
-        "Collection complete: %" PRIu64 " perf records, %" PRIu64 " phase records, orch_summary=%s", total_perf_records,
-        total_phase_records, orch_valid ? "yes" : "no"
+        "Phase data collection complete: %d remaining records, orch_summary=%s", total_phase_records,
+        orch_valid ? "yes" : "no"
     );
-
-    if (total_tasks > 0 && total_perf_records < total_tasks) {
-        LOG_WARN(
-            "Incomplete collection: %" PRIu64 " / %u records (some cores may have filled their L2PerfBuffer)",
-            total_perf_records, total_tasks
-        );
-    }
-
-    return 0;
 }
 
 int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
@@ -580,7 +1547,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         }
     }
 
-    // Core-to-thread mapping
     if (!core_to_thread_.empty()) {
         outfile << ",\n  \"core_to_thread\": [";
         for (size_t i = 0; i < core_to_thread_.size(); i++) {
@@ -590,9 +1556,8 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         outfile << "]";
     }
 
-    outfile << "\n}\n";
-
     // Step 9: Close file
+    outfile << "\n}\n";
     outfile.close();
 
     uint32_t record_count = static_cast<uint32_t>(tagged_records.size());
@@ -603,55 +1568,104 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
     return 0;
 }
 
-int L2PerfCollector::finalize() {
-    if (setup_header_dev_ == nullptr && core_buffers_dev_.empty() && phase_buffers_dev_.empty()) {
+int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb) {
+    if (perf_shared_mem_host_ == nullptr) {
         return 0;
     }
 
+    stop_memory_manager();
+
     LOG_DEBUG("Cleaning up performance profiling resources");
 
-    // Free per-core L2PerfBuffers
-    if (free_cb_ != nullptr) {
-        for (void *ptr : core_buffers_dev_) {
-            if (ptr != nullptr) {
-                free_cb_(ptr);
+    for (int i = 0; i < num_aicore_; i++) {
+        L2PerfBufferState *host_state = get_perf_buffer_state(perf_shared_mem_host_, i);
+        L2PerfBufferState *dev_state = get_perf_buffer_state(perf_shared_mem_dev_, i);
+        profiling_copy_from_device(host_state, dev_state, sizeof(L2PerfBufferState));
+    }
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        PhaseBufferState *host_state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *dev_state = get_phase_buffer_state(perf_shared_mem_dev_, num_aicore_, t);
+        profiling_copy_from_device(host_state, dev_state, sizeof(PhaseBufferState));
+    }
+
+    // Free buffers in free_queues and current_buf_ptr
+    for (int i = 0; i < num_aicore_; i++) {
+        L2PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, i);
+
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            memory_manager_.free_buffer(reinterpret_cast<void *>(state->current_buf_ptr));
+        }
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                memory_manager_.free_buffer(reinterpret_cast<void *>(buf_ptr));
             }
+            head++;
+        }
+        if (head != tail) {
+            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
         }
     }
-    core_buffers_dev_.clear();
 
-    // Free per-thread PhaseBuffers
-    if (free_cb_ != nullptr) {
-        for (void *ptr : phase_buffers_dev_) {
-            if (ptr != nullptr) {
-                free_cb_(ptr);
+    int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
+    for (int t = 0; t < num_phase_threads; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+
+        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
+            memory_manager_.free_buffer(reinterpret_cast<void *>(state->current_buf_ptr));
+        }
+
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
+        while (head != tail && max_iters-- > 0) {
+            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+            if (buf_ptr != 0 && free_cb != nullptr) {
+                memory_manager_.free_buffer(reinterpret_cast<void *>(buf_ptr));
             }
+            head++;
+        }
+        if (head != tail) {
+            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
         }
     }
-    phase_buffers_dev_.clear();
 
-    // Free L2PerfSetupHeader
-    if (free_cb_ != nullptr && setup_header_dev_ != nullptr) {
-        free_cb_(setup_header_dev_);
+    // Unregister host mapping if SVM was used
+    if (unregister_cb != nullptr && register_cb_ != nullptr) {
+        int rc = unregister_cb(perf_shared_mem_dev_, device_id_);
+        if (rc != 0) {
+            LOG_ERROR("halHostUnregister failed: %d", rc);
+            return rc;
+        }
+        LOG_DEBUG("Host mapping unregistered");
     }
-    setup_header_dev_ = nullptr;
 
-    // Clear host-side state
+    // Free host shadow of shared memory (only in non-SVM mode)
+    if (register_cb_ == nullptr && perf_shared_mem_host_ != nullptr && perf_shared_mem_host_ != perf_shared_mem_dev_) {
+        free(perf_shared_mem_host_);
+    }
+
+    if (free_cb != nullptr && perf_shared_mem_dev_ != nullptr) {
+        free_cb(perf_shared_mem_dev_);
+        LOG_DEBUG("Shared memory freed");
+    }
+
+    perf_shared_mem_dev_ = nullptr;
+    perf_shared_mem_host_ = nullptr;
     collected_perf_records_.clear();
     collected_phase_records_.clear();
-    memset(&collected_orch_summary_, 0, sizeof(collected_orch_summary_));
     core_to_thread_.clear();
     has_phase_data_ = false;
-
-    num_aicore_ = 0;
-    num_phase_threads_ = 0;
     device_id_ = -1;
-    l2_perf_buffer_bytes_ = 0;
-    phase_buffer_bytes_ = 0;
     alloc_cb_ = nullptr;
+    register_cb_ = nullptr;
     free_cb_ = nullptr;
-    copy_to_dev_cb_ = nullptr;
-    copy_from_dev_cb_ = nullptr;
 
     LOG_DEBUG("Performance profiling cleanup complete");
     return 0;

--- a/src/a5/platform/src/host/pmu_collector.cpp
+++ b/src/a5/platform/src/host/pmu_collector.cpp
@@ -11,274 +11,476 @@
 
 #include "host/pmu_collector.h"
 
+#include <cassert>
 #include <cstring>
-#include <fstream>
+#include <iomanip>
+#include <ios>
+#include <thread>
 
-PmuCollector::~PmuCollector() {
-    if (setup_header_dev_ != nullptr) {
-        // Not called finalize() — best-effort free to avoid leaking device memory
-        // on abnormal exits. Errors swallowed because we are already unwinding.
-        (void)finalize();
-    }
-}
+#include "common/unified_log.h"
 
-int PmuCollector::initialize(
-    int num_cores, PmuEventType event_type, uint64_t *kernel_args_pmu_data_base, PmuAllocCallback alloc_cb,
-    PmuFreeCallback free_cb, PmuCopyToDeviceCallback copy_to_dev_cb, PmuCopyFromDeviceCallback copy_from_dev_cb
+// ---------------------------------------------------------------------------
+// Destructor
+// ---------------------------------------------------------------------------
+
+PmuCollector::~PmuCollector() = default;
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+int PmuCollector::init(
+    int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
+    PmuEventType event_type, PmuAllocCallback alloc_cb, PmuFreeCallback free_cb, void *user_data, int device_id
 ) {
-    if (num_cores <= 0 || num_cores > PLATFORM_MAX_CORES || kernel_args_pmu_data_base == nullptr ||
-        alloc_cb == nullptr || free_cb == nullptr || copy_to_dev_cb == nullptr || copy_from_dev_cb == nullptr) {
-        LOG_ERROR("PmuCollector::initialize invalid arguments (num_cores=%d)", num_cores);
+    if (num_cores <= 0 || num_threads <= 0 || kernel_args_pmu_data_base == nullptr || alloc_cb == nullptr ||
+        free_cb == nullptr) {
+        LOG_ERROR("PmuCollector::init: invalid arguments");
         return -1;
     }
 
     num_cores_ = num_cores;
+    num_threads_ = num_threads;
+    device_id_ = device_id;
     event_type_ = event_type;
     alloc_cb_ = alloc_cb;
     free_cb_ = free_cb;
-    copy_to_dev_cb_ = copy_to_dev_cb;
-    copy_from_dev_cb_ = copy_from_dev_cb;
-    pmu_buffer_bytes_ = sizeof(PmuBuffer);
-    setup_region_bytes_ = calc_pmu_setup_size(num_cores_);
+    user_data_ = user_data;
+    csv_path_ = csv_path;
 
-    // Allocate the [PmuSetupHeader][PmuBufferState[num_cores]] shared region
-    // on device in a single allocation.
-    setup_header_dev_ = alloc_cb_(setup_region_bytes_);
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("PmuCollector::initialize: failed to alloc PMU setup region (%zu bytes)", setup_region_bytes_);
+    // Reset per-run accumulators. The collector instance is reused across
+    // tests within the same process; without this, a small test running
+    // after a large one inherits the previous run's collected/drained state
+    // and the cross-check at drain time spuriously reports a mismatch.
+    total_collected_ = 0;
+    drained_bufs_.clear();
+    execution_complete_.store(false, std::memory_order_release);
+    if (csv_file_.is_open()) {
+        csv_file_.close();
+    }
+
+    // ---- Allocate shared header + buffer-state region ----
+    shm_size_ = calc_pmu_data_size(num_cores);
+    shm_dev_ = alloc_cb(shm_size_, user_data);
+    if (shm_dev_ == nullptr) {
+        LOG_ERROR("PmuCollector: failed to allocate PMU shared memory (%zu bytes)", shm_size_);
         return -1;
     }
 
-    // Allocate one PmuBuffer per core and remember the device pointers.
-    core_buffers_dev_.assign(num_cores_, nullptr);
-    std::vector<uint8_t> host_setup(setup_region_bytes_, 0);
-    PmuSetupHeader *host_header = get_pmu_setup_header(host_setup.data());
-    host_header->num_cores = static_cast<uint32_t>(num_cores_);
-    host_header->event_type = static_cast<uint32_t>(event_type_);
-    for (int i = 0; i < num_cores_; ++i) {
-        void *buf_dev = alloc_cb_(pmu_buffer_bytes_);
-        if (buf_dev == nullptr) {
-            LOG_ERROR("PmuCollector::initialize: failed to alloc PmuBuffer for core %d", i);
-            finalize();
-            return -1;
-        }
-        core_buffers_dev_[i] = buf_dev;
-        host_header->buffer_ptrs[i] = reinterpret_cast<uint64_t>(buf_dev);
+    // Allocate host shadow
+    shm_host_ = std::malloc(shm_size_);
+    if (shm_host_ == nullptr) {
+        LOG_ERROR("PmuCollector: failed to allocate host shadow (%zu bytes)", shm_size_);
+        free_cb(shm_dev_, user_data);
+        shm_dev_ = nullptr;
+        return -1;
+    }
+    std::memset(shm_host_, 0, shm_size_);
 
-        // Zero the buffer header on device so count starts at 0. Per-core
-        // dropped/total counters live in PmuBufferState (zero-init below).
-        PmuBuffer zero_hdr{};
-        int rc = copy_to_dev_cb_(buf_dev, &zero_hdr, PMU_BUFFER_HEADER_BYTES);
-        if (rc != 0) {
-            LOG_ERROR("PmuCollector::initialize: failed to zero PmuBuffer header for core %d (rc=%d)", i, rc);
-            finalize();
-            return rc;
+    // Write event_type into header so AICPU can read it from SHM
+    get_pmu_header(shm_host_)->event_type = static_cast<uint32_t>(event_type);
+
+    // Publish device address to KernelArgs
+    *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(shm_dev_);
+
+    // ---- Allocate per-core PmuBuffers and populate free_queues ----
+    const size_t buf_size = sizeof(PmuBuffer);
+    int total_bufs = num_cores * PLATFORM_PMU_BUFFERS_PER_CORE;
+    buf_pool_.resize(total_bufs);
+
+    for (int c = 0; c < num_cores; c++) {
+        PmuBufferState *state = pmu_state_host(c);
+
+        for (int b = 0; b < PLATFORM_PMU_BUFFERS_PER_CORE; b++) {
+            int idx = c * PLATFORM_PMU_BUFFERS_PER_CORE + b;
+            void *dev_ptr = alloc_cb(buf_size, user_data);
+            if (dev_ptr == nullptr) {
+                LOG_ERROR("PmuCollector: failed to allocate PmuBuffer c=%d b=%d", c, b);
+                return -1;
+            }
+
+            void *host_ptr = std::malloc(buf_size);
+            if (host_ptr == nullptr) {
+                LOG_ERROR("PmuCollector: failed to allocate host shadow for PmuBuffer c=%d b=%d", c, b);
+                free_cb(dev_ptr, user_data);
+                return -1;
+            }
+            std::memset(host_ptr, 0, buf_size);
+
+            // Zero the device buffer
+            profiling_copy_to_device(dev_ptr, host_ptr, buf_size);
+
+            buf_pool_[idx] = {dev_ptr, host_ptr};
+
+            // Push into free_queue (host is producer, device is consumer)
+            uint32_t tail = state->free_queue.tail;
+            assert(tail - state->free_queue.head < PLATFORM_PMU_SLOT_COUNT && "free_queue overflow on init");
+            state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
+            __sync_synchronize();
+            state->free_queue.tail = tail + 1;
+            __sync_synchronize();
         }
     }
 
-    // Publish the setup region (header + zero-initialized PmuBufferState[]) to device.
-    int rc = copy_to_dev_cb_(setup_header_dev_, host_setup.data(), setup_region_bytes_);
-    if (rc != 0) {
-        LOG_ERROR("PmuCollector::initialize: failed to publish PMU setup region (rc=%d)", rc);
-        finalize();
-        return rc;
+    // Copy the entire host shadow (header + buffer states + free_queue contents) to device
+    profiling_copy_to_device(shm_dev_, shm_host_, shm_size_);
+
+    // ---- Build CSV header string (file is opened lazily on first record) ----
+    // Deferring the open avoids leaving a header-only CSV on disk when the
+    // device hangs before producing any PMU records.
+    {
+        std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
+        const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type);
+        if (evt == nullptr) {
+            evt = &PMU_EVENTS_A5_PIPE_UTIL;
+        }
+        // Emit only counters with a non-empty name (= valid counters for this event).
+        // Trailing slots in the event table are padded with empty names and skipped.
+        for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
+            const char *name = evt->counter_names[i];
+            if (name == nullptr || name[0] == '\0') {
+                continue;
+            }
+            header += ',';
+            header += name;
+        }
+        header += ",event_type\n";
+        csv_header_ = std::move(header);
     }
 
-    *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(setup_header_dev_);
+    initialized_ = true;
     LOG_INFO_V0(
-        "PMU collector initialized: %d cores, event_type=%u, setup_header=0x%lx", num_cores_,
-        static_cast<uint32_t>(event_type_), static_cast<unsigned long>(*kernel_args_pmu_data_base)
+        "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
+        num_threads, static_cast<unsigned long>(*kernel_args_pmu_data_base), csv_path_.c_str()
     );
     return 0;
 }
 
-int PmuCollector::collect_all() {
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("PmuCollector::collect_all: not initialized");
-        return -1;
-    }
-    collected_records_.assign(num_cores_, {});
-    dropped_counts_.assign(num_cores_, 0);
-    total_counts_.assign(num_cores_, 0);
-    owning_thread_ids_.assign(num_cores_, 0);
+// ---------------------------------------------------------------------------
+// Collector lifecycle
+// ---------------------------------------------------------------------------
 
-    // Pull the full setup region back to read all PmuBufferState[] in one shot.
-    std::vector<uint8_t> host_setup(setup_region_bytes_, 0);
-    int rc = copy_from_dev_cb_(host_setup.data(), setup_header_dev_, setup_region_bytes_);
-    if (rc != 0) {
-        LOG_ERROR("PmuCollector::collect_all: setup region copy failed (rc=%d)", rc);
-        return rc;
-    }
-    for (int i = 0; i < num_cores_; ++i) {
-        PmuBufferState *state = get_pmu_buffer_state(host_setup.data(), i);
-        dropped_counts_[i] = state->dropped_record_count;
-        total_counts_[i] = state->total_record_count;
-        owning_thread_ids_[i] = state->owning_thread_id;
-    }
+void PmuCollector::signal_execution_complete() { execution_complete_.store(true, std::memory_order_release); }
 
-    PmuBuffer header_buf{};
-    for (int i = 0; i < num_cores_; ++i) {
-        void *buf_dev = core_buffers_dev_[i];
-        if (buf_dev == nullptr) {
-            continue;
-        }
-        // Copy the 64-byte header to learn record count.
-        rc = copy_from_dev_cb_(&header_buf, buf_dev, PMU_BUFFER_HEADER_BYTES);
-        if (rc != 0) {
-            LOG_ERROR("PmuCollector::collect_all: header copy failed for core %d (rc=%d)", i, rc);
-            return rc;
-        }
-        uint32_t count = header_buf.count;
-        if (count > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
-            LOG_WARN(
-                "PmuCollector::collect_all: core %d count=%u clamped to capacity %d", i, count,
-                PLATFORM_PMU_RECORDS_PER_BUFFER
-            );
-            count = PLATFORM_PMU_RECORDS_PER_BUFFER;
-        }
-        if (count == 0) {
-            continue;
-        }
+// ---------------------------------------------------------------------------
+// write_buffer_to_csv
+// ---------------------------------------------------------------------------
 
-        // Copy just the used portion of the records array.
-        collected_records_[i].resize(count);
-        const uint8_t *records_dev = reinterpret_cast<const uint8_t *>(buf_dev) + offsetof(PmuBuffer, records);
-        rc = copy_from_dev_cb_(
-            collected_records_[i].data(), const_cast<uint8_t *>(records_dev),
-            static_cast<size_t>(count) * sizeof(PmuRecord)
-        );
-        if (rc != 0) {
-            LOG_ERROR("PmuCollector::collect_all: records copy failed for core %d (rc=%d)", i, rc);
-            return rc;
-        }
+void PmuCollector::ensure_csv_open_unlocked() {
+    if (csv_file_.is_open()) {
+        return;
     }
-    return 0;
+    csv_file_.open(csv_path_, std::ios::out | std::ios::trunc);
+    if (!csv_file_.is_open()) {
+        LOG_ERROR("PmuCollector: failed to open CSV file: %s", csv_path_.c_str());
+        return;
+    }
+    csv_file_ << csv_header_;
 }
 
-int PmuCollector::export_csv(const std::string &output_dir) {
-    if (setup_header_dev_ == nullptr) {
-        return -1;
+void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr) {
+    const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(buf_host_ptr);
+    uint32_t n = buf->count;
+    if (n > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
+        n = static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER);
+    }
+    if (n == 0) {
+        return;
     }
 
-    const PmuEventConfig *cfg = pmu_resolve_event_config_a5(event_type_);
-    if (cfg == nullptr) {
-        cfg = &PMU_EVENTS_A5_PIPE_UTIL;
+    std::lock_guard<std::mutex> lock(csv_mutex_);
+    ensure_csv_open_unlocked();
+    if (!csv_file_.is_open()) {
+        return;
     }
-
-    std::string csv_path = make_pmu_csv_path(output_dir);
-    std::ofstream csv(csv_path);
-    if (!csv.is_open()) {
-        LOG_ERROR("PmuCollector::export_csv: failed to open %s", csv_path.c_str());
-        return -1;
+    total_collected_ += n;
+    const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type_);
+    if (evt == nullptr) {
+        evt = &PMU_EVENTS_A5_PIPE_UTIL;
     }
-
-    // Count named columns. Matches pypto's tilefwk_pmu_to_csv.py
-    // table_pmu_header_3510 — each event group lists only the columns that
-    // correspond to a named counter. pypto then trims each row to
-    // len(fixed_header) + len(named) via _trim_task_pmu_list; we do the
-    // equivalent positional trim here (first `named_count` counter values,
-    // pmu_counters[0..named_count-1]).
-    int named_count = 0;
-    for (int i = 0; i < PMU_COUNTER_COUNT_A5; ++i) {
-        if (cfg->counter_names[i] != nullptr && cfg->counter_names[i][0] != '\0') {
-            ++named_count;
-        }
-    }
-
-    // Header: fixed columns + named counter names + event_type column.
-    // Column order matches a2a3 host pmu_collector for downstream tooling parity.
-    csv << "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
-    int emitted = 0;
-    for (int i = 0; i < PMU_COUNTER_COUNT_A5 && emitted < named_count; ++i) {
-        if (cfg->counter_names[i] != nullptr && cfg->counter_names[i][0] != '\0') {
-            csv << "," << cfg->counter_names[i];
-            ++emitted;
-        }
-    }
-    csv << ",event_type\n";
-
-    uint64_t total_rows = 0;
-    uint64_t total_dropped = 0;
-    uint64_t device_total = 0;
-    for (int core_id = 0; core_id < num_cores_; ++core_id) {
-        const auto &records = collected_records_[core_id];
-        uint32_t thread_id = owning_thread_ids_[core_id];
-        for (const auto &rec : records) {
-            csv << thread_id << "," << core_id << ",0x" << std::hex << rec.task_id << std::dec << "," << rec.func_id
-                << "," << static_cast<int>(rec.core_type) << "," << rec.pmu_total_cycles;
-            for (int i = 0; i < named_count; ++i) {
-                csv << "," << rec.pmu_counters[i];
+    for (uint32_t i = 0; i < n; i++) {
+        const PmuRecord &r = buf->records[i];
+        csv_file_ << thread_idx << ',' << core_id << ',';
+        // task_id is printed as hex so the PTO2 (ring_id<<32)|local_id encoding is
+        // readable at a glance.
+        csv_file_ << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec
+                  << std::setfill(' ');
+        csv_file_ << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
+        // Only emit columns for counters with a non-empty name, matching the header.
+        for (int k = 0; k < PMU_COUNTER_COUNT_A5; k++) {
+            const char *name = evt->counter_names[k];
+            if (name == nullptr || name[0] == '\0') {
+                continue;
             }
-            csv << "," << static_cast<uint32_t>(event_type_) << "\n";
-            ++total_rows;
+            csv_file_ << ',' << r.pmu_counters[k];
         }
-        total_dropped += dropped_counts_[core_id];
-        device_total += total_counts_[core_id];
+        csv_file_ << ',' << static_cast<uint32_t>(event_type_) << '\n';
     }
-    csv.flush();
-    LOG_INFO_V0("PMU CSV written to %s", csv_path.c_str());
+    csv_file_.flush();
+}
 
-    // Cross-check device-side totals against what we wrote to CSV. Invariant:
-    //   device_total == collected + dropped (buffer-full) + slot-mismatch
-    // collected + dropped should account for every commit attempt; any
-    // remainder is silent slot-mismatch loss (AICore not yet published).
-    if (total_dropped > 0) {
+// ---------------------------------------------------------------------------
+// resolve_host_ptr: device address -> host shadow
+// ---------------------------------------------------------------------------
+
+void *PmuCollector::resolve_host_ptr(uint64_t dev_addr) {
+    for (auto &e : buf_pool_) {
+        if (reinterpret_cast<uint64_t>(e.dev_ptr) == dev_addr) {
+            return e.host_ptr;
+        }
+    }
+    return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// push_to_free_queue: recycle a buffer back to a core's free_queue
+// ---------------------------------------------------------------------------
+
+void PmuCollector::push_to_free_queue(int core_id, uint64_t buf_dev_addr) {
+    // Sync host shadow of this core's buffer state from device
+    profiling_copy_from_device(pmu_state_host(core_id), pmu_state_dev(core_id), sizeof(PmuBufferState));
+
+    PmuBufferState *state = pmu_state_host(core_id);
+
+    // Zero the count on the host shadow buffer
+    void *buf_host = resolve_host_ptr(buf_dev_addr);
+    if (buf_host != nullptr) {
+        PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(buf_host);
+        buf->count = 0;
+        // Zero count on device too
+        uint32_t zero = 0;
+        uintptr_t dev_count_addr = static_cast<uintptr_t>(buf_dev_addr) + offsetof(PmuBuffer, count);
+        profiling_copy_to_device(reinterpret_cast<void *>(dev_count_addr), &zero, sizeof(uint32_t));
+    }
+
+    // Write the buffer address into the free_queue slot on host shadow
+    uint32_t tail = state->free_queue.tail;
+    state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = buf_dev_addr;
+    __sync_synchronize();
+    state->free_queue.tail = tail + 1;
+    __sync_synchronize();
+
+    // Copy updated free_queue slot and tail back to device
+    PmuBufferState *dev_state = pmu_state_dev(core_id);
+    uint64_t slot_val = buf_dev_addr;
+    profiling_copy_to_device(
+        &dev_state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT], &slot_val, sizeof(uint64_t)
+    );
+    uint32_t new_tail = tail + 1;
+    profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+}
+
+// ---------------------------------------------------------------------------
+// poll_and_collect: collector thread body
+// ---------------------------------------------------------------------------
+
+void PmuCollector::poll_and_collect() {
+    if (shm_host_ == nullptr) {
+        return;
+    }
+
+    PmuDataHeader *hdr = pmu_header_host();
+    PmuDataHeader *dev_hdr = pmu_header_dev();
+    constexpr int kIdleTimeoutMs = PLATFORM_PMU_TIMEOUT_SECONDS * 1000;
+    constexpr int kPollIntervalUs = 100;
+    int idle_ms = 0;
+
+    while (true) {
+        bool found_any = false;
+
+        // Read queue_tails from device
+        profiling_copy_from_device(hdr->queue_tails, dev_hdr->queue_tails, sizeof(hdr->queue_tails));
+
+        for (int t = 0; t < num_threads_; t++) {
+            __sync_synchronize();
+            uint32_t head = hdr->queue_heads[t];
+            uint32_t tail = hdr->queue_tails[t];
+
+            while (head != tail) {
+                // Read the ready queue entry from device
+                PmuReadyQueueEntry entry;
+                profiling_copy_from_device(
+                    &entry, &dev_hdr->queues[t][head % PLATFORM_PMU_READYQUEUE_SIZE], sizeof(PmuReadyQueueEntry)
+                );
+
+                uint32_t core_id = entry.core_index;
+                uint64_t buf_dev = entry.buffer_ptr;
+
+                // Copy buffer from device to host shadow
+                void *buf_host = resolve_host_ptr(buf_dev);
+                if (buf_host != nullptr) {
+                    profiling_copy_from_device(buf_host, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
+                    drained_bufs_.insert(buf_dev);
+                    write_buffer_to_csv(static_cast<int>(core_id), t, buf_host);
+                    push_to_free_queue(static_cast<int>(core_id), buf_dev);
+                } else {
+                    LOG_WARN("PMU collector: unknown buffer 0x%lx from core %u", buf_dev, core_id);
+                }
+
+                head = (head + 1) % PLATFORM_PMU_READYQUEUE_SIZE;
+                hdr->queue_heads[t] = head;
+
+                // Write updated head back to device
+                profiling_copy_to_device(&dev_hdr->queue_heads[t], &head, sizeof(uint32_t));
+
+                found_any = true;
+            }
+        }
+
+        if (!found_any) {
+            if (execution_complete_.load(std::memory_order_acquire)) {
+                // Done — exit after one final drain pass
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::microseconds(kPollIntervalUs));
+            idle_ms += kPollIntervalUs / 1000;
+            if (idle_ms >= kIdleTimeoutMs) {
+                LOG_WARN("PMU collector: idle timeout (%d ms), stopping", kIdleTimeoutMs);
+                break;
+            }
+        } else {
+            idle_ms = 0;
+        }
+    }
+
+    LOG_INFO_V0("PMU collector thread exiting");
+}
+
+// ---------------------------------------------------------------------------
+// drain_remaining_buffers: after collector thread exits, pick up leftovers
+// ---------------------------------------------------------------------------
+
+void PmuCollector::drain_remaining_buffers() {
+    if (shm_host_ == nullptr) {
+        return;
+    }
+
+    // Sync entire shared memory region from device
+    profiling_copy_from_device(shm_host_, shm_dev_, shm_size_);
+
+    PmuDataHeader *hdr = pmu_header_host();
+
+    // Drain any ready_queue entries the collector thread may have missed
+    for (int t = 0; t < num_threads_; t++) {
+        __sync_synchronize();
+        uint32_t head = hdr->queue_heads[t];
+        uint32_t tail = hdr->queue_tails[t];
+
+        while (head != tail) {
+            const PmuReadyQueueEntry &entry = hdr->queues[t][head % PLATFORM_PMU_READYQUEUE_SIZE];
+            uint32_t core_id = entry.core_index;
+            uint64_t buf_dev = entry.buffer_ptr;
+
+            if (drained_bufs_.find(buf_dev) == drained_bufs_.end()) {
+                void *buf_host = resolve_host_ptr(buf_dev);
+                if (buf_host != nullptr) {
+                    profiling_copy_from_device(buf_host, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
+                    write_buffer_to_csv(static_cast<int>(core_id), t, buf_host);
+                    drained_bufs_.insert(buf_dev);
+                }
+            }
+
+            head = (head + 1) % PLATFORM_PMU_READYQUEUE_SIZE;
+            hdr->queue_heads[t] = head;
+        }
+    }
+
+    // Also check current_buf_ptr for each core (AICPU may have flushed but
+    // not enqueued if the ready_queue was observed full during flush)
+    for (int c = 0; c < num_cores_; c++) {
+        PmuBufferState *state = pmu_state_host(c);
+        __sync_synchronize();
+        uint64_t buf_dev = state->current_buf_ptr;
+        if (buf_dev == 0 || drained_bufs_.count(buf_dev) > 0) {
+            continue;
+        }
+        void *buf_host = resolve_host_ptr(buf_dev);
+        if (buf_host != nullptr) {
+            profiling_copy_from_device(buf_host, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
+            const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(buf_host);
+            if (buf->count > 0) {
+                write_buffer_to_csv(c, -1, buf_host);
+                drained_bufs_.insert(buf_dev);
+            }
+        }
+    }
+
+    if (csv_file_.is_open()) {
+        csv_file_.flush();
+    }
+
+    // Cross-check device-side totals against what we wrote to CSV.
+    // Invariant: sum(total_record_count) == collected + sum(dropped_record_count).
+    uint64_t total_device = 0;
+    uint64_t dropped_device = 0;
+    for (int c = 0; c < num_cores_; c++) {
+        PmuBufferState *state = pmu_state_host(c);
+        __sync_synchronize();
+        total_device += state->total_record_count;
+        dropped_device += state->dropped_record_count;
+    }
+
+    if (dropped_device > 0) {
         LOG_WARN(
-            "PMU collector: %lu records dropped on device side (PmuBuffer full). "
-            "Increase PLATFORM_PMU_RECORDS_PER_BUFFER if this is frequent.",
-            static_cast<unsigned long>(total_dropped)
+            "PMU collector: %lu records dropped on device side (free_queue empty or ready_queue full). "
+            "Increase PLATFORM_PMU_BUFFERS_PER_CORE / PLATFORM_PMU_READYQUEUE_SIZE if this is frequent.",
+            static_cast<unsigned long>(dropped_device)
         );
     }
-    if (total_rows + total_dropped != device_total) {
+    if (total_collected_ + dropped_device != total_device) {
         LOG_WARN(
-            "PMU collector: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu, "
-            "diff=%ld silent slot-mismatch losses)",
-            static_cast<unsigned long>(total_rows), static_cast<unsigned long>(total_dropped),
-            static_cast<unsigned long>(device_total),
-            static_cast<long>(device_total) - static_cast<long>(total_rows + total_dropped)
+            "PMU collector: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device)
         );
     } else {
         LOG_INFO_V0(
             "PMU collector: record counts match (collected=%lu, dropped=%lu, device_total=%lu)",
-            static_cast<unsigned long>(total_rows), static_cast<unsigned long>(total_dropped),
-            static_cast<unsigned long>(device_total)
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device)
         );
     }
-    return 0;
+
+    LOG_INFO_V0("PMU collector: drain_remaining_buffers complete");
 }
 
-int PmuCollector::finalize() {
-    int rc = 0;
-    for (void *&buf : core_buffers_dev_) {
-        if (buf != nullptr) {
-            int r = free_cb_ ? free_cb_(buf) : 0;
-            if (r != 0 && rc == 0) {
-                rc = r;
-            }
-            buf = nullptr;
+// ---------------------------------------------------------------------------
+// finalize
+// ---------------------------------------------------------------------------
+
+void PmuCollector::finalize(PmuUnregisterCallback /*unregister_cb*/, PmuFreeCallback free_cb, void *user_data) {
+    if (!initialized_) {
+        return;
+    }
+
+    if (csv_file_.is_open()) {
+        csv_file_.close();
+    }
+
+    PmuFreeCallback cb = free_cb != nullptr ? free_cb : free_cb_;
+    void *ud = free_cb != nullptr ? user_data : user_data_;
+
+    // Free individual PmuBuffers
+    for (auto &entry : buf_pool_) {
+        if (entry.dev_ptr != nullptr && cb != nullptr) {
+            cb(entry.dev_ptr, ud);
+        }
+        if (entry.host_ptr != nullptr) {
+            std::free(entry.host_ptr);
         }
     }
-    core_buffers_dev_.clear();
+    buf_pool_.clear();
 
-    if (setup_header_dev_ != nullptr && free_cb_ != nullptr) {
-        int r = free_cb_(setup_header_dev_);
-        if (r != 0 && rc == 0) {
-            rc = r;
-        }
+    // Free shared header region
+    if (shm_dev_ != nullptr && cb != nullptr) {
+        cb(shm_dev_, ud);
     }
-    setup_header_dev_ = nullptr;
+    if (shm_host_ != nullptr) {
+        std::free(shm_host_);
+    }
+    shm_dev_ = nullptr;
+    shm_host_ = nullptr;
 
-    num_cores_ = 0;
-    event_type_ = PmuEventType::PIPE_UTILIZATION;
-    pmu_buffer_bytes_ = 0;
-    setup_region_bytes_ = 0;
-    collected_records_.clear();
-    dropped_counts_.clear();
-    total_counts_.clear();
-    owning_thread_ids_.clear();
-    alloc_cb_ = nullptr;
-    free_cb_ = nullptr;
-    copy_to_dev_cb_ = nullptr;
-    copy_from_dev_cb_ = nullptr;
-    return rc;
+    initialized_ = false;
+    LOG_INFO_V0("PMU collector finalized");
 }

--- a/src/a5/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a5/platform/src/host/tensor_dump_collector.cpp
@@ -11,11 +11,15 @@
 
 /**
  * @file tensor_dump_collector.cpp
- * @brief Host-side tensor dump collector implementation (memcpy-based)
+ * @brief Host-side tensor dump collector implementation
  *
- * - Allocate device buffers, copy header to device
- * - After stream sync, two-step copy (header then data)
- * - Export to JSON manifest + binary payload
+ * Mirrors l2_perf_collector.cpp patterns:
+ * - DumpMemoryManager: background thread polling dump ready queues
+ * - TensorDumpCollector: lifecycle management, arena reads, file export
+ *
+ * A5 specifics: all device memory access goes through host shadow
+ * buffers + explicit profiling_copy_{to,from}_device() hooks,
+ * instead of SVM (halHostRegister).
  */
 
 #include "host/tensor_dump_collector.h"
@@ -32,257 +36,630 @@
 #include "common/unified_log.h"
 
 // =============================================================================
+// DumpMemoryManager
+// =============================================================================
+
+DumpMemoryManager::~DumpMemoryManager() {
+    if (running_.load()) {
+        stop();
+    }
+}
+
+void DumpMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
+
+void *DumpMemoryManager::resolve_host_ptr(void *dev_ptr) {
+    auto it = dev_to_host_.find(dev_ptr);
+    if (it != dev_to_host_.end()) {
+        return it->second;
+    }
+    LOG_ERROR("DumpMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
+    return nullptr;
+}
+
+void *DumpMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size);
+    if (dev_ptr == nullptr) {
+        LOG_WARN(
+            "DumpMemoryManager: alloc failed for %zu bytes, "
+            "increase PLATFORM_DUMP_BUFFERS_PER_THREAD to reduce tensor dump data loss",
+            size
+        );
+        *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void *host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("DumpMemoryManager: register failed: %d", rc);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+    } else {
+        void *host_ptr = std::malloc(size);
+        if (host_ptr == nullptr) {
+            LOG_ERROR("DumpMemoryManager: host shadow alloc failed for %zu bytes", size);
+            free_buffer(dev_ptr);
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        std::memset(host_ptr, 0, size);
+        profiling_copy_to_device(dev_ptr, host_ptr, size);
+        *host_ptr_out = host_ptr;
+    }
+
+    dev_to_host_[dev_ptr] = *host_ptr_out;
+    return dev_ptr;
+}
+
+void DumpMemoryManager::free_buffer(void *dev_ptr) {
+    if (dev_ptr == nullptr) return;
+
+    if (free_cb_ != nullptr) {
+        auto it = dev_to_host_.find(dev_ptr);
+        if (it != dev_to_host_.end()) {
+            if (register_cb_ == nullptr && it->second != nullptr && it->second != dev_ptr) {
+                std::free(it->second);
+            }
+            dev_to_host_.erase(it);
+        }
+        free_cb_(dev_ptr);
+    }
+}
+
+void DumpMemoryManager::process_dump_entry(
+    DumpDataHeader * /*header*/, int thread_idx, const DumpReadyQueueEntry &entry
+) {
+    void *dev_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
+    void *host_ptr = resolve_host_ptr(dev_ptr);
+    if (host_ptr != nullptr) {
+        profiling_copy_from_device(host_ptr, dev_ptr, sizeof(DumpMetaBuffer));
+    }
+
+    DumpReadyBufferInfo info;
+    info.thread_index = entry.thread_index;
+    info.dev_buffer_ptr = dev_ptr;
+    info.host_buffer_ptr = host_ptr;
+    info.buffer_seq = entry.buffer_seq;
+
+    {
+        std::lock_guard<std::mutex> lock(ready_mutex_);
+        ready_queue_.push(info);
+    }
+    ready_cv_.notify_one();
+
+    // Replenish: fill free_queue to capacity
+    DumpBufferState *state = get_dump_buffer_state(shared_mem_host_, thread_idx);
+    DumpBufferState *dev_state = get_dump_buffer_state(shared_mem_dev_, thread_idx);
+    profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
+
+    rmb();
+    uint32_t fq_head = state->free_queue.head;
+    uint32_t fq_tail = state->free_queue.tail;
+    uint32_t fq_used = fq_tail - fq_head;
+
+    while (fq_used < PLATFORM_DUMP_SLOT_COUNT) {
+        void *new_dev = nullptr;
+        if (!recycled_dump_buffers_.empty()) {
+            new_dev = recycled_dump_buffers_.back();
+            recycled_dump_buffers_.pop_back();
+        } else {
+            int batch = PLATFORM_DUMP_BUFFERS_PER_THREAD - PLATFORM_DUMP_SLOT_COUNT;
+            if (batch < 1) {
+                batch = 1;
+            }
+            for (int i = 0; i < batch; i++) {
+                void *host = nullptr;
+                void *dev = alloc_and_register(sizeof(DumpMetaBuffer), &host);
+                if (dev == nullptr) {
+                    break;
+                }
+                recycled_dump_buffers_.push_back(dev);
+            }
+            if (!recycled_dump_buffers_.empty()) {
+                new_dev = recycled_dump_buffers_.back();
+                recycled_dump_buffers_.pop_back();
+            }
+        }
+        if (new_dev == nullptr) {
+            break;
+        }
+
+        // Zero the count on host shadow and push to device
+        void *new_host = resolve_host_ptr(new_dev);
+        if (new_host != nullptr) {
+            reinterpret_cast<DumpMetaBuffer *>(new_host)->count = 0;
+            uint32_t zero = 0;
+            profiling_copy_to_device(
+                reinterpret_cast<char *>(new_dev) + offsetof(DumpMetaBuffer, count), &zero, sizeof(uint32_t)
+            );
+        }
+
+        state->free_queue.buffer_ptrs[fq_tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(new_dev);
+        wmb();
+        fq_tail++;
+        state->free_queue.tail = fq_tail;
+        wmb();
+
+        // Write slot and tail back to device
+        uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev);
+        profiling_copy_to_device(
+            &dev_state->free_queue.buffer_ptrs[(fq_tail - 1) % PLATFORM_DUMP_SLOT_COUNT], &slot_val, sizeof(uint64_t)
+        );
+        uint32_t new_tail = fq_tail;
+        profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+
+        fq_used++;
+    }
+}
+
+void DumpMemoryManager::mgmt_loop() {
+    if (set_device_cb_ != nullptr) {
+        set_device_cb_(device_id_);
+    }
+
+    DumpDataHeader *header = get_dump_header(shared_mem_host_);
+    DumpDataHeader *dev_header = get_dump_header(shared_mem_dev_);
+    uint64_t total_entries_processed = 0;
+
+    while (running_.load()) {
+        bool did_work = false;
+
+        // 1. Recycle done queue
+        {
+            std::lock_guard<std::mutex> lock(done_mutex_);
+            while (!done_queue_.empty()) {
+                void *dev_ptr = done_queue_.front();
+                done_queue_.pop();
+                recycled_dump_buffers_.push_back(dev_ptr);
+                did_work = true;
+            }
+        }
+
+        // 2. Poll all threads' ready queues (copy tails from device)
+        profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
+
+        for (int t = 0; t < num_dump_threads_; t++) {
+            rmb();
+            uint32_t head = header->queue_heads[t];
+            uint32_t tail = header->queue_tails[t];
+
+            if (head >= PLATFORM_DUMP_READYQUEUE_SIZE || tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
+                LOG_ERROR(
+                    "DumpMemoryManager: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
+                    PLATFORM_DUMP_READYQUEUE_SIZE
+                );
+                continue;
+            }
+
+            while (head != tail) {
+                DumpReadyQueueEntry entry;
+                profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(DumpReadyQueueEntry));
+
+                process_dump_entry(header, t, entry);
+
+                head = (head + 1) % PLATFORM_DUMP_READYQUEUE_SIZE;
+                header->queue_heads[t] = head;
+                wmb();
+
+                // Write updated head back to device
+                profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
+
+                did_work = true;
+                total_entries_processed++;
+
+                // Re-read tail in case more entries arrived
+                profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
+                rmb();
+                tail = header->queue_tails[t];
+                if (tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
+                    LOG_ERROR("DumpMemoryManager: invalid tail for thread %d: %u", t, tail);
+                    break;
+                }
+            }
+        }
+
+        // 3. Push recycled buffers into free queues that have space
+        for (int t = 0; t < num_dump_threads_ && !recycled_dump_buffers_.empty(); t++) {
+            DumpBufferState *state = get_dump_buffer_state(shared_mem_host_, t);
+            DumpBufferState *dev_state = get_dump_buffer_state(shared_mem_dev_, t);
+            profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
+            rmb();
+            uint32_t fq_head = state->free_queue.head;
+            uint32_t fq_tail = state->free_queue.tail;
+            uint32_t fq_used = fq_tail - fq_head;
+
+            while (fq_used < PLATFORM_DUMP_SLOT_COUNT && !recycled_dump_buffers_.empty()) {
+                void *new_dev = recycled_dump_buffers_.back();
+                recycled_dump_buffers_.pop_back();
+
+                void *new_host = resolve_host_ptr(new_dev);
+                if (new_host != nullptr) {
+                    reinterpret_cast<DumpMetaBuffer *>(new_host)->count = 0;
+                    uint32_t zero = 0;
+                    profiling_copy_to_device(
+                        reinterpret_cast<char *>(new_dev) + offsetof(DumpMetaBuffer, count), &zero, sizeof(uint32_t)
+                    );
+                }
+
+                state->free_queue.buffer_ptrs[fq_tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(new_dev);
+                wmb();
+                fq_tail++;
+                state->free_queue.tail = fq_tail;
+                wmb();
+
+                uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev);
+                profiling_copy_to_device(
+                    &dev_state->free_queue.buffer_ptrs[(fq_tail - 1) % PLATFORM_DUMP_SLOT_COUNT], &slot_val,
+                    sizeof(uint64_t)
+                );
+                uint32_t new_tail = fq_tail;
+                profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
+
+                fq_used++;
+                did_work = true;
+            }
+        }
+
+        if (!did_work) {
+            std::this_thread::sleep_for(std::chrono::microseconds(10));
+        }
+    }
+
+    // Final drain: process any remaining entries
+    profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
+    for (int t = 0; t < num_dump_threads_; t++) {
+        rmb();
+        uint32_t head = header->queue_heads[t];
+        uint32_t tail = header->queue_tails[t];
+        if (head >= PLATFORM_DUMP_READYQUEUE_SIZE || tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
+            LOG_ERROR("DumpMemoryManager drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
+            continue;
+        }
+        while (head != tail) {
+            DumpReadyQueueEntry entry;
+            profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(DumpReadyQueueEntry));
+            process_dump_entry(header, t, entry);
+            head = (head + 1) % PLATFORM_DUMP_READYQUEUE_SIZE;
+            header->queue_heads[t] = head;
+            wmb();
+            profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
+            profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
+            rmb();
+            tail = header->queue_tails[t];
+            if (tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
+                LOG_ERROR("DumpMemoryManager drain: invalid tail for thread %d: %u", t, tail);
+                break;
+            }
+        }
+    }
+
+    LOG_DEBUG("Dump memory manager: %lu ready entries processed", total_entries_processed);
+}
+
+void DumpMemoryManager::start(
+    void *shared_mem_host, void *shared_mem_dev, int num_dump_threads, DumpAllocCallback alloc_cb,
+    DumpRegisterCallback register_cb, DumpFreeCallback free_cb, int device_id, DumpSetDeviceCallback set_device_cb
+) {
+    shared_mem_host_ = shared_mem_host;
+    shared_mem_dev_ = shared_mem_dev;
+    num_dump_threads_ = num_dump_threads;
+    alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
+    free_cb_ = free_cb;
+    device_id_ = device_id;
+    set_device_cb_ = set_device_cb;
+
+    LOG_INFO_V0("Starting dump memory manager (device=%d, threads=%d)", device_id, num_dump_threads);
+    running_.store(true);
+    mgmt_thread_ = std::thread(&DumpMemoryManager::mgmt_loop, this);
+}
+
+void DumpMemoryManager::stop() {
+    running_.store(false);
+    if (mgmt_thread_.joinable()) {
+        mgmt_thread_.join();
+    }
+}
+
+bool DumpMemoryManager::try_pop_ready(DumpReadyBufferInfo &info) {
+    std::lock_guard<std::mutex> lock(ready_mutex_);
+    if (ready_queue_.empty()) {
+        return false;
+    }
+    info = ready_queue_.front();
+    ready_queue_.pop();
+    return true;
+}
+
+bool DumpMemoryManager::wait_pop_ready(DumpReadyBufferInfo &info, std::chrono::milliseconds timeout) {
+    std::unique_lock<std::mutex> lock(ready_mutex_);
+    if (ready_cv_.wait_for(lock, timeout, [this] {
+            return !ready_queue_.empty();
+        })) {
+        info = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+    return false;
+}
+
+void DumpMemoryManager::notify_copy_done(void *dev_buffer_ptr) {
+    std::lock_guard<std::mutex> lock(done_mutex_);
+    done_queue_.push(dev_buffer_ptr);
+}
+
+// =============================================================================
 // TensorDumpCollector
 // =============================================================================
 
 TensorDumpCollector::~TensorDumpCollector() {
-    if (is_initialized()) {
-        LOG_ERROR("TensorDumpCollector destroyed without finalize()");
+    if (memory_manager_.is_running()) {
+        memory_manager_.stop();
     }
+}
+
+void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size);
+    if (dev_ptr == nullptr) {
+        return nullptr;
+    }
+
+    if (register_cb_ != nullptr) {
+        void *host_ptr = nullptr;
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            free_cb_(dev_ptr);
+            return nullptr;
+        }
+        if (host_ptr_out) {
+            *host_ptr_out = host_ptr;
+        }
+    } else {
+        void *host_ptr = std::malloc(size);
+        if (host_ptr == nullptr) {
+            free_cb_(dev_ptr);
+            return nullptr;
+        }
+        std::memset(host_ptr, 0, size);
+        profiling_copy_to_device(dev_ptr, host_ptr, size);
+        if (host_ptr_out) {
+            *host_ptr_out = host_ptr;
+        }
+    }
+
+    return dev_ptr;
 }
 
 int TensorDumpCollector::initialize(
-    int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpFreeCallback free_cb,
-    DumpCopyToDeviceCallback copy_to_dev_cb, DumpCopyFromDeviceCallback copy_from_dev_cb
+    int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
+    DumpFreeCallback free_cb, DumpSetDeviceCallback set_device_cb
 ) {
-    if (is_initialized()) {
-        LOG_ERROR("TensorDumpCollector already initialized");
-        return -1;
-    }
-
     num_dump_threads_ = num_dump_threads;
     device_id_ = device_id;
     alloc_cb_ = alloc_cb;
+    register_cb_ = register_cb;
     free_cb_ = free_cb;
-    copy_to_dev_cb_ = copy_to_dev_cb;
-    copy_from_dev_cb_ = copy_from_dev_cb;
+    set_device_cb_ = set_device_cb;
 
-    int capacity = PLATFORM_DUMP_RECORDS_PER_BUFFER;
-    dump_buffer_bytes_ = calc_dump_buffer_size(capacity);
+    // Allocate dump shared memory (header + buffer states)
+    size_t shm_size = calc_dump_data_size(num_dump_threads);
+    dump_shared_mem_dev_ = alloc_single_buffer(shm_size, &dump_shared_mem_host_);
+    if (dump_shared_mem_dev_ == nullptr) {
+        LOG_ERROR("Failed to allocate dump shared memory (%zu bytes)", shm_size);
+        return -1;
+    }
+
+    // Initialize header on host shadow
+    memset(dump_shared_mem_host_, 0, shm_size);
+    DumpDataHeader *header = get_dump_header(dump_shared_mem_host_);
+    header->magic = TENSOR_DUMP_MAGIC;
+    header->num_dump_threads = static_cast<uint32_t>(num_dump_threads);
+    header->records_per_buffer = PLATFORM_DUMP_RECORDS_PER_BUFFER;
+
     uint64_t arena_size = calc_dump_arena_size();
+    header->arena_size_per_thread = arena_size;
+
+    // Allocate per-thread arenas
+    arenas_.resize(num_dump_threads);
+    for (int t = 0; t < num_dump_threads; t++) {
+        ArenaInfo &ai = arenas_[t];
+        ai.size = arena_size;
+        ai.dev_ptr = alloc_single_buffer(arena_size, &ai.host_ptr);
+        if (ai.dev_ptr == nullptr) {
+            LOG_ERROR("Failed to allocate dump arena for thread %d (%lu bytes)", t, arena_size);
+            return -1;
+        }
+
+        // Set arena info in buffer state (host shadow)
+        DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+        state->arena_base = reinterpret_cast<uint64_t>(ai.dev_ptr);
+        state->arena_size = arena_size;
+        state->arena_write_offset = 0;
+        state->dropped_record_count = 0;
+
+        LOG_INFO_V0(
+            "Thread %d: dump arena allocated (dev=%p, host=%p, size=%lu MB)", t, ai.dev_ptr, ai.host_ptr,
+            arena_size / (1024 * 1024)
+        );
+    }
+
+    // Allocate initial DumpMetaBuffers and push into free_queues
+    for (int t = 0; t < num_dump_threads; t++) {
+        DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+
+        for (int b = 0; b < PLATFORM_DUMP_BUFFERS_PER_THREAD; b++) {
+            void *host_ptr = nullptr;
+            void *dev_ptr = alloc_single_buffer(sizeof(DumpMetaBuffer), &host_ptr);
+            if (dev_ptr == nullptr) {
+                LOG_ERROR("Failed to allocate dump meta buffer %d for thread %d", b, t);
+                return -1;
+            }
+
+            memory_manager_.register_mapping(dev_ptr, host_ptr);
+
+            if (b < PLATFORM_DUMP_SLOT_COUNT) {
+                // Push into SPSC free_queue
+                uint32_t tail = state->free_queue.tail;
+                state->free_queue.buffer_ptrs[tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
+                state->free_queue.tail = tail + 1;
+            } else {
+                // Remaining go to recycled pool
+                memory_manager_.recycled_dump_buffers_.push_back(dev_ptr);
+            }
+        }
+    }
+
+    // Copy the entire initialized shared memory region to device
+    profiling_copy_to_device(dump_shared_mem_dev_, dump_shared_mem_host_, shm_size);
 
     LOG_INFO_V0(
-        "Initializing tensor dump: %d threads, %d records/buffer, %zu bytes/buffer, %lu bytes/arena", num_dump_threads,
-        capacity, dump_buffer_bytes_, arena_size
+        "Tensor dump initialized: %d threads, arena=%lu MB/thread, %d buffers/thread", num_dump_threads,
+        arena_size / (1024 * 1024), PLATFORM_DUMP_BUFFERS_PER_THREAD
     );
 
-    // Allocate DumpSetupHeader on device
-    setup_header_dev_ = alloc_cb_(sizeof(DumpSetupHeader));
-    if (setup_header_dev_ == nullptr) {
-        LOG_ERROR("Failed to allocate DumpSetupHeader (%zu bytes)", sizeof(DumpSetupHeader));
-        return -1;
-    }
-
-    // Build host-side setup header
-    DumpSetupHeader host_header = {};
-    host_header.num_dump_threads = static_cast<uint32_t>(num_dump_threads);
-    host_header.records_per_buffer = static_cast<uint32_t>(capacity);
-    host_header.magic = TENSOR_DUMP_MAGIC;
-
-    // Allocate per-thread buffers and arenas
-    dump_buffers_dev_.resize(num_dump_threads, nullptr);
-    arena_headers_dev_.resize(num_dump_threads, nullptr);
-    arena_data_dev_.resize(num_dump_threads, nullptr);
-
-    for (int t = 0; t < num_dump_threads; t++) {
-        // Allocate DumpBuffer
-        void *buf = alloc_cb_(dump_buffer_bytes_);
-        if (buf == nullptr) {
-            LOG_ERROR("Failed to allocate DumpBuffer for thread %d (%zu bytes)", t, dump_buffer_bytes_);
-            finalize();
-            return -1;
-        }
-        dump_buffers_dev_[t] = buf;
-
-        // Initialize DumpBuffer on host then copy to device
-        std::vector<uint8_t> buf_init(dump_buffer_bytes_, 0);
-        DumpBuffer *buf_host = reinterpret_cast<DumpBuffer *>(buf_init.data());
-        buf_host->count = 0;
-        buf_host->capacity = static_cast<uint32_t>(capacity);
-        buf_host->dropped_count = 0;
-        int rc = copy_to_dev_cb_(buf, buf_init.data(), dump_buffer_bytes_);
-        if (rc != 0) {
-            LOG_ERROR("Failed to initialize DumpBuffer for thread %d: %d", t, rc);
-            finalize();
-            return rc;
-        }
-
-        // Allocate DumpArenaHeader
-        void *arena_hdr = alloc_cb_(sizeof(DumpArenaHeader));
-        if (arena_hdr == nullptr) {
-            LOG_ERROR("Failed to allocate DumpArenaHeader for thread %d", t);
-            finalize();
-            return -1;
-        }
-        arena_headers_dev_[t] = arena_hdr;
-
-        // Initialize arena header
-        DumpArenaHeader host_arena_hdr = {};
-        host_arena_hdr.write_offset = 0;
-        host_arena_hdr.arena_size = arena_size;
-        rc = copy_to_dev_cb_(arena_hdr, &host_arena_hdr, sizeof(DumpArenaHeader));
-        if (rc != 0) {
-            LOG_ERROR("Failed to initialize DumpArenaHeader for thread %d: %d", t, rc);
-            finalize();
-            return rc;
-        }
-
-        // Allocate arena data
-        void *arena = alloc_cb_(static_cast<size_t>(arena_size));
-        if (arena == nullptr) {
-            LOG_ERROR("Failed to allocate arena for thread %d (%lu bytes)", t, arena_size);
-            finalize();
-            return -1;
-        }
-        arena_data_dev_[t] = arena;
-
-        // Fill setup header pointers
-        host_header.dump_buffer_ptrs[t] = reinterpret_cast<uint64_t>(buf);
-        host_header.arena_header_ptrs[t] = reinterpret_cast<uint64_t>(arena_hdr);
-        host_header.arena_data_ptrs[t] = reinterpret_cast<uint64_t>(arena);
-        host_header.arena_sizes[t] = arena_size;
-    }
-
-    // Copy setup header to device
-    int rc = copy_to_dev_cb_(setup_header_dev_, &host_header, sizeof(DumpSetupHeader));
-    if (rc != 0) {
-        LOG_ERROR("Failed to copy DumpSetupHeader to device: %d", rc);
-        finalize();
-        return rc;
-    }
-
-    LOG_INFO_V0("Tensor dump initialized: %d threads, header at %p", num_dump_threads, setup_header_dev_);
     return 0;
 }
 
-int TensorDumpCollector::collect_all() {
-    if (!is_initialized()) {
-        return -1;
+void TensorDumpCollector::start_memory_manager() {
+    execution_complete_.store(false);
+    memory_manager_.start(
+        dump_shared_mem_host_, dump_shared_mem_dev_, num_dump_threads_, alloc_cb_, register_cb_, free_cb_, device_id_,
+        set_device_cb_
+    );
+}
+
+void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
+    // Track processed buffer pointers to prevent double-processing
+    // (flush + drain can deliver a buffer that scan_remaining also sees)
+    if (processed_buffers_.count(info.dev_buffer_ptr)) {
+        return;
+    }
+    processed_buffers_.insert(info.dev_buffer_ptr);
+
+    DumpMetaBuffer *buf = reinterpret_cast<DumpMetaBuffer *>(info.host_buffer_ptr);
+    uint32_t count = buf->count;
+
+    if (count == 0) {
+        return;
     }
 
-    LOG_INFO_V0("Collecting tensor dump data from %d threads...", num_dump_threads_);
+    if (count > PLATFORM_DUMP_RECORDS_PER_BUFFER) {
+        LOG_ERROR(
+            "Dump collector: invalid record count %u in buffer (thread=%u, seq=%u, max=%d), skipping", count,
+            info.thread_index, info.buffer_seq, PLATFORM_DUMP_RECORDS_PER_BUFFER
+        );
+        return;
+    }
 
-    uint64_t arena_size = calc_dump_arena_size();
+    // Copy arena data from device to host shadow for this thread
+    int thread_idx = static_cast<int>(info.thread_index);
+    if (thread_idx < static_cast<int>(arenas_.size())) {
+        ArenaInfo &ai = arenas_[thread_idx];
+        // Read arena_write_offset from device to know how much to copy
+        DumpBufferState *dev_state = get_dump_buffer_state(dump_shared_mem_dev_, thread_idx);
+        DumpBufferState state_copy;
+        profiling_copy_from_device(&state_copy, dev_state, sizeof(DumpBufferState));
+        uint64_t write_offset = state_copy.arena_write_offset;
 
-    for (int t = 0; t < num_dump_threads_; t++) {
-        // Step 1: Copy back DumpBuffer header (64 bytes) to read count
-        DumpBuffer host_buf_header = {};
-        int rc = copy_from_dev_cb_(&host_buf_header, dump_buffers_dev_[t], sizeof(DumpBuffer));
-        if (rc != 0) {
-            LOG_ERROR("Thread %d: failed to copy DumpBuffer header: %d", t, rc);
-            continue;
+        // Copy arena data (up to min(write_offset, arena_size) bytes)
+        uint64_t bytes_to_copy = (write_offset < ai.size) ? write_offset : ai.size;
+        if (bytes_to_copy > 0) {
+            profiling_copy_from_device(ai.host_ptr, ai.dev_ptr, bytes_to_copy);
         }
+    }
 
-        uint32_t count = host_buf_header.count;
-        uint32_t dropped = host_buf_header.dropped_count;
-        total_dropped_count_ += dropped;
+    for (uint32_t i = 0; i < count; i++) {
+        const TensorDumpRecord &rec = buf->records[i];
 
-        if (count == 0) {
-            LOG_DEBUG("Thread %d: no dump records", t);
-            continue;
+        DumpedTensor dt;
+        dt.task_id = rec.task_id;
+        dt.subtask_id = rec.subtask_id;
+        dt.func_id = rec.func_id;
+        dt.arg_index = rec.arg_index;
+        dt.role = static_cast<TensorDumpRole>(rec.role);
+        dt.stage = static_cast<TensorDumpStage>(rec.stage);
+        dt.dtype = rec.dtype;
+        dt.ndims = rec.ndims;
+        dt.is_contiguous = (rec.is_contiguous != 0);
+        dt.truncated = (rec.truncated != 0);
+        dt.overwritten = false;
+        if (dt.truncated && ++total_truncated_count_ == 1) {
+            LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
         }
+        memcpy(dt.raw_shapes, rec.raw_shapes, sizeof(dt.raw_shapes));
+        memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
+        memcpy(dt.offsets, rec.offsets, sizeof(dt.offsets));
 
-        // Step 2: Copy back the actual records (count * sizeof(TensorDumpRecord))
-        size_t records_bytes = static_cast<size_t>(count) * sizeof(TensorDumpRecord);
-        std::vector<uint8_t> records_buf(records_bytes);
-        void *dev_records = reinterpret_cast<char *>(dump_buffers_dev_[t]) + sizeof(DumpBuffer);
-        rc = copy_from_dev_cb_(records_buf.data(), dev_records, records_bytes);
-        if (rc != 0) {
-            LOG_ERROR("Thread %d: failed to copy %u dump records: %d", t, count, rc);
-            continue;
-        }
+        // Read tensor data from arena host shadow
+        if (thread_idx < static_cast<int>(arenas_.size())) {
+            ArenaInfo &ai = arenas_[thread_idx];
+            char *arena_host = reinterpret_cast<char *>(ai.host_ptr);
+            uint64_t arena_sz = ai.size;
 
-        // Step 3: Copy back arena header
-        DumpArenaHeader host_arena_hdr = {};
-        rc = copy_from_dev_cb_(&host_arena_hdr, arena_headers_dev_[t], sizeof(DumpArenaHeader));
-        if (rc != 0) {
-            LOG_ERROR("Thread %d: failed to copy arena header: %d", t, rc);
-            continue;
-        }
-
-        // Step 4: Copy back arena data (only up to min(write_offset, arena_size))
-        uint64_t arena_bytes_to_copy = host_arena_hdr.write_offset;
-        if (arena_bytes_to_copy > arena_size) {
-            arena_bytes_to_copy = arena_size;  // Circular wraparound — copy entire arena
-        }
-        std::vector<uint8_t> arena_buf(static_cast<size_t>(arena_bytes_to_copy));
-        if (arena_bytes_to_copy > 0) {
-            rc = copy_from_dev_cb_(arena_buf.data(), arena_data_dev_[t], static_cast<size_t>(arena_bytes_to_copy));
-            if (rc != 0) {
-                LOG_ERROR("Thread %d: failed to copy arena data (%lu bytes): %d", t, arena_bytes_to_copy, rc);
-                continue;
-            }
-        }
-
-        // Step 5: Reconstruct DumpedTensor entries
-        const TensorDumpRecord *records = reinterpret_cast<const TensorDumpRecord *>(records_buf.data());
-        for (uint32_t i = 0; i < count; i++) {
-            const TensorDumpRecord &rec = records[i];
-
-            DumpedTensor dt = {};
-            dt.task_id = rec.task_id;
-            dt.subtask_id = rec.subtask_id;
-            dt.func_id = rec.func_id;
-            dt.arg_index = rec.arg_index;
-            dt.role = static_cast<TensorDumpRole>(rec.role);
-            dt.stage = static_cast<TensorDumpStage>(rec.stage);
-            dt.dtype = rec.dtype;
-            dt.ndims = rec.ndims;
-            dt.is_contiguous = (rec.is_contiguous != 0);
-            dt.truncated = (rec.truncated != 0);
-            dt.payload_size = rec.payload_size;
-
-            for (int d = 0; d < rec.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-                dt.shapes[d] = rec.shapes[d];
-                dt.offsets[d] = rec.offsets[d];
-                dt.raw_shapes[d] = rec.raw_shapes[d];
-            }
-
-            if (dt.truncated) {
-                total_truncated_count_++;
-            }
-
-            // Check for arena overwrite
-            bool overwritten = false;
-            if (host_arena_hdr.write_offset > arena_size) {
-                uint64_t oldest_valid = host_arena_hdr.write_offset - arena_size;
-                if (rec.payload_offset < oldest_valid) {
-                    overwritten = true;
-                    total_overwrite_count_++;
+            // Check if data was overwritten (offset too old)
+            uint64_t high_water = ai.high_water;
+            if (high_water > arena_sz && rec.payload_offset < high_water - arena_sz) {
+                dt.overwritten = true;
+                if (++total_overwrite_count_ == 1) {
+                    LOG_WARN(
+                        "Tensor dump overwrite detected: host drain was slower than arena reuse. "
+                        "Increase PLATFORM_DUMP_BUFFERS_PER_THREAD."
+                    );
                 }
+            } else {
+                dt.overwritten = false;
             }
-            dt.overwritten = overwritten;
 
-            // Extract payload from arena
-            if (rec.payload_size > 0 && !overwritten && arena_bytes_to_copy > 0) {
-                uint64_t arena_sz = arena_size;
+            if (!dt.overwritten && rec.payload_size > 0) {
+                dt.bytes.resize(rec.payload_size);
                 uint64_t pos = rec.payload_offset % arena_sz;
-                uint64_t sz = rec.payload_size;
-                dt.bytes.resize(static_cast<size_t>(sz));
-
-                if (pos + sz <= arena_sz) {
-                    memcpy(dt.bytes.data(), arena_buf.data() + pos, static_cast<size_t>(sz));
+                if (pos + rec.payload_size <= arena_sz) {
+                    memcpy(dt.bytes.data(), arena_host + pos, rec.payload_size);
                 } else {
-                    // Circular wraparound read
+                    // Wraparound read
                     uint64_t first = arena_sz - pos;
-                    memcpy(dt.bytes.data(), arena_buf.data() + pos, static_cast<size_t>(first));
-                    memcpy(dt.bytes.data() + first, arena_buf.data(), static_cast<size_t>(sz - first));
+                    memcpy(dt.bytes.data(), arena_host + pos, first);
+                    memcpy(dt.bytes.data() + first, arena_host, rec.payload_size - first);
                 }
             }
 
-            collected_.push_back(std::move(dt));
+            // Update high-water mark
+            uint64_t end_offset = rec.payload_offset + rec.payload_size;
+            if (end_offset > ai.high_water) {
+                ai.high_water = end_offset;
+            }
         }
 
-        LOG_INFO_V0("Thread %d: collected %u records (dropped=%u)", t, count, dropped);
+        dt.payload_size = dt.bytes.size();
+
+        bool has_payload = !dt.overwritten && !dt.bytes.empty();
+        dt.bin_offset = has_payload ? next_bin_offset_ : 0;
+        if (has_payload) {
+            next_bin_offset_ += dt.payload_size;
+        }
+
+        // Store metadata-only copy in collected_ (no payload bytes)
+        DumpedTensor meta = dt;
+        meta.bytes.clear();
+        {
+            std::lock_guard<std::mutex> lock(collected_mutex_);
+            collected_.push_back(std::move(meta));
+        }
+
+        // Enqueue full tensor (with payload) to writer thread
+        if (has_payload) {
+            {
+                std::lock_guard<std::mutex> lock(write_mutex_);
+                write_queue_.push(std::move(dt));
+            }
+            write_cv_.notify_one();
+        }
     }
-
-    LOG_INFO_V0("Tensor dump collection complete: %zu tensors total", collected_.size());
-    return 0;
 }
-
-// =============================================================================
-// Export Helpers
-// =============================================================================
 
 static const char *tensor_dump_role_name(TensorDumpRole role) {
     switch (role) {
@@ -319,6 +696,174 @@ static std::string dims_to_string(const uint32_t dims[], int ndims) {
     return ss.str();
 }
 
+void TensorDumpCollector::poll_and_collect(const std::string &output_path) {
+    const auto wait_timeout = std::chrono::milliseconds(100);
+    const auto idle_timeout = std::chrono::seconds(PLATFORM_DUMP_TIMEOUT_SECONDS);
+    uint64_t buffers_collected = 0;
+    auto start_time = std::chrono::steady_clock::now();
+    auto last_progress_time = start_time;
+    bool idle_timer_started = false;
+    std::chrono::steady_clock::time_point idle_start;
+
+    // Set up the run directory and start writer thread. Caller-provided
+    // `output_path` is the per-task uniqueness boundary (no timestamp).
+    run_dir_ = std::filesystem::path(output_path) / "tensor_dump";
+    std::filesystem::create_directories(run_dir_);
+    std::string base_name = run_dir_.filename().string();
+    bin_file_.open(run_dir_ / (base_name + ".bin"), std::ios::binary);
+    next_bin_offset_ = 0;
+
+    writer_done_.store(false);
+    bytes_written_.store(0);
+    writer_thread_ = std::thread(&TensorDumpCollector::writer_loop, this);
+
+    while (true) {
+        DumpReadyBufferInfo info;
+        if (memory_manager_.try_pop_ready(info)) {
+            process_dump_buffer(info);
+            memory_manager_.notify_copy_done(info.dev_buffer_ptr);
+            buffers_collected++;
+            idle_timer_started = false;
+
+            auto now = std::chrono::steady_clock::now();
+            if (std::chrono::duration_cast<std::chrono::seconds>(now - last_progress_time).count() >= 5) {
+                auto elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
+                LOG_INFO_V0(
+                    "Collecting: %zu tensors, %.1f GB written (%lds)", collected_.size(), bytes_written_.load() / 1e9,
+                    elapsed_s
+                );
+                last_progress_time = now;
+            }
+        } else {
+            if (!memory_manager_.wait_pop_ready(info, wait_timeout)) {
+                if (execution_complete_.load()) {
+                    DumpReadyBufferInfo drain_info;
+                    while (memory_manager_.try_pop_ready(drain_info)) {
+                        process_dump_buffer(drain_info);
+                        memory_manager_.notify_copy_done(drain_info.dev_buffer_ptr);
+                        buffers_collected++;
+                    }
+                    break;
+                }
+
+                if (!idle_timer_started) {
+                    idle_start = std::chrono::steady_clock::now();
+                    idle_timer_started = true;
+                }
+                auto idle_elapsed = std::chrono::steady_clock::now() - idle_start;
+                if (idle_elapsed >= idle_timeout) {
+                    LOG_ERROR(
+                        "Tensor dump collection idle timeout after %ld seconds",
+                        std::chrono::duration_cast<std::chrono::seconds>(idle_elapsed).count()
+                    );
+                    LOG_ERROR(
+                        "Collected %lu buffers and %zu tensors before timeout", buffers_collected, collected_.size()
+                    );
+                    break;
+                }
+                continue;
+            }
+            process_dump_buffer(info);
+            memory_manager_.notify_copy_done(info.dev_buffer_ptr);
+            buffers_collected++;
+            idle_timer_started = false;
+        }
+    }
+
+    // Stop writer thread and wait for it to drain
+    writer_done_.store(true);
+    write_cv_.notify_one();
+    while (writer_thread_.joinable()) {
+        if (write_queue_.empty()) {
+            writer_thread_.join();
+            break;
+        }
+        auto elapsed_s =
+            std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time).count();
+        LOG_INFO_V0(
+            "Writing to disk: %.1f GB written, %zu tensors remaining (%lds)", bytes_written_.load() / 1e9,
+            write_queue_.size(), elapsed_s
+        );
+        std::this_thread::sleep_for(std::chrono::seconds(10));
+    }
+
+    bin_file_.close();
+
+    auto elapsed_ms =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count();
+    LOG_INFO_V0(
+        "Collected %zu tensors, wrote %.1f GB to disk (%.1fs)", collected_.size(), bytes_written_.load() / 1e9,
+        elapsed_ms / 1000.0
+    );
+}
+
+void TensorDumpCollector::signal_execution_complete() { execution_complete_.store(true); }
+
+void TensorDumpCollector::stop_memory_manager() { memory_manager_.stop(); }
+
+void TensorDumpCollector::drain_remaining_buffers() {
+    DumpReadyBufferInfo info;
+    while (memory_manager_.try_pop_ready(info)) {
+        process_dump_buffer(info);
+        memory_manager_.notify_copy_done(info.dev_buffer_ptr);
+    }
+}
+
+void TensorDumpCollector::scan_remaining_dump_buffers() {
+    uint32_t dropped_total = 0;
+    // Scan current_buf_ptr for each thread for partial buffers not yet enqueued
+    for (int t = 0; t < num_dump_threads_; t++) {
+        DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+
+        // Copy buffer state from device to get the latest values
+        DumpBufferState *dev_state = get_dump_buffer_state(dump_shared_mem_dev_, t);
+        profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
+
+        // Accumulate dropped-record counts
+        total_dropped_record_count_ += state->dropped_record_count;
+        dropped_total += state->dropped_record_count;
+
+        uint64_t cur_ptr = state->current_buf_ptr;
+        if (cur_ptr == 0) {
+            continue;
+        }
+
+        void *dev_ptr = reinterpret_cast<void *>(cur_ptr);
+        void *host_ptr = memory_manager_.resolve_host_ptr(dev_ptr);
+        if (host_ptr == nullptr) {
+            continue;
+        }
+
+        // Copy the buffer from device to host shadow
+        profiling_copy_from_device(host_ptr, dev_ptr, sizeof(DumpMetaBuffer));
+
+        // Copy arena data for this thread
+        ArenaInfo &ai = arenas_[t];
+        uint64_t write_offset = state->arena_write_offset;
+        uint64_t bytes_to_copy = (write_offset < ai.size) ? write_offset : ai.size;
+        if (bytes_to_copy > 0) {
+            profiling_copy_from_device(ai.host_ptr, ai.dev_ptr, bytes_to_copy);
+        }
+
+        DumpMetaBuffer *buf = reinterpret_cast<DumpMetaBuffer *>(host_ptr);
+        if (buf->count > 0) {
+            DumpReadyBufferInfo info;
+            info.thread_index = static_cast<uint32_t>(t);
+            info.dev_buffer_ptr = dev_ptr;
+            info.host_buffer_ptr = host_ptr;
+            info.buffer_seq = state->current_buf_seq;
+            process_dump_buffer(info);
+        }
+    }
+    if (dropped_total > 0) {
+        LOG_WARN(
+            "Dump collector: %u records dropped on device side. "
+            "Increase PLATFORM_DUMP_BUFFERS_PER_THREAD or PLATFORM_DUMP_READYQUEUE_SIZE.",
+            dropped_total
+        );
+    }
+}
+
 static std::string get_dtype_name_from_raw(uint8_t dtype) { return get_dtype_name(static_cast<DataType>(dtype)); }
 
 static uint64_t get_num_elements(const DumpedTensor &dt) {
@@ -329,14 +874,39 @@ static uint64_t get_num_elements(const DumpedTensor &dt) {
     return (dt.ndims == 0) ? 1 : numel;
 }
 
-int TensorDumpCollector::export_dump_files(const std::string &output_path) {
+void TensorDumpCollector::writer_loop() {
+    while (true) {
+        DumpedTensor dt;
+        {
+            std::unique_lock<std::mutex> lock(write_mutex_);
+            write_cv_.wait(lock, [this] {
+                return !write_queue_.empty() || writer_done_.load();
+            });
+            if (write_queue_.empty() && writer_done_.load()) {
+                break;
+            }
+            dt = std::move(write_queue_.front());
+            write_queue_.pop();
+        }
+
+        if (!dt.bytes.empty()) {
+            bin_file_.write(
+                reinterpret_cast<const char *>(dt.bytes.data()), static_cast<std::streamsize>(dt.bytes.size())
+            );
+        }
+
+        bytes_written_ += dt.bytes.size();
+    }
+}
+
+int TensorDumpCollector::export_dump_files() {
     if (collected_.empty()) {
         LOG_WARN("No tensor dump data to export");
         return 0;
     }
     auto export_start = std::chrono::steady_clock::now();
 
-    // Sort by task_id then subtask_id then func_id
+    // Sort by task_id then subtask_id then func_id.
     std::sort(collected_.begin(), collected_.end(), [](const DumpedTensor &a, const DumpedTensor &b) {
         if (a.task_id != b.task_id) return a.task_id < b.task_id;
         if (a.subtask_id != b.subtask_id) return a.subtask_id < b.subtask_id;
@@ -346,30 +916,8 @@ int TensorDumpCollector::export_dump_files(const std::string &output_path) {
         return static_cast<uint8_t>(a.role) < static_cast<uint8_t>(b.role);
     });
 
-    // The run directory is fixed (`<prefix>/tensor_dump`) — caller-provided
-    // `output_path` is the per-task uniqueness boundary.
-    std::filesystem::path run_dir = std::filesystem::path(output_path) / "tensor_dump";
-    std::filesystem::create_directories(run_dir);
+    LOG_INFO_V0("Writing JSON manifest for %zu tensors...", collected_.size());
 
-    std::string base_name = run_dir.filename().string();
-
-    // Write binary payload file
-    std::ofstream bin_file(run_dir / (base_name + ".bin"), std::ios::binary);
-    uint64_t bin_offset = 0;
-    for (auto &dt : collected_) {
-        dt.bin_offset = bin_offset;
-        if (!dt.bytes.empty()) {
-            bin_file.write(
-                reinterpret_cast<const char *>(dt.bytes.data()), static_cast<std::streamsize>(dt.bytes.size())
-            );
-            bin_offset += dt.bytes.size();
-        }
-        dt.bytes.clear();  // Free memory after writing
-        dt.bytes.shrink_to_fit();
-    }
-    bin_file.close();
-
-    // Count stats
     uint32_t num_before_dispatch = 0;
     uint32_t num_after_completion = 0;
     uint32_t num_input_tensors = 0;
@@ -394,9 +942,9 @@ int TensorDumpCollector::export_dump_files(const std::string &output_path) {
         }
     }
 
-    // Write JSON manifest
-    LOG_INFO_V0("Writing JSON manifest for %zu tensors...", collected_.size());
-    std::ofstream json(run_dir / (base_name + ".json"));
+    // Write JSON manifest (txt/bin files already written by writer thread)
+    std::string base_name = run_dir_.filename().string();
+    std::ofstream json(run_dir_ / (base_name + ".json"));
     json << "{\n";
     json << "  \"run_dir\": \"" << base_name << "\",\n";
     json << "  \"bin_format\": {\n";
@@ -410,12 +958,13 @@ int TensorDumpCollector::export_dump_files(const std::string &output_path) {
     json << "  \"output_tensors\": " << num_output_tensors << ",\n";
     json << "  \"inout_tensors\": " << num_inout_tensors << ",\n";
     json << "  \"truncated_tensors\": " << total_truncated_count_ << ",\n";
-    json << "  \"dropped_records\": " << total_dropped_count_ << ",\n";
+    json << "  \"dropped_records\": " << total_dropped_record_count_ << ",\n";
     json << "  \"dropped_overwrite\": " << total_overwrite_count_ << ",\n";
     json << "  \"bin_file\": \"" << base_name << ".bin\",\n";
     json << "  \"tensors\": [\n";
 
     bool first_entry = true;
+
     for (size_t i = 0; i < collected_.size(); i++) {
         const DumpedTensor &dt = collected_[i];
         std::string dtype_name = get_dtype_name_from_raw(dt.dtype);
@@ -444,65 +993,142 @@ int TensorDumpCollector::export_dump_files(const std::string &output_path) {
 
     auto export_end = std::chrono::steady_clock::now();
     auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(export_end - export_start).count();
-    LOG_INFO_V0(
-        "Wrote dump files (%zu tensors, %lu bytes payload) to %s (%ldms)", collected_.size(), bin_offset,
-        run_dir.c_str(), total_ms
-    );
+    LOG_INFO_V0("Wrote JSON manifest (%zu tensors) to %s (%ldms)", collected_.size(), run_dir_.c_str(), total_ms);
 
-    if (total_truncated_count_ > 0 || total_dropped_count_ > 0 || total_overwrite_count_ > 0) {
+    if (total_truncated_count_ > 0 || total_dropped_record_count_ > 0 || total_overwrite_count_ > 0) {
         LOG_WARN(
             "Tensor dump anomalies: truncated=%u, dropped_records=%u, overwritten=%u", total_truncated_count_,
-            total_dropped_count_, total_overwrite_count_
+            total_dropped_record_count_, total_overwrite_count_
         );
     }
 
-    // Clear state for potential subsequent runs
+    // Clear state so subsequent runs don't accumulate data from previous runs
     collected_.clear();
-    total_dropped_count_ = 0;
+    processed_buffers_.clear();
+    total_dropped_record_count_ = 0;
     total_truncated_count_ = 0;
     total_overwrite_count_ = 0;
+    for (auto &ai : arenas_) {
+        ai.high_water = 0;
+    }
     return 0;
 }
 
-int TensorDumpCollector::finalize() {
-    if (!is_initialized()) {
-        return 0;
+int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb) {
+    (void)unregister_cb;
+    // Stop memory manager if still running
+    if (memory_manager_.is_running()) {
+        memory_manager_.stop();
     }
 
-    // Free per-thread arena data
-    for (auto *ptr : arena_data_dev_) {
-        if (ptr != nullptr && free_cb_ != nullptr) {
-            free_cb_(ptr);
+    std::unordered_set<void *> released_meta_buffers;
+    auto release_meta_buffer = [&](void *ptr) {
+        if (ptr == nullptr || !released_meta_buffers.insert(ptr).second) {
+            return;
+        }
+        // Free host shadow if non-SVM
+        auto it = memory_manager_.dev_to_host_.find(ptr);
+        if (it != memory_manager_.dev_to_host_.end()) {
+            if (register_cb_ == nullptr && it->second != nullptr && it->second != ptr) {
+                std::free(it->second);
+            }
+            memory_manager_.dev_to_host_.erase(it);
+        }
+        if (free_cb) {
+            free_cb(ptr);
+        }
+    };
+
+    // Free DumpMetaBuffers still in free_queues and current_buf_ptr
+    if (dump_shared_mem_host_) {
+        for (int t = 0; t < num_dump_threads_; t++) {
+            DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+
+            // Copy latest state from device
+            DumpBufferState *dev_state = get_dump_buffer_state(dump_shared_mem_dev_, t);
+            profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
+
+            // Free current buffer if any
+            release_meta_buffer(reinterpret_cast<void *>(state->current_buf_ptr));
+            state->current_buf_ptr = 0;
+
+            // Free all buffers remaining in free_queue
+            rmb();
+            uint32_t head = state->free_queue.head;
+            uint32_t tail = state->free_queue.tail;
+            uint32_t queued = tail - head;
+            if (queued > PLATFORM_DUMP_SLOT_COUNT) {
+                queued = PLATFORM_DUMP_SLOT_COUNT;
+            }
+            for (uint32_t i = 0; i < queued; i++) {
+                uint32_t slot = (head + i) % PLATFORM_DUMP_SLOT_COUNT;
+                release_meta_buffer(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+                state->free_queue.buffer_ptrs[slot] = 0;
+            }
+            state->free_queue.head = tail;
         }
     }
-    arena_data_dev_.clear();
 
-    // Free per-thread arena headers
-    for (auto *ptr : arena_headers_dev_) {
-        if (ptr != nullptr && free_cb_ != nullptr) {
-            free_cb_(ptr);
+    // Free buffers still queued for host processing
+    {
+        std::lock_guard<std::mutex> lock(memory_manager_.ready_mutex_);
+        while (!memory_manager_.ready_queue_.empty()) {
+            release_meta_buffer(memory_manager_.ready_queue_.front().dev_buffer_ptr);
+            memory_manager_.ready_queue_.pop();
         }
     }
-    arena_headers_dev_.clear();
 
-    // Free per-thread DumpBuffers
-    for (auto *ptr : dump_buffers_dev_) {
-        if (ptr != nullptr && free_cb_ != nullptr) {
-            free_cb_(ptr);
+    // Free buffers held by memory manager (done_queue + recycled pool)
+    {
+        std::lock_guard<std::mutex> lock(memory_manager_.done_mutex_);
+        while (!memory_manager_.done_queue_.empty()) {
+            void *ptr = memory_manager_.done_queue_.front();
+            memory_manager_.done_queue_.pop();
+            release_meta_buffer(ptr);
         }
     }
-    dump_buffers_dev_.clear();
-
-    // Free setup header
-    if (setup_header_dev_ != nullptr && free_cb_ != nullptr) {
-        free_cb_(setup_header_dev_);
+    for (void *ptr : memory_manager_.recycled_dump_buffers_) {
+        release_meta_buffer(ptr);
     }
-    setup_header_dev_ = nullptr;
+    memory_manager_.recycled_dump_buffers_.clear();
+    memory_manager_.dev_to_host_.clear();
 
-    collected_.clear();
+    // Free arenas (device + host shadow)
+    for (auto &ai : arenas_) {
+        if (ai.dev_ptr) {
+            if (register_cb_ == nullptr && ai.host_ptr != nullptr && ai.host_ptr != ai.dev_ptr) {
+                std::free(ai.host_ptr);
+            }
+            if (free_cb) {
+                free_cb(ai.dev_ptr);
+            }
+            ai.dev_ptr = nullptr;
+            ai.host_ptr = nullptr;
+        }
+    }
+    arenas_.clear();
+
+    // Free shared memory (device + host shadow)
+    if (dump_shared_mem_dev_) {
+        if (register_cb_ == nullptr && dump_shared_mem_host_ != nullptr &&
+            dump_shared_mem_host_ != dump_shared_mem_dev_) {
+            std::free(dump_shared_mem_host_);
+        }
+        if (free_cb) {
+            free_cb(dump_shared_mem_dev_);
+        }
+        dump_shared_mem_dev_ = nullptr;
+        dump_shared_mem_host_ = nullptr;
+    }
+
+    // Reset state
     num_dump_threads_ = 0;
-    device_id_ = -1;
+    execution_complete_.store(false);
+    collected_.clear();
+    processed_buffers_.clear();
+    total_dropped_record_count_ = 0;
+    total_truncated_count_ = 0;
+    total_overwrite_count_ = 0;
 
-    LOG_INFO_V0("TensorDumpCollector finalized");
     return 0;
 }

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -1089,6 +1089,19 @@ int AicpuExecutor::run(Runtime *runtime) {
     int completed = resolve_and_dispatch(*runtime, thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
 
+    // Flush performance buffers for cores managed by this thread.
+    if (is_l2_swimlane_enabled()) {
+        l2_perf_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
+    }
+#if PTO2_PROFILING
+    if (is_pmu_enabled()) {
+        pmu_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
+    }
+    if (is_dump_tensor_enabled()) {
+        dump_tensor_flush(thread_idx);
+    }
+#endif
+
 #if PTO2_PROFILING
     // Restore PMU CTRL registers for this thread's cores before AICore shutdown
     if (is_pmu_enabled()) {
@@ -1100,12 +1113,6 @@ int AicpuExecutor::run(Runtime *runtime) {
     if (rc != 0) {
         return rc;
     }
-
-#if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_flush(thread_idx);
-    }
-#endif
 
     LOG_INFO_V0("Thread %d: Completed", thread_idx);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -750,6 +750,13 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
 void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
 ) {
+#if PTO2_PROFILING
+    if (is_l2_swimlane_enabled()) {
+        // Flush orchestrator's phase record buffer
+        l2_perf_aicpu_flush_phase_buffers(thread_idx);
+    }
+#endif
+
     total_tasks_ = total_tasks;
 
     // Fold tasks completed inline during orchestration

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -160,6 +160,15 @@ void SchedulerContext::dispatch_subtask_to_core(
 #endif
         tracker.change_core_state(core_offset);
     }
+#if PTO2_PROFILING
+    if (l2_perf.l2_perf_enabled) {
+        if (core_exec_state.dispatch_count >= PLATFORM_PROF_BUFFER_SIZE) {
+            l2_perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
+            core_exec_state.dispatch_count = 0;
+        }
+        core_exec_state.dispatch_count++;
+    }
+#endif
 
     write_reg(core_exec_state.reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
     tracker.set_pending_occupied(core_offset);
@@ -334,7 +343,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
         if (is_l2_swimlane_enabled()) {
             l2_perf_aicpu_init_profiling(runtime);
-            l2_perf_aicpu_init_phase_profiling(sched_thread_num_);
+            l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
             l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
@@ -598,8 +607,23 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 
 #if PTO2_PROFILING
+    if (l2_perf.l2_perf_enabled) {
+        l2_perf_aicpu_flush_buffers(
+            thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
+        );
+        l2_perf_aicpu_flush_phase_buffers(thread_idx);
+    }
+#endif
+#if PTO2_PROFILING
     if (is_dump_tensor_enabled()) {
         dump_tensor_flush(thread_idx);
+    }
+#endif
+#if PTO2_PROFILING
+    if (is_pmu_enabled()) {
+        pmu_aicpu_flush_buffers(
+            thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
+        );
     }
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -81,9 +81,10 @@ struct alignas(64) CoreExecState {
     uint8_t pad0_[2];                       // offset 38: alignment padding
 #if PTO2_PROFILING
     // --- Profiling fields (dispatch path, compile-time gated) ---
-    uint64_t running_dispatch_timestamp;  // offset 40: AICPU dispatch timestamp for running task
-    uint64_t pending_dispatch_timestamp;  // offset 48: AICPU dispatch timestamp for pending task
-    uint8_t pad1_[8];                     // offset 56: pad to 64 bytes
+    uint32_t dispatch_count;              // offset 40: dispatched task count (buffer mgmt)
+    uint32_t pad1_;                       // offset 44: alignment padding for timestamp
+    uint64_t running_dispatch_timestamp;  // offset 48: AICPU dispatch timestamp for running task
+    uint64_t pending_dispatch_timestamp;  // offset 56: AICPU dispatch timestamp for pending task
 #else
     // --- Cold fields (init/diagnostics only, never in hot path) ---
     int32_t worker_id;          // offset 40: index in runtime.workers[]


### PR DESCRIPTION
Rework the three a5 profiling subsystems (PMU, L2 perf swimlane,
tensor dump) .  The main themes are
streaming-buffer unification, non-SVM memory transport, and comment /
style alignment with a2a3.

PMU profiling:
- Restructure PmuCollector into init / poll_and_collect /
  drain_remaining_buffers / finalize lifecycle matching a2a3
- Add host shadow buffers and rtMemcpy-based transport (a5 has no
  halHostRegister / SVM)
- Introduce PmuFreeQueue SPSC protocol for buffer recycling
- Add cross-check of collected + dropped == device_total on drain

L2 perf swimlane:
- Port ProfMemoryManager (dynamic buffer management thread) to a5
  with platform copy hooks instead of SVM direct access
- Add PhaseBuffer streaming for AICPU scheduler / orchestrator phases
- Add proactive free_queue replenishment and alloc-fallback in
  mgmt_loop
- Export version-2 swimlane JSON with phase and orch_summary sections

Tensor dump:
- Rework DumpCollector with streaming buffer architecture (free_queue /
  ready_queue) matching the L2 perf and PMU patterns
- Add per-thread ready queues and memory manager thread
- Add host shadow transport via dump_platform_copy_to/from_device

Shared / platform:
- Extend platform_config.h with profiling buffer size constants
- Add profiling flag bitmask (PMU, L2_SWIMLANE, DUMP_TENSOR) to
  Handshake and DeviceRunner
- Wire all three collectors into device_runner.cpp run() / finalize()
  lifecycle with RAII scope guards