### PR TITLE
Fix PTO2 dep pool fatal exits

### DIFF
--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -105,6 +105,7 @@ void platform_init_aicore_regs(uint64_t reg_addr);
  * This function sends exit signal and closes fast path control.
  *
  * @param reg_addr  Register base address of the AICore
+ * @return 0 if the core acknowledged exit, non-zero on timeout
  */
 int32_t platform_deinit_aicore_regs(uint64_t reg_addr);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -186,6 +186,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
  */
 int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
+    int32_t run_rc = 0;
     LOG_INFO_V0("Thread %d: Start", thread_idx);
 
     // Orchestrator check
@@ -614,16 +615,21 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         } else {
             sched_ctx_.bind_runtime(rt);
             int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
-            LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+            if (completed < 0) {
+                LOG_ERROR("Thread %d: Scheduler failed with rc=%d", thread_idx, completed);
+                run_rc = completed;
+            } else {
+                LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+            }
         }
     }
 
     // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_trackers_[thread_idx].core_num() == 0 so they skip the loop harmlessly.
-    auto rc = sched_ctx_.shutdown(thread_idx);
-    if (rc != 0) {
-        return rc;
+    int32_t shutdown_rc = sched_ctx_.shutdown(thread_idx);
+    if (shutdown_rc != 0 && run_rc == 0) {
+        run_rc = shutdown_rc;
     }
 
     LOG_INFO_V0("Thread %d: Completed", thread_idx);
@@ -645,7 +651,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
     }
 
-    return 0;
+    return run_rc;
 }
 
 void AicpuExecutor::deinit(Runtime *runtime) {
@@ -719,7 +725,6 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     int32_t rc = g_aicpu_executor.run(runtime);
     if (rc != 0) {
         LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
-        return rc;
     }
 
     int32_t runtime_rc = read_pto2_runtime_status(runtime);
@@ -733,6 +738,10 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime_rc != 0) {
         LOG_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
         return runtime_rc;
+    }
+
+    if (rc != 0) {
+        return rc;
     }
 
     LOG_INFO_V0("%s", "aicpu_execute: Kernel execution completed successfully");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -213,7 +213,10 @@ static bool append_fanin_or_fail(
     }
 
     PTO2FaninPool &fanin_pool = fanin_builder->spill_pool;
-    fanin_pool.ensure_space(orch->sm_header->rings[ring_id], 1);
+    if (!fanin_pool.ensure_space(orch->sm_header->rings[ring_id], 1)) {
+        orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
+        return false;
+    }
     int32_t spill_idx = fanin_pool.top;
     PTO2FaninSpillEntry *entry = fanin_pool.alloc();
     if (entry == nullptr) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -20,9 +20,16 @@
 #include "pto_ring_buffer.h"
 #include <inttypes.h>
 #include <string.h>
-#include <stdlib.h>  // for exit()
 #include "common/unified_log.h"
 #include "scheduler/pto_scheduler.h"
+
+static void latch_pool_error(std::atomic<int32_t> *error_code_ptr, int32_t error_code) {
+    if (error_code_ptr == nullptr) {
+        return;
+    }
+    int32_t expected = PTO2_ERROR_NONE;
+    error_code_ptr->compare_exchange_strong(expected, error_code, std::memory_order_acq_rel);
+}
 
 // =============================================================================
 // Fanin Spill Pool Implementation
@@ -46,14 +53,14 @@ void PTO2FaninPool::reclaim(PTO2SharedMemoryRingHeader &ring, int32_t sm_last_ta
     reclaim_task_cursor = scan_end;
 }
 
-void PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
-    if (available() >= needed) return;
+bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
+    if (available() >= needed) return true;
 
     int spin_count = 0;
     int32_t prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
     while (available() < needed) {
         reclaim(ring, prev_last_alive);
-        if (available() >= needed) return;
+        if (available() >= needed) return true;
 
         spin_count++;
 
@@ -88,10 +95,12 @@ void PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
             LOG_ERROR("  Compile-time: PTO2_DEP_LIST_POOL_SIZE in pto_runtime2_types.h");
             LOG_ERROR("  Runtime env:  PTO2_RING_DEP_POOL=%d", high_water * 2);
             LOG_ERROR("========================================");
-            exit(1);
+            latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
+            return false;
         }
         SPIN_WAIT_HINT();
     }
+    return true;
 }
 
 // =============================================================================
@@ -107,14 +116,14 @@ void PTO2DepListPool::reclaim(PTO2SharedMemoryRingHeader &ring, int32_t sm_last_
     }
 }
 
-void PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
-    if (available() >= needed) return;
+bool PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
+    if (available() >= needed) return true;
 
     int spin_count = 0;
     int32_t prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
     while (available() < needed) {
         reclaim(ring, prev_last_alive);
-        if (available() >= needed) return;
+        if (available() >= needed) return true;
 
         spin_count++;
 
@@ -150,8 +159,10 @@ void PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t nee
             LOG_ERROR("  Compile-time: PTO2_DEP_LIST_POOL_SIZE in pto_runtime2_types.h");
             LOG_ERROR("  Runtime env:  PTO2_RING_DEP_POOL=%d", high_water * 2);
             LOG_ERROR("========================================");
-            exit(1);
+            latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
+            return false;
         }
         SPIN_WAIT_HINT();
     }
+    return true;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -392,7 +392,7 @@ struct PTO2FaninPool {
 
     void reclaim(PTO2SharedMemoryRingHeader &ring, int32_t sm_last_task_alive);
 
-    void ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
 
     PTO2FaninSpillEntry *alloc() {
         int32_t used = top - tail;
@@ -570,7 +570,7 @@ struct PTO2DepListPool {
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -129,9 +129,9 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
+    std::atomic<uint32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
 };
 
 static_assert(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -33,6 +33,7 @@ static void latch_scheduler_error(PTO2SharedMemoryHeader *header, int32_t thread
     if (header == nullptr || error_code == PTO2_ERROR_NONE) {
         return;
     }
+    // The first error code/thread pair wins; the bitmap cumulatively records all reporting threads.
     int32_t expected = PTO2_ERROR_NONE;
     if (header->sched_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
         header->sched_error_thread.store(thread_idx, std::memory_order_release);
@@ -63,7 +64,9 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
     int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
     if (sched_err != PTO2_ERROR_NONE) {
         LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
-        completed_.store(true, std::memory_order_release);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
         return LoopAction::BREAK_LOOP;
     }
 
@@ -113,7 +116,9 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
     int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
     if (sched_err != PTO2_ERROR_NONE) {
         LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
-        completed_.store(true, std::memory_order_release);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
         return LoopAction::BREAK_LOOP;
     }
     return LoopAction::NONE;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -29,12 +29,25 @@
 // Cold-path helpers for the main dispatch loop (noinline to reduce hot-loop icache)
 // =============================================================================
 
+static void latch_scheduler_error(PTO2SharedMemoryHeader *header, int32_t thread_idx, int32_t error_code) {
+    if (header == nullptr || error_code == PTO2_ERROR_NONE) {
+        return;
+    }
+    int32_t expected = PTO2_ERROR_NONE;
+    if (header->sched_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
+        header->sched_error_thread.store(thread_idx, std::memory_order_release);
+    }
+    if (thread_idx >= 0 && thread_idx < 32) {
+        header->sched_error_bitmap.fetch_or(1U << static_cast<uint32_t>(thread_idx), std::memory_order_acq_rel);
+    }
+}
+
 LoopAction SchedulerContext::handle_orchestrator_exit(
     int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count
 ) {
-    bool orch_done = orchestrator_done_;
-    if (!orch_done) return LoopAction::NONE;
-
+    if (completed_.load(std::memory_order_acquire)) {
+        return LoopAction::BREAK_LOOP;
+    }
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
         LOG_ERROR(
@@ -42,10 +55,20 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
             "completed_tasks=%d, total_tasks=%d",
             thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
         );
-        emergency_shutdown(runtime);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
+        return LoopAction::BREAK_LOOP;
+    }
+    int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
+    if (sched_err != PTO2_ERROR_NONE) {
+        LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
         completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
+
+    bool orch_done = orchestrator_done_;
+    if (!orch_done) return LoopAction::NONE;
 
     task_count = total_tasks_;
     if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
@@ -76,10 +99,20 @@ LoopAction SchedulerContext::handle_core_transition(bool &cores_released) {
 
 LoopAction
 SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime) {
+    if (completed_.load(std::memory_order_acquire)) {
+        return LoopAction::BREAK_LOOP;
+    }
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
         LOG_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
-        emergency_shutdown(runtime);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
+        return LoopAction::BREAK_LOOP;
+    }
+    int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
+    if (sched_err != PTO2_ERROR_NONE) {
+        LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
         completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
@@ -167,13 +200,17 @@ void SchedulerContext::log_stall_diagnostics(
 }
 
 int32_t SchedulerContext::handle_timeout_exit(
-    int32_t thread_idx, int32_t idle_iterations
+    int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
 #if PTO2_PROFILING
     ,
     uint64_t sched_start_ts
 #endif
 ) {
     LOG_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+    latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
+    if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+        emergency_shutdown(runtime);
+    }
 #if PTO2_PROFILING
     uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
     LOG_INFO_V9(
@@ -182,7 +219,7 @@ int32_t SchedulerContext::handle_timeout_exit(
         cycles_to_us(sched_timeout_ts - sched_start_ts)
     );
 #endif
-    return -1;
+    return -PTO2_ERROR_SCHEDULER_TIMEOUT;
 }
 
 #if PTO2_PROFILING
@@ -357,6 +394,7 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 #endif
 
     LOG_INFO_V0("Thread %d: Shutting down %d cores", thread_idx, core_num);
+    int32_t rc = 0;
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cores[i];
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
@@ -364,13 +402,14 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
             // Timeout means AICore is unresponsive. Log and continue deiniting remaining cores.
             if (platform_deinit_aicore_regs(reg_addr) != 0) {
                 LOG_ERROR("Thread %d: Core %d deinit timed out", thread_idx, core_id);
+                rc = -1;
             }
         } else {
             LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
         }
     }
     LOG_INFO_V0("Thread %d: Shutdown complete", thread_idx);
-    return 0;
+    return rc;
 }
 
 // =============================================================================
@@ -606,13 +645,19 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    int32_t timeout_count = 0;
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_exec_states_[i].reg_addr != 0) {
-            platform_deinit_aicore_regs(core_exec_states_[i].reg_addr);
+            if (platform_deinit_aicore_regs(core_exec_states_[i].reg_addr) != 0) {
+                timeout_count++;
+            }
         }
+    }
+    if (timeout_count > 0) {
+        LOG_ERROR("Emergency shutdown: %d cores did not acknowledge exit", timeout_count);
     }
     LOG_WARN("Emergency shutdown complete");
 }
@@ -786,8 +831,9 @@ void SchedulerContext::on_orchestration_done(
         orch_err = sched_->sm_header->orch_error_code.load(std::memory_order_relaxed);
     }
     if (orch_err != PTO2_ERROR_NONE) {
-        emergency_shutdown(runtime);
-        completed_.store(true, std::memory_order_release);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
     }
 
     // Skip core transition on fatal error — cores already shut down above.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -277,7 +277,7 @@ private:
     log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
-        int32_t thread_idx, int32_t idle_iterations
+        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
 #if PTO2_PROFILING
         ,
         uint64_t sched_start_ts

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -372,6 +372,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 
     while (true) {
+        if (completed_.load(std::memory_order_acquire)) {
+            break;
+        }
         bool made_progress = false;
 #if PTO2_PROFILING
         CYCLE_COUNT_START();
@@ -566,7 +569,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 return handle_timeout_exit(
-                    thread_idx, idle_iterations
+                    thread_idx, header, runtime, idle_iterations
 #if PTO2_PROFILING
                     ,
                     l2_perf.sched_start_ts

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -96,8 +96,9 @@ void platform_init_aicore_regs(uint64_t reg_addr);
  * This function sends exit signal and closes fast path control.
  *
  * @param reg_addr  Register base address of the AICore
+ * @return 0 if the core acknowledged exit, non-zero on timeout
  */
-void platform_deinit_aicore_regs(uint64_t reg_addr);
+int32_t platform_deinit_aicore_regs(uint64_t reg_addr);
 
 /**
  * Get physical core count for current platform

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -135,6 +135,14 @@ constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 500000;
 constexpr uint64_t PLATFORM_PROF_SYS_CNT_FREQ = 1000000000;  // 1000 MHz
 
 /**
+ * AICore deinit wait timeout (ticks at PLATFORM_PROF_SYS_CNT_FREQ).
+ * platform_deinit_aicore_regs waits for AICore to acknowledge the exit
+ * signal. If AICore is stuck (STARS-killed op, hardware fault), waiting
+ * forever blocks the AICPU scheduling thread. This timeout bounds the wait.
+ */
+constexpr uint64_t PLATFORM_DEINIT_TIMEOUT_TICKS = PLATFORM_PROF_SYS_CNT_FREQ;  // 1s
+
+/**
  * Timeout duration for performance data collection (seconds)
  */
 constexpr int PLATFORM_PROF_TIMEOUT_SECONDS = 30;

--- a/src/a5/platform/src/aicpu/platform_regs.cpp
+++ b/src/a5/platform/src/aicpu/platform_regs.cpp
@@ -21,6 +21,10 @@
 #include <cstdint>
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
+#include "common/unified_log.h"
+#include "spin_hint.h"
+
+constexpr int32_t AICORE_EXIT_ACK_SPIN_LIMIT = 100000;
 
 static uint64_t g_platform_regs = 0;
 
@@ -33,15 +37,22 @@ void platform_init_aicore_regs(uint64_t reg_addr) {
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
 }
 
-void platform_deinit_aicore_regs(uint64_t reg_addr) {
+int32_t platform_deinit_aicore_regs(uint64_t reg_addr) {
     // Send exit signal to AICore
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
 
     // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND
-    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {}
+    for (int32_t spin = 0; spin < AICORE_EXIT_ACK_SPIN_LIMIT; spin++) {
+        if (read_reg(reg_addr, RegId::COND) == AICORE_EXITED_VALUE) {
+            // Initialize task dispatch register to idle state
+            write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
+            return 0;
+        }
+        SPIN_WAIT_HINT();
+    }
 
-    // Initialize task dispatch register to idle state
-    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
+    LOG_ERROR("Timed out waiting for AICore exit ack at reg_addr=0x%lx", static_cast<unsigned long>(reg_addr));
+    return -1;
 }
 
 uint32_t platform_get_physical_cores_count() {

--- a/src/a5/platform/src/aicpu/platform_regs.cpp
+++ b/src/a5/platform/src/aicpu/platform_regs.cpp
@@ -19,12 +19,11 @@
  */
 
 #include <cstdint>
+#include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "spin_hint.h"
-
-constexpr int32_t AICORE_EXIT_ACK_SPIN_LIMIT = 100000;
 
 static uint64_t g_platform_regs = 0;
 
@@ -41,18 +40,19 @@ int32_t platform_deinit_aicore_regs(uint64_t reg_addr) {
     // Send exit signal to AICore
     write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICORE_EXIT_SIGNAL);
 
-    // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND
-    for (int32_t spin = 0; spin < AICORE_EXIT_ACK_SPIN_LIMIT; spin++) {
-        if (read_reg(reg_addr, RegId::COND) == AICORE_EXITED_VALUE) {
-            // Initialize task dispatch register to idle state
-            write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
-            return 0;
+    // Wait for AICore to acknowledge exit by writing AICORE_EXITED_VALUE to COND.
+    uint64_t t0 = get_sys_cnt_aicpu();
+    while (read_reg(reg_addr, RegId::COND) != AICORE_EXITED_VALUE) {
+        if (get_sys_cnt_aicpu() - t0 > PLATFORM_DEINIT_TIMEOUT_TICKS) {
+            LOG_ERROR("Timed out waiting for AICore exit ack at reg_addr=0x%lx", static_cast<unsigned long>(reg_addr));
+            return -1;
         }
         SPIN_WAIT_HINT();
     }
 
-    LOG_ERROR("Timed out waiting for AICore exit ack at reg_addr=0x%lx", static_cast<unsigned long>(reg_addr));
-    return -1;
+    // Initialize task dispatch register to idle state
+    write_reg(reg_addr, RegId::DATA_MAIN_BASE, AICPU_IDLE_TASK_ID);
+    return 0;
 }
 
 uint32_t platform_get_physical_cores_count() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -186,6 +186,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
  */
 int32_t AicpuExecutor::run(Runtime *runtime) {
     int32_t thread_idx = thread_idx_++;
+    int32_t run_rc = 0;
     LOG_INFO_V0("Thread %d: Start", thread_idx);
 
     // Orchestrator check
@@ -618,16 +619,21 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         } else {
             sched_ctx_.bind_runtime(rt);
             int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
-            LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+            if (completed < 0) {
+                LOG_ERROR("Thread %d: Scheduler failed with rc=%d", thread_idx, completed);
+                run_rc = completed;
+            } else {
+                LOG_INFO_V0("Thread %d: Executed %d tasks from runtime", thread_idx, completed);
+            }
         }
     }
 
     // Always shutdown AICore — even if sched_ctx_.completed_ was already true.
     // platform_deinit_aicore_regs is idempotent; orchestrator threads have
     // core_trackers_[thread_idx].core_num() == 0 so they skip the loop harmlessly.
-    auto rc = sched_ctx_.shutdown(thread_idx);
-    if (rc != 0) {
-        return rc;
+    int32_t shutdown_rc = sched_ctx_.shutdown(thread_idx);
+    if (shutdown_rc != 0 && run_rc == 0) {
+        run_rc = shutdown_rc;
     }
 
     LOG_INFO_V0("Thread %d: Completed", thread_idx);
@@ -649,7 +655,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         }
     }
 
-    return 0;
+    return run_rc;
 }
 
 void AicpuExecutor::deinit(Runtime *runtime) {
@@ -723,7 +729,6 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     int32_t rc = g_aicpu_executor.run(runtime);
     if (rc != 0) {
         LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
-        return rc;
     }
 
     int32_t runtime_rc = read_runtime_status(runtime);
@@ -737,6 +742,10 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
     if (runtime_rc != 0) {
         LOG_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);
         return runtime_rc;
+    }
+
+    if (rc != 0) {
+        return rc;
     }
 
     LOG_INFO_V0("%s", "aicpu_execute: Kernel execution completed successfully");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -213,7 +213,10 @@ static bool append_fanin_or_fail(
     }
 
     PTO2FaninPool &fanin_pool = fanin_builder->spill_pool;
-    fanin_pool.ensure_space(orch->sm_header->rings[ring_id], 1);
+    if (!fanin_pool.ensure_space(orch->sm_header->rings[ring_id], 1)) {
+        orch_mark_fatal(orch, PTO2_ERROR_DEP_POOL_OVERFLOW);
+        return false;
+    }
     int32_t spill_idx = fanin_pool.top;
     PTO2FaninSpillEntry *entry = fanin_pool.alloc();
     if (entry == nullptr) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -20,9 +20,16 @@
 #include "pto_ring_buffer.h"
 #include <inttypes.h>
 #include <string.h>
-#include <stdlib.h>  // for exit()
 #include "common/unified_log.h"
 #include "scheduler/pto_scheduler.h"
+
+static void latch_pool_error(std::atomic<int32_t> *error_code_ptr, int32_t error_code) {
+    if (error_code_ptr == nullptr) {
+        return;
+    }
+    int32_t expected = PTO2_ERROR_NONE;
+    error_code_ptr->compare_exchange_strong(expected, error_code, std::memory_order_acq_rel);
+}
 
 // =============================================================================
 // Fanin Spill Pool Implementation
@@ -46,14 +53,14 @@ void PTO2FaninPool::reclaim(PTO2SharedMemoryRingHeader &ring, int32_t sm_last_ta
     reclaim_task_cursor = scan_end;
 }
 
-void PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
-    if (available() >= needed) return;
+bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
+    if (available() >= needed) return true;
 
     int spin_count = 0;
     int32_t prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
     while (available() < needed) {
         reclaim(ring, prev_last_alive);
-        if (available() >= needed) return;
+        if (available() >= needed) return true;
 
         spin_count++;
 
@@ -88,10 +95,12 @@ void PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
             LOG_ERROR("  Compile-time: PTO2_DEP_LIST_POOL_SIZE in pto_runtime2_types.h");
             LOG_ERROR("  Runtime env:  PTO2_RING_DEP_POOL=%d", high_water * 2);
             LOG_ERROR("========================================");
-            exit(1);
+            latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
+            return false;
         }
         SPIN_WAIT_HINT();
     }
+    return true;
 }
 
 // =============================================================================
@@ -107,14 +116,14 @@ void PTO2DepListPool::reclaim(PTO2SharedMemoryRingHeader &ring, int32_t sm_last_
     }
 }
 
-void PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
-    if (available() >= needed) return;
+bool PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed) {
+    if (available() >= needed) return true;
 
     int spin_count = 0;
     int32_t prev_last_alive = ring.fc.last_task_alive.load(std::memory_order_acquire);
     while (available() < needed) {
         reclaim(ring, prev_last_alive);
-        if (available() >= needed) return;
+        if (available() >= needed) return true;
 
         spin_count++;
 
@@ -150,8 +159,10 @@ void PTO2DepListPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t nee
             LOG_ERROR("  Compile-time: PTO2_DEP_LIST_POOL_SIZE in pto_runtime2_types.h");
             LOG_ERROR("  Runtime env:  PTO2_RING_DEP_POOL=%d", high_water * 2);
             LOG_ERROR("========================================");
-            exit(1);
+            latch_pool_error(error_code_ptr, PTO2_ERROR_DEP_POOL_OVERFLOW);
+            return false;
         }
         SPIN_WAIT_HINT();
     }
+    return true;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -392,7 +392,7 @@ struct PTO2FaninPool {
 
     void reclaim(PTO2SharedMemoryRingHeader &ring, int32_t sm_last_task_alive);
 
-    void ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
 
     PTO2FaninSpillEntry *alloc() {
         int32_t used = top - tail;
@@ -570,7 +570,7 @@ struct PTO2DepListPool {
      * Ensure dep pool for a specific ring has at least `needed` entries available.
      * Spin-waits for reclamation if under pressure. Detects deadlock if no progress.
      */
-    void ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
+    bool ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t needed);
 
     /**
      * Allocate a single entry from the pool (single-thread per pool instance)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -129,9 +129,9 @@ struct alignas(PTO2_ALIGN_SIZE) PTO2SharedMemoryHeader {
 
     // Scheduler error state (Scheduler → Host, independent of orchestrator)
     // Written by scheduler threads on timeout; read by orchestrator and host.
-    std::atomic<int32_t> sched_error_bitmap;  // Bit X set = thread X had error
-    std::atomic<int32_t> sched_error_code;    // Last scheduler error code (last-writer-wins)
-    std::atomic<int32_t> sched_error_thread;  // Thread index of last error writer
+    std::atomic<uint32_t> sched_error_bitmap;  // Bit X set = thread X had error
+    std::atomic<int32_t> sched_error_code;     // Last scheduler error code (last-writer-wins)
+    std::atomic<int32_t> sched_error_thread;   // Thread index of last error writer
 };
 
 static_assert(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -29,12 +29,25 @@
 // Cold-path helpers for the main dispatch loop (noinline to reduce hot-loop icache)
 // =============================================================================
 
+static void latch_scheduler_error(PTO2SharedMemoryHeader *header, int32_t thread_idx, int32_t error_code) {
+    if (header == nullptr || error_code == PTO2_ERROR_NONE) {
+        return;
+    }
+    int32_t expected = PTO2_ERROR_NONE;
+    if (header->sched_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
+        header->sched_error_thread.store(thread_idx, std::memory_order_release);
+    }
+    if (thread_idx >= 0 && thread_idx < 32) {
+        header->sched_error_bitmap.fetch_or(1U << static_cast<uint32_t>(thread_idx), std::memory_order_acq_rel);
+    }
+}
+
 LoopAction SchedulerContext::handle_orchestrator_exit(
     int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t &task_count
 ) {
-    bool orch_done = orchestrator_done_;
-    if (!orch_done) return LoopAction::NONE;
-
+    if (completed_.load(std::memory_order_acquire)) {
+        return LoopAction::BREAK_LOOP;
+    }
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
         LOG_ERROR(
@@ -42,10 +55,20 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
             "completed_tasks=%d, total_tasks=%d",
             thread_idx, orch_err, completed_tasks_.load(std::memory_order_relaxed), total_tasks_
         );
-        emergency_shutdown(runtime);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
+        return LoopAction::BREAK_LOOP;
+    }
+    int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
+    if (sched_err != PTO2_ERROR_NONE) {
+        LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
         completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
+
+    bool orch_done = orchestrator_done_;
+    if (!orch_done) return LoopAction::NONE;
 
     task_count = total_tasks_;
     if (task_count > 0 && completed_tasks_.load(std::memory_order_relaxed) >= task_count) {
@@ -76,10 +99,20 @@ LoopAction SchedulerContext::handle_core_transition(bool &cores_released) {
 
 LoopAction
 SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime) {
+    if (completed_.load(std::memory_order_acquire)) {
+        return LoopAction::BREAK_LOOP;
+    }
     int32_t orch_err = header->orch_error_code.load(std::memory_order_acquire);
     if (orch_err != PTO2_ERROR_NONE) {
         LOG_ERROR("Thread %d: Fatal error detected (code=%d), sending EXIT_SIGNAL to all cores", thread_idx, orch_err);
-        emergency_shutdown(runtime);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
+        return LoopAction::BREAK_LOOP;
+    }
+    int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
+    if (sched_err != PTO2_ERROR_NONE) {
+        LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
         completed_.store(true, std::memory_order_release);
         return LoopAction::BREAK_LOOP;
     }
@@ -167,13 +200,17 @@ void SchedulerContext::log_stall_diagnostics(
 }
 
 int32_t SchedulerContext::handle_timeout_exit(
-    int32_t thread_idx, int32_t idle_iterations
+    int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
 #if PTO2_PROFILING
     ,
     uint64_t sched_start_ts
 #endif
 ) {
     LOG_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+    latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
+    if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+        emergency_shutdown(runtime);
+    }
 #if PTO2_PROFILING
     uint64_t sched_timeout_ts = get_sys_cnt_aicpu();
     LOG_INFO_V9(
@@ -182,7 +219,7 @@ int32_t SchedulerContext::handle_timeout_exit(
         cycles_to_us(sched_timeout_ts - sched_start_ts)
     );
 #endif
-    return -1;
+    return -PTO2_ERROR_SCHEDULER_TIMEOUT;
 }
 
 #if PTO2_PROFILING
@@ -358,17 +395,21 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 #endif
 
     LOG_INFO_V0("Thread %d: Shutting down %d cores", thread_idx, core_num);
+    int32_t rc = 0;
     for (int32_t i = 0; i < core_num; i++) {
         int32_t core_id = cores[i];
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
         if (reg_addr != 0) {
-            platform_deinit_aicore_regs(reg_addr);
+            if (platform_deinit_aicore_regs(reg_addr) != 0) {
+                LOG_ERROR("Thread %d: Core %d shutdown timed out", thread_idx, core_id);
+                rc = -1;
+            }
         } else {
             LOG_ERROR("Thread %d: Core %d has invalid register address", thread_idx, core_id);
         }
     }
     LOG_INFO_V0("Thread %d: Shutdown complete", thread_idx);
-    return 0;
+    return rc;
 }
 
 // =============================================================================
@@ -603,13 +644,19 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
     Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    int32_t timeout_count = 0;
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake *hank = &all_handshakes[i];
         OUT_OF_ORDER_STORE_BARRIER();
         hank->aicpu_regs_ready = 1;
         if (core_exec_states_[i].reg_addr != 0) {
-            platform_deinit_aicore_regs(core_exec_states_[i].reg_addr);
+            if (platform_deinit_aicore_regs(core_exec_states_[i].reg_addr) != 0) {
+                timeout_count++;
+            }
         }
+    }
+    if (timeout_count > 0) {
+        LOG_ERROR("Emergency shutdown: %d cores did not acknowledge exit", timeout_count);
     }
     LOG_WARN("Emergency shutdown complete");
 }
@@ -775,8 +822,9 @@ void SchedulerContext::on_orchestration_done(
         orch_err = sched_->sm_header->orch_error_code.load(std::memory_order_relaxed);
     }
     if (orch_err != PTO2_ERROR_NONE) {
-        emergency_shutdown(runtime);
-        completed_.store(true, std::memory_order_release);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
     }
 
     // Skip core transition on fatal error — cores already shut down above.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -33,6 +33,7 @@ static void latch_scheduler_error(PTO2SharedMemoryHeader *header, int32_t thread
     if (header == nullptr || error_code == PTO2_ERROR_NONE) {
         return;
     }
+    // The first error code/thread pair wins; the bitmap cumulatively records all reporting threads.
     int32_t expected = PTO2_ERROR_NONE;
     if (header->sched_error_code.compare_exchange_strong(expected, error_code, std::memory_order_acq_rel)) {
         header->sched_error_thread.store(thread_idx, std::memory_order_release);
@@ -63,7 +64,9 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
     int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
     if (sched_err != PTO2_ERROR_NONE) {
         LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
-        completed_.store(true, std::memory_order_release);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
         return LoopAction::BREAK_LOOP;
     }
 
@@ -113,7 +116,9 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
     int32_t sched_err = header->sched_error_code.load(std::memory_order_acquire);
     if (sched_err != PTO2_ERROR_NONE) {
         LOG_ERROR("Thread %d: Scheduler fatal error detected (code=%d)", thread_idx, sched_err);
-        completed_.store(true, std::memory_order_release);
+        if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+            emergency_shutdown(runtime);
+        }
         return LoopAction::BREAK_LOOP;
     }
     return LoopAction::NONE;
@@ -400,8 +405,9 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
         int32_t core_id = cores[i];
         uint64_t reg_addr = core_exec_states_[core_id].reg_addr;
         if (reg_addr != 0) {
+            // Timeout means AICore is unresponsive. Log and continue deiniting remaining cores.
             if (platform_deinit_aicore_regs(reg_addr) != 0) {
-                LOG_ERROR("Thread %d: Core %d shutdown timed out", thread_idx, core_id);
+                LOG_ERROR("Thread %d: Core %d deinit timed out", thread_idx, core_id);
                 rc = -1;
             }
         } else {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -281,7 +281,7 @@ private:
     log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
-        int32_t thread_idx, int32_t idle_iterations
+        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
 #if PTO2_PROFILING
         ,
         uint64_t sched_start_ts

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -391,6 +391,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 
     while (true) {
+        if (completed_.load(std::memory_order_acquire)) {
+            break;
+        }
         bool made_progress = false;
 #if PTO2_PROFILING
         CYCLE_COUNT_START();
@@ -581,7 +584,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
             if (idle_iterations > MAX_IDLE_ITERATIONS) {
                 return handle_timeout_exit(
-                    thread_idx, idle_iterations
+                    thread_idx, header, runtime, idle_iterations
 #if PTO2_PROFILING
                     ,
                     l2_perf.sched_start_ts

--- a/tests/ut/cpp/a2a3/test_dep_list_pool.cpp
+++ b/tests/ut/cpp/a2a3/test_dep_list_pool.cpp
@@ -79,6 +79,20 @@ TEST_F(DepListPoolTest, OverflowDetection) {
     EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
 }
 
+TEST_F(DepListPoolTest, EnsureSpaceDeadlockReturnsFalseAndLatchesError) {
+    for (int i = 0; i < POOL_CAP; i++) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    PTO2SharedMemoryRingHeader ring{};
+    ring.fc.init();
+    ring.fc.current_task_index.store(POOL_CAP + 1, std::memory_order_release);
+    ring.fc.last_task_alive.store(0, std::memory_order_release);
+
+    EXPECT_FALSE(pool.ensure_space(ring, 1));
+    EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
+}
+
 // Prepend builds LIFO linked list: verify each slot_state pointer.
 TEST_F(DepListPoolTest, PrependChainCorrectness) {
     PTO2TaskSlotState slots[5]{};

--- a/tests/ut/cpp/a2a3/test_fanin_pool.cpp
+++ b/tests/ut/cpp/a2a3/test_fanin_pool.cpp
@@ -86,6 +86,20 @@ TEST_F(FaninPoolTest, OverflowReturnsNullptr) {
     EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
 }
 
+TEST_F(FaninPoolTest, EnsureSpaceDeadlockReturnsFalseAndLatchesError) {
+    for (int i = 0; i < POOL_CAP; i++) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    PTO2SharedMemoryRingHeader ring{};
+    ring.fc.init();
+    ring.fc.current_task_index.store(POOL_CAP + 1, std::memory_order_release);
+    ring.fc.last_task_alive.store(0, std::memory_order_release);
+
+    EXPECT_FALSE(pool.ensure_space(ring, 1));
+    EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
+}
+
 TEST_F(FaninPoolTest, AdvanceTailFreesSpace) {
     for (int i = 0; i < 10; i++) {
         pool.alloc();

--- a/tests/ut/cpp/a5/test_dep_list_pool.cpp
+++ b/tests/ut/cpp/a5/test_dep_list_pool.cpp
@@ -79,6 +79,20 @@ TEST_F(DepListPoolTest, OverflowDetection) {
     EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
 }
 
+TEST_F(DepListPoolTest, EnsureSpaceDeadlockReturnsFalseAndLatchesError) {
+    for (int i = 0; i < POOL_CAP; i++) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    PTO2SharedMemoryRingHeader ring{};
+    ring.fc.init();
+    ring.fc.current_task_index.store(POOL_CAP + 1, std::memory_order_release);
+    ring.fc.last_task_alive.store(0, std::memory_order_release);
+
+    EXPECT_FALSE(pool.ensure_space(ring, 1));
+    EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
+}
+
 // Prepend builds LIFO linked list: verify each slot_state pointer.
 TEST_F(DepListPoolTest, PrependChainCorrectness) {
     PTO2TaskSlotState slots[5]{};

--- a/tests/ut/cpp/a5/test_fanin_pool.cpp
+++ b/tests/ut/cpp/a5/test_fanin_pool.cpp
@@ -86,6 +86,20 @@ TEST_F(FaninPoolTest, OverflowReturnsNullptr) {
     EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
 }
 
+TEST_F(FaninPoolTest, EnsureSpaceDeadlockReturnsFalseAndLatchesError) {
+    for (int i = 0; i < POOL_CAP; i++) {
+        ASSERT_NE(pool.alloc(), nullptr);
+    }
+
+    PTO2SharedMemoryRingHeader ring{};
+    ring.fc.init();
+    ring.fc.current_task_index.store(POOL_CAP + 1, std::memory_order_release);
+    ring.fc.last_task_alive.store(0, std::memory_order_release);
+
+    EXPECT_FALSE(pool.ensure_space(ring, 1));
+    EXPECT_EQ(error_code.load(), PTO2_ERROR_DEP_POOL_OVERFLOW);
+}
+
 TEST_F(FaninPoolTest, AdvanceTailFreesSpace) {
     for (int i = 0; i < 10; i++) {
         pool.alloc();


### PR DESCRIPTION
## Summary

This PR handles the first layer of #729: when PTO2 detects a fanin/dep pool fatal condition, runtime should report the original fatal status and exit cleanly instead of getting stuck in an unrecoverable spin or secondary failure path.

Changes:
- Make fanin/dep pool `ensure_space()` return `false` and latch `PTO2_ERROR_DEP_POOL_OVERFLOW` instead of calling `exit(1)`.
- Stop orchestrator submission when fanin spill allocation cannot make progress.
- Teach scheduler threads to observe orchestrator/scheduler fatal state before orchestration completes, perform one emergency shutdown, and return the latched runtime status.
- Preserve AICore deinit timeout handling and propagate shutdown failures instead of hiding them.
- Add C++ unit coverage for deadlocked `ensure_space()` returning false and latching the error.

This does not attempt to fix the second-layer root cause from #729: over-broad whole-tensor dependencies after disjoint view writes. That still needs codegen/runtime region precision or backpressure work.

## Validation

- `git diff --check`
- `source .venv/bin/activate && python simpler_setup/build_runtimes.py --platforms a2a3sim a5sim`
- `cmake -S tests/ut/cpp -B temp/ut_cpp_build && cmake --build temp/ut_cpp_build --target test_fanin_pool test_dep_list_pool --parallel 8 && ctest --test-dir temp/ut_cpp_build -R 'test_(fanin|dep_list)_pool' --output-on-failure`
- `source .venv/bin/activate && python tests/lint/clang_tidy.py --diff-base origin/main`
- From `pypto-lib`, after reinstalling this runtime branch into that local venv: `timeout 180s env PTOAS_ROOT=/home/bot/code/PTO/ptoas-bin PYTHONPATH=.:models/deepseek/v4 python models/deepseek/v4/repro_fanin_spill_pool_deadlock.py -p a2a3sim`
  - Expected fatal was reported as `orch_error_code=4`, Python raised `RuntimeError: run_runtime failed with code -4`, and the process returned before timeout.

## Notes

`pre-commit run --all-files` is currently blocked locally by unrelated existing repository issues: missing copyright headers in files outside this diff and markdownlint table style issues in existing docs. Running `pre-commit --files` on this diff also hit a local clang-tidy compile-database cache race; the direct `clang_tidy.py --diff-base origin/main` gate passes.
