### PR TITLE
Refactor: align deferred notification API

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -24,7 +24,7 @@
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     uint64_t notify_counter_addr = static_cast<uint64_t>(args[1]);
     uint32_t expected_value = static_cast<uint32_t>(args[2]);
-    PTO2AsyncCtx ctx = pto2_async_ctx(args);
-    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(notify_counter_addr), expected_value);
-    pto2_defer_flush(ctx);
+    pto2_save_expected_notification_counter(
+        args, reinterpret_cast<volatile __gm__ void *>(notify_counter_addr), expected_value
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -19,10 +19,9 @@
 #endif
 
 #include <pto/pto-inst.hpp>
-#include <pto/comm/comm_types.hpp>
-#include <pto/comm/pto_comm_inst.hpp>
 
 #include "platform_comm/comm_context.h"
+#include "pto_async_kernel_api.h"
 #include "tensor.h"
 
 using namespace pto;
@@ -75,7 +74,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
 
     __gm__ int32_t *remote_counter = comm_remote_ptr(comm_ctx, local_counter, peer_rank);
-    pto::comm::Signal remote_signal(remote_counter);
-    pto::comm::TNOTIFY(remote_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    pto2_send_notification(remote_counter, 1, pto::comm::NotifyOp::AtomicAdd);
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""TNOTIFY + deferred completion smoke test for onboard a2a3."""
+"""Notification counter + deferred completion smoke test for onboard a2a3."""
 
 from __future__ import annotations
 

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -25,7 +25,7 @@
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     uint64_t counter_addr = static_cast<uint64_t>(args[1]);
     uint32_t expected_value = static_cast<uint32_t>(args[2]);
-    PTO2AsyncCtx ctx = pto2_async_ctx(args);
-    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(counter_addr), expected_value);
-    pto2_defer_flush(ctx);
+    pto2_save_expected_notification_counter(
+        args, reinterpret_cast<volatile __gm__ void *>(counter_addr), expected_value
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -12,8 +12,6 @@
 #include <cstdint>
 
 #include <pto/pto-inst.hpp>
-#include <pto/comm/comm_types.hpp>
-#include <pto/comm/pto_comm_inst.hpp>
 
 #ifndef __gm__
 #define __gm__
@@ -23,6 +21,7 @@
 #endif
 
 #include "platform_comm/comm_context.h"
+#include "pto_async_kernel_api.h"
 #include "tensor.h"
 
 template <typename T>
@@ -60,6 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 #endif
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
-    pto::comm::Signal peer_signal(peer_counter);
-    pto::comm::TNOTIFY(peer_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    pto2_send_notification(peer_counter, 1, pto::comm::NotifyOp::AtomicAdd);
 }

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -24,7 +24,7 @@
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     uint64_t notify_counter_addr = static_cast<uint64_t>(args[1]);
     uint32_t expected_value = static_cast<uint32_t>(args[2]);
-    PTO2AsyncCtx ctx = pto2_async_ctx(args);
-    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(notify_counter_addr), expected_value);
-    pto2_defer_flush(ctx);
+    pto2_save_expected_notification_counter(
+        args, reinterpret_cast<volatile __gm__ void *>(notify_counter_addr), expected_value
+    );
 }

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -19,10 +19,9 @@
 #endif
 
 #include <pto/pto-inst.hpp>
-#include <pto/comm/comm_types.hpp>
-#include <pto/comm/pto_comm_inst.hpp>
 
 #include "platform_comm/comm_context.h"
+#include "pto_async_kernel_api.h"
 #include "tensor.h"
 
 using namespace pto;
@@ -75,7 +74,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
 
     __gm__ int32_t *remote_counter = comm_remote_ptr(comm_ctx, local_counter, peer_rank);
-    pto::comm::Signal remote_signal(remote_counter);
-    pto::comm::TNOTIFY(remote_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    pto2_send_notification(remote_counter, 1, pto::comm::NotifyOp::AtomicAdd);
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""TNOTIFY + deferred completion smoke test for onboard a5."""
+"""Notification counter + deferred completion smoke test for onboard a5."""
 
 from __future__ import annotations
 

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_notify_wait.cpp
@@ -25,7 +25,7 @@
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     uint64_t counter_addr = static_cast<uint64_t>(args[1]);
     uint32_t expected_value = static_cast<uint32_t>(args[2]);
-    PTO2AsyncCtx ctx = pto2_async_ctx(args);
-    pto2_defer_counter(ctx, reinterpret_cast<volatile __gm__ void *>(counter_addr), expected_value);
-    pto2_defer_flush(ctx);
+    pto2_save_expected_notification_counter(
+        args, reinterpret_cast<volatile __gm__ void *>(counter_addr), expected_value
+    );
 }

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -12,8 +12,6 @@
 #include <cstdint>
 
 #include <pto/pto-inst.hpp>
-#include <pto/comm/comm_types.hpp>
-#include <pto/comm/pto_comm_inst.hpp>
 
 #ifndef __gm__
 #define __gm__
@@ -23,6 +21,7 @@
 #endif
 
 #include "platform_comm/comm_context.h"
+#include "pto_async_kernel_api.h"
 #include "tensor.h"
 
 template <typename T>
@@ -60,6 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 #endif
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
-    pto::comm::Signal peer_signal(peer_counter);
-    pto::comm::TNOTIFY(peer_signal, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    pto2_send_notification(peer_counter, 1, pto::comm::NotifyOp::AtomicAdd);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -14,6 +14,9 @@
 
 #include <stdint.h>
 
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
+
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
 #include "pto_runtime_status.h"
@@ -41,10 +44,10 @@ inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
     return ctx;
 }
 
-inline __aicore__ bool pto2_async_ctx_is_deferred(const PTO2AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
-
-inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
-    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) {
+inline __aicore__ void pto2_defer_condition(
+    PTO2AsyncCtx &ctx, volatile __gm__ void *addr, uint32_t expected, uint32_t engine, int32_t completion_type
+) {
+    if (ctx.task_token.is_invalid() || ctx.ingress == nullptr) {
         return;
     }
 
@@ -55,16 +58,16 @@ inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ voi
     }
 
     volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.ingress->entries[idx];
-    slot->addr = reinterpret_cast<uint64_t>(counter_addr);
+    slot->addr = reinterpret_cast<uint64_t>(addr);
     slot->expected_value = expected;
-    slot->engine = PTO2_COMPLETION_ENGINE_SDMA;
-    slot->completion_type = PTO2_COMPLETION_TYPE_COUNTER;
+    slot->engine = engine;
+    slot->completion_type = completion_type;
     slot->_pad = 0;
     ctx.ingress->count = idx + 1;
 }
 
 inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
-    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) return;
+    if (ctx.task_token.is_invalid() || ctx.ingress == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
     dcci((__gm__ int32_t *)ctx.ingress->entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     dcci((__gm__ int32_t *)ctx.ingress, SINGLE_CACHE_LINE, CACHELINE_OUT);
@@ -78,6 +81,21 @@ inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
     (void)ctx;
     __asm__ __volatile__("" ::: "memory");
 #endif
+}
+
+inline __aicore__ void
+pto2_send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
+    __gm__ int32_t *counter = reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ void *>(remote_counter_addr));
+    pto::comm::Signal signal(counter);
+    pto::comm::TNOTIFY(signal, value, notify_op);
+}
+
+inline __aicore__ void pto2_save_expected_notification_counter(
+    __gm__ int64_t *args, volatile __gm__ void *counter_addr, uint32_t expected_value
+) {
+    PTO2AsyncCtx ctx = pto2_async_ctx(args);
+    pto2_defer_condition(ctx, counter_addr, expected_value, PTO2_COMPLETION_ENGINE_SDMA, PTO2_COMPLETION_TYPE_COUNTER);
+    pto2_defer_flush(ctx);
 }
 
 #endif  // PTO_ASYNC_KERNEL_API_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
@@ -42,6 +42,7 @@ struct PTO2TaskId {
     constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
     constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
     constexpr bool is_valid() const { return raw != UINT64_MAX; }
+    constexpr bool is_invalid() const { return raw == UINT64_MAX; }
 
     constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
     constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -14,6 +14,9 @@
 
 #include <stdint.h>
 
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
+
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
 #include "pto_runtime_status.h"
@@ -41,10 +44,10 @@ inline __aicore__ PTO2AsyncCtx pto2_async_ctx(__gm__ int64_t *args) {
     return ctx;
 }
 
-inline __aicore__ bool pto2_async_ctx_is_deferred(const PTO2AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
-
-inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
-    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) {
+inline __aicore__ void pto2_defer_condition(
+    PTO2AsyncCtx &ctx, volatile __gm__ void *addr, uint32_t expected, uint32_t engine, int32_t completion_type
+) {
+    if (ctx.task_token.is_invalid() || ctx.ingress == nullptr) {
         return;
     }
 
@@ -55,16 +58,16 @@ inline __aicore__ void pto2_defer_counter(PTO2AsyncCtx &ctx, volatile __gm__ voi
     }
 
     volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.ingress->entries[idx];
-    slot->addr = reinterpret_cast<uint64_t>(counter_addr);
+    slot->addr = reinterpret_cast<uint64_t>(addr);
     slot->expected_value = expected;
-    slot->engine = PTO2_COMPLETION_ENGINE_SDMA;
-    slot->completion_type = PTO2_COMPLETION_TYPE_COUNTER;
+    slot->engine = engine;
+    slot->completion_type = completion_type;
     slot->_pad = 0;
     ctx.ingress->count = idx + 1;
 }
 
 inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
-    if (!ctx.task_token.is_valid() || ctx.ingress == nullptr) return;
+    if (ctx.task_token.is_invalid() || ctx.ingress == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
     dcci((__gm__ int32_t *)ctx.ingress->entries, ENTIRE_DATA_CACHE, CACHELINE_OUT);
     dcci((__gm__ int32_t *)ctx.ingress, SINGLE_CACHE_LINE, CACHELINE_OUT);
@@ -78,6 +81,21 @@ inline __aicore__ void pto2_defer_flush(PTO2AsyncCtx &ctx) {
     (void)ctx;
     __asm__ __volatile__("" ::: "memory");
 #endif
+}
+
+inline __aicore__ void
+pto2_send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
+    __gm__ int32_t *counter = reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ void *>(remote_counter_addr));
+    pto::comm::Signal signal(counter);
+    pto::comm::TNOTIFY(signal, value, notify_op);
+}
+
+inline __aicore__ void pto2_save_expected_notification_counter(
+    __gm__ int64_t *args, volatile __gm__ void *counter_addr, uint32_t expected_value
+) {
+    PTO2AsyncCtx ctx = pto2_async_ctx(args);
+    pto2_defer_condition(ctx, counter_addr, expected_value, PTO2_COMPLETION_ENGINE_SDMA, PTO2_COMPLETION_TYPE_COUNTER);
+    pto2_defer_flush(ctx);
 }
 
 #endif  // PTO_ASYNC_KERNEL_API_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_task_id.h
@@ -42,6 +42,7 @@ struct PTO2TaskId {
     constexpr uint8_t ring() const { return static_cast<uint8_t>(raw >> 32); }
     constexpr uint32_t local() const { return static_cast<uint32_t>(raw & 0xFFFFFFFFu); }
     constexpr bool is_valid() const { return raw != UINT64_MAX; }
+    constexpr bool is_invalid() const { return raw == UINT64_MAX; }
 
     constexpr bool operator==(const PTO2TaskId &other) const { return raw == other.raw; }
     constexpr bool operator!=(const PTO2TaskId &other) const { return raw != other.raw; }


### PR DESCRIPTION
- Add notification-counter wrappers for a2a3 and a5 runtimes
- Route notify demo producer and wait kernels through the wrappers
- Keep task binding implicit through the runtime async context