### PR TITLE
Refactor: drop WorkerThread::Mode::THREAD (mailbox IPC is the only mode)

### DIFF
--- a/docs/hierarchical_level_runtime.md
+++ b/docs/hierarchical_level_runtime.md
@@ -100,23 +100,21 @@ See [scheduler.md](scheduler.md) for the dispatch loop and coordination.
 ### Worker / WorkerManager / WorkerThread
 
 The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`s
-(next-level pool and sub pool). Each `WorkerThread`:
+(next-level pool and sub pool). Each `WorkerThread` owns one std::thread that
+encodes `(callable, config, args_blob)` into a `MAILBOX_SIZE`-byte shared
+memory region, signals the pre-forked Python child, and spin-polls
+`TASK_DONE`.
 
-- owns one `IWorker` (`ChipWorker` or nested `Worker`) for next-level workers
-- has its own `std::thread`
-- runs in one of two modes:
-  - `THREAD`: calls `worker->run(callable, view, config)` directly in-process
-  - `PROCESS`: forks a child at init; each dispatch writes task data to a shm
-    mailbox, the child decodes and runs
+- Next-level (chip) children run `_chip_process_loop`, which constructs a
+  `ChipWorker` and dispatches each kernel through it.
+- SUB children run `_sub_worker_loop`, which decodes the args blob into a
+  `TaskArgs` and calls the registered Python callable as `fn(args)`. There
+  is no C++ `SubWorker` class — SUB workers exist only as a worker-type
+  enum value plus a Python child loop.
 
-SUB workers are Python-only: the forked child process runs a Python loop
-(``_sub_worker_loop``) that reads the args blob from the mailbox, decodes it
-into a ``TaskArgs``, and calls the registered callable as ``fn(args)``.
-There is no C++ ``SubWorker`` class.
-
-See [worker-manager.md](worker-manager.md) for thread/process mechanics, fork
-ordering, and mailbox layout. See [task-flow.md](task-flow.md) for what flows
-through `IWorker::run`.
+See [worker-manager.md](worker-manager.md) for the dispatch state machine,
+fork ordering, and mailbox layout. See [task-flow.md](task-flow.md) for
+what flows through `IWorker::run`.
 
 ---
 
@@ -230,34 +228,31 @@ Python handles **when** things happen (fork ordering, lifecycle). C++ handles
 ## 6. Process Model
 
 ```text
-┌─────────────────────────────────────────────────────┐
-│  Parent (main) process                              │
-│                                                      │
-│  Python main thread (Orch)                           │
-│    │                                                 │
-│    ├── C++ Scheduler thread                          │
-│    ├── C++ WorkerThread[0] → ChipWorker[0]           │
-│    ├── C++ WorkerThread[1] → ChipWorker[1]           │
-│    ├── C++ WorkerThread[2] → SubWorker[0]            │
-│    └── C++ WorkerThread[3] → SubWorker[1]            │
-│                                                      │
-└──────────────────────────┬──────────────────────────┘
-                           │ fork() (PROCESS mode only, before C++ threads start)
-            ┌──────────────┼──────────────┐
-            ▼                             ▼
-   ┌────────────────┐            ┌────────────────┐
-   │ Child process 0 │            │ Child process 1 │
-   │ poll mailbox    │            │ poll mailbox    │
-   │ run callable    │            │ run callable    │
-   └────────────────┘            └────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│  Parent (main) process                                       │
+│                                                              │
+│  Python main thread (Orch)                                   │
+│    │                                                         │
+│    ├── C++ Scheduler thread                                  │
+│    ├── C++ WorkerThread[0] ── shm mailbox ──► chip child 0   │
+│    ├── C++ WorkerThread[1] ── shm mailbox ──► chip child 1   │
+│    ├── C++ WorkerThread[2] ── shm mailbox ──► sub  child 0   │
+│    └── C++ WorkerThread[3] ── shm mailbox ──► sub  child 1   │
+│                                                              │
+└─────────────────────────────┬────────────────────────────────┘
+                              │ fork() (before any C++ thread starts)
+            ┌─────────────────┼─────────────────┐
+            ▼                                   ▼
+   ┌─────────────────┐                 ┌─────────────────┐
+   │ Chip child 0    │                 │ Chip child 1    │
+   │ poll mailbox    │       …         │ poll mailbox    │
+   │ ChipWorker.run  │                 │ ChipWorker.run  │
+   └─────────────────┘                 └─────────────────┘
 ```
 
-**Fork ordering invariant**: Python forks child processes FIRST (before C++
-`Scheduler` / `WorkerThread` threads are started). This avoids
-fork-in-multithreaded-process hazards.
-
-THREAD mode workers skip the fork entirely — they run in the parent process's
-`WorkerThread::std::thread`.
+**Fork ordering invariant**: Python forks every child process FIRST, before
+any C++ `Scheduler` / `WorkerThread` is started. This avoids the classical
+fork-in-a-multi-threaded-process hazard.
 
 ---
 
@@ -283,13 +278,11 @@ device allocation algorithm.
 | ---- | ---- |
 | `src/common/hierarchical/orchestrator.{h,cpp}` | `Orchestrator`: submit, TensorMap, Scope |
 | `src/common/hierarchical/scheduler.{h,cpp}` | `Scheduler`: dispatch loop + queues |
-| `src/common/hierarchical/worker_manager.{h,cpp}` | `WorkerManager`: WorkerThread pool |
-| `src/common/hierarchical/worker_thread.{h,cpp}` | `WorkerThread`: THREAD/PROCESS dispatch |
+| `src/common/hierarchical/worker_manager.{h,cpp}` | `WorkerManager` + `WorkerThread`: pool, mailbox-IPC dispatch |
 | `src/common/hierarchical/worker.{h,cpp}` | `Worker` (L3+): composes the above |
 | `src/common/hierarchical/ring.{h,cpp}` | slot allocator |
 | `src/common/hierarchical/tensormap.{h,cpp}` | base_ptr → producer slot |
 | `src/common/hierarchical/scope.{h,cpp}` | scope lifetime management |
-| `src/common/worker/chip_worker.{h,cpp}` | L2 `ChipWorker` (IWorker leaf) |
-| `src/common/worker/sub_worker.{h,cpp}` | `SubWorker` (IWorker leaf for Python callables) |
+| `src/common/worker/chip_worker.{h,cpp}` | L2 `ChipWorker` (IWorker leaf, runs in the forked chip child) |
 | `python/bindings/` | nanobind exposure of C++ engine to Python |
 | `python/simpler/worker.py` | Python `Worker` factory + lifecycle wrapper |

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -45,9 +45,8 @@ private:
 struct SubmitResult { TaskSlot task_slot; };  // field is `task_slot` in current code
 ```
 
-**Status**: `submit_sub` takes only `(callable_id, args)` — no `config`, SUB
-has no per-call config. Target design (plan §"Why L2 has no submit") allows
-callable IDs that may later unify with ChipCallable pointers; see PR-E.
+**Status**: `submit_sub` takes only `(callable_id, args)` — no `config`,
+since SUB has no per-call config.
 
 `scope_begin` / `scope_end` / `drain` are invoked from Python `Worker.run` via
 `_scope_begin` / `_scope_end` / `_drain` bindings. They are not part of the
@@ -248,10 +247,10 @@ SubmitResult Orchestrator::submit_sub(Callable cb, TaskArgs args, const CallConf
 1. A **monotonic task id** — allocated on every `alloc()`, shared across
    all rings. There is no fixed window and no modulo wrap at L3: slot
    state lives in parent-process heap (never crossed into child workers),
-   so the ring index L2 uses to address shmem descriptors buys us nothing
-   here (see plan Allowed Exception #6). A monotonic `int32_t` gives ~2
-   billion ids per `reset_to_empty()` interval, reset to 0 at the end of
-   every `Worker.run()`.
+   so the ring-index addressing scheme L2 needs for shmem descriptors
+   buys us nothing here. A monotonic `int32_t` gives ~2 billion ids per
+   `reset_to_empty()` interval, reset to 0 at the end of every
+   `Worker.run()`.
 2. **`MAX_RING_DEPTH = 4` independent shared-memory heap slabs**
    (Strict-1; matches L2's `PTO2_MAX_RING_DEPTH`). Each slab has its own
    `mmap(MAP_SHARED | MAP_ANONYMOUS)` region, bump cursor, FIFO
@@ -625,7 +624,7 @@ OUTPUT tensors whose `data` is already set are left alone (legacy
 
 The HeapRing size is a `Worker` ctor parameter, surfaced on the Python
 `Worker` as `heap_ring_size=` (default 1 GiB). The heap is `mmap`'d in the
-C++ ctor — before Python forks the ChipProcess / SubWorker children — so
+C++ ctor — before Python forks the chip / sub child processes — so the
 children inherit the same `MAP_SHARED | MAP_ANONYMOUS` region at the same
 virtual address.
 

--- a/docs/sim_multi_device_isolation.md
+++ b/docs/sim_multi_device_isolation.md
@@ -10,17 +10,17 @@ When 2+ ChipWorkers run concurrently on the sim platform, `host_runtime.so` glob
 
 ## Solution: Fork+SHM Process Isolation
 
-Each ChipWorker runs in its own forked child process (`ChipProcess`). The OS provides full address-space isolation — all global state in `host_runtime.so` is automatically separate per process.
+Each ChipWorker runs in its own forked Python child process. The OS provides full address-space isolation — all global state in `host_runtime.so` is automatically separate per process.
 
 ```text
 Main process (Scheduler)
-  ├── WorkerThread[0] → ChipProcess[0] → shm mailbox → Child process 0
-  └── WorkerThread[1] → ChipProcess[1] → shm mailbox → Child process 1
-                                                              └── dlopen(host_runtime.so)
-                                                                  ← isolated globals
+  ├── WorkerThread[0] → shm mailbox → Child process 0 (ChipWorker[0])
+  └── WorkerThread[1] → shm mailbox → Child process 1 (ChipWorker[1])
+                                            └── dlopen(host_runtime.so)
+                                                ← isolated globals
 ```
 
-Communication uses a 4096-byte shared-memory mailbox per chip (same pattern as `SubWorker`). The parent copies `ChipStorageTaskArgs` into the mailbox; the child copies it to heap before calling `run_runtime` (sim runtime requires heap-backed args, not mmap-backed).
+Communication uses a 4096-byte shared-memory mailbox per chip — the same layout used for SUB-type workers. The parent copies `ChipStorageTaskArgs` into the mailbox; the child copies it to heap before calling `run_runtime` (sim runtime requires heap-backed args, not mmap-backed).
 
 ## Why Not Fix the Globals
 
@@ -30,5 +30,5 @@ The global state in `host_runtime.so` spans multiple files (`cpu_sim_context.cpp
 
 | File | Role |
 | ---- | ---- |
-| `src/common/hierarchical/chip_process.h/.cpp` | C++ IWorker: mailbox protocol for forked chip |
-| `python/worker.py` (`_chip_process_loop`) | Python child: init ChipWorker, poll mailbox, run tasks |
+| `src/common/hierarchical/worker_manager.{h,cpp}` | C++ `WorkerThread`: mailbox-IPC dispatcher for the forked chip child |
+| `python/simpler/worker.py` (`_chip_process_loop`) | Python child: init ChipWorker, poll mailbox, run tasks |

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -444,7 +444,7 @@ On first `run()`, the deferred `_start_hierarchical()`:
    own children are forked lazily on L3's first `run()`.
 3. Child enters `_child_worker_loop(mailbox, registry, inner_worker)`
 4. **Parent**: registers each mailbox with L4's Worker via
-   `add_next_level_process(mailbox_addr)`
+   `add_next_level_worker(mailbox_addr)`
 
 ```text
 L4 parent process
@@ -478,14 +478,6 @@ L4 parent process
 Each level's orch fn receives **its own** `Orchestrator` — the recursion is
 symmetric. `Worker` code does not branch on `level`; the level is only a
 diagnostic label.
-
-### THREAD mode (alternative)
-
-For in-process dispatch (no fork), L4 can register an L3 `Worker` as a
-THREAD-mode child. `Worker::run()` invokes a Python callback
-(`_run_as_child`) that looks up the orch function in the callable registry
-and calls `Worker.run(orch_fn, args, config)`. The GIL is acquired by the
-binding layer before entering Python.
 
 ---
 
@@ -567,16 +559,15 @@ Slots carry scheduler-only state (atomics, mutex, `std::vector` of fanout
 consumers) that is parent-private. Putting them in shm would force cross-
 process atomics and shm-safe containers. The only data that needs to cross
 the fork boundary is per-task: callable, config, args — and that fits in a
-~2 KB mailbox with a one-time memcpy per dispatch (matches the pattern
-already used by `ChipProcess` today).
+~2 KB mailbox with a one-time memcpy per dispatch.
 
 ### Why TaskArgs in slot (not encoded blob in slot)
 
 `TaskArgs` is vector-backed. Storing an `uint8_t args_blob[N]` inline in the
 slot would cap task size per level and waste memory per slot. Since the slot
 is parent-heap, there is no fork-boundary constraint on what it holds — just
-store the `TaskArgs` object and encode only at dispatch (PROCESS only), or
-hand over `task_args.view()` (THREAD).
+store the `TaskArgs` object and encode it into the mailbox blob at dispatch
+time.
 
 ### Why `TaskArgsView` is just pointers + counts
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -1,10 +1,10 @@
-# Worker Manager — Pool, Threading, and Dispatch Modes
+# Worker Manager — Pool, Threading, and Dispatch
 
 `WorkerManager` and `WorkerThread` together implement the **execution layer**
 of a `Worker` engine. `WorkerManager` owns two pools of `WorkerThread`s (one
-for next-level workers, one for sub workers); each `WorkerThread` owns an
-`IWorker` and a `std::thread`, and dispatches to it in either THREAD or
-PROCESS mode.
+for next-level workers, one for sub workers); each `WorkerThread` drives a
+shared-memory mailbox that a forked Python child consumes — the child runs
+the real `IWorker` in its own address space.
 
 For the high-level role of this layer among the three engine components, see
 [hierarchical_level_runtime.md](hierarchical_level_runtime.md). For what the
@@ -19,27 +19,24 @@ For the high-level role of this layer among the three engine components, see
 ```cpp
 class WorkerManager {
 public:
-    enum class Mode { THREAD, PROCESS };
-
-    explicit WorkerManager(Mode mode);
-
-    // Registration (before init)
-    void add_next_level(IWorker *worker);
-    void add_sub       (IWorker *worker);
+    // Registration (before init). `mailbox` is a MAILBOX_SIZE-byte
+    // MAP_SHARED region; the real IWorker lives in the forked child.
+    void add_next_level(void *mailbox);
+    void add_sub       (void *mailbox);
 
     // Lifecycle
-    void start(OnCompleteFn on_complete);   // starts all WorkerThreads
+    void start(Ring *ring, OnCompleteFn on_complete);   // starts all WorkerThreads
     void stop();
 
     // Scheduler API
-    WorkerThread *pick_idle(WorkerType type);
-    std::vector<WorkerThread *> pick_n_idle(WorkerType type, int n);
-    void dispatch(WorkerThread *wt, TaskSlot slot_id);
+    WorkerThread *pick_idle(WorkerType type) const;
+    std::vector<WorkerThread *> pick_n_idle(WorkerType type, int n) const;
 
 private:
-    Mode mode_;
-    std::vector<std::unique_ptr<WorkerThread>> next_level_;
-    std::vector<std::unique_ptr<WorkerThread>> sub_;
+    std::vector<void *> next_level_entries_;
+    std::vector<void *> sub_entries_;
+    std::vector<std::unique_ptr<WorkerThread>> next_level_threads_;
+    std::vector<std::unique_ptr<WorkerThread>> sub_threads_;
 };
 ```
 
@@ -48,21 +45,7 @@ private:
 - **Pool ownership**: two `std::vector` pools, sized at init from `add_*`
   calls
 - **Idle selection**: `pick_idle(type)` finds a WorkerThread whose queue is
-  empty; blocks if none available
-- **Mode propagation**: every `WorkerThread` constructed under this manager
-  inherits `mode_` (picked per `Worker` at construction)
-
-### Mode choice
-
-| Deployment | Recommended mode |
-| ---------- | ---------------- |
-| Onboard real hardware | `THREAD` — driver is thread-safe per device, no fork overhead |
-| Simulation (sim runtime) | `PROCESS` — sim backend has shared state that needs isolation |
-| Parallel scene-test orchestrator (`simpler_setup/parallel_scheduler.py`) | `PROCESS` — test independence; per-test dlopen state |
-| L4+ when L3 children are thread-safe composites | `THREAD` |
-
-Mode is a per-`Worker` decision. Different levels in a nested hierarchy can
-use different modes independently (e.g., L4 THREAD containing L3 PROCESS).
+  empty; returns nullptr if none available
 
 ---
 
@@ -78,41 +61,31 @@ struct WorkerDispatch {
 
 class WorkerThread {
 public:
-    enum class Mode { THREAD, PROCESS };
-
-    WorkerThread(Mode mode,
-                 IWorker *worker,
-                 Ring *ring,
-                 size_t mailbox_size = 0);
-
-    void start(OnCompleteFn on_done);
+    void start(Ring *ring, WorkerManager *manager,
+               const std::function<void(TaskSlot)> &on_complete,
+               void *mailbox);
     void stop();
     void dispatch(WorkerDispatch d);       // slot id + group sub-index
-    bool is_idle() const;
+    bool idle() const;
 
 private:
-    Mode mode_;
-    IWorker *worker_;
     Ring *ring_;                       // reads slot state via ring->slot_state(id)
-    std::thread parent_thread_;
-    LockFreeQueue<WorkerDispatch> queue_;
-
-    // PROCESS mode only
-    void *mailbox_ = nullptr;              // shm
-    pid_t child_pid_ = -1;
-    size_t mailbox_size_ = 0;
+    void *mailbox_ = nullptr;          // MAP_SHARED region the child polls
+    std::thread thread_;
+    std::queue<WorkerDispatch> queue_;
+    std::mutex mu_;
+    std::condition_variable cv_;
 
     void loop();
-    void dispatch_thread(WorkerDispatch d);
-    void dispatch_process(WorkerDispatch d);
-    [[noreturn]] void child_loop();
-    void fork_child();
+    void dispatch_process(TaskSlotState &s, int32_t group_index);
 };
 ```
 
-The WorkerThread's `std::thread` always exists regardless of mode — it pumps
-the internal queue and either runs the worker in-process or drives the shm
-handshake to a forked child.
+The WorkerThread's `std::thread` pumps the internal queue and drives the
+shm handshake — one mailbox round trip per dispatch. The forked child loop
+that consumes the mailbox lives in Python (`_chip_process_loop` /
+`_sub_worker_loop` in `python/simpler/worker.py`); the parent does not fork
+children.
 
 `WorkerDispatch` carries only `{slot_id, group_index}`; the thread reads
 `slot.callable` / `slot.task_args` / `slot.config` on each dispatch via
@@ -125,95 +98,15 @@ group sub-index.
 
 ---
 
-## 3. THREAD mode
+## 3. Dispatch via shm mailbox
 
-The simple case: same process, no shm, no serialization.
+Each WorkerThread drives a `MAILBOX_SIZE`-byte `MAP_SHARED` region. The
+Python facade forks one child per mailbox **before** `WorkerManager::start()`
+(so the parent has only the Python main thread when fork runs, avoiding the
+classical "fork in a multi-threaded process" hazard) and the child polls
+the mailbox for the lifetime of the worker.
 
-```cpp
-void WorkerThread::dispatch_thread(WorkerDispatch d) {
-    TaskSlotState &s = *ring_->slot_state(d.task_slot);
-    uint64_t callable = (s.worker_type == WorkerType::SUB)
-        ? static_cast<uint64_t>(s.callable_id)      // registry id for sub path
-        : s.callable;                                // ChipCallable buffer ptr
-    TaskArgsView view = s.args_view(d.group_index); // 0 for single tasks
-    worker_->run(callable, view, s.config);
-    on_complete_(d.task_slot);
-}
-```
-
-- `slot.args_view(i)` returns a zero-copy `TaskArgsView` over
-  `task_args` (single) or `task_args_list[i]` (group member). The backing
-  `std::vector` lives on the parent heap until the slot reaches CONSUMED.
-- `callable` unifies the two registry shapes: `uint64 = ChipCallable*`
-  for next-level, `uint64 = callable_id` for sub. The receiving
-  `IWorker` casts back appropriately.
-- `IWorker::run` dispatches polymorphically based on the actual worker type.
-
-Note: SUB workers in PROCESS mode bypass `IWorker` entirely — the Python
-child loop (``_sub_worker_loop``) reads the args blob from the mailbox,
-decodes it into a ``TaskArgs``, and calls the registered callable as
-``fn(args)``. The C++ dispatch path writes the same mailbox format for
-both worker types.
-
-**When is THREAD mode safe?**
-
-- The IWorker implementation must be thread-safe relative to other concurrent
-  calls and other system state
-- `ChipWorker` (dlsym'd runtime.so) is safe when the runtime `.so` and its
-  device driver support concurrent use
-- SUB workers run in Python child processes (PROCESS mode) where the
-  callable receives ``TaskArgs`` as its sole argument
-
----
-
-## 4. PROCESS mode
-
-Each WorkerThread forks a child at init. Each dispatch encodes task data into
-a shm mailbox, signals the child, and polls for completion.
-
-### 4.1 Fork at init
-
-`fork_child()` is called once by `WorkerThread::start()` **before any C++
-worker thread spawns**:
-
-```cpp
-void WorkerThread::fork_child() {
-    // Alloc mailbox in MAP_SHARED shm
-    mailbox_ = mmap(nullptr, mailbox_size_,
-                    PROT_READ | PROT_WRITE,
-                    MAP_SHARED | MAP_ANONYMOUS, -1, 0);
-    // Initialize mailbox state to IDLE
-    write_state(mailbox_, MailboxState::IDLE);
-
-    pid_t pid = fork();
-    if (pid == 0) {
-        // Child
-        child_loop();   // never returns
-    } else {
-        child_pid_ = pid;
-    }
-}
-```
-
-### 4.2 Fork ordering invariant
-
-**Fork must happen before any `std::thread` is created in the parent.** The
-Python `Worker` ensures this by:
-
-1. `Worker.register(fn)` registers Python callables (pre-fork)
-2. C++ `WorkerManager::add_*` registers IWorker pointers
-3. `Worker::init`:
-   - First: `WorkerManager::start()` — this calls each WorkerThread's
-     `start`, which **forks the child, then spawns the parent's
-     std::thread** for that WT
-   - Then: `Scheduler::start()` spawns the scheduler thread
-4. Fork ordering: at the moment `fork()` is called, the parent has only the
-   Python main thread and zero C++ worker threads. Safe.
-
-This avoids the classical "fork in multithreaded process" hazard where a
-child inherits locks held by threads that don't exist post-fork.
-
-### 4.3 Parent-side dispatch
+### 3.1 Parent-side dispatch
 
 ```cpp
 void WorkerThread::dispatch_process(WorkerDispatch d) {
@@ -254,41 +147,20 @@ Parent-side cost per dispatch:
 
 Total ~nanoseconds overhead; the wait is dominated by actual kernel execution.
 
-### 4.4 Child loop
+### 3.2 Child loop
 
-```cpp
-void WorkerThread::child_loop() {
-    for (;;) {
-        while (read_state(mailbox_) != MailboxState::TASK_READY)
-            pause_short();
-
-        if (read_state(mailbox_) == MailboxState::SHUTDOWN) exit(0);
-
-        uint8_t *d = (uint8_t*)mailbox_ + HEADER_SIZE;
-        Callable     cb     = *reinterpret_cast<Callable*>(d);
-        CallConfig   config = *reinterpret_cast<CallConfig*>(d + 8);
-        TaskArgsView view   = read_blob(d + 8 + sizeof(CallConfig));
-
-        int err = 0;
-        try {
-            worker_->run(cb, view, config);
-        } catch (...) {
-            err = 1;
-        }
-        write_error(mailbox_, err);
-        write_state(mailbox_, MailboxState::TASK_DONE);
-    }
-}
-```
-
-Child's `worker_` is polymorphic (ChipWorker / SubWorker / nested Worker).
+The child loop lives in Python — see `_chip_process_loop` and
+`_sub_worker_loop` in `python/simpler/worker.py`. Each child polls
+`MAILBOX_OFF_STATE`, decodes the args blob on `TASK_READY`, runs the
+real `IWorker` (`ChipWorker` for chip children) or registered Python
+callable (sub workers), writes back any error, and publishes `TASK_DONE`.
 The child inherits the parent's full address space at fork time, so:
 
 - ChipCallable objects (pre-fork allocated) are COW-visible at the same VA
-- `py_registry` (for SubWorker) is COW-visible
+- The Python callable registry is COW-visible
 - Tensor data in `torch.share_memory_()` regions is fully shared (MAP_SHARED)
 
-### 4.5 Mailbox layout
+### 3.3 Mailbox layout
 
 ```text
 offset 0:                              int32  state    (IDLE / TASK_READY / TASK_DONE / SHUTDOWN)
@@ -309,39 +181,29 @@ mailbox_size_ = HEADER_SIZE                    // 8 B (state + error)
 
 Per-worker total: ~2 KB. Typical pool: 4-8 workers → ~8-16 KB shm total.
 
-### 4.6 Shutdown
+### 3.4 Shutdown
 
-```cpp
-void WorkerThread::stop() {
-    if (mode_ == Mode::PROCESS) {
-        write_state(mailbox_, MailboxState::SHUTDOWN);
-        waitpid(child_pid_, nullptr, 0);
-        munmap(mailbox_, mailbox_size_);
-    }
-    // Signal parent thread to exit its loop
-    queue_.push_sentinel();
-    parent_thread_.join();
-}
-```
+`WorkerManager::shutdown_children()` writes `SHUTDOWN` to every registered
+mailbox; each child loop sees it on its next poll and exits. The Python
+facade owns the child PIDs and calls `waitpid()` after writing `SHUTDOWN`
+to its own mailbox copy. The parent's `WorkerThread::stop()` only joins
+the C++ dispatcher thread — it does not own the child process.
 
 ---
 
-## 5. Adding a new IWorker type
+## 4. Adding a new IWorker type
 
 To add a new worker kind (e.g., a RemoteWorker over RPC):
 
-1. Implement `IWorker::run(Callable, TaskArgsView, const CallConfig&)` on the
+1. Implement `IWorker::run(callable, TaskArgsView, const CallConfig&)` on the
    new class
-2. Register via `manager.add_next_level(ptr)` or `manager.add_sub(ptr)`
-3. If the new worker needs to run in PROCESS mode, ensure any resources it
-   needs (shm regions, sockets) are established before fork
+2. Decode the mailbox in a child-process loop (mirroring
+   `_chip_process_loop`) so the parent talks to it through the same
+   handshake as `ChipWorker`
+3. Register the mailbox via `manager.add_next_level(mailbox)` or
+   `manager.add_sub(mailbox)`
 
-The dispatch path (THREAD vs PROCESS) is chosen by `WorkerManager::mode_`,
-not by the IWorker type — so the same IWorker implementation works in both
-modes. This is why `ChipWorker`, `SubWorker`, and `Worker` all share one
-interface: the dispatch layer is orthogonal to the worker semantics.
-
-### 5.1 Nested fork ordering (L4+ Worker children)
+### 4.1 Nested fork ordering (L4+ Worker children)
 
 When an L4 Worker has L3 Worker children (PROCESS mode), the fork sequence
 nests:
@@ -368,18 +230,18 @@ address. C++ scheduler threads start only after all forks at that level.
 
 ---
 
-## 6. Why this layering
+## 5. Why this layering
 
 Three decisions that led here:
 
-### 6.1 Why not fork per task?
+### 5.1 Why not fork per task?
 
 Forking per submit eliminates the mailbox and serialization, but costs
 ~1-10 ms per fork (COW page-table setup for a large parent image). For
 thousands of tasks per DAG, the overhead dominates. Pre-forked pool amortizes
 fork across many dispatches.
 
-### 6.2 Why slot pool on parent heap, not shm?
+### 5.2 Why slot pool on parent heap, not shm?
 
 The scheduling state (TaskSlotState.fanin_count, fanout_consumers,
 fanout_mu) is parent-only — Scheduler and Orchestrator read/write it, but
@@ -387,7 +249,7 @@ children never do. Putting the slot in shm would force cross-process atomics
 and shm-safe containers for no benefit. See
 [task-flow.md](task-flow.md) §11 for full rationale.
 
-### 6.3 Why one WorkerThread per IWorker?
+### 5.3 Why one WorkerThread per IWorker?
 
 Alternative: N workers share one dispatch queue. Rejected because:
 
@@ -398,7 +260,7 @@ Alternative: N workers share one dispatch queue. Rejected because:
 
 ---
 
-## 7. Related
+## 6. Related
 
 - [hierarchical_level_runtime.md](hierarchical_level_runtime.md) — where this
   layer fits in the three-component engine

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -15,16 +15,15 @@
  * Compiled into the same _task_interface extension module as task_interface.cpp.
  * Call bind_worker(m) from the NB_MODULE definition in task_interface.cpp.
  *
- * PR-D-2: `ChipProcess` and `SubWorker` bindings are removed; their
- * PROCESS-mode dispatch logic now lives inside `WorkerThread`. Python callers
- * register PROCESS-mode workers via `add_next_level_process(mailbox_ptr)` /
- * `add_sub_process(mailbox_ptr)` instead of wrapping an IWorker subclass.
+ * Python callers register sub-workers via `add_next_level_worker(mailbox_ptr)`
+ * / `add_sub_worker(mailbox_ptr)`. Each mailbox addresses a MAILBOX_SIZE-byte
+ * MAP_SHARED region; the real IWorker lives in a forked Python child consuming
+ * the mailbox via `_chip_process_loop` / `_sub_worker_loop`.
  */
 
 #pragma once
 
 #include <nanobind/nanobind.h>
-#include <nanobind/stl/function.h>
 #include <nanobind/stl/string.h>
 #include <nanobind/stl/vector.h>
 
@@ -32,7 +31,6 @@
 #include <stdexcept>
 
 #include "chip_bootstrap_channel.h"
-#include "chip_worker.h"
 #include "ring.h"
 #include "orchestrator.h"
 #include "types.h"
@@ -194,73 +192,29 @@ inline void bind_worker(nb::module_ &m) {
             "(default 1 GiB; total VA = 4 × heap_ring_size)."
         )
 
-        // THREAD-mode registration (parent calls worker->run directly).
         .def(
             "add_next_level_worker",
-            [](Worker &self, Worker &w) {
-                self.add_worker(WorkerType::NEXT_LEVEL, &w);
-            },
-            nb::arg("worker"), "Add a lower-level Worker as a NEXT_LEVEL sub-worker (THREAD mode)."
-        )
-        .def(
-            "add_next_level_worker",
-            [](Worker &self, ChipWorker &w) {
-                self.add_worker(WorkerType::NEXT_LEVEL, &w);
-            },
-            nb::arg("worker"), "Add a ChipWorker as a NEXT_LEVEL sub-worker (THREAD mode)."
-        )
-
-        // PROCESS-mode registration (parent writes unified mailbox; child runs
-        // the real IWorker in its own address space).
-        .def(
-            "add_next_level_process",
             [](Worker &self, uint64_t mailbox_ptr) {
-                self.add_process_worker(WorkerType::NEXT_LEVEL, reinterpret_cast<void *>(mailbox_ptr));
+                self.add_worker(WorkerType::NEXT_LEVEL, reinterpret_cast<void *>(mailbox_ptr));
             },
             nb::arg("mailbox_ptr"),
-            "Add a PROCESS-mode NEXT_LEVEL worker. `mailbox_ptr` is the address of a "
-            "MAILBOX_SIZE-byte MAP_SHARED region. The child process loop is "
+            "Add a NEXT_LEVEL sub-worker. `mailbox_ptr` is the address of a "
+            "MAILBOX_SIZE-byte MAP_SHARED region; the child process loop is "
             "Python-managed (fork + _chip_process_loop)."
         )
         .def(
-            "add_sub_process",
+            "add_sub_worker",
             [](Worker &self, uint64_t mailbox_ptr) {
-                self.add_process_worker(WorkerType::SUB, reinterpret_cast<void *>(mailbox_ptr));
+                self.add_worker(WorkerType::SUB, reinterpret_cast<void *>(mailbox_ptr));
             },
             nb::arg("mailbox_ptr"),
-            "Add a PROCESS-mode SUB worker. `mailbox_ptr` is the address of a "
-            "MAILBOX_SIZE-byte MAP_SHARED region. The child process loop is "
+            "Add a SUB sub-worker. `mailbox_ptr` is the address of a "
+            "MAILBOX_SIZE-byte MAP_SHARED region; the child process loop is "
             "Python-managed (fork + _sub_worker_loop)."
         )
 
         .def("init", &Worker::init, "Start the Scheduler thread.")
         .def("close", &Worker::close, "Stop the Scheduler thread.")
-
-        // THREAD-mode callback for L4+ recursion (approach b: Python callback).
-        // The lambda captures the Python callable and wraps it with GIL
-        // acquisition + TaskArgsView→TaskArgs reconstruction so the Python
-        // side receives normal objects.
-        .def(
-            "set_run_callback",
-            [](Worker &self, nb::object cb) {
-                self.set_run_callback(
-                    [cb_stored = nb::object(cb)](uint64_t callable, TaskArgsView view, const CallConfig &config) {
-                        nb::gil_scoped_acquire gil;
-                        TaskArgs args;
-                        for (int32_t i = 0; i < view.tensor_count; i++) {
-                            args.add_tensor(view.tensors[i]);
-                        }
-                        for (int32_t i = 0; i < view.scalar_count; i++) {
-                            args.add_scalar(view.scalars[i]);
-                        }
-                        cb_stored(callable, &args, &config);
-                    }
-                );
-            },
-            nb::arg("callback"),
-            "Set the Python callback for THREAD-mode L4+ dispatch. The callback "
-            "receives (callable_id, TaskArgs, CallConfig) with the GIL held."
-        )
 
         .def(
             "get_orchestrator", &Worker::get_orchestrator, nb::rv_policy::reference_internal,

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -832,14 +832,14 @@ class Worker:
         # Register chip workers as NEXT_LEVEL (L3)
         if device_ids:
             for shm in self._chip_shms:
-                dw.add_next_level_process(_mailbox_addr(shm))
+                dw.add_next_level_worker(_mailbox_addr(shm))
 
         # Register Worker children as NEXT_LEVEL (L4+)
         for shm in self._next_level_shms:
-            dw.add_next_level_process(_mailbox_addr(shm))
+            dw.add_next_level_worker(_mailbox_addr(shm))
 
         for shm in self._sub_shms:
-            dw.add_sub_process(_mailbox_addr(shm))
+            dw.add_sub_worker(_mailbox_addr(shm))
 
         # Start Scheduler + WorkerThreads (C++ threads start here, after fork)
         dw.init()
@@ -1074,17 +1074,6 @@ class Worker:
                 # would hang on in-flight tasks.
                 self._orch._scope_end()
                 self._orch._drain()
-
-    def _run_as_child(self, cid: int, args, config) -> None:
-        """Called from C++ _Worker::run when this Worker is a THREAD-mode child.
-
-        Looks up the orch function from the callable registry and delegates
-        to ``self.run(orch_fn, args, config)``.
-        """
-        orch_fn = self._callable_registry.get(cid)
-        if orch_fn is None:
-            raise KeyError(f"callable id {cid} not found in registry")
-        self.run(orch_fn, args, config)
 
     # ------------------------------------------------------------------
     # close

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -18,14 +18,13 @@
  *   - TaskSlotState: per-task scheduling bookkeeping (stores TaskArgs
  *                        directly — no separate dispatch carrier struct)
  *   - ReadyQueue: Orch→Scheduler notification channel
- *   - IWorker: abstract interface implemented by ChipWorker, SubWorker,
- *              and Worker itself (recursive composition)
+ *   - IWorker: abstract interface implemented by ChipWorker (the in-child
+ *              worker invoked from `_chip_process_loop`)
  *
  * IWorker::run takes (callable, TaskArgsView, CallConfig) directly.
- * THREAD-mode dispatch builds the view via `slot.args_view(i)` from the
- * slot's stored TaskArgs; PROCESS-mode dispatch encodes the TaskArgs into
- * the per-WorkerThread shm mailbox via write_blob() and the child rebuilds
- * the view with read_blob().
+ * Dispatch encodes the TaskArgs into the per-WorkerThread shm mailbox with
+ * inline std::memcpy of [int32 T][int32 S][ContinuousTensor × T][uint64 × S];
+ * the forked child decodes the same layout to rebuild the view.
  */
 
 #pragma once
@@ -108,9 +107,9 @@ enum class TaskState : int32_t {
 // =============================================================================
 //
 // Stores the submitted TaskArgs directly. Dispatch builds a TaskArgsView on
-// demand via `args_view(i)` (THREAD mode) or write_blob → read_blob
-// (PROCESS mode). There is no separate dispatch carrier struct; the old
-// WorkerPayload was removed in PR-C.
+// demand via `args_view(i)` and encodes it into the mailbox blob via
+// write_blob; the child decodes with read_blob. There is no separate
+// dispatch carrier struct — the slot itself is the dispatch state.
 
 struct TaskSlotState {
     std::atomic<TaskState> state{TaskState::FREE};
@@ -222,17 +221,12 @@ class IWorker {
 public:
     virtual ~IWorker() = default;
 
-    // Execute one task synchronously. Called in the worker's own thread,
-    // blocking until the task is complete.
+    // Execute one task synchronously. Invoked in the forked child process
+    // by `_chip_process_loop`, blocking until the task is complete.
     //
-    // Each implementation interprets `callable` per its semantics:
-    //   - ChipWorker: uint64 holding a ChipCallable buffer ptr; builds a
-    //     ChipStorageTaskArgs POD from `args` and calls pto2_run_runtime.
-    //   - ChipProcess / SubWorker: dispatch proxies — forward
-    //     callable / config / args through the shm mailbox to the forked
-    //     child, which invokes the actual IWorker in its own address space.
-    //   - Worker (L4+): `callable` decodes to an orch-fn handle;
-    //     placeholder until PR-F.
+    // For ChipWorker, `callable` is a uint64 holding a ChipCallable buffer
+    // pointer; the implementation builds a ChipStorageTaskArgs POD from
+    // `args` and calls pto2_run_runtime.
     //
     // slot_id is not a parameter — completion routing is owned by
     // WorkerThread / Scheduler at a higher layer.

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -11,11 +11,7 @@
 
 #include "worker.h"
 
-#include <pthread.h>
-
-#include <cstdio>
 #include <cstdlib>
-#include <cstring>
 #include <mutex>
 #include <stdexcept>
 
@@ -24,27 +20,11 @@
 // ---------------------------------------------------------------------------
 //
 // Thread-pool libraries linked transitively into the Python process (OpenMP,
-// OpenBLAS, MKL, BLIS, KMP) spin up worker threads the first time they are
-// touched, and those threads do not survive `fork()` cleanly. Pin every
-// library we know about to a single thread before Worker.init() spawns its
-// own pool, and let KMP tolerate duplicate libomp loads on macOS where
-// multiple shared libraries link against their own copy.
-//
-// pthread_atfork installs handlers once per process that take the locks we
-// own in a fixed order on the parent side and release them in reverse on
-// both parent and child. The order is coarse-to-fine so nested locking in
-// normal paths cannot deadlock the atfork handler. The set of locks is
-// intentionally narrow: only those we own. Foreign locks (malloc, GIL) are
-// out of scope and handled by the other libraries' own atfork plumbing.
-//
-// The handler list is process-global (pthread_atfork cannot be unregistered)
-// and idempotent — installing it more than once is harmless because the
-// actual state it touches is per-Worker. For PR-H we keep the handler empty
-// until we have a second Worker-owned lock worth guarding (Allocator::mu_
-// is the only one so far, and its lifetime is tied to a Worker that
-// always fork-then-init). Registering an empty handler is still valuable as
-// a diagnostic hook for fork misuse and as a landing pad for locks added
-// in PR-C / PR-D (per-scope rings, per-worker-type queues, callable registry).
+// OpenBLAS, MKL, BLIS, KMP) spin up worker threads on first use, and those
+// threads do not survive `fork()` cleanly. Pin each library to a single
+// thread before Worker children are forked, and let KMP tolerate duplicate
+// libomp loads on macOS where multiple shared libraries link against their
+// own copy.
 
 namespace {
 
@@ -61,41 +41,7 @@ void apply_env_defaults_once() {
 #endif
 }
 
-void atfork_prepare() {
-    // Reserved for locks we own. Acquisition order (coarse-to-fine):
-    //   1. callable_registry.mu_   (owned by Python Worker today; future
-    //      PR-E will move this to C++)
-    //   2. worker_manager.pool_mu_ (PR-D)
-    //   3. worker_thread.queue_mu_ (PR-D, per thread)
-    //   4. scheduler.completion_mu_
-    //   5. allocator.mu_
-    //   6. tensormap.mu_
-    // Locks are taken in this order and released in reverse on prepare/parent
-    // handlers so the handlers never themselves deadlock. Today none of our
-    // locks are held across potential fork points, so the handler is empty;
-    // keep the landing pad so subsequent PRs can add locks without revisiting
-    // the atfork bookkeeping.
-}
-
-void atfork_parent() {}
-
-void atfork_child() {}
-
-void install_atfork_once() {
-    // Registered once per process; the handlers close over file-scope statics
-    // so multiple Worker instances share a single registration.
-    static std::once_flag s_atfork;
-    std::call_once(s_atfork, []() {
-        pthread_atfork(atfork_prepare, atfork_parent, atfork_child);
-    });
-}
-
-void fork_hygiene_once() {
-    std::call_once(g_fork_hygiene_once, []() {
-        apply_env_defaults_once();
-        install_atfork_once();
-    });
-}
+void fork_hygiene_once() { std::call_once(g_fork_hygiene_once, apply_env_defaults_once); }
 
 }  // namespace
 
@@ -119,16 +65,10 @@ Worker::~Worker() {
     if (initialized_) close();
 }
 
-void Worker::add_worker(WorkerType type, IWorker *worker) {
+void Worker::add_worker(WorkerType type, void *mailbox) {
     if (initialized_) throw std::runtime_error("Worker: add_worker after init");
-    if (type == WorkerType::NEXT_LEVEL) manager_.add_next_level(worker);
-    else manager_.add_sub(worker);
-}
-
-void Worker::add_process_worker(WorkerType type, void *mailbox) {
-    if (initialized_) throw std::runtime_error("Worker: add_process_worker after init");
-    if (type == WorkerType::NEXT_LEVEL) manager_.add_next_level_process(mailbox);
-    else manager_.add_sub_process(mailbox);
+    if (type == WorkerType::NEXT_LEVEL) manager_.add_next_level(mailbox);
+    else manager_.add_sub(mailbox);
 }
 
 void Worker::init() {
@@ -161,15 +101,4 @@ void Worker::close() {
     manager_.stop();
     allocator_.shutdown();
     initialized_ = false;
-}
-
-// =============================================================================
-// IWorker::run() — Worker as sub-worker of a higher level (THREAD mode)
-// =============================================================================
-
-void Worker::run(uint64_t callable, TaskArgsView args, const CallConfig &config) {
-    config.validate();
-    if (run_callback_) {
-        run_callback_(callable, args, config);
-    }
 }

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -13,17 +13,19 @@
  * Worker — top-level distributed worker node.
  *
  * Worker is the implementation of one level in the hierarchy (L3, L4, …).
- * From the level above it looks like an IWorker; internally it contains the
- * full scheduling engine (TensorMap, Allocator, Scope, Orchestrator, Scheduler)
- * and a set of sub-IWorkers it dispatches to.
+ * It contains the full scheduling engine (TensorMap, Allocator, Scope,
+ * Orchestrator, Scheduler) and a set of sub-workers (each a forked Python
+ * child reachable via a shared-memory mailbox) it dispatches to.
  *
  * Public surface:
- *   - add_worker(type, IWorker*)  — register sub-workers (before init)
+ *   - add_worker(type, mailbox)    — register a sub-worker (before init).
+ *                                    `mailbox` is a MAILBOX_SIZE-byte
+ *                                    MAP_SHARED region; the real IWorker
+ *                                    lives in the forked child.
  *   - init() / close()             — lifecycle
- *   - get_orchestrator()           — accessor used by Worker::run / Python facade
- *                                    (scope_begin / drain / scope_end live on the
- *                                     Orchestrator, not here)
- *   - run(payload)                 — IWorker entry (placeholder for L4+ recursion)
+ *   - get_orchestrator()           — accessor used by the Python facade
+ *                                    (scope_begin / drain / scope_end live
+ *                                     on the Orchestrator, not here)
  *
  * Worker holds no submit / scope / drain / active-task bookkeeping — those
  * concepts belong to Orchestrator.
@@ -47,7 +49,7 @@
 #include "types.h"
 #include "worker_manager.h"
 
-class Worker : public IWorker {
+class Worker {
 public:
     // Construct a Worker for hierarchy `level`. `heap_ring_size` is the
     // MAP_SHARED|MAP_ANONYMOUS region handed out by the Orchestrator for
@@ -59,19 +61,15 @@ public:
     // installation) also runs in the ctor, still in the parent, before
     // child forks.
     explicit Worker(int32_t level, uint64_t heap_ring_size = DEFAULT_HEAP_RING_SIZE);
-    ~Worker() override;
+    ~Worker();
 
     Worker(const Worker &) = delete;
     Worker &operator=(const Worker &) = delete;
 
-    // Register sub-workers before calling init().
-    // THREAD mode — parent calls worker->run() directly.
-    void add_worker(WorkerType type, IWorker *worker);
-
-    // PROCESS mode — parent writes the unified mailbox; a pre-forked child
-    // process reads it and runs the real IWorker in its own address space.
-    // `mailbox` must point to a MAILBOX_SIZE-byte MAP_SHARED region.
-    void add_process_worker(WorkerType type, void *mailbox);
+    // Register a sub-worker before calling init(). `mailbox` is a
+    // MAILBOX_SIZE-byte MAP_SHARED region; the real IWorker lives in the
+    // forked child and consumes the mailbox via the Python child loop.
+    void add_worker(WorkerType type, void *mailbox);
 
     // Start the scheduler thread. Must be called AFTER the parent has forked
     // any child workers — init() spins up threads in the parent that would
@@ -85,31 +83,20 @@ public:
     // only between init() and close().
     Orchestrator &get_orchestrator() { return orchestrator_; }
 
-    // IWorker — used when this Worker is itself a sub-worker of L4+.
-    // In THREAD mode, the parent's WorkerThread calls run() directly;
-    // run() invokes run_callback_ which acquires the GIL and delegates
-    // to the Python Worker._run_as_child method (approach (b): Python
-    // callback — simpler than full C++ registry lookup).
-    void run(uint64_t callable, TaskArgsView args, const CallConfig &config) override;
-
-    using RunCallback = std::function<void(uint64_t, TaskArgsView, const CallConfig &)>;
-    void set_run_callback(RunCallback cb) { run_callback_ = std::move(cb); }
-
 private:
-    RunCallback run_callback_;
     int32_t level_;
     bool initialized_{false};
 
     // --- Scheduling engine components ---
     // Per-task slot state lives inside `allocator_` (Ring) — Orchestrator
-    // and Scheduler access it via `allocator_.slot_state(id)`. No separate
-    // fixed-size slots array at L3 (see plan Allowed Exception #6).
+    // and Scheduler access it via `allocator_.slot_state(id)`. The slot
+    // itself is the dispatch state; no separate fixed-size slots array.
     TensorMap tensormap_;
     Ring allocator_;
     Scope scope_;
-    // Strict-4: one ready queue per WorkerType. Submit routes by
-    // s.worker_type; the Scheduler drains each queue independently so
-    // saturation of one pool cannot head-of-line-block the other.
+    // One ready queue per WorkerType. Submit routes by s.worker_type;
+    // the Scheduler drains each queue independently so saturation of
+    // one pool cannot head-of-line-block the other.
     ReadyQueue ready_next_level_queue_;
     ReadyQueue ready_sub_queue_;
     Orchestrator orchestrator_;

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -15,7 +15,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "../worker/chip_worker.h"
 #include "ring.h"
 
 namespace {
@@ -33,7 +32,7 @@ std::string read_error_msg(const char *mbox) {
 }  // namespace
 
 // =============================================================================
-// WorkerThread — mailbox helpers (PROCESS mode)
+// WorkerThread — mailbox helpers
 // =============================================================================
 
 MailboxState WorkerThread::read_mailbox_state() const {
@@ -68,11 +67,9 @@ void WorkerThread::write_mailbox_state(MailboxState s) {
 // =============================================================================
 
 void WorkerThread::start(
-    Mode mode, IWorker *worker, Ring *ring, WorkerManager *manager, const std::function<void(TaskSlot)> &on_complete,
-    void *mailbox
+    Ring *ring, WorkerManager *manager, const std::function<void(TaskSlot)> &on_complete, void *mailbox
 ) {
-    mode_ = mode;
-    worker_ = worker;
+    if (mailbox == nullptr) throw std::invalid_argument("WorkerThread::start: null mailbox");
     ring_ = ring;
     manager_ = manager;
     on_complete_ = on_complete;
@@ -99,7 +96,7 @@ void WorkerThread::stop() {
 }
 
 void WorkerThread::shutdown_child() {
-    if (mode_ == Mode::PROCESS && mailbox_) {
+    if (mailbox_) {
         write_mailbox_state(MailboxState::SHUTDOWN);
     }
 }
@@ -123,20 +120,15 @@ void WorkerThread::loop() {
 
         TaskSlotState &s = *ring_->slot_state(d.task_slot);
 
-        // Dispatch may throw from THREAD mode (worker_->run raised) or
-        // PROCESS mode (dispatch_process saw non-zero ERROR from the
-        // child). An uncaught exception escaping loop() would terminate
-        // the std::thread via std::terminate — instead, capture it and
-        // let the orch thread observe it at the next submit_*/drain.
+        // dispatch_process may throw on a non-zero ERROR from the child.
+        // An uncaught exception escaping loop() would terminate the
+        // std::thread via std::terminate — instead, capture it and let
+        // the orch thread observe it at the next submit_*/drain.
         // on_complete_ still fires so the scheduler releases consumers
         // and active_tasks_ eventually reaches zero; otherwise drain()
         // would hang.
         try {
-            if (mode_ == Mode::THREAD) {
-                dispatch_thread(s, d.group_index);
-            } else {
-                dispatch_process(s, d.group_index);
-            }
+            dispatch_process(s, d.group_index);
         } catch (...) {
             if (manager_) manager_->report_error(std::current_exception());
         }
@@ -146,15 +138,15 @@ void WorkerThread::loop() {
     }
 }
 
-void WorkerThread::dispatch_thread(TaskSlotState &s, int32_t group_index) {
-    uint64_t callable = (s.worker_type == WorkerType::SUB) ? static_cast<uint64_t>(s.callable_id) : s.callable;
-    TaskArgsView view = s.args_view(group_index);
-    worker_->run(callable, view, s.config);
-}
-
 void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     uint64_t callable = (s.worker_type == WorkerType::SUB) ? static_cast<uint64_t>(s.callable_id) : s.callable;
     TaskArgsView view = s.args_view(group_index);
+
+    // Hold mailbox_mu_ for the entire round trip (write payload + state +
+    // spin-poll TASK_DONE + reset to IDLE). Any control_* request from the
+    // orch thread waits for the dispatch to finish before claiming the
+    // mailbox; without this they would race on MAILBOX_OFF_STATE.
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
 
     // Clear the child-writable error fields so stale bytes from a prior
     // dispatch cannot masquerade as a fresh failure.
@@ -219,27 +211,16 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
 // WorkerManager
 // =============================================================================
 
-void WorkerManager::add_next_level(IWorker *worker) {
-    next_level_entries_.push_back({worker, WorkerThread::Mode::THREAD, nullptr});
-}
+void WorkerManager::add_next_level(void *mailbox) { next_level_entries_.push_back(mailbox); }
 
-void WorkerManager::add_sub(IWorker *worker) { sub_entries_.push_back({worker, WorkerThread::Mode::THREAD, nullptr}); }
-
-void WorkerManager::add_next_level_process(void *mailbox) {
-    next_level_entries_.push_back({nullptr, WorkerThread::Mode::PROCESS, mailbox});
-}
-
-void WorkerManager::add_sub_process(void *mailbox) {
-    sub_entries_.push_back({nullptr, WorkerThread::Mode::PROCESS, mailbox});
-}
+void WorkerManager::add_sub(void *mailbox) { sub_entries_.push_back(mailbox); }
 
 void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete) {
     if (ring == nullptr) throw std::invalid_argument("WorkerManager::start: null ring");
-    auto make_threads = [&](const std::vector<WorkerEntry> &entries,
-                            std::vector<std::unique_ptr<WorkerThread>> &threads) {
-        for (const WorkerEntry &e : entries) {
+    auto make_threads = [&](const std::vector<void *> &entries, std::vector<std::unique_ptr<WorkerThread>> &threads) {
+        for (void *mailbox : entries) {
             auto wt = std::make_unique<WorkerThread>();
-            wt->start(e.mode, e.worker, ring, this, on_complete, e.mailbox);
+            wt->start(ring, this, on_complete, mailbox);
             threads.push_back(std::move(wt));
         }
     };
@@ -342,67 +323,50 @@ static uint64_t read_control_result(const char *mbox) {
     return r;
 }
 
-uint64_t WorkerThread::control_malloc(size_t size) {
-    if (mode_ == Mode::THREAD) {
-        auto *cw = dynamic_cast<ChipWorker *>(worker_);
-        if (!cw) throw std::runtime_error("control_malloc: worker is not a ChipWorker");
-        return cw->malloc(size);
-    }
+// Issue a control sub-command and block until the child publishes
+// CONTROL_DONE. Caller must hold `mailbox_mu_`. On a non-zero error code
+// from the child, throws and leaves the mailbox in IDLE before unwinding
+// (so the next claim starts from a clean state). The `op_name` is used
+// only for the exception message.
+void WorkerThread::run_control_command(const char *op_name) {
     int32_t zero_err = 0;
     std::memcpy(mbox() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
     std::memset(mbox() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
-    write_control_args(mbox(), CTRL_MALLOC, static_cast<uint64_t>(size));
     write_mailbox_state(MailboxState::CONTROL_REQUEST);
     while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
-    int32_t err;
+    int32_t err = 0;
     std::memcpy(&err, mbox() + MAILBOX_OFF_ERROR, sizeof(int32_t));
     if (err != 0) {
         std::string msg = read_error_msg(mbox());
         write_mailbox_state(MailboxState::IDLE);
-        throw std::runtime_error("control_malloc failed on child: " + msg);
+        throw std::runtime_error(std::string(op_name) + " failed on child: " + msg);
     }
-    uint64_t result = read_control_result(mbox());
     write_mailbox_state(MailboxState::IDLE);
-    return result;
+}
+
+uint64_t WorkerThread::control_malloc(size_t size) {
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    write_control_args(mbox(), CTRL_MALLOC, static_cast<uint64_t>(size));
+    run_control_command("control_malloc");
+    return read_control_result(mbox());
 }
 
 void WorkerThread::control_free(uint64_t ptr) {
-    if (mode_ == Mode::THREAD) {
-        auto *cw = dynamic_cast<ChipWorker *>(worker_);
-        if (!cw) throw std::runtime_error("control_free: worker is not a ChipWorker");
-        cw->free(ptr);
-        return;
-    }
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_FREE, ptr);
-    write_mailbox_state(MailboxState::CONTROL_REQUEST);
-    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
-    write_mailbox_state(MailboxState::IDLE);
+    run_control_command("control_free");
 }
 
 void WorkerThread::control_copy_to(uint64_t dst, uint64_t src, size_t size) {
-    if (mode_ == Mode::THREAD) {
-        auto *cw = dynamic_cast<ChipWorker *>(worker_);
-        if (!cw) throw std::runtime_error("control_copy_to: worker is not a ChipWorker");
-        cw->copy_to(dst, src, size);
-        return;
-    }
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_COPY_TO, dst, src, static_cast<uint64_t>(size));
-    write_mailbox_state(MailboxState::CONTROL_REQUEST);
-    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
-    write_mailbox_state(MailboxState::IDLE);
+    run_control_command("control_copy_to");
 }
 
 void WorkerThread::control_copy_from(uint64_t dst, uint64_t src, size_t size) {
-    if (mode_ == Mode::THREAD) {
-        auto *cw = dynamic_cast<ChipWorker *>(worker_);
-        if (!cw) throw std::runtime_error("control_copy_from: worker is not a ChipWorker");
-        cw->copy_from(dst, src, size);
-        return;
-    }
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_COPY_FROM, dst, src, static_cast<uint64_t>(size));
-    write_mailbox_state(MailboxState::CONTROL_REQUEST);
-    while (read_mailbox_state() != MailboxState::CONTROL_DONE) {}
-    write_mailbox_state(MailboxState::IDLE);
+    run_control_command("control_copy_from");
 }
 
 bool WorkerManager::any_busy() const {

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -16,18 +16,11 @@
  * Provides idle-worker selection and dispatch to the Scheduler.
  * The Scheduler drives the DAG; the Manager drives the workers.
  *
- * Each WorkerThread operates in one of two modes:
- *
- *   THREAD  — calls `worker_->run(callable, view, config)` directly in
- *             the parent process.
- *   PROCESS — encodes `(callable, config, args_blob)` into a pre-forked
- *             child's shared-memory mailbox, signals TASK_READY, and
- *             spin-polls TASK_DONE. The child process loop (Python) reads
- *             the mailbox and calls the appropriate IWorker / Python
- *             callable in its own address space.
- *
- * PROCESS mode absorbs the logic that used to live in the standalone
- * `ChipProcess` and `SubWorker` classes (deleted in PR-D-2).
+ * Each WorkerThread encodes `(callable, config, args_blob)` into a
+ * pre-forked child's shared-memory mailbox, signals TASK_READY, and
+ * spin-polls TASK_DONE. The child process loop (Python) reads the
+ * mailbox and calls the appropriate IWorker / Python callable in its
+ * own address space.
  */
 
 #pragma once
@@ -57,8 +50,7 @@ class WorkerManager;
 //
 // One layout for both NEXT_LEVEL (chip) and SUB workers. SUB children
 // read `callable` as a uint64 encoding the callable_id and ignore
-// config + args_blob. Matches the former ChipProcess layout at the
-// byte level so the chip child loop in Python needs no offset changes.
+// config + args_blob.
 
 enum class MailboxState : int32_t {
     IDLE = 0,
@@ -131,13 +123,11 @@ struct WorkerDispatch {
 };
 
 // =============================================================================
-// WorkerThread — one worker, one std::thread, two execution modes.
+// WorkerThread — one worker, one std::thread, mailbox-IPC dispatch.
 // =============================================================================
 
 class WorkerThread {
 public:
-    enum class Mode { THREAD, PROCESS };
-
     WorkerThread() = default;
     ~WorkerThread() { stop(); }
     WorkerThread(const WorkerThread &) = delete;
@@ -145,12 +135,9 @@ public:
 
     // Start the worker thread.
     //
-    // THREAD mode: `worker` is called directly via `worker->run(...)`.
-    //   `mailbox` must be nullptr.
-    //
-    // PROCESS mode: `worker` is nullptr (the real IWorker lives in the
-    //   forked child). `mailbox` points to a MAILBOX_SIZE-byte
-    //   MAP_SHARED region managed by the Python facade.
+    // `mailbox` points to a MAILBOX_SIZE-byte MAP_SHARED region managed
+    // by the Python facade — the real IWorker lives in the forked child
+    // and consumes the mailbox via `_chip_process_loop` / `_sub_worker_loop`.
     //
     // `ring` is a borrowed pointer to the engine's slot-state pool —
     // the thread reads callable/args/config from
@@ -158,10 +145,7 @@ public:
     // on_complete(slot) is called (in the WorkerThread) after each run().
     // `manager` is a borrowed pointer used to report dispatch failures
     // (exception_ptr routed out of the worker thread to the orch thread).
-    void start(
-        Mode mode, IWorker *worker, Ring *ring, WorkerManager *manager,
-        const std::function<void(TaskSlot)> &on_complete, void *mailbox = nullptr
-    );
+    void start(Ring *ring, WorkerManager *manager, const std::function<void(TaskSlot)> &on_complete, void *mailbox);
 
     // Enqueue a dispatch for the worker. Non-blocking.
     void dispatch(WorkerDispatch d);
@@ -171,23 +155,24 @@ public:
 
     void stop();
 
-    // PROCESS mode only: write SHUTDOWN to the mailbox so the child
-    // process exits its loop. No-op in THREAD mode. Does NOT waitpid —
-    // the Python facade owns the child PID.
+    // Write SHUTDOWN to the mailbox so the child process exits its loop.
+    // Does NOT waitpid — the Python facade owns the child PID.
     void shutdown_child();
 
     // Memory control — callable from the orch thread while the worker
-    // thread may be running a task (MemoryAllocator is mutex-protected).
-    // THREAD mode: direct call on the ChipWorker.
-    // PROCESS mode: control command via mailbox (blocks until child responds).
+    // thread may be running a task. Issues a control command via the
+    // mailbox and blocks until the child responds.
+    //
+    // The mailbox is a single shared region; dispatch_process and the
+    // control_* methods both write its state field. They serialize on
+    // `mailbox_mu_` so a control request issued mid-dispatch waits for
+    // TASK_DONE before claiming the mailbox.
     uint64_t control_malloc(size_t size);
     void control_free(uint64_t ptr);
     void control_copy_to(uint64_t dst, uint64_t src, size_t size);
     void control_copy_from(uint64_t dst, uint64_t src, size_t size);
 
 private:
-    Mode mode_{Mode::THREAD};
-    IWorker *worker_{nullptr};
     Ring *ring_{nullptr};
     WorkerManager *manager_{nullptr};
     void *mailbox_{nullptr};
@@ -200,9 +185,18 @@ private:
     bool shutdown_{false};
     std::atomic<bool> idle_{true};
 
+    // Serializes parent-side mailbox access between this WorkerThread's
+    // dispatch loop and the orch-thread control_* path. Per-WorkerThread,
+    // so different workers can dispatch in parallel.
+    std::mutex mailbox_mu_;
+
     void loop();
-    void dispatch_thread(TaskSlotState &s, int32_t group_index);
     void dispatch_process(TaskSlotState &s, int32_t group_index);
+
+    // Common tail for the four control_* methods. Caller writes the args
+    // region and holds `mailbox_mu_`; this helper signals the child,
+    // spin-polls CONTROL_DONE, and throws on a non-zero child error code.
+    void run_control_command(const char *op_name);
 
     char *mbox() const { return static_cast<char *>(mailbox_); }
     MailboxState read_mailbox_state() const;
@@ -217,14 +211,10 @@ class WorkerManager {
 public:
     using OnCompleteFn = std::function<void(TaskSlot)>;
 
-    // THREAD mode: worker is called directly.
-    void add_next_level(IWorker *worker);
-    void add_sub(IWorker *worker);
-
-    // PROCESS mode: mailbox is a MAILBOX_SIZE-byte MAP_SHARED region.
-    // Worker is nullptr (child has its own).
-    void add_next_level_process(void *mailbox);
-    void add_sub_process(void *mailbox);
+    // Register a worker. `mailbox` is a MAILBOX_SIZE-byte MAP_SHARED
+    // region; the real IWorker lives in the forked child.
+    void add_next_level(void *mailbox);
+    void add_sub(void *mailbox);
 
     void start(Ring *ring, const OnCompleteFn &on_complete);
     void stop();
@@ -240,7 +230,7 @@ public:
 
     bool any_busy() const;
 
-    // Write SHUTDOWN to every PROCESS-mode mailbox.
+    // Write SHUTDOWN to every registered mailbox.
     void shutdown_children();
 
     // Error propagation: first dispatch failure from any WorkerThread wins.
@@ -252,14 +242,8 @@ public:
     void clear_error();
 
 private:
-    struct WorkerEntry {
-        IWorker *worker;  // nullptr for PROCESS mode
-        WorkerThread::Mode mode;
-        void *mailbox;  // nullptr for THREAD mode
-    };
-
-    std::vector<WorkerEntry> next_level_entries_;
-    std::vector<WorkerEntry> sub_entries_;
+    std::vector<void *> next_level_entries_;
+    std::vector<void *> sub_entries_;
 
     std::vector<std::unique_ptr<WorkerThread>> next_level_threads_;
     std::vector<std::unique_ptr<WorkerThread>> sub_threads_;

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -12,8 +12,10 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <iterator>
 #include <mutex>
 #include <thread>
@@ -30,16 +32,31 @@
 #include "task_args.h"
 
 // ---------------------------------------------------------------------------
-// MockWorker: run() blocks until complete() is called by the test thread.
+// MockMailboxWorker: in-process stand-in for the forked Python child loop.
+//
+// The production dispatch path writes (callable, config, args_blob) into a
+// MAILBOX_SIZE-byte shared region and spin-polls TASK_DONE; the real child
+// (`_chip_process_loop` in python/simpler/worker.py) decodes the mailbox and
+// runs an IWorker. For unit testing the Scheduler / WorkerManager state
+// machine in isolation, we replace the forked child with a thread inside
+// the test process that mimics the same handshake but blocks until the
+// test thread releases it via `complete()`.
+//
+// API parity with the previous IWorker-based MockWorker:
+//   - dispatched[i].callable / .tensor_key — recorded on TASK_READY
+//   - is_running                            — atomic flag the test polls
+//   - wait_running()                        — spin-wait until is_running flips
+//   - complete()                            — release the parked dispatch so
+//                                             the loop writes TASK_DONE
 // ---------------------------------------------------------------------------
 
-struct MockWorker : public IWorker {
+struct MockMailboxWorker {
     struct Record {
         uint64_t callable;
-        uint64_t tensor_key;              // tensors[0].data (unique per submit in tests)
-        const ContinuousTensor *tensors;  // backing pointer (distinct per group member)
+        uint64_t tensor_key;  // first tensor's `data` field (unique per submit in tests)
     };
 
+    alignas(8) std::array<char, MAILBOX_SIZE> mailbox{};
     std::vector<Record> dispatched;
     std::mutex dispatched_mu;
 
@@ -47,22 +64,33 @@ struct MockWorker : public IWorker {
     std::condition_variable run_cv;
     std::atomic<bool> should_complete{false};
     std::atomic<bool> is_running{false};
+    std::atomic<bool> stop_flag{false};
+    std::thread loop_thread;
 
-    void run(uint64_t callable, TaskArgsView args, const CallConfig & /*cfg*/) override {
-        {
-            std::lock_guard<std::mutex> lk(dispatched_mu);
-            uint64_t key = (args.tensor_count > 0) ? args.tensors[0].data : 0;
-            dispatched.push_back({callable, key, args.tensors});
-        }
-        is_running.store(true, std::memory_order_release);
-
-        std::unique_lock<std::mutex> lk(run_mu);
-        run_cv.wait(lk, [this] {
-            return should_complete.load(std::memory_order_acquire);
-        });
-        should_complete.store(false, std::memory_order_relaxed);
-        is_running.store(false, std::memory_order_release);
+    void start() {
+        // SharedMemory zero-fills, but std::array does not — explicitly
+        // store IDLE (=0) to mirror production parity and keep the polling
+        // loop's first read deterministic.
+        write_state(MailboxState::IDLE);
+        loop_thread = std::thread(&MockMailboxWorker::loop, this);
     }
+
+    ~MockMailboxWorker() {
+        // Defensive teardown — if a test fails before completing every
+        // dispatch, set stop_flag and wake the parked loop so the thread
+        // joins instead of leaking. The loop's TASK_READY branch always
+        // publishes TASK_DONE before checking stop_flag, so any in-flight
+        // WorkerThread::dispatch_process completes its spin-poll cleanly.
+        stop_flag.store(true, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lk(run_mu);
+            should_complete.store(true, std::memory_order_release);
+            run_cv.notify_one();
+        }
+        if (loop_thread.joinable()) loop_thread.join();
+    }
+
+    void *mailbox_ptr() { return mailbox.data(); }
 
     void complete() {
         std::lock_guard<std::mutex> lk(run_mu);
@@ -80,6 +108,76 @@ struct MockWorker : public IWorker {
     int dispatched_count() {
         std::lock_guard<std::mutex> lk(dispatched_mu);
         return static_cast<int>(dispatched.size());
+    }
+
+private:
+    // Mirror the acquire/release semantics in
+    // worker_manager.cpp::read_mailbox_state / write_mailbox_state. Plain
+    // memcpy on the mailbox state would let the parent observe the state
+    // flip before the preceding error-field stores are visible.
+    MailboxState read_state() const {
+        const auto *ptr = reinterpret_cast<const volatile int32_t *>(mailbox.data() + MAILBOX_OFF_STATE);
+        int32_t v = __atomic_load_n(ptr, __ATOMIC_ACQUIRE);
+        return static_cast<MailboxState>(v);
+    }
+
+    void write_state(MailboxState s) {
+        auto *ptr = reinterpret_cast<volatile int32_t *>(mailbox.data() + MAILBOX_OFF_STATE);
+        __atomic_store_n(ptr, static_cast<int32_t>(s), __ATOMIC_RELEASE);
+    }
+
+    void loop() {
+        while (true) {
+            if (stop_flag.load(std::memory_order_acquire)) return;
+            MailboxState s = read_state();
+            if (s == MailboxState::TASK_READY) {
+                uint64_t callable = 0;
+                std::memcpy(&callable, mailbox.data() + MAILBOX_OFF_CALLABLE, sizeof(uint64_t));
+                int32_t t_count = 0;
+                std::memcpy(&t_count, mailbox.data() + MAILBOX_OFF_ARGS, sizeof(int32_t));
+                uint64_t tensor_key = 0;
+                if (t_count > 0) {
+                    ContinuousTensor first{};
+                    std::memcpy(
+                        &first, mailbox.data() + MAILBOX_OFF_ARGS + TASK_ARGS_BLOB_HEADER_SIZE, sizeof(ContinuousTensor)
+                    );
+                    tensor_key = first.data;
+                }
+                {
+                    std::lock_guard<std::mutex> lk(dispatched_mu);
+                    dispatched.push_back({callable, tensor_key});
+                }
+                is_running.store(true, std::memory_order_release);
+
+                {
+                    std::unique_lock<std::mutex> lk(run_mu);
+                    run_cv.wait(lk, [this] {
+                        return should_complete.load(std::memory_order_acquire);
+                    });
+                    should_complete.store(false, std::memory_order_relaxed);
+                }
+                is_running.store(false, std::memory_order_release);
+
+                int32_t zero_err = 0;
+                std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
+                std::memset(mailbox.data() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+                write_state(MailboxState::TASK_DONE);
+            } else if (s == MailboxState::CONTROL_REQUEST) {
+                // Acknowledge the control request so a future test using
+                // WorkerThread::control_* doesn't hang on the spin-poll.
+                // No memory operation is simulated — result stays zero.
+                int32_t zero_err = 0;
+                std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
+                std::memset(mailbox.data() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+                uint64_t zero_result = 0;
+                std::memcpy(mailbox.data() + CTRL_OFF_RESULT, &zero_result, sizeof(uint64_t));
+                write_state(MailboxState::CONTROL_DONE);
+            } else if (s == MailboxState::SHUTDOWN) {
+                return;
+            } else {
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
+            }
+        }
     }
 };
 
@@ -110,7 +208,7 @@ struct SchedulerFixture : public ::testing::Test {
     ReadyQueue rq_next_level;
     ReadyQueue rq_sub;
     Orchestrator orch;
-    MockWorker mock_worker;
+    MockMailboxWorker mock_worker;
     WorkerManager manager;
     Scheduler sched;
     CallConfig cfg;
@@ -124,7 +222,8 @@ struct SchedulerFixture : public ::testing::Test {
         allocator.init(/*heap_bytes=*/1ULL << 20);
         orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
 
-        manager.add_next_level(&mock_worker);
+        mock_worker.start();
+        manager.add_next_level(mock_worker.mailbox_ptr());
         manager.start(&allocator, [this](TaskSlot slot) {
             sched.worker_done(slot);
         });
@@ -205,7 +304,7 @@ TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
 }
 
 // ===========================================================================
-// Group task tests -- fixture with 2 MockWorkers
+// Group task tests -- fixture with 2 MockMailboxWorkers
 // ===========================================================================
 
 struct GroupSchedulerFixture : public ::testing::Test {
@@ -216,8 +315,8 @@ struct GroupSchedulerFixture : public ::testing::Test {
     ReadyQueue rq_next_level;
     ReadyQueue rq_sub;
     Orchestrator orch;
-    MockWorker worker_a;
-    MockWorker worker_b;
+    MockMailboxWorker worker_a;
+    MockMailboxWorker worker_b;
     WorkerManager manager;
     Scheduler sched;
     CallConfig cfg;
@@ -231,8 +330,10 @@ struct GroupSchedulerFixture : public ::testing::Test {
         allocator.init(/*heap_bytes=*/1ULL << 20);
         orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
 
-        manager.add_next_level(&worker_a);
-        manager.add_next_level(&worker_b);
+        worker_a.start();
+        worker_b.start();
+        manager.add_next_level(worker_a.mailbox_ptr());
+        manager.add_next_level(worker_b.mailbox_ptr());
         manager.start(&allocator, [this](TaskSlot slot) {
             sched.worker_done(slot);
         });
@@ -283,12 +384,12 @@ TEST_F(GroupSchedulerFixture, GroupDispatchesToNWorkers) {
     EXPECT_EQ(worker_a.dispatched_count(), 1);
     EXPECT_EQ(worker_b.dispatched_count(), 1);
 
-    // Each worker got a different TaskArgs from the slot's task_args_list.
+    // Each worker got a different TaskArgs from the slot's task_args_list —
+    // proven by the keys 0xA0 and 0xA1 each landing on exactly one worker.
     uint64_t keys[2] = {worker_a.dispatched[0].tensor_key, worker_b.dispatched[0].tensor_key};
     std::sort(std::begin(keys), std::end(keys));
     EXPECT_EQ(keys[0], 0xA0u);
     EXPECT_EQ(keys[1], 0xA1u);
-    EXPECT_NE(worker_a.dispatched[0].tensors, worker_b.dispatched[0].tensors);
     (void)slot;
 
     worker_a.complete();
@@ -327,8 +428,8 @@ struct MixedTypeSchedulerFixture : public ::testing::Test {
     ReadyQueue rq_next_level;
     ReadyQueue rq_sub;
     Orchestrator orch;
-    MockWorker next_level_worker;
-    MockWorker sub_worker;
+    MockMailboxWorker next_level_worker;
+    MockMailboxWorker sub_worker;
     WorkerManager manager;
     Scheduler sched;
     CallConfig cfg;
@@ -342,8 +443,10 @@ struct MixedTypeSchedulerFixture : public ::testing::Test {
         allocator.init(/*heap_bytes=*/1ULL << 20);
         orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
 
-        manager.add_next_level(&next_level_worker);
-        manager.add_sub(&sub_worker);
+        next_level_worker.start();
+        sub_worker.start();
+        manager.add_next_level(next_level_worker.mailbox_ptr());
+        manager.add_sub(sub_worker.mailbox_ptr());
         manager.start(&allocator, [this](TaskSlot slot) {
             sched.worker_done(slot);
         });


### PR DESCRIPTION
## Summary

`WorkerThread` had two dispatch modes — `THREAD` (parent calls `IWorker::run` directly) and `PROCESS` (mailbox IPC to a forked Python child). Production code has only ever used PROCESS; THREAD's only live consumer was four C++ scheduler unit-test fixtures using a `MockWorker : public IWorker`. This PR deletes THREAD mode end-to-end and rebuilds the scheduler unit tests on top of a `MockMailboxWorker` that mimics `_chip_process_loop` in-process.

## What changed

**C++ core**
- `worker_manager.{h,cpp}`: drop the `Mode` enum, `dispatch_thread`, `worker_` field, `IWorker*` registration overloads. `WorkerEntry` collapses to `void*`. `WorkerThread::start` no longer takes a mode or worker pointer. THREAD-mode branches removed from `control_malloc`/`free`/`copy_to`/`copy_from`.
- `worker.{h,cpp}`: drop `Worker : public IWorker` along with `run()`, `RunCallback`, `set_run_callback`, `run_callback_`. `add_process_worker` becomes the single `add_worker(WorkerType, void*)` entry. The speculative `pthread_atfork` landing-pad (handlers were all empty no-ops) is removed.
- `types.h`: shrink `IWorker` doc to its only implementer (`ChipWorker`); drop the historical `ChipProcess` / `SubWorker` references.

**Python**
- `worker_bind.h`: drop the THREAD overloads of `add_next_level_worker` (`Worker&` / `ChipWorker&`) and the `set_run_callback` binding. Rename `add_*_process` → `add_*_worker`.
- `simpler/worker.py`: 3 call-site renames; delete `_run_as_child` (only reachable via the deleted `set_run_callback` callback).

**Tests**
- `tests/ut/cpp/hierarchical/test_scheduler.cpp`: replace `MockWorker : IWorker` with `MockMailboxWorker` — owns a stack-allocated mailbox and a polling thread that mirrors `_chip_process_loop` (acquire/release on `MAILBOX_OFF_STATE`, decode args blob, block on a condvar until the test calls `complete()`, write `TASK_DONE`). Same `wait_running` / `complete` / `dispatched` API so test bodies are unchanged except for one THREAD-only pointer-distinctness assertion (the `tensor_key` checks already prove the scheduler's intent under PROCESS semantics).

**Docs**
- `task-flow.md`, `worker-manager.md`, `hierarchical_level_runtime.md`, `sim_multi_device_isolation.md`, `orchestrator.md`: drop the THREAD vs PROCESS framing and the "ChipProcess" / C++ "SubWorker" class lies (neither has ever existed). Also strip stale planning breadcrumbs (`PR-C` / `PR-D` / `PR-E` / `PR-H`, "plan Allowed Exception #6") from comments and prose.

## Test plan

- [x] `pip install --no-build-isolation -e .` — clean build on macOS arm64.
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 21/21 pass (the 6 rewritten `test_scheduler` cases pass with the new `MockMailboxWorker`).
- [x] `pytest tests/ut/py/test_chip_worker.py tests/ut/py/test_worker/test_{multi_worker,l4_recursive,bootstrap_context_sim}.py` — 33/33 pass (covers the renamed Python→C++ binding path end-to-end, including L3 chip dispatch and L4 recursive composition).
- [ ] CI: full `pytest tests/ut` and `ctest` on Linux.
- [ ] CI: hardware sanity (a2a3 / a5) — no behavioral change expected since production code never used THREAD mode.