### PR TITLE
Refactor: remove pto2_ prefix and modernize tensormap_and_ringbuffer C++ API

### DIFF
--- a/docs/manual-scope.md
+++ b/docs/manual-scope.md
@@ -36,9 +36,9 @@ PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
 Manual mode still uses the normal submit calls:
 
 ```cpp
-auto out = pto2_rt_submit_aic_task(FUNC_ID, args);
-auto out = pto2_rt_submit_aiv_task(FUNC_ID, args);
-auto out = pto2_rt_submit_task(mixed_kernels, args);
+auto out = rt_submit_aic_task(FUNC_ID, args);
+auto out = rt_submit_aiv_task(FUNC_ID, args);
+auto out = rt_submit_task(mixed_kernels, args);
 ```
 
 ### Explicit deps
@@ -89,8 +89,8 @@ The runtime keeps two manual-scope-specific pieces of state:
 
 `manual_begin_depth` decides whether the current submit is in manual mode.
 `scope_tasks[...]` remains scope-lifetime bookkeeping for `scope_end()`.
-`manual_begin_depth` is explicitly initialized in `pto2_orchestrator_init()` and
-reset in `pto2_orchestrator_done()` so a reused orchestrator starts cleanly on
+`manual_begin_depth` is explicitly initialized in `PTO2OrchestratorState::init()` and
+reset in `mark_done()` so a reused orchestrator starts cleanly on
 the next run.
 
 The depth model treats `manual_begin_depth` as the depth where the outermost
@@ -129,20 +129,20 @@ PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
     qk.add_input(qi, kj);
     qk.add_output(sij_ci);
     qk.add_dep(alloc.task_id());
-    auto qk_out = pto2_rt_submit_aic_task(FUNC_QK, qk);
+    auto qk_out = rt_submit_aic_task(FUNC_QK, qk);
 
     Arg sf;
     sf.add_input(qk_out.get_ref(0));
     sf.add_output(pij_ci, li_ci, mi_ci);
     sf.add_dep(qk_out.task_id());
-    auto sf_out = pto2_rt_submit_aiv_task(FUNC_SF, sf);
+    auto sf_out = rt_submit_aiv_task(FUNC_SF, sf);
 
     Arg up;
     up.add_input(sf_out.get_ref(1), sf_out.get_ref(2), pv_out.get_ref(0));
     up.add_inout(mi, li, out_view, tmp);
     up.add_dep(sf_out.task_id());
     up.add_dep(pv_out.task_id());
-    auto up_out = pto2_rt_submit_aiv_task(FUNC_UP, up);
+    auto up_out = rt_submit_aiv_task(FUNC_UP, up);
 }
 ```
 
@@ -155,7 +155,7 @@ for (...) {
     if (prev_update.is_valid()) {
         up.add_dep(prev_update);
     }
-    prev_update = pto2_rt_submit_aiv_task(FUNC_UP, up).task_id();
+    prev_update = rt_submit_aiv_task(FUNC_UP, up).task_id();
 }
 ```
 

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -44,7 +44,7 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_producer.add_output(output);
     params_producer.add_scalar(notify_counter.buffer.addr);
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
-    pto2_rt_submit_aiv_task(0, params_producer);
+    rt_submit_aiv_task(0, params_producer);
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
@@ -52,7 +52,7 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
-    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    TaskOutputTensors notify_outputs = rt_submit_aiv_task_deferred(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
@@ -60,7 +60,7 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_consumer.add_input(output);
     params_consumer.add_output(result);
     params_consumer.add_scalar(notify_counter.buffer.addr);
-    pto2_rt_submit_aiv_task(1, params_consumer);
+    rt_submit_aiv_task(1, params_consumer);
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -100,14 +100,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_gemm.add_input(B_view);
             params_gemm.add_output(group_ci);
             params_gemm.add_input(ext_config);
-            TaskOutputTensors gemm_outs = pto2_rt_submit_aic_task(FUNC_GEMM_TILE, params_gemm);
+            TaskOutputTensors gemm_outs = rt_submit_aic_task(FUNC_GEMM_TILE, params_gemm);
             total_gemm++;
 
             Arg params_add;
             params_add.add_inout(C_view);
             params_add.add_input(gemm_outs.get_ref(0));
             params_add.add_input(ext_config);
-            pto2_rt_submit_aiv_task(FUNC_TILE_ADD, params_add);
+            rt_submit_aiv_task(FUNC_TILE_ADD, params_add);
             total_add++;
         }
     }

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -47,7 +47,7 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_producer.add_output(producer_output_info);
     params_producer.add_scalar(notify_counter.buffer.addr);
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
-    pto2_rt_submit_aiv_task(0, params_producer);
+    rt_submit_aiv_task(0, params_producer);
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
@@ -55,7 +55,7 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
-    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    TaskOutputTensors notify_outputs = rt_submit_aiv_task_deferred(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
@@ -63,7 +63,7 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_consumer.add_input(mailbox);
     params_consumer.add_output(result);
     params_consumer.add_scalar(notify_counter.buffer.addr);
-    pto2_rt_submit_aiv_task(1, params_consumer);
+    rt_submit_aiv_task(1, params_consumer);
 }
 
 }  // extern "C"

--- a/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -52,30 +52,30 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
    ```
 
 5. Submit tasks with one of:
-   - `pto2_rt_submit_aic_task(kernel_id, args)` — AIC (CUBE) task
-   - `pto2_rt_submit_aiv_task(kernel_id, args)` — AIV (VECTOR) task
-   - `pto2_rt_submit_task(mixed_kernels, args)` — mixed task with a `MixedKernels` struct
+   - `rt_submit_aic_task(kernel_id, args)` — AIC (CUBE) task
+   - `rt_submit_aiv_task(kernel_id, args)` — AIV (VECTOR) task
+   - `rt_submit_task(mixed_kernels, args)` — mixed task with a `MixedKernels` struct
 
 Dependencies are inferred by TensorMap from input/inout/output tensors, so you do not add explicit edges.
 
 ## Submit API And Kernel IDs
 
 - Submit helpers are defined in `pto_orchestration_api.h`.
-- `pto2_rt_submit_aic_task` and `pto2_rt_submit_aiv_task` are convenience wrappers around `pto2_rt_submit_task` with a `MixedKernels` struct.
+- `rt_submit_aic_task` and `rt_submit_aiv_task` are convenience wrappers around `rt_submit_task` with a `MixedKernels` struct.
 - For mixed AIC+AIV tasks, construct a `MixedKernels` struct directly:
 
   ```cpp
   MixedKernels mk;
   mk.aic_kernel_id = FUNC_QK;
   mk.aiv0_kernel_id = FUNC_SF;
-  pto2_rt_submit_task(mk, args);
+  rt_submit_task(mk, args);
   ```
 
 - Kernel `func_id` values are defined in `kernels/kernel_config.py` under `KERNELS`.
 
 ## Completion Semantics
 
-Do not call `pto2_rt_orchestration_done` yourself in device mode. The executor wraps the entry call in an outer scope and signals completion after `aicpu_orchestration_entry` returns.
+Do not call `rt_orchestration_done` yourself in device mode. The executor wraps the entry call in an outer scope and signals completion after `aicpu_orchestration_entry` returns.
 
 ## Examples
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -193,7 +193,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij = qk_outs.get_ref(0);
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -211,7 +211,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -223,7 +223,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -243,7 +243,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
                 }

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -189,7 +189,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij = qk_outs.get_ref(0);
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -208,7 +208,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_dep(qk_outs.task_id());
                     params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -221,7 +221,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_output(tile2d_ci);
                     params_pv.add_dep(sf_outs.task_id());
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -252,7 +252,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors up_outs = pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    TaskOutputTensors up_outs = rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     prev_update_task = up_outs.task_id();
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -212,7 +212,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_qk.add_scalar(n_blocks);
                     params_qk.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -239,7 +239,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_scalar(n_blocks);
                     params_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_buf = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -258,7 +258,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -290,7 +290,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors update_outs = pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    TaskOutputTensors update_outs = rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     pre_task_id = update_outs.task_id();
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -68,7 +68,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     params_c.add_input(ext_a);
     params_c.add_input(ext_b);
     params_c.add_output(inter_ci);
-    TaskOutputTensors c_outs = pto2_rt_submit_aiv_task(FUNC_ADD, params_c);
+    TaskOutputTensors c_outs = rt_submit_aiv_task(FUNC_ADD, params_c);
     const Tensor &c = c_outs.get_ref(0);
 
     // =========================================================
@@ -121,7 +121,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     {
         Arg args;
         args.add_inout(scalar_tensor);
-        pto2_rt_submit_aiv_task(FUNC_NOOP, args);
+        rt_submit_aiv_task(FUNC_NOOP, args);
     }
 
     // =========================================================
@@ -174,7 +174,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     params_e.add_input(d);
     params_e.add_input(ext_a);
     params_e.add_output(inter_ci);
-    TaskOutputTensors e_outs = pto2_rt_submit_aiv_task(FUNC_ADD, params_e);
+    TaskOutputTensors e_outs = rt_submit_aiv_task(FUNC_ADD, params_e);
     const Tensor &e = e_outs.get_ref(0);
 
     float e0_val = get_tensor_data<float>(e, 1, idx);
@@ -203,7 +203,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         args.add_input(c);
         args.add_input(ext_b);
         args.add_output(inter_ci);
-        (void)pto2_rt_submit_aiv_task(FUNC_ADD, args);  // NOLINT(readability/casting)
+        (void)rt_submit_aiv_task(FUNC_ADD, args);  // NOLINT(readability/casting)
     }
 
     // set_tensor_data auto-waits for producer + consumer before writing
@@ -233,7 +233,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     {
         Arg args;
         args.add_output(ext_b);  // write-only: creates TensorMap entry (not add_input!)
-        pto2_rt_submit_aiv_task(FUNC_NOOP, args);
+        rt_submit_aiv_task(FUNC_NOOP, args);
     }
 
     idx[0] = 0;
@@ -257,7 +257,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         args.add_input(ext_a);
         args.add_input(ext_b);
         args.add_output(ext_result);
-        pto2_rt_submit_aiv_task(FUNC_ADD, args);
+        rt_submit_aiv_task(FUNC_ADD, args);
     }
 
     LOG_INFO("scalar_data_test: orchestration complete");

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -69,7 +69,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(inter_ci);
-    TaskOutputTensors outs_t0 = pto2_rt_submit_aiv_task(0, params_t0);  // kernel_add
+    TaskOutputTensors outs_t0 = rt_submit_aiv_task(0, params_t0);  // kernel_add
     const Tensor &c = outs_t0.get_ref(0);
 
     // Inner scope: owns t1, t2, t3, t4; intermediates d, e, g release on scope end.
@@ -81,7 +81,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t1.add_output(inter_ci);
         params_t1.add_scalar(1.0f);
         params_t1.add_scalar(3u);
-        TaskOutputTensors outs_t1 = pto2_rt_submit_aiv_task(1, params_t1);  // kernel_add_scalar
+        TaskOutputTensors outs_t1 = rt_submit_aiv_task(1, params_t1);  // kernel_add_scalar
         const Tensor &d = outs_t1.get_ref(0);
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t2.add_output(inter_ci);
         params_t2.add_scalar(2.0f);
         params_t2.add_scalar(3u);
-        TaskOutputTensors outs_t2 = pto2_rt_submit_aiv_task(1, params_t2);  // kernel_add_scalar
+        TaskOutputTensors outs_t2 = rt_submit_aiv_task(1, params_t2);  // kernel_add_scalar
         const Tensor &e = outs_t2.get_ref(0);
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
@@ -99,7 +99,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t3.add_input(e);
         params_t3.add_output(inter_ci);
         params_t3.add_scalar(3u);
-        TaskOutputTensors outs_t3 = pto2_rt_submit_aiv_task(2, params_t3);  // kernel_mul
+        TaskOutputTensors outs_t3 = rt_submit_aiv_task(2, params_t3);  // kernel_mul
         const Tensor &g = outs_t3.get_ref(0);
 
         // t4: f = g + c (kernel_id=0, kernel_add)
@@ -107,7 +107,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);
-        pto2_rt_submit_aiv_task(0, params_t4);  // kernel_add
+        rt_submit_aiv_task(0, params_t4);  // kernel_add
     }  // inner scope ends: releases d, e, g
 }
 

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -44,7 +44,7 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_producer.add_output(output);
     params_producer.add_scalar(notify_counter.buffer.addr);
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
-    pto2_rt_submit_aiv_task(0, params_producer);
+    rt_submit_aiv_task(0, params_producer);
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
@@ -52,7 +52,7 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
-    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    TaskOutputTensors notify_outputs = rt_submit_aiv_task_deferred(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
@@ -60,7 +60,7 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
     params_consumer.add_input(output);
     params_consumer.add_output(result);
     params_consumer.add_scalar(notify_counter.buffer.addr);
-    pto2_rt_submit_aiv_task(1, params_consumer);
+    rt_submit_aiv_task(1, params_consumer);
 }
 
 }  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -106,7 +106,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         mk.aic_kernel_id = FUNC_GEMM_TILE;
                         mk.aiv0_kernel_id = FUNC_TILE_ADD;
                         mk.aiv1_kernel_id = FUNC_TILE_ADD;
-                        pto2_rt_submit_task(mk, args);
+                        rt_submit_task(mk, args);
                     }
                 }
             }

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -47,7 +47,7 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_producer.add_output(producer_output_info);
     params_producer.add_scalar(notify_counter.buffer.addr);
     params_producer.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
-    pto2_rt_submit_aiv_task(0, params_producer);
+    rt_submit_aiv_task(0, params_producer);
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
@@ -55,7 +55,7 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
-    TaskOutputTensors notify_outputs = pto2_rt_submit_aiv_task_deferred(2, params_notify);
+    TaskOutputTensors notify_outputs = rt_submit_aiv_task_deferred(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
     Arg params_consumer;
@@ -63,7 +63,7 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
     params_consumer.add_input(mailbox);
     params_consumer.add_output(result);
     params_consumer.add_scalar(notify_counter.buffer.addr);
-    pto2_rt_submit_aiv_task(1, params_consumer);
+    rt_submit_aiv_task(1, params_consumer);
 }
 
 }  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -188,7 +188,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij = qk_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -206,7 +206,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -218,7 +218,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -238,7 +238,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
                 }

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -188,7 +188,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij = qk_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -207,7 +207,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_scalar(scale_value);
                     params_sf.add_dep(qk_outs.task_id());
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -220,7 +220,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_output(tile2d_ci);
                     params_pv.add_dep(sf_outs.task_id());
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -250,7 +250,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors up_outs = pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    TaskOutputTensors up_outs = rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     prev_update_task = up_outs.task_id();
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -205,7 +205,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_qk.add_scalar(n_blocks);
                     params_qk.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -231,7 +231,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_scalar(n_blocks);
                     params_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_buf = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -249,7 +249,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -280,7 +280,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors update_outs = pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    TaskOutputTensors update_outs = rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     prev_update_task = update_outs.task_id();
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;

--- a/examples/workers/l2/vector_add/README.md
+++ b/examples/workers/l2/vector_add/README.md
@@ -25,7 +25,7 @@ vector_add/
 The kernel source is a verbatim copy of
 `examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/aiv/kernel_add.cpp`.
 The orchestration is intentionally simpler than the `vector_example` one — it
-calls `pto2_rt_submit_aiv_task` exactly once and has no nested scopes.
+calls `rt_submit_aiv_task` exactly once and has no nested scopes.
 
 ## The six steps in `main.py`
 
@@ -72,7 +72,7 @@ chip_callable = ChipCallable.build(
 
 `func_name` must match the `__attribute__((visibility("default")))` symbol in
 the orchestration `.cpp`. The `children` list maps `func_id` integers used in
-`pto2_rt_submit_aiv_task(func_id, ...)` to the corresponding `CoreCallable`.
+`rt_submit_aiv_task(func_id, ...)` to the corresponding `CoreCallable`.
 In our orch `func_id=0` is the only value, so one child.
 
 ### 4. Allocate device memory, push inputs

--- a/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
@@ -41,7 +41,7 @@ __attribute__((visibility("default"))) void vector_add_orchestration(const ChipS
     params.add_input(a);
     params.add_input(b);
     params.add_output(out);
-    pto2_rt_submit_aiv_task(0, params);  // func_id=0 -> vector_add_kernel
+    rt_submit_aiv_task(0, params);  // func_id=0 -> vector_add_kernel
 }
 
 }  // extern "C"

--- a/examples/workers/l2/vector_add/main.py
+++ b/examples/workers/l2/vector_add/main.py
@@ -109,7 +109,7 @@ def build_chip_callable(platform: str) -> ChipCallable:
 
     # 3. Wrap the kernel bytes as a CoreCallable with its tensor-arg signature
     # (a, b are inputs; out is output). ``func_id=0`` matches the first
-    # (and only) ``pto2_rt_submit_aiv_task(0, ...)`` in vector_add_orch.cpp.
+    # (and only) ``rt_submit_aiv_task(0, ...)`` in vector_add_orch.cpp.
     core_callable = CoreCallable.build(
         signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
         binary=kernel_bytes,

--- a/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_orch.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_orch.cpp
@@ -50,7 +50,7 @@ __attribute__((visibility("default"))) void allreduce_orchestration(const ChipSt
     params.add_inout(scratch);
     params.add_scalar(orch_args.scalar(0));  // nranks
     params.add_scalar(orch_args.scalar(1));  // CommContext
-    pto2_rt_submit_aiv_task(0, params);
+    rt_submit_aiv_task(0, params);
 }
 
 }  // extern "C"

--- a/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/allreduce_sum_orch.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/allreduce_sum_orch.cpp
@@ -41,7 +41,7 @@ __attribute__((visibility("default"))) void allreduce_sum_orchestration(const Ch
     params.add_inout(scratch);
     params.add_scalar(orch_args.scalar(0));  // nranks
     params.add_scalar(orch_args.scalar(1));  // CommContext
-    pto2_rt_submit_aiv_task(1, params);
+    rt_submit_aiv_task(1, params);
 }
 
 }  // extern "C"

--- a/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/ffn_local_orch.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/ffn_local_orch.cpp
@@ -37,7 +37,7 @@ __attribute__((visibility("default"))) void ffn_local_orchestration(const ChipSt
     params.add_input(x_shard);
     params.add_input(w_shard);
     params.add_output(partial_local);
-    pto2_rt_submit_aic_task(0, params);
+    rt_submit_aic_task(0, params);
 }
 
 }  // extern "C"

--- a/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
@@ -41,7 +41,7 @@ __attribute__((visibility("default"))) void vector_add_orchestration(const ChipS
     params.add_input(a);
     params.add_input(b);
     params.add_output(out);
-    pto2_rt_submit_aiv_task(0, params);  // func_id=0 -> vector_add_kernel
+    rt_submit_aiv_task(0, params);  // func_id=0 -> vector_add_kernel
 }
 
 }  // extern "C"

--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -157,7 +157,7 @@ void l2_perf_aicpu_set_orch_thread_idx(int thread_idx);
 /**
  * Record a single orchestrator phase
  *
- * Appends an AicpuPhaseRecord for one sub-step of pto2_submit_task().
+ * Appends an AicpuPhaseRecord for one sub-step of submit_task().
  * Uses the orchestrator's dedicated buffer slot (set via set_orch_thread_idx).
  *
  * @param phase_id Orchestrator phase identifier (ORCH_SYNC..ORCH_SCOPE_END)

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -240,7 +240,7 @@ struct L2PerfDataHeader {
  * AICPU phase identifier
  *
  * Scheduler phases (0-3): four phases in each scheduler loop iteration.
- * Orchestrator phases (16-24): sub-steps within each pto2_submit_task() call.
+ * Orchestrator phases (16-24): sub-steps within each submit_task() call.
  */
 enum class AicpuPhaseId : uint32_t {
     // Scheduler phases (0-3)

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -223,7 +223,7 @@ int run_runtime(
         );
         LOG_DEBUG("init_runtime_impl returned: %d", rc);
         if (rc != 0) {
-            r->set_pto2_gm_sm_ptr(nullptr);
+            r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);
             r->~Runtime();
             return rc;

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -180,7 +180,7 @@ int run_runtime(
             r, reinterpret_cast<const ChipCallable *>(callable), reinterpret_cast<const ChipStorageTaskArgs *>(args)
         );
         if (rc != 0) {
-            r->set_pto2_gm_sm_ptr(nullptr);
+            r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -1975,7 +1975,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // Signal completion and trigger core transition
-            pto2_rt_orchestration_done(rt);
+            rt_orchestration_done(rt);
 
             void *sm = runtime->get_gm_sm_ptr();
             PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);

--- a/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/aicpu/aicpu_executor.cpp
@@ -862,8 +862,8 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
 
     // Initialize runtime execution state
     // Task count comes from PTO2 shared memory
-    if (runtime->get_pto2_gm_sm_ptr()) {
-        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
+    if (runtime->get_gm_sm_ptr()) {
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
         int32_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
@@ -930,7 +930,7 @@ int32_t AicpuExecutor::resolve_and_dispatch_pto2(Runtime *runtime, int32_t threa
     CoreStateTracker &tracker = trackers_[thread_idx];
     DEV_INFO("Thread %d: resolve_and_dispatch_pto2 entry", thread_idx);
 
-    void *sm_base = runtime->get_pto2_gm_sm_ptr();
+    void *sm_base = runtime->get_gm_sm_ptr();
     if (!sm_base) {
         DEV_ERROR("PTO2 dispatch: sm_base is null");
         return -1;
@@ -1789,7 +1789,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             const ChipStorageTaskArgs &args = runtime->get_orch_args();
             int32_t arg_count = args.tensor_count() + args.scalar_count();
-            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
             for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
                 const ContinuousTensor &t = args.tensor(i);
                 DEV_INFO(
@@ -1824,23 +1824,23 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            if (runtime->pto2_task_window_size > 0) {
-                task_window_size = runtime->pto2_task_window_size;
+            if (runtime->task_window_size > 0) {
+                task_window_size = runtime->task_window_size;
             }
-            if (runtime->pto2_heap_size > 0) {
-                heap_size = runtime->pto2_heap_size;
+            if (runtime->heap_size > 0) {
+                heap_size = runtime->heap_size;
             }
             int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-            if (runtime->pto2_dep_pool_size > 0) {
-                dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
+            if (runtime->dep_pool_size > 0) {
+                dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
             }
             DEV_INFO(
                 "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
                 static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
             );
 
-            void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
-            void *gm_heap = runtime->get_pto2_gm_heap_ptr();
+            void *sm_ptr = runtime->get_gm_sm_ptr();
+            void *gm_heap = runtime->get_gm_heap_ptr();
 
             uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
             PTO2SharedMemoryHandle *sm_handle =
@@ -1870,7 +1870,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
-            runtime->set_pto2_slot_states_ptr(nullptr);
+            runtime->set_slot_states_ptr(nullptr);
 
             // Store shared state for orchestrator thread
             orch_func_ = orch_func;
@@ -1977,7 +1977,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Signal completion and trigger core transition
             pto2_rt_orchestration_done(rt);
 
-            void *sm = runtime->get_pto2_gm_sm_ptr();
+            void *sm = runtime->get_gm_sm_ptr();
             PTO2SharedMemoryHeader *sm_header = static_cast<PTO2SharedMemoryHeader *>(sm);
             int32_t pto2_task_count = 0;
             if (sm_header) {
@@ -1998,7 +1998,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             orchestrator_done_ = true;
             {
                 int32_t orch_err = 0;
-                void *sm = runtime->get_pto2_gm_sm_ptr();
+                void *sm = runtime->get_gm_sm_ptr();
                 if (sm) {
                     orch_err =
                         static_cast<PTO2SharedMemoryHeader *>(sm)->orch_error_code.load(std::memory_order_relaxed);

--- a/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/host/runtime_maker.cpp
@@ -209,27 +209,22 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
 
     // Read ring buffer size overrides from environment
     {
-        runtime->pto2_task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
-        if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
+        runtime->task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        runtime->dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
+        if (runtime->task_window_size || runtime->heap_size || runtime->dep_pool_size) {
             LOG_INFO(
                 "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
-                static_cast<uint64_t>(
-                    runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE
-                ),
-                static_cast<uint64_t>(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                static_cast<uint64_t>(
-                    runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE
-                )
+                static_cast<uint64_t>(runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE),
+                static_cast<uint64_t>(runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE),
+                static_cast<uint64_t>(runtime->dep_pool_size ? runtime->dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
             );
         }
     }
 
     // Resolve effective sizes (env override or compile-time default)
-    uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size =
-        runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+    uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
+    uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
 
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
@@ -241,7 +236,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         return -1;
     }
     runtime->record_tensor_pair(nullptr, gm_heap, total_heap_size);
-    runtime->set_pto2_gm_heap(gm_heap);
+    runtime->set_gm_heap(gm_heap);
 
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
@@ -252,7 +247,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         LOG_ERROR("Failed to allocate PTO2 shared memory");
         return -1;
     }
-    runtime->set_pto2_gm_sm_ptr(sm_ptr);
+    runtime->set_gm_sm_ptr(sm_ptr);
     runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
 
     // Set up device orchestration state
@@ -299,7 +294,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO("Tensor pairs to process: %d", tensor_pair_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
-    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    void *pto2_sm = runtime->get_gm_sm_ptr();
     uint64_t graph_out_ptr = 0;
     uint64_t graph_out_size = 0;
 

--- a/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/aicpu_build_graph/orchestration/pto_orchestration_api.h
@@ -94,14 +94,14 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline SubmitResult pto2_rt_submit_task(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
+static inline SubmitResult rt_submit_task(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
     return rt->ops->submit_task(rt, mixed_kernels, args);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline SubmitResult pto2_rt_submit_aic_task(PTO2Runtime *rt, int32_t kernel_id, const Arg &args) {
+static inline SubmitResult rt_submit_aic_task(PTO2Runtime *rt, int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -110,7 +110,7 @@ static inline SubmitResult pto2_rt_submit_aic_task(PTO2Runtime *rt, int32_t kern
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline SubmitResult pto2_rt_submit_aiv_task(PTO2Runtime *rt, int32_t kernel_id, const Arg &args) {
+static inline SubmitResult rt_submit_aiv_task(PTO2Runtime *rt, int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt->ops->submit_task(rt, mk, args);
@@ -119,17 +119,17 @@ static inline SubmitResult pto2_rt_submit_aiv_task(PTO2Runtime *rt, int32_t kern
 /**
  * Add an explicit dependency: consumer waits for producer to complete.
  */
-static inline void pto2_rt_add_dependency(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer) {
+static inline void rt_add_dependency(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId consumer) {
     rt->ops->add_dependency(rt, producer, consumer);
 }
 
-static inline void pto2_rt_scope_begin(PTO2Runtime *rt) { rt->ops->scope_begin(rt); }
+static inline void rt_scope_begin(PTO2Runtime *rt) { rt->ops->scope_begin(rt); }
 
-static inline void pto2_rt_scope_end(PTO2Runtime *rt) { rt->ops->scope_end(rt); }
+static inline void rt_scope_end(PTO2Runtime *rt) { rt->ops->scope_end(rt); }
 
-static inline void pto2_rt_orchestration_done(PTO2Runtime *rt) { rt->ops->orchestration_done(rt); }
+static inline void rt_orchestration_done(PTO2Runtime *rt) { rt->ops->orchestration_done(rt); }
 
-static inline bool pto2_rt_is_fatal(PTO2Runtime *rt) { return rt->ops->is_fatal(rt); }
+static inline bool rt_is_fatal(PTO2Runtime *rt) { return rt->ops->is_fatal(rt); }
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
@@ -168,7 +168,7 @@ private:
 /**
  * Scoped block macro:
  *   PTO2_SCOPE(rt) {
- *       pto2_rt_submit_task(rt, ...);
+ *       rt_submit_task(rt, ...);
  *   }
  */
 #define PTO2_SCOPE(rt) if (PTO2_SCOPE_GUARD(rt); true)

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.cpp
@@ -37,20 +37,20 @@ static void add_dependency_impl(PTO2Runtime *rt, PTO2TaskId producer, PTO2TaskId
     pto2_add_dependency(&rt->orchestrator, producer, consumer);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrator); }
+void rt_scope_begin(PTO2Runtime *rt) { pto2_scope_begin(&rt->orchestrator); }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
+void rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
+void rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
     .add_dependency = add_dependency_impl,
-    .scope_begin = pto2_rt_scope_begin,
-    .scope_end = pto2_rt_scope_end,
-    .orchestration_done = pto2_rt_orchestration_done,
+    .scope_begin = rt_scope_begin,
+    .scope_end = rt_scope_end,
+    .orchestration_done = rt_orchestration_done,
     .is_fatal = is_fatal_impl,
     .log_error = unified_log_error,
     .log_warn = unified_log_warn,

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_runtime2.h
@@ -169,7 +169,7 @@ void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void pto2_rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
@@ -177,14 +177,14 @@ void pto2_rt_scope_begin(PTO2Runtime *rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void pto2_rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(PTO2Runtime *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void pto2_rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(PTO2Runtime *rt);
 
 /**
  * Scope helper macros for C
@@ -194,35 +194,35 @@ void pto2_rt_orchestration_done(PTO2Runtime *rt);
  *
  * Usage (C):
  *   PTO2_SCOPE_BEGIN(rt);
- *   pto2_rt_submit_task(...);
- *   pto2_rt_submit_task(...);
+ *   rt_submit_task(...);
+ *   rt_submit_task(...);
  *   PTO2_SCOPE_END(rt);
  */
-#define PTO2_SCOPE_BEGIN(rt) pto2_rt_scope_begin(rt)
-#define PTO2_SCOPE_END(rt) pto2_rt_scope_end(rt)
+#define PTO2_SCOPE_BEGIN(rt) rt_scope_begin(rt)
+#define PTO2_SCOPE_END(rt) rt_scope_end(rt)
 
 /**
  * RAII Scope Guard for C++
  *
  * PTO2ScopeGuard is a C++ RAII wrapper that automatically manages scope lifetime.
- * It calls pto2_rt_scope_begin() on construction and pto2_rt_scope_end() on destruction,
+ * It calls rt_scope_begin() on construction and rt_scope_end() on destruction,
  * ensuring proper cleanup even in error paths.
  *
  * Usage Option 1 - Direct instantiation (recommended):
  *   PTO2ScopeGuard scope_guard(rt);
- *   pto2_rt_submit_task(...);
- *   pto2_rt_submit_task(...);
+ *   rt_submit_task(...);
+ *   rt_submit_task(...);
  *   // scope automatically ends here when scope_guard destructor is called
  *
  * Usage Option 2 - Macro for anonymous guard:
  *   PTO2_SCOPE_GUARD(rt);
- *   pto2_rt_submit_task(...);
+ *   rt_submit_task(...);
  *   // scope automatically ends at end of current block
  *
  * Usage Option 3 - Scoped block with if statement:
  *   PTO2_SCOPE(rt) {
- *       pto2_rt_submit_task(...);
- *       pto2_rt_submit_task(...);
+ *       rt_submit_task(...);
+ *       rt_submit_task(...);
  *   } // scope automatically ends here
  *
  * Benefits:
@@ -235,9 +235,9 @@ class PTO2ScopeGuard {
 public:
     explicit PTO2ScopeGuard(PTO2Runtime *rt) :
         rt_(rt) {
-        pto2_rt_scope_begin(rt_);
+        rt_scope_begin(rt_);
     }
-    ~PTO2ScopeGuard() { pto2_rt_scope_end(rt_); }
+    ~PTO2ScopeGuard() { rt_scope_end(rt_); }
 
 private:
     PTO2Runtime *rt_;
@@ -250,7 +250,7 @@ private:
  *
  * Example:
  *   PTO2_SCOPE_GUARD(rt);
- *   pto2_rt_submit_task(...);
+ *   rt_submit_task(...);
  */
 #define _PTO2_CONCATENATE_IMPL(x, y) x##y
 #define _PTO2_CONCATENATE(x, y) _PTO2_CONCATENATE_IMPL(x, y)
@@ -262,7 +262,7 @@ private:
  *
  * Example:
  *   PTO2_SCOPE(rt) {
- *       pto2_rt_submit_task(...);
+ *       rt_submit_task(...);
  *   } // scope automatically ends here
  */
 #define PTO2_SCOPE(rt) if (PTO2_SCOPE_GUARD(rt); true)

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/pto_types.h
@@ -135,7 +135,7 @@ union TensorRef {
  *   args.add_input(x);
  *   args.add_output(TensorCreateInfo(shapes, 2));
  *   args.add_scalar(some_value);
- *   SubmitResult r = pto2_rt_submit_aic_task(rt, kernel_id, args);
+ *   SubmitResult r = rt_submit_aic_task(rt, kernel_id, args);
  *   const Tensor& y = r.outputs.get_ref(0);
  */
 struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.cpp
@@ -34,9 +34,9 @@ Runtime::Runtime() {
     worker_count = 0;
     sche_cpu_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    pto2_task_window_size = 0;
-    pto2_heap_size = 0;
-    pto2_dep_pool_size = 0;
+    task_window_size = 0;
+    heap_size = 0;
+    dep_pool_size = 0;
     orch_to_sched = false;
 
     // Initialize tensor pairs
@@ -44,9 +44,9 @@ Runtime::Runtime() {
 
     // Initialize device orchestration state
     orch_built_on_host_ = true;
-    pto2_gm_sm_ptr_ = nullptr;
-    pto2_gm_heap_ptr_ = nullptr;
-    pto2_slot_states_ptr_ = nullptr;
+    gm_sm_ptr_ = nullptr;
+    gm_heap_ptr_ = nullptr;
+    slot_states_ptr_ = nullptr;
     orch_args_storage_.clear();
 
     // Initialize device orchestration SO binary
@@ -90,13 +90,13 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // =============================================================================
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
-void *Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
-void *Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
+void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
 const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
-void Runtime::set_pto2_gm_sm_ptr(void *p) { pto2_gm_sm_ptr_ = p; }
-void Runtime::set_pto2_gm_heap(void *p) { pto2_gm_heap_ptr_ = p; }
-void Runtime::set_pto2_slot_states_ptr(void *p) { pto2_slot_states_ptr_ = p; }
+void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
+void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
+void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }
 void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
 
 // Device orchestration SO metadata (bytes live in a separate device buffer

--- a/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/aicpu_build_graph/runtime/runtime.h
@@ -17,7 +17,7 @@
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, sche_cpu_num)
  * - Tensor pair management for host-device memory tracking
- * - Device orchestration state (pto2_gm_sm_ptr_, orch_args_)
+ * - Device orchestration state (gm_sm_ptr_, orch_args_)
  * - Function address mapping (func_id_to_addr_)
  *
  * Task dispatch uses PTO2DispatchPayload from PTO2 shared memory.
@@ -162,9 +162,9 @@ public:
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)
-    uint64_t pto2_task_window_size;
-    uint64_t pto2_heap_size;
-    uint64_t pto2_dep_pool_size;
+    uint64_t task_window_size;
+    uint64_t heap_size;
+    uint64_t dep_pool_size;
 
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
@@ -187,9 +187,9 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void *pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
-    void *pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
-    void *pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
+    void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
+    void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Device orchestration SO (for dlopen on AICPU thread 3).
@@ -238,13 +238,13 @@ public:
     // =========================================================================
 
     bool get_orch_built_on_host() const;
-    void *get_pto2_gm_sm_ptr() const;
-    void *get_pto2_gm_heap_ptr() const;
+    void *get_gm_sm_ptr() const;
+    void *get_gm_heap_ptr() const;
     const ChipStorageTaskArgs &get_orch_args() const;
     void set_orch_built_on_host(bool v);
-    void set_pto2_gm_sm_ptr(void *p);
-    void set_pto2_gm_heap(void *p);
-    void set_pto2_slot_states_ptr(void *p);
+    void set_gm_sm_ptr(void *p);
+    void set_gm_heap(void *p);
+    void set_slot_states_ptr(void *p);
     void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -428,7 +428,7 @@ public:
      * Set PTO2 shared memory pointer (stub for host_build_graph).
      * This is a no-op for host orchestration; only used by rt2.
      */
-    void set_pto2_gm_sm_ptr(void *) { /* no-op */ }
+    void set_gm_sm_ptr(void *) { /* no-op */ }
 
     /**
      * Get function binary address by func_id.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -51,7 +51,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
  * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * AICPU writes &s_pto2_payload_per_core[i] to hank->task before setting
+ * AICPU writes &s_payload_per_core[i] to hank->task before setting
  * aicpu_ready=1. AICore caches this pointer and reads function_bin_addr +
  * args pointer from it on each dispatch. reg_val is a monotonically
  * increasing task ID used only for dispatch signaling and ACK/FIN protocol.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -77,7 +77,7 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
         return 0;
     }
 
-    void *sm = runtime->get_pto2_gm_sm_ptr();
+    void *sm = runtime->get_gm_sm_ptr();
     if (sm == nullptr) {
         return 0;
     }
@@ -387,7 +387,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // reused above.
             const ChipStorageTaskArgs &args = runtime->get_orch_args();
             int32_t arg_count = args.tensor_count() + args.scalar_count();
-            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
             for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
                 const ContinuousTensor &t = args.tensor(i);
                 DEV_INFO(
@@ -405,23 +405,23 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
             uint64_t heap_size = PTO2_HEAP_SIZE;
 
-            if (runtime->pto2_task_window_size > 0) {
-                task_window_size = runtime->pto2_task_window_size;
+            if (runtime->task_window_size > 0) {
+                task_window_size = runtime->task_window_size;
             }
-            if (runtime->pto2_heap_size > 0) {
-                heap_size = runtime->pto2_heap_size;
+            if (runtime->heap_size > 0) {
+                heap_size = runtime->heap_size;
             }
             int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-            if (runtime->pto2_dep_pool_size > 0) {
-                dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
+            if (runtime->dep_pool_size > 0) {
+                dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
             }
             DEV_INFO(
                 "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
                 static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
             );
 
-            void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
-            void *gm_heap = runtime->get_pto2_gm_heap_ptr();
+            void *sm_ptr = runtime->get_gm_sm_ptr();
+            void *gm_heap = runtime->get_gm_heap_ptr();
 
             uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(task_window_size);
             PTO2SharedMemoryHandle *sm_handle =
@@ -451,7 +451,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             rt->orchestrator.total_aiv_count = sched_ctx_.aiv_count();
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
-            runtime->set_pto2_slot_states_ptr(nullptr);
+            runtime->set_slot_states_ptr(nullptr);
 
             orch_args_cached_ = &args;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -425,9 +425,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
             void *gm_heap = runtime->get_pto2_gm_heap_ptr();
 
-            uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(task_window_size);
             PTO2SharedMemoryHandle *sm_handle =
-                pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+                PTO2SharedMemoryHandle::create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
             if (!sm_handle) {
                 DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 // Unblock scheduler threads before returning so they don't spin forever.
@@ -438,7 +438,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
             if (!rt) {
                 DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
-                pto2_sm_destroy(sm_handle);
+                sm_handle->destroy();
                 // Unblock scheduler threads before returning so they don't spin forever.
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -85,7 +85,7 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
     auto *header = static_cast<PTO2SharedMemoryHeader *>(sm);
     int32_t orch_error_code = header->orch_error_code.load(std::memory_order_acquire);
     int32_t sched_error_code = header->sched_error_code.load(std::memory_order_acquire);
-    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
+    return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
 static PTO2Runtime *rt{nullptr};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -489,7 +489,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
-            PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
+            PTO2OrchProfilingData p = orchestrator_get_profiling();
             uint64_t total =
                 p.sync_cycle + p.alloc_cycle + p.args_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -66,8 +66,8 @@ typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_pto2_current_runtime here (distinct from
-// pto2_framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
-extern "C" void pto2_framework_bind_runtime(PTO2Runtime *rt);
+// framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
+extern "C" void framework_bind_runtime(PTO2Runtime *rt);
 
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
@@ -327,12 +327,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 dlerror();
                 auto bind_runtime_func =
-                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
+                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "framework_bind_runtime"));
                 const char *bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
-                    DEV_ERROR(
-                        "Thread %d: dlsym failed for pto2_framework_bind_runtime: %s", thread_idx, bind_runtime_error
-                    );
+                    DEV_ERROR("Thread %d: dlsym failed for framework_bind_runtime: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
@@ -435,7 +433,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            rt = runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
             if (!rt) {
                 DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                 sm_handle->destroy();
@@ -475,13 +473,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if PTO2_PROFILING
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
-            pto2_framework_bind_runtime(rt);
+            framework_bind_runtime(rt);
             if (orch_bind_runtime_ != nullptr) {
                 orch_bind_runtime_(rt);
             }
-            pto2_rt_scope_begin(rt);
+            rt_scope_begin(rt);
             orch_func_(*orch_args_cached_);
-            pto2_rt_scope_end(rt);
+            rt_scope_end(rt);
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             (void)orch_cycle_end;
@@ -571,7 +569,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // Signal completion to the orchestrator state machine
-            pto2_rt_orchestration_done(rt);
+            rt_orchestration_done(rt);
 
             // Latch task count from PTO2 shared memory
             int32_t total_tasks = 0;
@@ -644,11 +642,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // the next run's cache-hit reuse (see run() reload_so branch).
         if (!runtime->get_orch_built_on_host() && rt != nullptr) {
             // Clear g_pto2_current_runtime in this DSO and in the orchestration SO before destroying rt.
-            pto2_framework_bind_runtime(nullptr);
+            framework_bind_runtime(nullptr);
             if (orch_bind_runtime_ != nullptr) {
                 orch_bind_runtime_(nullptr);
             }
-            pto2_runtime_destroy(rt);
+            runtime_destroy(rt);
         }
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -65,7 +65,7 @@ typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 // Config function exported by orchestration .so
 typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
 
-// From orchestration/common.cpp linked into this DSO — updates g_pto2_current_runtime here (distinct from
+// From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
 extern "C" void framework_bind_runtime(PTO2Runtime *rt);
 
@@ -641,7 +641,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // always tear them down here, but we keep orch_so_handle_ alive for
         // the next run's cache-hit reuse (see run() reload_so branch).
         if (!runtime->get_orch_built_on_host() && rt != nullptr) {
-            // Clear g_pto2_current_runtime in this DSO and in the orchestration SO before destroying rt.
+            // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
             framework_bind_runtime(nullptr);
             if (orch_bind_runtime_ != nullptr) {
                 orch_bind_runtime_(nullptr);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -38,7 +38,7 @@
 #define PTO2_ERROR_ASYNC_WAIT_OVERFLOW 102
 #define PTO2_ERROR_ASYNC_REGISTRATION_FAILED 103
 
-static inline int32_t pto2_runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
+static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
     if (orch_error_code != PTO2_ERROR_NONE) {
         return orch_error_code < 0 ? orch_error_code : -orch_error_code;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -93,7 +93,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     uint64_t heap_size;
     uint64_t task_descriptors_offset;
 
-    // Per-ring data pointers (host-side, set by pto2_sm_setup_pointers)
+    // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -31,7 +31,7 @@ task_id.raw = (ring_id << 32) | local_id
 
 | API | Purpose |
 | --- | ------- |
-| `pto2_make_task_id(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
+| `PTO2TaskId::make(ring_id, local_id)` | Compose a 64-bit task ID (`PTO2TaskId`) |
 | `task_id.ring()` | Extract `ring_id` (bits 63-32) |
 | `task_id.local()` | Extract `local_id` (bits 31-0) |
 | `task_id.raw` | Access the packed 64-bit encoding |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -434,8 +434,8 @@ Scopes control the lifetime of intermediate buffers. Each scope:
 ```cpp
 PTO2_SCOPE(rt) {
     // Tasks submitted here belong to this scope
-    pto2_rt_submit_aic_task(FUNC_QK, args);
-    pto2_rt_submit_aiv_task(FUNC_SF, args);
+    rt_submit_aic_task(FUNC_QK, args);
+    rt_submit_aiv_task(FUNC_SF, args);
 }
 // scope_end: scope reference released from all tasks above
 ```
@@ -617,11 +617,11 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 
 | Function/Macro | Purpose |
 | -------------- | ------- |
-| `pto2_rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
-| `pto2_rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
-| `pto2_rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
+| `rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
+| `rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
+| `rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
 | `PTO2_SCOPE() { ... }` | RAII scope for buffer lifetime |
-| `pto2_rt_orchestration_done()` | Signal orchestration complete |
+| `rt_orchestration_done()` | Signal orchestration complete |
 
 ### 11.2 Parameter Construction
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -162,7 +162,7 @@ The task ring manages task slot allocation with back-pressure flow control.
 
 **Slot mapping**: `slot = task_id & (window_size - 1)`
 
-**Allocation** (`pto2_task_ring_alloc`):
+**Allocation** (`PTO2TaskAllocator::alloc`):
 
 ```text
 active_count = current_index - *last_alive_ptr
@@ -203,11 +203,11 @@ A simple bump allocator for `PTO2DepListEntry` nodes used in fanin/fanout linked
 
 The ring buffer mechanism provides **flow control** between the orchestrator (producer) and the scheduler (consumer). When a ring is exhausted, the orchestrator **blocks** — it cannot submit new tasks or allocate more output memory until the scheduler reclaims slots/space by advancing the watermarks.
 
-**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `pto2_task_ring_alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
+**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `PTO2TaskAllocator::alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
 
-**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `pto2_heap_ring_alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
+**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `PTO2TaskAllocator::alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
 
-**TensorMap pool back-pressure**: When the entry pool is exhausted, `new_entry()` spin-waits on `pto2_orchestrator_sync_tensormap(force=true)` until cleanup frees entries (see Section 5.4).
+**TensorMap pool back-pressure**: When the entry pool is exhausted, `new_entry()` spin-waits on `PTO2TensorMap::sync_tensormap(force=true)` until cleanup frees entries (see Section 5.4).
 
 This back-pressure is essential for correctness with small ring sizes — for example, with `PTO2_RING_TASK_WINDOW=16` and 208 tasks, the orchestrator blocks ~192 times, each time waiting for the scheduler to drain completed tasks before continuing.
 
@@ -273,7 +273,7 @@ Unlike the Task Ring and Heap Ring, TensorMap entries are **not** managed by a r
 
 1. **Free list first**: `free_entry_list[]` stores pointers to released entries. Allocation pops from here (O(1)).
 2. **Bump allocation**: if free list is empty, `entry_pool[next_entry_idx++]` allocates from the end of the pool.
-3. **Blocking reclaim**: if the pool is fully exhausted, `pto2_orchestrator_sync_tensormap(force=true)` reads the latest `last_task_alive` and calls `cleanup_retired` to batch-free all entries belonging to retired tasks, returning them to the free list.
+3. **Blocking reclaim**: if the pool is fully exhausted, `PTO2TensorMap::sync_tensormap(force=true)` reads the latest `last_task_alive` and calls `cleanup_retired` to batch-free all entries belonging to retired tasks, returning them to the free list.
 
 This design avoids the complexity of ring-based wrapping while still being bounded by `PTO2_TENSORMAP_POOL_SIZE` (default 65536 entries).
 
@@ -288,19 +288,19 @@ Three complementary mechanisms achieve this:
 
 **Layer 1 — Chain Truncation during Lookup** (lazy, per-bucket):
 
-Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `pto2_tensormap_lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
+Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `PTO2TensorMap::lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
 
 This guarantees lookup only traverses valid entries — O(valid_entries_in_bucket), not O(total_entries).
 
 **Layer 2 — Periodic Batch Cleanup** (`cleanup_retired`, per-task):
 
-Every time the orchestrator submits a task (Step 0 of `pto2_submit_task`), it calls `pto2_orchestrator_sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `pto2_tensormap_cleanup_retired` runs:
+Every time the orchestrator submits a task (Step 0 of `PTO2OrchestratorState::submit_task`), it calls `PTO2TensorMap::sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `PTO2TensorMap::cleanup_retired` runs:
 
 This uses the **per-task entry chain** (`task_entry_head[task_slot]`) — each task's entries are doubly-linked together at insert time via `next_in_task`/`prev_in_task`, allowing O(entries_per_task) cleanup without scanning the entire pool or all buckets. Freed entries are returned to `free_entry_list` for immediate reuse.
 
 **Layer 3 — Back-Pressure on Pool Exhaustion** (blocking):
 
-If both the free list and bump region are depleted, `new_entry()` blocks until `pto2_orchestrator_sync_tensormap(force=true)` frees entries by advancing `last_task_alive` through `cleanup_retired`.
+If both the free list and bump region are depleted, `new_entry()` blocks until `PTO2TensorMap::sync_tensormap(force=true)` frees entries by advancing `last_task_alive` through `cleanup_retired`.
 
 This forms a back-pressure mechanism analogous to the Task Ring's flow control.
 
@@ -316,11 +316,11 @@ In steady state, the number of valid TensorMap entries ≈ `active_tasks × avg_
 
 ### 5.5 Dependency Discovery Flow
 
-When `pto2_submit_task` processes parameters:
+When `PTO2OrchestratorState::submit_task` processes parameters:
 
-1. **INPUT/INOUT**: `pto2_tensormap_lookup` searches for overlapping producers (with chain truncation)
-2. For each producer found: `pto2_add_consumer_to_producer` adds the dependency
-3. **OUTPUT/INOUT**: `pto2_tensormap_insert` registers the current task as the new producer at bucket head
+1. **INPUT/INOUT**: `PTO2TensorMap::lookup` searches for overlapping producers (with chain truncation)
+2. For each producer found: `append_fanin_or_fail` adds the dependency
+3. **OUTPUT/INOUT**: `PTO2TensorMap::insert` registers the current task as the new producer at bucket head
 4. Stale entries are pruned lazily during lookup (Layer 1) and periodically by cleanup (Layer 2)
 
 ---
@@ -386,12 +386,12 @@ Key members:
 - `scheduler`: pointer to scheduler state (for wiring queue and ready queue access)
 - `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
 
-### 7.2 Task Submission Flow (`pto2_submit_mixed_task`)
+### 7.2 Task Submission Flow (`PTO2OrchestratorState::submit_task`)
 
 | Step | Operation |
 | ---- | --------- |
-| 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
-| 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
+| 0 | `PTO2TensorMap::sync_tensormap` — prune stale TensorMap entries |
+| 1 | `PTO2TaskAllocator::alloc` — allocate task slot (may block on flow control) |
 | 2 | Initialize task descriptor + slot state, copy parameters |
 | 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
 | 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -479,7 +479,7 @@ After these phases, the scheduler updates profiling headers and checks for termi
 Ready queues use a lock-free bounded MPMC (Vyukov) design:
 
 - One `PTO2ReadyQueue` per resource shape (5 shapes: `AIC_ONLY`, `AIV_X1`, `AIV_X2`, `AIC_AIV_X1`, `AIC_AIV_X2`)
-- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `active_mask_to_shape(task->active_mask)`
+- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `task->active_mask.to_shape()`
 - **Pop**: scheduler threads pop from the queue matching the idle core's resource shape
 - Per-slot sequence counters prevent ABA problems
 - `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -479,7 +479,7 @@ After these phases, the scheduler updates profiling headers and checks for termi
 Ready queues use a lock-free bounded MPMC (Vyukov) design:
 
 - One `PTO2ReadyQueue` per resource shape (5 shapes: `AIC_ONLY`, `AIV_X1`, `AIV_X2`, `AIC_AIV_X1`, `AIC_AIV_X2`)
-- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `pto2_active_mask_to_shape(task->active_mask)`
+- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `active_mask_to_shape(task->active_mask)`
 - **Pop**: scheduler threads pop from the queue matching the idle core's resource shape
 - Per-slot sequence counters prevent ABA problems
 - `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -80,7 +80,7 @@ TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 scalar_ci.set_initial_value(float_to_u64(77.0f));
 Arg args;
 args.add_output(scalar_ci);
-TaskOutputTensors outs = pto2_rt_submit_aiv_task(FUNC_NOOP, args);
+TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
 const Tensor& scalar_tensor = outs.get_ref(0);
 
 // Orchestration-side blocking read (waits for kernel completion)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -58,17 +58,17 @@ struct MixedKernels {
     int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
 };
 
-static inline void pto2_rt_submit_task(PTO2Runtime* rt,
+static inline void rt_submit_task(PTO2Runtime* rt,
                                        const MixedKernels& mixed_kernels,
                                        Arg* args,
                                        int32_t num_args);
 
-static inline void pto2_rt_submit_aic_task(PTO2Runtime* rt,
+static inline void rt_submit_aic_task(PTO2Runtime* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);
 
-static inline void pto2_rt_submit_aiv_task(PTO2Runtime* rt,
+static inline void rt_submit_aiv_task(PTO2Runtime* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -56,7 +56,7 @@ Thread 3: PTO2 total submitted tasks = 16704
 | Field | Source (`pto_orchestrator.cpp`) | Description |
 | ----- | ------------------------------- | ----------- |
 | **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
-| **total** | Sum of all sub-steps below | Accumulated time inside `pto2_submit_task` across all tasks |
+| **total** | Sum of all sub-steps below | Accumulated time inside `submit_task` across all tasks |
 | **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
 | **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
 | **param_copy** | `g_orch_args_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
@@ -64,12 +64,12 @@ Thread 3: PTO2 total submitted tasks = 16704
 | **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
 | **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
 | **fanin+ready** | `g_orch_fanin_cycle` | Building the fanin list + checking if task is already ready (Step 5/5b) |
-| **scope_end** | `g_orch_scope_end_cycle` | `pto2_scope_end` overhead (notifying scheduler of scope completion) |
+| **scope_end** | `g_orch_scope_end_cycle` | `end_scope` overhead (notifying scheduler of scope completion) |
 | **avg/task** | `total / submit_count` | Average orchestrator time per task submission |
 
 ### Interpreting the Numbers
 
-- **cost > total**: The difference is overhead outside `pto2_submit_task` (the orchestration user code itself, scope_begin/end, TensorCreateInfo construction, etc.).
+- **cost > total**: The difference is overhead outside `submit_task` (the orchestration user code itself, scope_begin/end, TensorCreateInfo construction, etc.).
 - **lookup+dep** is typically the dominant cost (~50%) because it involves TensorMap hash lookups and building dependency edges with spinlock-protected fanout list insertions.
 - **param_copy** scales with the number of parameters per task.
 - **avg/task < 1us** indicates efficient graph construction.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -88,7 +88,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
 
     int32_t orch_error_code = host_header->orch_error_code.load(std::memory_order_relaxed);
     int32_t sched_error_code = host_header->sched_error_code.load(std::memory_order_relaxed);
-    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
+    return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -268,7 +268,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
 
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
-    uint64_t sm_size = pto2_sm_calculate_size(eff_task_window_size);
+    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
     void *sm_ptr = runtime->host_api.device_malloc(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -75,7 +75,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
         return 0;
     }
 
-    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    void *pto2_sm = runtime->get_gm_sm_ptr();
     if (pto2_sm == nullptr) {
         return 0;
     }
@@ -236,23 +236,22 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
 
     // Read ring buffer size overrides from environment
     {
-        runtime->pto2_task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
-        if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
+        runtime->task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        runtime->dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
+        if (runtime->task_window_size || runtime->heap_size || runtime->dep_pool_size) {
             LOG_INFO(
                 "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
-                (uint64_t)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
-                (uint64_t)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                (uint64_t)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
+                (uint64_t)(runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE),
+                (uint64_t)(runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE),
+                (uint64_t)(runtime->dep_pool_size ? runtime->dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
             );
         }
     }
 
     // Resolve effective sizes (env override or compile-time default)
-    uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size =
-        runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+    uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
+    uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
 
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
@@ -264,7 +263,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         return -1;
     }
     runtime->record_tensor_pair(nullptr, gm_heap, total_heap_size);
-    runtime->set_pto2_gm_heap(gm_heap);
+    runtime->set_gm_heap(gm_heap);
 
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
@@ -275,7 +274,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         LOG_ERROR("Failed to allocate PTO2 shared memory");
         return -1;
     }
-    runtime->set_pto2_gm_sm_ptr(sm_ptr);
+    runtime->set_gm_sm_ptr(sm_ptr);
     runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
 
     // Set up device orchestration state

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -29,18 +29,16 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime *g_pto2_current_runtime = nullptr;
+PTO2Runtime *g_current_runtime = nullptr;
 }  // namespace
 
-extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime *rt) {
-    g_pto2_current_runtime = rt;
+extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(PTO2Runtime *rt) {
+    g_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *pto2_framework_current_runtime() {
-    return g_pto2_current_runtime;
-}
+extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *framework_current_runtime() { return g_current_runtime; }
 
 /**
  * Use addr2line to convert an address to file:line information.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -143,9 +143,10 @@ typedef struct PTO2RuntimeOps {
 /**
  * Partial PTO2Runtime definition for orchestration.
  *
- * Only the ops pointer is visible.  The real struct (in pto_runtime2.h)
- * has the same first field, so accessing rt->ops through this definition
- * is well-defined (C struct layout guarantee).
+ * Exposes the ops pointer (for runtime calls) and pending_scope_mode
+ * (read directly by inline scope wrappers).  The real struct (in
+ * pto_runtime2.h) has the same first fields, so accessing them through
+ * this definition is well-defined (C struct layout guarantee).
  */
 struct PTO2Runtime {
     const PTO2RuntimeOps *ops;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -103,8 +103,8 @@ extern "C" {
  * aicpu_orchestration_entry(), so orchestration helpers can fetch the
  * current PTO2Runtime without explicit parameter threading.
  */
-PTO2Runtime *pto2_framework_current_runtime(void);
-void pto2_framework_bind_runtime(PTO2Runtime *rt);
+PTO2Runtime *framework_current_runtime(void);
+void framework_bind_runtime(PTO2Runtime *rt);
 
 #ifdef __cplusplus
 }
@@ -156,10 +156,10 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime *pto2_current_runtime() { return pto2_framework_current_runtime(); }
+static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
 
 static inline TaskOutputTensors alloc_tensors(const Arg &args) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -167,7 +167,7 @@ static inline TaskOutputTensors alloc_tensors(const Arg &args) {
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -192,7 +192,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -209,44 +209,44 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors
-pto2_rt_submit_task_impl(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
-    PTO2Runtime *rt = pto2_current_runtime();
+rt_submit_task_impl(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
     return rt->ops->submit_task(rt, mixed_kernels, args, complete_in_future);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_rt_submit_task_impl(mixed_kernels, args, false);
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    return rt_submit_task_impl(mixed_kernels, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
-    return pto2_rt_submit_task_impl(mk, args, false);
+    return rt_submit_task_impl(mk, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    return pto2_rt_submit_task_impl(mk, args, false);
+    return rt_submit_task_impl(mk, args, false);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aiv_task_deferred(int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    return pto2_rt_submit_task_impl(mk, args, true);
+    return rt_submit_task_impl(mk, args, true);
 }
 
-static inline void pto2_rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -254,39 +254,39 @@ static inline void pto2_rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO)
     rt->ops->scope_begin(rt);
 }
 
-static inline void pto2_rt_scope_end() {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline void rt_scope_end() {
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
     rt->ops->scope_end(rt);
 }
 
-static inline void pto2_rt_orchestration_done() {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline void rt_orchestration_done() {
+    PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
-static inline bool pto2_rt_is_fatal() {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline bool rt_is_fatal() {
+    PTO2Runtime *rt = current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
-#define pto2_rt_report_fatal(code, fmt, ...)                                               \
-    do {                                                                                   \
-        PTO2Runtime *_pto2_rt = pto2_current_runtime();                                    \
-        _pto2_rt->ops->report_fatal(_pto2_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
+#define rt_report_fatal(code, fmt, ...)                                          \
+    do {                                                                         \
+        PTO2Runtime *_rt = current_runtime();                                    \
+        _rt->ops->report_fatal(_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
     } while (0)
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
 // =============================================================================
 
-#define LOG_ERROR(fmt, ...) pto2_current_runtime()->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...) pto2_current_runtime()->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...) pto2_current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_DEBUG(fmt, ...) pto2_current_runtime()->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_ALWAYS(fmt, ...) pto2_current_runtime()->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_ERROR(fmt, ...) current_runtime()->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) current_runtime()->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_DEBUG(fmt, ...) current_runtime()->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_ALWAYS(fmt, ...) current_runtime()->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
 
 // =============================================================================
 // Cross-Layer Data Access
@@ -307,7 +307,7 @@ static inline bool pto2_rt_is_fatal() {
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return from_u64<T>(0);
     }
@@ -343,7 +343,7 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -360,7 +360,7 @@ static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const u
 class PTO2ScopeGuard {
 public:
     explicit PTO2ScopeGuard(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) :
-        rt_(pto2_current_runtime()) {
+        rt_(current_runtime()) {
         if (!rt_->ops->is_fatal(rt_)) {
             rt_->pending_scope_mode = mode;
             rt_->ops->scope_begin(rt_);
@@ -384,7 +384,7 @@ private:
 /**
  * Scoped block macro:
  *   PTO2_SCOPE() {
- *       pto2_rt_submit_task(...);
+ *       rt_submit_task(...);
  *   }
  */
 #define PTO2_SCOPE(...) if (PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -60,7 +60,7 @@ static_assert(
 /**
  * Per-core dispatch payload: function address + args[] + SPMD context.
  *
- * AICPU maintains a static array s_pto2_payload_per_core[RUNTIME_MAX_WORKER].
+ * AICPU maintains a static array s_payload_per_core[RUNTIME_MAX_WORKER].
  * AICore caches a pointer to its per-core slot at startup (via Handshake.task)
  * and reads from it on each dispatch.
  *

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -28,11 +28,11 @@ struct PTO2CompletionStats;
 inline constexpr int32_t PTO2_MAX_ASYNC_WAITS = 64;
 inline constexpr int32_t PTO2_MAX_PENDING_COMPLETIONS = 128;
 
-inline uintptr_t pto2_completion_ingress_cache_line(const volatile void *addr) {
+inline uintptr_t completion_ingress_cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
 }
 
-inline void pto2_completion_ingress_invalidate_entries(
+inline void completion_ingress_invalidate_entries(
     volatile PTO2CompletionIngressQueue *completion_ingress, uint64_t tail, uint64_t head
 ) {
     uint64_t active_count = head - tail;
@@ -59,7 +59,7 @@ inline void pto2_completion_ingress_invalidate_entries(
     );
 }
 
-inline bool pto2_completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
+inline bool completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
     if (completion_ingress == nullptr) return false;
     cache_invalidate_range(
         const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
@@ -173,7 +173,7 @@ struct PTO2AsyncWaitList {
             );
             uint64_t head_snapshot = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
             if (tail >= head_snapshot) break;
-            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head_snapshot);
+            completion_ingress_invalidate_entries(completion_ingress, tail, head_snapshot);
 
             while (tail < head_snapshot) {
                 volatile PTO2CompletionIngressEntry *slot =
@@ -327,7 +327,7 @@ struct PTO2AsyncWaitList {
             volatile PTO2DeferredCompletionEntry *deferred = &ingress->entries[i];
             volatile uint32_t *counter = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
             cache_invalidate_range(
-                reinterpret_cast<const void *>(pto2_completion_ingress_cache_line(counter)), sizeof(uint32_t)
+                reinterpret_cast<const void *>(completion_ingress_cache_line(counter)), sizeof(uint32_t)
             );
             if (!append_condition_locked(
                     *entry, deferred->addr, deferred->expected_value, static_cast<PTO2AsyncEngine>(deferred->engine),

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -123,7 +123,7 @@ struct PTO2AsyncPollResult {
     PTO2TaskSlotState *failed_slot_state{nullptr};
 };
 
-inline const char *pto2_async_engine_name(PTO2AsyncEngine engine) {
+inline const char *async_engine_name(PTO2AsyncEngine engine) {
     switch (engine) {
     case PTO2_ASYNC_ENGINE_SDMA:
         return "SDMA";

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -300,7 +300,8 @@ static void pto2_prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count
 }
 
 static bool pto2_prepare_task(
-    PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, uint8_t active_mask, PTO2PreparedTask *out
+    PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, ActiveMask active_mask,
+    PTO2PreparedTask *out
 ) {
     uint8_t ring_id = orch->current_ring_id();
     auto &allocator = orch->rings[ring_id].task_allocator;
@@ -332,7 +333,7 @@ static bool pto2_prepare_task(
     out->slot_state->task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     int16_t block_num = args.launch_spec.block_num();
     out->slot_state->total_required_subtasks =
-        static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+        static_cast<int16_t>(block_num * __builtin_popcount(active_mask.core_mask()));
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
     // fanin_count is set by scheduler during wiring
@@ -531,8 +532,8 @@ TaskOutputTensors pto2_submit_mixed_task(
     }
     always_assert(orch->scheduler != nullptr);
     // === Validate submit inputs ===
-    uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
-    always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
+    ActiveMask active_mask = mixed_kernels.to_active_mask();
+    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
 
     int16_t block_num = args.launch_spec.block_num();
     always_assert(block_num >= 1 && "block_num must be >= 1");
@@ -549,7 +550,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     if (!has_aic && has_aiv1 && !has_aiv0) {
         normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
         normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
-        active_mask = pto2_mixed_kernels_to_active_mask(normalized);
+        active_mask = normalized.to_active_mask();
     }
 
     // Encode require_sync_start into active_mask bit 3 (only meaningful for tasks with block_num > 1)
@@ -557,7 +558,7 @@ TaskOutputTensors pto2_submit_mixed_task(
         // Deadlock check: block_num >= total available slots of the required type.
         // For MIX/AIC: limit is total_cluster_count (one AIC per cluster).
         // For AIV:     limit is total_aiv_count.
-        PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
+        PTO2ResourceShape shape = active_mask.to_shape();
         int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
         if (limit > 0 && block_num > limit) {
             pto2_orch_report_fatal(
@@ -566,7 +567,7 @@ TaskOutputTensors pto2_submit_mixed_task(
             );
             return result;
         }
-        active_mask |= PTO2_SUBTASK_FLAG_SYNC_START;
+        active_mask.set_sync_start();
     }
     PTO2OutputLayout layout = pto2_calculate_output_layout(args);
     PTO2PreparedTask prepared;
@@ -789,7 +790,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 
     PTO2OutputLayout layout = pto2_calculate_output_layout(args);
     PTO2PreparedTask prepared;
-    if (!pto2_prepare_task(orch, args, layout.total_output_size, 0, &prepared)) {
+    if (!pto2_prepare_task(orch, args, layout.total_output_size, ActiveMask{}, &prepared)) {
         return TaskOutputTensors{};
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -181,7 +181,7 @@ struct PTO2FaninBuilder {
 
     template <typename Fn>
     PTO2FaninForEachReturn<Fn> for_each(Fn &&fn) const {
-        return pto2_for_each_fanin_storage(inline_slots, count, spill_start, spill_pool, static_cast<Fn &&>(fn));
+        return for_each_fanin_storage(inline_slots, count, spill_start, spill_pool, static_cast<Fn &&>(fn));
     }
 
     bool contains(PTO2TaskSlotState *prod_state) const {
@@ -702,7 +702,7 @@ PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg 
 
     // Increment fanout_count on each producer (no lock — only orch writes this field).
     // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
-    pto2_for_each_fanin_storage(
+    for_each_fanin_storage(
         fanin_builder.inline_slots, fanin_builder.count, fanin_builder.spill_start, fanin_builder.spill_pool,
         [](PTO2TaskSlotState *producer) {
             producer->fanout_count++;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -115,7 +115,7 @@ static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
 #endif
 
-static void *pto2_aligned_zalloc(size_t size, size_t alignment) {
+static void *aligned_zalloc(size_t size, size_t alignment) {
     void *ptr = nullptr;
     if (posix_memalign(&ptr, alignment, size) != 0) {
         return nullptr;
@@ -124,7 +124,7 @@ static void *pto2_aligned_zalloc(size_t size, size_t alignment) {
     return ptr;
 }
 
-static int32_t pto2_orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
+static int32_t orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
     always_assert(orch != nullptr);
     orch->fatal = true;
     if (error_code == PTO2_ERROR_NONE || orch->sm_header == nullptr) {
@@ -139,10 +139,9 @@ static int32_t pto2_orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_c
     return expected;
 }
 
-static void pto2_orch_report_fatal_v(
-    PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args
-) {
-    int32_t latched_code = pto2_orch_mark_fatal(orch, error_code);
+static void
+orch_report_fatal_v(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args) {
+    int32_t latched_code = orch_mark_fatal(orch, error_code);
 
     if (fmt == nullptr || fmt[0] == '\0') {
         if (latched_code != PTO2_ERROR_NONE && latched_code != error_code) {
@@ -162,10 +161,11 @@ static void pto2_orch_report_fatal_v(
     unified_log_error(func, "FATAL(code=%d): %s", error_code, message);
 }
 
-void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...) {
+void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, const char *fmt, ...) {
+    auto *orch = this;
     va_list args;
     va_start(args, fmt);
-    pto2_orch_report_fatal_v(orch, error_code, func, fmt, args);
+    orch_report_fatal_v(orch, error_code, func, fmt, args);
     va_end(args);
 }
 
@@ -200,7 +200,7 @@ struct PTO2FaninBuilder {
     }
 };
 
-static bool pto2_append_fanin_or_fail(
+static bool append_fanin_or_fail(
     PTO2OrchestratorState *orch, PTO2TaskSlotState *prod_state, PTO2FaninBuilder *fanin_builder, uint8_t ring_id
 ) {
     if (fanin_builder->contains(prod_state)) {
@@ -217,7 +217,7 @@ static bool pto2_append_fanin_or_fail(
     int32_t spill_idx = fanin_pool.top;
     PTO2FaninSpillEntry *entry = fanin_pool.alloc();
     if (entry == nullptr) {
-        pto2_orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
+        orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
     }
     if (fanin_builder->count == PTO2_FANIN_INLINE_CAP) {
@@ -238,7 +238,7 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
-static PTO2OutputLayout pto2_calculate_output_layout(const Arg &args) {
+static PTO2OutputLayout calculate_output_layout(const Arg &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) != TensorArgType::OUTPUT) {
@@ -252,8 +252,7 @@ static PTO2OutputLayout pto2_calculate_output_layout(const Arg &args) {
     return layout;
 }
 
-static bool
-pto2_check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator &allocator, uint8_t ring_id) {
+static bool check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator &allocator, uint8_t ring_id) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
 
     int32_t scope_task_count = orch->scope_tasks_size - orch->scope_begins[orch->scope_stack_top];
@@ -282,11 +281,11 @@ pto2_check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator 
     LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
     LOG_ERROR("  3. Split work across multiple scopes");
     LOG_ERROR("========================================");
-    pto2_orch_mark_fatal(orch, PTO2_ERROR_SCOPE_DEADLOCK);
+    orch_mark_fatal(orch, PTO2_ERROR_SCOPE_DEADLOCK);
     return false;
 }
 
-static void pto2_prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count, int32_t scalar_count) {
+static void prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count, int32_t scalar_count) {
     for (int32_t i = 0; i < tensor_count; i++) {
         __builtin_prefetch(&payload->tensors[i], 1, 3);
         __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
@@ -299,20 +298,20 @@ static void pto2_prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count
     __builtin_prefetch(reinterpret_cast<char *>(payload) + 128, 1, 3);
 }
 
-static bool pto2_prepare_task(
+static bool prepare_task(
     PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, ActiveMask active_mask,
     PTO2PreparedTask *out
 ) {
     uint8_t ring_id = orch->current_ring_id();
     auto &allocator = orch->rings[ring_id].task_allocator;
 
-    if (!pto2_check_scope_can_accept_task(orch, allocator, ring_id)) {
+    if (!check_scope_can_accept_task(orch, allocator, ring_id)) {
         return false;
     }
 
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
-        pto2_orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
+        orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
 
@@ -321,7 +320,7 @@ static bool pto2_prepare_task(
     out->task = &orch->sm_header->rings[ring_id].task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->rings[ring_id].task_payloads[out->alloc_result.slot];
 
-    pto2_prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
+    prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
 
     // Fields already reset by advance_ring_pointers (eager reset after CONSUMED):
     //   fanout_lock=0, fanout_count=1, fanout_head=nullptr,
@@ -346,10 +345,10 @@ static bool pto2_prepare_task(
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState *orch, PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size,
-    int32_t dep_pool_capacity
+bool PTO2OrchestratorState::init(
+    PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size, int32_t dep_pool_capacity
 ) {
+    auto *orch = this;
     *orch = PTO2OrchestratorState{};
 
     orch->sm_header = sm_header;
@@ -371,7 +370,7 @@ bool pto2_orchestrator_init(
         size_t fanin_pool_bytes =
             PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         PTO2FaninSpillEntry *fanin_entries =
-            reinterpret_cast<PTO2FaninSpillEntry *>(pto2_aligned_zalloc(fanin_pool_bytes, PTO2_ALIGN_SIZE));
+            reinterpret_cast<PTO2FaninSpillEntry *>(aligned_zalloc(fanin_pool_bytes, PTO2_ALIGN_SIZE));
         if (!fanin_entries) {
             for (int j = 0; j < r; j++) {
                 free(orch->rings[j].fanin_pool.base);
@@ -417,7 +416,8 @@ bool pto2_orchestrator_init(
     return true;
 }
 
-void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
+void PTO2OrchestratorState::destroy() {
+    auto *orch = this;
     orch->tensor_map.destroy();
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -431,9 +431,7 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     orch->scope_begins = NULL;
 }
 
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler) {
-    orch->scheduler = scheduler;
-}
+void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this->scheduler = scheduler; }
 
 // =============================================================================
 // Scope Management
@@ -451,15 +449,14 @@ static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *tas
     orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
 }
 
-void pto2_scope_begin(PTO2OrchestratorState *orch, PTO2ScopeMode mode) {
+void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
+    auto *orch = this;
     if (orch->fatal) {
         return;
     }
     assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
     if (mode == PTO2ScopeMode::AUTO && orch->in_manual_scope()) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "auto scope nested inside manual scope is not supported"
-        );
+        report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "auto scope nested inside manual scope is not supported");
         return;
     }
 
@@ -471,7 +468,8 @@ void pto2_scope_begin(PTO2OrchestratorState *orch, PTO2ScopeMode mode) {
     }
 }
 
-void pto2_scope_end(PTO2OrchestratorState *orch) {
+void PTO2OrchestratorState::end_scope() {
+    auto *orch = this;
     if (orch->fatal) {
         return;
     }
@@ -505,9 +503,9 @@ void pto2_scope_end(PTO2OrchestratorState *orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors pto2_submit_mixed_task(
-    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
-) {
+TaskOutputTensors
+PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
+    auto *orch = this;
     CYCLE_COUNT_START();
 
     TaskOutputTensors result;
@@ -527,7 +525,7 @@ TaskOutputTensors pto2_submit_mixed_task(
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
         LOG_ERROR("This is a bug in the orchestration code.");
         LOG_ERROR("========================================");
-        pto2_orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
+        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
         return result;
     }
     always_assert(orch->scheduler != nullptr);
@@ -561,17 +559,17 @@ TaskOutputTensors pto2_submit_mixed_task(
         PTO2ResourceShape shape = active_mask.to_shape();
         int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
         if (limit > 0 && block_num > limit) {
-            pto2_orch_report_fatal(
-                orch, PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
+            report_fatal(
+                PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
                 "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
             );
             return result;
         }
         active_mask.set_sync_start();
     }
-    PTO2OutputLayout layout = pto2_calculate_output_layout(args);
+    PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
-    if (!pto2_prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
+    if (!prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
         return result;
     }
     uint8_t ring_id = prepared.task_id.ring();
@@ -605,9 +603,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         PTO2TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
-            pto2_orch_report_fatal(
-                orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id"
-            );
+            report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
             return result;
         }
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];
@@ -617,7 +613,7 @@ TaskOutputTensors pto2_submit_mixed_task(
             continue;
         }
         PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_task_id(dep_local_task_id);
-        if (!pto2_append_fanin_or_fail(orch, producer_slot_state, &fanin_builder, ring_id)) {
+        if (!append_fanin_or_fail(orch, producer_slot_state, &fanin_builder, ring_id)) {
             return result;
         }
     }
@@ -639,7 +635,7 @@ TaskOutputTensors pto2_submit_mixed_task(
                 PTO2TaskSlotState *prod_state =
                     &orch->sm_header->rings[owner.ring()].get_slot_state_by_task_id(owner.local());
                 if (prod_state->task != nullptr && prod_state->task->task_id == owner &&
-                    !pto2_append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
+                    !append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
                     return result;
                 }
             }
@@ -662,7 +658,7 @@ TaskOutputTensors pto2_submit_mixed_task(
                 if (prod_state->task == nullptr || prod_state->task->task_id != producer_task_id) {
                     return true;
                 }
-                if (!pto2_append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
+                if (!append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
                     lookup_fatal = true;
                     return false;
                 }
@@ -750,7 +746,8 @@ TaskOutputTensors pto2_submit_mixed_task(
     return result;
 }
 
-TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const Arg &args) {
+    auto *orch = this;
     // Orchestration API should short-circuit after fatal, but keep this entry
     // robust as a no-op in case a caller reaches it directly.
     if (orch->fatal) {
@@ -758,21 +755,17 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     }
 
     if (args.tensor_count() <= 0) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors requires at least one TensorCreateInfo"
-        );
+        report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors requires at least one TensorCreateInfo");
         return TaskOutputTensors{};
     }
     if (args.scalar_count() != 0) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
-        );
+        report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args");
         return TaskOutputTensors{};
     }
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) != TensorArgType::OUTPUT) {
-            pto2_orch_report_fatal(
-                orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
+            report_fatal(
+                PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
             );
             return TaskOutputTensors{};
         }
@@ -781,16 +774,16 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     CYCLE_COUNT_START();
 
     if (args.has_error) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+        report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
             args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
         );
         return TaskOutputTensors{};
     }
 
-    PTO2OutputLayout layout = pto2_calculate_output_layout(args);
+    PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
-    if (!pto2_prepare_task(orch, args, layout.total_output_size, ActiveMask{}, &prepared)) {
+    if (!prepare_task(orch, args, layout.total_output_size, ActiveMask{}, &prepared)) {
         return TaskOutputTensors{};
     }
 
@@ -826,7 +819,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
         // consumer can exist, so they have no fanout to notify and no worker
         // subtasks to retire. Running the full on_mixed_task_complete path
         // would only pay unnecessary fanout_lock / traversal overhead here.
-        // The generic slot initialization done in pto2_prepare_task() is still
+        // The generic slot initialization done in prepare_task() is still
         // required so scope_end can release the producer-side reference and
         // drive the slot to CONSUMED, but worker dispatch fields are never
         // observed for hidden alloc tasks.
@@ -851,7 +844,8 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 // Flow Control
 // =============================================================================
 
-void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
+void PTO2OrchestratorState::mark_done() {
+    auto *orch = this;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
@@ -875,7 +869,7 @@ void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
 }
 
 #if PTO2_ORCH_PROFILING
-PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
+PTO2OrchProfilingData orchestrator_get_profiling() {
     PTO2OrchProfilingData d;
     d.sync_cycle = g_orch_sync_cycle;
     d.alloc_cycle = g_orch_alloc_cycle;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -542,9 +542,9 @@ PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg 
     // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
     // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
     MixedKernels normalized = mixed_kernels;
-    bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
-    bool has_aiv0 = (active_mask & PTO2_SUBTASK_MASK_AIV0) != 0;
-    bool has_aiv1 = (active_mask & PTO2_SUBTASK_MASK_AIV1) != 0;
+    bool has_aic = active_mask.has_mask(PTO2_SUBTASK_MASK_AIC);
+    bool has_aiv0 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV0);
+    bool has_aiv1 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV1);
     if (!has_aic && has_aiv1 && !has_aiv0) {
         normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
         normalized.aiv1_kernel_id = INVALID_KERNEL_ID;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -113,104 +113,22 @@ struct PTO2OrchestratorState {
     }
 
     bool in_manual_scope() const { return scope_stack_top >= manual_begin_depth; }
+
+    // === Cold-path API (defined in pto_orchestrator.cpp) ===
+
+    bool init(
+        PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size,
+        int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+    );
+    void destroy();
+    void set_scheduler(PTO2SchedulerState *scheduler);
+    void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
+    void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
+    void end_scope();
+    TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future);
+    TaskOutputTensors alloc_tensors(const Arg &args);
+    void mark_done();
 };
-
-// =============================================================================
-// Orchestrator API
-// =============================================================================
-
-/**
- * Initialize orchestrator state
- *
- * @param orch       Orchestrator state to initialize
- * @param sm_header  Shared memory header
- * @param gm_heap    GM heap memory for output buffers
- * @param heap_size  Size of GM heap
- * @return true on success
- */
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState *orch, PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
-);
-
-/**
- * Destroy orchestrator state and free resources
- */
-void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
-
-/**
- * Set scheduler reference (for simulated mode)
- */
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
-
-// =============================================================================
-// Fatal Reporting
-// =============================================================================
-
-void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...);
-
-// =============================================================================
-// Scope Management
-// =============================================================================
-
-/**
- * Begin a new scope
- *
- * Pushes a new empty task list onto the scope stack.
- * Tasks submitted while this scope is at the top of the stack are
- * owned by it and have their fanout_count initialized to 1.
- */
-void pto2_scope_begin(PTO2OrchestratorState *orch, PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
-
-/**
- * End current scope
- *
- * Pops the top scope and increments fanout_refcount for each task
- * directly owned by that scope.
- * May trigger buffer release for tasks that are now fully consumed.
- */
-void pto2_scope_end(PTO2OrchestratorState *orch);
-
-// =============================================================================
-// Task Submission
-// =============================================================================
-
-/**
- * Submit a task with InCore function and parameters
- *
- * This is the main API for building the task graph:
- * 1. Allocates task slot + packed output buffer via TaskAllocator (blocks until available)
- * 2. Looks up inputs in TensorMap to find dependencies
- * 3. Updates producer's fanout_count/list (with spinlock)
- * 4. Registers outputs in TensorMap
- * 5. Initializes task state in scheduler
- *
- * @param orch        Orchestrator state
- * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
- * @param args      Aggregated tensor and scalar parameters
- */
-TaskOutputTensors pto2_submit_mixed_task(
-    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
-);
-
-/**
- * Allocate fresh tensors by creating one hidden runtime-owned output task.
- *
- * The returned tensors are already materialized and bound to the same creator
- * task id for scope lifetime and future creator-retention dependencies.
- */
-TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &args);
-
-// =============================================================================
-// Flow Control
-// =============================================================================
-
-/**
- * Mark orchestration as complete
- *
- * Signals to scheduler that no more tasks will be submitted.
- */
-void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Orchestrator Profiling Data
@@ -237,11 +155,7 @@ struct PTO2OrchProfilingData {
     uint64_t scope_end_atomic_count;
 };
 
-/**
- * Get and reset orchestrator profiling data.
- * Returns accumulated profiling data and resets counters.
- */
-PTO2OrchProfilingData pto2_orchestrator_get_profiling();
+PTO2OrchProfilingData orchestrator_get_profiling();
 #endif
 
 #endif  // PTO_ORCHESTRATOR_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -439,7 +439,7 @@ template <typename Fn>
 using PTO2FaninForEachReturn = std::conditional_t<std::is_same_v<PTO2FaninCallbackResult<Fn>, void>, void, bool>;
 
 template <typename InlineSlots, typename Fn>
-inline PTO2FaninForEachReturn<Fn> pto2_for_each_fanin_storage(
+inline PTO2FaninForEachReturn<Fn> for_each_fanin_storage(
     InlineSlots &&inline_slot_states, int32_t fanin_count, int32_t spill_start, PTO2FaninPool &spill_pool, Fn &&fn
 ) {
     using FaninCallbackResult = PTO2FaninCallbackResult<Fn>;
@@ -504,8 +504,8 @@ inline PTO2FaninForEachReturn<Fn> pto2_for_each_fanin_storage(
 }
 
 template <typename Fn>
-inline PTO2FaninForEachReturn<Fn> pto2_for_each_fanin_slot_state(const PTO2TaskPayload &payload, Fn &&fn) {
-    return pto2_for_each_fanin_storage(
+inline PTO2FaninForEachReturn<Fn> for_each_fanin_slot_state(const PTO2TaskPayload &payload, Fn &&fn) {
+    return for_each_fanin_storage(
         payload.fanin_inline_slot_states, payload.fanin_actual_count, payload.fanin_spill_start,
         *payload.fanin_spill_pool, static_cast<Fn &&>(fn)
     );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -47,19 +47,19 @@ static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime *rt) {
+void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
     rt->orchestrator.begin_scope(mode);
 }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
+void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
+void rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
-void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
@@ -187,7 +187,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
@@ -208,9 +208,7 @@ uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t nd
     return result;
 }
 
-void pto2_set_tensor_data(
-    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
-) {
+void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "set_tensor_data: buffer not allocated (addr=0). "
@@ -232,18 +230,18 @@ void pto2_set_tensor_data(
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
-    .scope_begin = pto2_rt_scope_begin,
-    .scope_end = pto2_rt_scope_end,
-    .orchestration_done = pto2_rt_orchestration_done,
+    .scope_begin = rt_scope_begin,
+    .scope_end = rt_scope_end,
+    .orchestration_done = rt_orchestration_done,
     .is_fatal = is_fatal_impl,
-    .report_fatal = pto2_rt_report_fatal,
+    .report_fatal = rt_report_fatal,
     .log_error = unified_log_error,
     .log_warn = unified_log_warn,
     .log_info = unified_log_info,
     .log_debug = unified_log_debug,
     .log_always = unified_log_always,
-    .get_tensor_data = pto2_get_tensor_data,
-    .set_tensor_data = pto2_set_tensor_data,
+    .get_tensor_data = get_tensor_data,
+    .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
 };
 
@@ -251,13 +249,12 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // Runtime Creation and Destruction
 // =============================================================================
 
-PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode) {
-    return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
+PTO2Runtime *runtime_create(PTO2RuntimeMode mode) {
+    return runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime *pto2_runtime_create_custom(
-    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity
-) {
+PTO2Runtime *
+runtime_create_custom(PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
     // Allocate runtime context
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) {
@@ -324,7 +321,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     return rt;
 }
 
-PTO2Runtime *pto2_runtime_create_from_sm(
+PTO2Runtime *runtime_create_from_sm(
     PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity
 ) {
@@ -365,7 +362,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     return rt;
 }
 
-void pto2_runtime_destroy(PTO2Runtime *rt) {
+void runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     rt->scheduler.destroy();
@@ -384,7 +381,7 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     free(rt);
 }
 
-void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
+void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -300,7 +300,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle->header, dep_pool_capacity)) {
+    if (!rt->scheduler.init(rt->sm_handle->header, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         rt->sm_handle->destroy();
@@ -313,7 +313,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
     if (!rt->completion_ingress) {
-        pto2_scheduler_destroy(&rt->scheduler);
+        rt->scheduler.destroy();
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
         rt->sm_handle->destroy();
@@ -346,7 +346,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle->header, dep_pool_capacity)) {
+    if (!rt->scheduler.init(rt->sm_handle->header, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;
@@ -356,7 +356,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 
     rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
     if (!rt->completion_ingress) {
-        pto2_scheduler_destroy(&rt->scheduler);
+        rt->scheduler.destroy();
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt);
         return NULL;
@@ -368,7 +368,7 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
-    pto2_scheduler_destroy(&rt->scheduler);
+    rt->scheduler.destroy();
     pto2_orchestrator_destroy(&rt->orchestrator);
 
     free(rt->completion_ingress);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -266,7 +266,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
-    rt->sm_handle = pto2_sm_create(task_window_size, heap_size);
+    rt->sm_handle = PTO2SharedMemoryHandle::create(task_window_size, heap_size);
     if (!rt->sm_handle) {
         free(rt);
         return NULL;
@@ -277,14 +277,14 @@ PTO2Runtime *pto2_runtime_create_custom(
     rt->gm_heap_size = total_heap_size;
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
     if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
 #else
     rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
     if (!rt->gm_heap) {
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
@@ -294,7 +294,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     // Initialize orchestrator
     if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
@@ -303,7 +303,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle->header, dep_pool_capacity)) {
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
@@ -316,7 +316,7 @@ PTO2Runtime *pto2_runtime_create_custom(
         pto2_scheduler_destroy(&rt->scheduler);
         pto2_orchestrator_destroy(&rt->orchestrator);
         free(rt->gm_heap);
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
@@ -378,7 +378,7 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     }
 
     if (rt->sm_handle) {
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
     }
 
     free(rt);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -40,22 +40,22 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 
 static TaskOutputTensors
 submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
-    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args, complete_in_future);
+    return rt->orchestrator.submit_task(mixed_kernels, args, complete_in_future);
 }
 
 static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
-    return pto2_alloc_tensors(&rt->orchestrator, args);
+    return rt->orchestrator.alloc_tensors(args);
 }
 
 void pto2_rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
-    pto2_scope_begin(&rt->orchestrator, mode);
+    rt->orchestrator.begin_scope(mode);
 }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
+void pto2_rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
+void pto2_rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
@@ -63,11 +63,11 @@ void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func,
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
-        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, nullptr);
+        rt->orchestrator.report_fatal(error_code, func, nullptr);
     } else {
         char message[1024];
         vsnprintf(message, sizeof(message), fmt, args);
-        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, "%s", message);
+        rt->orchestrator.report_fatal(error_code, func, "%s", message);
     }
     va_end(args);
 }
@@ -104,8 +104,8 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                pto2_orch_report_fatal(
-                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                orch.report_fatal(
+                    PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
                 );
@@ -123,8 +123,8 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                pto2_orch_report_fatal(
-                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                orch.report_fatal(
+                    PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
                 );
@@ -292,7 +292,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     rt->gm_heap_owned = true;
 
     // Initialize orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!rt->orchestrator.init(rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
         rt->sm_handle->destroy();
         free(rt);
@@ -301,7 +301,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     // Initialize scheduler (heap_size = per-ring heap size)
     if (!rt->scheduler.init(rt->sm_handle->header, dep_pool_capacity)) {
-        pto2_orchestrator_destroy(&rt->orchestrator);
+        rt->orchestrator.destroy();
         free(rt->gm_heap);
         rt->sm_handle->destroy();
         free(rt);
@@ -309,12 +309,12 @@ PTO2Runtime *pto2_runtime_create_custom(
     }
 
     // Connect orchestrator to scheduler (for simulated mode)
-    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
+    rt->orchestrator.set_scheduler(&rt->scheduler);
 
     rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
     if (!rt->completion_ingress) {
         rt->scheduler.destroy();
-        pto2_orchestrator_destroy(&rt->orchestrator);
+        rt->orchestrator.destroy();
         free(rt->gm_heap);
         rt->sm_handle->destroy();
         free(rt);
@@ -340,24 +340,24 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
 
-    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!rt->orchestrator.init(rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
     if (!rt->scheduler.init(rt->sm_handle->header, dep_pool_capacity)) {
-        pto2_orchestrator_destroy(&rt->orchestrator);
+        rt->orchestrator.destroy();
         free(rt);
         return NULL;
     }
 
-    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
+    rt->orchestrator.set_scheduler(&rt->scheduler);
 
     rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
     if (!rt->completion_ingress) {
         rt->scheduler.destroy();
-        pto2_orchestrator_destroy(&rt->orchestrator);
+        rt->orchestrator.destroy();
         free(rt);
         return NULL;
     }
@@ -369,7 +369,7 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
     rt->scheduler.destroy();
-    pto2_orchestrator_destroy(&rt->orchestrator);
+    rt->orchestrator.destroy();
 
     free(rt->completion_ingress);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -151,7 +151,7 @@ PTO2Runtime *pto2_runtime_create_custom(
  * Does not allocate sm_handle or gm_heap; caller owns them.
  *
  * @param mode      Execution mode
- * @param sm_handle Pre-created shared memory handle (e.g. from pto2_sm_create_from_buffer)
+ * @param sm_handle Pre-created shared memory handle (e.g. from PTO2SharedMemoryHandle::create_from_buffer)
  * @param gm_heap   GM heap base for output buffers (or NULL if not used)
  * @param heap_size GM heap size in bytes
  * @return Runtime context, or NULL on failure

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -22,12 +22,12 @@
  * - Orchestrator-Scheduler decoupling via shared memory
  *
  * Usage:
- *   1. Create runtime: pto2_runtime_create()
+ *   1. Create runtime: PTO2Runtime create methods
  *   2. Build task graph in orchestration function:
- *      - pto2_scope_begin() / pto2_scope_end()
- *      - pto2_submit_task()
- *   3. Mark orchestration complete: pto2_orchestrator_done()
- *   4. Destroy runtime: pto2_runtime_destroy()
+ *      - begin_scope() / end_scope()
+ *      - submit_task()
+ *   3. Mark orchestration complete: mark_done()
+ *   4. Destroy runtime
  *
  * Based on: docs/RUNTIME_LOGIC.md
  */

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -131,7 +131,7 @@ struct PTO2Runtime {
  * @param mode Execution mode
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
+PTO2Runtime *runtime_create(PTO2RuntimeMode mode);
 
 /**
  * Create runtime with custom sizes
@@ -141,7 +141,7 @@ PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
  * @param heap_size        Size of GM heap
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime *pto2_runtime_create_custom(
+PTO2Runtime *runtime_create_custom(
     PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
@@ -156,7 +156,7 @@ PTO2Runtime *pto2_runtime_create_custom(
  * @param heap_size GM heap size in bytes
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime *pto2_runtime_create_from_sm(
+PTO2Runtime *runtime_create_from_sm(
     PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
@@ -164,12 +164,12 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 /**
  * Destroy runtime and free all resources
  */
-void pto2_runtime_destroy(PTO2Runtime *rt);
+void runtime_destroy(PTO2Runtime *rt);
 
 /**
  * Set execution mode
  */
-void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
+void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 
 // =============================================================================
 // Orchestration API (called by orchestration function)
@@ -182,7 +182,7 @@ void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void pto2_rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
@@ -190,33 +190,31 @@ void pto2_rt_scope_begin(PTO2Runtime *rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void pto2_rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(PTO2Runtime *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void pto2_rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(PTO2Runtime *rt);
 
 /**
  * Enter fatal state explicitly from orchestration.
  */
-void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
+uint64_t get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
  * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
  * See set_tensor_data in pto_orchestration_api.h for full documentation.
  */
-void pto2_set_tensor_data(
-    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
-);
+void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
 
 /**
  * Slim config struct exported by orchestration .so via aicpu_orchestration_config().

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -101,7 +101,7 @@
 
 // Task management
 // NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
-// Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
+// Actual window size is passed at runtime to runtime_create_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
 #define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -343,7 +343,7 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor *task;
 
     // --- Set per-submit (depend on task inputs) ---
-    uint8_t active_mask;       // Bitmask of active subtask slots (set once)
+    ActiveMask active_mask;    // Bitmask of active subtask slots (set once)
     uint8_t ring_id;           // Ring layer (immutable after init)
     int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -383,67 +383,56 @@ struct alignas(64) PTO2TaskSlotState {
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx = 0;
     }
+
+    // === Per-task fanout spinlock ===
+    //
+    // Used by BOTH the orchestrator and the scheduler. The fanout_lock MUST
+    // be held whenever reading or writing fanout_head / fanout_count, because
+    // the orchestrator adds consumers concurrently with the scheduler
+    // traversing the list after task completion.
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    void lock_fanout(uint64_t &atomic_count, uint64_t &wait_cycle) {
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+
+        for (;;) {
+            while (fanout_lock.load(std::memory_order_acquire) != 0) {
+                contended = true;
+                atomic_ops++;
+                SPIN_WAIT_HINT();
+            }
+            int32_t expected = 0;
+            if (fanout_lock.compare_exchange_weak(expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                atomic_ops++;
+                atomic_count += atomic_ops;
+                if (contended) {
+                    wait_cycle += (get_sys_cnt_aicpu() - t0);
+                }
+                return;
+            }
+            contended = true;
+            atomic_ops++;
+        }
+    }
+#endif
+
+    void lock_fanout() {
+        for (;;) {
+            while (fanout_lock.load(std::memory_order_acquire) != 0) {
+                SPIN_WAIT_HINT();
+            }
+            int32_t expected = 0;
+            if (fanout_lock.compare_exchange_weak(expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                return;
+            }
+        }
+    }
+
+    void unlock_fanout() { fanout_lock.store(0, std::memory_order_release); }
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
-
-// =============================================================================
-// Per-task fanout spinlock helpers
-//
-// Used by BOTH the orchestrator (pto_orchestrator.cpp) and the scheduler
-// (aicpu_executor.cpp). Placing them here ensures both translation units use
-// identical acquire/release semantics.
-//
-// The fanout_lock MUST be held whenever reading or writing fanout_head /
-// fanout_count, because the orchestrator adds consumers concurrently with the
-// scheduler traversing the list after task completion.
-// =============================================================================
-
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
-    uint64_t t0 = get_sys_cnt_aicpu();
-    bool contended = false;
-    uint32_t atomic_ops = 0;
-
-    for (;;) {
-        while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
-            contended = true;
-            atomic_ops++;  // each load = 1 atomic
-            SPIN_WAIT_HINT();
-        }
-        int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
-            )) {
-            atomic_ops++;  // successful CAS = 1 atomic
-            atomic_count += atomic_ops;
-            if (contended) {
-                wait_cycle += (get_sys_cnt_aicpu() - t0);
-            }
-            return;
-        }
-        contended = true;
-        atomic_ops++;  // failed CAS = 1 atomic
-    }
-}
-#endif
-
-static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state) {
-    for (;;) {
-        while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
-            SPIN_WAIT_HINT();
-        }
-        int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
-            )) {
-            return;
-        }
-    }
-}
-
-static inline void pto2_fanout_unlock(PTO2TaskSlotState &slot_state) {
-    slot_state.fanout_lock.store(0, std::memory_order_release);
-}
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -41,10 +41,6 @@
 
 #include "pto_runtime2_types.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // =============================================================================
 // Shared Memory Header
 // =============================================================================
@@ -76,7 +72,7 @@ static_assert(sizeof(PTO2RingFlowControl) == 128, "PTO2RingFlowControl must be e
  * Per-ring shared memory header section.
  *
  * Groups flow-control, layout info, and per-ring data pointers for a single ring.
- * Pointers are host-side only (set by pto2_sm_setup_pointers, invalid on device).
+ * Pointers are host-side only (set by setup_pointers, invalid on device).
  */
 struct alignas(64) PTO2SharedMemoryRingHeader {
     PTO2RingFlowControl fc;
@@ -87,7 +83,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     uint64_t heap_size;
     uint64_t task_descriptors_offset;  // Offset from SM base, in bytes
 
-    // Per-ring data pointers (host-side, set by pto2_sm_setup_pointers)
+    // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;
@@ -159,91 +155,30 @@ struct PTO2SharedMemoryHandle {
 
     // Ownership flag
     bool is_owner;  // True if this handle allocated the memory
+
+    // === Static factory methods ===
+
+    static uint64_t calculate_size(uint64_t task_window_size);
+    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+
+    static PTO2SharedMemoryHandle *create(uint64_t task_window_size, uint64_t heap_size);
+    static PTO2SharedMemoryHandle *create_default();
+    static PTO2SharedMemoryHandle *
+    create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
+
+    // === Instance methods ===
+
+    void destroy();
+    void print_layout();
+    bool validate();
+
+private:
+    void init_header(uint64_t task_window_size, uint64_t heap_size);
+    void init_header_per_ring(
+        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    );
+    void setup_pointers(uint64_t task_window_size);
+    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
 };
-
-// =============================================================================
-// Shared Memory API
-// =============================================================================
-
-/**
- * Calculate required shared memory size
- *
- * @param task_window_size  Number of task slots per ring
- * @return Total bytes required
- */
-uint64_t pto2_sm_calculate_size(uint64_t task_window_size);
-
-/**
- * Calculate required shared memory size for per-ring task windows.
- *
- * @param task_window_sizes  Array of window sizes per ring
- * @return Total bytes required
- */
-uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
-
-/**
- * Create shared memory for Orchestrator and Scheduler
- *
- * @param task_window_size  Number of task slots per ring
- * @param heap_size         Heap size per ring for output buffers
- * @return Handle with both views, or NULL on failure
- */
-PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
-
-/**
- * Create shared memory with default sizes
- */
-PTO2SharedMemoryHandle *pto2_sm_create_default(void);
-
-/**
- * Wrap an existing buffer as shared memory (e.g. device GM buffer).
- * Caller owns the buffer; handle will not free sm_base.
- *
- * @param sm_base            Base address of pre-allocated buffer
- * @param sm_size            Total size in bytes
- * @param task_window_size   Number of task slots per ring (must match buffer layout)
- * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
- * @return Handle, or NULL on failure
- */
-PTO2SharedMemoryHandle *
-pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
-
-/**
- * Destroy shared memory and free resources
- */
-void pto2_sm_destroy(PTO2SharedMemoryHandle *handle);
-
-/**
- * Initialize shared memory header with layout information
- * Called after memory is allocated
- */
-void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size);
-
-/**
- * Initialize shared memory header with per-ring layout information.
- */
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-);
-
-// =============================================================================
-// Debug Utilities
-// =============================================================================
-
-/**
- * Print shared memory layout info
- */
-void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle);
-
-/**
- * Validate shared memory integrity
- * @return true if valid, false if corrupted
- */
-bool pto2_sm_validate(PTO2SharedMemoryHandle *handle);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif  // PTO_SHARED_MEMORY_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -37,43 +37,12 @@ enum class PTO2SubtaskSlot : uint8_t {
 };
 
 /**
- * Subtask mask bits (for active_mask)
+ * Subtask mask bits (for ActiveMask)
  */
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);         // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);        // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);        // 0x4
 inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all blocks must launch atomically
-
-/**
- * Test whether a subtask slot is active in a given mask
- */
-static inline bool pto2_subtask_active(uint8_t mask, PTO2SubtaskSlot slot) {
-    return (mask & (1u << static_cast<uint8_t>(slot))) != 0;
-}
-
-/**
- * Extract only the core bits from active_mask (strips flag bits).
- */
-static inline uint8_t pto2_core_mask(uint8_t active_mask) { return active_mask & 0x07u; }
-
-/**
- * Check whether a task requires all blocks to be launched atomically.
- */
-static inline bool pto2_requires_sync_start(uint8_t active_mask) {
-    return (active_mask & PTO2_SUBTASK_FLAG_SYNC_START) != 0;
-}
-
-/**
- * Mixed-task submit contract.
- *
- * Each field holds either a valid kernel ID or INVALID_KERNEL_ID (inactive).
- * At least one slot must be valid.
- */
-struct MixedKernels {
-    int32_t aic_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv0_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
-};
 
 /**
  * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
@@ -92,27 +61,70 @@ enum class PTO2ResourceShape : uint8_t {
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
 
 /**
- * Derive resource shape from active_mask.
- * Caller must ensure active_mask is valid (at least one bit set).
+ * Bitmask of active subtask slots + flags, sizeof == 1.
  */
-static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
-    uint8_t core_mask = pto2_core_mask(active_mask);
-    int bit_count = __builtin_popcount(core_mask);
-    if (bit_count >= 2) return PTO2ResourceShape::MIX;
-    if (core_mask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;
-    return PTO2ResourceShape::AIV;
-}
+class ActiveMask {
+public:
+    constexpr ActiveMask() = default;
+    constexpr explicit ActiveMask(uint8_t raw) :
+        raw_(raw) {}
+
+    uint8_t raw() const { return raw_; }
+
+    bool subtask_active(PTO2SubtaskSlot slot) const { return (raw_ & (1u << static_cast<uint8_t>(slot))) != 0; }
+
+    uint8_t core_mask() const { return raw_ & 0x07u; }
+
+    bool requires_sync_start() const { return (raw_ & PTO2_SUBTASK_FLAG_SYNC_START) != 0; }
+
+    PTO2ResourceShape to_shape() const {
+        uint8_t cmask = core_mask();
+        int bit_count = __builtin_popcount(cmask);
+        if (bit_count >= 2) return PTO2ResourceShape::MIX;
+        if (cmask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;
+        return PTO2ResourceShape::AIV;
+    }
+
+    void set_sync_start() { raw_ |= PTO2_SUBTASK_FLAG_SYNC_START; }
+
+    bool operator==(ActiveMask other) const { return raw_ == other.raw_; }
+    bool operator!=(ActiveMask other) const { return raw_ != other.raw_; }
+
+    ActiveMask operator|(ActiveMask other) const { return ActiveMask(raw_ | other.raw_); }
+    ActiveMask &operator|=(ActiveMask other) {
+        raw_ |= other.raw_;
+        return *this;
+    }
+
+    uint8_t operator&(uint8_t mask) const { return raw_ & mask; }
+
+    explicit operator bool() const { return raw_ != 0; }
+
+private:
+    uint8_t raw_{0};
+};
+
+static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 
 /**
- * Compute active_mask from MixedKernels.
+ * Mixed-task submit contract.
+ *
+ * Each field holds either a valid kernel ID or INVALID_KERNEL_ID (inactive).
+ * At least one slot must be valid.
  */
-static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels &mk) {
-    uint8_t mask = 0;
-    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
-    if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
-    if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
-    return mask;
-}
+struct MixedKernels {
+    int32_t aic_kernel_id{INVALID_KERNEL_ID};
+    int32_t aiv0_kernel_id{INVALID_KERNEL_ID};
+    int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
+
+    ActiveMask to_active_mask() const {
+        uint8_t mask = 0;
+        if (aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+        if (aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
+        if (aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
+        return ActiveMask(mask);
+    }
+};
 
 /**
  * SPMD launch parameters carried inside Arg.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -96,7 +96,9 @@ public:
         return *this;
     }
 
-    uint8_t operator&(uint8_t mask) const { return raw_ & mask; }
+    ActiveMask operator&(uint8_t mask) const { return ActiveMask(raw_ & mask); }
+
+    bool has_mask(uint8_t mask) const { return (raw_ & mask) != 0; }
 
     explicit operator bool() const { return raw_ != 0; }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -149,7 +149,7 @@ union TensorRef {
  *   args.add_input(x);
  *   args.add_output(ci);
  *   args.add_scalar(some_value);
- *   TaskOutputTensors outs = pto2_rt_submit_aic_task(kernel_id, args);
+ *   TaskOutputTensors outs = rt_submit_aic_task(kernel_id, args);
  *   const Tensor& y = outs.get_ref(0);
  */
 struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -17,7 +17,7 @@
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, sche_cpu_num)
  * - Tensor pair management for host-device memory tracking
- * - Device orchestration state (pto2_gm_sm_ptr_, orch_args_)
+ * - Device orchestration state (gm_sm_ptr_, orch_args_)
  * - Function address mapping (func_id_to_addr_)
  *
  * Task dispatch uses a per-core PTO2DispatchPayload written by the scheduler.
@@ -166,9 +166,9 @@ public:
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)
-    uint64_t pto2_task_window_size;
-    uint64_t pto2_heap_size;
-    uint64_t pto2_dep_pool_size;
+    uint64_t task_window_size;
+    uint64_t heap_size;
+    uint64_t dep_pool_size;
 
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
@@ -191,9 +191,9 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void *pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
-    void *pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
-    void *pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
+    void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
+    void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Device orchestration SO (for dlopen on AICPU thread 3).
@@ -247,13 +247,13 @@ public:
     // =========================================================================
 
     bool get_orch_built_on_host() const;
-    void *get_pto2_gm_sm_ptr() const;
-    void *get_pto2_gm_heap_ptr() const;
+    void *get_gm_sm_ptr() const;
+    void *get_gm_heap_ptr() const;
     const ChipStorageTaskArgs &get_orch_args() const;
     void set_orch_built_on_host(bool v);
-    void set_pto2_gm_sm_ptr(void *p);
-    void set_pto2_gm_heap(void *p);
-    void set_pto2_slot_states_ptr(void *p);
+    void set_gm_sm_ptr(void *p);
+    void set_gm_heap(void *p);
+    void set_slot_states_ptr(void *p);
     void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -86,7 +86,7 @@ const char *task_state_name(PTO2TaskState state) {
 // Ready Queue Implementation
 // =============================================================================
 
-bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
+bool ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
     queue->slots = (PTO2ReadyQueueSlot *)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
     if (!queue->slots) {
         return false;
@@ -105,7 +105,7 @@ bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
     return true;
 }
 
-void pto2_ready_queue_destroy(PTO2ReadyQueue *queue) {
+void ready_queue_destroy(PTO2ReadyQueue *queue) {
     if (queue->slots) {
         free(queue->slots);
         queue->slots = NULL;
@@ -157,10 +157,10 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
 
     // Initialize ready queues (one per resource shape, global)
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!pto2_ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {
+        if (!ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {
             // Cleanup on failure
             for (int j = 0; j < i; j++) {
-                pto2_ready_queue_destroy(&sched->ready_queues[j]);
+                ready_queue_destroy(&sched->ready_queues[j]);
             }
             for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                 sched->ring_sched_states[r].destroy();
@@ -178,7 +178,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
                 free(sched->ring_sched_states[j].dep_pool.base);
             }
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+                ready_queue_destroy(&sched->ready_queues[i]);
             }
             sched->wiring.queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
@@ -195,7 +195,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
             free(sched->ring_sched_states[r].dep_pool.base);
         }
         for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-            pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            ready_queue_destroy(&sched->ready_queues[i]);
         }
         for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
             sched->ring_sched_states[rr].destroy();
@@ -219,7 +219,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     sched->wiring.queue.destroy();
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        pto2_ready_queue_destroy(&sched->ready_queues[i]);
+        ready_queue_destroy(&sched->ready_queues[i]);
     }
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -42,7 +42,7 @@ uint64_t g_sched_self_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
 uint64_t g_sched_pop_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
 uint64_t g_sched_complete_count[PLATFORM_MAX_AICPU_THREADS] = {};
 
-PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
+PTO2SchedProfilingData scheduler_get_profiling(int thread_idx) {
     PTO2SchedProfilingData d;
     d.lock_cycle = std::exchange(g_sched_lock_cycle[thread_idx], 0);
     d.fanout_cycle = std::exchange(g_sched_fanout_cycle[thread_idx], 0);
@@ -138,7 +138,8 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHeader *sm_header,
 
 void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
 
-bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity) {
+bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity) {
+    PTO2SchedulerState *sched = this;
     sched->sm_header = sm_header;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -209,7 +210,8 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
     return true;
 }
 
-void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
+void PTO2SchedulerState::destroy() {
+    PTO2SchedulerState *sched = this;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
         free(sched->ring_sched_states[r].dep_pool.base);
@@ -227,7 +229,8 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
+void PTO2SchedulerState::print_stats() {
+    PTO2SchedulerState *sched = this;
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
@@ -249,7 +252,8 @@ void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
     LOG_INFO("============================");
 }
 
-void pto2_scheduler_print_queues(PTO2SchedulerState *sched) {
+void PTO2SchedulerState::print_queues() {
+    PTO2SchedulerState *sched = this;
     LOG_INFO("=== Ready Queues ===");
 
     const char *shape_names[] = {"AIC", "AIV", "MIX"};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -65,7 +65,7 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 // Task State Names
 // =============================================================================
 
-const char *pto2_task_state_name(PTO2TaskState state) {
+const char *task_state_name(PTO2TaskState state) {
     switch (state) {
     case PTO2_TASK_PENDING:
         return "PENDING";
@@ -130,7 +130,7 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHeader *sm_header,
         ring->slot_states[i].bind(&ring->task_payloads[i], &ring->task_descriptors[i], static_cast<uint8_t>(ring_id));
         ring->slot_states[i].reset_for_reuse();
         ring->slot_states[i].fanin_count = 0;
-        ring->slot_states[i].active_mask = 0;
+        ring->slot_states[i].active_mask = ActiveMask{};
     }
 
     return true;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -678,11 +678,11 @@ struct PTO2SchedulerState {
             int32_t init_rc = early_finished + 1;
             int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
             if (new_rc >= ws->fanin_count) {
-                ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+                ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
             }
         } else {
             ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
-            ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+            ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
         }
 
         ws->dep_pool_mark = rss.dep_pool.top;
@@ -773,7 +773,7 @@ struct PTO2SchedulerState {
         if (new_refcount == slot_state.fanin_count) {
             // Local-first: try per-CoreType thread-local buffer before global queue
             // Route by active_mask: AIC-containing tasks → buf[0], AIV-only → buf[1]
-            PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
+            PTO2ResourceShape shape = slot_state.active_mask.to_shape();
             if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                 ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
             }
@@ -797,7 +797,7 @@ struct PTO2SchedulerState {
                 )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
                 // Local-first: try per-CoreType thread-local buffer before global queue
-                PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
+                PTO2ResourceShape shape = slot_state.active_mask.to_shape();
                 if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                     ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
                 }
@@ -1072,7 +1072,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
 
 void pto2_scheduler_print_stats(PTO2SchedulerState *sched);
 void pto2_scheduler_print_queues(PTO2SchedulerState *sched);
-const char *pto2_task_state_name(PTO2TaskState state);
+const char *task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -985,16 +985,16 @@ struct PTO2SchedulerState {
 #endif
         return payload->fanin_actual_count;
     }
+
+    // === Cold-path API (defined in pto_scheduler.cpp) ===
+    bool init(PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    void destroy();
+    void print_stats();
+    void print_queues();
 };
 
-// =============================================================================
-// Scheduler API (cold path, defined in pto_scheduler.cpp)
-// =============================================================================
-
-bool pto2_scheduler_init(
-    PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
-);
-void pto2_scheduler_destroy(PTO2SchedulerState *sched);
+// Scheduler cold-path API is declared as PTO2SchedulerState member functions.
+// See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
 template <bool Profiling>
 inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
@@ -1072,8 +1072,6 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState *sched);
-void pto2_scheduler_print_queues(PTO2SchedulerState *sched);
 const char *task_state_name(PTO2TaskState state);
 
 // =============================================================================
@@ -1107,5 +1105,5 @@ struct PTO2SchedProfilingData {
  * Get and reset scheduler profiling data for a specific thread.
  * Returns accumulated profiling data and resets counters.
  */
-PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
+PTO2SchedProfilingData scheduler_get_profiling(int thread_idx);
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -666,7 +666,7 @@ struct PTO2SchedulerState {
 
         if (wfanin != 0) {
             int32_t early_finished = 0;
-            pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
+            for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
                 producer->lock_fanout();
                 int32_t pstate = producer->task_state.load(std::memory_order_acquire);
                 if (pstate >= PTO2_TASK_COMPLETED) {
@@ -961,7 +961,7 @@ struct PTO2SchedulerState {
     int32_t on_task_release(PTO2TaskSlotState &slot_state) {
 #endif
         PTO2TaskPayload *payload = slot_state.payload;
-        pto2_for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot_state) {
+        for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot_state) {
 #if PTO2_SCHED_PROFILING
             release_producer(*producer_slot_state, fanin_atomics);
 #else

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -665,14 +665,14 @@ struct PTO2SchedulerState {
         if (wfanin != 0) {
             int32_t early_finished = 0;
             pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
-                pto2_fanout_lock(*producer);
+                producer->lock_fanout();
                 int32_t pstate = producer->task_state.load(std::memory_order_acquire);
                 if (pstate >= PTO2_TASK_COMPLETED) {
                     early_finished++;
                 } else {
                     producer->fanout_head = rss.dep_pool.prepend(producer->fanout_head, ws);
                 }
-                pto2_fanout_unlock(*producer);
+                producer->unlock_fanout();
             });
 
             int32_t init_rc = early_finished + 1;
@@ -902,13 +902,13 @@ struct PTO2SchedulerState {
 #endif
 
 #if PTO2_SCHED_PROFILING
-        pto2_fanout_lock(slot_state, lock_atomics, lock_wait);
+        slot_state.lock_fanout(lock_atomics, lock_wait);
 #else
-        pto2_fanout_lock(slot_state);
+        slot_state.lock_fanout();
 #endif
         slot_state.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
         PTO2DepListEntry *current = slot_state.fanout_head;  // Protected by fanout_lock
-        pto2_fanout_unlock(slot_state);
+        slot_state.unlock_fanout();
 
 #if PTO2_SCHED_PROFILING
         lock_atomics += 2;  // state.store + unlock.store
@@ -1081,7 +1081,7 @@ const char *task_state_name(PTO2TaskState state);
 #if PTO2_SCHED_PROFILING
 struct PTO2SchedProfilingData {
     // Sub-phase cycle breakdown within on_mixed_task_complete
-    uint64_t lock_cycle;           // pto2_fanout_lock + state store + unlock
+    uint64_t lock_cycle;           // lock_fanout + state store + unlock
     uint64_t fanout_cycle;         // fanout traversal
     uint64_t fanin_cycle;          // fanin traversal
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -401,8 +401,10 @@ struct alignas(64) PTO2ReadyQueue {
 };
 
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
-bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
-void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
+// Declared as non-member to keep PTO2ReadyQueue a POD-like struct with
+// cache-line alignment. The struct body above contains only hot-path inlines.
+bool ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
+void ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
 // SPSC Queue (Single-Producer Single-Consumer, wait-free)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1024,7 +1024,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
             PTO2CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
             if (cond.counter_addr) {
-                uintptr_t counter_line = pto2_completion_ingress_cache_line(cond.counter_addr);
+                uintptr_t counter_line = completion_ingress_cache_line(cond.counter_addr);
                 if (counter_line != last_invalidated_counter_line) {
                     cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
                     last_invalidated_counter_line = counter_line;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -640,8 +640,8 @@ int32_t SchedulerContext::init(
     }
 
     // Initialize task counters. Task count comes from PTO2 shared memory.
-    if (runtime->get_pto2_gm_sm_ptr()) {
-        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
+    if (runtime->get_gm_sm_ptr()) {
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
         int32_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -201,7 +201,7 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
 
 #if PTO2_SCHED_PROFILING
     {
-        PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
+        PTO2SchedProfilingData sp = scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
         uint64_t complete_poll = (l2_perf.sched_complete_cycle > otc_total + l2_perf.sched_complete_perf_cycle) ?
                                      (l2_perf.sched_complete_cycle - otc_total - l2_perf.sched_complete_perf_cycle) :

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -112,8 +112,8 @@ void SchedulerContext::complete_slot_task(
         if (is_dump_tensor_enabled()) {
             dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                 thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
-                [](uint8_t active_mask, uint8_t raw_subtask_id) {
-                    return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+                [](ActiveMask active_mask, int raw_subtask_id) {
+                    return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
@@ -357,7 +357,7 @@ void SchedulerContext::drain_worker_dispatch(Runtime *runtime, int32_t block_num
         drain_state_.sync_start_pending.store(0, std::memory_order_release);
         return;
     }
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state->active_mask);
+    PTO2ResourceShape shape = slot_state->active_mask.to_shape();
 
     for (int32_t t = 0; t < active_sched_threads_ && slot_state->next_block_idx < block_num; t++) {
         auto valid = core_trackers_[t].get_idle_core_offset_states(shape);
@@ -428,7 +428,7 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
 
     // Elected: check if global resources are sufficient.
     PTO2TaskSlotState *slot_state = drain_state_.pending_task;
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state->active_mask);
+    PTO2ResourceShape shape = slot_state->active_mask.to_shape();
     int32_t available = count_global_available(shape);
 
     if (available < block_num) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -84,7 +84,7 @@ public:
     //  - folds inline_completed_tasks into completed_tasks_
     //  - flips orchestrator_done_ and triggers core transition
     //    (skipped on fatal error — emergency_shutdown runs instead)
-    // Callers must invoke pto2_rt_orchestration_done(rt) before this — that
+    // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
     void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -185,22 +185,22 @@ void SchedulerContext::dispatch_mix_block_to_cluster(
     Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
-    uint8_t core_mask = pto2_core_mask(slot_state.active_mask);
-    if (core_mask & PTO2_SUBTASK_MASK_AIC) {
+    uint8_t cmask = slot_state.active_mask.core_mask();
+    if (cmask & PTO2_SUBTASK_MASK_AIC) {
         bool aic_to_pending = to_pending && !tracker.is_aic_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
             aic_to_pending
         );
     }
-    if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
+    if (cmask & PTO2_SUBTASK_MASK_AIV0) {
         bool aiv0_to_pending = to_pending && !tracker.is_aiv0_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
             aiv0_to_pending
         );
     }
-    if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
+    if (cmask & PTO2_SUBTASK_MASK_AIV1) {
         bool aiv1_to_pending = to_pending && !tracker.is_aiv1_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
@@ -217,8 +217,8 @@ void SchedulerContext::dispatch_block(
     if (is_dump_tensor_enabled()) {
         dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
             thread_idx, slot_state, TensorDumpStage::BEFORE_DISPATCH,
-            [](uint8_t active_mask, uint8_t raw_subtask_id) {
-                return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+            [](ActiveMask active_mask, int raw_subtask_id) {
+                return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
             },
             [this](int32_t func_id) {
                 return get_function_bin_addr(func_id);
@@ -234,7 +234,7 @@ void SchedulerContext::dispatch_block(
         dispatch_subtask_to_core(runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending);
     }
 #if PTO2_PROFILING
-    sched_l2_perf_[thread_idx].phase_dispatch_count += __builtin_popcount(pto2_core_mask(slot_state.active_mask));
+    sched_l2_perf_[thread_idx].phase_dispatch_count += __builtin_popcount(slot_state.active_mask.core_mask());
 #endif
 }
 
@@ -261,7 +261,7 @@ void SchedulerContext::dispatch_shape(
         for (int bi = 0; bi < got; bi++) {
             PTO2TaskSlotState *slot_state = batch[bi];
 
-            if (pto2_requires_sync_start(slot_state->active_mask)) {
+            if (slot_state->active_mask.requires_sync_start()) {
                 if (is_pending) {
                     sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -27,15 +27,15 @@
 // Size Calculation
 // =============================================================================
 
-uint64_t pto2_sm_calculate_size(uint64_t task_window_size) {
+uint64_t PTO2SharedMemoryHandle::calculate_size(uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    return pto2_sm_calculate_size_per_ring(task_window_sizes);
+    return calculate_size_per_ring(task_window_sizes);
 }
 
-uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     uint64_t size = 0;
 
     // Header (aligned to cache line)
@@ -55,17 +55,16 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // Creation and Destruction
 // =============================================================================
 
-static void
-pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
-    char *ptr = (char *)handle->sm_base;
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    char *ptr = (char *)sm_base;
 
     // Header
-    handle->header = (PTO2SharedMemoryHeader *)ptr;
+    header = (PTO2SharedMemoryHeader *)ptr;
     ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
 
     // Per-ring task descriptors, payloads, and slot states
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        auto &ring = handle->header->rings[r];
+        auto &ring = header->rings[r];
         ring.task_descriptors = (PTO2TaskDescriptor *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
 
@@ -77,15 +76,15 @@ pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t t
     }
 }
 
-static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle *handle, uint64_t task_window_size) {
+void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes);
 }
 
-PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
+PTO2SharedMemoryHandle *PTO2SharedMemoryHandle::create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
     PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
@@ -93,7 +92,7 @@ PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_
     }
 
     // Calculate total size
-    uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+    uint64_t sm_size = calculate_size(task_window_size);
 
 // Allocate shared memory (aligned for DMA efficiency)
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
@@ -116,21 +115,24 @@ PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_
     memset(handle->sm_base, 0, static_cast<size_t>(sm_size));
 
     // Set up pointers
-    pto2_sm_setup_pointers(handle, task_window_size);
+    handle->setup_pointers(task_window_size);
 
     // Initialize header
-    pto2_sm_init_header(handle, task_window_size, heap_size);
+    handle->init_header(task_window_size, heap_size);
 
     return handle;
 }
 
-PTO2SharedMemoryHandle *pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
+PTO2SharedMemoryHandle *PTO2SharedMemoryHandle::create_default() {
+    return create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
+}
 
-PTO2SharedMemoryHandle *
-pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
+PTO2SharedMemoryHandle *PTO2SharedMemoryHandle::create_from_buffer(
+    void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size
+) {
     if (!sm_base || sm_size == 0) return NULL;
 
-    uint64_t required = pto2_sm_calculate_size(task_window_size);
+    uint64_t required = calculate_size(task_window_size);
     if (sm_size < required) return NULL;
 
     PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
@@ -140,20 +142,18 @@ pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window
     handle->sm_size = sm_size;
     handle->is_owner = false;
 
-    pto2_sm_setup_pointers(handle, task_window_size);
-    pto2_sm_init_header(handle, task_window_size, heap_size);
+    handle->setup_pointers(task_window_size);
+    handle->init_header(task_window_size, heap_size);
 
     return handle;
 }
 
-void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
-    if (!handle) return;
-
-    if (handle->is_owner && handle->sm_base) {
-        free(handle->sm_base);
+void PTO2SharedMemoryHandle::destroy() {
+    if (is_owner && sm_base) {
+        free(sm_base);
     }
 
-    free(handle);
+    free(this);
 }
 
 // =============================================================================
@@ -161,22 +161,19 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size) {
+void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = heap_size;
     }
-    pto2_sm_init_header_per_ring(handle, task_window_sizes, heap_sizes);
+    init_header_per_ring(task_window_sizes, heap_sizes);
 }
 
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+void PTO2SharedMemoryHandle::init_header_per_ring(
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 ) {
-    PTO2SharedMemoryHeader *header = handle->header;
-
     // Per-ring flow control (start at 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         header->rings[r].fc.init();
@@ -196,7 +193,7 @@ void pto2_sm_init_header_per_ring(
         offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     }
 
-    header->total_size = handle->sm_size;
+    header->total_size = sm_size;
     header->graph_output_ptr.store(0, std::memory_order_relaxed);
     header->graph_output_size.store(0, std::memory_order_relaxed);
 
@@ -211,13 +208,13 @@ void pto2_sm_init_header_per_ring(
 // Debug Utilities
 // =============================================================================
 
-void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
-    if (!handle || !handle->header) return;
+void PTO2SharedMemoryHandle::print_layout() {
+    if (!header) return;
 
-    PTO2SharedMemoryHeader *h = handle->header;
+    PTO2SharedMemoryHeader *h = header;
 
     LOG_INFO("=== PTO2 Shared Memory Layout ===");
-    LOG_INFO("Base address:       %p", handle->sm_base);
+    LOG_INFO("Base address:       %p", sm_base);
     LOG_INFO("Total size:         %" PRIu64 " bytes", h->total_size);
     LOG_INFO("Ring depth:         %d", PTO2_MAX_RING_DEPTH);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -240,15 +237,14 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
     LOG_INFO("================================");
 }
 
-bool pto2_sm_validate(PTO2SharedMemoryHandle *handle) {
-    if (!handle) return false;
-    if (!handle->sm_base) return false;
-    if (!handle->header) return false;
+bool PTO2SharedMemoryHandle::validate() {
+    if (!sm_base) return false;
+    if (!header) return false;
 
-    PTO2SharedMemoryHeader *h = handle->header;
+    PTO2SharedMemoryHeader *h = header;
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!h->rings[r].fc.validate(handle, r)) return false;
+        if (!h->rings[r].fc.validate(this, r)) return false;
     }
 
     return true;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -34,9 +34,9 @@ Runtime::Runtime() {
     worker_count = 0;
     sche_cpu_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    pto2_task_window_size = 0;
-    pto2_heap_size = 0;
-    pto2_dep_pool_size = 0;
+    task_window_size = 0;
+    heap_size = 0;
+    dep_pool_size = 0;
     orch_to_sched = false;
 
     // Initialize tensor pairs
@@ -44,9 +44,9 @@ Runtime::Runtime() {
 
     // Initialize device orchestration state
     orch_built_on_host_ = true;
-    pto2_gm_sm_ptr_ = nullptr;
-    pto2_gm_heap_ptr_ = nullptr;
-    pto2_slot_states_ptr_ = nullptr;
+    gm_sm_ptr_ = nullptr;
+    gm_heap_ptr_ = nullptr;
+    slot_states_ptr_ = nullptr;
     orch_args_storage_.clear();
 
     // Initialize device orchestration SO binary
@@ -92,13 +92,13 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // =============================================================================
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
-void *Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
-void *Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
+void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
 const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
-void Runtime::set_pto2_gm_sm_ptr(void *p) { pto2_gm_sm_ptr_ = p; }
-void Runtime::set_pto2_gm_heap(void *p) { pto2_gm_heap_ptr_ = p; }
-void Runtime::set_pto2_slot_states_ptr(void *p) { pto2_slot_states_ptr_ = p; }
+void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
+void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
+void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }
 void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
 
 // Device orchestration SO metadata (bytes live in a separate device buffer

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -139,7 +139,7 @@ void l2_perf_aicpu_set_orch_thread_idx(int thread_idx);
 /**
  * Record a single orchestrator phase
  *
- * Appends an AicpuPhaseRecord for one sub-step of pto2_submit_task().
+ * Appends an AicpuPhaseRecord for one sub-step of submit_task().
  * Uses the orchestrator's dedicated buffer slot (set via set_orch_thread_idx).
  *
  * @param phase_id Orchestrator phase identifier (ORCH_SYNC..ORCH_SCOPE_END)

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -107,7 +107,7 @@ struct L2PerfBuffer {
  * AICPU phase identifier
  *
  * Scheduler phases (0-3): four phases in each scheduler loop iteration.
- * Orchestrator phases (16-24): sub-steps within each pto2_submit_task() call.
+ * Orchestrator phases (16-24): sub-steps within each submit_task() call.
  */
 enum class AicpuPhaseId : uint32_t {
     // Scheduler phases (0-3)

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -190,7 +190,7 @@ int run_runtime(
         );
         LOG_DEBUG("init_runtime_impl returned: %d", rc);
         if (rc != 0) {
-            r->set_pto2_gm_sm_ptr(nullptr);
+            r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);
             r->~Runtime();
             return rc;

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -180,7 +180,7 @@ int run_runtime(
             r, reinterpret_cast<const ChipCallable *>(callable), reinterpret_cast<const ChipStorageTaskArgs *>(args)
         );
         if (rc != 0) {
-            r->set_pto2_gm_sm_ptr(nullptr);
+            r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -431,7 +431,7 @@ public:
      * Set PTO2 shared memory pointer (stub for host_build_graph).
      * This is a no-op for host orchestration; only used by rt2.
      */
-    void set_pto2_gm_sm_ptr(void *) { /* no-op */ }
+    void set_gm_sm_ptr(void *) { /* no-op */ }
 
     /**
      * Get function binary address by func_id.

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -52,7 +52,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * 3. Cache per-core PTO2DispatchPayload pointer from hank->task
  * 4. Poll DATA_MAIN_BASE register for task dispatch until exit signal
  *
- * AICPU writes &s_pto2_payload_per_core[i] to hank->task before setting
+ * AICPU writes &s_payload_per_core[i] to hank->task before setting
  * aicpu_ready=1. AICore caches this pointer and reads function_bin_addr +
  * args pointer from it on each dispatch. reg_val is a monotonically
  * increasing task ID used only for dispatch signaling and ACK/FIN protocol.

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -65,14 +65,14 @@ typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 // Config function exported by orchestration .so
 typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
 
-// From orchestration/common.cpp linked into this DSO — updates g_pto2_current_runtime here (distinct from
-// pto2_framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
-extern "C" void pto2_framework_bind_runtime(PTO2Runtime *rt);
+// From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
+// framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
+extern "C" void framework_bind_runtime(PTO2Runtime *rt);
 
 constexpr const char *DEFAULT_ORCH_ENTRY_SYMBOL = "aicpu_orchestration_entry";
 constexpr const char *DEFAULT_ORCH_CONFIG_SYMBOL = "aicpu_orchestration_config";
 
-static int32_t read_pto2_runtime_status(Runtime *runtime) {
+static int32_t read_runtime_status(Runtime *runtime) {
     if (runtime == nullptr) {
         return 0;
     }
@@ -85,7 +85,7 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
     auto *header = static_cast<PTO2SharedMemoryHeader *>(sm);
     int32_t orch_error_code = header->orch_error_code.load(std::memory_order_acquire);
     int32_t sched_error_code = header->sched_error_code.load(std::memory_order_acquire);
-    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
+    return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
 static PTO2Runtime *rt{nullptr};
@@ -193,7 +193,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     if (thread_idx >= sched_thread_num_) {
 #if PTO2_PROFILING
         uint64_t orch_cycle_start = 0;
-        int32_t pto2_submitted_tasks = -1;
+        int32_t submitted_tasks = -1;
 #endif
         if (runtime->get_orch_built_on_host()) {
             DEV_INFO("Thread %d: Host orchestration mode, no-op", thread_idx);
@@ -327,12 +327,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
                 dlerror();
                 auto bind_runtime_func =
-                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "pto2_framework_bind_runtime"));
+                    reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "framework_bind_runtime"));
                 const char *bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
-                    DEV_ERROR(
-                        "Thread %d: dlsym failed for pto2_framework_bind_runtime: %s", thread_idx, bind_runtime_error
-                    );
+                    DEV_ERROR("Thread %d: dlsym failed for framework_bind_runtime: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
@@ -425,9 +423,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             void *sm_ptr = runtime->get_gm_sm_ptr();
             void *gm_heap = runtime->get_gm_heap_ptr();
 
-            uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(task_window_size);
             PTO2SharedMemoryHandle *sm_handle =
-                pto2_sm_create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
+                PTO2SharedMemoryHandle::create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
             if (!sm_handle) {
                 DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 // Unblock scheduler threads before returning so they don't spin forever.
@@ -435,10 +433,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 return -1;
             }
 
-            rt = pto2_runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
+            rt = runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
             if (!rt) {
                 DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
-                pto2_sm_destroy(sm_handle);
+                sm_handle->destroy();
                 // Unblock scheduler threads before returning so they don't spin forever.
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
@@ -464,7 +462,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             runtime_init_ready_.store(true, std::memory_order_release);
 
             // Wait for scheduler's one-time init to complete
-            sched_ctx_.wait_pto2_init_complete();
+            sched_ctx_.wait_init_complete();
 
 #if PTO2_PROFILING
             if (is_l2_swimlane_enabled()) {
@@ -475,13 +473,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #if PTO2_PROFILING
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
-            pto2_framework_bind_runtime(rt);
+            framework_bind_runtime(rt);
             if (orch_bind_runtime_ != nullptr) {
                 orch_bind_runtime_(rt);
             }
-            pto2_rt_scope_begin(rt);
+            rt_scope_begin(rt);
             orch_func_(*orch_args_cached_);
-            pto2_rt_scope_end(rt);
+            rt_scope_end(rt);
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             (void)orch_cycle_end;
@@ -489,7 +487,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             // Print orchestrator profiling data
 #if PTO2_ORCH_PROFILING
-            PTO2OrchProfilingData p = pto2_orchestrator_get_profiling();
+            PTO2OrchProfilingData p = orchestrator_get_profiling();
             uint64_t total =
                 p.sync_cycle + p.alloc_cycle + p.args_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
@@ -571,7 +569,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // Signal completion to the orchestrator state machine
-            pto2_rt_orchestration_done(rt);
+            rt_orchestration_done(rt);
 
             // Latch task count from PTO2 shared memory
             int32_t total_tasks = 0;
@@ -582,7 +580,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 }
             }
 #if PTO2_PROFILING
-            pto2_submitted_tasks = total_tasks;
+            submitted_tasks = total_tasks;
 #endif
 
             if (is_l2_swimlane_enabled() && total_tasks > 0) {
@@ -598,9 +596,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             static_cast<uint64_t>(orch_cycle_start), static_cast<uint64_t>(orch_end_ts),
             cycles_to_us(orch_end_ts - orch_cycle_start)
         );
-        if (pto2_submitted_tasks >= 0) {
+        if (submitted_tasks >= 0) {
             DEV_ALWAYS(
-                "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
+                "PTO2 total submitted tasks = %d, already executed %d tasks", submitted_tasks,
                 sched_ctx_.completed_tasks_count()
             );
         }
@@ -643,12 +641,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // always tear them down here, but we keep orch_so_handle_ alive for
         // the next run's cache-hit reuse (see run() reload_so branch).
         if (!runtime->get_orch_built_on_host() && rt != nullptr) {
-            // Clear g_pto2_current_runtime in this DSO and in the orchestration SO before destroying rt.
-            pto2_framework_bind_runtime(nullptr);
+            // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
+            framework_bind_runtime(nullptr);
             if (orch_bind_runtime_ != nullptr) {
                 orch_bind_runtime_(nullptr);
             }
-            pto2_runtime_destroy(rt);
+            runtime_destroy(rt);
         }
     }
 
@@ -729,7 +727,7 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
         return rc;
     }
 
-    int32_t runtime_rc = read_pto2_runtime_status(runtime);
+    int32_t runtime_rc = read_runtime_status(runtime);
 
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -77,7 +77,7 @@ static int32_t read_pto2_runtime_status(Runtime *runtime) {
         return 0;
     }
 
-    void *sm = runtime->get_pto2_gm_sm_ptr();
+    void *sm = runtime->get_gm_sm_ptr();
     if (sm == nullptr) {
         return 0;
     }
@@ -389,7 +389,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // reused above.
             const ChipStorageTaskArgs &args = runtime->get_orch_args();
             int32_t arg_count = args.tensor_count() + args.scalar_count();
-            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_pto2_gm_sm_ptr(), arg_count);
+            DEV_INFO("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
             for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
                 const ContinuousTensor &t = args.tensor(i);
                 DEV_INFO(
@@ -407,23 +407,23 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
             uint64_t heap_size = PTO2_HEAP_SIZE;
 
-            if (runtime->pto2_task_window_size > 0) {
-                task_window_size = runtime->pto2_task_window_size;
+            if (runtime->task_window_size > 0) {
+                task_window_size = runtime->task_window_size;
             }
-            if (runtime->pto2_heap_size > 0) {
-                heap_size = runtime->pto2_heap_size;
+            if (runtime->heap_size > 0) {
+                heap_size = runtime->heap_size;
             }
             int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-            if (runtime->pto2_dep_pool_size > 0) {
-                dep_pool_capacity = static_cast<int32_t>(runtime->pto2_dep_pool_size);
+            if (runtime->dep_pool_size > 0) {
+                dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
             }
             DEV_INFO(
                 "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
                 static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
             );
 
-            void *sm_ptr = runtime->get_pto2_gm_sm_ptr();
-            void *gm_heap = runtime->get_pto2_gm_heap_ptr();
+            void *sm_ptr = runtime->get_gm_sm_ptr();
+            void *gm_heap = runtime->get_gm_heap_ptr();
 
             uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
             PTO2SharedMemoryHandle *sm_handle =
@@ -453,7 +453,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             rt->orchestrator.total_aiv_count = sched_ctx_.aiv_count();
 
             // With multi-ring, slot_states are per-ring inside the scheduler.
-            runtime->set_pto2_slot_states_ptr(nullptr);
+            runtime->set_slot_states_ptr(nullptr);
 
             orch_args_cached_ = &args;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/pto_runtime_status.h
@@ -38,7 +38,7 @@
 #define PTO2_ERROR_ASYNC_WAIT_OVERFLOW 102
 #define PTO2_ERROR_ASYNC_REGISTRATION_FAILED 103
 
-static inline int32_t pto2_runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
+static inline int32_t runtime_status_from_error_codes(int32_t orch_error_code, int32_t sched_error_code) {
     if (orch_error_code != PTO2_ERROR_NONE) {
         return orch_error_code < 0 ? orch_error_code : -orch_error_code;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -93,7 +93,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     uint64_t heap_size;
     uint64_t task_descriptors_offset;
 
-    // Per-ring data pointers (host-side, set by pto2_sm_setup_pointers)
+    // Per-ring data pointers (host-side, set by PTO2SharedMemoryHandle::setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -162,7 +162,7 @@ The task ring manages task slot allocation with back-pressure flow control.
 
 **Slot mapping**: `slot = task_id & (window_size - 1)`
 
-**Allocation** (`pto2_task_ring_alloc`):
+**Allocation** (`PTO2TaskAllocator::alloc`):
 
 ```text
 active_count = current_index - *last_alive_ptr
@@ -203,11 +203,11 @@ A simple bump allocator for `PTO2DepListEntry` nodes used in fanin/fanout linked
 
 The ring buffer mechanism provides **flow control** between the orchestrator (producer) and the scheduler (consumer). When a ring is exhausted, the orchestrator **blocks** — it cannot submit new tasks or allocate more output memory until the scheduler reclaims slots/space by advancing the watermarks.
 
-**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `pto2_task_ring_alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
+**Task Ring back-pressure**: When `active_count = current_index - last_task_alive >= window_size - 1`, `PTO2TaskAllocator::alloc` spin-waits until the scheduler completes tasks and advances `last_task_alive`.
 
-**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `pto2_heap_ring_alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
+**Heap Ring back-pressure**: When the heap has insufficient contiguous space, `PTO2TaskAllocator::alloc` spin-waits until the scheduler advances `heap_tail` past completed tasks' output buffers.
 
-**TensorMap pool back-pressure**: When the entry pool is exhausted, `new_entry()` spin-waits on `pto2_orchestrator_sync_tensormap(force=true)` until cleanup frees entries (see Section 5.4).
+**TensorMap pool back-pressure**: When the entry pool is exhausted, `new_entry()` spin-waits on `PTO2TensorMap::sync_tensormap(force=true)` until cleanup frees entries (see Section 5.4).
 
 This back-pressure is essential for correctness with small ring sizes — for example, with `PTO2_RING_TASK_WINDOW=16` and 208 tasks, the orchestrator blocks ~192 times, each time waiting for the scheduler to drain completed tasks before continuing.
 
@@ -273,7 +273,7 @@ Unlike the Task Ring and Heap Ring, TensorMap entries are **not** managed by a r
 
 1. **Free list first**: `free_entry_list[]` stores pointers to released entries. Allocation pops from here (O(1)).
 2. **Bump allocation**: if free list is empty, `entry_pool[next_entry_idx++]` allocates from the end of the pool.
-3. **Blocking reclaim**: if the pool is fully exhausted, `pto2_orchestrator_sync_tensormap(force=true)` reads the latest `last_task_alive` and calls `cleanup_retired` to batch-free all entries belonging to retired tasks, returning them to the free list.
+3. **Blocking reclaim**: if the pool is fully exhausted, `PTO2TensorMap::sync_tensormap(force=true)` reads the latest `last_task_alive` and calls `cleanup_retired` to batch-free all entries belonging to retired tasks, returning them to the free list.
 
 This design avoids the complexity of ring-based wrapping while still being bounded by `PTO2_TENSORMAP_POOL_SIZE` (default 65536 entries).
 
@@ -288,19 +288,19 @@ Three complementary mechanisms achieve this:
 
 **Layer 1 — Chain Truncation during Lookup** (lazy, per-bucket):
 
-Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `pto2_tensormap_lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
+Since `insert` always prepends to the bucket head, entries in each bucket chain are in **descending task_id order**. When `PTO2TensorMap::lookup` encounters the first stale entry (`producer_task_id < last_task_alive`), all subsequent entries in the chain are guaranteed stale too. The entire tail is truncated in one operation using `prev_in_bucket` pointers for O(1) unlinking.
 
 This guarantees lookup only traverses valid entries — O(valid_entries_in_bucket), not O(total_entries).
 
 **Layer 2 — Periodic Batch Cleanup** (`cleanup_retired`, per-task):
 
-Every time the orchestrator submits a task (Step 0 of `pto2_submit_task`), it calls `pto2_orchestrator_sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `pto2_tensormap_cleanup_retired` runs:
+Every time the orchestrator submits a task (Step 0 of `PTO2OrchestratorState::submit_task`), it calls `PTO2TensorMap::sync_tensormap`. When `last_task_alive` has advanced by more than `PTO2_TENSORMAP_CLEANUP_INTERVAL` (default 64) tasks since the last cleanup, `PTO2TensorMap::cleanup_retired` runs:
 
 This uses the **per-task entry chain** (`task_entry_head[task_slot]`) — each task's entries are doubly-linked together at insert time via `next_in_task`/`prev_in_task`, allowing O(entries_per_task) cleanup without scanning the entire pool or all buckets. Freed entries are returned to `free_entry_list` for immediate reuse.
 
 **Layer 3 — Back-Pressure on Pool Exhaustion** (blocking):
 
-If both the free list and bump region are depleted, `new_entry()` blocks until `pto2_orchestrator_sync_tensormap(force=true)` frees entries by advancing `last_task_alive` through `cleanup_retired`.
+If both the free list and bump region are depleted, `new_entry()` blocks until `PTO2TensorMap::sync_tensormap(force=true)` frees entries by advancing `last_task_alive` through `cleanup_retired`.
 
 This forms a back-pressure mechanism analogous to the Task Ring's flow control.
 
@@ -316,11 +316,11 @@ In steady state, the number of valid TensorMap entries ≈ `active_tasks × avg_
 
 ### 5.5 Dependency Discovery Flow
 
-When `pto2_submit_task` processes parameters:
+When `PTO2OrchestratorState::submit_task` processes parameters:
 
-1. **INPUT/INOUT**: `pto2_tensormap_lookup` searches for overlapping producers (with chain truncation)
-2. For each producer found: `pto2_add_consumer_to_producer` adds the dependency
-3. **OUTPUT/INOUT**: `pto2_tensormap_insert` registers the current task as the new producer at bucket head
+1. **INPUT/INOUT**: `PTO2TensorMap::lookup` searches for overlapping producers (with chain truncation)
+2. For each producer found: `append_fanin_or_fail` adds the dependency
+3. **OUTPUT/INOUT**: `PTO2TensorMap::insert` registers the current task as the new producer at bucket head
 4. Stale entries are pruned lazily during lookup (Layer 1) and periodically by cleanup (Layer 2)
 
 ---
@@ -386,12 +386,12 @@ Key members:
 - `scheduler`: pointer to scheduler state (for wiring queue and ready queue access)
 - `gm_heap_base`, `gm_heap_size`: GM heap for output buffers
 
-### 7.2 Task Submission Flow (`pto2_submit_mixed_task`)
+### 7.2 Task Submission Flow (`PTO2OrchestratorState::submit_task`)
 
 | Step | Operation |
 | ---- | --------- |
-| 0 | `pto2_orchestrator_sync_tensormap` — prune stale TensorMap entries |
-| 1 | `pto2_task_ring_alloc` — allocate task slot (may block on flow control) |
+| 0 | `PTO2TensorMap::sync_tensormap` — prune stale TensorMap entries |
+| 1 | `PTO2TaskAllocator::alloc` — allocate task slot (may block on flow control) |
 | 2 | Initialize task descriptor + slot state, copy parameters |
 | 3 | **Lookup**: for each INPUT/INOUT param, search TensorMap for producers; collect producer pointers in `PTO2FaninBuilder` |
 | 4 | **Insert**: register OUTPUT/INOUT args in TensorMap |

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -434,8 +434,8 @@ Scopes control the lifetime of intermediate buffers. Each scope:
 ```cpp
 PTO2_SCOPE(rt) {
     // Tasks submitted here belong to this scope
-    pto2_rt_submit_aic_task(FUNC_QK, args);
-    pto2_rt_submit_aiv_task(FUNC_SF, args);
+    rt_submit_aic_task(FUNC_QK, args);
+    rt_submit_aiv_task(FUNC_SF, args);
 }
 // scope_end: scope reference released from all tasks above
 ```
@@ -479,7 +479,7 @@ After these phases, the scheduler updates profiling headers and checks for termi
 Ready queues use a lock-free bounded MPMC (Vyukov) design:
 
 - One `PTO2ReadyQueue` per resource shape (5 shapes: `AIC_ONLY`, `AIV_X1`, `AIV_X2`, `AIC_AIV_X1`, `AIC_AIV_X2`)
-- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `pto2_active_mask_to_shape(task->active_mask)`
+- **Push**: any thread (orchestrator via `init_task`, or scheduler on completion) pushes newly-ready tasks to the queue matching `task->active_mask.to_shape()`
 - **Pop**: scheduler threads pop from the queue matching the idle core's resource shape
 - Per-slot sequence counters prevent ABA problems
 - `enqueue_pos` and `dequeue_pos` are on separate cache lines to avoid false sharing
@@ -617,11 +617,11 @@ The orchestration API is defined in `pto_orchestration_api.h`. Orchestration cod
 
 | Function/Macro | Purpose |
 | -------------- | ------- |
-| `pto2_rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
-| `pto2_rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
-| `pto2_rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
+| `rt_submit_task(mixed_kernels, args)` | Submit a mixed task with `MixedKernels` struct |
+| `rt_submit_aic_task(kernel_id, args)` | Convenience: submit AIC-only task |
+| `rt_submit_aiv_task(kernel_id, args)` | Convenience: submit AIV-only task |
 | `PTO2_SCOPE() { ... }` | RAII scope for buffer lifetime |
-| `pto2_rt_orchestration_done()` | Signal orchestration complete |
+| `rt_orchestration_done()` | Signal orchestration complete |
 
 ### 11.2 Parameter Construction
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -80,7 +80,7 @@ TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 scalar_ci.set_initial_value(float_to_u64(77.0f));
 Arg args;
 args.add_output(scalar_ci);
-TaskOutputTensors outs = pto2_rt_submit_aiv_task(FUNC_NOOP, args);
+TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
 const Tensor& scalar_tensor = outs.get_ref(0);
 
 // Orchestration-side blocking read (waits for kernel completion)

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SUBMIT_BY_CLUSTER.md
@@ -58,17 +58,17 @@ struct MixedKernels {
     int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
 };
 
-static inline void pto2_rt_submit_task(PTO2Runtime* rt,
+static inline void rt_submit_task(PTO2Runtime* rt,
                                        const MixedKernels& mixed_kernels,
                                        Arg* args,
                                        int32_t num_args);
 
-static inline void pto2_rt_submit_aic_task(PTO2Runtime* rt,
+static inline void rt_submit_aic_task(PTO2Runtime* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);
 
-static inline void pto2_rt_submit_aiv_task(PTO2Runtime* rt,
+static inline void rt_submit_aiv_task(PTO2Runtime* rt,
                                            int32_t kernel_id,
                                            Arg* args,
                                            int32_t num_args);

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -56,7 +56,7 @@ Thread 3: PTO2 total submitted tasks = 16704
 | Field | Source (`pto_orchestrator.cpp`) | Description |
 | ----- | ------------------------------- | ----------- |
 | **cost** | Wall-clock around `orch_func()` call | Total time including orchestration logic + scope overhead |
-| **total** | Sum of all sub-steps below | Accumulated time inside `pto2_submit_task` across all tasks |
+| **total** | Sum of all sub-steps below | Accumulated time inside `submit_task` across all tasks |
 | **sync_tensormap** | `g_orch_sync_cycle` | TensorMap validity sync and optional cleanup before each submission |
 | **task_ring_alloc** | `g_orch_alloc_cycle` | Allocating a task slot from the task ring buffer |
 | **param_copy** | `g_orch_args_cycle` | Copying param descriptors + tensor descriptor copies into task-owned storage |
@@ -64,12 +64,12 @@ Thread 3: PTO2 total submitted tasks = 16704
 | **heap_alloc** | `g_orch_heap_cycle` | Allocating packed output buffers from the heap ring |
 | **tensormap_ins** | `g_orch_insert_cycle` | Inserting output/inout tensors into the TensorMap |
 | **fanin+ready** | `g_orch_fanin_cycle` | Building the fanin list + checking if task is already ready (Step 5/5b) |
-| **scope_end** | `g_orch_scope_end_cycle` | `pto2_scope_end` overhead (notifying scheduler of scope completion) |
+| **scope_end** | `g_orch_scope_end_cycle` | `end_scope` overhead (notifying scheduler of scope completion) |
 | **avg/task** | `total / submit_count` | Average orchestrator time per task submission |
 
 ### Interpreting the Numbers
 
-- **cost > total**: The difference is overhead outside `pto2_submit_task` (the orchestration user code itself, scope_begin/end, TensorCreateInfo construction, etc.).
+- **cost > total**: The difference is overhead outside `submit_task` (the orchestration user code itself, scope_begin/end, TensorCreateInfo construction, etc.).
 - **lookup+dep** is typically the dominant cost (~50%) because it involves TensorMap hash lookups and building dependency edges with spinlock-protected fanout list insertions.
 - **param_copy** scales with the number of parameters per task.
 - **avg/task < 1us** indicates efficient graph construction.

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -75,7 +75,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
         return 0;
     }
 
-    void *pto2_sm = runtime->get_pto2_gm_sm_ptr();
+    void *pto2_sm = runtime->get_gm_sm_ptr();
     if (pto2_sm == nullptr) {
         return 0;
     }
@@ -233,23 +233,22 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
 
     // Read ring buffer size overrides from environment
     {
-        runtime->pto2_task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->pto2_heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->pto2_dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
-        if (runtime->pto2_task_window_size || runtime->pto2_heap_size || runtime->pto2_dep_pool_size) {
+        runtime->task_window_size = parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
+        runtime->heap_size = parse_env_uint64("PTO2_RING_HEAP", 1024, true);
+        runtime->dep_pool_size = parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
+        if (runtime->task_window_size || runtime->heap_size || runtime->dep_pool_size) {
             LOG_INFO(
                 "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
-                (uint64_t)(runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE),
-                (uint64_t)(runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE),
-                (uint64_t)(runtime->pto2_dep_pool_size ? runtime->pto2_dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
+                (uint64_t)(runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE),
+                (uint64_t)(runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE),
+                (uint64_t)(runtime->dep_pool_size ? runtime->dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
             );
         }
     }
 
     // Resolve effective sizes (env override or compile-time default)
-    uint64_t eff_heap_size = runtime->pto2_heap_size ? runtime->pto2_heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size =
-        runtime->pto2_task_window_size ? runtime->pto2_task_window_size : PTO2_TASK_WINDOW_SIZE;
+    uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
+    uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
 
     // Allocate GM heap for orchestrator output buffers (all rings combined)
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
@@ -261,7 +260,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         return -1;
     }
     runtime->record_tensor_pair(nullptr, gm_heap, total_heap_size);
-    runtime->set_pto2_gm_heap(gm_heap);
+    runtime->set_gm_heap(gm_heap);
 
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
@@ -272,7 +271,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
         LOG_ERROR("Failed to allocate PTO2 shared memory");
         return -1;
     }
-    runtime->set_pto2_gm_sm_ptr(sm_ptr);
+    runtime->set_gm_sm_ptr(sm_ptr);
     runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
 
     // Set up device orchestration state

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -70,17 +70,17 @@ static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool requir
     return static_cast<uint64_t>(val);
 }
 
-static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
+static int32_t read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
     if (runtime == nullptr || host_header == nullptr) {
         return 0;
     }
 
-    void *pto2_sm = runtime->get_gm_sm_ptr();
-    if (pto2_sm == nullptr) {
+    void *sm_ptr = runtime->get_gm_sm_ptr();
+    if (sm_ptr == nullptr) {
         return 0;
     }
 
-    int hdr_rc = runtime->host_api.copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
+    int hdr_rc = runtime->host_api.copy_from_device(host_header, sm_ptr, sizeof(PTO2SharedMemoryHeader));
     if (hdr_rc != 0) {
         LOG_WARN("Failed to copy PTO2 header from device");
         return 0;
@@ -88,7 +88,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
 
     int32_t orch_error_code = host_header->orch_error_code.load(std::memory_order_relaxed);
     int32_t sched_error_code = host_header->sched_error_code.load(std::memory_order_relaxed);
-    return pto2_runtime_status_from_error_codes(orch_error_code, sched_error_code);
+    return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
 /**
@@ -264,7 +264,7 @@ extern "C" int init_runtime_impl(Runtime *runtime, const ChipCallable *callable,
 
     // Allocate PTO2 shared memory
     int64_t t_sm_start = _now_ms();
-    uint64_t sm_size = pto2_sm_calculate_size(eff_task_window_size);
+    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
     void *sm_ptr = runtime->host_api.device_malloc(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {
@@ -325,7 +325,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     PTO2SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
 
-    runtime_status = pto2_read_runtime_status(runtime, &host_header);
+    runtime_status = read_runtime_status(runtime, &host_header);
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -29,18 +29,16 @@ namespace {
 // crash (BZ #32412) when the orchestration SO is dlclose'd/re-dlopen'd
 // between execution rounds.  All orchestrator threads bind the same rt
 // value, so per-thread storage is unnecessary.
-PTO2Runtime *g_pto2_current_runtime = nullptr;
+PTO2Runtime *g_current_runtime = nullptr;
 }  // namespace
 
-extern "C" __attribute__((visibility("default"))) void pto2_framework_bind_runtime(PTO2Runtime *rt) {
-    g_pto2_current_runtime = rt;
+extern "C" __attribute__((visibility("default"))) void framework_bind_runtime(PTO2Runtime *rt) {
+    g_current_runtime = rt;
 }
 
 // Keep current_runtime local to this .so so orchestration helpers do not
 // accidentally bind to the AICPU binary's same-named symbol.
-extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *pto2_framework_current_runtime() {
-    return g_pto2_current_runtime;
-}
+extern "C" __attribute__((visibility("hidden"))) PTO2Runtime *framework_current_runtime() { return g_current_runtime; }
 
 /**
  * Use addr2line to convert an address to file:line information.

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -143,9 +143,10 @@ typedef struct PTO2RuntimeOps {
 /**
  * Partial PTO2Runtime definition for orchestration.
  *
- * Only the ops pointer is visible.  The real struct (in pto_runtime2.h)
- * has the same first field, so accessing rt->ops through this definition
- * is well-defined (C struct layout guarantee).
+ * Exposes the ops pointer (for runtime calls) and pending_scope_mode
+ * (read directly by inline scope wrappers).  The real struct (in
+ * pto_runtime2.h) has the same first fields, so accessing them through
+ * this definition is well-defined (C struct layout guarantee).
  */
 struct PTO2Runtime {
     const PTO2RuntimeOps *ops;

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -103,8 +103,8 @@ extern "C" {
  * aicpu_orchestration_entry(), so orchestration helpers can fetch the
  * current PTO2Runtime without explicit parameter threading.
  */
-PTO2Runtime *pto2_framework_current_runtime(void);
-void pto2_framework_bind_runtime(PTO2Runtime *rt);
+PTO2Runtime *framework_current_runtime(void);
+void framework_bind_runtime(PTO2Runtime *rt);
 
 #ifdef __cplusplus
 }
@@ -143,10 +143,9 @@ typedef struct PTO2RuntimeOps {
 /**
  * Partial PTO2Runtime definition for orchestration.
  *
- * Orchestration only relies on the prefix shared with the full runtime:
- * the ops pointer plus pending_scope_mode. The real struct
- * (in pto_runtime2.h) starts with the same fields in the same order,
- * so accessing that prefix through this definition is well-defined.
+ * Only the ops pointer is visible.  The real struct (in pto_runtime2.h)
+ * has the same first field, so accessing rt->ops through this definition
+ * is well-defined (C struct layout guarantee).
  */
 struct PTO2Runtime {
     const PTO2RuntimeOps *ops;
@@ -157,10 +156,10 @@ struct PTO2Runtime {
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================
 
-static inline PTO2Runtime *pto2_current_runtime() { return pto2_framework_current_runtime(); }
+static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
 
 static inline TaskOutputTensors alloc_tensors(const Arg &args) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -168,7 +167,7 @@ static inline TaskOutputTensors alloc_tensors(const Arg &args) {
 }
 
 static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_infos[], uint32_t count) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -193,7 +192,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
         (std::is_same_v<std::decay_t<CIs>, TensorCreateInfo> && ...),
         "alloc_tensors only accepts TensorCreateInfo arguments"
     );
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
@@ -210,44 +209,44 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
 }
 
 static inline TaskOutputTensors
-pto2_rt_submit_task_impl(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
-    PTO2Runtime *rt = pto2_current_runtime();
+rt_submit_task_impl(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
     return rt->ops->submit_task(rt, mixed_kernels, args, complete_in_future);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
-    return pto2_rt_submit_task_impl(mixed_kernels, args, false);
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    return rt_submit_task_impl(mixed_kernels, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline TaskOutputTensors pto2_rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
-    return pto2_rt_submit_task_impl(mk, args, false);
+    return rt_submit_task_impl(mk, args, false);
 }
 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline TaskOutputTensors pto2_rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    return pto2_rt_submit_task_impl(mk, args, false);
+    return rt_submit_task_impl(mk, args, false);
 }
 
-static inline TaskOutputTensors pto2_rt_submit_aiv_task_deferred(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aiv_task_deferred(int32_t kernel_id, const Arg &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
-    return pto2_rt_submit_task_impl(mk, args, true);
+    return rt_submit_task_impl(mk, args, true);
 }
 
-static inline void pto2_rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -255,39 +254,39 @@ static inline void pto2_rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO)
     rt->ops->scope_begin(rt);
 }
 
-static inline void pto2_rt_scope_end() {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline void rt_scope_end() {
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
     rt->ops->scope_end(rt);
 }
 
-static inline void pto2_rt_orchestration_done() {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline void rt_orchestration_done() {
+    PTO2Runtime *rt = current_runtime();
     rt->ops->orchestration_done(rt);
 }
 
-static inline bool pto2_rt_is_fatal() {
-    PTO2Runtime *rt = pto2_current_runtime();
+static inline bool rt_is_fatal() {
+    PTO2Runtime *rt = current_runtime();
     return rt->ops->is_fatal(rt);
 }
 
-#define pto2_rt_report_fatal(code, fmt, ...)                                               \
-    do {                                                                                   \
-        PTO2Runtime *_pto2_rt = pto2_current_runtime();                                    \
-        _pto2_rt->ops->report_fatal(_pto2_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
+#define rt_report_fatal(code, fmt, ...)                                          \
+    do {                                                                         \
+        PTO2Runtime *_rt = current_runtime();                                    \
+        _rt->ops->report_fatal(_rt, (code), __FUNCTION__, (fmt), ##__VA_ARGS__); \
     } while (0)
 
 // =============================================================================
 // Logging Macros for Orchestration (call through ops table)
 // =============================================================================
 
-#define LOG_ERROR(fmt, ...) pto2_current_runtime()->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_WARN(fmt, ...) pto2_current_runtime()->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_INFO(fmt, ...) pto2_current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_DEBUG(fmt, ...) pto2_current_runtime()->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
-#define LOG_ALWAYS(fmt, ...) pto2_current_runtime()->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_ERROR(fmt, ...) current_runtime()->ops->log_error(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_WARN(fmt, ...) current_runtime()->ops->log_warn(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_INFO(fmt, ...) current_runtime()->ops->log_info(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_DEBUG(fmt, ...) current_runtime()->ops->log_debug(__FUNCTION__, fmt, ##__VA_ARGS__)
+#define LOG_ALWAYS(fmt, ...) current_runtime()->ops->log_always(__FUNCTION__, fmt, ##__VA_ARGS__)
 
 // =============================================================================
 // Cross-Layer Data Access
@@ -308,7 +307,7 @@ static inline bool pto2_rt_is_fatal() {
  */
 template <typename T = uint64_t>
 static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return from_u64<T>(0);
     }
@@ -344,7 +343,7 @@ static inline T get_tensor_data(const Tensor &tensor, uint32_t ndims, const uint
  */
 template <typename T = uint64_t>
 static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const uint32_t indices[], T value) {
-    PTO2Runtime *rt = pto2_current_runtime();
+    PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return;
     }
@@ -361,7 +360,7 @@ static inline void set_tensor_data(const Tensor &tensor, uint32_t ndims, const u
 class PTO2ScopeGuard {
 public:
     explicit PTO2ScopeGuard(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) :
-        rt_(pto2_current_runtime()) {
+        rt_(current_runtime()) {
         if (!rt_->ops->is_fatal(rt_)) {
             rt_->pending_scope_mode = mode;
             rt_->ops->scope_begin(rt_);
@@ -386,7 +385,7 @@ private:
 /**
  * Scoped block macro:
  *   PTO2_SCOPE() {
- *       pto2_rt_submit_task(...);
+ *       rt_submit_task(...);
  *   }
  */
 #define PTO2_SCOPE(...) if (PTO2ScopeGuard _PTO2_CONCATENATE(scope_guard_, __COUNTER__){__VA_ARGS__}; true)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -60,7 +60,7 @@ static_assert(
 /**
  * Per-core dispatch payload: function address + args[] + SPMD context.
  *
- * AICPU maintains a static array s_pto2_payload_per_core[RUNTIME_MAX_WORKER].
+ * AICPU maintains a static array s_payload_per_core[RUNTIME_MAX_WORKER].
  * AICore caches a pointer to its per-core slot at startup (via Handshake.task)
  * and reads from it on each dispatch.
  *

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -28,11 +28,11 @@ struct PTO2CompletionStats;
 inline constexpr int32_t PTO2_MAX_ASYNC_WAITS = 64;
 inline constexpr int32_t PTO2_MAX_PENDING_COMPLETIONS = 128;
 
-inline uintptr_t pto2_completion_ingress_cache_line(const volatile void *addr) {
+inline uintptr_t completion_ingress_cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
 }
 
-inline void pto2_completion_ingress_invalidate_entries(
+inline void completion_ingress_invalidate_entries(
     volatile PTO2CompletionIngressQueue *completion_ingress, uint64_t tail, uint64_t head
 ) {
     uint64_t active_count = head - tail;
@@ -59,7 +59,7 @@ inline void pto2_completion_ingress_invalidate_entries(
     );
 }
 
-inline bool pto2_completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
+inline bool completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
     if (completion_ingress == nullptr) return false;
     cache_invalidate_range(
         const_cast<const void *>(reinterpret_cast<volatile void *>(&completion_ingress->head)),
@@ -123,7 +123,7 @@ struct PTO2AsyncPollResult {
     PTO2TaskSlotState *failed_slot_state{nullptr};
 };
 
-inline const char *pto2_async_engine_name(PTO2AsyncEngine engine) {
+inline const char *async_engine_name(PTO2AsyncEngine engine) {
     switch (engine) {
     case PTO2_ASYNC_ENGINE_SDMA:
         return "SDMA";
@@ -173,7 +173,7 @@ struct PTO2AsyncWaitList {
             );
             uint64_t head_snapshot = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
             if (tail >= head_snapshot) break;
-            pto2_completion_ingress_invalidate_entries(completion_ingress, tail, head_snapshot);
+            completion_ingress_invalidate_entries(completion_ingress, tail, head_snapshot);
 
             while (tail < head_snapshot) {
                 volatile PTO2CompletionIngressEntry *slot =
@@ -327,7 +327,7 @@ struct PTO2AsyncWaitList {
             volatile PTO2DeferredCompletionEntry *deferred = &ingress->entries[i];
             volatile uint32_t *counter = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
             cache_invalidate_range(
-                reinterpret_cast<const void *>(pto2_completion_ingress_cache_line(counter)), sizeof(uint32_t)
+                reinterpret_cast<const void *>(completion_ingress_cache_line(counter)), sizeof(uint32_t)
             );
             if (!append_condition_locked(
                     *entry, deferred->addr, deferred->expected_value, static_cast<PTO2AsyncEngine>(deferred->engine),

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -542,9 +542,9 @@ PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg 
     // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
     // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
     MixedKernels normalized = mixed_kernels;
-    bool has_aic = (active_mask & PTO2_SUBTASK_MASK_AIC) != 0;
-    bool has_aiv0 = (active_mask & PTO2_SUBTASK_MASK_AIV0) != 0;
-    bool has_aiv1 = (active_mask & PTO2_SUBTASK_MASK_AIV1) != 0;
+    bool has_aic = active_mask.has_mask(PTO2_SUBTASK_MASK_AIC);
+    bool has_aiv0 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV0);
+    bool has_aiv1 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV1);
     if (!has_aic && has_aiv1 && !has_aiv0) {
         normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
         normalized.aiv1_kernel_id = INVALID_KERNEL_ID;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -115,7 +115,7 @@ static uint32_t g_orch_submit_idx = 0;
 #define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)
 #endif
 
-static void *pto2_aligned_zalloc(size_t size, size_t alignment) {
+static void *aligned_zalloc(size_t size, size_t alignment) {
     void *ptr = nullptr;
     if (posix_memalign(&ptr, alignment, size) != 0) {
         return nullptr;
@@ -124,7 +124,7 @@ static void *pto2_aligned_zalloc(size_t size, size_t alignment) {
     return ptr;
 }
 
-static int32_t pto2_orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
+static int32_t orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_code) {
     always_assert(orch != nullptr);
     orch->fatal = true;
     if (error_code == PTO2_ERROR_NONE || orch->sm_header == nullptr) {
@@ -139,10 +139,9 @@ static int32_t pto2_orch_mark_fatal(PTO2OrchestratorState *orch, int32_t error_c
     return expected;
 }
 
-static void pto2_orch_report_fatal_v(
-    PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args
-) {
-    int32_t latched_code = pto2_orch_mark_fatal(orch, error_code);
+static void
+orch_report_fatal_v(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, va_list args) {
+    int32_t latched_code = orch_mark_fatal(orch, error_code);
 
     if (fmt == nullptr || fmt[0] == '\0') {
         if (latched_code != PTO2_ERROR_NONE && latched_code != error_code) {
@@ -162,10 +161,11 @@ static void pto2_orch_report_fatal_v(
     unified_log_error(func, "FATAL(code=%d): %s", error_code, message);
 }
 
-void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...) {
+void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, const char *fmt, ...) {
+    auto *orch = this;
     va_list args;
     va_start(args, fmt);
-    pto2_orch_report_fatal_v(orch, error_code, func, fmt, args);
+    orch_report_fatal_v(orch, error_code, func, fmt, args);
     va_end(args);
 }
 
@@ -181,7 +181,7 @@ struct PTO2FaninBuilder {
 
     template <typename Fn>
     PTO2FaninForEachReturn<Fn> for_each(Fn &&fn) const {
-        return pto2_for_each_fanin_storage(inline_slots, count, spill_start, spill_pool, static_cast<Fn &&>(fn));
+        return for_each_fanin_storage(inline_slots, count, spill_start, spill_pool, static_cast<Fn &&>(fn));
     }
 
     bool contains(PTO2TaskSlotState *prod_state) const {
@@ -200,7 +200,7 @@ struct PTO2FaninBuilder {
     }
 };
 
-static bool pto2_append_fanin_or_fail(
+static bool append_fanin_or_fail(
     PTO2OrchestratorState *orch, PTO2TaskSlotState *prod_state, PTO2FaninBuilder *fanin_builder, uint8_t ring_id
 ) {
     if (fanin_builder->contains(prod_state)) {
@@ -217,7 +217,7 @@ static bool pto2_append_fanin_or_fail(
     int32_t spill_idx = fanin_pool.top;
     PTO2FaninSpillEntry *entry = fanin_pool.alloc();
     if (entry == nullptr) {
-        pto2_orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
+        orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
         return false;
     }
     if (fanin_builder->count == PTO2_FANIN_INLINE_CAP) {
@@ -238,7 +238,7 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
-static PTO2OutputLayout pto2_calculate_output_layout(const Arg &args) {
+static PTO2OutputLayout calculate_output_layout(const Arg &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) != TensorArgType::OUTPUT) {
@@ -252,8 +252,7 @@ static PTO2OutputLayout pto2_calculate_output_layout(const Arg &args) {
     return layout;
 }
 
-static bool
-pto2_check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator &allocator, uint8_t ring_id) {
+static bool check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator &allocator, uint8_t ring_id) {
     always_assert(orch->scope_stack_top >= 0 && "Cannot submit task outside a scope");
 
     int32_t scope_task_count = orch->scope_tasks_size - orch->scope_begins[orch->scope_stack_top];
@@ -282,11 +281,11 @@ pto2_check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAllocator 
     LOG_ERROR("     Runtime env:  PTO2_RING_TASK_WINDOW=<power-of-2>");
     LOG_ERROR("  3. Split work across multiple scopes");
     LOG_ERROR("========================================");
-    pto2_orch_mark_fatal(orch, PTO2_ERROR_SCOPE_DEADLOCK);
+    orch_mark_fatal(orch, PTO2_ERROR_SCOPE_DEADLOCK);
     return false;
 }
 
-static void pto2_prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count, int32_t scalar_count) {
+static void prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count, int32_t scalar_count) {
     for (int32_t i = 0; i < tensor_count; i++) {
         __builtin_prefetch(&payload->tensors[i], 1, 3);
         __builtin_prefetch(reinterpret_cast<char *>(&payload->tensors[i]) + 64, 1, 3);
@@ -299,19 +298,20 @@ static void pto2_prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count
     __builtin_prefetch(reinterpret_cast<char *>(payload) + 128, 1, 3);
 }
 
-static bool pto2_prepare_task(
-    PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, uint8_t active_mask, PTO2PreparedTask *out
+static bool prepare_task(
+    PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, ActiveMask active_mask,
+    PTO2PreparedTask *out
 ) {
     uint8_t ring_id = orch->current_ring_id();
     auto &allocator = orch->rings[ring_id].task_allocator;
 
-    if (!pto2_check_scope_can_accept_task(orch, allocator, ring_id)) {
+    if (!check_scope_can_accept_task(orch, allocator, ring_id)) {
         return false;
     }
 
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
-        pto2_orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
+        orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }
 
@@ -320,7 +320,7 @@ static bool pto2_prepare_task(
     out->task = &orch->sm_header->rings[ring_id].task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->rings[ring_id].task_payloads[out->alloc_result.slot];
 
-    pto2_prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
+    prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
 
     // Fields already reset by advance_ring_pointers (eager reset after CONSUMED):
     //   fanout_lock=0, fanout_count=1, fanout_head=nullptr,
@@ -332,7 +332,7 @@ static bool pto2_prepare_task(
     out->slot_state->task_state.store(PTO2_TASK_PENDING, std::memory_order_relaxed);
     int16_t block_num = args.launch_spec.core_num();
     out->slot_state->total_required_subtasks =
-        static_cast<int16_t>(block_num * __builtin_popcount(pto2_core_mask(active_mask)));
+        static_cast<int16_t>(block_num * __builtin_popcount(active_mask.core_mask()));
     out->slot_state->logical_block_num = block_num;
     out->slot_state->active_mask = active_mask;
     // fanin_count is set by scheduler during wiring
@@ -345,10 +345,10 @@ static bool pto2_prepare_task(
 // Orchestrator Initialization
 // =============================================================================
 
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState *orch, PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size,
-    int32_t dep_pool_capacity
+bool PTO2OrchestratorState::init(
+    PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size, int32_t dep_pool_capacity
 ) {
+    auto *orch = this;
     *orch = PTO2OrchestratorState{};
 
     orch->sm_header = sm_header;
@@ -370,7 +370,7 @@ bool pto2_orchestrator_init(
         size_t fanin_pool_bytes =
             PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         PTO2FaninSpillEntry *fanin_entries =
-            reinterpret_cast<PTO2FaninSpillEntry *>(pto2_aligned_zalloc(fanin_pool_bytes, PTO2_ALIGN_SIZE));
+            reinterpret_cast<PTO2FaninSpillEntry *>(aligned_zalloc(fanin_pool_bytes, PTO2_ALIGN_SIZE));
         if (!fanin_entries) {
             for (int j = 0; j < r; j++) {
                 free(orch->rings[j].fanin_pool.base);
@@ -416,7 +416,8 @@ bool pto2_orchestrator_init(
     return true;
 }
 
-void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
+void PTO2OrchestratorState::destroy() {
+    auto *orch = this;
     orch->tensor_map.destroy();
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -430,9 +431,7 @@ void pto2_orchestrator_destroy(PTO2OrchestratorState *orch) {
     orch->scope_begins = NULL;
 }
 
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler) {
-    orch->scheduler = scheduler;
-}
+void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this->scheduler = scheduler; }
 
 // =============================================================================
 // Scope Management
@@ -450,15 +449,14 @@ static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *tas
     orch->scope_tasks[orch->scope_tasks_size++] = task_slot_state;
 }
 
-void pto2_scope_begin(PTO2OrchestratorState *orch, PTO2ScopeMode mode) {
+void PTO2OrchestratorState::begin_scope(PTO2ScopeMode mode) {
+    auto *orch = this;
     if (orch->fatal) {
         return;
     }
     assert(orch->scope_stack_top < static_cast<int32_t>(orch->scope_stack_capacity - 1) && "Scope stack overflow");
     if (mode == PTO2ScopeMode::AUTO && orch->in_manual_scope()) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "auto scope nested inside manual scope is not supported"
-        );
+        report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "auto scope nested inside manual scope is not supported");
         return;
     }
 
@@ -470,7 +468,8 @@ void pto2_scope_begin(PTO2OrchestratorState *orch, PTO2ScopeMode mode) {
     }
 }
 
-void pto2_scope_end(PTO2OrchestratorState *orch) {
+void PTO2OrchestratorState::end_scope() {
+    auto *orch = this;
     if (orch->fatal) {
         return;
     }
@@ -504,14 +503,15 @@ void pto2_scope_end(PTO2OrchestratorState *orch) {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors pto2_submit_mixed_task(
-    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
-) {
+TaskOutputTensors
+PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
+    auto *orch = this;
     CYCLE_COUNT_START();
 
     TaskOutputTensors result;
 
-    // Fast path after fatal error — all subsequent submits are no-ops
+    // Orchestration API should short-circuit after fatal, but keep this entry
+    // robust as a no-op in case a caller reaches it directly.
     if (orch->fatal) {
         return result;
     }
@@ -525,15 +525,13 @@ TaskOutputTensors pto2_submit_mixed_task(
         LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
         LOG_ERROR("This is a bug in the orchestration code.");
         LOG_ERROR("========================================");
-        pto2_orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
+        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
         return result;
     }
-
     always_assert(orch->scheduler != nullptr);
-
     // === Validate submit inputs ===
-    uint8_t active_mask = pto2_mixed_kernels_to_active_mask(mixed_kernels);
-    always_assert(active_mask != 0 && "MixedKernels must have at least one active slot");
+    ActiveMask active_mask = mixed_kernels.to_active_mask();
+    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
 
     int16_t block_num = args.launch_spec.core_num();
     always_assert(block_num >= 1 && "block_num must be >= 1");
@@ -550,7 +548,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     if (!has_aic && has_aiv1 && !has_aiv0) {
         normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
         normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
-        active_mask = pto2_mixed_kernels_to_active_mask(normalized);
+        active_mask = normalized.to_active_mask();
     }
 
     // Encode require_sync_start into active_mask bit 3 (only meaningful for tasks with block_num > 1)
@@ -558,21 +556,20 @@ TaskOutputTensors pto2_submit_mixed_task(
         // Deadlock check: block_num >= total available slots of the required type.
         // For MIX/AIC: limit is total_cluster_count (one AIC per cluster).
         // For AIV:     limit is total_aiv_count.
-        PTO2ResourceShape shape = pto2_active_mask_to_shape(active_mask);
+        PTO2ResourceShape shape = active_mask.to_shape();
         int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
         if (limit > 0 && block_num > limit) {
-            pto2_orch_report_fatal(
-                orch, PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
+            report_fatal(
+                PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
                 "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
             );
             return result;
         }
-        active_mask |= PTO2_SUBTASK_FLAG_SYNC_START;
+        active_mask.set_sync_start();
     }
-
-    PTO2OutputLayout layout = pto2_calculate_output_layout(args);
+    PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
-    if (!pto2_prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
+    if (!prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
         return result;
     }
     uint8_t ring_id = prepared.task_id.ring();
@@ -606,9 +603,7 @@ TaskOutputTensors pto2_submit_mixed_task(
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         PTO2TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
-            pto2_orch_report_fatal(
-                orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id"
-            );
+            report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
             return result;
         }
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];
@@ -618,7 +613,7 @@ TaskOutputTensors pto2_submit_mixed_task(
             continue;
         }
         PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_task_id(dep_local_task_id);
-        if (!pto2_append_fanin_or_fail(orch, producer_slot_state, &fanin_builder, ring_id)) {
+        if (!append_fanin_or_fail(orch, producer_slot_state, &fanin_builder, ring_id)) {
             return result;
         }
     }
@@ -640,7 +635,7 @@ TaskOutputTensors pto2_submit_mixed_task(
                 PTO2TaskSlotState *prod_state =
                     &orch->sm_header->rings[owner.ring()].get_slot_state_by_task_id(owner.local());
                 if (prod_state->task != nullptr && prod_state->task->task_id == owner &&
-                    !pto2_append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
+                    !append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
                     return result;
                 }
             }
@@ -663,7 +658,7 @@ TaskOutputTensors pto2_submit_mixed_task(
                 if (prod_state->task == nullptr || prod_state->task->task_id != producer_task_id) {
                     return true;
                 }
-                if (!pto2_append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
+                if (!append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id)) {
                     lookup_fatal = true;
                     return false;
                 }
@@ -694,7 +689,7 @@ TaskOutputTensors pto2_submit_mixed_task(
 
     CYCLE_COUNT_LAP_RECORD(g_orch_insert_cycle, AicpuPhaseId::ORCH_INSERT, task_id.raw);
 
-    // === STEP 5: Batch-write to GM (single cache line burst) + Record fanin metadata ===
+    // === STEP 5: Batch-write to GM (single cache line burst) ===
     // Deferred from allocation phase to avoid scattered GM writes that get
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
@@ -707,7 +702,7 @@ TaskOutputTensors pto2_submit_mixed_task(
 
     // Increment fanout_count on each producer (no lock — only orch writes this field).
     // Prevents premature CONSUMED: scope_end's release_producer checks fanout_refcount == fanout_count.
-    pto2_for_each_fanin_storage(
+    for_each_fanin_storage(
         fanin_builder.inline_slots, fanin_builder.count, fanin_builder.spill_start, fanin_builder.spill_pool,
         [](PTO2TaskSlotState *producer) {
             producer->fanout_count++;
@@ -751,27 +746,26 @@ TaskOutputTensors pto2_submit_mixed_task(
     return result;
 }
 
-TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const Arg &args) {
+    auto *orch = this;
+    // Orchestration API should short-circuit after fatal, but keep this entry
+    // robust as a no-op in case a caller reaches it directly.
     if (orch->fatal) {
         return TaskOutputTensors{};
     }
 
     if (args.tensor_count() <= 0) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors requires at least one TensorCreateInfo"
-        );
+        report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors requires at least one TensorCreateInfo");
         return TaskOutputTensors{};
     }
     if (args.scalar_count() != 0) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
-        );
+        report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args");
         return TaskOutputTensors{};
     }
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) != TensorArgType::OUTPUT) {
-            pto2_orch_report_fatal(
-                orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
+            report_fatal(
+                PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "alloc_tensors only accepts output TensorCreateInfo args"
             );
             return TaskOutputTensors{};
         }
@@ -780,16 +774,16 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     CYCLE_COUNT_START();
 
     if (args.has_error) {
-        pto2_orch_report_fatal(
-            orch, PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
+        report_fatal(
+            PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "%s",
             args.error_msg ? args.error_msg : "alloc_tensors failed to construct output-only Arg"
         );
         return TaskOutputTensors{};
     }
 
-    PTO2OutputLayout layout = pto2_calculate_output_layout(args);
+    PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
-    if (!pto2_prepare_task(orch, args, layout.total_output_size, 0, &prepared)) {
+    if (!prepare_task(orch, args, layout.total_output_size, ActiveMask{}, &prepared)) {
         return TaskOutputTensors{};
     }
 
@@ -818,7 +812,6 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
     payload.fanin_actual_count = 0;
     payload.fanin_spill_start = 0;
     payload.fanin_spill_pool = &orch->rings[prepared.task_id.ring()].fanin_pool;
-
     CYCLE_COUNT_LAP_RECORD(g_orch_args_cycle, AicpuPhaseId::ORCH_PARAMS, prepared.task_id.raw);
 
     if (prepared.slot_state != nullptr) {
@@ -826,7 +819,7 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
         // consumer can exist, so they have no fanout to notify and no worker
         // subtasks to retire. Running the full on_mixed_task_complete path
         // would only pay unnecessary fanout_lock / traversal overhead here.
-        // The generic slot initialization done in pto2_prepare_task() is still
+        // The generic slot initialization done in prepare_task() is still
         // required so scope_end can release the producer-side reference and
         // drive the slot to CONSUMED, but worker dispatch fields are never
         // observed for hidden alloc tasks.
@@ -851,7 +844,8 @@ TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &arg
 // Flow Control
 // =============================================================================
 
-void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
+void PTO2OrchestratorState::mark_done() {
+    auto *orch = this;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         int32_t total_tasks = orch->rings[r].task_allocator.active_count();
         if (total_tasks > 0) {
@@ -875,7 +869,7 @@ void pto2_orchestrator_done(PTO2OrchestratorState *orch) {
 }
 
 #if PTO2_ORCH_PROFILING
-PTO2OrchProfilingData pto2_orchestrator_get_profiling() {
+PTO2OrchProfilingData orchestrator_get_profiling() {
     PTO2OrchProfilingData d;
     d.sync_cycle = g_orch_sync_cycle;
     d.alloc_cycle = g_orch_alloc_cycle;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -113,104 +113,22 @@ struct PTO2OrchestratorState {
     }
 
     bool in_manual_scope() const { return scope_stack_top >= manual_begin_depth; }
+
+    // === Cold-path API (defined in pto_orchestrator.cpp) ===
+
+    bool init(
+        PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size,
+        int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
+    );
+    void destroy();
+    void set_scheduler(PTO2SchedulerState *scheduler);
+    void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
+    void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
+    void end_scope();
+    TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future);
+    TaskOutputTensors alloc_tensors(const Arg &args);
+    void mark_done();
 };
-
-// =============================================================================
-// Orchestrator API
-// =============================================================================
-
-/**
- * Initialize orchestrator state
- *
- * @param orch       Orchestrator state to initialize
- * @param sm_handle  Shared memory handle
- * @param gm_heap    GM heap memory for output buffers
- * @param heap_size  Size of GM heap
- * @return true on success
- */
-bool pto2_orchestrator_init(
-    PTO2OrchestratorState *orch, PTO2SharedMemoryHeader *sm_header, void *gm_heap, uint64_t heap_size,
-    int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
-);
-
-/**
- * Destroy orchestrator state and free resources
- */
-void pto2_orchestrator_destroy(PTO2OrchestratorState *orch);
-
-/**
- * Set scheduler reference (for simulated mode)
- */
-void pto2_orchestrator_set_scheduler(PTO2OrchestratorState *orch, PTO2SchedulerState *scheduler);
-
-// =============================================================================
-// Fatal Reporting
-// =============================================================================
-
-void pto2_orch_report_fatal(PTO2OrchestratorState *orch, int32_t error_code, const char *func, const char *fmt, ...);
-
-// =============================================================================
-// Scope Management
-// =============================================================================
-
-/**
- * Begin a new scope
- *
- * Pushes a new empty task list onto the scope stack.
- * Tasks submitted while this scope is at the top of the stack are
- * owned by it and have their fanout_count initialized to 1.
- */
-void pto2_scope_begin(PTO2OrchestratorState *orch, PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
-
-/**
- * End current scope
- *
- * Pops the top scope and increments fanout_refcount for each task
- * directly owned by that scope.
- * May trigger buffer release for tasks that are now fully consumed.
- */
-void pto2_scope_end(PTO2OrchestratorState *orch);
-
-// =============================================================================
-// Task Submission
-// =============================================================================
-
-/**
- * Submit a task with InCore function and parameters
- *
- * This is the main API for building the task graph:
- * 1. Allocates task slot + packed output buffer via TaskAllocator (blocks until available)
- * 2. Looks up inputs in TensorMap to find dependencies
- * 3. Updates producer's fanout_count/list (with spinlock)
- * 4. Registers outputs in TensorMap
- * 5. Initializes task state in scheduler
- *
- * @param orch        Orchestrator state
- * @param mixed_kernels  Kernel IDs for AIC/AIV0/AIV1 slots
- * @param args      Aggregated tensor and scalar parameters
- */
-TaskOutputTensors pto2_submit_mixed_task(
-    PTO2OrchestratorState *orch, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future
-);
-
-/**
- * Allocate fresh tensors by creating one hidden runtime-owned output task.
- *
- * The returned tensors are already materialized and bound to the same creator
- * task id for scope lifetime and future creator-retention dependencies.
- */
-TaskOutputTensors pto2_alloc_tensors(PTO2OrchestratorState *orch, const Arg &args);
-
-// =============================================================================
-// Flow Control
-// =============================================================================
-
-/**
- * Mark orchestration as complete
- *
- * Signals to scheduler that no more tasks will be submitted.
- */
-void pto2_orchestrator_done(PTO2OrchestratorState *orch);
 
 // =============================================================================
 // Orchestrator Profiling Data
@@ -237,11 +155,7 @@ struct PTO2OrchProfilingData {
     uint64_t scope_end_atomic_count;
 };
 
-/**
- * Get and reset orchestrator profiling data.
- * Returns accumulated profiling data and resets counters.
- */
-PTO2OrchProfilingData pto2_orchestrator_get_profiling();
+PTO2OrchProfilingData orchestrator_get_profiling();
 #endif
 
 #endif  // PTO_ORCHESTRATOR_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -439,7 +439,7 @@ template <typename Fn>
 using PTO2FaninForEachReturn = std::conditional_t<std::is_same_v<PTO2FaninCallbackResult<Fn>, void>, void, bool>;
 
 template <typename InlineSlots, typename Fn>
-inline PTO2FaninForEachReturn<Fn> pto2_for_each_fanin_storage(
+inline PTO2FaninForEachReturn<Fn> for_each_fanin_storage(
     InlineSlots &&inline_slot_states, int32_t fanin_count, int32_t spill_start, PTO2FaninPool &spill_pool, Fn &&fn
 ) {
     using FaninCallbackResult = PTO2FaninCallbackResult<Fn>;
@@ -504,8 +504,8 @@ inline PTO2FaninForEachReturn<Fn> pto2_for_each_fanin_storage(
 }
 
 template <typename Fn>
-inline PTO2FaninForEachReturn<Fn> pto2_for_each_fanin_slot_state(const PTO2TaskPayload &payload, Fn &&fn) {
-    return pto2_for_each_fanin_storage(
+inline PTO2FaninForEachReturn<Fn> for_each_fanin_slot_state(const PTO2TaskPayload &payload, Fn &&fn) {
+    return for_each_fanin_storage(
         payload.fanin_inline_slot_states, payload.fanin_actual_count, payload.fanin_spill_start,
         *payload.fanin_spill_pool, static_cast<Fn &&>(fn)
     );

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -40,34 +40,34 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 
 static TaskOutputTensors
 submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args, bool complete_in_future) {
-    return pto2_submit_mixed_task(&rt->orchestrator, mixed_kernels, args, complete_in_future);
+    return rt->orchestrator.submit_task(mixed_kernels, args, complete_in_future);
 }
 
 static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
-    return pto2_alloc_tensors(&rt->orchestrator, args);
+    return rt->orchestrator.alloc_tensors(args);
 }
 
-void pto2_rt_scope_begin(PTO2Runtime *rt) {
+void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
-    pto2_scope_begin(&rt->orchestrator, mode);
+    rt->orchestrator.begin_scope(mode);
 }
 
-void pto2_rt_scope_end(PTO2Runtime *rt) { pto2_scope_end(&rt->orchestrator); }
+void rt_scope_end(PTO2Runtime *rt) { rt->orchestrator.end_scope(); }
 
-void pto2_rt_orchestration_done(PTO2Runtime *rt) { pto2_orchestrator_done(&rt->orchestrator); }
+void rt_orchestration_done(PTO2Runtime *rt) { rt->orchestrator.mark_done(); }
 
 static bool is_fatal_impl(PTO2Runtime *rt) { return rt->orchestrator.fatal; }
 
-void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
+void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...) {
     va_list args;
     va_start(args, fmt);
     if (fmt == nullptr || fmt[0] == '\0') {
-        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, nullptr);
+        rt->orchestrator.report_fatal(error_code, func, nullptr);
     } else {
         char message[1024];
         vsnprintf(message, sizeof(message), fmt, args);
-        pto2_orch_report_fatal(&rt->orchestrator, error_code, func, "%s", message);
+        rt->orchestrator.report_fatal(error_code, func, "%s", message);
     }
     va_end(args);
 }
@@ -104,8 +104,8 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.task_state.load(std::memory_order_acquire) < PTO2_TASK_COMPLETED) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                pto2_orch_report_fatal(
-                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                orch.report_fatal(
+                    PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): producer (ring=%d, local=%d) not completed",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
                 );
@@ -123,8 +123,8 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
         while (slot.fanout_refcount.load(std::memory_order_acquire) < slot.fanout_count - 1) {
             SPIN_WAIT_HINT();
             if ((++spin_count & 1023) == 0 && get_sys_cnt_aicpu() - t0 > PTO2_TENSOR_DATA_TIMEOUT_CYCLES) {
-                pto2_orch_report_fatal(
-                    &orch, PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
+                orch.report_fatal(
+                    PTO2_ERROR_TENSOR_WAIT_TIMEOUT, caller,
                     "Timeout (%llu cycles): consumers of producer (ring=%d, local=%d) not done",
                     (unsigned long long)PTO2_TENSOR_DATA_TIMEOUT_CYCLES, ring_id, local_id
                 );
@@ -187,7 +187,7 @@ static bool wait_for_tensor_ready(PTO2Runtime *rt, const Tensor &tensor, bool wa
 }
 MAYBE_UNINITIALIZED_END
 
-uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
+uint64_t get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "get_tensor_data: buffer not allocated (addr=0). "
@@ -208,9 +208,7 @@ uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t nd
     return result;
 }
 
-void pto2_set_tensor_data(
-    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
-) {
+void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value) {
     if (tensor.buffer.addr == 0) {
         unified_log_error(
             __FUNCTION__, "set_tensor_data: buffer not allocated (addr=0). "
@@ -232,18 +230,18 @@ void pto2_set_tensor_data(
 
 static const PTO2RuntimeOps s_runtime_ops = {
     .submit_task = submit_task_impl,
-    .scope_begin = pto2_rt_scope_begin,
-    .scope_end = pto2_rt_scope_end,
-    .orchestration_done = pto2_rt_orchestration_done,
+    .scope_begin = rt_scope_begin,
+    .scope_end = rt_scope_end,
+    .orchestration_done = rt_orchestration_done,
     .is_fatal = is_fatal_impl,
-    .report_fatal = pto2_rt_report_fatal,
+    .report_fatal = rt_report_fatal,
     .log_error = unified_log_error,
     .log_warn = unified_log_warn,
     .log_info = unified_log_info,
     .log_debug = unified_log_debug,
     .log_always = unified_log_always,
-    .get_tensor_data = pto2_get_tensor_data,
-    .set_tensor_data = pto2_set_tensor_data,
+    .get_tensor_data = get_tensor_data,
+    .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
 };
 
@@ -251,13 +249,12 @@ static const PTO2RuntimeOps s_runtime_ops = {
 // Runtime Creation and Destruction
 // =============================================================================
 
-PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode) {
-    return pto2_runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
+PTO2Runtime *runtime_create(PTO2RuntimeMode mode) {
+    return runtime_create_custom(mode, PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
 }
 
-PTO2Runtime *pto2_runtime_create_custom(
-    PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity
-) {
+PTO2Runtime *
+runtime_create_custom(PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size, int32_t dep_pool_capacity) {
     // Allocate runtime context
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(calloc(1, sizeof(PTO2Runtime)));
     if (!rt) {
@@ -266,7 +263,7 @@ PTO2Runtime *pto2_runtime_create_custom(
 
     rt->ops = &s_runtime_ops;
     rt->mode = mode;
-    rt->sm_handle = pto2_sm_create(task_window_size, heap_size);
+    rt->sm_handle = PTO2SharedMemoryHandle::create(task_window_size, heap_size);
     if (!rt->sm_handle) {
         free(rt);
         return NULL;
@@ -277,14 +274,14 @@ PTO2Runtime *pto2_runtime_create_custom(
     rt->gm_heap_size = total_heap_size;
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
     if (posix_memalign(&rt->gm_heap, PTO2_ALIGN_SIZE, total_heap_size) != 0) {
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
 #else
     rt->gm_heap = aligned_alloc(PTO2_ALIGN_SIZE, total_heap_size);
     if (!rt->gm_heap) {
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
@@ -292,31 +289,31 @@ PTO2Runtime *pto2_runtime_create_custom(
     rt->gm_heap_owned = true;
 
     // Initialize orchestrator
-    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!rt->orchestrator.init(rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt->gm_heap);
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle->header, dep_pool_capacity)) {
-        pto2_orchestrator_destroy(&rt->orchestrator);
+    if (!rt->scheduler.init(rt->sm_handle->header, dep_pool_capacity)) {
+        rt->orchestrator.destroy();
         free(rt->gm_heap);
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
 
     // Connect orchestrator to scheduler (for simulated mode)
-    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
+    rt->orchestrator.set_scheduler(&rt->scheduler);
 
     rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
     if (!rt->completion_ingress) {
-        pto2_scheduler_destroy(&rt->scheduler);
-        pto2_orchestrator_destroy(&rt->orchestrator);
+        rt->scheduler.destroy();
+        rt->orchestrator.destroy();
         free(rt->gm_heap);
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
         free(rt);
         return NULL;
     }
@@ -324,7 +321,7 @@ PTO2Runtime *pto2_runtime_create_custom(
     return rt;
 }
 
-PTO2Runtime *pto2_runtime_create_from_sm(
+PTO2Runtime *runtime_create_from_sm(
     PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity
 ) {
@@ -340,24 +337,24 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
     rt->gm_heap_owned = false;
 
-    if (!pto2_orchestrator_init(&rt->orchestrator, rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
+    if (!rt->orchestrator.init(rt->sm_handle->header, rt->gm_heap, heap_size, dep_pool_capacity)) {
         free(rt);
         return NULL;
     }
 
     // Initialize scheduler (heap_size = per-ring heap size)
-    if (!pto2_scheduler_init(&rt->scheduler, rt->sm_handle->header, dep_pool_capacity)) {
-        pto2_orchestrator_destroy(&rt->orchestrator);
+    if (!rt->scheduler.init(rt->sm_handle->header, dep_pool_capacity)) {
+        rt->orchestrator.destroy();
         free(rt);
         return NULL;
     }
 
-    pto2_orchestrator_set_scheduler(&rt->orchestrator, &rt->scheduler);
+    rt->orchestrator.set_scheduler(&rt->scheduler);
 
     rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
     if (!rt->completion_ingress) {
-        pto2_scheduler_destroy(&rt->scheduler);
-        pto2_orchestrator_destroy(&rt->orchestrator);
+        rt->scheduler.destroy();
+        rt->orchestrator.destroy();
         free(rt);
         return NULL;
     }
@@ -365,11 +362,11 @@ PTO2Runtime *pto2_runtime_create_from_sm(
     return rt;
 }
 
-void pto2_runtime_destroy(PTO2Runtime *rt) {
+void runtime_destroy(PTO2Runtime *rt) {
     if (!rt) return;
 
-    pto2_scheduler_destroy(&rt->scheduler);
-    pto2_orchestrator_destroy(&rt->orchestrator);
+    rt->scheduler.destroy();
+    rt->orchestrator.destroy();
 
     free(rt->completion_ingress);
 
@@ -378,13 +375,13 @@ void pto2_runtime_destroy(PTO2Runtime *rt) {
     }
 
     if (rt->sm_handle) {
-        pto2_sm_destroy(rt->sm_handle);
+        rt->sm_handle->destroy();
     }
 
     free(rt);
 }
 
-void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
+void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode) {
     if (rt) {
         rt->mode = mode;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -22,12 +22,12 @@
  * - Orchestrator-Scheduler decoupling via shared memory
  *
  * Usage:
- *   1. Create runtime: pto2_runtime_create()
+ *   1. Create runtime: PTO2Runtime create methods
  *   2. Build task graph in orchestration function:
- *      - pto2_scope_begin() / pto2_scope_end()
- *      - pto2_submit_task()
- *   3. Mark orchestration complete: pto2_orchestrator_done()
- *   4. Destroy runtime: pto2_runtime_destroy()
+ *      - begin_scope() / end_scope()
+ *      - submit_task()
+ *   3. Mark orchestration complete: mark_done()
+ *   4. Destroy runtime
  *
  * Based on: docs/RUNTIME_LOGIC.md
  */
@@ -131,7 +131,7 @@ struct PTO2Runtime {
  * @param mode Execution mode
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
+PTO2Runtime *runtime_create(PTO2RuntimeMode mode);
 
 /**
  * Create runtime with custom sizes
@@ -141,7 +141,7 @@ PTO2Runtime *pto2_runtime_create(PTO2RuntimeMode mode);
  * @param heap_size        Size of GM heap
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime *pto2_runtime_create_custom(
+PTO2Runtime *runtime_create_custom(
     PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
@@ -151,12 +151,12 @@ PTO2Runtime *pto2_runtime_create_custom(
  * Does not allocate sm_handle or gm_heap; caller owns them.
  *
  * @param mode      Execution mode
- * @param sm_handle Pre-created shared memory handle (e.g. from pto2_sm_create_from_buffer)
+ * @param sm_handle Pre-created shared memory handle (e.g. from PTO2SharedMemoryHandle::create_from_buffer)
  * @param gm_heap   GM heap base for output buffers (or NULL if not used)
  * @param heap_size GM heap size in bytes
  * @return Runtime context, or NULL on failure
  */
-PTO2Runtime *pto2_runtime_create_from_sm(
+PTO2Runtime *runtime_create_from_sm(
     PTO2RuntimeMode mode, PTO2SharedMemoryHandle *sm_handle, void *gm_heap, uint64_t heap_size,
     int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
@@ -164,12 +164,12 @@ PTO2Runtime *pto2_runtime_create_from_sm(
 /**
  * Destroy runtime and free all resources
  */
-void pto2_runtime_destroy(PTO2Runtime *rt);
+void runtime_destroy(PTO2Runtime *rt);
 
 /**
  * Set execution mode
  */
-void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
+void runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
 
 // =============================================================================
 // Orchestration API (called by orchestration function)
@@ -182,7 +182,7 @@ void pto2_runtime_set_mode(PTO2Runtime *rt, PTO2RuntimeMode mode);
  * bounded by the scope. When scope_end() is called, the scope
  * releases its reference to all enclosed tasks.
  */
-void pto2_rt_scope_begin(PTO2Runtime *rt);
+void rt_scope_begin(PTO2Runtime *rt);
 
 /**
  * End current scope
@@ -190,33 +190,31 @@ void pto2_rt_scope_begin(PTO2Runtime *rt);
  * Releases scope reference for all tasks submitted since scope_begin().
  * Tasks whose refcount reaches zero will have their buffers released.
  */
-void pto2_rt_scope_end(PTO2Runtime *rt);
+void rt_scope_end(PTO2Runtime *rt);
 
 /**
  * Mark orchestration as complete
  *
  * Signals that no more tasks will be submitted.
  */
-void pto2_rt_orchestration_done(PTO2Runtime *rt);
+void rt_orchestration_done(PTO2Runtime *rt);
 
 /**
  * Enter fatal state explicitly from orchestration.
  */
-void pto2_rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
+void rt_report_fatal(PTO2Runtime *rt, int32_t error_code, const char *func, const char *fmt, ...);
 
 /**
  * Cross-layer data access: read a tensor value by waiting for its producer.
  */
-uint64_t pto2_get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
+uint64_t get_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[]);
 
 /**
  * Cross-layer data access: write a value to a tensor at given indices.
  * Waits for producer completion (WAW) and all consumers (WAR) via TensorMap.
  * See set_tensor_data in pto_orchestration_api.h for full documentation.
  */
-void pto2_set_tensor_data(
-    PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
-);
+void set_tensor_data(PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value);
 
 /**
  * Slim config struct exported by orchestration .so via aicpu_orchestration_config().

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -92,7 +92,7 @@
 
 // Task management
 // NOTE: PTO2_TASK_WINDOW_SIZE is now a per-ring default value.
-// Actual window size is passed at runtime to pto2_runtime_create_threaded_custom().
+// Actual window size is passed at runtime to runtime_create_custom().
 // Use pto2_task_slot(sched, task_id) for slot calculation.
 #define PTO2_TASK_WINDOW_SIZE 16384  // Default per-ring task window size (power of 2)
 
@@ -171,6 +171,10 @@ struct PTO2OutputLayout {
 // Dependency List Entry
 // =============================================================================
 
+/**
+ * Fanin spill entry
+ * Stored in the dedicated fanin spill ring buffer.
+ */
 struct PTO2TaskSlotState;  // Forward declaration
 struct PTO2FaninPool;      // Forward declaration
 struct PTO2FaninSpillEntry {
@@ -249,7 +253,7 @@ struct PTO2TaskPayload {
      * - INPUT / INOUT -> use refs[i].tensor
      *
      * @param args                Task arguments (tensors + scalars)
-     * @param materialized_outputs  Materialized output tensors (from TensorCreateInfo path)
+     * @param result  Materialized output tensors (from TensorCreateInfo path)
      */
     void init(
         const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout,
@@ -330,7 +334,7 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor *task;
 
     // --- Set per-submit (depend on task inputs) ---
-    uint8_t active_mask;       // Bitmask of active subtask slots (set once)
+    ActiveMask active_mask;    // Bitmask of active subtask slots (set once)
     uint8_t ring_id;           // Ring layer (immutable after init)
     int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 
@@ -370,67 +374,56 @@ struct alignas(64) PTO2TaskSlotState {
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx = 0;
     }
+
+    // === Per-task fanout spinlock ===
+    //
+    // Used by BOTH the orchestrator and the scheduler. The fanout_lock MUST
+    // be held whenever reading or writing fanout_head / fanout_count, because
+    // the orchestrator adds consumers concurrently with the scheduler
+    // traversing the list after task completion.
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+    void lock_fanout(uint64_t &atomic_count, uint64_t &wait_cycle) {
+        uint64_t t0 = get_sys_cnt_aicpu();
+        bool contended = false;
+        uint32_t atomic_ops = 0;
+
+        for (;;) {
+            while (fanout_lock.load(std::memory_order_acquire) != 0) {
+                contended = true;
+                atomic_ops++;
+                SPIN_WAIT_HINT();
+            }
+            int32_t expected = 0;
+            if (fanout_lock.compare_exchange_weak(expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                atomic_ops++;
+                atomic_count += atomic_ops;
+                if (contended) {
+                    wait_cycle += (get_sys_cnt_aicpu() - t0);
+                }
+                return;
+            }
+            contended = true;
+            atomic_ops++;
+        }
+    }
+#endif
+
+    void lock_fanout() {
+        for (;;) {
+            while (fanout_lock.load(std::memory_order_acquire) != 0) {
+                SPIN_WAIT_HINT();
+            }
+            int32_t expected = 0;
+            if (fanout_lock.compare_exchange_weak(expected, 1, std::memory_order_acquire, std::memory_order_relaxed)) {
+                return;
+            }
+        }
+    }
+
+    void unlock_fanout() { fanout_lock.store(0, std::memory_order_release); }
 };
 
 static_assert(sizeof(PTO2TaskSlotState) == 64);
-
-// =============================================================================
-// Per-task fanout spinlock helpers
-//
-// Used by BOTH the orchestrator (pto_orchestrator.cpp) and the scheduler
-// (aicpu_executor.cpp). Placing them here ensures both translation units use
-// identical acquire/release semantics.
-//
-// The fanout_lock MUST be held whenever reading or writing fanout_head /
-// fanout_count, because the orchestrator adds consumers concurrently with the
-// scheduler traversing the list after task completion.
-// =============================================================================
-
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state, uint64_t &atomic_count, uint64_t &wait_cycle) {
-    uint64_t t0 = get_sys_cnt_aicpu();
-    bool contended = false;
-    uint32_t atomic_ops = 0;
-
-    for (;;) {
-        while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
-            contended = true;
-            atomic_ops++;  // each load = 1 atomic
-            SPIN_WAIT_HINT();
-        }
-        int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
-            )) {
-            atomic_ops++;  // successful CAS = 1 atomic
-            atomic_count += atomic_ops;
-            if (contended) {
-                wait_cycle += (get_sys_cnt_aicpu() - t0);
-            }
-            return;
-        }
-        contended = true;
-        atomic_ops++;  // failed CAS = 1 atomic
-    }
-}
-#endif
-
-static inline void pto2_fanout_lock(PTO2TaskSlotState &slot_state) {
-    for (;;) {
-        while (slot_state.fanout_lock.load(std::memory_order_acquire) != 0) {
-            SPIN_WAIT_HINT();
-        }
-        int32_t expected = 0;
-        if (slot_state.fanout_lock.compare_exchange_weak(
-                expected, 1, std::memory_order_acquire, std::memory_order_relaxed
-            )) {
-            return;
-        }
-    }
-}
-
-static inline void pto2_fanout_unlock(PTO2TaskSlotState &slot_state) {
-    slot_state.fanout_lock.store(0, std::memory_order_release);
-}
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -41,10 +41,6 @@
 
 #include "pto_runtime2_types.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 // =============================================================================
 // Shared Memory Header
 // =============================================================================
@@ -76,7 +72,7 @@ static_assert(sizeof(PTO2RingFlowControl) == 128, "PTO2RingFlowControl must be e
  * Per-ring shared memory header section.
  *
  * Groups flow-control, layout info, and per-ring data pointers for a single ring.
- * Pointers are host-side only (set by pto2_sm_setup_pointers, invalid on device).
+ * Pointers are host-side only (set by setup_pointers, invalid on device).
  */
 struct alignas(64) PTO2SharedMemoryRingHeader {
     PTO2RingFlowControl fc;
@@ -87,7 +83,7 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     uint64_t heap_size;
     uint64_t task_descriptors_offset;  // Offset from SM base, in bytes
 
-    // Per-ring data pointers (host-side, set by pto2_sm_setup_pointers)
+    // Per-ring data pointers (host-side, set by setup_pointers)
     PTO2TaskDescriptor *task_descriptors;
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;
@@ -159,91 +155,30 @@ struct PTO2SharedMemoryHandle {
 
     // Ownership flag
     bool is_owner;  // True if this handle allocated the memory
+
+    // === Static factory methods ===
+
+    static uint64_t calculate_size(uint64_t task_window_size);
+    static uint64_t calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
+
+    static PTO2SharedMemoryHandle *create(uint64_t task_window_size, uint64_t heap_size);
+    static PTO2SharedMemoryHandle *create_default();
+    static PTO2SharedMemoryHandle *
+    create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
+
+    // === Instance methods ===
+
+    void destroy();
+    void print_layout();
+    bool validate();
+
+private:
+    void init_header(uint64_t task_window_size, uint64_t heap_size);
+    void init_header_per_ring(
+        const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    );
+    void setup_pointers(uint64_t task_window_size);
+    void setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
 };
-
-// =============================================================================
-// Shared Memory API
-// =============================================================================
-
-/**
- * Calculate required shared memory size
- *
- * @param task_window_size  Number of task slots per ring
- * @return Total bytes required
- */
-uint64_t pto2_sm_calculate_size(uint64_t task_window_size);
-
-/**
- * Calculate required shared memory size for per-ring task windows.
- *
- * @param task_window_sizes  Array of window sizes per ring
- * @return Total bytes required
- */
-uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]);
-
-/**
- * Create shared memory for Orchestrator and Scheduler
- *
- * @param task_window_size  Number of task slots per ring
- * @param heap_size         Heap size per ring for output buffers
- * @return Handle with both views, or NULL on failure
- */
-PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size);
-
-/**
- * Create shared memory with default sizes
- */
-PTO2SharedMemoryHandle *pto2_sm_create_default(void);
-
-/**
- * Wrap an existing buffer as shared memory (e.g. device GM buffer).
- * Caller owns the buffer; handle will not free sm_base.
- *
- * @param sm_base            Base address of pre-allocated buffer
- * @param sm_size            Total size in bytes
- * @param task_window_size   Number of task slots per ring (must match buffer layout)
- * @param heap_size          Heap size per ring (for layout; buffer has no heap region)
- * @return Handle, or NULL on failure
- */
-PTO2SharedMemoryHandle *
-pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
-
-/**
- * Destroy shared memory and free resources
- */
-void pto2_sm_destroy(PTO2SharedMemoryHandle *handle);
-
-/**
- * Initialize shared memory header with layout information
- * Called after memory is allocated
- */
-void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size);
-
-/**
- * Initialize shared memory header with per-ring layout information.
- */
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
-);
-
-// =============================================================================
-// Debug Utilities
-// =============================================================================
-
-/**
- * Print shared memory layout info
- */
-void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle);
-
-/**
- * Validate shared memory integrity
- * @return true if valid, false if corrupted
- */
-bool pto2_sm_validate(PTO2SharedMemoryHandle *handle);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif  // PTO_SHARED_MEMORY_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -96,7 +96,9 @@ public:
         return *this;
     }
 
-    uint8_t operator&(uint8_t mask) const { return raw_ & mask; }
+    ActiveMask operator&(uint8_t mask) const { return ActiveMask(raw_ & mask); }
+
+    bool has_mask(uint8_t mask) const { return (raw_ & mask) != 0; }
 
     explicit operator bool() const { return raw_ != 0; }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -37,43 +37,12 @@ enum class PTO2SubtaskSlot : uint8_t {
 };
 
 /**
- * Subtask mask bits (for active_mask)
+ * Subtask mask bits (for ActiveMask)
  */
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIC = (1u << 0);         // 0x1
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV0 = (1u << 1);        // 0x2
 inline constexpr uint8_t PTO2_SUBTASK_MASK_AIV1 = (1u << 2);        // 0x4
 inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all blocks must launch atomically
-
-/**
- * Test whether a subtask slot is active in a given mask
- */
-static inline bool pto2_subtask_active(uint8_t mask, PTO2SubtaskSlot slot) {
-    return (mask & (1u << static_cast<uint8_t>(slot))) != 0;
-}
-
-/**
- * Extract only the core bits from active_mask (strips flag bits).
- */
-static inline uint8_t pto2_core_mask(uint8_t active_mask) { return active_mask & 0x07u; }
-
-/**
- * Check whether a task requires all blocks to be launched atomically.
- */
-static inline bool pto2_requires_sync_start(uint8_t active_mask) {
-    return (active_mask & PTO2_SUBTASK_FLAG_SYNC_START) != 0;
-}
-
-/**
- * Mixed-task submit contract.
- *
- * Each field holds either a valid kernel ID or INVALID_KERNEL_ID (inactive).
- * At least one slot must be valid.
- */
-struct MixedKernels {
-    int32_t aic_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv0_kernel_id{INVALID_KERNEL_ID};
-    int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
-};
 
 /**
  * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
@@ -92,34 +61,77 @@ enum class PTO2ResourceShape : uint8_t {
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
 
 /**
- * Derive resource shape from active_mask.
- * Caller must ensure active_mask is valid (at least one bit set).
+ * Bitmask of active subtask slots + flags, sizeof == 1.
  */
-static inline PTO2ResourceShape pto2_active_mask_to_shape(uint8_t active_mask) {
-    uint8_t core_mask = pto2_core_mask(active_mask);
-    int bit_count = __builtin_popcount(core_mask);
-    if (bit_count >= 2) return PTO2ResourceShape::MIX;
-    if (core_mask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;
-    return PTO2ResourceShape::AIV;
-}
+class ActiveMask {
+public:
+    constexpr ActiveMask() = default;
+    constexpr explicit ActiveMask(uint8_t raw) :
+        raw_(raw) {}
+
+    uint8_t raw() const { return raw_; }
+
+    bool subtask_active(PTO2SubtaskSlot slot) const { return (raw_ & (1u << static_cast<uint8_t>(slot))) != 0; }
+
+    uint8_t core_mask() const { return raw_ & 0x07u; }
+
+    bool requires_sync_start() const { return (raw_ & PTO2_SUBTASK_FLAG_SYNC_START) != 0; }
+
+    PTO2ResourceShape to_shape() const {
+        uint8_t cmask = core_mask();
+        int bit_count = __builtin_popcount(cmask);
+        if (bit_count >= 2) return PTO2ResourceShape::MIX;
+        if (cmask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;
+        return PTO2ResourceShape::AIV;
+    }
+
+    void set_sync_start() { raw_ |= PTO2_SUBTASK_FLAG_SYNC_START; }
+
+    bool operator==(ActiveMask other) const { return raw_ == other.raw_; }
+    bool operator!=(ActiveMask other) const { return raw_ != other.raw_; }
+
+    ActiveMask operator|(ActiveMask other) const { return ActiveMask(raw_ | other.raw_); }
+    ActiveMask &operator|=(ActiveMask other) {
+        raw_ |= other.raw_;
+        return *this;
+    }
+
+    uint8_t operator&(uint8_t mask) const { return raw_ & mask; }
+
+    explicit operator bool() const { return raw_ != 0; }
+
+private:
+    uint8_t raw_{0};
+};
+
+static_assert(sizeof(ActiveMask) == 1, "ActiveMask must be exactly 1 byte");
 
 /**
- * Compute active_mask from MixedKernels.
+ * Mixed-task submit contract.
+ *
+ * Each field holds either a valid kernel ID or INVALID_KERNEL_ID (inactive).
+ * At least one slot must be valid.
  */
-static inline uint8_t pto2_mixed_kernels_to_active_mask(const MixedKernels &mk) {
-    uint8_t mask = 0;
-    if (mk.aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
-    if (mk.aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
-    if (mk.aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
-    return mask;
-}
+struct MixedKernels {
+    int32_t aic_kernel_id{INVALID_KERNEL_ID};
+    int32_t aiv0_kernel_id{INVALID_KERNEL_ID};
+    int32_t aiv1_kernel_id{INVALID_KERNEL_ID};
+
+    ActiveMask to_active_mask() const {
+        uint8_t mask = 0;
+        if (aic_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIC;
+        if (aiv0_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV0;
+        if (aiv1_kernel_id != INVALID_KERNEL_ID) mask |= PTO2_SUBTASK_MASK_AIV1;
+        return ActiveMask(mask);
+    }
+};
 
 /**
  * SPMD launch parameters carried inside Arg.
  *
  * Controls how many logical blocks (SPMD dimension) a single task
  * is expanded into at dispatch time.  Each block receives a unique
- * core_idx in [0, core_num) via the per-dispatch LocalContext.
+ * block_idx in [0, core_num) via the per-dispatch LocalContext.
  */
 class PTO2LaunchSpec {
 public:

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -149,7 +149,7 @@ union TensorRef {
  *   args.add_input(x);
  *   args.add_output(ci);
  *   args.add_scalar(some_value);
- *   TaskOutputTensors outs = pto2_rt_submit_aic_task(kernel_id, args);
+ *   TaskOutputTensors outs = rt_submit_aic_task(kernel_id, args);
  *   const Tensor& y = outs.get_ref(0);
  */
 struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -17,7 +17,7 @@
  * - Handshake buffers for AICPU-AICore communication
  * - Execution parameters (block_dim, sche_cpu_num)
  * - Tensor pair management for host-device memory tracking
- * - Device orchestration state (pto2_gm_sm_ptr_, orch_args_)
+ * - Device orchestration state (gm_sm_ptr_, orch_args_)
  * - Function address mapping (func_id_to_addr_)
  *
  * Task dispatch uses a per-core PTO2DispatchPayload written by the scheduler.
@@ -170,9 +170,9 @@ public:
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)
-    uint64_t pto2_task_window_size;
-    uint64_t pto2_heap_size;
-    uint64_t pto2_dep_pool_size;
+    uint64_t task_window_size;
+    uint64_t heap_size;
+    uint64_t dep_pool_size;
 
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
@@ -195,9 +195,9 @@ private:
 
     // Device orchestration: when false, orchestration runs on device (thread 3)
     bool orch_built_on_host_;
-    void *pto2_gm_sm_ptr_;                   // GM pointer to PTO2 shared memory (device)
-    void *pto2_gm_heap_ptr_;                 // GM heap for orchestrator output buffers (device)
-    void *pto2_slot_states_ptr_;             // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
+    void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
+    void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
+    void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
     // Device orchestration SO (for dlopen on AICPU thread 3).
@@ -251,13 +251,13 @@ public:
     // =========================================================================
 
     bool get_orch_built_on_host() const;
-    void *get_pto2_gm_sm_ptr() const;
-    void *get_pto2_gm_heap_ptr() const;
+    void *get_gm_sm_ptr() const;
+    void *get_gm_heap_ptr() const;
     const ChipStorageTaskArgs &get_orch_args() const;
     void set_orch_built_on_host(bool v);
-    void set_pto2_gm_sm_ptr(void *p);
-    void set_pto2_gm_heap(void *p);
-    void set_pto2_slot_states_ptr(void *p);
+    void set_gm_sm_ptr(void *p);
+    void set_gm_heap(void *p);
+    void set_slot_states_ptr(void *p);
     void set_orch_args(const ChipStorageTaskArgs &args);
 
     // Device orchestration SO binary (for dlopen on AICPU thread 3)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -42,7 +42,7 @@ uint64_t g_sched_self_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
 uint64_t g_sched_pop_atomic_count[PLATFORM_MAX_AICPU_THREADS] = {};
 uint64_t g_sched_complete_count[PLATFORM_MAX_AICPU_THREADS] = {};
 
-PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
+PTO2SchedProfilingData scheduler_get_profiling(int thread_idx) {
     PTO2SchedProfilingData d;
     d.lock_cycle = std::exchange(g_sched_lock_cycle[thread_idx], 0);
     d.fanout_cycle = std::exchange(g_sched_fanout_cycle[thread_idx], 0);
@@ -65,7 +65,7 @@ PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx) {
 // Task State Names
 // =============================================================================
 
-const char *pto2_task_state_name(PTO2TaskState state) {
+const char *task_state_name(PTO2TaskState state) {
     switch (state) {
     case PTO2_TASK_PENDING:
         return "PENDING";
@@ -86,7 +86,7 @@ const char *pto2_task_state_name(PTO2TaskState state) {
 // Ready Queue Implementation
 // =============================================================================
 
-bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
+bool ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
     queue->slots = (PTO2ReadyQueueSlot *)malloc(capacity * sizeof(PTO2ReadyQueueSlot));
     if (!queue->slots) {
         return false;
@@ -105,7 +105,7 @@ bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity) {
     return true;
 }
 
-void pto2_ready_queue_destroy(PTO2ReadyQueue *queue) {
+void ready_queue_destroy(PTO2ReadyQueue *queue) {
     if (queue->slots) {
         free(queue->slots);
         queue->slots = NULL;
@@ -130,7 +130,7 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHeader *sm_header,
         ring->slot_states[i].bind(&ring->task_payloads[i], &ring->task_descriptors[i], static_cast<uint8_t>(ring_id));
         ring->slot_states[i].reset_for_reuse();
         ring->slot_states[i].fanin_count = 0;
-        ring->slot_states[i].active_mask = 0;
+        ring->slot_states[i].active_mask = ActiveMask{};
     }
 
     return true;
@@ -138,7 +138,8 @@ bool PTO2SchedulerState::RingSchedState::init(PTO2SharedMemoryHeader *sm_header,
 
 void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
 
-bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity) {
+bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity) {
+    PTO2SchedulerState *sched = this;
     sched->sm_header = sm_header;
 #if PTO2_SCHED_PROFILING
     sched->tasks_completed.store(0, std::memory_order_relaxed);
@@ -157,10 +158,10 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
 
     // Initialize ready queues (one per resource shape, global)
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        if (!pto2_ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {
+        if (!ready_queue_init(&sched->ready_queues[i], PTO2_READY_QUEUE_SIZE)) {
             // Cleanup on failure
             for (int j = 0; j < i; j++) {
-                pto2_ready_queue_destroy(&sched->ready_queues[j]);
+                ready_queue_destroy(&sched->ready_queues[j]);
             }
             for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                 sched->ring_sched_states[r].destroy();
@@ -178,7 +179,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
                 free(sched->ring_sched_states[j].dep_pool.base);
             }
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-                pto2_ready_queue_destroy(&sched->ready_queues[i]);
+                ready_queue_destroy(&sched->ready_queues[i]);
             }
             sched->wiring.queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
@@ -195,7 +196,7 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
             free(sched->ring_sched_states[r].dep_pool.base);
         }
         for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-            pto2_ready_queue_destroy(&sched->ready_queues[i]);
+            ready_queue_destroy(&sched->ready_queues[i]);
         }
         for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
             sched->ring_sched_states[rr].destroy();
@@ -209,7 +210,8 @@ bool pto2_scheduler_init(PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_h
     return true;
 }
 
-void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
+void PTO2SchedulerState::destroy() {
+    PTO2SchedulerState *sched = this;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         sched->ring_sched_states[r].destroy();
         free(sched->ring_sched_states[r].dep_pool.base);
@@ -219,7 +221,7 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
     sched->wiring.queue.destroy();
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
-        pto2_ready_queue_destroy(&sched->ready_queues[i]);
+        ready_queue_destroy(&sched->ready_queues[i]);
     }
 }
 
@@ -227,7 +229,8 @@ void pto2_scheduler_destroy(PTO2SchedulerState *sched) {
 // Debug Utilities
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
+void PTO2SchedulerState::print_stats() {
+    PTO2SchedulerState *sched = this;
     LOG_INFO("=== Scheduler Statistics ===");
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         if (sched->ring_sched_states[r].last_task_alive > 0) {
@@ -249,7 +252,8 @@ void pto2_scheduler_print_stats(PTO2SchedulerState *sched) {
     LOG_INFO("============================");
 }
 
-void pto2_scheduler_print_queues(PTO2SchedulerState *sched) {
+void PTO2SchedulerState::print_queues() {
+    PTO2SchedulerState *sched = this;
     LOG_INFO("=== Ready Queues ===");
 
     const char *shape_names[] = {"AIC", "AIV", "MIX"};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -401,8 +401,10 @@ struct alignas(64) PTO2ReadyQueue {
 };
 
 // Cold-path ready queue operations (defined in pto_scheduler.cpp)
-bool pto2_ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
-void pto2_ready_queue_destroy(PTO2ReadyQueue *queue);
+// Declared as non-member to keep PTO2ReadyQueue a POD-like struct with
+// cache-line alignment. The struct body above contains only hot-path inlines.
+bool ready_queue_init(PTO2ReadyQueue *queue, uint64_t capacity);
+void ready_queue_destroy(PTO2ReadyQueue *queue);
 
 // =============================================================================
 // SPSC Queue (Single-Producer Single-Consumer, wait-free)
@@ -497,9 +499,6 @@ struct alignas(64) PTO2SpscQueue {
 };
 
 static_assert(sizeof(PTO2SpscQueue) == 256, "PTO2SpscQueue must be exactly 4 cache lines (256B)");
-
-// =============================================================================
-// Scheduler State
 // =============================================================================
 
 /**
@@ -667,25 +666,25 @@ struct PTO2SchedulerState {
 
         if (wfanin != 0) {
             int32_t early_finished = 0;
-            pto2_for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
-                pto2_fanout_lock(*producer);
+            for_each_fanin_slot_state(*wp, [&](PTO2TaskSlotState *producer) {
+                producer->lock_fanout();
                 int32_t pstate = producer->task_state.load(std::memory_order_acquire);
                 if (pstate >= PTO2_TASK_COMPLETED) {
                     early_finished++;
                 } else {
                     producer->fanout_head = rss.dep_pool.prepend(producer->fanout_head, ws);
                 }
-                pto2_fanout_unlock(*producer);
+                producer->unlock_fanout();
             });
 
             int32_t init_rc = early_finished + 1;
             int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
             if (new_rc >= ws->fanin_count) {
-                ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+                ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
             }
         } else {
             ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
-            ready_queues[static_cast<int32_t>(pto2_active_mask_to_shape(ws->active_mask))].push(ws);
+            ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
         }
 
         ws->dep_pool_mark = rss.dep_pool.top;
@@ -776,7 +775,7 @@ struct PTO2SchedulerState {
         if (new_refcount == slot_state.fanin_count) {
             // Local-first: try per-CoreType thread-local buffer before global queue
             // Route by active_mask: AIC-containing tasks → buf[0], AIV-only → buf[1]
-            PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
+            PTO2ResourceShape shape = slot_state.active_mask.to_shape();
             if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                 ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
             }
@@ -800,7 +799,7 @@ struct PTO2SchedulerState {
                 )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
                 // Local-first: try per-CoreType thread-local buffer before global queue
-                PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state.active_mask);
+                PTO2ResourceShape shape = slot_state.active_mask.to_shape();
                 if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                     ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
                 }
@@ -905,13 +904,13 @@ struct PTO2SchedulerState {
 #endif
 
 #if PTO2_SCHED_PROFILING
-        pto2_fanout_lock(slot_state, lock_atomics, lock_wait);
+        slot_state.lock_fanout(lock_atomics, lock_wait);
 #else
-        pto2_fanout_lock(slot_state);
+        slot_state.lock_fanout();
 #endif
         slot_state.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
         PTO2DepListEntry *current = slot_state.fanout_head;  // Protected by fanout_lock
-        pto2_fanout_unlock(slot_state);
+        slot_state.unlock_fanout();
 
 #if PTO2_SCHED_PROFILING
         lock_atomics += 2;  // state.store + unlock.store
@@ -962,7 +961,7 @@ struct PTO2SchedulerState {
     int32_t on_task_release(PTO2TaskSlotState &slot_state) {
 #endif
         PTO2TaskPayload *payload = slot_state.payload;
-        pto2_for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot_state) {
+        for_each_fanin_slot_state(*payload, [&](PTO2TaskSlotState *producer_slot_state) {
 #if PTO2_SCHED_PROFILING
             release_producer(*producer_slot_state, fanin_atomics);
 #else
@@ -986,16 +985,16 @@ struct PTO2SchedulerState {
 #endif
         return payload->fanin_actual_count;
     }
+
+    // === Cold-path API (defined in pto_scheduler.cpp) ===
+    bool init(PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    void destroy();
+    void print_stats();
+    void print_queues();
 };
 
-// =============================================================================
-// Scheduler API (cold path, defined in pto_scheduler.cpp)
-// =============================================================================
-
-bool pto2_scheduler_init(
-    PTO2SchedulerState *sched, PTO2SharedMemoryHeader *sm_header, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
-);
-void pto2_scheduler_destroy(PTO2SchedulerState *sched);
+// Scheduler cold-path API is declared as PTO2SchedulerState member functions.
+// See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
 template <bool Profiling>
 inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
@@ -1025,7 +1024,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
             PTO2CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
             if (cond.counter_addr) {
-                uintptr_t counter_line = pto2_completion_ingress_cache_line(cond.counter_addr);
+                uintptr_t counter_line = completion_ingress_cache_line(cond.counter_addr);
                 if (counter_line != last_invalidated_counter_line) {
                     cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
                     last_invalidated_counter_line = counter_line;
@@ -1073,9 +1072,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
 // Debug Utilities (cold path, defined in pto_scheduler.cpp)
 // =============================================================================
 
-void pto2_scheduler_print_stats(PTO2SchedulerState *sched);
-void pto2_scheduler_print_queues(PTO2SchedulerState *sched);
-const char *pto2_task_state_name(PTO2TaskState state);
+const char *task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data
@@ -1084,7 +1081,7 @@ const char *pto2_task_state_name(PTO2TaskState state);
 #if PTO2_SCHED_PROFILING
 struct PTO2SchedProfilingData {
     // Sub-phase cycle breakdown within on_mixed_task_complete
-    uint64_t lock_cycle;           // pto2_fanout_lock + state store + unlock
+    uint64_t lock_cycle;           // lock_fanout + state store + unlock
     uint64_t fanout_cycle;         // fanout traversal
     uint64_t fanin_cycle;          // fanin traversal
     uint64_t self_consumed_cycle;  // self check_and_handle_consumed
@@ -1108,5 +1105,5 @@ struct PTO2SchedProfilingData {
  * Get and reset scheduler profiling data for a specific thread.
  * Returns accumulated profiling data and resets counters.
  */
-PTO2SchedProfilingData pto2_scheduler_get_profiling(int thread_idx);
+PTO2SchedProfilingData scheduler_get_profiling(int thread_idx);
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -640,8 +640,8 @@ int32_t SchedulerContext::init(
     }
 
     // Initialize task counters. Task count comes from PTO2 shared memory.
-    if (runtime->get_pto2_gm_sm_ptr()) {
-        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_pto2_gm_sm_ptr());
+    if (runtime->get_gm_sm_ptr()) {
+        auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
         int32_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
             pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -201,7 +201,7 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
 
 #if PTO2_SCHED_PROFILING
     {
-        PTO2SchedProfilingData sp = pto2_scheduler_get_profiling(thread_idx);
+        PTO2SchedProfilingData sp = scheduler_get_profiling(thread_idx);
         uint64_t otc_total = sp.lock_cycle + sp.fanout_cycle + sp.fanin_cycle + sp.self_consumed_cycle;
         uint64_t complete_poll = (l2_perf.sched_complete_cycle > otc_total + l2_perf.sched_complete_perf_cycle) ?
                                      (l2_perf.sched_complete_cycle - otc_total - l2_perf.sched_complete_perf_cycle) :
@@ -642,11 +642,11 @@ int32_t SchedulerContext::init(
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
-        int32_t pto2_count = 0;
+        int32_t task_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+            task_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
         }
-        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
+        total_tasks_ = task_count > 0 ? task_count : 0;
     } else {
         total_tasks_ = 0;
     }
@@ -702,8 +702,8 @@ void SchedulerContext::deinit() {
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
     orchestrator_done_ = false;
-    pto2_init_done_.store(false, std::memory_order_release);
-    pto2_init_complete_.store(false, std::memory_order_release);
+    init_done_.store(false, std::memory_order_release);
+    init_complete_.store(false, std::memory_order_release);
 
     // Reset core transition state
     transition_requested_.store(false, std::memory_order_release);
@@ -729,8 +729,8 @@ void SchedulerContext::deinit() {
     func_id_to_addr_ = nullptr;
 }
 
-void SchedulerContext::wait_pto2_init_complete() const {
-    while (!pto2_init_complete_.load(std::memory_order_acquire)) {
+void SchedulerContext::wait_init_complete() const {
+    while (!init_complete_.load(std::memory_order_acquire)) {
         SPIN_WAIT_HINT();
     }
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -112,8 +112,8 @@ void SchedulerContext::complete_slot_task(
         if (is_dump_tensor_enabled()) {
             dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                 thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
-                [](uint8_t active_mask, uint8_t raw_subtask_id) {
-                    return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+                [](ActiveMask active_mask, int raw_subtask_id) {
+                    return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
                 },
                 [this](int32_t func_id) {
                     return get_function_bin_addr(func_id);
@@ -362,7 +362,7 @@ void SchedulerContext::drain_worker_dispatch(Runtime *runtime, int32_t block_num
         drain_state_.sync_start_pending.store(0, std::memory_order_release);
         return;
     }
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state->active_mask);
+    PTO2ResourceShape shape = slot_state->active_mask.to_shape();
 
     for (int32_t t = 0; t < active_sched_threads_ && slot_state->next_block_idx < block_num; t++) {
         auto valid = core_trackers_[t].get_idle_core_offset_states(shape);
@@ -433,7 +433,7 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
 
     // Elected: check if global resources are sufficient.
     PTO2TaskSlotState *slot_state = drain_state_.pending_task;
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(slot_state->active_mask);
+    PTO2ResourceShape shape = slot_state->active_mask.to_shape();
     int32_t available = count_global_available(shape);
 
     if (available < block_num) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -83,7 +83,7 @@ public:
     //  - folds inline_completed_tasks into completed_tasks_
     //  - flips orchestrator_done_ and triggers core transition
     //    (skipped on fatal error — emergency_shutdown runs instead)
-    // Callers must invoke pto2_rt_orchestration_done(rt) before this — that
+    // Callers must invoke rt_orchestration_done(rt) before this — that
     // step belongs to the orchestrator lifecycle, not the scheduler.
     void on_orchestration_done(Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks);
 
@@ -102,7 +102,7 @@ public:
 
     // Block until the first scheduler thread has finished one-time PTO2 init.
     // Called by the orchestrator thread in device-orch mode.
-    void wait_pto2_init_complete() const;
+    void wait_init_complete() const;
 
 private:
     // =========================================================================
@@ -175,8 +175,8 @@ private:
     uint64_t regs_{0};
 
     // --- One-time init coordination ---
-    std::atomic<bool> pto2_init_done_{false};
-    std::atomic<bool> pto2_init_complete_{false};
+    std::atomic<bool> init_done_{false};
+    std::atomic<bool> init_complete_{false};
 
     // =========================================================================
     // Core management (scheduler_cold_path.cpp)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -177,22 +177,22 @@ void SchedulerContext::dispatch_mix_block_to_cluster(
     Runtime *runtime, int32_t thread_idx, int32_t cluster_offset, PTO2TaskSlotState &slot_state, bool to_pending
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
-    uint8_t core_mask = pto2_core_mask(slot_state.active_mask);
-    if (core_mask & PTO2_SUBTASK_MASK_AIC) {
+    uint8_t cmask = slot_state.active_mask.core_mask();
+    if (cmask & PTO2_SUBTASK_MASK_AIC) {
         bool aic_to_pending = to_pending && !tracker.is_aic_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
             aic_to_pending
         );
     }
-    if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
+    if (cmask & PTO2_SUBTASK_MASK_AIV0) {
         bool aiv0_to_pending = to_pending && !tracker.is_aiv0_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
             aiv0_to_pending
         );
     }
-    if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
+    if (cmask & PTO2_SUBTASK_MASK_AIV1) {
         bool aiv1_to_pending = to_pending && !tracker.is_aiv1_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
@@ -209,8 +209,8 @@ void SchedulerContext::dispatch_block(
     if (is_dump_tensor_enabled()) {
         dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
             thread_idx, slot_state, TensorDumpStage::BEFORE_DISPATCH,
-            [](uint8_t active_mask, uint8_t raw_subtask_id) {
-                return pto2_subtask_active(active_mask, static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+            [](ActiveMask active_mask, int raw_subtask_id) {
+                return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
             },
             [this](int32_t func_id) {
                 return get_function_bin_addr(func_id);
@@ -226,7 +226,7 @@ void SchedulerContext::dispatch_block(
         dispatch_subtask_to_core(runtime, thread_idx, core_offset, slot_state, PTO2SubtaskSlot::AIV0, to_pending);
     }
 #if PTO2_PROFILING
-    sched_l2_perf_[thread_idx].phase_dispatch_count += __builtin_popcount(pto2_core_mask(slot_state.active_mask));
+    sched_l2_perf_[thread_idx].phase_dispatch_count += __builtin_popcount(slot_state.active_mask.core_mask());
 #endif
 }
 
@@ -253,7 +253,7 @@ void SchedulerContext::dispatch_shape(
         for (int bi = 0; bi < got; bi++) {
             PTO2TaskSlotState *slot_state = batch[bi];
 
-            if (pto2_requires_sync_start(slot_state->active_mask)) {
+            if (slot_state->active_mask.requires_sync_start()) {
                 if (is_pending) {
                     sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
@@ -336,7 +336,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
-    if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
+    if (!init_done_.exchange(true, std::memory_order_acq_rel)) {
         DEV_INFO("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
@@ -357,9 +357,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 
         DEV_INFO("Thread %d: one-time init done", thread_idx);
-        pto2_init_complete_.store(true, std::memory_order_release);
+        init_complete_.store(true, std::memory_order_release);
     } else {
-        while (!pto2_init_complete_.load(std::memory_order_acquire)) {
+        while (!init_complete_.load(std::memory_order_acquire)) {
             SPIN_WAIT_HINT();
         }
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -27,15 +27,15 @@
 // Size Calculation
 // =============================================================================
 
-uint64_t pto2_sm_calculate_size(uint64_t task_window_size) {
+uint64_t PTO2SharedMemoryHandle::calculate_size(uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    return pto2_sm_calculate_size_per_ring(task_window_sizes);
+    return calculate_size_per_ring(task_window_sizes);
 }
 
-uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+uint64_t PTO2SharedMemoryHandle::calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
     uint64_t size = 0;
 
     // Header (aligned to cache line)
@@ -55,17 +55,16 @@ uint64_t pto2_sm_calculate_size_per_ring(const uint64_t task_window_sizes[PTO2_M
 // Creation and Destruction
 // =============================================================================
 
-static void
-pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
-    char *ptr = (char *)handle->sm_base;
+void PTO2SharedMemoryHandle::setup_pointers_per_ring(const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]) {
+    char *ptr = (char *)sm_base;
 
     // Header
-    handle->header = (PTO2SharedMemoryHeader *)ptr;
+    header = (PTO2SharedMemoryHeader *)ptr;
     ptr += PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
 
     // Per-ring task descriptors, payloads, and slot states
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        auto &ring = handle->header->rings[r];
+        auto &ring = header->rings[r];
         ring.task_descriptors = (PTO2TaskDescriptor *)ptr;
         ptr += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskDescriptor), PTO2_ALIGN_SIZE);
 
@@ -77,15 +76,15 @@ pto2_sm_setup_pointers_per_ring(PTO2SharedMemoryHandle *handle, const uint64_t t
     }
 }
 
-static void pto2_sm_setup_pointers(PTO2SharedMemoryHandle *handle, uint64_t task_window_size) {
+void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
     }
-    pto2_sm_setup_pointers_per_ring(handle, task_window_sizes);
+    setup_pointers_per_ring(task_window_sizes);
 }
 
-PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_size) {
+PTO2SharedMemoryHandle *PTO2SharedMemoryHandle::create(uint64_t task_window_size, uint64_t heap_size) {
     // Allocate handle
     PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
     if (!handle) {
@@ -93,7 +92,7 @@ PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_
     }
 
     // Calculate total size
-    uint64_t sm_size = pto2_sm_calculate_size(task_window_size);
+    uint64_t sm_size = calculate_size(task_window_size);
 
 // Allocate shared memory (aligned for DMA efficiency)
 #if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L
@@ -116,21 +115,24 @@ PTO2SharedMemoryHandle *pto2_sm_create(uint64_t task_window_size, uint64_t heap_
     memset(handle->sm_base, 0, static_cast<size_t>(sm_size));
 
     // Set up pointers
-    pto2_sm_setup_pointers(handle, task_window_size);
+    handle->setup_pointers(task_window_size);
 
     // Initialize header
-    pto2_sm_init_header(handle, task_window_size, heap_size);
+    handle->init_header(task_window_size, heap_size);
 
     return handle;
 }
 
-PTO2SharedMemoryHandle *pto2_sm_create_default(void) { return pto2_sm_create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE); }
+PTO2SharedMemoryHandle *PTO2SharedMemoryHandle::create_default() {
+    return create(PTO2_TASK_WINDOW_SIZE, PTO2_HEAP_SIZE);
+}
 
-PTO2SharedMemoryHandle *
-pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size) {
+PTO2SharedMemoryHandle *PTO2SharedMemoryHandle::create_from_buffer(
+    void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size
+) {
     if (!sm_base || sm_size == 0) return NULL;
 
-    uint64_t required = pto2_sm_calculate_size(task_window_size);
+    uint64_t required = calculate_size(task_window_size);
     if (sm_size < required) return NULL;
 
     PTO2SharedMemoryHandle *handle = (PTO2SharedMemoryHandle *)calloc(1, sizeof(PTO2SharedMemoryHandle));
@@ -140,20 +142,18 @@ pto2_sm_create_from_buffer(void *sm_base, uint64_t sm_size, uint64_t task_window
     handle->sm_size = sm_size;
     handle->is_owner = false;
 
-    pto2_sm_setup_pointers(handle, task_window_size);
-    pto2_sm_init_header(handle, task_window_size, heap_size);
+    handle->setup_pointers(task_window_size);
+    handle->init_header(task_window_size, heap_size);
 
     return handle;
 }
 
-void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
-    if (!handle) return;
-
-    if (handle->is_owner && handle->sm_base) {
-        free(handle->sm_base);
+void PTO2SharedMemoryHandle::destroy() {
+    if (is_owner && sm_base) {
+        free(sm_base);
     }
 
-    free(handle);
+    free(this);
 }
 
 // =============================================================================
@@ -161,22 +161,19 @@ void pto2_sm_destroy(PTO2SharedMemoryHandle *handle) {
 // =============================================================================
 //
 // no need init data in pool, init pool data when used
-void pto2_sm_init_header(PTO2SharedMemoryHandle *handle, uint64_t task_window_size, uint64_t heap_size) {
+void PTO2SharedMemoryHandle::init_header(uint64_t task_window_size, uint64_t heap_size) {
     uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
     uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         task_window_sizes[r] = task_window_size;
         heap_sizes[r] = heap_size;
     }
-    pto2_sm_init_header_per_ring(handle, task_window_sizes, heap_sizes);
+    init_header_per_ring(task_window_sizes, heap_sizes);
 }
 
-void pto2_sm_init_header_per_ring(
-    PTO2SharedMemoryHandle *handle, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
-    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+void PTO2SharedMemoryHandle::init_header_per_ring(
+    const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH], const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 ) {
-    PTO2SharedMemoryHeader *header = handle->header;
-
     // Per-ring flow control (start at 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         header->rings[r].fc.init();
@@ -196,7 +193,7 @@ void pto2_sm_init_header_per_ring(
         offset += PTO2_ALIGN_UP(task_window_sizes[r] * sizeof(PTO2TaskSlotState), PTO2_ALIGN_SIZE);
     }
 
-    header->total_size = handle->sm_size;
+    header->total_size = sm_size;
     header->graph_output_ptr.store(0, std::memory_order_relaxed);
     header->graph_output_size.store(0, std::memory_order_relaxed);
 
@@ -211,13 +208,13 @@ void pto2_sm_init_header_per_ring(
 // Debug Utilities
 // =============================================================================
 
-void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
-    if (!handle || !handle->header) return;
+void PTO2SharedMemoryHandle::print_layout() {
+    if (!header) return;
 
-    PTO2SharedMemoryHeader *h = handle->header;
+    PTO2SharedMemoryHeader *h = header;
 
     LOG_INFO("=== PTO2 Shared Memory Layout ===");
-    LOG_INFO("Base address:       %p", handle->sm_base);
+    LOG_INFO("Base address:       %p", sm_base);
     LOG_INFO("Total size:         %" PRIu64 " bytes", h->total_size);
     LOG_INFO("Ring depth:         %d", PTO2_MAX_RING_DEPTH);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -240,15 +237,14 @@ void pto2_sm_print_layout(PTO2SharedMemoryHandle *handle) {
     LOG_INFO("================================");
 }
 
-bool pto2_sm_validate(PTO2SharedMemoryHandle *handle) {
-    if (!handle) return false;
-    if (!handle->sm_base) return false;
-    if (!handle->header) return false;
+bool PTO2SharedMemoryHandle::validate() {
+    if (!sm_base) return false;
+    if (!header) return false;
 
-    PTO2SharedMemoryHeader *h = handle->header;
+    PTO2SharedMemoryHeader *h = header;
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (!h->rings[r].fc.validate(handle, r)) return false;
+        if (!h->rings[r].fc.validate(this, r)) return false;
     }
 
     return true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -34,9 +34,9 @@ Runtime::Runtime() {
     worker_count = 0;
     sche_cpu_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    pto2_task_window_size = 0;
-    pto2_heap_size = 0;
-    pto2_dep_pool_size = 0;
+    task_window_size = 0;
+    heap_size = 0;
+    dep_pool_size = 0;
     orch_to_sched = false;
 
     // Initialize profiling state
@@ -46,9 +46,9 @@ Runtime::Runtime() {
 
     // Initialize device orchestration state
     orch_built_on_host_ = true;
-    pto2_gm_sm_ptr_ = nullptr;
-    pto2_gm_heap_ptr_ = nullptr;
-    pto2_slot_states_ptr_ = nullptr;
+    gm_sm_ptr_ = nullptr;
+    gm_heap_ptr_ = nullptr;
+    slot_states_ptr_ = nullptr;
     orch_args_storage_.clear();
 
     // Initialize device orchestration SO binary
@@ -94,13 +94,13 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // =============================================================================
 
 bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
-void *Runtime::get_pto2_gm_sm_ptr() const { return pto2_gm_sm_ptr_; }
-void *Runtime::get_pto2_gm_heap_ptr() const { return pto2_gm_heap_ptr_; }
+void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
+void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
 const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
 void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
-void Runtime::set_pto2_gm_sm_ptr(void *p) { pto2_gm_sm_ptr_ = p; }
-void Runtime::set_pto2_gm_heap(void *p) { pto2_gm_heap_ptr_ = p; }
-void Runtime::set_pto2_slot_states_ptr(void *p) { pto2_slot_states_ptr_ = p; }
+void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
+void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
+void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }
 void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
 
 // Device orchestration SO metadata (bytes live in a separate device buffer

--- a/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -105,13 +105,13 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                         args_gemm.add_input(A_view);
                         args_gemm.add_input(B_view);
                         args_gemm.add_output(TensorCreateInfo(tile_shapes, 1, DataType::FLOAT32));
-                        SubmitResult r_gemm = pto2_rt_submit_aic_task(rt, FUNC_GEMM_TILE, args_gemm);
+                        SubmitResult r_gemm = rt_submit_aic_task(rt, FUNC_GEMM_TILE, args_gemm);
 
                         // C[m,n] += P
                         Arg args_add;
                         args_add.add_inout(C_view);
                         args_add.add_input(r_gemm.outputs.get_ref(0));
-                        SubmitResult r_add = pto2_rt_submit_aiv_task(rt, FUNC_TILE_ADD, args_add);
+                        SubmitResult r_add = rt_submit_aiv_task(rt, FUNC_TILE_ADD, args_add);
 
                         // gemm -> add: add reads P which gemm produces
                         pto2_rt_add_dependency(rt, r_gemm.task_id, r_add.task_id);

--- a/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -28,7 +28,7 @@
  *     P = A[m,k] @ B[k,n]    (gemm_tile on Cube core, func_id=0)
  *     C[m,n] = C[m,n] + P    (tile_add on Vector core, func_id=1)
  *
- * Dependencies are explicit via pto2_rt_add_dependency:
+ * Dependencies are explicit via rt_add_dependency:
  *   - gemm(k) -> add(k): add reads P which gemm produces
  *   - add(k-1) -> add(k): add reads/writes C_view (K accumulation chain)
  *
@@ -114,10 +114,10 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                         SubmitResult r_add = rt_submit_aiv_task(rt, FUNC_TILE_ADD, args_add);
 
                         // gemm -> add: add reads P which gemm produces
-                        pto2_rt_add_dependency(rt, r_gemm.task_id, r_add.task_id);
+                        rt_add_dependency(rt, r_gemm.task_id, r_add.task_id);
                         // K accumulation chain: previous add -> current add
                         if (has_last_add) {
-                            pto2_rt_add_dependency(rt, last_add_task, r_add.task_id);
+                            rt_add_dependency(rt, last_add_task, r_add.task_id);
                         }
 
                         last_add_task = r_add.task_id;

--- a/tests/st/a2a3/aicpu_build_graph/orch_so_cache/kernels/orchestration/example_orchestration.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/orch_so_cache/kernels/orchestration/example_orchestration.cpp
@@ -48,7 +48,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args.add_input(ext_a);
         args.add_input(ext_b);
         args.add_inout(ext_f);
-        pto2_rt_submit_aiv_task(rt, FUNC_ADD, args);
+        rt_submit_aiv_task(rt, FUNC_ADD, args);
     }
 }
 

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -117,7 +117,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                 args_inplace.add_output(TensorCreateInfo(oi_shapes, 2, DataType::FLOAT32));
                 args_inplace.add_output(TensorCreateInfo(li_shapes, 1, DataType::FLOAT32));
                 args_inplace.add_output(TensorCreateInfo(mi_shapes, 1, DataType::FLOAT32));
-                SubmitResult r_hub = pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, args_inplace);
+                SubmitResult r_hub = rt_submit_aiv_task(rt, FUNC_AIV_HUB, args_inplace);
                 const Tensor &oi = r_hub.outputs.get_ref(0);
                 const Tensor &li_update = r_hub.outputs.get_ref(1);
                 const Tensor &mi_update = r_hub.outputs.get_ref(2);
@@ -141,7 +141,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_qk.add_input(qi);
                     args_qk.add_input(kj);
                     args_qk.add_output(TensorCreateInfo(sij_shapes, 2, DataType::FLOAT32));
-                    SubmitResult r_qk = pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, args_qk);
+                    SubmitResult r_qk = rt_submit_aic_task(rt, FUNC_QK_MATMUL, args_qk);
 
                     // === Task 2: Softmax ===
                     uint32_t sij_valid_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(valid_len)};
@@ -154,7 +154,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_sf.add_output(TensorCreateInfo(mi_shapes, 1, DataType::FLOAT32));
                     args_sf.add_output(TensorCreateInfo(li_shapes, 1, DataType::FLOAT32));
                     args_sf.add_scalar(scale_value);
-                    SubmitResult r_sf = pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, args_sf);
+                    SubmitResult r_sf = rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, args_sf);
                     pto2_rt_add_dependency(rt, r_qk.task_id, r_sf.task_id);
 
                     // === Task 3: PV matmul ===
@@ -164,7 +164,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_pv.add_input(r_sf.outputs.get_ref(0));
                     args_pv.add_input(vj);
                     args_pv.add_output(TensorCreateInfo(oi_tmp_shapes, 2, DataType::FLOAT32));
-                    SubmitResult r_pv = pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, args_pv);
+                    SubmitResult r_pv = rt_submit_aic_task(rt, FUNC_PV_MATMUL, args_pv);
                     pto2_rt_add_dependency(rt, r_sf.task_id, r_pv.task_id);
 
                     // === Task 4: Online update ===
@@ -181,7 +181,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_up.add_inout(out_view);
                     args_up.add_scalar(is_first);
                     args_up.add_scalar(is_last);
-                    SubmitResult r_up = pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, args_up);
+                    SubmitResult r_up = rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, args_up);
                     pto2_rt_add_dependency(rt, r_sf.task_id, r_up.task_id);
                     pto2_rt_add_dependency(rt, r_pv.task_id, r_up.task_id);
                     pto2_rt_add_dependency(rt, prev_update_task, r_up.task_id);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -155,7 +155,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_sf.add_output(TensorCreateInfo(li_shapes, 1, DataType::FLOAT32));
                     args_sf.add_scalar(scale_value);
                     SubmitResult r_sf = rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, args_sf);
-                    pto2_rt_add_dependency(rt, r_qk.task_id, r_sf.task_id);
+                    rt_add_dependency(rt, r_qk.task_id, r_sf.task_id);
 
                     // === Task 3: PV matmul ===
                     uint32_t oi_tmp_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -165,7 +165,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_pv.add_input(vj);
                     args_pv.add_output(TensorCreateInfo(oi_tmp_shapes, 2, DataType::FLOAT32));
                     SubmitResult r_pv = rt_submit_aic_task(rt, FUNC_PV_MATMUL, args_pv);
-                    pto2_rt_add_dependency(rt, r_sf.task_id, r_pv.task_id);
+                    rt_add_dependency(rt, r_sf.task_id, r_pv.task_id);
 
                     // === Task 4: Online update ===
                     uint64_t is_first = (bn == 0) ? 1 : 0;
@@ -182,9 +182,9 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_up.add_scalar(is_first);
                     args_up.add_scalar(is_last);
                     SubmitResult r_up = rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, args_up);
-                    pto2_rt_add_dependency(rt, r_sf.task_id, r_up.task_id);
-                    pto2_rt_add_dependency(rt, r_pv.task_id, r_up.task_id);
-                    pto2_rt_add_dependency(rt, prev_update_task, r_up.task_id);
+                    rt_add_dependency(rt, r_sf.task_id, r_up.task_id);
+                    rt_add_dependency(rt, r_pv.task_id, r_up.task_id);
+                    rt_add_dependency(rt, prev_update_task, r_up.task_id);
 
                     prev_update_task = r_up.task_id;
                 }

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -260,7 +260,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     CYCLE_COUNT_LAP(prof_param_setup);
                     SubmitResult r_sf = rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, args_sf);
                     // QK → Softmax (sij_buf)
-                    pto2_rt_add_dependency(rt, r_qk.task_id, r_sf.task_id);
+                    rt_add_dependency(rt, r_qk.task_id, r_sf.task_id);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -282,7 +282,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     CYCLE_COUNT_LAP(prof_param_setup);
                     SubmitResult r_pv = rt_submit_aic_task(rt, FUNC_PV_MATMUL, args_pv);
                     // Softmax → PV (pij_buf)
-                    pto2_rt_add_dependency(rt, r_sf.task_id, r_pv.task_id);
+                    rt_add_dependency(rt, r_sf.task_id, r_pv.task_id);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -305,11 +305,11 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     CYCLE_COUNT_LAP(prof_param_setup);
                     SubmitResult r_up = rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, args_up);
                     // Softmax → Update (mi, li)
-                    pto2_rt_add_dependency(rt, r_sf.task_id, r_up.task_id);
+                    rt_add_dependency(rt, r_sf.task_id, r_up.task_id);
                     // PV → Update (oi_new)
-                    pto2_rt_add_dependency(rt, r_pv.task_id, r_up.task_id);
+                    rt_add_dependency(rt, r_pv.task_id, r_up.task_id);
                     // Previous update → this update (mi_update, li_update, oi accumulation chain)
-                    pto2_rt_add_dependency(rt, prev_update_task, r_up.task_id);
+                    rt_add_dependency(rt, prev_update_task, r_up.task_id);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);

--- a/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -194,7 +194,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                 args_inplace.add_output(TensorCreateInfo(li_shapes, 1, DataType::FLOAT32));
                 args_inplace.add_output(TensorCreateInfo(mi_shapes, 1, DataType::FLOAT32));
                 CYCLE_COUNT_LAP(prof_param_setup);
-                SubmitResult r_hub = pto2_rt_submit_aiv_task(rt, FUNC_AIV_HUB, args_inplace);
+                SubmitResult r_hub = rt_submit_aiv_task(rt, FUNC_AIV_HUB, args_inplace);
                 const Tensor &oi = r_hub.outputs.get_ref(0);
                 const Tensor &li_update = r_hub.outputs.get_ref(1);
                 const Tensor &mi_update = r_hub.outputs.get_ref(2);
@@ -234,7 +234,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_qk.add_scalar(n_blocks);
                     args_qk.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    SubmitResult r_qk = pto2_rt_submit_aic_task(rt, FUNC_QK_MATMUL, args_qk);
+                    SubmitResult r_qk = rt_submit_aic_task(rt, FUNC_QK_MATMUL, args_qk);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
@@ -258,7 +258,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_sf.add_scalar(n_blocks);
                     args_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    SubmitResult r_sf = pto2_rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, args_sf);
+                    SubmitResult r_sf = rt_submit_aiv_task(rt, FUNC_SOFTMAX_PREPARE, args_sf);
                     // QK → Softmax (sij_buf)
                     pto2_rt_add_dependency(rt, r_qk.task_id, r_sf.task_id);
 #ifdef ENABLE_PROFILING
@@ -280,7 +280,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_pv.add_scalar(n_blocks);
                     args_pv.add_scalar(reinterpret_cast<uint64_t>(bt_base + bn));
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    SubmitResult r_pv = pto2_rt_submit_aic_task(rt, FUNC_PV_MATMUL, args_pv);
+                    SubmitResult r_pv = rt_submit_aic_task(rt, FUNC_PV_MATMUL, args_pv);
                     // Softmax → PV (pij_buf)
                     pto2_rt_add_dependency(rt, r_sf.task_id, r_pv.task_id);
 #ifdef ENABLE_PROFILING
@@ -303,7 +303,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
                     args_up.add_scalar(is_first);
                     args_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    SubmitResult r_up = pto2_rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, args_up);
+                    SubmitResult r_up = rt_submit_aiv_task(rt, FUNC_ONLINE_UPDATE, args_up);
                     // Softmax → Update (mi, li)
                     pto2_rt_add_dependency(rt, r_sf.task_id, r_up.task_id);
                     // PV → Update (oi_new)

--- a/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
@@ -62,7 +62,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args_t1.add_output(TensorCreateInfo(shapes, 1, DataType::FLOAT32));
         args_t1.add_scalar(1.0f);
         SubmitResult r1 = rt_submit_aiv_task(rt, 1, args_t1);
-        pto2_rt_add_dependency(rt, r0.task_id, r1.task_id);
+        rt_add_dependency(rt, r0.task_id, r1.task_id);
 
         // t2: e = c + 2.0
         Arg args_t2;
@@ -70,7 +70,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args_t2.add_output(TensorCreateInfo(shapes, 1, DataType::FLOAT32));
         args_t2.add_scalar(2.0f);
         SubmitResult r2 = rt_submit_aiv_task(rt, 1, args_t2);
-        pto2_rt_add_dependency(rt, r0.task_id, r2.task_id);
+        rt_add_dependency(rt, r0.task_id, r2.task_id);
 
         // t3: f = d * e
         Arg args_t3;
@@ -78,8 +78,8 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args_t3.add_input(r2.outputs.get_ref(0));
         args_t3.add_inout(ext_f);
         SubmitResult r3 = rt_submit_aiv_task(rt, 2, args_t3);
-        pto2_rt_add_dependency(rt, r1.task_id, r3.task_id);
-        pto2_rt_add_dependency(rt, r2.task_id, r3.task_id);
+        rt_add_dependency(rt, r1.task_id, r3.task_id);
+        rt_add_dependency(rt, r2.task_id, r3.task_id);
     }  // scope_end: batch-publish all tasks
 }
 

--- a/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
+++ b/tests/st/a2a3/aicpu_build_graph/vector_example/kernels/orchestration/orchestration.cpp
@@ -54,14 +54,14 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args_t0.add_input(ext_a);
         args_t0.add_input(ext_b);
         args_t0.add_output(TensorCreateInfo(shapes, 1, DataType::FLOAT32));
-        SubmitResult r0 = pto2_rt_submit_aiv_task(rt, 0, args_t0);
+        SubmitResult r0 = rt_submit_aiv_task(rt, 0, args_t0);
 
         // t1: d = c + 1.0
         Arg args_t1;
         args_t1.add_input(r0.outputs.get_ref(0));
         args_t1.add_output(TensorCreateInfo(shapes, 1, DataType::FLOAT32));
         args_t1.add_scalar(1.0f);
-        SubmitResult r1 = pto2_rt_submit_aiv_task(rt, 1, args_t1);
+        SubmitResult r1 = rt_submit_aiv_task(rt, 1, args_t1);
         pto2_rt_add_dependency(rt, r0.task_id, r1.task_id);
 
         // t2: e = c + 2.0
@@ -69,7 +69,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args_t2.add_input(r0.outputs.get_ref(0));
         args_t2.add_output(TensorCreateInfo(shapes, 1, DataType::FLOAT32));
         args_t2.add_scalar(2.0f);
-        SubmitResult r2 = pto2_rt_submit_aiv_task(rt, 1, args_t2);
+        SubmitResult r2 = rt_submit_aiv_task(rt, 1, args_t2);
         pto2_rt_add_dependency(rt, r0.task_id, r2.task_id);
 
         // t3: f = d * e
@@ -77,7 +77,7 @@ aicpu_orchestration_entry(PTO2Runtime *rt, const ChipStorageTaskArgs &orch_args)
         args_t3.add_input(r1.outputs.get_ref(0));
         args_t3.add_input(r2.outputs.get_ref(0));
         args_t3.add_inout(ext_f);
-        SubmitResult r3 = pto2_rt_submit_aiv_task(rt, 2, args_t3);
+        SubmitResult r3 = rt_submit_aiv_task(rt, 2, args_t3);
         pto2_rt_add_dependency(rt, r1.task_id, r3.task_id);
         pto2_rt_add_dependency(rt, r2.task_id, r3.task_id);
     }  // scope_end: batch-publish all tasks

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -96,7 +96,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_matmul.add_input(A_view);
             params_matmul.add_input(B_view);
             params_matmul.add_output(C_view);
-            pto2_rt_submit_aic_task(FUNC_MATMUL, params_matmul);
+            rt_submit_aic_task(FUNC_MATMUL, params_matmul);
             total_matmul++;
         }
 
@@ -116,7 +116,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             params_add.add_input(X_view);
             params_add.add_input(Y_view);
             params_add.add_output(Z_view);
-            pto2_rt_submit_aiv_task(FUNC_ADD, params_add);
+            rt_submit_aiv_task(FUNC_ADD, params_add);
             total_add++;
         }
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -153,7 +153,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_qk.add_scalar(block_num);
                         params_qk.add_scalar(num_heads);
                         params_qk.add_scalar(batch_start);
-                        TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                        TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                         const Tensor &sij_b = qk_outs.get_ref(0);
 
                         Arg params_sf;
@@ -166,7 +166,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_sf.add_scalar(chunk_bc);
                         params_sf.add_scalar(bn);
                         params_sf.add_scalar(batch_start);
-                        TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                        TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                         const Tensor &pij_b = sf_outs.get_ref(0);
                         const Tensor &mij_b = sf_outs.get_ref(1);
                         const Tensor &lij_b = sf_outs.get_ref(2);
@@ -180,7 +180,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_pv.add_scalar(bn);
                         params_pv.add_scalar(block_num);
                         params_pv.add_scalar(batch_start);
-                        TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                        TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                         const Tensor &oi_new_b = pv_outs.get_ref(0);
 
                         uint64_t is_first = (bn == 0) ? 1 : 0;
@@ -199,7 +199,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         params_up.add_scalar(q_offset);
                         params_up.add_scalar(num_heads);
                         params_up.add_scalar(batch_start);
-                        pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                        rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                     }
                 }
             }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -105,7 +105,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_G);
                 args.add_input(ext_H);
                 args.add_output(I_view);
-                pto2_rt_submit_task(mk, args);
+                rt_submit_task(mk, args);
             }
 
             // 2. AIC_ONLY: standalone matmul
@@ -114,7 +114,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(J_view);
-                pto2_rt_submit_aic_task(FUNC_MATMUL, args);
+                rt_submit_aic_task(FUNC_MATMUL, args);
             }
 
             // 3. AIV_X1: standalone add
@@ -123,7 +123,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(K_view);
-                pto2_rt_submit_aiv_task(FUNC_ADD_STANDALONE, args);
+                rt_submit_aiv_task(FUNC_ADD_STANDALONE, args);
             }
 
             // 4. AIV_X2: add (AIV0) + mul (AIV1)
@@ -138,7 +138,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_G);
                 args.add_input(ext_H);
                 args.add_output(M_view);
-                pto2_rt_submit_task(mk, args);
+                rt_submit_task(mk, args);
             }
 
             // 5. AIC_AIV_X1: matmul (AIC) + add (AIV0)
@@ -153,7 +153,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(O_view);
-                pto2_rt_submit_task(mk, args);
+                rt_submit_task(mk, args);
             }
         }
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -208,7 +208,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_qk.add_output(sij_buf_ci);
                     params_qk.add_scalar(n_blocks, b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -230,7 +230,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_output(pij_buf_ci, scalar_ci, scalar_ci);
                     params_sf.add_scalar(scale_value, n_blocks, valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_buf = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -245,7 +245,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_output(tile2d_ci);
                     params_pv.add_scalar(n_blocks, b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -261,7 +261,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(mi_update, li_update, oi, out_view);
                     params_up.add_scalar(is_first, is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
@@ -132,7 +132,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_qk.add_output(sij_buf_ci);
                     params_qk.add_scalar(n_blocks);
                     params_qk.add_scalar(b_idx * block_num + bn);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
 
                     // === Task 2: Two-pass softmax — produces 4D pij_buf, 3D mi, li ===
@@ -147,7 +147,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_scalar(scale_value);
                     params_sf.add_scalar(n_blocks);
                     params_sf.add_scalar(valid_len_last);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_buf = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -160,7 +160,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_output(tile4d_ci);
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);
 
                     // === Task 4: Online update (per-group) ===
@@ -177,7 +177,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(out_view);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
                 }
             }
         }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -49,7 +49,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     Arg args;
     args.add_inout(ext_output);
 
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 
     LOG_ALWAYS("[spmd_basic_orch] Submitted 1 MIX task (AIC+AIV0+AIV1)");
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
@@ -47,7 +47,7 @@ static void submit_spmd_mix(Tensor &out, int16_t block_num, int64_t base_cl) {
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -45,7 +45,7 @@ static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, i
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
-    pto2_rt_submit_aiv_task(kernel_id, args);
+    rt_submit_aiv_task(kernel_id, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -53,7 +53,7 @@ submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, i
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -148,7 +148,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         mk.aic_kernel_id = FUNC_PA_AIC;
         mk.aiv0_kernel_id = FUNC_PA_AIV;
         mk.aiv1_kernel_id = FUNC_PA_AIV;
-        pto2_rt_submit_task(mk, args);
+        rt_submit_task(mk, args);
     }
 
     LOG_INFO(

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -62,7 +62,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -57,7 +57,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -51,7 +51,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
+    rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -55,7 +55,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -64,7 +64,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
@@ -73,7 +73,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
+    rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -105,7 +105,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_G);
                 args.add_input(ext_H);
                 args.add_output(I_view);
-                pto2_rt_submit_task(mk, args);
+                rt_submit_task(mk, args);
             }
 
             // 2. AIC_ONLY: standalone matmul
@@ -114,7 +114,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(J_view);
-                pto2_rt_submit_aic_task(FUNC_MATMUL, args);
+                rt_submit_aic_task(FUNC_MATMUL, args);
             }
 
             // 3. AIV_X1: standalone add
@@ -123,7 +123,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(K_view);
-                pto2_rt_submit_aiv_task(FUNC_ADD_STANDALONE, args);
+                rt_submit_aiv_task(FUNC_ADD_STANDALONE, args);
             }
 
             // 4. AIV_X2: add (AIV0) + mul (AIV1)
@@ -138,7 +138,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_G);
                 args.add_input(ext_H);
                 args.add_output(M_view);
-                pto2_rt_submit_task(mk, args);
+                rt_submit_task(mk, args);
             }
 
             // 5. AIC_AIV_X1: matmul (AIC) + add (AIV0)
@@ -153,7 +153,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(O_view);
-                pto2_rt_submit_task(mk, args);
+                rt_submit_task(mk, args);
             }
         }
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/orch_so_cache/kernels/orchestration/example_orchestration.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/orch_so_cache/kernels/orchestration/example_orchestration.cpp
@@ -46,7 +46,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     params.add_input(ext_a);
     params.add_input(ext_b);
     params.add_output(ext_f);
-    pto2_rt_submit_aiv_task(FUNC_ADD, params);
+    rt_submit_aiv_task(FUNC_ADD, params);
 }
 
 }  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -219,7 +219,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_qk.add_scalar(n_blocks);
                     params_qk.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = pto2_rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                     const Tensor &sij_buf = qk_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -245,7 +245,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_scalar(n_blocks);
                     params_sf.add_scalar(valid_len_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = pto2_rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_buf = sf_outs.get_ref(0);
                     const Tensor &mi = sf_outs.get_ref(1);
                     const Tensor &li = sf_outs.get_ref(2);
@@ -263,7 +263,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = pto2_rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_new = pv_outs.get_ref(0);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
@@ -285,7 +285,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);
-                    pto2_rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+                    rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
 #ifdef ENABLE_PROFILING
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -49,7 +49,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     Arg args;
     args.add_inout(ext_output);
 
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 
     LOG_ALWAYS("[spmd_basic_orch] Submitted 1 MIX task (AIC+AIV0+AIV1)");
 }

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -45,7 +45,7 @@ static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, i
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
-    pto2_rt_submit_aiv_task(kernel_id, args);
+    rt_submit_aiv_task(kernel_id, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -53,7 +53,7 @@ submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, i
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -62,7 +62,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -57,7 +57,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -51,7 +51,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
+    rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -55,7 +55,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -64,7 +64,7 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_task(mk, args);
+    rt_submit_task(mk, args);
 }
 
 static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
@@ -73,7 +73,7 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     args.launch_spec.set_require_sync_start(sync_start);
-    pto2_rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
+    rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {

--- a/tests/st/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
+++ b/tests/st/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
@@ -30,7 +30,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TensorCreateInfo ci(shape, 1, DataType::FLOAT32);
     (void)alloc_tensors(ci);
 
-    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "st injected fatal");
+    rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "st injected fatal");
 
     // Exercise API short-circuit after fatal. These calls must become no-ops
     // instead of falling through into runtime-side asserts or extra reporting.
@@ -42,8 +42,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     (void)get_tensor_data<uint64_t>(dummy, 0, indices);
     set_tensor_data<uint64_t>(dummy, 0, indices, 1U);
 
-    pto2_rt_scope_begin();
-    pto2_rt_scope_end();
+    rt_scope_begin();
+    rt_scope_end();
 }
 
 }  // extern "C"

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -29,8 +29,8 @@ namespace {
 
 PTO2Runtime *g_bound_runtime = nullptr;
 
-extern "C" PTO2Runtime *pto2_framework_current_runtime(void) { return g_bound_runtime; }
-extern "C" void pto2_framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+extern "C" PTO2Runtime *framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
 
 struct FakeRuntime {
     const PTO2RuntimeOps *ops;
@@ -113,8 +113,8 @@ const PTO2RuntimeOps kFakeOps = {
 
 class RuntimeBindingGuard {
 public:
-    explicit RuntimeBindingGuard(PTO2Runtime *rt) { pto2_framework_bind_runtime(rt); }
-    ~RuntimeBindingGuard() { pto2_framework_bind_runtime(nullptr); }
+    explicit RuntimeBindingGuard(PTO2Runtime *rt) { framework_bind_runtime(rt); }
+    ~RuntimeBindingGuard() { framework_bind_runtime(nullptr); }
 };
 
 TensorCreateInfo make_ci() {
@@ -136,12 +136,12 @@ TEST(A2A3Fatal, ApiShortCircuitsAfterFatal) {
     uint32_t shape[1] = {1};
     Tensor tensor = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
 
-    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_TRUE(alloc_tensors(args).empty());
     EXPECT_EQ(get_tensor_data<uint64_t>(tensor, 0, indices), 0U);
     set_tensor_data<uint64_t>(tensor, 0, indices, 1U);
-    pto2_rt_scope_begin();
-    pto2_rt_scope_end();
+    rt_scope_begin();
+    rt_scope_end();
     {
         PTO2ScopeGuard guard;
         (void)guard;
@@ -161,7 +161,7 @@ TEST(A2A3Fatal, ExplicitFatalRoutesThroughOps) {
     runtime.ops = &kFakeOps;
     RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
 
-    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
+    rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
 
     EXPECT_TRUE(runtime.fatal);
     EXPECT_EQ(runtime.report_fatal_calls, 1);
@@ -171,7 +171,7 @@ TEST(A2A3Fatal, ExplicitFatalRoutesThroughOps) {
 
     MixedKernels mixed{};
     Arg args;
-    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_EQ(runtime.submit_calls, 0);
 }
 

--- a/tests/ut/cpp/a2a3/test_fanin_pool.cpp
+++ b/tests/ut/cpp/a2a3/test_fanin_pool.cpp
@@ -9,13 +9,13 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Unit tests for PTO2FaninPool and pto2_for_each_fanin_storage/slot_state
+ * Unit tests for PTO2FaninPool and for_each_fanin_storage/slot_state
  * from pto_ring_buffer.h / pto_ring_buffer.cpp
  *
  * Tests:
  * 1. PTO2FaninPool — ring buffer allocation, overflow, tail advance,
  *    high-water tracking
- * 2. pto2_for_each_fanin_storage — inline-only, spill without wrap,
+ * 2. for_each_fanin_storage — inline-only, spill without wrap,
  *    spill with wrap, callback early return
  */
 
@@ -137,7 +137,7 @@ TEST_F(FaninPoolTest, WrapAroundAllocation) {
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: inline only
+// for_each_fanin_storage: inline only
 // =============================================================================
 
 class ForEachFaninTest : public ::testing::Test {
@@ -165,7 +165,7 @@ TEST_F(ForEachFaninTest, InlineOnlyVoid) {
     }
 
     std::vector<PTO2TaskSlotState *> visited;
-    pto2_for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *s) {
+    for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *s) {
         visited.push_back(s);
     });
 
@@ -182,7 +182,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolEarlyReturn) {
     }
 
     int count = 0;
-    bool result = pto2_for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *) -> bool {
         count++;
         return count < 3;  // stop after 3rd
     });
@@ -197,7 +197,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
         inline_slots[i] = &slots[i];
     }
 
-    bool result = pto2_for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](PTO2TaskSlotState *) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](PTO2TaskSlotState *) -> bool {
         return true;
     });
 
@@ -207,14 +207,14 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
 TEST_F(ForEachFaninTest, ZeroFanin) {
     PTO2TaskSlotState *inline_slots[PTO2_FANIN_INLINE_CAP] = {};
     int count = 0;
-    pto2_for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](PTO2TaskSlotState *) {
+    for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](PTO2TaskSlotState *) {
         count++;
     });
     EXPECT_EQ(count, 0);
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: spill without wrap
+// for_each_fanin_storage: spill without wrap
 // =============================================================================
 
 TEST_F(ForEachFaninTest, SpillNoWrap) {
@@ -232,7 +232,7 @@ TEST_F(ForEachFaninTest, SpillNoWrap) {
     s1->slot_state = &slots[17];
 
     std::vector<PTO2TaskSlotState *> visited;
-    pto2_for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
+    for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
         visited.push_back(s);
     });
 
@@ -245,7 +245,7 @@ TEST_F(ForEachFaninTest, SpillNoWrap) {
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: spill with wrap
+// for_each_fanin_storage: spill with wrap
 // =============================================================================
 
 TEST_F(ForEachFaninTest, SpillWithWrap) {
@@ -268,7 +268,7 @@ TEST_F(ForEachFaninTest, SpillWithWrap) {
     }
 
     std::vector<PTO2TaskSlotState *> visited;
-    pto2_for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
+    for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
         visited.push_back(s);
     });
 
@@ -284,7 +284,7 @@ TEST_F(ForEachFaninTest, SpillWithWrap) {
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: spill with bool callback early return
+// for_each_fanin_storage: spill with bool callback early return
 // =============================================================================
 
 TEST_F(ForEachFaninTest, SpillBoolEarlyReturnInSpillRegion) {
@@ -300,11 +300,10 @@ TEST_F(ForEachFaninTest, SpillBoolEarlyReturnInSpillRegion) {
     }
 
     int count = 0;
-    bool result =
-        pto2_for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *) -> bool {
-            count++;
-            return count < 17;  // stop on 17th (first spill entry)
-        });
+    bool result = for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *) -> bool {
+        count++;
+        return count < 17;  // stop on 17th (first spill entry)
+    });
 
     EXPECT_FALSE(result);
     EXPECT_EQ(count, 17);

--- a/tests/ut/cpp/a2a3/test_ready_queue.cpp
+++ b/tests/ut/cpp/a2a3/test_ready_queue.cpp
@@ -56,9 +56,9 @@ protected:
 
     PTO2ReadyQueue queue;
 
-    void SetUp() override { ASSERT_TRUE(pto2_ready_queue_init(&queue, CAPACITY)); }
+    void SetUp() override { ASSERT_TRUE(ready_queue_init(&queue, CAPACITY)); }
 
-    void TearDown() override { pto2_ready_queue_destroy(&queue); }
+    void TearDown() override { ready_queue_destroy(&queue); }
 };
 
 // =============================================================================
@@ -217,8 +217,8 @@ protected:
     PTO2ReadyQueue queue{};
     PTO2TaskSlotState dummy[8]{};
 
-    void SetUp() override { ASSERT_TRUE(pto2_ready_queue_init(&queue, QUEUE_CAP)); }
-    void TearDown() override { pto2_ready_queue_destroy(&queue); }
+    void SetUp() override { ASSERT_TRUE(ready_queue_init(&queue, QUEUE_CAP)); }
+    void TearDown() override { ready_queue_destroy(&queue); }
 };
 
 TEST_F(ReadyQueueBoundaryTest, ExactCapacityFillDrain) {
@@ -307,8 +307,8 @@ protected:
     static constexpr uint64_t CAPACITY = 1024;
     PTO2ReadyQueue queue;
 
-    void SetUp() override { ASSERT_TRUE(pto2_ready_queue_init(&queue, CAPACITY)); }
-    void TearDown() override { pto2_ready_queue_destroy(&queue); }
+    void SetUp() override { ASSERT_TRUE(ready_queue_init(&queue, CAPACITY)); }
+    void TearDown() override { ready_queue_destroy(&queue); }
 };
 
 TEST_P(ReadyQueueMPMCTest, NoDuplicateNoLoss) {

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -27,16 +27,16 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
 
     void SetUp() override {
-        sm_handle = pto2_sm_create_default();
+        sm_handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(sm_handle, nullptr);
-        bool ok = pto2_scheduler_init(&sched, sm_handle->header);
+        bool ok = sched.init(sm_handle->header);
         ASSERT_TRUE(ok);
     }
 
     void TearDown() override {
-        pto2_scheduler_destroy(&sched);
+        sched.destroy();
         if (sm_handle) {
-            pto2_sm_destroy(sm_handle);
+            sm_handle->destroy();
         }
     }
 
@@ -52,7 +52,7 @@ protected:
         slot.fanout_lock.store(0);
         slot.fanout_head = nullptr;
         slot.ring_id = ring_id;
-        slot.active_mask = PTO2_SUBTASK_MASK_AIC;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
         slot.completed_subtasks.store(0);
         slot.total_required_subtasks = 1;
         slot.logical_block_num = 1;

--- a/tests/ut/cpp/a2a3/test_shared_memory.cpp
+++ b/tests/ut/cpp/a2a3/test_shared_memory.cpp
@@ -16,13 +16,13 @@
  *
  * Design contracts:
  *
- * - pto2_sm_validate checks `top > heap_size`.  top == heap_size is a
+ * - validate() checks `top > heap_size`.  top == heap_size is a
  *   legitimate "filled exactly to end" state, so strict > is correct.
  *
- * - Zero window size: if pto2_sm_calculate_size() is called with 0, all ring
+ * - Zero window size: if calculate_size() is called with 0, all ring
  *   descriptors/payloads alias the same address.  Current entry path
- *   (pto2_sm_create) is called only with valid sizes, but there is no
- *   explicit guard.  pto2_sm_create should reject task_window_size==0.
+ *   (create) is called only with valid sizes, but there is no
+ *   explicit guard.  create should reject task_window_size==0.
  *
  * - Flow control heap_top validation: validate() does not verify
  *   heap_top <= heap_size.  After a corruption, heap_top could exceed
@@ -42,13 +42,13 @@ protected:
     PTO2SharedMemoryHandle *handle = nullptr;
 
     void SetUp() override {
-        handle = pto2_sm_create_default();
+        handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(handle, nullptr);
     }
 
     void TearDown() override {
         if (handle) {
-            pto2_sm_destroy(handle);
+            handle->destroy();
             handle = nullptr;
         }
     }
@@ -79,7 +79,7 @@ TEST_F(SharedMemoryTest, HeaderInitValues) {
     }
 }
 
-TEST_F(SharedMemoryTest, Validate) { EXPECT_TRUE(pto2_sm_validate(handle)); }
+TEST_F(SharedMemoryTest, Validate) { EXPECT_TRUE(handle->validate()); }
 
 TEST_F(SharedMemoryTest, PerRingIndependence) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -106,7 +106,7 @@ TEST_F(SharedMemoryTest, HeaderAlignment) {
 // Descriptor and payload regions don't overlap within or across rings.
 TEST_F(SharedMemoryTest, RegionsNonOverlapping) {
     uint64_t ws = 64;  // Use a known window size for byte arithmetic
-    PTO2SharedMemoryHandle *h = pto2_sm_create(ws, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create(ws, 4096);
     ASSERT_NE(h, nullptr);
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -123,7 +123,7 @@ TEST_F(SharedMemoryTest, RegionsNonOverlapping) {
         EXPECT_GE(next_desc_start, this_payload_end) << "Ring " << r << " and " << (r + 1) << " should not overlap";
     }
 
-    pto2_sm_destroy(h);
+    h->destroy();
 }
 
 // =============================================================================
@@ -131,13 +131,13 @@ TEST_F(SharedMemoryTest, RegionsNonOverlapping) {
 // =============================================================================
 
 TEST(SharedMemoryCalcSize, NonZero) {
-    uint64_t size = pto2_sm_calculate_size(PTO2_TASK_WINDOW_SIZE);
+    uint64_t size = PTO2SharedMemoryHandle::calculate_size(PTO2_TASK_WINDOW_SIZE);
     EXPECT_GT(size, 0u);
 }
 
 TEST(SharedMemoryCalcSize, LargerWindowGivesLargerSize) {
-    uint64_t small_size = pto2_sm_calculate_size(64);
-    uint64_t large_size = pto2_sm_calculate_size(256);
+    uint64_t small_size = PTO2SharedMemoryHandle::calculate_size(64);
+    uint64_t large_size = PTO2SharedMemoryHandle::calculate_size(256);
     EXPECT_GT(large_size, small_size);
 }
 
@@ -145,9 +145,9 @@ TEST(SharedMemoryCalcSize, HeaderAligned) { EXPECT_EQ(sizeof(PTO2SharedMemoryHea
 
 TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
     uint64_t ws[PTO2_MAX_RING_DEPTH] = {128, 256, 512, 1024};
-    uint64_t size = pto2_sm_calculate_size_per_ring(ws);
+    uint64_t size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
-    uint64_t uniform_size = pto2_sm_calculate_size(128);
+    uint64_t uniform_size = PTO2SharedMemoryHandle::calculate_size(128);
     EXPECT_GT(size, uniform_size);
 }
 
@@ -157,35 +157,33 @@ TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
 
 // Zero window size: all ring descriptors collapse to same address.
 TEST(SharedMemoryBoundary, ZeroWindowSize) {
-    uint64_t size = pto2_sm_calculate_size(0);
+    uint64_t size = PTO2SharedMemoryHandle::calculate_size(0);
     uint64_t header_size = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     EXPECT_EQ(size, header_size);
 
-    PTO2SharedMemoryHandle *h = pto2_sm_create(0, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create(0, 4096);
     if (h) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH - 1; r++) {
             EXPECT_EQ(h->header->rings[r].task_descriptors, h->header->rings[r + 1].task_descriptors)
                 << "Zero window: all rings' descriptor pointers collapse to same address";
         }
-        pto2_sm_destroy(h);
+        h->destroy();
     }
 }
 
 TEST(SharedMemoryBoundary, ValidateDetectsCorruption) {
-    PTO2SharedMemoryHandle *h = pto2_sm_create(256, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create(256, 4096);
     ASSERT_NE(h, nullptr);
-    EXPECT_TRUE(pto2_sm_validate(h));
+    EXPECT_TRUE(h->validate());
 
     h->header->rings[0].fc.current_task_index.store(-1);
-    EXPECT_FALSE(pto2_sm_validate(h));
+    EXPECT_FALSE(h->validate());
 
-    pto2_sm_destroy(h);
+    h->destroy();
 }
-
-TEST(SharedMemoryBoundary, ValidateNullHandle) { EXPECT_FALSE(pto2_sm_validate(nullptr)); }
 
 TEST(SharedMemoryBoundary, CreateFromUndersizedBuffer) {
     char buf[64]{};
-    PTO2SharedMemoryHandle *h = pto2_sm_create_from_buffer(buf, 64, 256, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create_from_buffer(buf, 64, 256, 4096);
     EXPECT_EQ(h, nullptr) << "Undersized buffer should fail";
 }

--- a/tests/ut/cpp/a2a3/test_task_state.cpp
+++ b/tests/ut/cpp/a2a3/test_task_state.cpp
@@ -36,16 +36,16 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
 
     void SetUp() override {
-        sm_handle = pto2_sm_create_default();
+        sm_handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(sm_handle, nullptr);
-        bool ok = pto2_scheduler_init(&sched, sm_handle->header);
+        bool ok = sched.init(sm_handle->header);
         ASSERT_TRUE(ok);
     }
 
     void TearDown() override {
-        pto2_scheduler_destroy(&sched);
+        sched.destroy();
         if (sm_handle) {
-            pto2_sm_destroy(sm_handle);
+            sm_handle->destroy();
         }
     }
 
@@ -59,7 +59,7 @@ protected:
         slot.fanout_lock.store(0);
         slot.fanout_head = nullptr;
         slot.ring_id = 0;
-        slot.active_mask = PTO2_SUBTASK_MASK_AIC;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
         slot.completed_subtasks.store(0);
         slot.total_required_subtasks = 1;
         slot.logical_block_num = 1;

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -41,16 +41,16 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
 
     void SetUp() override {
-        sm_handle = pto2_sm_create_default();
+        sm_handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(sm_handle, nullptr);
-        bool ok = pto2_scheduler_init(&sched, sm_handle->header);
+        bool ok = sched.init(sm_handle->header);
         ASSERT_TRUE(ok);
     }
 
     void TearDown() override {
-        pto2_scheduler_destroy(&sched);
+        sched.destroy();
         if (sm_handle) {
-            pto2_sm_destroy(sm_handle);
+            sm_handle->destroy();
         }
     }
 
@@ -67,7 +67,7 @@ protected:
         slot.fanout_lock.store(0);
         slot.fanout_head = nullptr;
         slot.ring_id = ring_id;
-        slot.active_mask = PTO2_SUBTASK_MASK_AIC;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
         slot.completed_subtasks.store(0);
         slot.total_required_subtasks = 1;
         slot.logical_block_num = 1;
@@ -100,7 +100,7 @@ TEST_F(WiringTest, WireTaskNoFaninBecomesReady) {
     EXPECT_EQ(task_slot.fanin_refcount.load(), 1);
 
     // Task should be in ready queue
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, &task_slot);
 }
@@ -139,7 +139,7 @@ TEST_F(WiringTest, WireTaskAllProducersEarlyFinished) {
     EXPECT_GE(task_slot.fanin_refcount.load(), task_slot.fanin_count);
 
     // Task should be in ready queue
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, &task_slot);
 }
@@ -177,7 +177,7 @@ TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
     EXPECT_LT(task_slot.fanin_refcount.load(), task_slot.fanin_count);
 
     // Ready queue should be empty
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, nullptr);
 
@@ -245,12 +245,12 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     // Consumer1: needs 1 more fanin to become ready
     init_slot(consumer1, PTO2_TASK_PENDING, 2, 1);
     consumer1.fanin_refcount.store(1);  // 1 of 2 satisfied
-    consumer1.active_mask = PTO2_SUBTASK_MASK_AIC;
+    consumer1.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
 
     // Consumer2: this release will make it ready
     init_slot(consumer2, PTO2_TASK_PENDING, 2, 1);
     consumer2.fanin_refcount.store(1);  // 1 of 2 satisfied
-    consumer2.active_mask = PTO2_SUBTASK_MASK_AIC;
+    consumer2.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
 
     // Build fanout chain: producer -> consumer2 -> consumer1
     PTO2DepListEntry dep_entries[2];
@@ -270,7 +270,7 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     EXPECT_EQ(consumer2.fanin_refcount.load(), 2);
 
     // Both consumers should be ready (fanin_refcount == fanin_count)
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(consumer1.active_mask);
+    PTO2ResourceShape shape = consumer1.active_mask.to_shape();
     auto *r1 = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     auto *r2 = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_TRUE((r1 == &consumer1 && r2 == &consumer2) || (r1 == &consumer2 && r2 == &consumer1));
@@ -403,7 +403,7 @@ TEST_F(WiringTest, DrainWiringQueueProcessesTasks) {
     EXPECT_EQ(wired, 1);
 
     // Task should be ready
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, &task_slot);
 }

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -23,8 +23,8 @@ namespace {
 
 PTO2Runtime *g_bound_runtime = nullptr;
 
-extern "C" PTO2Runtime *pto2_framework_current_runtime(void) { return g_bound_runtime; }
-extern "C" void pto2_framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
+extern "C" PTO2Runtime *framework_current_runtime(void) { return g_bound_runtime; }
+extern "C" void framework_bind_runtime(PTO2Runtime *rt) { g_bound_runtime = rt; }
 
 struct FakeRuntime {
     const PTO2RuntimeOps *ops;
@@ -107,8 +107,8 @@ const PTO2RuntimeOps kFakeOps = {
 
 class RuntimeBindingGuard {
 public:
-    explicit RuntimeBindingGuard(PTO2Runtime *rt) { pto2_framework_bind_runtime(rt); }
-    ~RuntimeBindingGuard() { pto2_framework_bind_runtime(nullptr); }
+    explicit RuntimeBindingGuard(PTO2Runtime *rt) { framework_bind_runtime(rt); }
+    ~RuntimeBindingGuard() { framework_bind_runtime(nullptr); }
 };
 
 TensorCreateInfo make_ci() {
@@ -130,12 +130,12 @@ TEST(A5Fatal, ApiShortCircuitsAfterFatal) {
     uint32_t shape[1] = {1};
     Tensor tensor = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
 
-    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_TRUE(alloc_tensors(args).empty());
     EXPECT_EQ(get_tensor_data<uint64_t>(tensor, 0, indices), 0U);
     set_tensor_data<uint64_t>(tensor, 0, indices, 1U);
-    pto2_rt_scope_begin();
-    pto2_rt_scope_end();
+    rt_scope_begin();
+    rt_scope_end();
     {
         PTO2ScopeGuard guard;
         (void)guard;
@@ -155,7 +155,7 @@ TEST(A5Fatal, ExplicitFatalRoutesThroughOps) {
     runtime.ops = &kFakeOps;
     RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
 
-    pto2_rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
+    rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "boom %d", 7);
 
     EXPECT_TRUE(runtime.fatal);
     EXPECT_EQ(runtime.report_fatal_calls, 1);
@@ -165,7 +165,7 @@ TEST(A5Fatal, ExplicitFatalRoutesThroughOps) {
 
     MixedKernels mixed{};
     Arg args;
-    EXPECT_TRUE(pto2_rt_submit_task(mixed, args).empty());
+    EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_EQ(runtime.submit_calls, 0);
 }
 

--- a/tests/ut/cpp/a5/test_fanin_pool.cpp
+++ b/tests/ut/cpp/a5/test_fanin_pool.cpp
@@ -9,13 +9,13 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * Unit tests for PTO2FaninPool and pto2_for_each_fanin_storage/slot_state
+ * Unit tests for PTO2FaninPool and for_each_fanin_storage/slot_state
  * from pto_ring_buffer.h / pto_ring_buffer.cpp
  *
  * Tests:
  * 1. PTO2FaninPool — ring buffer allocation, overflow, tail advance,
  *    high-water tracking
- * 2. pto2_for_each_fanin_storage — inline-only, spill without wrap,
+ * 2. for_each_fanin_storage — inline-only, spill without wrap,
  *    spill with wrap, callback early return
  */
 
@@ -137,7 +137,7 @@ TEST_F(FaninPoolTest, WrapAroundAllocation) {
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: inline only
+// for_each_fanin_storage: inline only
 // =============================================================================
 
 class ForEachFaninTest : public ::testing::Test {
@@ -165,7 +165,7 @@ TEST_F(ForEachFaninTest, InlineOnlyVoid) {
     }
 
     std::vector<PTO2TaskSlotState *> visited;
-    pto2_for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *s) {
+    for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *s) {
         visited.push_back(s);
     });
 
@@ -182,7 +182,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolEarlyReturn) {
     }
 
     int count = 0;
-    bool result = pto2_for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 5, 0, spill_pool, [&](PTO2TaskSlotState *) -> bool {
         count++;
         return count < 3;  // stop after 3rd
     });
@@ -197,7 +197,7 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
         inline_slots[i] = &slots[i];
     }
 
-    bool result = pto2_for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](PTO2TaskSlotState *) -> bool {
+    bool result = for_each_fanin_storage(inline_slots, 3, 0, spill_pool, [](PTO2TaskSlotState *) -> bool {
         return true;
     });
 
@@ -207,14 +207,14 @@ TEST_F(ForEachFaninTest, InlineOnlyBoolAllTrue) {
 TEST_F(ForEachFaninTest, ZeroFanin) {
     PTO2TaskSlotState *inline_slots[PTO2_FANIN_INLINE_CAP] = {};
     int count = 0;
-    pto2_for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](PTO2TaskSlotState *) {
+    for_each_fanin_storage(inline_slots, 0, 0, spill_pool, [&](PTO2TaskSlotState *) {
         count++;
     });
     EXPECT_EQ(count, 0);
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: spill without wrap
+// for_each_fanin_storage: spill without wrap
 // =============================================================================
 
 TEST_F(ForEachFaninTest, SpillNoWrap) {
@@ -232,7 +232,7 @@ TEST_F(ForEachFaninTest, SpillNoWrap) {
     s1->slot_state = &slots[17];
 
     std::vector<PTO2TaskSlotState *> visited;
-    pto2_for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
+    for_each_fanin_storage(inline_slots, 18, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
         visited.push_back(s);
     });
 
@@ -245,7 +245,7 @@ TEST_F(ForEachFaninTest, SpillNoWrap) {
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: spill with wrap
+// for_each_fanin_storage: spill with wrap
 // =============================================================================
 
 TEST_F(ForEachFaninTest, SpillWithWrap) {
@@ -268,7 +268,7 @@ TEST_F(ForEachFaninTest, SpillWithWrap) {
     }
 
     std::vector<PTO2TaskSlotState *> visited;
-    pto2_for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
+    for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *s) {
         visited.push_back(s);
     });
 
@@ -284,7 +284,7 @@ TEST_F(ForEachFaninTest, SpillWithWrap) {
 }
 
 // =============================================================================
-// pto2_for_each_fanin_storage: spill with bool callback early return
+// for_each_fanin_storage: spill with bool callback early return
 // =============================================================================
 
 TEST_F(ForEachFaninTest, SpillBoolEarlyReturnInSpillRegion) {
@@ -300,11 +300,10 @@ TEST_F(ForEachFaninTest, SpillBoolEarlyReturnInSpillRegion) {
     }
 
     int count = 0;
-    bool result =
-        pto2_for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *) -> bool {
-            count++;
-            return count < 17;  // stop on 17th (first spill entry)
-        });
+    bool result = for_each_fanin_storage(inline_slots, 20, spill_start, spill_pool, [&](PTO2TaskSlotState *) -> bool {
+        count++;
+        return count < 17;  // stop on 17th (first spill entry)
+    });
 
     EXPECT_FALSE(result);
     EXPECT_EQ(count, 17);

--- a/tests/ut/cpp/a5/test_ready_queue.cpp
+++ b/tests/ut/cpp/a5/test_ready_queue.cpp
@@ -56,9 +56,9 @@ protected:
 
     PTO2ReadyQueue queue;
 
-    void SetUp() override { ASSERT_TRUE(pto2_ready_queue_init(&queue, CAPACITY)); }
+    void SetUp() override { ASSERT_TRUE(ready_queue_init(&queue, CAPACITY)); }
 
-    void TearDown() override { pto2_ready_queue_destroy(&queue); }
+    void TearDown() override { ready_queue_destroy(&queue); }
 };
 
 // =============================================================================
@@ -217,8 +217,8 @@ protected:
     PTO2ReadyQueue queue{};
     PTO2TaskSlotState dummy[8]{};
 
-    void SetUp() override { ASSERT_TRUE(pto2_ready_queue_init(&queue, QUEUE_CAP)); }
-    void TearDown() override { pto2_ready_queue_destroy(&queue); }
+    void SetUp() override { ASSERT_TRUE(ready_queue_init(&queue, QUEUE_CAP)); }
+    void TearDown() override { ready_queue_destroy(&queue); }
 };
 
 TEST_F(ReadyQueueBoundaryTest, ExactCapacityFillDrain) {
@@ -307,8 +307,8 @@ protected:
     static constexpr uint64_t CAPACITY = 1024;
     PTO2ReadyQueue queue;
 
-    void SetUp() override { ASSERT_TRUE(pto2_ready_queue_init(&queue, CAPACITY)); }
-    void TearDown() override { pto2_ready_queue_destroy(&queue); }
+    void SetUp() override { ASSERT_TRUE(ready_queue_init(&queue, CAPACITY)); }
+    void TearDown() override { ready_queue_destroy(&queue); }
 };
 
 TEST_P(ReadyQueueMPMCTest, NoDuplicateNoLoss) {

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -27,16 +27,16 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
 
     void SetUp() override {
-        sm_handle = pto2_sm_create_default();
+        sm_handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(sm_handle, nullptr);
-        bool ok = pto2_scheduler_init(&sched, sm_handle->header);
+        bool ok = sched.init(sm_handle->header);
         ASSERT_TRUE(ok);
     }
 
     void TearDown() override {
-        pto2_scheduler_destroy(&sched);
+        sched.destroy();
         if (sm_handle) {
-            pto2_sm_destroy(sm_handle);
+            sm_handle->destroy();
         }
     }
 
@@ -52,7 +52,7 @@ protected:
         slot.fanout_lock.store(0);
         slot.fanout_head = nullptr;
         slot.ring_id = ring_id;
-        slot.active_mask = PTO2_SUBTASK_MASK_AIC;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
         slot.completed_subtasks.store(0);
         slot.total_required_subtasks = 1;
         slot.logical_block_num = 1;

--- a/tests/ut/cpp/a5/test_shared_memory.cpp
+++ b/tests/ut/cpp/a5/test_shared_memory.cpp
@@ -16,13 +16,13 @@
  *
  * Design contracts:
  *
- * - pto2_sm_validate checks `top > heap_size`.  top == heap_size is a
+ * - PTO2SharedMemoryHandle::validate checks `top > heap_size`.  top == heap_size is a
  *   legitimate "filled exactly to end" state, so strict > is correct.
  *
- * - Zero window size: if pto2_sm_calculate_size() is called with 0, all ring
+ * - Zero window size: if PTO2SharedMemoryHandle::calculate_size() is called with 0, all ring
  *   descriptors/payloads alias the same address.  Current entry path
- *   (pto2_sm_create) is called only with valid sizes, but there is no
- *   explicit guard.  pto2_sm_create should reject task_window_size==0.
+ *   (PTO2SharedMemoryHandle::create) is called only with valid sizes, but there is no
+ *   explicit guard.  PTO2SharedMemoryHandle::create should reject task_window_size==0.
  *
  * - Flow control heap_top validation: validate() does not verify
  *   heap_top <= heap_size.  After a corruption, heap_top could exceed
@@ -42,13 +42,13 @@ protected:
     PTO2SharedMemoryHandle *handle = nullptr;
 
     void SetUp() override {
-        handle = pto2_sm_create_default();
+        handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(handle, nullptr);
     }
 
     void TearDown() override {
         if (handle) {
-            pto2_sm_destroy(handle);
+            handle->destroy();
             handle = nullptr;
         }
     }
@@ -79,7 +79,7 @@ TEST_F(SharedMemoryTest, HeaderInitValues) {
     }
 }
 
-TEST_F(SharedMemoryTest, Validate) { EXPECT_TRUE(pto2_sm_validate(handle)); }
+TEST_F(SharedMemoryTest, Validate) { EXPECT_TRUE(handle->validate()); }
 
 TEST_F(SharedMemoryTest, PerRingIndependence) {
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -106,7 +106,7 @@ TEST_F(SharedMemoryTest, HeaderAlignment) {
 // Descriptor and payload regions don't overlap within or across rings.
 TEST_F(SharedMemoryTest, RegionsNonOverlapping) {
     uint64_t ws = 64;  // Use a known window size for byte arithmetic
-    PTO2SharedMemoryHandle *h = pto2_sm_create(ws, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create(ws, 4096);
     ASSERT_NE(h, nullptr);
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -123,7 +123,7 @@ TEST_F(SharedMemoryTest, RegionsNonOverlapping) {
         EXPECT_GE(next_desc_start, this_payload_end) << "Ring " << r << " and " << (r + 1) << " should not overlap";
     }
 
-    pto2_sm_destroy(h);
+    h->destroy();
 }
 
 // =============================================================================
@@ -131,13 +131,13 @@ TEST_F(SharedMemoryTest, RegionsNonOverlapping) {
 // =============================================================================
 
 TEST(SharedMemoryCalcSize, NonZero) {
-    uint64_t size = pto2_sm_calculate_size(PTO2_TASK_WINDOW_SIZE);
+    uint64_t size = PTO2SharedMemoryHandle::calculate_size(PTO2_TASK_WINDOW_SIZE);
     EXPECT_GT(size, 0u);
 }
 
 TEST(SharedMemoryCalcSize, LargerWindowGivesLargerSize) {
-    uint64_t small_size = pto2_sm_calculate_size(64);
-    uint64_t large_size = pto2_sm_calculate_size(256);
+    uint64_t small_size = PTO2SharedMemoryHandle::calculate_size(64);
+    uint64_t large_size = PTO2SharedMemoryHandle::calculate_size(256);
     EXPECT_GT(large_size, small_size);
 }
 
@@ -145,9 +145,9 @@ TEST(SharedMemoryCalcSize, HeaderAligned) { EXPECT_EQ(sizeof(PTO2SharedMemoryHea
 
 TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
     uint64_t ws[PTO2_MAX_RING_DEPTH] = {128, 256, 512, 1024};
-    uint64_t size = pto2_sm_calculate_size_per_ring(ws);
+    uint64_t size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
 
-    uint64_t uniform_size = pto2_sm_calculate_size(128);
+    uint64_t uniform_size = PTO2SharedMemoryHandle::calculate_size(128);
     EXPECT_GT(size, uniform_size);
 }
 
@@ -157,35 +157,38 @@ TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
 
 // Zero window size: all ring descriptors collapse to same address.
 TEST(SharedMemoryBoundary, ZeroWindowSize) {
-    uint64_t size = pto2_sm_calculate_size(0);
+    uint64_t size = PTO2SharedMemoryHandle::calculate_size(0);
     uint64_t header_size = PTO2_ALIGN_UP(sizeof(PTO2SharedMemoryHeader), PTO2_ALIGN_SIZE);
     EXPECT_EQ(size, header_size);
 
-    PTO2SharedMemoryHandle *h = pto2_sm_create(0, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create(0, 4096);
     if (h) {
         for (int r = 0; r < PTO2_MAX_RING_DEPTH - 1; r++) {
             EXPECT_EQ(h->header->rings[r].task_descriptors, h->header->rings[r + 1].task_descriptors)
                 << "Zero window: all rings' descriptor pointers collapse to same address";
         }
-        pto2_sm_destroy(h);
+        h->destroy();
     }
 }
 
 TEST(SharedMemoryBoundary, ValidateDetectsCorruption) {
-    PTO2SharedMemoryHandle *h = pto2_sm_create(256, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create(256, 4096);
     ASSERT_NE(h, nullptr);
-    EXPECT_TRUE(pto2_sm_validate(h));
+    EXPECT_TRUE(h->validate());
 
     h->header->rings[0].fc.current_task_index.store(-1);
-    EXPECT_FALSE(pto2_sm_validate(h));
+    EXPECT_FALSE(h->validate());
 
-    pto2_sm_destroy(h);
+    h->destroy();
 }
 
-TEST(SharedMemoryBoundary, ValidateNullHandle) { EXPECT_FALSE(pto2_sm_validate(nullptr)); }
+TEST(SharedMemoryBoundary, ValidateNullHandle) {
+    PTO2SharedMemoryHandle handle{};
+    EXPECT_FALSE(handle.validate());
+}
 
 TEST(SharedMemoryBoundary, CreateFromUndersizedBuffer) {
     char buf[64]{};
-    PTO2SharedMemoryHandle *h = pto2_sm_create_from_buffer(buf, 64, 256, 4096);
+    PTO2SharedMemoryHandle *h = PTO2SharedMemoryHandle::create_from_buffer(buf, 64, 256, 4096);
     EXPECT_EQ(h, nullptr) << "Undersized buffer should fail";
 }

--- a/tests/ut/cpp/a5/test_task_state.cpp
+++ b/tests/ut/cpp/a5/test_task_state.cpp
@@ -36,16 +36,16 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
 
     void SetUp() override {
-        sm_handle = pto2_sm_create_default();
+        sm_handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(sm_handle, nullptr);
-        bool ok = pto2_scheduler_init(&sched, sm_handle->header);
+        bool ok = sched.init(sm_handle->header);
         ASSERT_TRUE(ok);
     }
 
     void TearDown() override {
-        pto2_scheduler_destroy(&sched);
+        sched.destroy();
         if (sm_handle) {
-            pto2_sm_destroy(sm_handle);
+            sm_handle->destroy();
         }
     }
 
@@ -59,7 +59,7 @@ protected:
         slot.fanout_lock.store(0);
         slot.fanout_head = nullptr;
         slot.ring_id = 0;
-        slot.active_mask = PTO2_SUBTASK_MASK_AIC;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
         slot.completed_subtasks.store(0);
         slot.total_required_subtasks = 1;
         slot.logical_block_num = 1;

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -41,16 +41,16 @@ protected:
     PTO2SharedMemoryHandle *sm_handle = nullptr;
 
     void SetUp() override {
-        sm_handle = pto2_sm_create_default();
+        sm_handle = PTO2SharedMemoryHandle::create_default();
         ASSERT_NE(sm_handle, nullptr);
-        bool ok = pto2_scheduler_init(&sched, sm_handle->header);
+        bool ok = sched.init(sm_handle->header);
         ASSERT_TRUE(ok);
     }
 
     void TearDown() override {
-        pto2_scheduler_destroy(&sched);
+        sched.destroy();
         if (sm_handle) {
-            pto2_sm_destroy(sm_handle);
+            sm_handle->destroy();
         }
     }
 
@@ -67,7 +67,7 @@ protected:
         slot.fanout_lock.store(0);
         slot.fanout_head = nullptr;
         slot.ring_id = ring_id;
-        slot.active_mask = PTO2_SUBTASK_MASK_AIC;
+        slot.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
         slot.completed_subtasks.store(0);
         slot.total_required_subtasks = 1;
         slot.logical_block_num = 1;
@@ -100,7 +100,7 @@ TEST_F(WiringTest, WireTaskNoFaninBecomesReady) {
     EXPECT_EQ(task_slot.fanin_refcount.load(), 1);
 
     // Task should be in ready queue
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, &task_slot);
 }
@@ -139,7 +139,7 @@ TEST_F(WiringTest, WireTaskAllProducersEarlyFinished) {
     EXPECT_GE(task_slot.fanin_refcount.load(), task_slot.fanin_count);
 
     // Task should be in ready queue
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, &task_slot);
 }
@@ -177,7 +177,7 @@ TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
     EXPECT_LT(task_slot.fanin_refcount.load(), task_slot.fanin_count);
 
     // Ready queue should be empty
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, nullptr);
 
@@ -245,12 +245,12 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     // Consumer1: needs 1 more fanin to become ready
     init_slot(consumer1, PTO2_TASK_PENDING, 2, 1);
     consumer1.fanin_refcount.store(1);  // 1 of 2 satisfied
-    consumer1.active_mask = PTO2_SUBTASK_MASK_AIC;
+    consumer1.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
 
     // Consumer2: this release will make it ready
     init_slot(consumer2, PTO2_TASK_PENDING, 2, 1);
     consumer2.fanin_refcount.store(1);  // 1 of 2 satisfied
-    consumer2.active_mask = PTO2_SUBTASK_MASK_AIC;
+    consumer2.active_mask = ActiveMask(PTO2_SUBTASK_MASK_AIC);
 
     // Build fanout chain: producer -> consumer2 -> consumer1
     PTO2DepListEntry dep_entries[2];
@@ -270,7 +270,7 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     EXPECT_EQ(consumer2.fanin_refcount.load(), 2);
 
     // Both consumers should be ready (fanin_refcount == fanin_count)
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(consumer1.active_mask);
+    PTO2ResourceShape shape = consumer1.active_mask.to_shape();
     auto *r1 = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     auto *r2 = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_TRUE((r1 == &consumer1 && r2 == &consumer2) || (r1 == &consumer2 && r2 == &consumer1));
@@ -403,7 +403,7 @@ TEST_F(WiringTest, DrainWiringQueueProcessesTasks) {
     EXPECT_EQ(wired, 1);
 
     // Task should be ready
-    PTO2ResourceShape shape = pto2_active_mask_to_shape(task_slot.active_mask);
+    PTO2ResourceShape shape = task_slot.active_mask.to_shape();
     auto *popped = sched.ready_queues[static_cast<int32_t>(shape)].pop();
     EXPECT_EQ(popped, &task_slot);
 }


### PR DESCRIPTION
## Summary

Remove `pto2_` prefix from all functions in `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/` and modernize the C++ API:

- Introduce `ActiveMask` class (sizeof==1) replacing raw `uint8_t active_mask` with type-safe methods (`subtask_active`, `core_mask`, `requires_sync_start`, `to_shape`, `set_sync_start`)
- Add `MixedKernels::to_active_mask()` member method
- Move `pto2_fanout_lock/unlock` into `PTO2TaskSlotState` as `lock_fanout()/unlock_fanout()`
- Move `pto2_sm_*` into `PTO2SharedMemoryHandle` as static factory methods and instance methods
- Move `pto2_scheduler_*` into `PTO2SchedulerState` member functions (`init`, `destroy`, `print_stats`, `print_queues`)
- Move `pto2_orchestrator_*`, `pto2_scope_*`, `pto2_submit_mixed_task`, `pto2_alloc_tensors` into `PTO2OrchestratorState` member functions
- Rename all runtime API functions (`pto2_runtime_create` → `runtime_create`, etc.)
- Rename all orchestration API wrappers (`pto2_rt_submit_task` → `rt_submit_task`, etc.) including dlsym lookup strings
- Remove `pto2_` prefix from `Runtime` class member variables and accessors across all runtime copies
- Sync all changes to a5 architecture, preserving a5-specific differences (`core_num` vs `block_num`, `alignas` layout, `PTO2_SCOPE_GUARD` variadic macro)
- Update all call sites in `examples/` and `tests/`

Zero functional change — pure code organization refactor.

## Testing

- [x] `pip install --no-build-isolation .` compiles successfully
- [x] `pytest tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll --device 9 --platform a2a3 --build` passes
- [x] `pytest tests/st/a5/tensormap_and_ringbuffer/mixed_example --platform a5sim --build` passes
- [x] `pytest tests/st/a5/tensormap_and_ringbuffer/spmd_basic --platform a5sim --build` passes
- [x] All pre-commit hooks pass (clang-format, clang-tidy, cpplint, markdownlint)