### PR TITLE
Refactor: log system polish (unify DEV_* and add host log prefix)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -216,9 +216,14 @@ python examples/a2a3/host_build_graph/vector_example/test_vector_example.py -p a
 
 Device logs written to `~/ascend/log/debug/device-<id>/`
 
-Kernel uses macros:
+Both host and AICPU kernel code use the unified `LOG_*` macros from
+`common/unified_log.h`:
 
-- `DEV_INFO`: Informational messages
-- `DEV_DEBUG`: Debug messages
-- `DEV_WARN`: Warnings
-- `DEV_ERROR`: Error messages
+- `LOG_INFO_V0` .. `LOG_INFO_V9`: INFO with verbosity tier (V0 most verbose,
+  V9 most must-see, V5 default)
+- `LOG_DEBUG`: Debug messages
+- `LOG_WARN`: Warnings
+- `LOG_ERROR`: Error messages
+
+Threshold is configured from Python via the `simpler` logger:
+`logging.getLogger("simpler").setLevel(simpler.V3)`.

--- a/src/a2a3/platform/include/aicpu/device_log.h
+++ b/src/a2a3/platform/include/aicpu/device_log.h
@@ -58,9 +58,6 @@ extern bool g_is_log_enable_error;
 // INFO verbosity threshold (0..9). Default 5.
 extern int g_log_info_v;
 
-// Platform constant (defined in platform-specific device_log.cpp)
-extern const char *TILE_FWK_DEVICE_MACHINE;
-
 // =============================================================================
 // Configuration setters (called by AICPU kernel init from KernelArgs)
 // =============================================================================
@@ -79,77 +76,6 @@ void dev_log_debug(const char *func, const char *fmt, ...);
 void dev_log_warn(const char *func, const char *fmt, ...);
 void dev_log_error(const char *func, const char *fmt, ...);
 void dev_log_info_v(int v, const char *func, const char *fmt, ...);
-
-// =============================================================================
-// High-level macros (platform-independent layer)
-// =============================================================================
-
-#define D_DEV_LOGD(MODE_NAME, fmt, ...)                      \
-    do {                                                     \
-        if (g_is_log_enable_debug) {                         \
-            dev_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                    \
-    } while (0)
-
-#define D_DEV_LOGW(MODE_NAME, fmt, ...)                     \
-    do {                                                    \
-        if (g_is_log_enable_warn) {                         \
-            dev_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                   \
-    } while (0)
-
-#define D_DEV_LOGE(MODE_NAME, fmt, ...)                      \
-    do {                                                     \
-        if (g_is_log_enable_error) {                         \
-            dev_log_error(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                    \
-    } while (0)
-
-#define D_DEV_LOGI_V(MODE_NAME, V, fmt, ...)                       \
-    do {                                                           \
-        if (g_is_log_enable_info && (V) >= g_log_info_v) {         \
-            dev_log_info_v((V), __FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                          \
-    } while (0)
-
-#define DEV_DEBUG(fmt, args...) D_DEV_LOGD(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_WARN(fmt, args...) D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_INFO_V(v, fmt, args...) D_DEV_LOGI_V(TILE_FWK_DEVICE_MACHINE, v, fmt, ##args)
-
-// =============================================================================
-// Assertions
-// =============================================================================
-
-#include <cassert>
-#define DEV_ASSERT(condition) assert(condition)
-
-#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...) \
-    do {                                           \
-        if (!(cond)) {                             \
-            DEV_ERROR(fmt, ##__VA_ARGS__);         \
-            DEV_ASSERT(0);                         \
-            return;                                \
-        }                                          \
-    } while (0)
-
-#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...) \
-    do {                                              \
-        if (!(cond)) {                                \
-            DEV_ERROR(fmt, ##__VA_ARGS__);            \
-            DEV_ASSERT(0);                            \
-            return (retval);                          \
-        }                                             \
-    } while (0)
-
-#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...) \
-    do {                                                  \
-        if ((ptr) == nullptr) {                           \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                \
-            DEV_ASSERT(0);                                \
-            return;                                       \
-        }                                                 \
-    } while (0)
 
 // =============================================================================
 // Helper Functions

--- a/src/a2a3/platform/onboard/aicpu/device_log.cpp
+++ b/src/a2a3/platform/onboard/aicpu/device_log.cpp
@@ -35,8 +35,6 @@ bool g_is_log_enable_error = false;
 
 int g_log_info_v = 5;
 
-const char *TILE_FWK_DEVICE_MACHINE = "AI_CPU";
-
 void init_log_switch() {
     g_is_log_enable_debug = CheckLogLevel(AICPU, DLOG_DEBUG);
     g_is_log_enable_info = CheckLogLevel(AICPU, DLOG_INFO);

--- a/src/a2a3/platform/onboard/aicpu/device_malloc.cpp
+++ b/src/a2a3/platform/onboard/aicpu/device_malloc.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "aicpu/device_malloc.h"
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 
 #include <dlfcn.h>
 #include <cstdlib>
@@ -37,7 +37,7 @@ static void resolve_hal_mem_functions() {
     g_halMemAlloc = reinterpret_cast<HalMemAllocFn>(dlsym(RTLD_DEFAULT, "halMemAlloc"));
     g_halMemFree = reinterpret_cast<HalMemFreeFn>(dlsym(RTLD_DEFAULT, "halMemFree"));
     if (g_halMemAlloc == nullptr || g_halMemFree == nullptr) {
-        DEV_ERROR("Failed to resolve halMemAlloc/halMemFree: %s", dlerror());
+        LOG_ERROR("Failed to resolve halMemAlloc/halMemFree: %s", dlerror());
         g_halMemAlloc = nullptr;
         g_halMemFree = nullptr;
     }
@@ -48,7 +48,7 @@ void *aicpu_device_malloc(size_t size) {
     resolve_hal_mem_functions();
 
     if (g_halMemAlloc == nullptr) {
-        DEV_ERROR("halMemAlloc not available, cannot allocate device memory");
+        LOG_ERROR("halMemAlloc not available, cannot allocate device memory");
         return nullptr;
     }
 
@@ -61,7 +61,7 @@ void *aicpu_device_malloc(size_t size) {
     unsigned long long flag = MEM_TYPE_HBM;
     int rc = g_halMemAlloc(&ptr, static_cast<unsigned long long>(size), flag);
     if (rc != 0 || ptr == nullptr) {
-        DEV_ERROR("halMemAlloc failed: rc=%d size=%zu flag=0x%llx", rc, size, flag);
+        LOG_ERROR("halMemAlloc failed: rc=%d size=%zu flag=0x%llx", rc, size, flag);
         return nullptr;
     }
     return ptr;
@@ -75,11 +75,11 @@ void aicpu_device_free(void *ptr) {
     resolve_hal_mem_functions();
 
     if (g_halMemFree == nullptr) {
-        DEV_ERROR("halMemFree not available, cannot free device memory");
+        LOG_ERROR("halMemFree not available, cannot free device memory");
         return;
     }
     int rc = g_halMemFree(ptr);
     if (rc != 0) {
-        DEV_ERROR("halMemFree failed: rc=%d ptr=%p", rc, ptr);
+        LOG_ERROR("halMemFree failed: rc=%d ptr=%p", rc, ptr);
     }
 }

--- a/src/a2a3/platform/sim/aicpu/device_log.cpp
+++ b/src/a2a3/platform/sim/aicpu/device_log.cpp
@@ -34,8 +34,6 @@ bool g_is_log_enable_error = true;
 // Default V5 (matches HostLogger / Python defaults).
 int g_log_info_v = 5;
 
-const char *TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
-
 // =============================================================================
 // Setters (called by AICPU init from KernelArgs)
 // =============================================================================

--- a/src/a2a3/platform/src/host/host_log.cpp
+++ b/src/a2a3/platform/src/host/host_log.cpp
@@ -15,8 +15,11 @@
 
 #include "host_log.h"
 
+#include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
+#include <pthread.h>
 
 using simpler::log::LogLevel;
 
@@ -65,8 +68,20 @@ const char *HostLogger::level_name(LogLevel level) const {
 }
 
 void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args) {
+    using namespace std::chrono;
+    auto now = system_clock::now();
+    auto t = system_clock::to_time_t(now);
+    auto us = duration_cast<microseconds>(now.time_since_epoch()) % 1'000'000;
+    struct tm tm_buf;
+    localtime_r(&t, &tm_buf);
+    char ts[40];
+    size_t n = strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm_buf);
+    snprintf(ts + n, sizeof(ts) - n, ".%06lld", static_cast<long long>(us.count()));
+
+    auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
+
     std::scoped_lock lock(mutex_);
-    fprintf(stderr, "[%s] %s: ", level_tag, func);
+    fprintf(stderr, "[%s][T0x%lx][%s] %s: ", ts, tid, level_tag, func);
     vfprintf(stderr, fmt, args);
     if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n') {
         fputc('\n', stderr);

--- a/src/a2a3/platform/src/host/unified_log_host.cpp
+++ b/src/a2a3/platform/src/host/unified_log_host.cpp
@@ -13,7 +13,8 @@
  * @brief Unified logging - Host implementation.
  *
  * Adapter that forwards the unified C ABI to HostLogger via va_list, avoiding
- * an intermediate vsnprintf-to-buffer round-trip.
+ * an intermediate vsnprintf-to-buffer round-trip. HostLogger::vlog{,_info_v}
+ * is the single authority for level gating; this adapter does not re-check.
  */
 
 #include "common/unified_log.h"
@@ -24,9 +25,6 @@
 using simpler::log::LogLevel;
 
 void unified_log_error(const char *func, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_severity_enabled(LogLevel::ERROR)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog(LogLevel::ERROR, func, fmt, args);
@@ -34,9 +32,6 @@ void unified_log_error(const char *func, const char *fmt, ...) {
 }
 
 void unified_log_warn(const char *func, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_severity_enabled(LogLevel::WARN)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog(LogLevel::WARN, func, fmt, args);
@@ -44,9 +39,6 @@ void unified_log_warn(const char *func, const char *fmt, ...) {
 }
 
 void unified_log_debug(const char *func, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_severity_enabled(LogLevel::DEBUG)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog(LogLevel::DEBUG, func, fmt, args);
@@ -54,9 +46,6 @@ void unified_log_debug(const char *func, const char *fmt, ...) {
 }
 
 void unified_log_info_v(const char *func, int v, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_info_v_enabled(v)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog_info_v(v, func, fmt, args);

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -742,7 +742,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
                                 dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
                             ) != 0) {
-                            DEV_ERROR(
+                            LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
                                 prev_running_id
                             );
@@ -761,7 +761,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
                             dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
                         ) != 0) {
-                        DEV_ERROR(
+                        LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
                         );
                     }
@@ -852,7 +852,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
                                 dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
                             ) != 0) {
-                            DEV_ERROR(
+                            LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
                                 prev_running_id
                             );
@@ -898,7 +898,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
                             dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
                         ) != 0) {
-                        DEV_ERROR(
+                        LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
                         );
                     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -22,7 +22,6 @@
 #include <sys/mman.h>
 #endif
 
-#include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/orch_so_file.h"
 #include "pto2_dispatch_payload.h"
@@ -150,10 +149,10 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return 0;
     }
 
-    DEV_INFO_V(0, "AicpuExecutor: Initializing");
+    LOG_INFO_V0("AicpuExecutor: Initializing");
 
     if (runtime == nullptr) {
-        DEV_ERROR("runtime is nullptr");
+        LOG_ERROR("runtime is nullptr");
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -165,7 +164,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     if (thread_num_ == 0) thread_num_ = 1;
 
     if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
-        DEV_ERROR("Invalid thread_num: %d", thread_num_);
+        LOG_ERROR("Invalid thread_num: %d", thread_num_);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -178,7 +177,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     finished_count_.store(0, std::memory_order_release);
 
     init_done_.store(true, std::memory_order_release);
-    DEV_INFO_V(0, "AicpuExecutor: Init complete");
+    LOG_INFO_V0("AicpuExecutor: Init complete");
     return 0;
 }
 
@@ -187,7 +186,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
  */
 int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
-    DEV_INFO_V(0, "Thread %d: Start", thread_idx);
+    LOG_INFO_V0("Thread %d: Start", thread_idx);
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
@@ -196,7 +195,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         int32_t pto2_submitted_tasks = -1;
 #endif
         if (runtime->get_orch_built_on_host()) {
-            DEV_INFO_V(0, "Thread %d: Host orchestration mode, no-op", thread_idx);
+            LOG_INFO_V0("Thread %d: Host orchestration mode, no-op", thread_idx);
         } else {
             // Two paths:
             //   1) has_new_orch_so == true → host believes the SO identity
@@ -209,7 +208,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             const bool reload_so = runtime->has_new_orch_so();
 
             if (reload_so) {
-                DEV_INFO_V(0, "Thread %d: New orch SO detected, (re)loading", thread_idx);
+                LOG_INFO_V0("Thread %d: New orch SO detected, (re)loading", thread_idx);
                 if (orch_so_handle_ != nullptr) {
                     dlclose(orch_so_handle_);
                     orch_so_handle_ = nullptr;
@@ -228,7 +227,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 size_t so_size = runtime->get_dev_orch_so_size();
 
                 if (so_data == nullptr || so_size == 0) {
-                    DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
+                    LOG_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
@@ -245,28 +244,26 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
                     int32_t fd = create_orch_so_file(candidate_dirs[i], so_path, sizeof(so_path));
                     if (fd < 0) {
-                        DEV_INFO_V(
-                            0, "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path,
-                            errno
+                        LOG_INFO_V0(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
                         );
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO_V(
-                            0, "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path,
-                            errno
+                        LOG_INFO_V0(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
                         );
                         unlink(so_path);
                         continue;
                     }
                     file_created = true;
-                    DEV_INFO_V(0, "Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+                    LOG_INFO_V0("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
                 }
 
                 if (!file_created) {
-                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                    LOG_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
@@ -276,13 +273,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
                 const char *dlopen_err = dlerror();
                 if (handle == nullptr) {
-                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                    LOG_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
                     unlink(so_path);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
                 }
-                DEV_INFO_V(0, "Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
+                LOG_INFO_V0("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
                 const char *entry_symbol = runtime->get_device_orch_func_name();
                 if (entry_symbol == nullptr || entry_symbol[0] == '\0') {
@@ -298,7 +295,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, entry_symbol));
                 const char *entry_dlsym_error = dlerror();
                 if (entry_dlsym_error != nullptr) {
-                    DEV_ERROR(
+                    LOG_ERROR(
                         "Thread %d: dlsym failed for entry symbol '%s': %s", thread_idx, entry_symbol, entry_dlsym_error
                     );
                     dlclose(handle);
@@ -308,7 +305,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     return -1;
                 }
                 if (orch_func == nullptr) {
-                    DEV_ERROR("Thread %d: dlsym returned NULL for entry symbol '%s'", thread_idx, entry_symbol);
+                    LOG_ERROR("Thread %d: dlsym returned NULL for entry symbol '%s'", thread_idx, entry_symbol);
                     dlclose(handle);
                     unlink(so_path);
                     // Unblock scheduler threads before returning so they don't spin forever.
@@ -320,7 +317,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 auto config_func = reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, config_symbol));
                 const char *config_dlsym_error = dlerror();
                 if (config_dlsym_error != nullptr || config_func == nullptr) {
-                    DEV_ERROR(
+                    LOG_ERROR(
                         "Thread %d: dlsym failed for config symbol '%s': %s", thread_idx, config_symbol,
                         config_dlsym_error ? config_dlsym_error : "NULL function pointer"
                     );
@@ -332,7 +329,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "framework_bind_runtime"));
                 const char *bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
-                    DEV_ERROR("Thread %d: dlsym failed for framework_bind_runtime: %s", thread_idx, bind_runtime_error);
+                    LOG_ERROR("Thread %d: dlsym failed for framework_bind_runtime: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
@@ -342,9 +339,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_config_func_ = config_func;
                 snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
             } else {
-                DEV_INFO_V(0, "Thread %d: Reusing cached orch SO handle=%p", thread_idx, orch_so_handle_);
+                LOG_INFO_V0("Thread %d: Reusing cached orch SO handle=%p", thread_idx, orch_so_handle_);
                 if (orch_so_handle_ == nullptr || orch_func_ == nullptr) {
-                    DEV_ERROR("Thread %d: has_new_orch_so=false but no cached SO handle/func", thread_idx);
+                    LOG_ERROR("Thread %d: has_new_orch_so=false but no cached SO handle/func", thread_idx);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
@@ -354,12 +351,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Validate arg count on every run (reload or cache hit).
             if (orch_config_func_ != nullptr) {
                 PTO2OrchestrationConfig cfg = orch_config_func_(runtime->get_orch_args());
-                DEV_INFO_V(0, "Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
+                LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                 if (cfg.expected_arg_count > 0) {
                     const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
                     int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
                     if (actual_arg_count < cfg.expected_arg_count) {
-                        DEV_ERROR(
+                        LOG_ERROR(
                             "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
                             cfg.expected_arg_count
                         );
@@ -381,7 +378,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     }
                 }
             } else {
-                DEV_INFO_V(0, "Thread %d: No config function, using defaults", thread_idx);
+                LOG_INFO_V0("Thread %d: No config function, using defaults", thread_idx);
             }
 
             // sm_handle / rt are bound to *this* run's memory and must be
@@ -389,17 +386,17 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // reused above.
             const ChipStorageTaskArgs &args = runtime->get_orch_args();
             int32_t arg_count = args.tensor_count() + args.scalar_count();
-            DEV_INFO_V(0, "Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
+            LOG_INFO_V0("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
             for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
                 const ContinuousTensor &t = args.tensor(i);
-                DEV_INFO_V(
-                    0, "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                LOG_INFO_V0(
+                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
                     static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
                 );
             }
             for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                DEV_INFO_V(
-                    0, "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                LOG_INFO_V0(
+                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
                     static_cast<uint64_t>(args.scalar(i))
                 );
             }
@@ -417,8 +414,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             if (runtime->dep_pool_size > 0) {
                 dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
             }
-            DEV_INFO_V(
-                0, "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+            LOG_INFO_V0(
+                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
                 static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
             );
 
@@ -429,7 +426,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             PTO2SharedMemoryHandle *sm_handle =
                 PTO2SharedMemoryHandle::create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
             if (!sm_handle) {
-                DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
+                LOG_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 // Unblock scheduler threads before returning so they don't spin forever.
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
@@ -437,7 +434,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             rt = runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
             if (!rt) {
-                DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
+                LOG_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                 sm_handle->destroy();
                 // Unblock scheduler threads before returning so they don't spin forever.
                 runtime_init_ready_.store(true, std::memory_order_release);
@@ -493,58 +490,58 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t total =
                 p.sync_cycle + p.alloc_cycle + p.args_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
-            DEV_INFO_V(
-                9, "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
                 static_cast<int64_t>(p.submit_count), cycles_to_us(total)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+            LOG_INFO_V9(
+                "Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
                 thread_idx, cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
                 cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
                 static_cast<uint64_t>(p.alloc_atomic_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle),
+            LOG_INFO_V9(
+                "Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle),
                 p.sync_cycle * 100.0 / total
             );
-            DEV_INFO_V(
-                9, "Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle),
+            LOG_INFO_V9(
+                "Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle),
                 p.lookup_cycle * 100.0 / total
             );
-            DEV_INFO_V(
-                9, "Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle),
+            LOG_INFO_V9(
+                "Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle),
                 p.insert_cycle * 100.0 / total
             );
-            DEV_INFO_V(
-                9, "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
                 cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+            LOG_INFO_V9(
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
                 thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
                 cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
                 static_cast<uint64_t>(p.fanin_atomic_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   avg/task       : %.3fus", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   avg/task       : %.3fus", thread_idx,
                 p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0
             );
 
 #if PTO2_TENSORMAP_PROFILING
             PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
-            DEV_INFO_V(9, "Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-            DEV_INFO_V(
-                9, "Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "", thread_idx,
+            LOG_INFO_V9("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
+            LOG_INFO_V9(
+                "Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "", thread_idx,
                 static_cast<uint64_t>(tp.lookup_count), static_cast<uint64_t>(tp.insert_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d", thread_idx,
                 static_cast<uint64_t>(tp.lookup_chain_total),
                 tp.lookup_count > 0 ? static_cast<double>(tp.lookup_chain_total) / tp.lookup_count : 0.0,
                 tp.lookup_chain_max
             );
-            DEV_INFO_V(
-                9, "Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)", thread_idx,
                 static_cast<uint64_t>(tp.overlap_checks), static_cast<uint64_t>(tp.overlap_hits),
                 tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0
             );
@@ -593,19 +590,19 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
-        DEV_INFO_V(
-            9, "Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus", thread_idx,
             static_cast<uint64_t>(orch_cycle_start), static_cast<uint64_t>(orch_end_ts),
             cycles_to_us(orch_end_ts - orch_cycle_start)
         );
         if (pto2_submitted_tasks >= 0) {
-            DEV_INFO_V(
-                9, "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
+            LOG_INFO_V9(
+                "PTO2 total submitted tasks = %d, already executed %d tasks", pto2_submitted_tasks,
                 sched_ctx_.completed_tasks_count()
             );
         }
 #endif
-        DEV_INFO_V(0, "Thread %d: Orchestrator completed", thread_idx);
+        LOG_INFO_V0("Thread %d: Orchestrator completed", thread_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
@@ -617,11 +614,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
         }
         if (rt == nullptr) {
-            DEV_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
+            LOG_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
         } else {
             sched_ctx_.bind_runtime(rt);
             int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
-            DEV_INFO_V(0, "Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+            LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
         }
     }
 
@@ -633,7 +630,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         return rc;
     }
 
-    DEV_INFO_V(0, "Thread %d: Completed", thread_idx);
+    LOG_INFO_V0("Thread %d: Completed", thread_idx);
 
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
@@ -680,7 +677,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
 
-    DEV_INFO_V(0, "DeInit: Runtime execution state reset");
+    LOG_INFO_V0("DeInit: Runtime execution state reset");
 
     initialized_.store(false, std::memory_order_release);
     init_done_.store(false, std::memory_order_release);
@@ -688,7 +685,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     thread_idx_.store(0, std::memory_order_release);
     finished_.store(false, std::memory_order_release);
 
-    DEV_INFO_V(0, "DeInit: AicpuExecutor reset complete");
+    LOG_INFO_V0("DeInit: AicpuExecutor reset complete");
 }
 
 // ===== Public Entry Point =====
@@ -708,24 +705,24 @@ void AicpuExecutor::deinit(Runtime *runtime) {
  */
 extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime == nullptr) {
-        DEV_ERROR("%s", "Invalid argument: null Runtime pointer");
+        LOG_ERROR("%s", "Invalid argument: null Runtime pointer");
         return -1;
     }
 
-    DEV_INFO_V(0, "%s", "aicpu_execute: Starting AICPU kernel execution");
+    LOG_INFO_V0("%s", "aicpu_execute: Starting AICPU kernel execution");
 
     g_aicpu_executor.init(runtime);
 
     while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
         if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
-            DEV_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
+            LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
             return -1;
         }
     }
 
     int32_t rc = g_aicpu_executor.run(runtime);
     if (rc != 0) {
-        DEV_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
+        LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
         return rc;
     }
 
@@ -733,15 +730,15 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
 
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
-        DEV_INFO_V(0, "aicpu_execute: Last thread finished, cleaning up");
+        LOG_INFO_V0("aicpu_execute: Last thread finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
     }
 
     if (runtime_rc != 0) {
-        DEV_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
+        LOG_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
         return runtime_rc;
     }
 
-    DEV_INFO_V(0, "%s", "aicpu_execute: Kernel execution completed successfully");
+    LOG_INFO_V0("%s", "aicpu_execute: Kernel execution completed successfully");
     return 0;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -12,7 +12,7 @@
 
 #include <cinttypes>
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_perf_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
@@ -37,7 +37,7 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
 
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
-        DEV_ERROR(
+        LOG_ERROR(
             "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
             "completed_tasks=%d, total_tasks=%d",
             thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
@@ -50,8 +50,8 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
     task_count = total_tasks_;
     if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
         completed_.store(true, std::memory_order_release);
-        DEV_INFO_V(
-            0, "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
+        LOG_INFO_V0(
+            "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
             task_count
         );
         return LoopAction::BREAK_LOOP;
@@ -78,7 +78,7 @@ LoopAction
 SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime) {
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
-        DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
+        LOG_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
         emergency_shutdown(runtime);
         completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
@@ -90,8 +90,8 @@ void SchedulerContext::log_stall_diagnostics(
     int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count
 ) {
     int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-    DEV_INFO_V(
-        9, "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
+    LOG_INFO_V9(
+        "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
         task_count, last_progress_count
     );
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -113,29 +113,29 @@ void SchedulerContext::log_stall_diagnostics(
             if (rc >= fi) {
                 cnt_ready++;
                 if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                    DEV_INFO_V(
-                        9, "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                    LOG_INFO_V9(
+                        "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
                         static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
                     );
                 }
             } else {
                 cnt_waiting++;
                 if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                    DEV_INFO_V(
-                        9, "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                    LOG_INFO_V9(
+                        "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
                         static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
                     );
                 }
             }
         }
     }
-    DEV_INFO_V(9, "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
+    LOG_INFO_V9("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
     int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
     int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
     int32_t total_running = aic_running + aiv_running;
-    DEV_INFO_V(
-        9, "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
-        aiv_running, core_trackers_[thread_idx].core_num()
+    LOG_INFO_V9(
+        "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running, aiv_running,
+        core_trackers_[thread_idx].core_num()
     );
     auto all_running = tracker.get_all_running_cores();
     int32_t dump_count = 0;
@@ -150,15 +150,15 @@ void SchedulerContext::log_stall_diagnostics(
             hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
         }
         uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
-        DEV_INFO_V(
-            9, "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
+        LOG_INFO_V9(
+            "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
             EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg), sw_tid, hw_kernel
         );
     }
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
-        DEV_INFO_V(
-            9, "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
+        LOG_INFO_V9(
+            "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
             tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
             tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
             tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
@@ -173,11 +173,11 @@ int32_t SchedulerContext::handle_timeout_exit(
     uint64_t sched_start_ts
 #endif
 ) {
-    DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+    LOG_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
 #if PTO2_PROFILING
     uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
-    DEV_INFO_V(
-        9, "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+    LOG_INFO_V9(
+        "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
         static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
         cycles_to_us(sched_timeout_ts - sched_start_ts)
     );
@@ -189,8 +189,8 @@ int32_t SchedulerContext::handle_timeout_exit(
 void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_thread_completed) {
     auto &l2_perf = sched_l2_perf_[thread_idx];
     uint64_t sched_end_ts = get_sys_cnt_aicpu();
-    DEV_INFO_V(
-        9, "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+    LOG_INFO_V9(
+        "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
         static_cast<uint64_t>(l2_perf.sched_start_ts), static_cast<uint64_t>(sched_end_ts),
         cycles_to_us(sched_end_ts - l2_perf.sched_start_ts)
     );
@@ -211,8 +211,8 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
                 (l2_perf.sched_dispatch_cycle - l2_perf.sched_dispatch_pop_cycle - l2_perf.sched_dispatch_setup_cycle) :
                 0;
 
-        DEV_INFO_V(
-            9, "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
             cycles_to_us(sched_total), cur_thread_completed
         );
 
@@ -220,8 +220,7 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
             cur_thread_completed > 0 ? static_cast<double>(l2_perf.notify_edges_total) / cur_thread_completed : 0.0;
         double fanin_avg =
             cur_thread_completed > 0 ? static_cast<double>(l2_perf.fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_INFO_V(
-            9,
+        LOG_INFO_V9(
             "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
             ", max_degree=%d, avg=%.1f]  [fanin: "
             "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
@@ -236,43 +235,42 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
                                            0;
         double complete_hit_rate =
             l2_perf.complete_probe_count > 0 ? l2_perf.complete_hit_count * 100.0 / l2_perf.complete_probe_count : 0.0;
-        DEV_INFO_V(
-            9, "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+        LOG_INFO_V9(
+            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
             thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
             static_cast<uint64_t>(l2_perf.complete_hit_count), static_cast<uint64_t>(complete_miss_count),
             complete_hit_rate
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx, cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+        LOG_INFO_V9(
+            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
             cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
             static_cast<uint64_t>(sp.lock_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx, cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+        LOG_INFO_V9(
+            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
             cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
             static_cast<uint64_t>(sp.fanout_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
             cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
             static_cast<uint64_t>(sp.fanin_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
             cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
             static_cast<uint64_t>(sp.self_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(l2_perf.sched_complete_perf_cycle), l2_perf.sched_complete_perf_cycle * 100.0 / c_parent
         );
 
         uint64_t pop_total = l2_perf.pop_hit + l2_perf.pop_miss;
         double pop_hit_rate = pop_total > 0 ? l2_perf.pop_hit * 100.0 / pop_total : 0.0;
-        DEV_INFO_V(
-            9,
+        LOG_INFO_V9(
             "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%]",
             thread_idx, cycles_to_us(l2_perf.sched_dispatch_cycle), l2_perf.sched_dispatch_cycle * 100.0 / sched_total,
             static_cast<uint64_t>(l2_perf.pop_hit), static_cast<uint64_t>(l2_perf.pop_miss), pop_hit_rate
@@ -280,8 +278,7 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
         uint64_t global_dispatch_count = l2_perf.pop_hit - l2_perf.local_dispatch_count;
         uint64_t total_dispatched = l2_perf.local_dispatch_count + global_dispatch_count;
         double local_hit_rate = total_dispatched > 0 ? l2_perf.local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_INFO_V(
-            9,
+        LOG_INFO_V9(
             "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
             ", local_rate=%.1f%%",
             thread_idx, static_cast<uint64_t>(l2_perf.local_dispatch_count),
@@ -290,55 +287,54 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
         );
 
         uint64_t d_parent = l2_perf.sched_dispatch_cycle > 0 ? l2_perf.sched_dispatch_cycle : 1;
-        DEV_INFO_V(
-            9, "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+        LOG_INFO_V9(
+            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
             dispatch_poll * 100.0 / d_parent
         );
-        DEV_INFO_V(
-            9, "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx, cycles_to_us(l2_perf.sched_dispatch_pop_cycle),
-            l2_perf.sched_dispatch_pop_cycle * 100.0 / d_parent,
+        LOG_INFO_V9(
+            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(l2_perf.sched_dispatch_pop_cycle), l2_perf.sched_dispatch_pop_cycle * 100.0 / d_parent,
             cycles_to_us(l2_perf.sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
             static_cast<uint64_t>(sp.pop_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(l2_perf.sched_dispatch_setup_cycle), l2_perf.sched_dispatch_setup_cycle * 100.0 / d_parent
         );
 
-        DEV_INFO_V(
-            9, "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_scan_cycle),
+        LOG_INFO_V9(
+            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_scan_cycle),
             l2_perf.sched_scan_cycle * 100.0 / sched_total
         );
 
 #if PTO2_SCHED_PROFILING
-        DEV_INFO_V(
-            9, "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx,
             cycles_to_us(l2_perf.sched_wiring_cycle), l2_perf.sched_wiring_cycle * 100.0 / sched_total,
             l2_perf.phase_wiring_count
         );
 #else
-        DEV_INFO_V(
-            9, "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_wiring_cycle),
+        LOG_INFO_V9(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_wiring_cycle),
             l2_perf.sched_wiring_cycle * 100.0 / sched_total
         );
 #endif
 
-        DEV_INFO_V(
-            9, "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_idle_cycle),
+        LOG_INFO_V9(
+            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_idle_cycle),
             l2_perf.sched_idle_cycle * 100.0 / sched_total
         );
 
         if (cur_thread_completed > 0) {
-            DEV_INFO_V(
-                9, "Thread %d:   avg/complete   : %.3fus", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   avg/complete   : %.3fus", thread_idx,
                 cycles_to_us(l2_perf.sched_complete_cycle) / cur_thread_completed
             );
         }
     }
 #endif
-    DEV_INFO_V(
-        9, "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+    LOG_INFO_V9(
+        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
         cycles_to_us(sched_total), static_cast<uint64_t>(l2_perf.sched_loop_count), cur_thread_completed
     );
 }
@@ -360,17 +356,17 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
     }
 #endif
 
-    DEV_INFO_V(0, "Thread %d: Shutting down %d cores", thread_idx, core_num);
+    LOG_INFO_V0("Thread %d: Shutting down %d cores", thread_idx, core_num);
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cores[i];
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
         if (reg_addr != 0) {
             platform_deinit_aicore_regs(reg_addr);
         } else {
-            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+            LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
         }
     }
-    DEV_INFO_V(0, "Thread %d: Shutdown complete", thread_idx);
+    LOG_INFO_V0("Thread %d: Shutdown complete", thread_idx);
     return 0;
 }
 
@@ -383,14 +379,14 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 
     // Validate cores_total_num_ before using as array index
     if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
-        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
+        LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
         return -1;
     }
 
     aic_count_ = 0;
     aiv_count_ = 0;
 
-    DEV_INFO_V(0, "Handshaking with %d cores", cores_total_num_);
+    LOG_INFO_V0("Handshaking with %d cores", cores_total_num_);
 
     // Step 1: Write per-core payload addresses and send handshake signal.
     // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
@@ -415,7 +411,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
         uint32_t physical_core_id = hank->physical_core_id;
 
         if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR(
+            LOG_ERROR(
                 "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
                 max_physical_cores_count
             );
@@ -452,10 +448,10 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 
         if (type == CoreType::AIC) {
             aic_worker_ids_[aic_count_++] = i;
-            DEV_INFO_V(0, "Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+            LOG_INFO_V0("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
         } else {
             aiv_worker_ids_[aiv_count_++] = i;
-            DEV_INFO_V(0, "Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+            LOG_INFO_V0("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
         }
     }
 
@@ -464,7 +460,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
         return -1;
     }
 
-    DEV_INFO_V(0, "Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
+    LOG_INFO_V0("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
     return 0;
 }
 
@@ -482,12 +478,12 @@ bool SchedulerContext::assign_cores_to_threads() {
     int32_t thread_cores_num = max_clusters_per_thread * 3;
 
     if (thread_cores_num > CoreTracker::MAX_CORE_PER_THREAD) {
-        DEV_ERROR("Can't assign more then 64 cores in per scheduler");
+        LOG_ERROR("Can't assign more then 64 cores in per scheduler");
         return false;
     }
 
-    DEV_INFO_V(
-        0, "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
+    LOG_INFO_V0(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
         active_sched_threads_, aic_count_, aiv_count_
     );
 
@@ -516,17 +512,17 @@ bool SchedulerContext::assign_cores_to_threads() {
 
         core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
 
-        DEV_INFO_V(0, "Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        LOG_INFO_V0("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < thread_num_; t++) {
-        DEV_INFO_V(
-            0, "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
+        LOG_INFO_V0(
+            "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count()
         );
     }
 
-    DEV_INFO_V(0, "Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
+    LOG_INFO_V0("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
     return true;
 }
 
@@ -534,8 +530,8 @@ bool SchedulerContext::assign_cores_to_threads() {
 // Reassign all cores across all threads (sched + orchestrator) after orchestration.
 // =============================================================================
 void SchedulerContext::reassign_cores_for_all_threads() {
-    DEV_INFO_V(
-        0, "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_
+    LOG_INFO_V0(
+        "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_
     );
 
     // Collect running worker_ids from all current trackers
@@ -588,12 +584,12 @@ void SchedulerContext::reassign_cores_for_all_threads() {
     }
 
     // Log final distribution
-    DEV_INFO_V(0, "Core reassignment complete:");
+    LOG_INFO_V0("Core reassignment complete:");
     for (int32_t t = 0; t < thread_num_; t++) {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
-        DEV_INFO_V(
-            0, "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_trackers_[t].core_num(),
+        LOG_INFO_V0(
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count(), aic_running, aiv_running
         );
     }
@@ -605,7 +601,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 // deinit their AICore register blocks. Idempotent.
 // =============================================================================
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
-    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+    LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake *hank = &all_handshakes[i];
@@ -615,7 +611,7 @@ void SchedulerContext::emergency_shutdown(Runtime *runtime) {
             platform_deinit_aicore_regs(core_exec_states_[i].reg_addr);
         }
     }
-    DEV_WARN("Emergency shutdown complete");
+    LOG_WARN("Emergency shutdown complete");
 }
 
 // =============================================================================
@@ -638,7 +634,7 @@ int32_t SchedulerContext::init(
     // Discover cores and assign to scheduler threads.
     int32_t rc = handshake_all_cores(runtime);
     if (rc != 0) {
-        DEV_ERROR("handshake_all_cores failed");
+        LOG_ERROR("handshake_all_cores failed");
         return rc;
     }
     if (!assign_cores_to_threads()) {
@@ -789,7 +785,7 @@ void SchedulerContext::on_orchestration_done(
         transition_requested_.store(true, std::memory_order_release);
         reassigned_.store(true, std::memory_order_release);
     } else if (orch_to_sched_) {
-        DEV_INFO_V(0, "Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+        LOG_INFO_V0("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
         transition_requested_.store(true, std::memory_order_release);
 
         // Wait for scheduler threads to acknowledge transition request

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -10,7 +10,7 @@
  */
 #include "scheduler_context.h"
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
 #include "common/l2_perf_profiling.h"
@@ -136,7 +136,7 @@ void SchedulerContext::complete_slot_task(
         if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
             deferred_release_slot_states[deferred_release_count++] = &slot_state;
         } else {
-            DEV_INFO_V(9, "Thread %d: release", thread_idx);
+            LOG_INFO_V9("Thread %d: release", thread_idx);
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
                 int32_t fe =
@@ -175,7 +175,7 @@ void SchedulerContext::complete_slot_task(
                 slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanout_arr,
                 fanout_n
             ) != 0) {
-            DEV_ERROR(
+            LOG_ERROR(
                 "Core %d: l2_perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
                 static_cast<uint64_t>(slot_state.task->task_id.raw)
             );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -11,7 +11,7 @@
 #ifndef SCHEDULER_CONTEXT_H
 #define SCHEDULER_CONTEXT_H
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "scheduler_types.h"
 
 #include "scheduler/pto_scheduler.h"
@@ -297,7 +297,7 @@ private:
 
     uint64_t get_function_bin_addr(int func_id) const {
         if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-            DEV_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
+            LOG_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
             return 0;
         }
         return func_id_to_addr_[func_id];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,7 +12,7 @@
 
 #include <cinttypes>
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
 #include "callable.h"
@@ -285,7 +285,7 @@ void SchedulerContext::dispatch_shape(
                 auto core_offset = cores.pop_first();
                 dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending);
                 slot_state->next_block_idx++;
-                DEV_DEBUG(
+                LOG_DEBUG(
                     "Thread %d: Dispatched %s %s task %" PRId64 " block %d/%d to core_offset %d", thread_idx,
                     is_pending ? "pending" : "idle", shape_name(shape),
                     static_cast<int64_t>(slot_state->task->task_id.raw), slot_state->next_block_idx - 1,
@@ -317,28 +317,28 @@ void SchedulerContext::dispatch_shape(
 int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
     always_assert(sched_ != nullptr);
     CoreTracker &tracker = core_trackers_[thread_idx];
-    DEV_INFO_V(0, "Thread %d: resolve_and_dispatch entry", thread_idx);
+    LOG_INFO_V0("Thread %d: resolve_and_dispatch entry", thread_idx);
 
     PTO2SharedMemoryHeader *header = sched_->sm_header;
     if (!header) {
-        DEV_ERROR("PTO2 dispatch: header is null");
+        LOG_ERROR("PTO2 dispatch: header is null");
         return -1;
     }
-    DEV_INFO_V(
-        0, "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
+    LOG_INFO_V0(
+        "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
         static_cast<uint64_t>(header->rings[0].task_descriptors_offset),
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
     Handshake *hank = static_cast<Handshake *>(runtime->workers);
-    DEV_INFO_V(
-        0, "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
+    LOG_INFO_V0(
+        "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
-        DEV_INFO_V(0, "Thread %d: doing one-time init", thread_idx);
+        LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
         if (is_l2_swimlane_enabled()) {
@@ -357,11 +357,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // Initialize PMU: program events, start counters, and pop initial buffers
         if (is_pmu_enabled()) {
             pmu_aicpu_init(physical_core_ids_, cores_total_num_);
-            DEV_INFO_V(0, "PMU profiling started on %d cores", cores_total_num_);
+            LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
         }
 #endif
 
-        DEV_INFO_V(0, "Thread %d: one-time init done", thread_idx);
+        LOG_INFO_V0("Thread %d: one-time init done", thread_idx);
         pto2_init_complete_.store(true, std::memory_order_release);
     } else {
         while (!pto2_init_complete_.load(std::memory_order_acquire)) {
@@ -369,7 +369,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
     }
 
-    DEV_INFO_V(0, "Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
+    LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
     int32_t cur_thread_completed = 0;
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
@@ -436,8 +436,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             if (thread_idx == 0 && task_count > 0) {
                 if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
                     new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
-                    DEV_INFO_V(
-                        9, "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
+                    LOG_INFO_V9(
+                        "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
                         100.0 * new_total / task_count
                     );
                 }

--- a/src/a5/platform/include/aicpu/device_log.h
+++ b/src/a5/platform/include/aicpu/device_log.h
@@ -58,9 +58,6 @@ extern bool g_is_log_enable_error;
 // INFO verbosity threshold (0..9). Default 5.
 extern int g_log_info_v;
 
-// Platform constant (defined in platform-specific device_log.cpp)
-extern const char *TILE_FWK_DEVICE_MACHINE;
-
 // =============================================================================
 // Configuration setters (called by AICPU kernel init from KernelArgs)
 // =============================================================================
@@ -79,77 +76,6 @@ void dev_log_debug(const char *func, const char *fmt, ...);
 void dev_log_warn(const char *func, const char *fmt, ...);
 void dev_log_error(const char *func, const char *fmt, ...);
 void dev_log_info_v(int v, const char *func, const char *fmt, ...);
-
-// =============================================================================
-// High-level macros (platform-independent layer)
-// =============================================================================
-
-#define D_DEV_LOGD(MODE_NAME, fmt, ...)                      \
-    do {                                                     \
-        if (g_is_log_enable_debug) {                         \
-            dev_log_debug(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                    \
-    } while (0)
-
-#define D_DEV_LOGW(MODE_NAME, fmt, ...)                     \
-    do {                                                    \
-        if (g_is_log_enable_warn) {                         \
-            dev_log_warn(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                   \
-    } while (0)
-
-#define D_DEV_LOGE(MODE_NAME, fmt, ...)                      \
-    do {                                                     \
-        if (g_is_log_enable_error) {                         \
-            dev_log_error(__FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                    \
-    } while (0)
-
-#define D_DEV_LOGI_V(MODE_NAME, V, fmt, ...)                       \
-    do {                                                           \
-        if (g_is_log_enable_info && (V) >= g_log_info_v) {         \
-            dev_log_info_v((V), __FUNCTION__, fmt, ##__VA_ARGS__); \
-        }                                                          \
-    } while (0)
-
-#define DEV_DEBUG(fmt, args...) D_DEV_LOGD(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_WARN(fmt, args...) D_DEV_LOGW(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_ERROR(fmt, args...) D_DEV_LOGE(TILE_FWK_DEVICE_MACHINE, fmt, ##args)
-#define DEV_INFO_V(v, fmt, args...) D_DEV_LOGI_V(TILE_FWK_DEVICE_MACHINE, v, fmt, ##args)
-
-// =============================================================================
-// Assertions
-// =============================================================================
-
-#include <cassert>
-#define DEV_ASSERT(condition) assert(condition)
-
-#define DEV_CHECK_COND_RETURN_VOID(cond, fmt, ...) \
-    do {                                           \
-        if (!(cond)) {                             \
-            DEV_ERROR(fmt, ##__VA_ARGS__);         \
-            DEV_ASSERT(0);                         \
-            return;                                \
-        }                                          \
-    } while (0)
-
-#define DEV_CHECK_COND_RETURN(cond, retval, fmt, ...) \
-    do {                                              \
-        if (!(cond)) {                                \
-            DEV_ERROR(fmt, ##__VA_ARGS__);            \
-            DEV_ASSERT(0);                            \
-            return (retval);                          \
-        }                                             \
-    } while (0)
-
-#define DEV_CHECK_POINTER_NULL_RETURN_VOID(ptr, fmt, ...) \
-    do {                                                  \
-        if ((ptr) == nullptr) {                           \
-            DEV_ERROR(fmt, ##__VA_ARGS__);                \
-            DEV_ASSERT(0);                                \
-            return;                                       \
-        }                                                 \
-    } while (0)
 
 // =============================================================================
 // Helper Functions

--- a/src/a5/platform/onboard/aicpu/device_log.cpp
+++ b/src/a5/platform/onboard/aicpu/device_log.cpp
@@ -35,8 +35,6 @@ bool g_is_log_enable_error = false;
 
 int g_log_info_v = 5;
 
-const char *TILE_FWK_DEVICE_MACHINE = "AI_CPU";
-
 void init_log_switch() {
     g_is_log_enable_debug = CheckLogLevel(AICPU, DLOG_DEBUG);
     g_is_log_enable_info = CheckLogLevel(AICPU, DLOG_INFO);

--- a/src/a5/platform/onboard/aicpu/device_malloc.cpp
+++ b/src/a5/platform/onboard/aicpu/device_malloc.cpp
@@ -18,7 +18,7 @@
  */
 
 #include "aicpu/device_malloc.h"
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 
 #include <dlfcn.h>
 #include <cstdlib>
@@ -37,7 +37,7 @@ static void resolve_hal_mem_functions() {
     g_halMemAlloc = reinterpret_cast<HalMemAllocFn>(dlsym(RTLD_DEFAULT, "halMemAlloc"));
     g_halMemFree = reinterpret_cast<HalMemFreeFn>(dlsym(RTLD_DEFAULT, "halMemFree"));
     if (g_halMemAlloc == nullptr || g_halMemFree == nullptr) {
-        DEV_ERROR("Failed to resolve halMemAlloc/halMemFree: %s", dlerror());
+        LOG_ERROR("Failed to resolve halMemAlloc/halMemFree: %s", dlerror());
         g_halMemAlloc = nullptr;
         g_halMemFree = nullptr;
     }
@@ -48,7 +48,7 @@ void *aicpu_device_malloc(size_t size) {
     resolve_hal_mem_functions();
 
     if (g_halMemAlloc == nullptr) {
-        DEV_ERROR("halMemAlloc not available, cannot allocate device memory");
+        LOG_ERROR("halMemAlloc not available, cannot allocate device memory");
         return nullptr;
     }
 
@@ -61,7 +61,7 @@ void *aicpu_device_malloc(size_t size) {
     unsigned long long flag = MEM_TYPE_HBM;
     int rc = g_halMemAlloc(&ptr, static_cast<unsigned long long>(size), flag);
     if (rc != 0 || ptr == nullptr) {
-        DEV_ERROR("halMemAlloc failed: rc=%d size=%zu flag=0x%llx", rc, size, flag);
+        LOG_ERROR("halMemAlloc failed: rc=%d size=%zu flag=0x%llx", rc, size, flag);
         return nullptr;
     }
     return ptr;
@@ -75,11 +75,11 @@ void aicpu_device_free(void *ptr) {
     resolve_hal_mem_functions();
 
     if (g_halMemFree == nullptr) {
-        DEV_ERROR("halMemFree not available, cannot free device memory");
+        LOG_ERROR("halMemFree not available, cannot free device memory");
         return;
     }
     int rc = g_halMemFree(ptr);
     if (rc != 0) {
-        DEV_ERROR("halMemFree failed: rc=%d ptr=%p", rc, ptr);
+        LOG_ERROR("halMemFree failed: rc=%d ptr=%p", rc, ptr);
     }
 }

--- a/src/a5/platform/sim/aicpu/device_log.cpp
+++ b/src/a5/platform/sim/aicpu/device_log.cpp
@@ -34,8 +34,6 @@ bool g_is_log_enable_error = true;
 // Default V5 (matches HostLogger / Python defaults).
 int g_log_info_v = 5;
 
-const char *TILE_FWK_DEVICE_MACHINE = "SIM_CPU";
-
 // =============================================================================
 // Setters (called by AICPU init from KernelArgs)
 // =============================================================================

--- a/src/a5/platform/src/host/host_log.cpp
+++ b/src/a5/platform/src/host/host_log.cpp
@@ -15,8 +15,11 @@
 
 #include "host_log.h"
 
+#include <chrono>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
+#include <pthread.h>
 
 using simpler::log::LogLevel;
 
@@ -65,8 +68,20 @@ const char *HostLogger::level_name(LogLevel level) const {
 }
 
 void HostLogger::emit(const char *level_tag, const char *func, const char *fmt, va_list args) {
+    using namespace std::chrono;
+    auto now = system_clock::now();
+    auto t = system_clock::to_time_t(now);
+    auto us = duration_cast<microseconds>(now.time_since_epoch()) % 1'000'000;
+    struct tm tm_buf;
+    localtime_r(&t, &tm_buf);
+    char ts[40];
+    size_t n = strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S", &tm_buf);
+    snprintf(ts + n, sizeof(ts) - n, ".%06lld", static_cast<long long>(us.count()));
+
+    auto tid = static_cast<unsigned long>(reinterpret_cast<uintptr_t>(pthread_self()));
+
     std::scoped_lock lock(mutex_);
-    fprintf(stderr, "[%s] %s: ", level_tag, func);
+    fprintf(stderr, "[%s][T0x%lx][%s] %s: ", ts, tid, level_tag, func);
     vfprintf(stderr, fmt, args);
     if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n') {
         fputc('\n', stderr);

--- a/src/a5/platform/src/host/unified_log_host.cpp
+++ b/src/a5/platform/src/host/unified_log_host.cpp
@@ -13,7 +13,8 @@
  * @brief Unified logging - Host implementation.
  *
  * Adapter that forwards the unified C ABI to HostLogger via va_list, avoiding
- * an intermediate vsnprintf-to-buffer round-trip.
+ * an intermediate vsnprintf-to-buffer round-trip. HostLogger::vlog{,_info_v}
+ * is the single authority for level gating; this adapter does not re-check.
  */
 
 #include "common/unified_log.h"
@@ -24,9 +25,6 @@
 using simpler::log::LogLevel;
 
 void unified_log_error(const char *func, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_severity_enabled(LogLevel::ERROR)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog(LogLevel::ERROR, func, fmt, args);
@@ -34,9 +32,6 @@ void unified_log_error(const char *func, const char *fmt, ...) {
 }
 
 void unified_log_warn(const char *func, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_severity_enabled(LogLevel::WARN)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog(LogLevel::WARN, func, fmt, args);
@@ -44,9 +39,6 @@ void unified_log_warn(const char *func, const char *fmt, ...) {
 }
 
 void unified_log_debug(const char *func, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_severity_enabled(LogLevel::DEBUG)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog(LogLevel::DEBUG, func, fmt, args);
@@ -54,9 +46,6 @@ void unified_log_debug(const char *func, const char *fmt, ...) {
 }
 
 void unified_log_info_v(const char *func, int v, const char *fmt, ...) {
-    if (!HostLogger::get_instance().is_info_v_enabled(v)) {
-        return;
-    }
     va_list args;
     va_start(args, fmt);
     HostLogger::get_instance().vlog_info_v(v, func, fmt, args);

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -743,7 +743,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
                                 dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
                             ) != 0) {
-                            DEV_ERROR(
+                            LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
                                 prev_running_id
                             );
@@ -762,7 +762,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
                             dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
                         ) != 0) {
-                        DEV_ERROR(
+                        LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
                         );
                     }
@@ -853,7 +853,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
                                 dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
                             ) != 0) {
-                            DEV_ERROR(
+                            LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
                                 prev_running_id
                             );
@@ -899,7 +899,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
                             dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
                         ) != 0) {
-                        DEV_ERROR(
+                        LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
                         );
                     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -22,7 +22,6 @@
 #include <sys/mman.h>
 #endif
 
-#include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/orch_so_file.h"
 #include "pto2_dispatch_payload.h"
@@ -150,10 +149,10 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return 0;
     }
 
-    DEV_INFO_V(0, "AicpuExecutor: Initializing");
+    LOG_INFO_V0("AicpuExecutor: Initializing");
 
     if (runtime == nullptr) {
-        DEV_ERROR("runtime is nullptr");
+        LOG_ERROR("runtime is nullptr");
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -165,7 +164,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     if (thread_num_ == 0) thread_num_ = 1;
 
     if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
-        DEV_ERROR("Invalid thread_num: %d", thread_num_);
+        LOG_ERROR("Invalid thread_num: %d", thread_num_);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -178,7 +177,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     finished_count_.store(0, std::memory_order_release);
 
     init_done_.store(true, std::memory_order_release);
-    DEV_INFO_V(0, "AicpuExecutor: Init complete");
+    LOG_INFO_V0("AicpuExecutor: Init complete");
     return 0;
 }
 
@@ -187,7 +186,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
  */
 int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
-    DEV_INFO_V(0, "Thread %d: Start", thread_idx);
+    LOG_INFO_V0("Thread %d: Start", thread_idx);
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {
@@ -196,7 +195,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         int32_t submitted_tasks = -1;
 #endif
         if (runtime->get_orch_built_on_host()) {
-            DEV_INFO_V(0, "Thread %d: Host orchestration mode, no-op", thread_idx);
+            LOG_INFO_V0("Thread %d: Host orchestration mode, no-op", thread_idx);
         } else {
             // Two paths:
             //   1) has_new_orch_so == true → host believes the SO identity
@@ -209,7 +208,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             const bool reload_so = runtime->has_new_orch_so();
 
             if (reload_so) {
-                DEV_INFO_V(0, "Thread %d: New orch SO detected, (re)loading", thread_idx);
+                LOG_INFO_V0("Thread %d: New orch SO detected, (re)loading", thread_idx);
                 if (orch_so_handle_ != nullptr) {
                     dlclose(orch_so_handle_);
                     orch_so_handle_ = nullptr;
@@ -228,7 +227,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 size_t so_size = runtime->get_dev_orch_so_size();
 
                 if (so_data == nullptr || so_size == 0) {
-                    DEV_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
+                    LOG_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
@@ -245,28 +244,26 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 for (int32_t i = 0; i < num_candidates && !file_created; i++) {
                     int32_t fd = create_orch_so_file(candidate_dirs[i], so_path, sizeof(so_path));
                     if (fd < 0) {
-                        DEV_INFO_V(
-                            0, "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path,
-                            errno
+                        LOG_INFO_V0(
+                            "Thread %d: Cannot create SO at %s (errno=%d), trying next path", thread_idx, so_path, errno
                         );
                         continue;
                     }
                     ssize_t written = write(fd, so_data, so_size);
                     close(fd);
                     if (written != static_cast<ssize_t>(so_size)) {
-                        DEV_INFO_V(
-                            0, "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path,
-                            errno
+                        LOG_INFO_V0(
+                            "Thread %d: Cannot write SO to %s (errno=%d), trying next path", thread_idx, so_path, errno
                         );
                         unlink(so_path);
                         continue;
                     }
                     file_created = true;
-                    DEV_INFO_V(0, "Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
+                    LOG_INFO_V0("Thread %d: Created SO file at %s (%zu bytes)", thread_idx, so_path, so_size);
                 }
 
                 if (!file_created) {
-                    DEV_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
+                    LOG_ERROR("Thread %d: Failed to create SO file in any candidate path", thread_idx);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
@@ -276,13 +273,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 void *handle = dlopen(so_path, RTLD_LAZY | RTLD_LOCAL);
                 const char *dlopen_err = dlerror();
                 if (handle == nullptr) {
-                    DEV_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
+                    LOG_ERROR("Thread %d: dlopen failed: %s", thread_idx, dlopen_err ? dlopen_err : "unknown");
                     unlink(so_path);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
                 }
-                DEV_INFO_V(0, "Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
+                LOG_INFO_V0("Thread %d: dlopen succeeded, handle=%p", thread_idx, handle);
 
                 const char *entry_symbol = runtime->get_device_orch_func_name();
                 if (entry_symbol == nullptr || entry_symbol[0] == '\0') {
@@ -298,7 +295,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     reinterpret_cast<DeviceOrchestrationFunc>(dlsym(handle, entry_symbol));
                 const char *entry_dlsym_error = dlerror();
                 if (entry_dlsym_error != nullptr) {
-                    DEV_ERROR(
+                    LOG_ERROR(
                         "Thread %d: dlsym failed for entry symbol '%s': %s", thread_idx, entry_symbol, entry_dlsym_error
                     );
                     dlclose(handle);
@@ -308,7 +305,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     return -1;
                 }
                 if (orch_func == nullptr) {
-                    DEV_ERROR("Thread %d: dlsym returned NULL for entry symbol '%s'", thread_idx, entry_symbol);
+                    LOG_ERROR("Thread %d: dlsym returned NULL for entry symbol '%s'", thread_idx, entry_symbol);
                     dlclose(handle);
                     unlink(so_path);
                     // Unblock scheduler threads before returning so they don't spin forever.
@@ -320,7 +317,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 auto config_func = reinterpret_cast<DeviceOrchestrationConfigFunc>(dlsym(handle, config_symbol));
                 const char *config_dlsym_error = dlerror();
                 if (config_dlsym_error != nullptr || config_func == nullptr) {
-                    DEV_ERROR(
+                    LOG_ERROR(
                         "Thread %d: dlsym failed for config symbol '%s': %s", thread_idx, config_symbol,
                         config_dlsym_error ? config_dlsym_error : "NULL function pointer"
                     );
@@ -332,7 +329,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     reinterpret_cast<DeviceOrchestrationBindRuntimeFunc>(dlsym(handle, "framework_bind_runtime"));
                 const char *bind_runtime_error = dlerror();
                 if (bind_runtime_error != nullptr) {
-                    DEV_ERROR("Thread %d: dlsym failed for framework_bind_runtime: %s", thread_idx, bind_runtime_error);
+                    LOG_ERROR("Thread %d: dlsym failed for framework_bind_runtime: %s", thread_idx, bind_runtime_error);
                     bind_runtime_func = nullptr;
                 }
 
@@ -342,9 +339,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 orch_config_func_ = config_func;
                 snprintf(orch_so_path_, sizeof(orch_so_path_), "%s", so_path);
             } else {
-                DEV_INFO_V(0, "Thread %d: Reusing cached orch SO handle=%p", thread_idx, orch_so_handle_);
+                LOG_INFO_V0("Thread %d: Reusing cached orch SO handle=%p", thread_idx, orch_so_handle_);
                 if (orch_so_handle_ == nullptr || orch_func_ == nullptr) {
-                    DEV_ERROR("Thread %d: has_new_orch_so=false but no cached SO handle/func", thread_idx);
+                    LOG_ERROR("Thread %d: has_new_orch_so=false but no cached SO handle/func", thread_idx);
                     // Unblock scheduler threads before returning so they don't spin forever.
                     runtime_init_ready_.store(true, std::memory_order_release);
                     return -1;
@@ -354,12 +351,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Validate arg count on every run (reload or cache hit).
             if (orch_config_func_ != nullptr) {
                 PTO2OrchestrationConfig cfg = orch_config_func_(runtime->get_orch_args());
-                DEV_INFO_V(0, "Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
+                LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                 if (cfg.expected_arg_count > 0) {
                     const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
                     int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
                     if (actual_arg_count < cfg.expected_arg_count) {
-                        DEV_ERROR(
+                        LOG_ERROR(
                             "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
                             cfg.expected_arg_count
                         );
@@ -381,7 +378,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     }
                 }
             } else {
-                DEV_INFO_V(0, "Thread %d: No config function, using defaults", thread_idx);
+                LOG_INFO_V0("Thread %d: No config function, using defaults", thread_idx);
             }
 
             // sm_handle / rt are bound to *this* run's memory and must be
@@ -389,17 +386,17 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // reused above.
             const ChipStorageTaskArgs &args = runtime->get_orch_args();
             int32_t arg_count = args.tensor_count() + args.scalar_count();
-            DEV_INFO_V(0, "Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
+            LOG_INFO_V0("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
             for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
                 const ContinuousTensor &t = args.tensor(i);
-                DEV_INFO_V(
-                    0, "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                LOG_INFO_V0(
+                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
                     static_cast<uint64_t>(t.data), t.ndims, static_cast<unsigned>(t.dtype)
                 );
             }
             for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                DEV_INFO_V(
-                    0, "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                LOG_INFO_V0(
+                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
                     static_cast<uint64_t>(args.scalar(i))
                 );
             }
@@ -417,8 +414,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             if (runtime->dep_pool_size > 0) {
                 dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
             }
-            DEV_INFO_V(
-                0, "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
+            LOG_INFO_V0(
+                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
                 static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
             );
 
@@ -429,7 +426,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             PTO2SharedMemoryHandle *sm_handle =
                 PTO2SharedMemoryHandle::create_from_buffer(sm_ptr, sm_size, task_window_size, heap_size);
             if (!sm_handle) {
-                DEV_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
+                LOG_ERROR("Thread %d: Failed to create shared memory handle", thread_idx);
                 // Unblock scheduler threads before returning so they don't spin forever.
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
@@ -437,7 +434,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             rt = runtime_create_from_sm(PTO2_MODE_EXECUTE, sm_handle, gm_heap, heap_size, dep_pool_capacity);
             if (!rt) {
-                DEV_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
+                LOG_ERROR("Thread %d: Failed to create PTO2Runtime", thread_idx);
                 sm_handle->destroy();
                 // Unblock scheduler threads before returning so they don't spin forever.
                 runtime_init_ready_.store(true, std::memory_order_release);
@@ -493,58 +490,58 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             uint64_t total =
                 p.sync_cycle + p.alloc_cycle + p.args_cycle + p.lookup_cycle + p.insert_cycle + p.fanin_cycle;
             if (total == 0) total = 1;  // avoid div-by-zero
-            DEV_INFO_V(
-                9, "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d: === Orchestrator Profiling: %" PRId64 " tasks, total=%.3fus ===", thread_idx,
                 static_cast<int64_t>(p.submit_count), cycles_to_us(total)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+            LOG_INFO_V9(
+                "Thread %d:   task+heap_alloc: %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
                 thread_idx, cycles_to_us(p.alloc_cycle), p.alloc_cycle * 100.0 / total,
                 cycles_to_us(p.alloc_cycle - p.alloc_wait_cycle), cycles_to_us(p.alloc_wait_cycle),
                 static_cast<uint64_t>(p.alloc_atomic_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle),
+            LOG_INFO_V9(
+                "Thread %d:   sync_tensormap : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.sync_cycle),
                 p.sync_cycle * 100.0 / total
             );
-            DEV_INFO_V(
-                9, "Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle),
+            LOG_INFO_V9(
+                "Thread %d:   lookup+dep     : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.lookup_cycle),
                 p.lookup_cycle * 100.0 / total
             );
-            DEV_INFO_V(
-                9, "Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle),
+            LOG_INFO_V9(
+                "Thread %d:   tensormap_ins  : %.3fus (%.1f%%)", thread_idx, cycles_to_us(p.insert_cycle),
                 p.insert_cycle * 100.0 / total
             );
-            DEV_INFO_V(
-                9, "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   param_copy     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
                 cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
+            LOG_INFO_V9(
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
                 thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
                 cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
                 static_cast<uint64_t>(p.fanin_atomic_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   avg/task       : %.3fus", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   avg/task       : %.3fus", thread_idx,
                 p.submit_count > 0 ? cycles_to_us(total) / p.submit_count : 0.0
             );
 
 #if PTO2_TENSORMAP_PROFILING
             PTO2TensorMapProfilingData tp = pto2_tensormap_get_profiling();
-            DEV_INFO_V(9, "Thread %d: === TensorMap Lookup Stats ===", thread_idx);
-            DEV_INFO_V(
-                9, "Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "", thread_idx,
+            LOG_INFO_V9("Thread %d: === TensorMap Lookup Stats ===", thread_idx);
+            LOG_INFO_V9(
+                "Thread %d:   lookups        : %" PRIu64 ", inserts: %" PRIu64 "", thread_idx,
                 static_cast<uint64_t>(tp.lookup_count), static_cast<uint64_t>(tp.insert_count)
             );
-            DEV_INFO_V(
-                9, "Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   chain walked   : total=%" PRIu64 ", avg=%.1f, max=%d", thread_idx,
                 static_cast<uint64_t>(tp.lookup_chain_total),
                 tp.lookup_count > 0 ? static_cast<double>(tp.lookup_chain_total) / tp.lookup_count : 0.0,
                 tp.lookup_chain_max
             );
-            DEV_INFO_V(
-                9, "Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   overlap checks : %" PRIu64 ", hits=%" PRIu64 " (%.1f%%)", thread_idx,
                 static_cast<uint64_t>(tp.overlap_checks), static_cast<uint64_t>(tp.overlap_hits),
                 tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0
             );
@@ -593,19 +590,19 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
 #if PTO2_PROFILING
         uint64_t orch_end_ts = get_sys_cnt_aicpu();
-        DEV_INFO_V(
-            9, "Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d: orch_start=%" PRIu64 " orch_end=%" PRIu64 " orch_cost=%.3fus", thread_idx,
             static_cast<uint64_t>(orch_cycle_start), static_cast<uint64_t>(orch_end_ts),
             cycles_to_us(orch_end_ts - orch_cycle_start)
         );
         if (submitted_tasks >= 0) {
-            DEV_INFO_V(
-                9, "PTO2 total submitted tasks = %d, already executed %d tasks", submitted_tasks,
+            LOG_INFO_V9(
+                "PTO2 total submitted tasks = %d, already executed %d tasks", submitted_tasks,
                 sched_ctx_.completed_tasks_count()
             );
         }
 #endif
-        DEV_INFO_V(0, "Thread %d: Orchestrator completed", thread_idx);
+        LOG_INFO_V0("Thread %d: Orchestrator completed", thread_idx);
     }
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
@@ -617,11 +614,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
         }
         if (rt == nullptr) {
-            DEV_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
+            LOG_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
         } else {
             sched_ctx_.bind_runtime(rt);
             int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
-            DEV_INFO_V(0, "Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+            LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
         }
     }
 
@@ -633,7 +630,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         return rc;
     }
 
-    DEV_INFO_V(0, "Thread %d: Completed", thread_idx);
+    LOG_INFO_V0("Thread %d: Completed", thread_idx);
 
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
@@ -680,7 +677,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
 
-    DEV_INFO_V(0, "DeInit: Runtime execution state reset");
+    LOG_INFO_V0("DeInit: Runtime execution state reset");
 
     initialized_.store(false, std::memory_order_release);
     init_done_.store(false, std::memory_order_release);
@@ -688,7 +685,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     thread_idx_.store(0, std::memory_order_release);
     finished_.store(false, std::memory_order_release);
 
-    DEV_INFO_V(0, "DeInit: AicpuExecutor reset complete");
+    LOG_INFO_V0("DeInit: AicpuExecutor reset complete");
 }
 
 // ===== Public Entry Point =====
@@ -708,24 +705,24 @@ void AicpuExecutor::deinit(Runtime *runtime) {
  */
 extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime == nullptr) {
-        DEV_ERROR("%s", "Invalid argument: null Runtime pointer");
+        LOG_ERROR("%s", "Invalid argument: null Runtime pointer");
         return -1;
     }
 
-    DEV_INFO_V(0, "%s", "aicpu_execute: Starting AICPU kernel execution");
+    LOG_INFO_V0("%s", "aicpu_execute: Starting AICPU kernel execution");
 
     g_aicpu_executor.init(runtime);
 
     while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
         if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
-            DEV_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
+            LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
             return -1;
         }
     }
 
     int32_t rc = g_aicpu_executor.run(runtime);
     if (rc != 0) {
-        DEV_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
+        LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
         return rc;
     }
 
@@ -733,15 +730,15 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
 
     // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
-        DEV_INFO_V(0, "aicpu_execute: Last thread finished, cleaning up");
+        LOG_INFO_V0("aicpu_execute: Last thread finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
     }
 
     if (runtime_rc != 0) {
-        DEV_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
+        LOG_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
         return runtime_rc;
     }
 
-    DEV_INFO_V(0, "%s", "aicpu_execute: Kernel execution completed successfully");
+    LOG_INFO_V0("%s", "aicpu_execute: Kernel execution completed successfully");
     return 0;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -12,7 +12,7 @@
 
 #include <cinttypes>
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_perf_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
@@ -37,7 +37,7 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
 
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
-        DEV_ERROR(
+        LOG_ERROR(
             "Thread %d: Fatal error (code=%d), sending EXIT_SIGNAL to all cores. "
             "completed_tasks=%d, total_tasks=%d",
             thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
@@ -50,8 +50,8 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
     task_count = total_tasks_;
     if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
         completed_.store(true, std::memory_order_release);
-        DEV_INFO_V(
-            0, "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
+        LOG_INFO_V0(
+            "Thread %d: PTO2 completed tasks %d/%d", thread_idx, completed_tasks_.load(std::memory_order_relaxed),
             task_count
         );
         return LoopAction::BREAK_LOOP;
@@ -78,7 +78,7 @@ LoopAction
 SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime) {
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
-        DEV_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
+        LOG_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
         emergency_shutdown(runtime);
         completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
@@ -90,8 +90,8 @@ void SchedulerContext::log_stall_diagnostics(
     int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count
 ) {
     int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-    DEV_INFO_V(
-        9, "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
+    LOG_INFO_V9(
+        "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
         task_count, last_progress_count
     );
     CoreTracker &tracker = core_trackers_[thread_idx];
@@ -113,29 +113,29 @@ void SchedulerContext::log_stall_diagnostics(
             if (rc >= fi) {
                 cnt_ready++;
                 if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                    DEV_INFO_V(
-                        9, "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                    LOG_INFO_V9(
+                        "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
                         static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
                     );
                 }
             } else {
                 cnt_waiting++;
                 if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                    DEV_INFO_V(
-                        9, "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
+                    LOG_INFO_V9(
+                        "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
                         static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
                     );
                 }
             }
         }
     }
-    DEV_INFO_V(9, "  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
+    LOG_INFO_V9("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
     int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
     int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
     int32_t total_running = aic_running + aiv_running;
-    DEV_INFO_V(
-        9, "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running,
-        aiv_running, core_trackers_[thread_idx].core_num()
+    LOG_INFO_V9(
+        "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running, aiv_running,
+        core_trackers_[thread_idx].core_num()
     );
     auto all_running = tracker.get_all_running_cores();
     int32_t dump_count = 0;
@@ -150,15 +150,15 @@ void SchedulerContext::log_stall_diagnostics(
             hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
         }
         uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
-        DEV_INFO_V(
-            9, "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
+        LOG_INFO_V9(
+            "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
             EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg), sw_tid, hw_kernel
         );
     }
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
-        DEV_INFO_V(
-            9, "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
+        LOG_INFO_V9(
+            "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
             tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
             tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
             tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
@@ -173,11 +173,11 @@ int32_t SchedulerContext::handle_timeout_exit(
     uint64_t sched_start_ts
 #endif
 ) {
-    DEV_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+    LOG_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
 #if PTO2_PROFILING
     uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
-    DEV_INFO_V(
-        9, "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+    LOG_INFO_V9(
+        "Thread %d: sched_start=%" PRIu64 " sched_end(timeout)=%" PRIu64 " sched_cost=%.3fus", thread_idx,
         static_cast<uint64_t>(sched_start_ts), static_cast<uint64_t>(sched_timeout_ts),
         cycles_to_us(sched_timeout_ts - sched_start_ts)
     );
@@ -189,8 +189,8 @@ int32_t SchedulerContext::handle_timeout_exit(
 void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_thread_completed) {
     auto &l2_perf = sched_l2_perf_[thread_idx];
     uint64_t sched_end_ts = get_sys_cnt_aicpu();
-    DEV_INFO_V(
-        9, "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
+    LOG_INFO_V9(
+        "Thread %d: sched_start=%" PRIu64 " sched_end=%" PRIu64 " sched_cost=%.3fus", thread_idx,
         static_cast<uint64_t>(l2_perf.sched_start_ts), static_cast<uint64_t>(sched_end_ts),
         cycles_to_us(sched_end_ts - l2_perf.sched_start_ts)
     );
@@ -211,8 +211,8 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
                 (l2_perf.sched_dispatch_cycle - l2_perf.sched_dispatch_pop_cycle - l2_perf.sched_dispatch_setup_cycle) :
                 0;
 
-        DEV_INFO_V(
-            9, "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d: === Scheduler Phase Breakdown: total=%.3fus, %d tasks ===", thread_idx,
             cycles_to_us(sched_total), cur_thread_completed
         );
 
@@ -220,8 +220,7 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
             cur_thread_completed > 0 ? static_cast<double>(l2_perf.notify_edges_total) / cur_thread_completed : 0.0;
         double fanin_avg =
             cur_thread_completed > 0 ? static_cast<double>(l2_perf.fanin_edges_total) / cur_thread_completed : 0.0;
-        DEV_INFO_V(
-            9,
+        LOG_INFO_V9(
             "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
             ", max_degree=%d, avg=%.1f]  [fanin: "
             "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
@@ -236,43 +235,42 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
                                            0;
         double complete_hit_rate =
             l2_perf.complete_probe_count > 0 ? l2_perf.complete_hit_count * 100.0 / l2_perf.complete_probe_count : 0.0;
-        DEV_INFO_V(
-            9, "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
+        LOG_INFO_V9(
+            "Thread %d:     poll         : %.3fus (%.1f%%)  hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%",
             thread_idx, cycles_to_us(complete_poll), complete_poll * 100.0 / c_parent,
             static_cast<uint64_t>(l2_perf.complete_hit_count), static_cast<uint64_t>(complete_miss_count),
             complete_hit_rate
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx, cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
+        LOG_INFO_V9(
+            "Thread %d:     otc_lock     : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.lock_cycle), sp.lock_cycle * 100.0 / c_parent,
             cycles_to_us(sp.lock_cycle - sp.lock_wait_cycle), cycles_to_us(sp.lock_wait_cycle),
             static_cast<uint64_t>(sp.lock_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx, cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
+        LOG_INFO_V9(
+            "Thread %d:     otc_fanout   : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(sp.fanout_cycle), sp.fanout_cycle * 100.0 / c_parent,
             cycles_to_us(sp.fanout_cycle - sp.push_wait_cycle), cycles_to_us(sp.push_wait_cycle),
             static_cast<uint64_t>(sp.fanout_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     otc_fanin    : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
             cycles_to_us(sp.fanin_cycle), sp.fanin_cycle * 100.0 / c_parent,
             static_cast<uint64_t>(sp.fanin_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     otc_self     : %.3fus (%.1f%%)  atomics=%" PRIu64 "", thread_idx,
             cycles_to_us(sp.self_consumed_cycle), sp.self_consumed_cycle * 100.0 / c_parent,
             static_cast<uint64_t>(sp.self_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     perf         : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(l2_perf.sched_complete_perf_cycle), l2_perf.sched_complete_perf_cycle * 100.0 / c_parent
         );
 
         uint64_t pop_total = l2_perf.pop_hit + l2_perf.pop_miss;
         double pop_hit_rate = pop_total > 0 ? l2_perf.pop_hit * 100.0 / pop_total : 0.0;
-        DEV_INFO_V(
-            9,
+        LOG_INFO_V9(
             "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%]",
             thread_idx, cycles_to_us(l2_perf.sched_dispatch_cycle), l2_perf.sched_dispatch_cycle * 100.0 / sched_total,
             static_cast<uint64_t>(l2_perf.pop_hit), static_cast<uint64_t>(l2_perf.pop_miss), pop_hit_rate
@@ -280,8 +278,7 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
         uint64_t global_dispatch_count = l2_perf.pop_hit - l2_perf.local_dispatch_count;
         uint64_t total_dispatched = l2_perf.local_dispatch_count + global_dispatch_count;
         double local_hit_rate = total_dispatched > 0 ? l2_perf.local_dispatch_count * 100.0 / total_dispatched : 0.0;
-        DEV_INFO_V(
-            9,
+        LOG_INFO_V9(
             "Thread %d:     local_disp   : local=%" PRIu64 ", global=%" PRIu64 ", overflow=%" PRIu64
             ", local_rate=%.1f%%",
             thread_idx, static_cast<uint64_t>(l2_perf.local_dispatch_count),
@@ -290,55 +287,54 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
         );
 
         uint64_t d_parent = l2_perf.sched_dispatch_cycle > 0 ? l2_perf.sched_dispatch_cycle : 1;
-        DEV_INFO_V(
-            9, "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
+        LOG_INFO_V9(
+            "Thread %d:     poll         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(dispatch_poll),
             dispatch_poll * 100.0 / d_parent
         );
-        DEV_INFO_V(
-            9, "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-            thread_idx, cycles_to_us(l2_perf.sched_dispatch_pop_cycle),
-            l2_perf.sched_dispatch_pop_cycle * 100.0 / d_parent,
+        LOG_INFO_V9(
+            "Thread %d:     pop          : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "", thread_idx,
+            cycles_to_us(l2_perf.sched_dispatch_pop_cycle), l2_perf.sched_dispatch_pop_cycle * 100.0 / d_parent,
             cycles_to_us(l2_perf.sched_dispatch_pop_cycle - sp.pop_wait_cycle), cycles_to_us(sp.pop_wait_cycle),
             static_cast<uint64_t>(sp.pop_atomic_count)
         );
-        DEV_INFO_V(
-            9, "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:     setup        : %.3fus (%.1f%%)", thread_idx,
             cycles_to_us(l2_perf.sched_dispatch_setup_cycle), l2_perf.sched_dispatch_setup_cycle * 100.0 / d_parent
         );
 
-        DEV_INFO_V(
-            9, "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_scan_cycle),
+        LOG_INFO_V9(
+            "Thread %d:   scan           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_scan_cycle),
             l2_perf.sched_scan_cycle * 100.0 / sched_total
         );
 
 #if PTO2_SCHED_PROFILING
-        DEV_INFO_V(
-            9, "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx,
+        LOG_INFO_V9(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)  tasks=%d", thread_idx,
             cycles_to_us(l2_perf.sched_wiring_cycle), l2_perf.sched_wiring_cycle * 100.0 / sched_total,
             l2_perf.phase_wiring_count
         );
 #else
-        DEV_INFO_V(
-            9, "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_wiring_cycle),
+        LOG_INFO_V9(
+            "Thread %d:   wiring         : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_wiring_cycle),
             l2_perf.sched_wiring_cycle * 100.0 / sched_total
         );
 #endif
 
-        DEV_INFO_V(
-            9, "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_idle_cycle),
+        LOG_INFO_V9(
+            "Thread %d:   idle           : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_idle_cycle),
             l2_perf.sched_idle_cycle * 100.0 / sched_total
         );
 
         if (cur_thread_completed > 0) {
-            DEV_INFO_V(
-                9, "Thread %d:   avg/complete   : %.3fus", thread_idx,
+            LOG_INFO_V9(
+                "Thread %d:   avg/complete   : %.3fus", thread_idx,
                 cycles_to_us(l2_perf.sched_complete_cycle) / cur_thread_completed
             );
         }
     }
 #endif
-    DEV_INFO_V(
-        9, "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
+    LOG_INFO_V9(
+        "Thread %d: Scheduler summary: total_time=%.3fus, loops=%" PRIu64 ", tasks_scheduled=%d", thread_idx,
         cycles_to_us(sched_total), static_cast<uint64_t>(l2_perf.sched_loop_count), cur_thread_completed
     );
 }
@@ -361,17 +357,17 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
     }
 #endif
 
-    DEV_INFO_V(0, "Thread %d: Shutting down %d cores", thread_idx, core_num);
+    LOG_INFO_V0("Thread %d: Shutting down %d cores", thread_idx, core_num);
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cores[i];
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
         if (reg_addr != 0) {
             platform_deinit_aicore_regs(reg_addr);
         } else {
-            DEV_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
+            LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
         }
     }
-    DEV_INFO_V(0, "Thread %d: Shutdown complete", thread_idx);
+    LOG_INFO_V0("Thread %d: Shutdown complete", thread_idx);
     return 0;
 }
 
@@ -384,14 +380,14 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 
     // Validate cores_total_num_ before using as array index
     if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
-        DEV_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
+        LOG_ERROR("Invalid cores_total_num %d (expected 1-%d)", cores_total_num_, RUNTIME_MAX_WORKER);
         return -1;
     }
 
     aic_count_ = 0;
     aiv_count_ = 0;
 
-    DEV_INFO_V(0, "Handshaking with %d cores", cores_total_num_);
+    LOG_INFO_V0("Handshaking with %d cores", cores_total_num_);
 
     // Step 1: Write per-core payload addresses and send handshake signal.
     // OUT_OF_ORDER_STORE_BARRIER() ensures task is globally visible before
@@ -416,7 +412,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
         uint32_t physical_core_id = hank->physical_core_id;
 
         if (physical_core_id >= max_physical_cores_count) {
-            DEV_ERROR(
+            LOG_ERROR(
                 "Core %d reported invalid physical_core_id=%u (platform max=%u)", i, physical_core_id,
                 max_physical_cores_count
             );
@@ -452,10 +448,10 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 
         if (type == CoreType::AIC) {
             aic_worker_ids_[aic_count_++] = i;
-            DEV_INFO_V(0, "Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+            LOG_INFO_V0("Core %d: AIC, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
         } else {
             aiv_worker_ids_[aiv_count_++] = i;
-            DEV_INFO_V(0, "Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
+            LOG_INFO_V0("Core %d: AIV, physical_id=%u, reg_addr=0x%lx", i, physical_core_id, reg_addr);
         }
     }
 
@@ -464,7 +460,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
         return -1;
     }
 
-    DEV_INFO_V(0, "Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
+    LOG_INFO_V0("Core discovery complete: %d AIC, %d AIV", aic_count_, aiv_count_);
     return 0;
 }
 
@@ -482,12 +478,12 @@ bool SchedulerContext::assign_cores_to_threads() {
     int32_t thread_cores_num = max_clusters_per_thread * 3;
 
     if (thread_cores_num > CoreTracker::MAX_CORE_PER_THREAD) {
-        DEV_ERROR("Can't assign more then 64 cores in per scheduler");
+        LOG_ERROR("Can't assign more then 64 cores in per scheduler");
         return false;
     }
 
-    DEV_INFO_V(
-        0, "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
+    LOG_INFO_V0(
+        "Assigning cores (round-robin): %d clusters across %d sched threads (%d AIC, %d AIV)", cluster_count,
         active_sched_threads_, aic_count_, aiv_count_
     );
 
@@ -516,17 +512,17 @@ bool SchedulerContext::assign_cores_to_threads() {
 
         core_trackers_[t].set_cluster(cluster_idx_per_thread[t]++, aic_wid, aiv0_wid, aiv1_wid);
 
-        DEV_INFO_V(0, "Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
+        LOG_INFO_V0("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
     for (int32_t t = 0; t < thread_num_; t++) {
-        DEV_INFO_V(
-            0, "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
+        LOG_INFO_V0(
+            "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count()
         );
     }
 
-    DEV_INFO_V(0, "Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
+    LOG_INFO_V0("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
     return true;
 }
 
@@ -534,8 +530,8 @@ bool SchedulerContext::assign_cores_to_threads() {
 // Reassign all cores across all threads (sched + orchestrator) after orchestration.
 // =============================================================================
 void SchedulerContext::reassign_cores_for_all_threads() {
-    DEV_INFO_V(
-        0, "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_
+    LOG_INFO_V0(
+        "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_
     );
 
     // Collect running worker_ids from all current trackers
@@ -588,12 +584,12 @@ void SchedulerContext::reassign_cores_for_all_threads() {
     }
 
     // Log final distribution
-    DEV_INFO_V(0, "Core reassignment complete:");
+    LOG_INFO_V0("Core reassignment complete:");
     for (int32_t t = 0; t < thread_num_; t++) {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
-        DEV_INFO_V(
-            0, "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_trackers_[t].core_num(),
+        LOG_INFO_V0(
+            "  Thread %d: %d cores, %d clusters (AIC running=%d, AIV running=%d)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count(), aic_running, aiv_running
         );
     }
@@ -605,7 +601,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 // deinit their AICore register blocks. Idempotent.
 // =============================================================================
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
-    DEV_WARN("Emergency shutdown: sending exit signal to all initialized cores");
+    LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake *hank = &all_handshakes[i];
@@ -615,7 +611,7 @@ void SchedulerContext::emergency_shutdown(Runtime *runtime) {
             platform_deinit_aicore_regs(core_exec_states_[i].reg_addr);
         }
     }
-    DEV_WARN("Emergency shutdown complete");
+    LOG_WARN("Emergency shutdown complete");
 }
 
 // =============================================================================
@@ -638,7 +634,7 @@ int32_t SchedulerContext::init(
     // Discover cores and assign to scheduler threads.
     int32_t rc = handshake_all_cores(runtime);
     if (rc != 0) {
-        DEV_ERROR("handshake_all_cores failed");
+        LOG_ERROR("handshake_all_cores failed");
         return rc;
     }
     if (!assign_cores_to_threads()) {
@@ -782,7 +778,7 @@ void SchedulerContext::on_orchestration_done(
         transition_requested_.store(true, std::memory_order_release);
         reassigned_.store(true, std::memory_order_release);
     } else if (orch_to_sched_) {
-        DEV_INFO_V(0, "Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
+        LOG_INFO_V0("Thread %d: Set orchestrator_done=true, requesting core transition", thread_idx);
         transition_requested_.store(true, std::memory_order_release);
 
         // Wait for scheduler threads to acknowledge transition request

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -10,7 +10,7 @@
  */
 #include "scheduler_context.h"
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
 #include "common/l2_perf_profiling.h"
@@ -136,7 +136,7 @@ void SchedulerContext::complete_slot_task(
         if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
             deferred_release_slot_states[deferred_release_count++] = &slot_state;
         } else {
-            DEV_INFO_V(9, "Thread %d: release", thread_idx);
+            LOG_INFO_V9("Thread %d: release", thread_idx);
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
                 int32_t fe =
@@ -175,7 +175,7 @@ void SchedulerContext::complete_slot_task(
                 slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanout_arr,
                 fanout_n
             ) != 0) {
-            DEV_ERROR(
+            LOG_ERROR(
                 "Core %d: l2_perf_aicpu_complete_record failed for task 0x%" PRIx64, core_id,
                 static_cast<uint64_t>(slot_state.task->task_id.raw)
             );

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -11,7 +11,7 @@
 #ifndef SCHEDULER_CONTEXT_H
 #define SCHEDULER_CONTEXT_H
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "scheduler_types.h"
 
 #include "scheduler/pto_scheduler.h"
@@ -298,7 +298,7 @@ private:
 
     uint64_t get_function_bin_addr(int func_id) const {
         if (!func_id_to_addr_ || func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-            DEV_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
+            LOG_ERROR("func_id=%d is out of range [0, %d) or map is null", func_id, RUNTIME_MAX_FUNC_ID);
             return 0;
         }
         return func_id_to_addr_[func_id];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,7 +12,7 @@
 
 #include <cinttypes>
 
-#include "aicpu/device_log.h"
+#include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
 #include "callable.h"
@@ -277,7 +277,7 @@ void SchedulerContext::dispatch_shape(
                 auto core_offset = cores.pop_first();
                 dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending);
                 slot_state->next_block_idx++;
-                DEV_DEBUG(
+                LOG_DEBUG(
                     "Thread %d: Dispatched %s %s task %" PRId64 " block %d/%d to core_offset %d", thread_idx,
                     is_pending ? "pending" : "idle", shape_name(shape),
                     static_cast<int64_t>(slot_state->task->task_id.raw), slot_state->next_block_idx - 1,
@@ -308,28 +308,28 @@ void SchedulerContext::dispatch_shape(
 
 int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_idx) {
     CoreTracker &tracker = core_trackers_[thread_idx];
-    DEV_INFO_V(0, "Thread %d: resolve_and_dispatch entry", thread_idx);
+    LOG_INFO_V0("Thread %d: resolve_and_dispatch entry", thread_idx);
 
     PTO2SharedMemoryHeader *header = sched_->sm_header;
     if (!header) {
-        DEV_ERROR("PTO2 dispatch: header is null");
+        LOG_ERROR("PTO2 dispatch: header is null");
         return -1;
     }
-    DEV_INFO_V(
-        0, "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
+    LOG_INFO_V0(
+        "Thread %d: header=%p, task_desc_offset[0]=%lu, window_size=%lu", thread_idx, static_cast<void *>(header),
         static_cast<uint64_t>(header->rings[0].task_descriptors_offset),
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
     Handshake *hank = static_cast<Handshake *>(runtime->workers);
-    DEV_INFO_V(
-        0, "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
+    LOG_INFO_V0(
+        "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
     if (!init_done_.exchange(true, std::memory_order_acq_rel)) {
-        DEV_INFO_V(0, "Thread %d: doing one-time init", thread_idx);
+        LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
         if (is_l2_swimlane_enabled()) {
@@ -344,11 +344,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
         if (is_pmu_enabled()) {
             pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
-            DEV_INFO_V(0, "PMU profiling started on %d cores", cores_total_num_);
+            LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
         }
 #endif
 
-        DEV_INFO_V(0, "Thread %d: one-time init done", thread_idx);
+        LOG_INFO_V0("Thread %d: one-time init done", thread_idx);
         init_complete_.store(true, std::memory_order_release);
     } else {
         while (!init_complete_.load(std::memory_order_acquire)) {
@@ -356,7 +356,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
     }
 
-    DEV_INFO_V(0, "Thread %d: PTO2 dispatch starting with %d cores", thread_idx, tracker.core_num());
+    LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, tracker.core_num());
     int32_t cur_thread_completed = 0;
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
@@ -423,8 +423,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             if (thread_idx == 0 && task_count > 0) {
                 if (new_total <= PROGRESS_VERBOSE_THRESHOLD ||
                     new_total / PROGRESS_LOG_INTERVAL != prev / PROGRESS_LOG_INTERVAL || new_total >= task_count) {
-                    DEV_INFO_V(
-                        9, "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
+                    LOG_INFO_V9(
+                        "PTO2 progress: completed=%d total=%d (%.1f%%)", new_total, task_count,
                         100.0 * new_total / task_count
                     );
                 }

--- a/tests/ut/cpp/a5/test_host_log_off.cpp
+++ b/tests/ut/cpp/a5/test_host_log_off.cpp
@@ -108,6 +108,29 @@ TEST(HostLogTest, InfoVerbosityCutsBelowThreshold) {
     EXPECT_NE(captured.err.find("v9-msg"), std::string::npos);
 }
 
+TEST(HostLogTest, EmitPrefixHasTimestampAndTid) {
+    auto captured = run_with_config(LogLevel::INFO, 5, [] {
+        HostLogger::get_instance().log(LogLevel::ERROR, "fn", "marker");
+    });
+    // Expected shape: "[YYYY-MM-DD HH:MM:SS.uuuuuu][T0x...][ERROR] fn: marker\n"
+    ASSERT_FALSE(captured.err.empty());
+    EXPECT_EQ(captured.err[0], '[');
+    // Year must be 4 ASCII digits.
+    for (int i = 1; i <= 4; ++i) {
+        EXPECT_GE(captured.err[i], '0');
+        EXPECT_LE(captured.err[i], '9');
+    }
+    EXPECT_EQ(captured.err[5], '-');
+    // Thread-id segment "[T0x" must appear before the level tag.
+    auto tid_pos = captured.err.find("][T0x");
+    auto level_pos = captured.err.find("][ERROR]");
+    ASSERT_NE(tid_pos, std::string::npos);
+    ASSERT_NE(level_pos, std::string::npos);
+    EXPECT_LT(tid_pos, level_pos);
+    // Body still present.
+    EXPECT_NE(captured.err.find("marker"), std::string::npos);
+}
+
 TEST(HostLogTest, AllOutputGoesToStderr) {
     auto captured = run_with_config(LogLevel::DEBUG, 0, [] {
         HostLogger::get_instance().log(LogLevel::ERROR, "fn", "e");


### PR DESCRIPTION
## Summary

Three independent follow-ups on the V0..V9 log system from #703 / #706,
bundled into a single PR because each touches the same headers and they
share the same a5/a2a3 mirror discipline.

- **#2 — host stderr prefix.** `HostLogger::emit` now prefixes
  `[YYYY-MM-DD HH:MM:SS.uuuuuu][T0x...]` before the existing
  `[level][func]` segments. Solves the pytest-xdist case where
  multiple chip subprocesses interleave stderr — output is now
  recoverable via `sort -k1` (timestamp) and `grep T0x...` (thread).
  New `TEST(HostLogTest, EmitPrefixHasTimestampAndTid)` asserts the
  prefix shape; existing tests use `find()` for body matches and are
  unaffected.

- **#4 — drop duplicate enabled-check.** `unified_log_host.cpp`
  adapters used to re-check `is_severity_enabled()` /
  `is_info_v_enabled()` before forwarding to
  `HostLogger::vlog{,_info_v}`, which already early-returns on the
  same condition. Removed; `HostLogger` is the single authority for
  level gating.

- **#6 — unify `DEV_*` → `LOG_*`.** The legacy `DEV_DEBUG` /
  `DEV_WARN` / `DEV_ERROR` / `DEV_INFO_V` macros (and the
  `D_DEV_LOG*` helpers backing them) were a pre-#703 device-side
  family that duplicates what `LOG_*` already does on both host and
  device. Sed-migrated 262 call sites across 14 files to `LOG_*` and
  deleted the macros from `aicpu/device_log.h`. Also removed
  `DEV_ASSERT`, `DEV_CHECK_*`, and `TILE_FWK_DEVICE_MACHINE` —
  confirmed unused outside the deleted macros. Refreshed
  `docs/getting-started.md § Logging` to drop the stale `DEV_*`
  names.

Net diff: 26 files, +449 / −583.

## Testing

- [x] `pip install --no-build-isolation -e .` clean (a5 + a2a3 onboard
      and sim builds)
- [x] `ctest --test-dir build/ut_cpp` — 21/21 pass (includes new
      prefix-shape test)
- [x] `pytest tests/ut/py` — 214/214 pass + 7 skipped (all skips
      pre-existing, unrelated)
- [x] `python examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py -p a5sim`
      — exits 0; sample `[INFO_V9]` lines visible from migrated
      `LOG_INFO_V9` call sites (formerly `DEV_INFO_V(9, ...)`)
- [ ] Hardware tests — please run `/test-all-device` in CI; no
      hardware available locally

## Notes for reviewers

- `device_log.h` shrinks from 167 lines to 92 — the deleted half is
  dead macro layer (`D_DEV_LOG*` helpers were called only by `DEV_*`,
  whose `MODE_NAME` parameter was unused). What stays: severity
  flags, INFO verbosity threshold, configuration setters,
  `dev_log_*` low-level functions, helper inline checks. Layering
  unchanged.
- Files that previously included `aicpu/device_log.h` only for
  `DEV_*` macros now include `common/unified_log.h` instead. Files
  that still need `device_log.h` (for `init_log_switch`) keep both
  includes.
- The `262` sed sites break down as: 180 `DEV_INFO_V` (all with
  literal integer `v` — pre-checked before sed) + 76 `DEV_ERROR` + 4
  `DEV_WARN` + 2 `DEV_DEBUG`.