### PR TITLE
Update: drop small manual-scope benchmark entry

### DIFF
--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -30,7 +30,6 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 declare -A TMR_EXAMPLE_CASES=(
     [alternating_matmul_add]="Case1"
     [benchmark_bgemm]="Case0"
-    [paged_attention_manual_scope]="Case1,Case2"
     [paged_attention_unroll]="Case1,Case2"
     [paged_attention_unroll_manual_scope]="Case1,Case2"
     [batch_paged_attention]="Case1"
@@ -39,7 +38,6 @@ declare -A TMR_EXAMPLE_CASES=(
 TMR_EXAMPLE_ORDER=(
     alternating_matmul_add
     benchmark_bgemm
-    paged_attention_manual_scope
     paged_attention_unroll
     paged_attention_unroll_manual_scope
     batch_paged_attention


### PR DESCRIPTION
## Benchmark Results

- Date: `2026-04-28T14:52:38+08:00`
- Platform: `a2a3`
- Runtime: `tensormap_and_ringbuffer`
- Command: `bash tools/benchmark_rounds.sh -p a2a3 -d 0 -r tensormap_and_ringbuffer -v`

| Example | Avg Elapsed (us) | Avg Sched (us) | Avg Orch (us) | Trimmed Elapsed (us) | Trimmed Sched (us) | Trimmed Orch (us) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `alternating_matmul_add (Case1)` | 789.4 | 789.4 | 788.4 | 787.5 | 787.4 | 786.6 |
| `benchmark_bgemm (Case0)` | 598.6 | 598.6 | 549.2 | 598.2 | 598.2 | 548.7 |
| `paged_attention_unroll (Case1)` | 1137.7 | 1137.7 | 721.6 | 1137.1 | 1137.1 | 720.4 |
| `paged_attention_unroll (Case2)` | 507.8 | 507.7 | 273.2 | 507.9 | 507.8 | 273.0 |
| `paged_attention_unroll_manual_scope (Case1)` | 1131.2 | 1131.2 | 621.0 | 1130.9 | 1130.8 | 618.3 |
| `paged_attention_unroll_manual_scope (Case2)` | 492.1 | 492.1 | 229.8 | 489.6 | 489.6 | 227.3 |
| `batch_paged_attention (Case1)` | 2752.6 | 2752.5 | 2005.5 | 2741.9 | 2741.9 | 2003.6 |
| `spmd_paged_attention (Case1)` | 1507.0 | 1507.0 | 6.6 | 1483.2 | 1483.2 | 6.3 |
| `spmd_paged_attention (Case2)` | 744.9 | 744.9 | 5.9 | 740.1 | 740.1 | 5.3 |