### PR TITLE
Refactor: ChipWorker.init takes RuntimeBinaries instead of paths

### DIFF
--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -248,36 +248,38 @@ class ChipWorker:
     def __init__(self):
         self._impl = _ChipWorker()
 
-    def init(
-        self,
-        host_path,
-        aicpu_path,
-        aicore_path,
-        simpler_log_lib_path,
-        sim_context_lib_path="",
-        log_level=1,
-        log_info_v=5,
-    ):
+    def init(self, bins, log_level=None, log_info_v=None):
         """Load host runtime library and cache platform binaries.
 
         Can only be called once — the runtime cannot be changed.
 
         Args:
-            host_path: Path to the host runtime shared library (.so).
-            aicpu_path: Path to the AICPU binary (.so).
-            aicore_path: Path to the AICore binary (.o).
-            simpler_log_lib_path: Path to libsimpler_log.so (loaded RTLD_GLOBAL
-                so HostLogger has one instance per process).
-            sim_context_lib_path: Path to libcpu_sim_context.so (sim only).
-            log_level: Severity floor (0=DEBUG..4=NUL). Forwarded to simpler_init().
-            log_info_v: INFO verbosity threshold (0..9). Forwarded to simpler_init().
+            bins: A `simpler_setup.runtime_builder.RuntimeBinaries` (or any
+                object exposing host_path / aicpu_path / aicore_path /
+                simpler_log_path / sim_context_path).
+            log_level: Severity floor (0=DEBUG..4=NUL). Defaults to a snapshot
+                of the simpler logger via `_log.get_current_config()`.
+            log_info_v: INFO verbosity threshold (0..9). Same default.
+
+        For tests that need to drive the binding directly with arbitrary path
+        strings (e.g. to assert dlopen failure on `/nonexistent/foo.so`), call
+        `_ChipWorker.init(...)` from `_task_interface` instead of going
+        through this wrapper.
         """
+        if log_level is None or log_info_v is None:
+            from . import _log  # noqa: PLC0415
+
+            sev, info_v = _log.get_current_config()
+            if log_level is None:
+                log_level = sev
+            if log_info_v is None:
+                log_info_v = info_v
         self._impl.init(
-            str(host_path),
-            str(aicpu_path),
-            str(aicore_path),
-            str(simpler_log_lib_path),
-            str(sim_context_lib_path),
+            str(bins.host_path),
+            str(bins.aicpu_path),
+            str(bins.aicore_path),
+            str(bins.simpler_log_path),
+            str(bins.sim_context_path) if bins.sim_context_path else "",
             log_level,
             log_info_v,
         )
@@ -317,6 +319,15 @@ class ChipWorker:
         for k, v in kwargs.items():
             setattr(config, k, v)
         self._impl.run(callable, args, config)
+
+    def run_from_blob(self, callable, blob_ptr, config):
+        """Execute via a serialized args blob in shared memory.
+
+        Used by `_chip_process_loop` after reading the mailbox: instead of
+        deserializing the args into Python objects, the C++ side parses the
+        POD blob directly at `blob_ptr`.
+        """
+        self._impl.run_from_blob(int(callable), int(blob_ptr), config)
 
     def malloc(self, size):
         """Allocate memory. Returns a pointer (uint64)."""

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -77,7 +77,6 @@ from .task_interface import (
     ContinuousTensor,
     DataType,
     TaskArgs,
-    _ChipWorker,
     _Worker,
 )
 
@@ -259,12 +258,8 @@ def _sub_worker_loop(buf, registry: dict) -> None:
 
 def _chip_process_loop(
     buf: memoryview,
-    host_lib_path: str,
+    bins,
     device_id: int,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_lib_path: str,
-    sim_context_lib_path: str = "",
     log_level: int = 1,
     log_info_v: int = 5,
 ) -> None:
@@ -280,16 +275,8 @@ def _chip_process_loop(
     import traceback as _tb  # noqa: PLC0415
 
     try:
-        cw = _ChipWorker()
-        cw.init(
-            host_lib_path,
-            aicpu_path,
-            aicore_path,
-            simpler_log_lib_path,
-            sim_context_lib_path,
-            log_level,
-            log_info_v,
-        )
+        cw = ChipWorker()
+        cw.init(bins, log_level=log_level, log_info_v=log_info_v)
         cw.set_device(device_id)
     except Exception as e:
         _tb.print_exc()
@@ -353,14 +340,10 @@ def _chip_process_loop(
             break
 
 
-def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0913
+def _chip_process_loop_with_bootstrap(  # noqa: PLR0912
     buf: memoryview,
-    host_lib_path: str,
+    bins,
     device_id: int,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_lib_path: str,
-    sim_context_lib_path: str,
     bootstrap_cfg: ChipBootstrapConfig,
     bootstrap_mailbox_addr: int,
     max_buffer_count: int,
@@ -382,15 +365,7 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0913
 
     cw = ChipWorker()
     try:
-        cw.init(
-            host_lib_path,
-            aicpu_path,
-            aicore_path,
-            simpler_log_lib_path,
-            sim_context_lib_path,
-            log_level,
-            log_info_v,
-        )
+        cw.init(bins, log_level=log_level, log_info_v=log_info_v)
     except Exception as e:  # noqa: BLE001
         traceback.print_exc()
         channel.write_error(1, f"{type(e).__name__}: chip_worker.init: {e}")
@@ -686,18 +661,8 @@ class Worker:
         builder = RuntimeBuilder(platform)
         binaries = builder.get_binaries(runtime, build=self._config.get("build", False))
 
-        sev, info_v = _simpler_log.get_current_config()
-
         self._chip_worker = ChipWorker()
-        self._chip_worker.init(
-            str(binaries.host_path),
-            str(binaries.aicpu_path),
-            str(binaries.aicore_path),
-            str(binaries.simpler_log_path),
-            str(binaries.sim_context_path) if binaries.sim_context_path else "",
-            sev,
-            info_v,
-        )
+        self._chip_worker.init(binaries)
         self._chip_worker.set_device(device_id)
 
     def _init_hierarchical(self) -> None:
@@ -721,13 +686,12 @@ class Worker:
             builder = RuntimeBuilder(platform)
             binaries = builder.get_binaries(runtime, build=self._config.get("build", False))
 
-            self._l3_host_lib_path = str(binaries.host_path)
-            self._l3_aicpu_path = str(binaries.aicpu_path)
-            self._l3_aicore_path = str(binaries.aicore_path)
-            self._l3_simpler_log_path = str(binaries.simpler_log_path)
-            self._l3_sim_ctx_path = (
-                str(binaries.sim_context_path) if getattr(binaries, "sim_context_path", None) else ""
-            )
+            # Stash the full RuntimeBinaries so forked chip children can
+            # construct a ChipWorker with one call (`cw.init(bins)`) instead
+            # of taking ~10 path strings via positional args.  Forked-child
+            # invocation is `os.fork()` + direct function call, so no pickle
+            # barrier — the bins object is just a Python value passed through.
+            self._l3_bins = binaries
 
             # Allocate chip mailboxes (unified layout, MAILBOX_SIZE each).
             for _ in device_ids:
@@ -809,12 +773,8 @@ class Worker:
                         bootstrap_addr = ctypes.addressof(ctypes.c_char.from_buffer(bootstrap_buf))
                         _chip_process_loop_with_bootstrap(
                             buf,
-                            self._l3_host_lib_path,
+                            self._l3_bins,
                             dev_id,
-                            self._l3_aicpu_path,
-                            self._l3_aicore_path,
-                            self._l3_simpler_log_path,
-                            self._l3_sim_ctx_path,
                             bootstrap_cfg,
                             bootstrap_addr,
                             max_buffer_count,
@@ -824,12 +784,8 @@ class Worker:
                     else:
                         _chip_process_loop(
                             buf,
-                            self._l3_host_lib_path,
+                            self._l3_bins,
                             dev_id,
-                            self._l3_aicpu_path,
-                            self._l3_aicore_path,
-                            self._l3_simpler_log_path,
-                            self._l3_sim_ctx_path,
                             chip_log_level,
                             chip_log_info_v,
                         )

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -804,21 +804,11 @@ class SceneTestCase:
 
     @classmethod
     def _create_worker(cls, platform, device_id=0, build=False):
-        from simpler import _log as _simpler_log  # noqa: PLC0415
         from simpler.task_interface import ChipWorker  # noqa: PLC0415
 
         bins = cls._get_binaries(platform, build=build)
-        sev, info_v = _simpler_log.get_current_config()
         w = ChipWorker()
-        w.init(
-            str(bins.host_path),
-            str(bins.aicpu_path),
-            str(bins.aicore_path),
-            str(bins.simpler_log_path),
-            str(bins.sim_context_path) if bins.sim_context_path else "",
-            sev,
-            info_v,
-        )
+        w.init(bins)
         w.set_device(device_id)
         return w
 

--- a/tests/ut/py/test_worker/test_bootstrap_context_hw.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_hw.py
@@ -41,11 +41,7 @@ def _bootstrap_rank_entry(  # noqa: PLR0913
     rank: int,
     nranks: int,
     device_id: int,
-    host_lib: str,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_path: str,
-    sim_context_path: str,
+    bins,
     rootinfo_path: str,
     window_size: int,
     buffer_nbytes: int,
@@ -62,7 +58,7 @@ def _bootstrap_rank_entry(  # noqa: PLR0913
         )
 
         worker = ChipWorker()
-        worker.init(host_lib, aicpu_path, aicore_path, simpler_log_path, sim_context_path)
+        worker.init(bins)
         result["stage"] = "init"
 
         cfg = ChipBootstrapConfig(
@@ -115,13 +111,6 @@ def test_two_rank_bootstrap_context(st_device_ids):
 
     build = bool(os.environ.get("PTO_UT_BUILD"))
     bins = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer", build=build)
-    host_lib = str(bins.host_path)
-    aicpu_path = str(bins.aicpu_path)
-    aicore_path = str(bins.aicore_path)
-
-    simpler_log_path = str(bins.simpler_log_path)
-    sim_context_path = str(bins.sim_context_path) if bins.sim_context_path else ""
-
     assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
     nranks = 2
     rootinfo_path = f"/tmp/pto_bootstrap_hw_rootinfo_{os.getpid()}.bin"
@@ -138,11 +127,7 @@ def test_two_rank_bootstrap_context(st_device_ids):
                 rank,
                 nranks,
                 int(st_device_ids[rank]),
-                host_lib,
-                aicpu_path,
-                aicore_path,
-                simpler_log_path,
-                sim_context_path,
+                bins,
                 rootinfo_path,
                 window_size,
                 buffer_nbytes,

--- a/tests/ut/py/test_worker/test_bootstrap_context_sim.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_sim.py
@@ -61,11 +61,7 @@ def _rank_entry(  # noqa: PLR0913
     nranks: int,
     rootinfo_path: str,
     window_size: int,
-    host_lib: str,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_path: str,
-    sim_context_path: str,
+    bins,
     buffer_specs: list[dict],
     host_input_specs: list[dict],
     channel_shm_name: str | None,
@@ -91,7 +87,7 @@ def _rank_entry(  # noqa: PLR0913
         )
 
         worker = ChipWorker()
-        worker.init(host_lib, aicpu_path, aicore_path, simpler_log_path, sim_context_path)
+        worker.init(bins)
         result["stage"] = "init"
 
         cfg = ChipBootstrapConfig(
@@ -157,13 +153,6 @@ def _run_two_rank(
     round-trip check.
     """
     bins = _sim_binaries()
-    host_lib = str(bins.host_path)
-    aicpu_path = str(bins.aicpu_path)
-    aicore_path = str(bins.aicore_path)
-    simpler_log_path = str(bins.simpler_log_path)
-
-    sim_context_path = str(bins.sim_context_path) if bins.sim_context_path else ""
-
     nranks = 2
     rootinfo_path = f"/tmp/pto_bootstrap_sim_{os.getpid()}_{rootinfo_suffix}.bin"
 
@@ -180,11 +169,7 @@ def _run_two_rank(
                 nranks,
                 rootinfo_path,
                 window_size,
-                host_lib,
-                aicpu_path,
-                aicore_path,
-                simpler_log_path,
-                sim_context_path,
+                bins,
                 buffer_specs,
                 staging,
                 channel_name,
@@ -279,13 +264,6 @@ class TestBootstrapContextHostStaging:
             ]
 
             bins = _sim_binaries()
-            host_lib = str(bins.host_path)
-            aicpu_path = str(bins.aicpu_path)
-            aicore_path = str(bins.aicore_path)
-            simpler_log_path = str(bins.simpler_log_path)
-
-            sim_context_path = str(bins.sim_context_path) if bins.sim_context_path else ""
-
             rootinfo_path = f"/tmp/pto_bootstrap_sim_{os.getpid()}_staging.bin"
             ctx = mp.get_context("fork")
             result_queue: mp.Queue = ctx.Queue()  # type: ignore[type-arg]
@@ -299,11 +277,7 @@ class TestBootstrapContextHostStaging:
                         2,
                         rootinfo_path,
                         4096,
-                        host_lib,
-                        aicpu_path,
-                        aicore_path,
-                        simpler_log_path,
-                        sim_context_path,
+                        bins,
                         specs,
                         staging,
                         None,
@@ -344,11 +318,7 @@ def _store_rank_entry(  # noqa: PLR0913
     nranks: int,
     rootinfo_path: str,
     window_size: int,
-    host_lib: str,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_path: str,
-    sim_context_path: str,
+    bins,
     buffer_specs: list[dict],
     host_output_specs: list[dict],
     payload: bytes | None,
@@ -373,7 +343,7 @@ def _store_rank_entry(  # noqa: PLR0913
         )
 
         worker = ChipWorker()
-        worker.init(host_lib, aicpu_path, aicore_path, simpler_log_path, sim_context_path)
+        worker.init(bins)
 
         cfg = ChipBootstrapConfig(
             comm=ChipCommBootstrapConfig(
@@ -457,13 +427,6 @@ class TestBootstrapContextStoreToHost:
             host_outputs_r0 = [{"name": "y", "shm_name": shm.name, "size": nbytes}]
 
             bins = _sim_binaries()
-            host_lib = str(bins.host_path)
-            aicpu_path = str(bins.aicpu_path)
-            aicore_path = str(bins.aicore_path)
-            simpler_log_path = str(bins.simpler_log_path)
-
-            sim_context_path = str(bins.sim_context_path) if bins.sim_context_path else ""
-
             rootinfo_path = f"/tmp/pto_bootstrap_sim_{os.getpid()}_store.bin"
             ctx = mp.get_context("fork")
             result_queue: mp.Queue = ctx.Queue()  # type: ignore[type-arg]
@@ -479,11 +442,7 @@ class TestBootstrapContextStoreToHost:
                         2,
                         rootinfo_path,
                         4096,
-                        host_lib,
-                        aicpu_path,
-                        aicore_path,
-                        simpler_log_path,
-                        sim_context_path,
+                        bins,
                         specs,
                         outputs,
                         pay,
@@ -566,11 +525,7 @@ class TestBootstrapContextChannel:
 
 
 def _missing_output_staging_rank_entry(
-    host_lib: str,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_path: str,
-    sim_context_path: str,
+    bins,
     channel_shm_name: str,
     result_queue: mp.Queue,  # type: ignore[type-arg]
 ) -> None:
@@ -590,7 +545,7 @@ def _missing_output_staging_rank_entry(
         )
 
         worker = ChipWorker()
-        worker.init(host_lib, aicpu_path, aicore_path, simpler_log_path, sim_context_path)
+        worker.init(bins)
 
         shm = SharedMemory(name=channel_shm_name)
         try:
@@ -636,13 +591,6 @@ class TestBootstrapContextMissingOutputStaging:
         )
 
         bins = _sim_binaries()
-        host_lib = str(bins.host_path)
-        aicpu_path = str(bins.aicpu_path)
-        aicore_path = str(bins.aicore_path)
-        simpler_log_path = str(bins.simpler_log_path)
-
-        sim_context_path = str(bins.sim_context_path) if bins.sim_context_path else ""
-
         shm = SharedMemory(create=True, size=CHIP_BOOTSTRAP_MAILBOX_SIZE)
         buf = shm.buf
         assert buf is not None
@@ -653,7 +601,7 @@ class TestBootstrapContextMissingOutputStaging:
             result_queue: mp.Queue = ctx.Queue()  # type: ignore[type-arg]
             p = ctx.Process(
                 target=_missing_output_staging_rank_entry,
-                args=(host_lib, aicpu_path, aicore_path, simpler_log_path, sim_context_path, shm.name, result_queue),
+                args=(bins, shm.name, result_queue),
                 daemon=False,
             )
             p.start()

--- a/tests/ut/py/test_worker/test_platform_comm.py
+++ b/tests/ut/py/test_worker/test_platform_comm.py
@@ -74,11 +74,7 @@ def _rank_entry(
     rank: int,
     nranks: int,
     device_id: int,
-    host_lib: str,
-    aicpu_path: str,
-    aicore_path: str,
-    simpler_log_path: str,
-    sim_context_path: str,
+    bins,
     rootinfo_path: str,
     result_queue: mp.Queue,  # type: ignore[type-arg]
 ) -> None:
@@ -88,7 +84,7 @@ def _rank_entry(
         from simpler.task_interface import ChipWorker
 
         worker = ChipWorker()
-        worker.init(host_lib, aicpu_path, aicore_path, simpler_log_path, sim_context_path)
+        worker.init(bins)
         result["stage"] = "init"
 
         worker.set_device(device_id)
@@ -181,13 +177,6 @@ def test_two_rank_comm_lifecycle(st_device_ids):
 
     build = bool(os.environ.get("PTO_UT_BUILD"))
     bins = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer", build=build)
-    host_lib = str(bins.host_path)
-    aicpu_path = str(bins.aicpu_path)
-    aicore_path = str(bins.aicore_path)
-
-    simpler_log_path = str(bins.simpler_log_path)
-    sim_context_path = str(bins.sim_context_path) if bins.sim_context_path else ""
-
     assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
     nranks = 2
     rootinfo_path = f"/tmp/pto_comm_py_ut_rootinfo_{os.getpid()}.bin"
@@ -202,11 +191,7 @@ def test_two_rank_comm_lifecycle(st_device_ids):
                 rank,
                 nranks,
                 int(st_device_ids[rank]),
-                host_lib,
-                aicpu_path,
-                aicore_path,
-                simpler_log_path,
-                sim_context_path,
+                bins,
                 rootinfo_path,
                 result_queue,
             ),


### PR DESCRIPTION
## Summary

After #713, every caller of `ChipWorker.init` had to pass 5 path strings
plus 2 log-config ints, and every call site duplicated the same recipe
(open `RuntimeBinaries`, snapshot the simpler logger, expand into
positional args). Missing one — which is exactly what I did with
`scene_test._create_worker` in #713 — broke standalone scene tests
silently until exit-code-10 hit.

This collapses the Python wrapper to:

```python
cw.init(bins, log_level=None, log_info_v=None)
```

`bins` is any object exposing `host_path`, `aicpu_path`, `aicore_path`,
`simpler_log_path`, `sim_context_path` (i.e. a `RuntimeBinaries`). When
`log_level` / `log_info_v` are omitted, the wrapper snapshots the simpler
logger via `_log.get_current_config()`.

## Slimmed call sites (all four)

| Call site | Before | After |
|---|---|---|
| `Worker._init_level2` | 11 lines | 2 lines |
| `_chip_process_loop` | 9 positional path args | `bins` |
| `_chip_process_loop_with_bootstrap` | 9 positional path args | `bins` |
| `SceneTestCase._create_worker` (standalone) | 11 lines | 4 lines |

The `Worker` instance stashes a single `_l3_bins` field instead of five
`_l3_*_path` strings.

## What's left alone

- The raw nanobind binding `_ChipWorker` keeps its path-based `init`
  (mirrors the C++ ABI). `test_chip_worker.py` — which exercises the
  binding's "dlopen of /nonexistent fails" path — is unchanged.
- C++ side: zero changes.
- `Worker` ↔ `ChipWorker` layering rule unchanged.

Net diff: **6 files, +57 / −191** (pure dedup).

## Testing

- [x] `pip install --no-build-isolation -e .` clean
- [x] `ctest --test-dir build/ut_cpp` — 21/21
- [x] `pytest tests/ut/py` — 214 + 7 skipped (pre-existing)
- [x] standalone `python test_bgemm.py -p a5sim` default — V0 hidden, V9 visible
- [x] standalone `python test_bgemm.py -p a5sim --log-level v0` — V0 host (42 lines) + device (78 lines) fire
- [ ] Hardware tests — please run `/test-all-device` in CI