### PR TITLE
Refactor: alias runtime MAX_TENSOR_ARGS / MAX_SCALAR_ARGS to common CORE_*

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -37,12 +37,13 @@
 #include "tensor.h"
 #include "tensor_arg.h"
 
-// Task arguments
-#define MAX_TENSOR_ARGS 16         // Maximum tensor arguments per task
-#define MAX_SCALAR_ARGS 32         // Maximum scalar arguments per task
-#define PTO2_MAX_OUTPUTS 16        // Maximum outputs per task
-#define PTO2_MAX_INPUTS 16         // Maximum inputs per task
-#define PTO2_MAX_INOUTS 8          // Maximum in-out args per task
+// Task arguments — alias the common CORE_MAX_* constants (single source of
+// truth in src/common/task_interface/arg_direction.h, transitively included
+// via task_args.h above). Keeping the MAX_TENSOR_ARGS / MAX_SCALAR_ARGS names
+// because they are referenced widely in this runtime (pto_runtime2_types.h,
+// pto2_dispatch_payload.h, intrinsic.h comments).
+#define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
+#define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 #define PTO2_MAX_EXPLICIT_DEPS 16  // Maximum explicit task dependencies per task
 
 typedef enum {
@@ -96,7 +97,7 @@ public:
 
     /// Runtime-internal: append one materialized output Tensor.
     void materialize_output(const Tensor &tensor) {
-        always_assert(output_count_ < PTO2_MAX_OUTPUTS);
+        always_assert(output_count_ < MAX_TENSOR_ARGS);
         tensors_[output_count_++] = &tensor;
     }
 
@@ -107,7 +108,9 @@ public:
 private:
     PTO2TaskId task_id_;
     uint32_t output_count_;
-    const Tensor *tensors_[PTO2_MAX_OUTPUTS];
+    // Upper bound: a task cannot have more outputs than total tensor args
+    // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
+    const Tensor *tensors_[MAX_TENSOR_ARGS];
 };
 
 using TaskSubmitResult = TaskOutputTensors;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -39,12 +39,13 @@
 #include "tensor.h"
 #include "tensor_arg.h"
 
-// Task arguments
-#define MAX_TENSOR_ARGS 16         // Maximum tensor arguments per task
-#define MAX_SCALAR_ARGS 32         // Maximum scalar arguments per task
-#define PTO2_MAX_OUTPUTS 16        // Maximum outputs per task
-#define PTO2_MAX_INPUTS 16         // Maximum inputs per task
-#define PTO2_MAX_INOUTS 8          // Maximum in-out args per task
+// Task arguments — alias the common CORE_MAX_* constants (single source of
+// truth in src/common/task_interface/arg_direction.h, transitively included
+// via task_args.h above). Keeping the MAX_TENSOR_ARGS / MAX_SCALAR_ARGS names
+// because they are referenced widely in this runtime (pto_runtime2_types.h,
+// pto2_dispatch_payload.h, intrinsic.h comments).
+#define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
+#define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 #define PTO2_MAX_EXPLICIT_DEPS 16  // Maximum explicit task dependencies per task
 
 typedef enum {
@@ -98,7 +99,7 @@ public:
 
     /// Runtime-internal: append one materialized output Tensor.
     void materialize_output(const Tensor &tensor) {
-        always_assert(output_count_ < PTO2_MAX_OUTPUTS);
+        always_assert(output_count_ < MAX_TENSOR_ARGS);
         tensors_[output_count_++] = &tensor;
     }
 
@@ -109,7 +110,9 @@ public:
 private:
     PTO2TaskId task_id_;
     uint32_t output_count_;
-    const Tensor *tensors_[PTO2_MAX_OUTPUTS];
+    // Upper bound: a task cannot have more outputs than total tensor args
+    // (every OUTPUT/OUTPUT_EXISTING slot is one of the Arg's tensor slots).
+    const Tensor *tensors_[MAX_TENSOR_ARGS];
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`src/{a5,a2a3}/runtime/tensormap_and_ringbuffer/runtime/pto_types.h`
re-defined `MAX_TENSOR_ARGS=16` and `MAX_SCALAR_ARGS=32` as standalone
macros, but those are the same numeric values as
`CORE_MAX_TENSOR_ARGS` / `CORE_MAX_SCALAR_ARGS` in
`src/common/task_interface/arg_direction.h`. The duplication is
semantically real (Arg's tensor capacity is exactly the maximum a
single kernel can accept), so the risk was silent drift if anyone
bumped the common constant without remembering to update both
runtimes.

Alias the runtime names to the common constants:

```cpp
#define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
#define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
```

`arg_direction.h` is already transitively included via `task_args.h`,
so no new `#include` is required. The runtime keeps its short
`MAX_TENSOR_ARGS` / `MAX_SCALAR_ARGS` spellings throughout
(`pto_runtime2_types.h`, `pto2_dispatch_payload.h`, error message
strings, etc.) — only the definition is rerouted.

## Dead-macro cleanup (same file)

While the section was open, drop three unused / redundant macros:

- `PTO2_MAX_INPUTS=16` — no references outside its own `#define`
- `PTO2_MAX_INOUTS=8` — no references outside its own `#define`
- `PTO2_MAX_OUTPUTS=16` — only used in `TaskOutputTensors`; outputs are
  a strict subset of an Arg's tensor slots (every OUTPUT /
  OUTPUT_EXISTING slot is one of `Arg::tensors_`), so the same
  `MAX_TENSOR_ARGS` bound applies. Inline at the two use sites with a
  short comment explaining the subset relationship.

## Testing

- [x] `pre-commit run` on changed files (clang-tidy / clang-format /
      cpplint all pass)
- [x] a5sim `mixed_example` (20 tasks, RTOL=1e-3 golden check) PASSED
- [x] a2a3sim `test_l3_dependency` PASSED
- [ ] Linux CI green