### PR TITLE
Fix: log-system follow-ups for #703

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ compile_commands.json
 # Built nanobind extensions
 python/_task_interface*.so
 python/_task_interface*.dylib
+.claude/scheduled_tasks.lock

--- a/conftest.py
+++ b/conftest.py
@@ -16,12 +16,28 @@ subprocess per runtime so each gets a clean CANN context. See docs/testing.md.
 
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import subprocess
 import sys
 import time
 import typing
+
+# Make simpler's V0..V9 and NUL acceptable to pytest's `--log-level` validator.
+# pytest does `int(getattr(logging, level.upper(), level))`, so the value must
+# exist as a module attribute on `logging` (not just registered via
+# `addLevelName`). Set both — the addLevelName side gives nice formatter output
+# (`%(levelname)s` shows `V3` instead of `Level 18`); the setattr side is what
+# pytest's CLI parser actually consumes.
+for _v in range(10):
+    logging.addLevelName(15 + _v, f"V{_v}")
+    setattr(logging, f"V{_v}", 15 + _v)
+logging.addLevelName(60, "NUL")
+setattr(logging, "NUL", 60)
+# `pytest --log-level null` upcases to "NULL" before the getattr lookup, so
+# expose both spellings.
+setattr(logging, "NULL", 60)
 
 # macOS libomp collision workaround — must run before any import that may
 # transitively load numpy or torch (i.e. before pytest collects scene test

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -114,7 +114,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--build` | | false | Compile runtime from source (not pre-built) |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
-| `--log-level LEVEL` | | `v5` | Simpler logger threshold. Accepts `debug` / `V0..V9` / `info` / `warn` / `error` / `null`. The "simpler" Python logger is the single source of truth; the value is propagated to host C++ `HostLogger` and AICPU via `KernelArgs` automatically on each `Worker.run()`. Onboard AICPU **severity** stays managed by CANN (`ASCEND_GLOBAL_LOG_LEVEL` / `dlog_setlevel`); only the INFO **verbosity** sub-tier is plumbed via simpler. See [Log levels](#log-levels). |
+| `--log-level LEVEL` | | `v5` | Simpler logger threshold. Accepts `debug` / `V0..V9` / `info` / `warn` / `error` / `null` (case-insensitive). pytest's own CLI validator does `int(getattr(logging, level.upper(), level))`, so the V tiers and `NUL`/`NULL` are exposed as attributes on the `logging` module via `setattr` (registration in `conftest.py` runs before pytest's option machinery). `logging.addLevelName` is also called so `%(levelname)s` formatters print `V3` instead of `Level 18`, but it is not what makes the CLI parser accept the value. The "simpler" Python logger is the single source of truth; the value is snapshotted into the platform SO at `Worker.init()` time (not per `Worker.run()`) and pushed to host `HostLogger`, runner state, and (onboard) CANN `dlog_setlevel`. AICPU receives it via `KernelArgs.log_info_v`. Changing the Python logger level after `Worker.init()` does not retroactively affect that worker. See [Log levels](#log-levels). |
 
 Profiling is enabled only on the first round to avoid overhead on subsequent iterations. Output tensors are reset to their initial values between rounds.
 
@@ -161,21 +161,31 @@ visible by default; lower the threshold (e.g. `--log-level warn`) to hide them.
   already called `setLevel`. Inheritance from the root logger is intentionally
   not used so `import simpler` doesn't kill INFO output by inheriting Python's
   default `WARNING`.
-- `Worker.run()` snapshots the current logger level into `CallConfig.log_level`
-  / `CallConfig.log_info_v`, which travel through `KernelArgs` to AICPU.
-- `pto_runtime_c_api::run_runtime` also pushes the same values into the
-  per-process `HostLogger` so host `LOG_*` calls in the platform SO see the
-  user's threshold.
+- `V0..V9` and `NUL` are registered with `logging.addLevelName` at import,
+  so name-based callers (`pytest --log-level v3`, `logger.setLevel("V3")`,
+  formatters writing `%(levelname)s`) accept and emit them.
+- **Snapshot at `Worker.init()`, not per-run**: when a `Worker` is initialised
+  it reads the current `simpler` logger level once and forwards it through
+  `ChipWorker.init(..., log_level, log_info_v)` to the platform SO's
+  `simpler_init`, which configures `HostLogger`, the runner's snapshot of the
+  values for AICPU `KernelArgs`, and (onboard) `dlog_setlevel`. **Subsequent
+  `logger.setLevel(...)` calls are not re-pushed to that worker** — recreate
+  the worker if you need to change levels mid-run.
+- L3 / L4 hierarchical workers fork chip subprocesses; the parent snapshots
+  the same `(severity, info_v)` pair before `fork()` and passes it explicitly
+  to `_chip_process_loop` so each subprocess starts its own `ChipWorker.init`
+  with the correct values.
 
 ### Onboard AICPU severity is CANN-owned
 
 The onboard AICPU library reads severity from CANN's `dlog` (CheckLogLevel),
 not from `KernelArgs.log_level`. Configure it via
 `ASCEND_GLOBAL_LOG_LEVEL=0..4` or `dlog_setlevel(-1, level, 0)`.
-`simpler/__init__.py` calls `dlog_setlevel(-1, INFO, 0)` once at import
-unless `ASCEND_GLOBAL_LOG_LEVEL` is already set, so the onboard default is
-INFO out of the box. The INFO **verbosity** sub-tier (V0..V9) is still
-controlled through the simpler logger.
+`simpler_init` (called from `ChipWorker::init` in the platform SO) issues
+`dlog_setlevel(-1, severity, 0)` automatically — derived from the snapshotted
+simpler logger level — unless `ASCEND_GLOBAL_LOG_LEVEL` is already set in
+the environment. The INFO **verbosity** sub-tier (V0..V9) is still
+controlled through the simpler logger and travels via `KernelArgs.log_info_v`.
 
 ### Behaviour change since the V0..V9 migration
 

--- a/python/simpler/_log.py
+++ b/python/simpler/_log.py
@@ -56,6 +56,22 @@ NUL = 60
 
 DEFAULT_THRESHOLD = _NATIVE_DEFAULT  # 20 (V5)
 
+# Register V0..V9 / NUL as Python logging level names so that:
+#   - `logging.LogRecord.levelname` for these tiers prints as "V0".."V9"
+#     instead of the default "Level 18" placeholder.
+#   - `logger.setLevel("V3")` (string form) resolves to 18.
+#   - pytest's own `--log-level` validator (which does
+#     `int(getattr(logging, name.upper(), name))`) accepts `pytest --log-level
+#     v3` — but only if the names exist as module attributes on `logging`.
+#     pytest validates the CLI value before conftest's first `import simpler`,
+#     so the same registration is also mirrored at conftest top-level.
+for _v in range(10):
+    logging.addLevelName(15 + _v, f"V{_v}")
+    setattr(logging, f"V{_v}", 15 + _v)
+logging.addLevelName(NUL, "NUL")
+setattr(logging, "NUL", NUL)
+setattr(logging, "NULL", NUL)  # pytest upcases user's `--log-level null` → NULL
+
 _LOGGER_NAME = "simpler"
 _logger = logging.getLogger(_LOGGER_NAME)
 if _logger.level == logging.NOTSET:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -264,17 +264,23 @@ def _chip_process_loop(
     aicpu_path: str,
     aicore_path: str,
     sim_context_lib_path: str = "",
+    log_level: int = 1,
+    log_info_v: int = 5,
 ) -> None:
     """Runs in forked child process. Loads host_runtime.so in own address space.
 
     Reads the unified mailbox layout (same offsets as _sub_worker_loop, but
     this loop also consumes config fields + args_blob).
+
+    `log_level` / `log_info_v` are the parent's snapshot of the simpler logger
+    (computed via `_log.get_current_config()`); the child cannot read the
+    parent's logger after fork, so the values are passed explicitly.
     """
     import traceback as _tb  # noqa: PLC0415
 
     try:
         cw = _ChipWorker()
-        cw.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path)
+        cw.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path, log_level, log_info_v)
         cw.set_device(device_id)
     except Exception as e:
         _tb.print_exc()
@@ -338,7 +344,7 @@ def _chip_process_loop(
             break
 
 
-def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
+def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0913
     buf: memoryview,
     host_lib_path: str,
     device_id: int,
@@ -348,6 +354,8 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
     bootstrap_cfg: ChipBootstrapConfig,
     bootstrap_mailbox_addr: int,
     max_buffer_count: int,
+    log_level: int = 1,
+    log_info_v: int = 5,
 ) -> None:
     """Chip child variant that runs ``bootstrap_context`` before the main loop.
 
@@ -364,7 +372,7 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
 
     cw = ChipWorker()
     try:
-        cw.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path)
+        cw.init(host_lib_path, aicpu_path, aicore_path, sim_context_lib_path, log_level, log_info_v)
     except Exception as e:  # noqa: BLE001
         traceback.print_exc()
         channel.write_error(1, f"{type(e).__name__}: chip_worker.init: {e}")
@@ -763,6 +771,10 @@ class Worker:
         # entering the normal task/control loop.
         bootstrap_configs = self._chip_bootstrap_configs
         use_bootstrap = bootstrap_configs is not None
+        # Snapshot the simpler logger config now, in the parent. After fork the
+        # child cannot read this same logger state across the process boundary,
+        # so the values must be passed explicitly to the child loop.
+        chip_log_level, chip_log_info_v = _simpler_log.get_current_config()
         if device_ids:
             for idx, dev_id in enumerate(device_ids):
                 pid = os.fork()
@@ -785,6 +797,8 @@ class Worker:
                             bootstrap_cfg,
                             bootstrap_addr,
                             max_buffer_count,
+                            chip_log_level,
+                            chip_log_info_v,
                         )
                     else:
                         _chip_process_loop(
@@ -794,6 +808,8 @@ class Worker:
                             self._l3_aicpu_path,
                             self._l3_aicore_path,
                             self._l3_sim_ctx_path,
+                            chip_log_level,
+                            chip_log_info_v,
                         )
                     os._exit(0)
                 else:


### PR DESCRIPTION
## Summary

Three follow-up issues found post-merge of #703 (the V0..V9 log redesign).

### 1. `pytest --log-level v0` was broken

pytest's CLI validator does:
```python
int(getattr(logging, level.upper(), level))
```

so accepted level names must be **module attributes on `logging`** — `logging.addLevelName` alone is insufficient. `addLevelName` only registers `_levelToName` / `_nameToLevel` dicts, which pytest doesn't consult here.

Fix: also `setattr(logging, "V0", 15) ... setattr(logging, "V9", 24)` plus `setattr(logging, "NUL", 60)` and `setattr(logging, "NULL", 60)` (pytest upcases `null` → `NULL` before lookup). Done in two places:

- `python/simpler/_log.py` — for the standalone `python test_*.py --log-level v3` path that goes through argparse after `import simpler`.
- `conftest.py` top-level — pytest validates the CLI value **before conftest's first `import simpler`**, so the module-level registration there is the one that actually saves pytest. The two registrations are redundant by design.

The `addLevelName` calls are kept for the side-benefit: `%(levelname)s` formatters now print `V3` instead of `Level 18`.

### 2. L3/L4 chip subprocesses ignored the simpler logger

`Worker.init()` correctly snapshotted Python's `simpler` logger and forwarded it through `ChipWorker.init(..., log_level, log_info_v)` for the L2 path. The L3/L4 fork loops (`_chip_process_loop` and `_chip_process_loop_with_bootstrap`) called `ChipWorker.init(...)` without the new args, so each subprocess started its `HostLogger` / AICPU at the binding default (V5/INFO) regardless of what the user had configured.

Fix: added `log_level` / `log_info_v` parameters to both child loops (defaulted to `1, 5` for safety), and snapshot the parent's logger config once before the fork loop in `_start_hierarchical` — explicitly forwarded to each child invocation. After fork the child can't read the parent's logger state, so values must travel through the call site.

### 3. `docs/testing.md` was stale

The "Configuration sources" paragraph still described the C2-era model where `Worker.run()` snapshots into `CallConfig.log_level` per-task. Those CallConfig fields were dropped in C4; the snapshot is now one-shot at `Worker.init()`. Rewrote the paragraph and the Option Reference row to match the actual implementation, and documented the L3/L4 fork plumbing.

## Test plan

- [x] `pytest --log-level v0/v3/v9/info/warn/error/null/debug` all accepted (8 variants × 11 cases pass)
- [x] `cpput`: 21/21
- [x] py UT: 210/210 (excluding torch-only)
- [ ] Hardware st-onboard-* and CI to be exercised in PR CI