### PR TITLE
Refactor(a2a3): decouple profiling from runtime, own it in platform

### DIFF
--- a/src/a2a3/platform/include/aicore/aicore_profiling_state.h
+++ b/src/a2a3/platform/include/aicore/aicore_profiling_state.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * @file aicore_profiling_state.h
+ * @brief AICore-side per-core profiling state set/get interface.
+ *
+ * Mirrors the AICPU-side `set_l2_swimlane_enabled` / `set_pmu_enabled` / etc.
+ * setters: the platform owns a per-core slot for profiling state, populated
+ * once by the AICore kernel entry from `KernelArgs`, and read by
+ * `aicore_execute` via getters. Runtime never touches the underlying storage,
+ * so adding profiling fields does not change `aicore_execute`'s signature or
+ * the runtime's `Handshake` struct.
+ *
+ * Storage backend:
+ *   - onboard: `[[block_local]]` static variables in aicore/kernel.cpp
+ *   - sim:     pthread TLS in aicore/kernel.cpp
+ *
+ * Lifecycle:
+ *   1. Host fills `KernelArgs::enable_profiling_flag` and
+ *      `KernelArgs::aicore_ring_addr`.
+ *   2. AICore kernel entry indexes `aicore_ring_addr[block_idx]` for this
+ *      core's `L2PerfAicoreRing*` and calls `set_aicore_profiling_flag()` +
+ *      `set_aicore_l2_perf_ring()` before invoking `aicore_execute`.
+ *   3. `aicore_execute` and downstream profiling helpers read via getters.
+ */
+
+#ifndef PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
+#define PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
+
+#include <cstdint>
+
+#include "aicore/aicore.h"
+#include "common/l2_perf_profiling.h"
+
+/**
+ * Profiling enable bitmask (umbrella over dump_tensor / l2_swimlane / pmu).
+ * Same layout as `KernelArgs::enable_profiling_flag`. AICore reads via
+ * `GET_PROFILING_FLAG(get_aicore_profiling_flag(), PROFILING_FLAG_*)`.
+ */
+__aicore__ void set_aicore_profiling_flag(uint32_t flag);
+__aicore__ uint32_t get_aicore_profiling_flag();
+
+/**
+ * Per-core L2Perf staging ring. Set once at kernel entry from
+ * `((uint64_t*)k_args->aicore_ring_addr)[block_idx]`; nullptr when the L2
+ * swimlane bit is off or the address table itself is null.
+ */
+__aicore__ void set_aicore_l2_perf_ring(__gm__ L2PerfAicoreRing *ring);
+__aicore__ __gm__ L2PerfAicoreRing *get_aicore_l2_perf_ring();
+
+#endif  // PLATFORM_AICORE_AICORE_PROFILING_STATE_H_

--- a/src/a2a3/platform/include/aicore/l2_perf_collector_aicore.h
+++ b/src/a2a3/platform/include/aicore/l2_perf_collector_aicore.h
@@ -43,7 +43,9 @@
  * For tensormap_and_ringbuffer, AICPU overwrites with the full (ring_id << 32) | local_id
  * encoding after handshake match.
  *
- * @param ring Per-core staging ring pointer (from Handshake::l2_perf_aicore_ring_addr)
+ * @param ring Per-core staging ring pointer (resolved at AICore kernel
+ *             entry from KernelArgs::aicore_ring_addr[block_idx] via
+ *             set_aicore_l2_perf_ring()/get_aicore_l2_perf_ring())
  * @param task_id Register dispatch id (DATA_MAIN_BASE), stored in task_id low 32 bits
  * @param start_time Start timestamp
  * @param end_time End timestamp

--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -20,7 +20,6 @@
 #define PLATFORM_AICPU_L2_PERF_COLLECTOR_AICPU_H_
 
 #include "common/l2_perf_profiling.h"
-#include "runtime.h"
 
 // Include platform-specific timestamp implementation
 // Build system selects the correct inner_aicpu.h based on platform:
@@ -31,7 +30,7 @@
 
 /**
  * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
- * entry (onboard) before `l2_perf_aicpu_init_profiling()` so AICPU code can
+ * entry (onboard) before `l2_perf_aicpu_init()` so AICPU code can
  * read perf state without reaching into the generic `Runtime` struct.
  */
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
@@ -44,10 +43,15 @@ extern "C" bool is_l2_swimlane_enabled();
  *
  * Sets up double buffers for each core and initializes tracking state.
  * Reads the perf device-base pointer published via `set_platform_l2_perf_base()`.
+ * AICPU caches each core's stable AICore staging-ring address from
+ * `L2PerfBufferState[i].aicore_ring_ptr` (host populated it before AICPU
+ * started). AICore receives the same per-core ring through
+ * `KernelArgs::aicore_ring_addr` + `set_aicore_l2_perf_ring()`, so this
+ * routine no longer touches runtime's Handshake.
  *
- * @param runtime Runtime instance pointer (used for worker_count / task_count only)
+ * @param worker_count  Number of AICore workers (cores) to initialize
  */
-void l2_perf_aicpu_init_profiling(Runtime *runtime);
+void l2_perf_aicpu_init(int worker_count);
 
 /**
  * Complete a L2PerfRecord with AICPU-side metadata after AICore task completion
@@ -101,12 +105,13 @@ void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, in
  * Initialize AICPU phase profiling
  *
  * Sets up AicpuPhaseHeader and clears per-thread phase record buffers.
- * Must be called once from thread 0 after l2_perf_aicpu_init_profiling().
+ * Must be called once from thread 0 after l2_perf_aicpu_init().
  *
- * @param runtime Runtime instance pointer
- * @param num_sched_threads Number of scheduler threads
+ * @param worker_count       Number of AICore workers (cores) — used to resolve
+ *                           the phase region's offset relative to the L2Perf base
+ * @param num_sched_threads  Number of scheduler threads
  */
-void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
+void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads);
 
 /**
  * Record a single scheduler phase

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -64,6 +64,12 @@ extern "C" {
  * - pmu_data_base: Written by host platform, read by AICPU platform layer;
  *   zero when PMU is unused
  *
+ * enable_profiling_flag bit definitions (umbrella bitmask — "profiling" is
+ * the umbrella, each bit is a parallel diagnostics sub-feature):
+ * - bit0: tensor dump enabled
+ * - bit1: L2 swimlane enabled
+ * - bit2: PMU enabled
+ *
  * Field Access Patterns:
  *       - AICPU: receives KernelArgs* via DynTileFwkBackendKernelServer
  *       - AICore: receives KernelArgs* via KERNEL_ENTRY
@@ -74,12 +80,17 @@ struct KernelArgs {
     __may_used_by_aicore__ Runtime *runtime_args{nullptr};  // Task runtime in device memory
     uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
     uint64_t ffts_base_addr{0};                             // FFTS base address for AICore
-    uint64_t dump_data_base{0};     // Dump shared memory base address; use explicit flags to detect enablement
-    uint64_t l2_perf_data_base{0};  // L2 perf shared memory base address; use explicit flags to detect enablement
-    uint64_t pmu_data_base{0};      // PMU shared memory base address; use explicit flags to detect enablement
-    uint64_t pmu_reg_addrs{0};      // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
-    uint32_t log_level{1};          // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
-    uint32_t log_info_v{5};         // INFO verbosity threshold (0..9); default V5
+    uint64_t dump_data_base{0};         // Dump shared memory base address; use explicit flags to detect enablement
+    uint64_t l2_perf_data_base{0};      // L2 perf shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_data_base{0};          // PMU shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_reg_addrs{0};          // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
+    uint64_t aicore_ring_addr{0};       // Device ptr to a uint64_t[num_aicore] table holding each core's
+                                        // L2PerfAicoreRing address. AICore kernel entry indexes by block_idx
+                                        // and forwards into platform set/get state. 0 when L2 swimlane is off.
+    uint32_t log_level{1};              // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
+    uint32_t log_info_v{5};             // INFO verbosity threshold (0..9); default V5
+    uint32_t enable_profiling_flag{0};  // Profiling umbrella bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+    uint32_t _pad{0};                   // Alignment padding
 };
 
 #ifdef __cplusplus

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -107,7 +107,9 @@ static_assert(sizeof(L2PerfRecord) % 64 == 0, "L2PerfRecord must be 64-byte alig
  * AICore stores each task's timing in `dual_issue_slots[reg_task_id %
  * PLATFORM_L2_AICORE_RING_SIZE]` and never touches any other L2Perf memory.
  * The ring is allocated once by the host, addressed through
- * `Handshake::l2_perf_aicore_ring_addr`, and lives for the entire run — its
+ * `L2PerfBufferState[block_idx].aicore_ring_ptr` (also published into the
+ * `KernelArgs::aicore_ring_addr` table the AICore kernel entry forwards
+ * into `set_aicore_l2_perf_ring()`), and lives for the entire run — its
  * address is never reassigned, decoupling AICore writes from the AICPU's
  * records-buffer rotation.
  *

--- a/src/a2a3/platform/include/host/l2_perf_collector.h
+++ b/src/a2a3/platform/include/host/l2_perf_collector.h
@@ -302,6 +302,16 @@ public:
     void *get_l2_perf_setup_device_ptr() const { return perf_shared_mem_dev_; }
 
     /**
+     * Device pointer to a uint64_t[num_aicore] table where each entry is
+     * `L2PerfBufferState[i].aicore_ring_ptr`. Allocated and populated by
+     * initialize(); freed by finalize(). Set kernel_args.aicore_ring_addr
+     * to this so the AICore kernel entry can index by block_idx and feed
+     * the per-core ring into the platform's set_l2_perf_aicore_ring().
+     * Returns nullptr before initialize() succeeds.
+     */
+    void *get_aicore_ring_addr_table_device_ptr() const { return aicore_ring_addr_table_dev_; }
+
+    /**
      * Read AICPU phase metadata that lives in AicpuPhaseHeader (not on the
      * buffer pipeline): the orchestrator summary and core→thread mapping.
      * Single-shot — must be called after stop() so orch_summary has settled.
@@ -330,6 +340,11 @@ private:
     // (set via set_memory_context in initialize()).
     void *perf_shared_mem_dev_{nullptr};
     bool was_registered_{false};
+
+    // Standalone uint64_t[num_aicore] table holding per-core L2PerfAicoreRing
+    // addresses. Allocated in initialize(), freed in finalize(). AICore reads
+    // ring_table[block_idx] via KernelArgs::aicore_ring_addr.
+    void *aicore_ring_addr_table_dev_{nullptr};
 
     int num_aicore_{0};
 

--- a/src/a2a3/platform/onboard/aicore/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicore/kernel.cpp
@@ -12,8 +12,10 @@
  * Minimal AICore Kernel
  */
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
+#include "common/l2_perf_profiling.h"
 
 #ifdef __DAV_VEC__
 #define KERNEL_ENTRY(x) \
@@ -30,6 +32,27 @@
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
+// Per-core profiling state. Populated once by KERNEL_ENTRY from KernelArgs;
+// read by aicore_execute and profiling helpers via the getters below. This
+// mirrors the AICPU-side set_l2_swimlane_enabled / set_pmu_enabled pattern,
+// keeping profiling fields out of runtime's Handshake and out of
+// aicore_execute's signature.
+//
+// The setters/getters are marked `weak` because kernel.cpp is compiled twice
+// (AIC + AIV) and linked into a single AICore binary; weak linkage lets the
+// linker dedup the otherwise-duplicate symbol definitions across the two
+// compilation units.
+[[block_local]] static uint32_t s_aicore_profiling_flag;
+[[block_local]] static __gm__ L2PerfAicoreRing *s_aicore_l2_perf_ring;
+
+__attribute__((weak)) __aicore__ void set_aicore_profiling_flag(uint32_t flag) { s_aicore_profiling_flag = flag; }
+__attribute__((weak)) __aicore__ uint32_t get_aicore_profiling_flag() { return s_aicore_profiling_flag; }
+
+__attribute__((weak)) __aicore__ void set_aicore_l2_perf_ring(__gm__ L2PerfAicoreRing *ring) {
+    s_aicore_l2_perf_ring = ring;
+}
+__attribute__((weak)) __aicore__ __gm__ L2PerfAicoreRing *get_aicore_l2_perf_ring() { return s_aicore_l2_perf_ring; }
+
 extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
 /**
@@ -44,6 +67,10 @@ extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, Co
  *    - Use DCCI to ensure cache coherency with AICPU
  *
  * Each core (AIC or AIV) gets its own handshake buffer indexed by block_idx.
+ * Profiling state flows from KernelArgs into platform-owned per-core slots
+ * via set_aicore_profiling_flag() / set_aicore_l2_perf_ring(); the runtime's
+ * Handshake stays profiling-free and aicore_execute keeps its original
+ * signature.
  *
  * @param runtime Address of Runtime structure in device memory
  */
@@ -58,5 +85,15 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ KernelA
 #endif
 
     set_ffts_base_addr((uint64_t)k_args->ffts_base_addr);
+
+    // Publish per-core profiling state into platform-owned slots before the
+    // executor runs. AICore reads via get_aicore_profiling_flag() /
+    // get_aicore_l2_perf_ring() — never touches Handshake for profiling.
+    set_aicore_profiling_flag(k_args->enable_profiling_flag);
+    if (GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE)) {
+        __gm__ uint64_t *ring_table = reinterpret_cast<__gm__ uint64_t *>(k_args->aicore_ring_addr);
+        set_aicore_l2_perf_ring(reinterpret_cast<__gm__ L2PerfAicoreRing *>(ring_table[block_idx]));
+    }
+
     aicore_execute(k_args->runtime_args, block_idx, core_type);
 }

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -93,12 +93,12 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     // The dump base address is only the backing storage location.
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
-    set_dump_tensor_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_dump_tensor_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_perf_base(k_args->l2_perf_data_base);
-    set_l2_swimlane_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
+    set_l2_swimlane_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
     set_platform_pmu_reg_addrs(k_args->pmu_reg_addrs);
-    set_pmu_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
+    set_pmu_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
     if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -543,6 +543,7 @@ int DeviceRunner::run(
     if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
+    kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
 
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
@@ -550,8 +551,6 @@ int DeviceRunner::run(
         runtime.workers[i].task = 0;
         // Set core type: first 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-        runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
-        runtime.workers[i].l2_perf_aicore_ring_addr = static_cast<uint64_t>(0);
     }
 
     // Set function_bin_addr for all tasks: func_id_to_addr_[] stores CoreCallable
@@ -1096,6 +1095,8 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
     }
 
     kernel_args_.args.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+    kernel_args_.args.aicore_ring_addr =
+        reinterpret_cast<uint64_t>(l2_perf_collector_.get_aicore_ring_addr_table_device_ptr());
     return 0;
 }
 

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -21,7 +21,9 @@
 
 #include "inner_kernel.h"
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "common/core_type.h"
+#include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
 #include "runtime.h"
 
@@ -30,17 +32,40 @@
 // with RTLD_LOCAL on aarch64.
 static pthread_key_t g_reg_base_key;
 static pthread_key_t g_core_id_key;
+static pthread_key_t g_aicore_profiling_flag_key;
+static pthread_key_t g_aicore_l2_perf_ring_key;
 static pthread_once_t g_tls_once = PTHREAD_ONCE_INIT;
 
 static void create_tls_keys() {
     pthread_key_create(&g_reg_base_key, nullptr);
     pthread_key_create(&g_core_id_key, nullptr);
+    pthread_key_create(&g_aicore_profiling_flag_key, nullptr);
+    pthread_key_create(&g_aicore_l2_perf_ring_key, nullptr);
 }
 
 volatile uint8_t *sim_get_reg_base() { return static_cast<volatile uint8_t *>(pthread_getspecific(g_reg_base_key)); }
 
 uint32_t sim_get_physical_core_id() {
     return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_core_id_key)));
+}
+
+// Per-core profiling state setters/getters. Same contract as the onboard
+// [[block_local]] backing in src/a2a3/platform/onboard/aicore/kernel.cpp —
+// AICPU never reaches into the runtime's Handshake for profiling, runtime's
+// aicore_execute keeps its original signature, and adding profiling fields
+// only touches KernelArgs + this state surface.
+__aicore__ void set_aicore_profiling_flag(uint32_t flag) {
+    pthread_setspecific(g_aicore_profiling_flag_key, reinterpret_cast<void *>(static_cast<uintptr_t>(flag)));
+}
+__aicore__ uint32_t get_aicore_profiling_flag() {
+    return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_aicore_profiling_flag_key)));
+}
+
+__aicore__ void set_aicore_l2_perf_ring(__gm__ L2PerfAicoreRing *ring) {
+    pthread_setspecific(g_aicore_l2_perf_ring_key, reinterpret_cast<void *>(ring));
+}
+__aicore__ __gm__ L2PerfAicoreRing *get_aicore_l2_perf_ring() {
+    return reinterpret_cast<__gm__ L2PerfAicoreRing *>(pthread_getspecific(g_aicore_l2_perf_ring_key));
 }
 
 // Core identity setter function pointers — set by DeviceRunner after dlopen.
@@ -59,10 +84,13 @@ extern "C" void set_sim_core_identity_helpers(void *set_subblock_id, void *set_c
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
 void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
-// Wrapper with extern "C" for dlsym lookup
-// NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
+// Wrapper with extern "C" for dlsym lookup. Mirrors the onboard kernel.cpp
+// KERNEL_ENTRY: receives launch arguments straight from the host, populates
+// the per-thread profiling slots via set_aicore_*(), then invokes the runtime
+// executor with its original signature.
 extern "C" void aicore_execute_wrapper(
-    __gm__ Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+    __gm__ Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs,
+    uint32_t enable_profiling_flag, uint64_t aicore_ring_addr
 ) {
     pthread_once(&g_tls_once, create_tls_keys);
 
@@ -75,6 +103,15 @@ extern "C" void aicore_execute_wrapper(
     }
 
     pthread_setspecific(g_core_id_key, reinterpret_cast<void *>(static_cast<uintptr_t>(physical_core_id)));
+
+    // Publish per-core profiling state before the executor runs.
+    set_aicore_profiling_flag(enable_profiling_flag);
+    if (aicore_ring_addr != 0) {
+        uint64_t *ring_table = reinterpret_cast<uint64_t *>(aicore_ring_addr);
+        set_aicore_l2_perf_ring(reinterpret_cast<__gm__ L2PerfAicoreRing *>(ring_table[block_idx]));
+    } else {
+        set_aicore_l2_perf_ring(nullptr);
+    }
 
     // Set core identity for pto-isa TPUSH/TPOP simulation.
     // Core layout in sim DeviceRunner:

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -43,7 +43,8 @@
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime *runtime);
 typedef void (*aicore_execute_func_t)(
-    Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+    Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs,
+    uint32_t enable_profiling_flag, uint64_t aicore_ring_addr
 );
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 typedef void (*set_platform_dump_base_func_t)(uint64_t dump_data_base);
@@ -232,9 +233,8 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
-        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime *, int, CoreType, uint32_t, uint64_t)>(
-            dlsym(aicore_so_handle_, "aicore_execute_wrapper")
-        );
+        aicore_execute_func_ =
+            reinterpret_cast<aicore_execute_func_t>(dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
             return -1;
@@ -350,6 +350,7 @@ int DeviceRunner::run(
     if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
+    kernel_args_.enable_profiling_flag = enable_profiling_flag;
 
     for (int i = 0; i < num_aicore; i++) {
         runtime.workers[i].aicpu_ready = 0;
@@ -357,7 +358,6 @@ int DeviceRunner::run(
         runtime.workers[i].task = 0;
         // First 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-        runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
     }
 
     // Set function_bin_addr for each task: func_id_to_addr_[] stores CoreCallable
@@ -562,7 +562,10 @@ int DeviceRunner::run(
         CoreType core_type = runtime.workers[i].core_type;
         uint32_t physical_core_id = static_cast<uint32_t>(i);
         aicore_threads.push_back(create_thread([this, &runtime, i, core_type, physical_core_id]() {
-            aicore_execute_func_(&runtime, i, core_type, physical_core_id, kernel_args_.regs);
+            aicore_execute_func_(
+                &runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
+                kernel_args_.aicore_ring_addr
+            );
         }));
     }
 
@@ -902,6 +905,8 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
     }
 
     kernel_args_.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+    kernel_args_.aicore_ring_addr =
+        reinterpret_cast<uint64_t>(l2_perf_collector_.get_aicore_ring_addr_table_device_ptr());
     return 0;
 }
 

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -244,7 +244,7 @@ private:
     void *aicpu_so_handle_{nullptr};
     void *aicore_so_handle_{nullptr};
     int (*aicpu_execute_func_)(Runtime *){nullptr};
-    void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t){nullptr};
+    void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t, uint32_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_dump_tensor_enabled_func_)(bool){nullptr};

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -95,7 +95,7 @@ static int enqueue_ready_buffer(
     return 0;
 }
 
-void l2_perf_aicpu_init_profiling(Runtime *runtime) {
+void l2_perf_aicpu_init(int worker_count) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize profiling");
@@ -104,21 +104,20 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
 
     s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
-    LOG_INFO_V0("Initializing performance profiling for %d cores (free queue)", runtime->worker_count);
+    LOG_INFO_V0("Initializing performance profiling for %d cores (free queue)", worker_count);
 
     // Pop first buffer from free_queue for each core
-    for (int i = 0; i < runtime->worker_count; i++) {
-        Handshake *h = &runtime->workers[i];
+    for (int i = 0; i < worker_count; i++) {
         L2PerfBufferState *state = get_perf_buffer_state(l2_perf_base, i);
 
         s_perf_buffer_states[i] = state;
 
         // Cache the per-core staging ring (host populated state->aicore_ring_ptr
-        // before the AICPU started). Publish it to the handshake so AICore can
-        // read it on every record_task call.
+        // before the AICPU started). AICore receives the same per-core ring via
+        // KernelArgs::aicore_ring_addr + set_aicore_l2_perf_ring() — no
+        // handshake hop, so this routine doesn't republish anything.
         L2PerfAicoreRing *ring = reinterpret_cast<L2PerfAicoreRing *>(state->aicore_ring_ptr);
         s_perf_aicore_rings[i] = ring;
-        h->l2_perf_aicore_ring_addr = state->aicore_ring_ptr;
 
         // Pop first buffer from free_queue
         rmb();
@@ -147,7 +146,7 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
 
     wmb();
 
-    LOG_INFO_V0("Performance profiling initialized for %d cores", runtime->worker_count);
+    LOG_INFO_V0("Performance profiling initialized for %d cores", worker_count);
 }
 
 /**
@@ -361,14 +360,14 @@ void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, in
     LOG_INFO_V0("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
-void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
+void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize phase profiling");
         return;
     }
 
-    s_phase_header = get_phase_header(l2_perf_base, runtime->worker_count);
+    s_phase_header = get_phase_header(l2_perf_base, worker_count);
     s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
     s_phase_header->magic = AICPU_PHASE_MAGIC;
@@ -386,7 +385,7 @@ void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads)
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(l2_perf_base, runtime->worker_count, t);
+        PhaseBufferState *state = get_phase_buffer_state(l2_perf_base, worker_count, t);
 
         s_phase_buffer_states[t] = state;
 

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -209,6 +209,25 @@ int L2PerfCollector::initialize(
         num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
     );
 
+    // Step 5b: Standalone uint64_t[num_aicore] table holding per-core ring
+    // addresses. AICore reads ring_table[block_idx] via KernelArgs::aicore_ring_addr
+    // and feeds it into the platform's set_l2_perf_aicore_ring().
+    {
+        size_t table_bytes = static_cast<size_t>(num_aicore) * sizeof(uint64_t);
+        void *ring_table_host = nullptr;
+        void *ring_table_dev = alloc_single_buffer(table_bytes, &ring_table_host);
+        if (ring_table_dev == nullptr) {
+            LOG_ERROR("Failed to allocate aicore_ring_addr table (%zu bytes)", table_bytes);
+            return -1;
+        }
+        uint64_t *ring_table = reinterpret_cast<uint64_t *>(ring_table_host);
+        for (int i = 0; i < num_aicore; i++) {
+            L2PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
+            ring_table[i] = state->aicore_ring_ptr;
+        }
+        aicore_ring_addr_table_dev_ = ring_table_dev;
+    }
+
     // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
     for (int t = 0; t < num_phase_threads; t++) {
         PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
@@ -806,6 +825,12 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     stop();
 
     LOG_DEBUG("Cleaning up performance profiling resources");
+
+    // Free standalone aicore_ring_addr table
+    if (aicore_ring_addr_table_dev_ != nullptr && free_cb != nullptr) {
+        free_cb(aicore_ring_addr_table_dev_, user_data);
+        aicore_ring_addr_table_dev_ = nullptr;
+    }
 
     // Release framework-owned buffers (recycled pools, done_queue, ready_queue).
     // These were not consumed via the AICPU side, so the per-pool free_queue

--- a/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "aicore/l2_perf_collector_aicore.h"
 #include "aicore/pmu_collector_aicore.h"
 #include "common/l2_perf_profiling.h"
@@ -53,14 +54,15 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
-    bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
-    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
+    uint32_t enable_profiling_flag = get_aicore_profiling_flag();
+    bool l2_perf_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
+    bool dump_tensor_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
 
-    // Ring address is published once by AICPU at init and never changes —
-    // cache it and the per-iteration handshake reload + dcci are gone.
-    __gm__ L2PerfAicoreRing *l2_perf_ring =
-        l2_perf_enabled ? (__gm__ L2PerfAicoreRing *)my_hank->l2_perf_aicore_ring_addr : nullptr;
+    // Per-core staging ring is published once at kernel entry from
+    // KernelArgs::aicore_ring_addr — cache the pointer locally here so the
+    // hot loop never re-reads platform state.
+    __gm__ L2PerfAicoreRing *l2_perf_ring = l2_perf_enabled ? get_aicore_l2_perf_ring() : nullptr;
 
     volatile uint32_t task_id = AICPU_IDLE_TASK_ID;
     volatile uint32_t last_task_id = AICPU_IDLE_TASK_ID;

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -319,12 +319,8 @@ int AicpuExecutor::init(Runtime *runtime) {
         core_id_to_reg_addr_[i] = 0;
     }
 
-    // L2Perf init must run BEFORE handshake_all_cores so AICore observes a
-    // non-zero l2_perf_aicore_ring_addr the moment aicpu_ready=1 unblocks
-    // its Phase 1 spin. AICore caches the ring address once after Phase 3
-    // and never re-reads it.
     if (is_l2_swimlane_enabled()) {
-        l2_perf_aicpu_init_profiling(runtime);
+        l2_perf_aicpu_init(runtime->worker_count);
     }
 
     // Perform core discovery: handshake with all cores and collect core type information

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -102,33 +102,21 @@
  * The structure is cache-line aligned (64 bytes) to prevent false sharing
  * between cores and optimize cache coherency operations.
  *
- * enable_profiling_flag bit definitions (umbrella bitmask — "profiling"
- * is the umbrella, each bit is a parallel diagnostics sub-feature):
- * - bit0: tensor dump enabled
- * - bit1: L2 swimlane enabled
- * - bit2: PMU enabled
- *
  * Field Access Patterns:
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = no task assigned)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
- * - l2_perf_aicore_ring_addr: Written by AICPU at init, read by AICore (stable
- *   per-core L2PerfAicoreRing address for timing publication; never reassigned)
  * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
- * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;               // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;               // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                      // Task pointer: 0=no task, non-zero=Task* address
-    volatile CoreType core_type;                 // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_aicore_ring_addr;  // Stable per-core L2PerfAicoreRing address (AICore writes timing here)
-    volatile uint32_t physical_core_id;          // Physical core ID
-    volatile uint32_t aicpu_regs_ready;          // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;         // AICore ID reported: 0=pending, 1=done
-    volatile uint32_t
-        enable_profiling_flag;  // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+    volatile uint32_t aicpu_ready;        // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;        // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;               // Task pointer: 0=no task, non-zero=Task* address
+    volatile CoreType core_type;          // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint32_t physical_core_id;   // Physical core ID
+    volatile uint32_t aicpu_regs_ready;   // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;  // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "aicore/l2_perf_collector_aicore.h"
 #include "aicore/pmu_collector_aicore.h"
 #include "common/l2_perf_profiling.h"
@@ -56,6 +57,11 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * args pointer from it on each dispatch. reg_val is a monotonically
  * increasing task ID used only for dispatch signaling and ACK/FIN protocol.
  *
+ * Profiling state (enable flag, L2 perf ring) is published into the platform
+ * via set_aicore_profiling_flag / set_aicore_l2_perf_ring at kernel entry —
+ * this routine reads it through the matching getters, so neither Handshake
+ * nor this signature carry profiling fields.
+ *
  * @param runtime Pointer to Runtime in global memory
  * @param block_idx Block index (core ID)
  * @param core_type Core type (AIC or AIV)
@@ -89,13 +95,15 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
-    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
-    bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
-    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
+    uint32_t enable_profiling_flag = get_aicore_profiling_flag();
+    bool l2_perf_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
+    bool dump_tensor_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
 
-    // Ring address is published once by AICPU at init and never changes — cache once.
-    __gm__ L2PerfAicoreRing *l2_perf_ring =
-        l2_perf_enabled ? (__gm__ L2PerfAicoreRing *)my_hank->l2_perf_aicore_ring_addr : nullptr;
+    // Per-core staging ring is published once at kernel entry from
+    // KernelArgs::aicore_ring_addr — cache the pointer locally here so the
+    // hot loop never re-reads platform state.
+    __gm__ L2PerfAicoreRing *l2_perf_ring = l2_perf_enabled ? get_aicore_l2_perf_ring() : nullptr;
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
     // Register encoding: AICPU_IDLE_TASK_ID=idle, task_id=task, AICORE_EXIT_SIGNAL=exit

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -229,8 +229,8 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ## Runtime Flag: enable_l2_swimlane
 
-L2 swimlane enablement is published through the handshake
-`enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
+L2 swimlane enablement is published through the
+`KernelArgs::enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
 AICPU code reads it via `is_l2_swimlane_enabled()` (set at launch time
 by the platform from `kernel_args.l2_perf_data_base` + the bitmask). It
 controls **data collection**, NOT log output.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -83,32 +83,20 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * The structure is cache-line aligned (64 bytes) to prevent false sharing
  * between cores and optimize cache coherency operations.
  *
- * enable_profiling_flag bit definitions (umbrella bitmask — "profiling"
- * is the umbrella, each bit is a parallel diagnostics sub-feature):
- * - bit0: tensor dump enabled
- * - bit1: L2 swimlane enabled
- * - bit2: PMU enabled
- *
  * Field Access Patterns:
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
- * - l2_perf_aicore_ring_addr: Written by AICPU at init, read by AICore (stable
- *   per-core L2PerfAicoreRing address for timing publication; never reassigned)
- * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;               // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;               // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                      // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
-    volatile CoreType core_type;                 // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_aicore_ring_addr;  // Stable per-core L2PerfAicoreRing address (AICore writes timing here)
-    volatile uint32_t physical_core_id;          // Physical core ID
-    volatile uint32_t aicpu_regs_ready;          // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;         // AICore ID reported: 0=pending, 1=done
-    volatile uint32_t
-        enable_profiling_flag;  // Generic profiling-related flags; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+    volatile uint32_t aicpu_ready;        // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;        // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;               // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile CoreType core_type;          // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint32_t physical_core_id;   // Physical core ID
+    volatile uint32_t aicpu_regs_ready;   // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;  // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -631,13 +631,10 @@ int32_t SchedulerContext::init(
     orch_to_sched_ = orch_to_sched;
     regs_ = regs_base;
 
-    // L2Perf init must run BEFORE handshake_all_cores so AICore observes a
-    // non-zero l2_perf_aicore_ring_addr the moment aicpu_ready=1 unblocks
-    // its Phase 1 spin. AICore caches the ring address once and never re-reads it.
 #if PTO2_PROFILING
     if (is_l2_swimlane_enabled()) {
-        l2_perf_aicpu_init_profiling(runtime);
-        l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
+        l2_perf_aicpu_init(runtime->worker_count);
+        l2_perf_aicpu_init_phase(runtime->worker_count, sched_thread_num_);
         l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
     }
 #endif


### PR DESCRIPTION
## Summary

Profiling becomes a **platform-layer concern** instead of part of the runtime/AICore handshake contract. `enable_profiling_flag` and `l2_perf_aicore_ring_addr` move out of the runtime's `Handshake` struct and into `KernelArgs` plus a platform-owned per-core state surface (`set_aicore_profiling_flag` / `set_aicore_l2_perf_ring`, with matching getters). Mirrors the AICPU-side `set_l2_swimlane_enabled` / `set_pmu_enabled` pattern.

After this change:

- The runtime/AICore handshake carries **only synchronization + identity** fields. Adding a new profiling sub-feature no longer touches `Handshake` or `aicore_execute`'s signature.
- Profiling lifetime is **fully owned by the platform**: the AICore kernel entry indexes its per-core `L2PerfAicoreRing*` from `KernelArgs::aicore_ring_addr` and publishes it via the setters; AICore code reads via the getters; the runtime never sees the storage.

## Key changes

- **New header**: `src/a2a3/platform/include/aicore/aicore_profiling_state.h` — set/get for the per-core profiling flag and L2Perf ring pointer
- **Onboard backing**: `[[block_local]]` statics in `onboard/aicore/kernel.cpp`; setters/getters use weak linkage to dedup across the AIC + AIV compilation units linked into one AICore binary
- **Sim backing**: pthread TLS in `sim/aicore/kernel.cpp`; the sim launch ABI gains `enable_profiling_flag` + `aicore_ring_addr` so the wrapper can populate slots before `aicore_execute`
- **`KernelArgs`** gains `aicore_ring_addr` (device ptr to a `uint64_t[num_aicore]` table of per-core `L2PerfAicoreRing*`) + `enable_profiling_flag`; the bit-layout doc moves here from `runtime.h`
- **Host `L2PerfCollector`** publishes the per-core ring address table that `KernelArgs::aicore_ring_addr` points at
- **Runtime `Handshake`** shrinks in both `host_build_graph/runtime/runtime.h` and `tensormap_and_ringbuffer/runtime/runtime.h` — `l2_perf_aicore_ring_addr` and `enable_profiling_flag` removed

## Merge order

This PR is the third in a chain. Please merge in this order:

1. **#705** — Refactor: unify PMU/L2Perf/TensorDump collectors on shared profiling framework
2. **#709** — Refactor: decouple AICore L2Perf writes via stable per-core staging ring
3. **This PR (#714)** — Refactor(a2a3): decouple profiling from runtime, own it in platform

Currently this PR is opened against `main`. After #705 and #709 land, I will rebase this branch onto the new `main` so the diff reflects only the runtime → platform decoupling.

## Testing

- [ ] Simulation tests pass
- [ ] Hardware tests pass