### PR TITLE
(readme) fix vector_example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd simpler
 pip install --no-build-isolation -e '.[test]'
 
 # Run the vector example (simulation, no hardware required)
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py -p a2a3sim
+python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim
 ```
 
 PTO ISA headers are automatically cloned on first run. See [Getting Started](docs/getting-started.md) for manual setup and troubleshooting.


### PR DESCRIPTION
Minor fix on README to update `vector_example` link.