### PR TITLE
Add: dep_gen capture (SubmitTrace) for a2a3 tensormap_and_ringbuffer

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -144,6 +144,12 @@ def pytest_addoption(parser):
     )
     parser.addoption("--dump-tensor", action="store_true", default=False, help="Dump per-task tensor I/O at runtime")
     parser.addoption(
+        "--enable-dep-gen",
+        action="store_true",
+        default=False,
+        help="Enable dep_gen capture (SubmitTrace ring, first round only)",
+    )
+    parser.addoption(
         "--enable-pmu",
         nargs="?",
         const=2,

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -580,6 +580,15 @@ NB_MODULE(_task_interface, m) {
         )
         .def_rw("enable_pmu", &CallConfig::enable_pmu)
         .def_prop_rw(
+            "enable_dep_gen",
+            [](const CallConfig &c) {
+                return static_cast<bool>(c.enable_dep_gen);
+            },
+            [](CallConfig &c, bool v) {
+                c.enable_dep_gen = v ? 1 : 0;
+            }
+        )
+        .def_prop_rw(
             "output_prefix",
             [](const CallConfig &c) -> std::string {
                 return std::string(c.output_prefix, ::strnlen(c.output_prefix, sizeof(c.output_prefix)));
@@ -600,7 +609,7 @@ NB_MODULE(_task_interface, m) {
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
                << ", enable_l2_swimlane=" << (self.enable_l2_swimlane ? "True" : "False")
                << ", enable_dump_tensor=" << (self.enable_dump_tensor ? "True" : "False")
-               << ", enable_pmu=" << self.enable_pmu;
+               << ", enable_pmu=" << self.enable_pmu << ", enable_dep_gen=" << (self.enable_dep_gen ? "True" : "False");
             if (self.output_prefix_set()) {
                 os << ", output_prefix='" << self.output_prefix << "'";
             }

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -109,10 +109,11 @@ _OFF_ERROR = 4
 _OFF_CALLABLE = 8
 _OFF_CONFIG = 16
 # Packed CallConfig wire layout — must match call_config.h byte for byte:
-# 5 int32 (block_dim, aicpu_thread_num, enable_l2_swimlane, enable_dump_tensor,
-# enable_pmu) + 1024-byte NUL-terminated output_prefix. Log config travels
-# separately via ChipWorker.init(log_level, log_info_v) — not on per-task wire.
-_CFG_FMT = struct.Struct("=iiiii1024s")
+# 6 int32 (block_dim, aicpu_thread_num, enable_l2_swimlane, enable_dump_tensor,
+# enable_pmu, enable_dep_gen) + 1024-byte NUL-terminated output_prefix. Log
+# config travels separately via ChipWorker.init(log_level, log_info_v) — not
+# on per-task wire.
+_CFG_FMT = struct.Struct("=iiiiii1024s")
 # Args region starts after CONFIG, rounded up to 8 bytes so the first
 # ContinuousTensor.data (uint64_t at OFF_ARGS+8) is 8-byte aligned, avoiding
 # SIGBUS on strict-alignment platforms (aarch64 atomics, some ARM cores).
@@ -549,13 +550,14 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
 
 def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     """Reconstruct a CallConfig from the unified mailbox layout."""
-    block_dim, aicpu_tn, swl, dt, pmu, prefix_bytes = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
+    block_dim, aicpu_tn, swl, dt, pmu, dep_gen, prefix_bytes = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
     cfg = CallConfig()
     cfg.block_dim = block_dim
     cfg.aicpu_thread_num = aicpu_tn
     cfg.enable_l2_swimlane = bool(swl)
     cfg.enable_dump_tensor = bool(dt)
     cfg.enable_pmu = pmu
+    cfg.enable_dep_gen = bool(dep_gen)
     # NUL-terminated C string in a 1024-byte field.
     cfg.output_prefix = prefix_bytes.split(b"\x00", 1)[0].decode("utf-8")
     return cfg

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -629,6 +629,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     enable_l2_swimlane,
     enable_dump_tensor,
     enable_pmu,
+    enable_dep_gen,
 ):
     """Execute a pre-filtered list of cases for one class (layers 5-6).
 
@@ -638,7 +639,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     """
     cls_name = type(cls_inst).__name__
     callable_spec = getattr(type(cls_inst), "CALLABLE", None)
-    diagnostics_on = enable_l2_swimlane or enable_dump_tensor or enable_pmu
+    diagnostics_on = enable_l2_swimlane or enable_dump_tensor or enable_pmu or enable_dep_gen
     for case in cases:
         case_label = f"{cls_name}_{case['name']}"
         # Per-case directory the runtime writes into. Required (non-empty) when
@@ -656,6 +657,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
                 enable_l2_swimlane=enable_l2_swimlane,
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
+                enable_dep_gen=enable_dep_gen,
                 output_prefix=str(prefix) if diagnostics_on else "",
             )
         finally:
@@ -828,7 +830,14 @@ class SceneTestCase:
         raise ValueError(f"Unsupported level: {self._st_level}")
 
     def _build_config(
-        self, config_dict, enable_l2_swimlane=False, enable_dump_tensor=False, enable_pmu=0, *, output_prefix=""
+        self,
+        config_dict,
+        enable_l2_swimlane=False,
+        enable_dump_tensor=False,
+        enable_pmu=0,
+        enable_dep_gen=False,
+        *,
+        output_prefix="",
     ):
         from simpler.task_interface import CallConfig  # noqa: PLC0415
 
@@ -838,6 +847,7 @@ class SceneTestCase:
         config.enable_l2_swimlane = enable_l2_swimlane
         config.enable_dump_tensor = enable_dump_tensor
         config.enable_pmu = enable_pmu  # 0=disabled, >0=enabled with event type
+        config.enable_dep_gen = enable_dep_gen
         # `output_prefix` is required by CallConfig::validate() whenever any
         # diagnostic flag is enabled. Caller threads it down from the per-case
         # directory built by _build_output_prefix().
@@ -862,7 +872,7 @@ class SceneTestCase:
     # Run + validate
     # ------------------------------------------------------------------
 
-    def _run_and_validate(
+    def _run_and_validate(  # noqa: PLR0913 -- threads CLI diagnostic flags + case context
         self,
         worker,
         callable_obj,
@@ -873,6 +883,7 @@ class SceneTestCase:
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         if self._st_level == 2:
@@ -885,6 +896,7 @@ class SceneTestCase:
                 enable_l2_swimlane=enable_l2_swimlane,
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
+                enable_dep_gen=enable_dep_gen,
                 output_prefix=output_prefix,
             )
         elif self._st_level == 3:
@@ -898,6 +910,7 @@ class SceneTestCase:
                 enable_l2_swimlane=enable_l2_swimlane,
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
+                enable_dep_gen=enable_dep_gen,
                 output_prefix=output_prefix,
             )
 
@@ -911,6 +924,7 @@ class SceneTestCase:
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         params = case.get("params", {})
@@ -953,6 +967,7 @@ class SceneTestCase:
                 enable_l2_swimlane=(enable_l2_swimlane and round_idx == 0),
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
+                enable_dep_gen=(enable_dep_gen and round_idx == 0),
                 output_prefix=output_prefix,
             )
 
@@ -962,7 +977,7 @@ class SceneTestCase:
             if not skip_golden:
                 _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
-    def _run_and_validate_l3(
+    def _run_and_validate_l3(  # noqa: PLR0913 -- threads CLI diagnostic flags + L3 ns context
         self,
         worker,
         compiled_callables,
@@ -973,6 +988,7 @@ class SceneTestCase:
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         # Defensive belt-and-braces: the pytest dispatcher and run_module both
@@ -1023,6 +1039,7 @@ class SceneTestCase:
                 enable_l2_swimlane=(enable_l2_swimlane and round_idx == 0),
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
+                enable_dep_gen=(enable_dep_gen and round_idx == 0),
                 output_prefix=output_prefix,
             )
 
@@ -1051,6 +1068,7 @@ class SceneTestCase:
         enable_l2_swimlane = request.config.getoption("--enable-l2-swimlane", default=False)
         enable_dump_tensor = request.config.getoption("--dump-tensor", default=False)
         enable_pmu = request.config.getoption("--enable-pmu", default=0)
+        enable_dep_gen = request.config.getoption("--enable-dep-gen", default=False)
         if rounds > 1:
             if enable_l2_swimlane:
                 logger.warning("Profiling disabled: --rounds > 1")
@@ -1061,6 +1079,9 @@ class SceneTestCase:
             if enable_pmu:
                 logger.warning("PMU disabled: --rounds > 1")
                 enable_pmu = 0
+            if enable_dep_gen:
+                logger.warning("dep_gen disabled: --rounds > 1")
+                enable_dep_gen = False
 
         cls_name = type(self).__name__
         callable_obj = self.build_callable(st_platform)
@@ -1111,6 +1132,7 @@ class SceneTestCase:
             enable_l2_swimlane=enable_l2_swimlane,
             enable_dump_tensor=enable_dump_tensor,
             enable_pmu=enable_pmu,
+            enable_dep_gen=enable_dep_gen,
         )
 
     # ------------------------------------------------------------------
@@ -1156,6 +1178,11 @@ class SceneTestCase:
             "--enable-l2-swimlane", action="store_true", help="Enable perf swimlane collection (first round only)"
         )
         parser.add_argument("--dump-tensor", action="store_true", help="Dump per-task tensor I/O at runtime")
+        parser.add_argument(
+            "--enable-dep-gen",
+            action="store_true",
+            help="Enable dep_gen capture (SubmitTrace ring, first round only)",
+        )
         parser.add_argument(
             "--enable-pmu",
             nargs="?",
@@ -1224,6 +1251,9 @@ class SceneTestCase:
         if args.rounds > 1 and args.enable_l2_swimlane:
             logger.warning("Profiling disabled: --rounds > 1")
             args.enable_l2_swimlane = False
+        if args.rounds > 1 and args.enable_dep_gen:
+            logger.warning("dep_gen disabled: --rounds > 1")
+            args.enable_dep_gen = False
 
         from .parallel_scheduler import default_max_parallel, device_range_to_list  # noqa: PLC0415
 
@@ -1362,6 +1392,7 @@ class SceneTestCase:
                                 enable_l2_swimlane=args.enable_l2_swimlane,
                                 enable_dump_tensor=args.dump_tensor,
                                 enable_pmu=args.enable_pmu,
+                                enable_dep_gen=args.enable_dep_gen,
                             )
                             print("PASSED")
                         except Exception as e:  # noqa: BLE001
@@ -1402,6 +1433,8 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
         common.append("--enable-l2-swimlane")
     if args.dump_tensor:
         common.append("--dump-tensor")
+    if args.enable_dep_gen:
+        common.append("--enable-dep-gen")
     if args.build:
         common.append("--build")
 

--- a/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector_aicpu.h
+ * @brief AICPU-side dep_gen (SubmitTrace) capture interface
+ *
+ * Lifecycle (called from aicpu_executor.cpp + pto_orchestrator.cpp):
+ *   dep_gen_aicpu_set_orch_thread_idx() — record which AICPU thread runs the
+ *                                         orchestrator (used to select the
+ *                                         per-thread ready_queue on flush).
+ *   dep_gen_aicpu_init()                — pop the initial DepGenBuffer from
+ *                                         the (single) instance's free_queue.
+ *   [submit_task loop]
+ *     dep_gen_aicpu_record_submit()     — append one DepGenRecord; rotate
+ *                                         buffer when full.
+ *   dep_gen_aicpu_flush()               — push current buffer (if non-empty)
+ *                                         to ready_queue.
+ *   dep_gen_aicpu_finalize()            — clear bookkeeping.
+ *
+ * All-primitive interface (no runtime types in platform header):
+ *   - task_id passed as raw uint64 (PTO2TaskId::raw)
+ *   - tensor data passed via opaque void* pointers (memcpy'd into the
+ *     DEP_GEN_TENSOR_SIZE-byte slot; static_asserted against sizeof(Tensor)
+ *     in the .cpp)
+ *   - explicit_deps passed as uint64*
+ *
+ * No-op when dep_gen is disabled (is_dep_gen_enabled() returns false).
+ */
+
+#ifndef PLATFORM_AICPU_DEP_GEN_COLLECTOR_AICPU_H_
+#define PLATFORM_AICPU_DEP_GEN_COLLECTOR_AICPU_H_
+
+#include <cstdint>
+
+#include "common/dep_gen.h"
+
+extern "C" void set_platform_dep_gen_base(uint64_t dep_gen_data_base);
+extern "C" uint64_t get_platform_dep_gen_base();
+extern "C" void set_dep_gen_enabled(bool enable);
+extern "C" bool is_dep_gen_enabled();
+
+/**
+ * Register the AICPU thread index that hosts the orchestrator. Used to select
+ * the per-thread ready_queue when buffers fill or on flush. Must be called by
+ * aicpu_executor.cpp before any dep_gen_aicpu_record_submit() can fire.
+ *
+ * Mirrors l2_perf_aicpu_set_orch_thread_idx().
+ */
+void dep_gen_aicpu_set_orch_thread_idx(int thread_idx);
+
+/**
+ * Initialize dep_gen capture: pop the initial DepGenBuffer from the (single)
+ * orchestrator instance's free_queue and stash it as the current buffer.
+ *
+ * Pre-conditions:
+ *   - Host has set the data base via set_platform_dep_gen_base()
+ *   - dep_gen is enabled via set_dep_gen_enabled(true)
+ *   - dep_gen_aicpu_set_orch_thread_idx() has been called
+ *
+ * If the free_queue is empty at init (host bug), the function leaves the
+ * current buffer as null and subsequent record_submit calls will bump
+ * dropped_record_count.
+ */
+void dep_gen_aicpu_init();
+
+/**
+ * Append one DepGenRecord for a completed submit_task call. Switches buffer
+ * via the SPSC free_queue / ready_queue protocol when the current buffer is
+ * full. No-op if dep_gen is disabled.
+ *
+ * Tensor handling: for slot i, if tensor_ptrs[i] is non-null, its first
+ * DEP_GEN_TENSOR_SIZE bytes are memcpy'd into record.tensors[i]. If null
+ * (e.g. arg_types[i] == OUTPUT, where the Tensor is materialized later by
+ * the runtime), the slot is left zeroed. Replay decides what to do with
+ * each slot based on arg_types[i].
+ *
+ * @param task_id_raw         PTO2TaskId::raw (the assigned task_id for this submit)
+ * @param in_manual_scope     true iff the submit happened inside a manual scope
+ * @param tensor_count        Number of slots in tensor_ptrs / arg_types (≤ CORE_MAX_TENSOR_ARGS)
+ * @param tensor_ptrs         Per-slot Tensor pointer (nullptr to skip the slot)
+ * @param arg_types           Per-slot TensorArgType (interpreted as raw byte)
+ * @param explicit_dep_count  Number of explicit_deps (≤ DEP_GEN_MAX_EXPLICIT_DEPS)
+ * @param explicit_deps_raw   Per-dep PTO2TaskId::raw
+ */
+void dep_gen_aicpu_record_submit(
+    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw
+);
+
+/**
+ * Push the current (partially-filled) DepGenBuffer to the orchestrator
+ * thread's ready_queue so the host can pick it up. Called once at end of
+ * run, after the orchestrator's last submit.
+ */
+void dep_gen_aicpu_flush();
+
+/**
+ * Clear file-local bookkeeping (current_buf cache, etc.). Called at shutdown.
+ */
+void dep_gen_aicpu_finalize();
+
+#endif  // PLATFORM_AICPU_DEP_GEN_COLLECTOR_AICPU_H_

--- a/src/a2a3/platform/include/common/dep_gen.h
+++ b/src/a2a3/platform/include/common/dep_gen.h
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen.h
+ * @brief dep_gen (SubmitTrace) shared-memory data structures
+ *
+ * Captures the inputs to every Orchestrator::submit_task call into a streaming
+ * ring of DepGenRecord. The host side replays these records offline to
+ * reconstruct the full task dependency graph (deps.json), bypassing the race
+ * window in L2PerfRecord::fanout[] (where an early-finishing producer would
+ * have its record sealed before later-submitted consumers can register).
+ *
+ * Streaming buffer design mirrors PMU / L2Perf / TensorDump (single source of
+ * algorithmic truth in src/a2a3/platform/include/host/profiling_common/profiler_base.h):
+ *
+ *   DepGenFreeQueue    — SPSC: Host pushes free DepGenBuffers, AICPU pops them.
+ *   DepGenBufferState  — Per-instance state: free_queue + current buffer ptr.
+ *   DepGenDataHeader   — Fixed shared-mem header: per-thread ready queues.
+ *   DepGenBuffer       — Fixed-capacity record buffer.
+ *
+ * Single-instance: the orchestrator is one AICPU thread, so the BufferState
+ * array has length 1. Kept array-shaped (vs scalar) for symmetry with PMU /
+ * L2Perf and to match ProfilerBase<DepGenModule>::for_each_instance.
+ *
+ * Tensor data is captured as opaque 128-byte blobs (`DEP_GEN_TENSOR_SIZE`)
+ * matching the runtime Tensor struct size. The AICPU writer
+ * (dep_gen_collector_aicpu.cpp) static_asserts sizeof(Tensor) == 128 against
+ * the runtime headers it imports; the platform shared-memory header stays
+ * runtime-agnostic.
+ */
+
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "arg_direction.h"  // CORE_MAX_TENSOR_ARGS
+#include "common/platform_config.h"
+
+// =============================================================================
+// dep_gen-local capacity constants
+// =============================================================================
+
+/**
+ * Bytes per captured Tensor slot — matches runtime sizeof(Tensor). Verified
+ * in dep_gen_collector_aicpu.cpp via static_assert against the runtime header.
+ * Two cache lines: cache line 1 (lookup hot path) + cache line 2 (offsets).
+ */
+constexpr int DEP_GEN_TENSOR_SIZE = 128;
+
+/**
+ * Max explicit_dep entries per submit. Mirrors runtime PTO2_MAX_EXPLICIT_DEPS;
+ * static_asserted in dep_gen_collector_aicpu.cpp against the runtime header.
+ */
+constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 16;
+
+// =============================================================================
+// DepGenRecord — one captured submit_task call
+// =============================================================================
+
+/**
+ * Bitmask flags for DepGenRecord.flags.
+ */
+enum DepGenRecordFlags : uint32_t {
+    DEP_GEN_FLAG_IN_MANUAL_SCOPE = 1u << 0,  // submit happened inside a manual scope
+};
+
+/**
+ * Per-submit_task capture. Replay reads these to reconstruct the dep graph.
+ *
+ * Layout:
+ *   - task_id, flags, counts, explicit_deps, arg_types in the first cache lines
+ *   - tensors[] (16 × 128 B opaque blobs) at the tail; covers ~64% of the entry
+ *
+ * Total size: 8 + 4 + 4 + 16*8 + 16 + 32 (pad) + 16*128 = 2240 bytes.
+ * Aligned to 64 B → 2240 B (already a multiple of 64). The 32-byte _pad0
+ * pushes the tensors[] array to offset 192 = 3 * 64 so each 128-byte tensor
+ * blob covers exactly two cache lines instead of straddling three.
+ */
+struct DepGenRecord {
+    uint64_t task_id;                                            // PTO2 encoding (ring_id << 32) | local_id
+    uint32_t flags;                                              // DepGenRecordFlags bitmask
+    uint16_t tensor_count;                                       // number of valid Tensor slots
+    uint16_t explicit_dep_count;                                 // number of valid explicit_dep slots
+    uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];           // PTO2TaskId::raw, length = explicit_dep_count
+    uint8_t arg_types[CORE_MAX_TENSOR_ARGS];                     // TensorArgType, length = tensor_count
+    uint8_t _pad0[32];                                           // align tensors[] to 64 B (offset 192)
+    uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DepGenRecord) % 64 == 0, "DepGenRecord must be cache-line aligned");
+static_assert(offsetof(DepGenRecord, tensors) % 64 == 0, "DepGenRecord::tensors[] must start on a cache-line boundary");
+
+// =============================================================================
+// DepGenBuffer — fixed-capacity record container
+// =============================================================================
+
+/**
+ * Fixed-capacity DepGenRecord buffer.
+ * Allocated by Host, pushed into the orchestrator instance's free_queue.
+ *
+ * AICPU writer is the orchestrator thread (single producer); it commits
+ * directly into records[count] without a dual_issue staging slot (PMU's
+ * staging slots exist because AICore reads MMIO and writes them, not us).
+ */
+struct DepGenBuffer {
+    // Header (first 64 bytes) — host copies this alone first to learn count.
+    volatile uint32_t count;  // Number of valid records committed
+    uint32_t _pad0[15];       // Pad count to 64 B; isolates count's cache line.
+
+    // Records (flexible-size, up to PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)
+    DepGenRecord records[PLATFORM_DEP_GEN_RECORDS_PER_BUFFER];
+} __attribute__((aligned(64)));
+
+static_assert(offsetof(DepGenBuffer, records) == 64, "DepGenBuffer header must be exactly 64 bytes");
+
+// =============================================================================
+// SPSC free queue
+// =============================================================================
+
+/**
+ * SPSC lock-free queue for free DepGenBuffer management.
+ *
+ * Producer: Host (DepGenCollector mgmt thread) pushes recycled/new buffers.
+ * Consumer: Device (AICPU orchestrator thread) pops buffers when switching.
+ */
+struct DepGenFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_DEP_GEN_SLOT_COUNT];
+    volatile uint32_t head;  // Consumer read position (Device increments)
+    volatile uint32_t tail;  // Producer write position (Host increments)
+    uint32_t _pad[22];       // Pad to 128 B
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DepGenFreeQueue) == 128, "DepGenFreeQueue must be 128 bytes");
+
+// =============================================================================
+// Per-instance buffer state
+// =============================================================================
+
+/**
+ * Per-instance state for dep_gen.
+ *
+ * Writers:
+ *   free_queue.tail:        Host writes (pushes new/recycled buffers)
+ *   free_queue.head:        Device writes (pops buffers)
+ *   current_buf_ptr:        Device writes (after pop), Host reads
+ *   current_buf_seq:        Device writes (monotonic counter)
+ *   dropped_record_count:   Device writes — submits dropped because free_queue
+ *                           was empty / ready_queue was full / no active buf
+ *   total_record_count:     Device writes — monotonic count of every submit
+ *                           the orchestrator attempted to record (success +
+ *                           dropped)
+ *
+ * Host reads dropped / total at finalize to cross-check:
+ *   collected_on_host + sum(dropped) == sum(total)
+ */
+struct DepGenBufferState {
+    DepGenFreeQueue free_queue;
+    volatile uint64_t current_buf_ptr;
+    volatile uint32_t current_buf_seq;
+    volatile uint32_t dropped_record_count;
+    volatile uint32_t total_record_count;
+    uint32_t _pad[11];
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DepGenBufferState) == 192, "DepGenBufferState must be 192 bytes");
+
+// =============================================================================
+// Ready queue entry
+// =============================================================================
+
+/**
+ * Ready queue entry — when a DepGenBuffer fills, AICPU pushes one of these
+ * onto the per-thread ready queue for host pickup.
+ */
+struct DepGenReadyQueueEntry {
+    uint32_t instance_index;  // Always 0 for dep_gen (single instance)
+    uint32_t _pad0;
+    uint64_t buffer_ptr;  // Device pointer to the full DepGenBuffer
+    uint32_t buffer_seq;
+    uint32_t _pad1;
+} __attribute__((aligned(32)));
+
+static_assert(sizeof(DepGenReadyQueueEntry) == 32, "DepGenReadyQueueEntry must be 32 bytes");
+
+// =============================================================================
+// Top-level shared-memory header
+// =============================================================================
+
+/**
+ * dep_gen data fixed header. Located at the start of dep_gen shared memory.
+ *
+ * Per-thread ready queues (one per AICPU scheduling thread):
+ *   Producer: AICPU thread (adds full DepGenBuffers)
+ *   Consumer: Host DepGenCollector mgmt thread
+ *
+ * Even though dep_gen is single-instance, ready queues are per-thread to
+ * match the ProfilerBase contract (which polls header->queues[q] for q in
+ * [0, num_threads)). The orchestrator currently writes into queue[0].
+ */
+struct DepGenDataHeader {
+    DepGenReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_DEP_GEN_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Host reads (consumer)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // AICPU writes (producer)
+    uint32_t num_instances;                                     // Always 1 for now
+    uint32_t _pad[3];
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// Memory layout helpers
+// =============================================================================
+
+/**
+ * Total bytes for the dep_gen shared-mem region (header + buffer states).
+ * Actual DepGenBuffers are dynamically allocated and tracked by the host.
+ */
+inline size_t calc_dep_gen_shm_size(int num_instances) {
+    return sizeof(DepGenDataHeader) + static_cast<size_t>(num_instances) * sizeof(DepGenBufferState);
+}
+
+inline DepGenDataHeader *get_dep_gen_header(void *base_ptr) { return reinterpret_cast<DepGenDataHeader *>(base_ptr); }
+
+inline DepGenBufferState *get_dep_gen_buffer_state(void *base_ptr, int instance_index) {
+    return reinterpret_cast<DepGenBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(DepGenDataHeader)) +
+           instance_index;
+}
+
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -63,12 +63,15 @@ extern "C" {
  *   tensor dump is unused
  * - pmu_data_base: Written by host platform, read by AICPU platform layer;
  *   zero when PMU is unused
+ * - dep_gen_data_base: Written by host platform, read by AICPU platform layer;
+ *   zero when dep_gen capture is unused
  *
  * enable_profiling_flag bit definitions (umbrella bitmask — "profiling" is
  * the umbrella, each bit is a parallel diagnostics sub-feature):
  * - bit0: tensor dump enabled
  * - bit1: L2 swimlane enabled
  * - bit2: PMU enabled
+ * - bit3: dep_gen capture enabled
  *
  * Field Access Patterns:
  *       - AICPU: receives KernelArgs* via DynTileFwkBackendKernelServer
@@ -84,6 +87,7 @@ struct KernelArgs {
     uint64_t l2_perf_data_base{0};      // L2 perf shared memory base address; use explicit flags to detect enablement
     uint64_t pmu_data_base{0};          // PMU shared memory base address; use explicit flags to detect enablement
     uint64_t pmu_reg_addrs{0};          // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
+    uint64_t dep_gen_data_base{0};      // dep_gen shared memory base address; use explicit flags to detect enablement
     uint64_t aicore_ring_addr{0};       // Device ptr to a uint64_t[num_aicore] table holding each core's
                                         // L2PerfAicoreRing address. AICore kernel entry indexes by block_idx
                                         // and forwards into platform set/get state. 0 when L2 swimlane is off.

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -176,6 +176,7 @@ inline double cycles_to_us(uint64_t cycles) {
 #define PROFILING_FLAG_DUMP_TENSOR (1u << 0)
 #define PROFILING_FLAG_L2_SWIMLANE (1u << 1)
 #define PROFILING_FLAG_PMU (1u << 2)
+#define PROFILING_FLAG_DEP_GEN (1u << 3)
 #define GET_PROFILING_FLAG(flags, bit) ((((uint32_t)(flags)) & ((uint32_t)(bit))) != 0u)
 #define SET_PROFILING_FLAG(flags, bit) ((flags) |= (uint32_t)(bit))
 #define CLEAR_PROFILING_FLAG(flags, bit) ((flags) &= ~((uint32_t)(bit)))
@@ -255,6 +256,39 @@ constexpr int PLATFORM_PMU_READYQUEUE_SIZE = PLATFORM_MAX_CORES * PLATFORM_PMU_B
  * Idle timeout duration for PMU collection (seconds)
  */
 constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
+
+// =============================================================================
+// dep_gen (SubmitTrace) Configuration
+// =============================================================================
+
+/**
+ * Number of DepGenRecord entries per DepGenBuffer.
+ * Each DepGenRecord is ~2.3 KB (16 Tensor blobs + small header), so a buffer
+ * of 32 records is ~74 KB — sized to fit a typical example's submit count
+ * (~100-200) in a few buffers.
+ */
+constexpr int PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32;
+
+/**
+ * SPSC free_queue slot count for dep_gen buffers (Host→Device hand-off depth).
+ */
+constexpr int PLATFORM_DEP_GEN_SLOT_COUNT = 4;
+
+/**
+ * Pre-allocated DepGenBuffer count per orchestrator instance.
+ */
+constexpr int PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE = 4;
+
+/**
+ * Ready queue capacity for dep_gen (per AICPU thread). dep_gen is single-
+ * instance so headroom over BUFFERS_PER_INSTANCE × num_instances is small.
+ */
+constexpr int PLATFORM_DEP_GEN_READYQUEUE_SIZE = PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE * 2;
+
+/**
+ * Idle timeout duration for dep_gen collection (seconds).
+ */
+constexpr int PLATFORM_DEP_GEN_TIMEOUT_SECONDS = 30;
 
 // =============================================================================
 // Register Communication Configuration

--- a/src/a2a3/platform/include/host/dep_gen_collector.h
+++ b/src/a2a3/platform/include/host/dep_gen_collector.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector.h
+ * @brief Host-side dep_gen (SubmitTrace) buffer allocation, streaming
+ *        collection, and raw binary export.
+ *
+ * Architecture:
+ * - BufferPoolManager<DepGenModule>: shared mgmt-thread infrastructure that
+ *   polls the per-thread ready queue, drains the done_queue, and replenishes
+ *   the (single instance's) free_queue from a unified recycled pool.
+ * - DepGenCollector: collector thread pops full DepGenBuffers from the manager
+ *   and appends their DepGenRecords to a binary file (submit_trace.bin).
+ *
+ * Lifecycle:
+ *   init()                       — Allocate header + 1 BufferState + N DepGenBuffers
+ *                                  (pre-fills free_queue; surplus → recycled pool).
+ *                                  Calls set_memory_context() on the base.
+ *   start(tf)                    — Inherited: launches mgmt + poll threads.
+ *   [device execution]
+ *   stop()                       — Inherited: drain queues, join threads.
+ *   reconcile_counters()         — Sanity-check current_buf_ptr is cleared by
+ *                                  AICPU flush, run collected+dropped==total
+ *                                  cross-check. If dropped_record_count > 0,
+ *                                  the host caller skips deps.json emission
+ *                                  (incomplete graph; user gets a warning).
+ *   finalize()                   — Free all device memory, unregister.
+ *
+ * Output format (submit_trace.bin): a fixed-size header followed by a
+ * contiguous stream of DepGenRecord values. Replay (future PR) reads this
+ * back. Layout intentionally trivial (no varint / framing) so the
+ * `sizeof(DepGenRecord)` ABI in `common/dep_gen.h` is the only contract.
+ */
+
+#ifndef SRC_A2A3_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_
+#define SRC_A2A3_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <system_error>
+
+#include "common/dep_gen.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+#include "host/profiling_common/profiler_base.h"
+
+// ---------------------------------------------------------------------------
+// dep_gen Module (drives BufferPoolManager<DepGenModule>)
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal hand-off struct delivered from the mgmt thread to the collector.
+ * thread_index identifies the AICPU thread queue the entry was popped from
+ * (always equal to the orchestrator thread index, since dep_gen is single-
+ * instance — exposed for symmetry with PmuReadyBufferInfo).
+ */
+struct DepGenReadyBufferInfo {
+    uint32_t instance_index;  // Always 0 (single instance)
+    uint32_t thread_index;    // AICPU thread queue index this entry came from
+    void *dev_buffer_ptr;
+    void *host_buffer_ptr;
+    uint32_t buffer_seq;
+};
+
+struct DepGenModule {
+    using DataHeader = DepGenDataHeader;
+    using ReadyEntry = DepGenReadyQueueEntry;
+    using ReadyBufferInfo = ::DepGenReadyBufferInfo;
+    using FreeQueue = DepGenFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_DEP_GEN_SLOT_COUNT;
+    static constexpr const char *kSubsystemName = "DepGenModule";
+
+    /**
+     * Buffers grown by proactive_replenish are batch-allocated up to the
+     * per-instance ceiling minus the slot count.
+     */
+    static constexpr int batch_size(int /*kind*/) {
+        constexpr int kBatch = PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE - PLATFORM_DEP_GEN_SLOT_COUNT;
+        return kBatch < 1 ? 1 : kBatch;
+    }
+
+    static DataHeader *header_from_shm(void *shm) { return get_dep_gen_header(shm); }
+
+    /**
+     * `count` is intentionally NOT reset here — AICPU is the sole writer and
+     * resets it itself on flush/drop/pop.
+     */
+    static std::optional<profiling_common::EntrySite<DepGenModule>>
+    resolve_entry(void *shm, DataHeader * /*header*/, int q, const ReadyEntry &entry) {
+        DepGenBufferState *state = get_dep_gen_buffer_state(shm, static_cast<int>(entry.instance_index));
+        profiling_common::EntrySite<DepGenModule> site;
+        site.kind = 0;
+        site.free_queue = &state->free_queue;
+        site.buffer_size = sizeof(DepGenBuffer);
+        site.info.instance_index = entry.instance_index;
+        site.info.thread_index = static_cast<uint32_t>(q);
+        site.info.dev_buffer_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
+        site.info.host_buffer_ptr = nullptr;  // filled by ProfilerAlgorithms
+        site.info.buffer_seq = entry.buffer_seq;
+        return site;
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void *shm, DataHeader *header, Cb &&cb) {
+        const int n = static_cast<int>(header->num_instances);
+        for (int i = 0; i < n; i++) {
+            DepGenBufferState *state = get_dep_gen_buffer_state(shm, i);
+            cb(/*kind=*/0, &state->free_queue, sizeof(DepGenBuffer));
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Memory operation callbacks (injected by DeviceRunner — same signatures as
+// PmuAlloc/Register/Free, in keeping with subsystem conventions)
+// ---------------------------------------------------------------------------
+
+using DepGenAllocCallback = void *(*)(size_t size, void *user_data);
+using DepGenRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
+using DepGenUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+using DepGenFreeCallback = int (*)(void *dev_ptr, void *user_data);
+
+// ---------------------------------------------------------------------------
+// DepGenCollector
+// ---------------------------------------------------------------------------
+
+class DepGenCollector : public profiling_common::ProfilerBase<DepGenCollector, DepGenModule> {
+public:
+    DepGenCollector() = default;
+    ~DepGenCollector();
+
+    DepGenCollector(const DepGenCollector &) = delete;
+    DepGenCollector &operator=(const DepGenCollector &) = delete;
+
+    static constexpr int kIdleTimeoutSec = PLATFORM_DEP_GEN_TIMEOUT_SECONDS;
+    static constexpr const char *kSubsystemName = "DepGen";
+
+    /**
+     * Allocate dep_gen shared memory and pre-populate the free_queue.
+     *
+     * Allocates a DepGenDataHeader + 1 DepGenBufferState, plus
+     * PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE DepGenBuffers. The first
+     * PLATFORM_DEP_GEN_SLOT_COUNT buffers go directly into the free_queue;
+     * the surplus go into BufferPoolManager's shared recycled pool.
+     *
+     * @param num_threads     Number of AICPU scheduling threads (so the
+     *                        DataHeader sizes its per-thread ready queues)
+     * @param submit_trace_path  Output file path (.bin)
+     * @param alloc_cb        Memory allocation callback
+     * @param register_cb     halHostRegister callback (nullptr in sim)
+     * @param free_cb         Memory free callback
+     * @param user_data       Opaque pointer forwarded to callbacks
+     * @param device_id       Device ID
+     * @return 0 on success, non-zero on failure
+     */
+    int init(
+        int num_threads, const std::string &submit_trace_path, DepGenAllocCallback alloc_cb,
+        DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb, void *user_data, int device_id
+    );
+
+    /**
+     * Device pointer to the DepGenDataHeader. Set kernel_args.dep_gen_data_base
+     * to this after init() so AICPU can find the shared memory via
+     * set_platform_dep_gen_base().
+     */
+    void *get_dep_gen_shm_device_ptr() const { return shm_dev_; }
+
+    /**
+     * Per-buffer callback invoked by ProfilerBase's poll loop. Appends each
+     * DepGenRecord to submit_trace.bin.
+     */
+    void on_buffer_collected(const DepGenReadyBufferInfo &info);
+
+    /**
+     * After stop(): cross-check collected + dropped == total. If dropped > 0,
+     * the host caller skips deps.json emission so users get an incomplete-
+     * graph warning rather than partial data they might mistake for complete.
+     *
+     * @return true iff the run captured a complete trace (no drops, no leftovers).
+     */
+    bool reconcile_counters();
+
+    /**
+     * Free all device memory and close output file. Idempotent.
+     */
+    void finalize(DepGenUnregisterCallback unregister_cb, DepGenFreeCallback free_cb, void *user_data);
+
+    /**
+     * @return true if init() succeeded and finalize() has not run.
+     */
+    bool is_initialized() const { return initialized_; }
+
+    /**
+     * Total DepGenRecords written to submit_trace.bin so far.
+     */
+    uint64_t total_collected() const { return total_collected_; }
+
+private:
+    bool initialized_ = false;
+    int num_threads_ = 0;
+
+    // Shared memory region (DepGenDataHeader + DepGenBufferState[1]).
+    // shm_host_ / device_id_ live on ProfilerBase (set via set_memory_context
+    // in init()).
+    void *shm_dev_ = nullptr;
+    bool shm_registered_ = false;
+    size_t shm_size_ = 0;
+
+    bool buffers_registered_ = false;
+
+    // Binary output. File opened lazily on first record so a run that
+    // produces no records leaves no empty file on disk.
+    std::string submit_trace_path_;
+    std::ofstream out_file_;
+    std::mutex out_mutex_;
+
+    // Running total of records written. Used at reconcile time for the
+    // collected + dropped == device_total cross-check.
+    uint64_t total_collected_ = 0;
+
+    DepGenDataHeader *dep_gen_header() const { return get_dep_gen_header(shm_host_); }
+    DepGenBufferState *dep_gen_state(int idx = 0) const { return get_dep_gen_buffer_state(shm_host_, idx); }
+
+    void ensure_out_open_unlocked();
+    void write_buffer(const void *buf_host_ptr);
+};
+
+/**
+ * Build the SubmitTrace .bin path under the caller-provided per-task
+ * directory. Filename is fixed (no timestamp) — the directory is the
+ * per-task uniqueness boundary, mirroring make_pmu_csv_path().
+ */
+inline std::string make_dep_gen_path(const std::string &output_dir) {
+    std::error_code ec;
+    std::filesystem::create_directories(output_dir, ec);
+    if (ec) {
+        LOG_WARN("Failed to create dep_gen output directory %s: %s", output_dir.c_str(), ec.message().c_str());
+    }
+    return output_dir + "/submit_trace.bin";
+}
+
+#endif  // SRC_A2A3_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -57,6 +57,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/tensor_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pmu_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/dep_gen_collector.cpp"
 )
 if(DEFINED CUSTOM_SOURCE_DIRS)
     foreach(SRC_DIR ${CUSTOM_SOURCE_DIRS})

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -563,6 +563,9 @@ int DeviceRunner::run(
     if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
+    if (enable_dep_gen_) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DEP_GEN);
+    }
     kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
 
     for (int i = 0; i < num_aicore; i++) {
@@ -617,6 +620,14 @@ int DeviceRunner::run(
         }
     }
 
+    if (enable_dep_gen_) {
+        rc = init_dep_gen(launch_aicpu_num, make_dep_gen_path(output_prefix_), device_id);
+        if (rc != 0) {
+            LOG_ERROR("init_dep_gen failed: %d", rc);
+            return rc;
+        }
+    }
+
     auto perf_cleanup = RAIIScopeGuard([this]() {
         if (l2_perf_collector_.is_initialized()) {
             l2_perf_collector_.stop();
@@ -626,6 +637,9 @@ int DeviceRunner::run(
         }
         if (pmu_collector_.is_initialized()) {
             pmu_collector_.stop();
+        }
+        if (dep_gen_collector_.is_initialized()) {
+            dep_gen_collector_.stop();
         }
     });
 
@@ -676,6 +690,9 @@ int DeviceRunner::run(
     }
     if (enable_pmu_) {
         pmu_collector_.start(thread_factory);
+    }
+    if (enable_dep_gen_) {
+        dep_gen_collector_.start(thread_factory);
     }
 
     LOG_INFO_V0("=== launch_aicpu_kernel DynTileFwkKernelServerInit ===");
@@ -752,6 +769,11 @@ int DeviceRunner::run(
     if (enable_pmu_) {
         pmu_collector_.stop();
         pmu_collector_.reconcile_counters();
+    }
+
+    if (enable_dep_gen_) {
+        dep_gen_collector_.stop();
+        dep_gen_collector_.reconcile_counters();
     }
 
     // Print handshake results (reads from device memory, must be before free)
@@ -1165,6 +1187,23 @@ int DeviceRunner::finalize() {
         pmu_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
     }
 
+    if (dep_gen_collector_.is_initialized()) {
+        auto unregister_cb = [](void *dev_ptr, int device_id) -> int {
+            HalHostUnregisterFn fn = get_halHostUnregister();
+            if (fn != nullptr) {
+                return fn(dev_ptr, device_id);
+            }
+            return 0;
+        };
+
+        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+            auto *allocator = static_cast<MemoryAllocator *>(user_data);
+            return allocator->free(dev_ptr);
+        };
+
+        dep_gen_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+    }
+
     // Free all remaining allocations (including handshake buffer and binGmAddr)
     mem_alloc_.finalize();
 
@@ -1455,5 +1494,39 @@ int DeviceRunner::init_pmu(
     }
 
     kernel_args_.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
+    return 0;
+}
+
+int DeviceRunner::init_dep_gen(int num_threads, const std::string &submit_trace_path, int device_id) {
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->alloc(size);
+    };
+
+    auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
+        if (load_hal_if_needed() != 0) {
+            LOG_ERROR("Failed to load ascend_hal for dep_gen: %s", dlerror());
+            return -1;
+        }
+        HalHostRegisterFn fn = get_halHostRegister();
+        if (fn == nullptr) {
+            LOG_ERROR("halHostRegister symbol not found: %s", dlerror());
+            return -1;
+        }
+        return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
+    };
+
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
+    int rc =
+        dep_gen_collector_.init(num_threads, submit_trace_path, alloc_cb, register_cb, free_cb, &mem_alloc_, device_id);
+    if (rc != 0) {
+        return rc;
+    }
+
+    kernel_args_.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -47,6 +47,7 @@
 #include "host/l2_perf_collector.h"
 #include "host/tensor_dump_collector.h"
 #include "host/pmu_collector.h"
+#include "host/dep_gen_collector.h"
 #include "runtime.h"
 
 /**
@@ -269,6 +270,7 @@ public:
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
+    void set_dep_gen_enabled(bool enable) { enable_dep_gen_ = enable; }
     // Severity floor (0=DEBUG..4=NUL) and INFO verbosity threshold (0..9).
     // Pushed in by the Python layer via run_runtime() and propagated to AICPU
     // through KernelArgs.
@@ -609,6 +611,8 @@ private:
     TensorDumpCollector dump_collector_;
     // PMU collector (independent of profiling pipeline)
     PmuCollector pmu_collector_;
+    // dep_gen collector — captures orchestrator submit_task inputs for offline replay
+    DepGenCollector dep_gen_collector_;
 
     /**
      * Ensure device is initialized (lazy initialization)
@@ -708,6 +712,20 @@ private:
      * @return 0 on success, error code on failure
      */
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+
+    /**
+     * Initialize dep_gen capture shared memory.
+     *
+     * Allocates DepGenDataHeader + 1 DepGenBufferState + N DepGenBuffers,
+     * registers them via halHostRegister, and stores the header address in
+     * kernel_args.dep_gen_data_base.
+     *
+     * @param num_threads        Number of AICPU scheduling threads
+     * @param submit_trace_path  Output binary file path (.bin)
+     * @param device_id          Device ID for host registration
+     * @return 0 on success, error code on failure
+     */
+    int init_dep_gen(int num_threads, const std::string &submit_trace_path, int device_id);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -715,6 +733,7 @@ private:
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
+    bool enable_dep_gen_{false};
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                  // diagnostic artifact root directory
     int log_level_{1};                                             // 0=DEBUG..4=NUL; default INFO

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -322,7 +322,8 @@ int prepare_callable(
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
+    const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
@@ -372,6 +373,7 @@ int run_prepared(
         runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
         runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
         runner->set_pmu_enabled(enable_pmu);
+        runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_output_prefix(output_prefix);
 
         std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -45,6 +45,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/l2_perf_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/tensor_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/pmu_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../src/host/dep_gen_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../aicpu/platform_aicpu_affinity.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform_comm/comm_sim.cpp"
 )

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -221,6 +221,19 @@ int DeviceRunner::ensure_binaries_loaded(
             return -1;
         }
 
+        set_platform_dep_gen_base_func_ =
+            reinterpret_cast<void (*)(uint64_t)>(dlsym(aicpu_so_handle_, "set_platform_dep_gen_base"));
+        if (set_platform_dep_gen_base_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_platform_dep_gen_base: %s", dlerror());
+            return -1;
+        }
+
+        set_dep_gen_enabled_func_ = reinterpret_cast<void (*)(bool)>(dlsym(aicpu_so_handle_, "set_dep_gen_enabled"));
+        if (set_dep_gen_enabled_func_ == nullptr) {
+            LOG_ERROR("dlsym failed for set_dep_gen_enabled: %s", dlerror());
+            return -1;
+        }
+
         // Log config bindings (optional; older SOs without these stay at their
         // compile-time defaults).
         set_log_level_func_ = reinterpret_cast<void (*)(int)>(dlsym(aicpu_so_handle_, "set_log_level"));
@@ -374,6 +387,9 @@ int DeviceRunner::run(
     if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
+    if (enable_dep_gen_) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DEP_GEN);
+    }
     kernel_args_.enable_profiling_flag = enable_profiling_flag;
 
     for (int i = 0; i < num_aicore; i++) {
@@ -432,6 +448,14 @@ int DeviceRunner::run(
         }
     }
 
+    if (enable_dep_gen_) {
+        rc = init_dep_gen(launch_aicpu_num, make_dep_gen_path(output_prefix_), device_id);
+        if (rc != 0) {
+            LOG_ERROR("init_dep_gen failed: %d", rc);
+            return rc;
+        }
+    }
+
     auto perf_cleanup = RAIIScopeGuard([this]() {
         if (l2_perf_collector_.is_initialized()) {
             l2_perf_collector_.stop();
@@ -441,6 +465,9 @@ int DeviceRunner::run(
         }
         if (pmu_collector_.is_initialized()) {
             pmu_collector_.stop();
+        }
+        if (dep_gen_collector_.is_initialized()) {
+            dep_gen_collector_.stop();
         }
     });
 
@@ -521,7 +548,8 @@ int DeviceRunner::run(
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
         set_platform_dump_base_func_ == nullptr || set_dump_tensor_enabled_func_ == nullptr ||
         set_platform_pmu_base_func_ == nullptr || set_platform_pmu_reg_addrs_func_ == nullptr ||
-        set_pmu_enabled_func_ == nullptr) {
+        set_pmu_enabled_func_ == nullptr || set_platform_dep_gen_base_func_ == nullptr ||
+        set_dep_gen_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
@@ -534,6 +562,8 @@ int DeviceRunner::run(
     set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
     set_platform_pmu_reg_addrs_func_(kernel_args_.pmu_reg_addrs);
     set_pmu_enabled_func_(enable_pmu_);
+    set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
+    set_dep_gen_enabled_func_(enable_dep_gen_);
 
     // Publish log config to the AICPU SO. Optional dlsym for forward
     // compatibility with pre-log-config SOs.
@@ -558,6 +588,9 @@ int DeviceRunner::run(
     }
     if (enable_pmu_) {
         pmu_collector_.start(thread_factory);
+    }
+    if (enable_dep_gen_) {
+        dep_gen_collector_.start(thread_factory);
     }
 
     // Launch AICPU threads (over-launch for affinity gate)
@@ -631,6 +664,11 @@ int DeviceRunner::run(
         pmu_collector_.reconcile_counters();
     }
 
+    if (enable_dep_gen_) {
+        dep_gen_collector_.stop();
+        dep_gen_collector_.reconcile_counters();
+    }
+
     // Print handshake results at end of run
     print_handshake_results();
 
@@ -678,6 +716,8 @@ void DeviceRunner::unload_executor_binaries() {
         set_platform_pmu_base_func_ = nullptr;
         set_platform_pmu_reg_addrs_func_ = nullptr;
         set_pmu_enabled_func_ = nullptr;
+        set_platform_dep_gen_base_func_ = nullptr;
+        set_dep_gen_enabled_func_ = nullptr;
         aicpu_so_loaded_ = false;
     }
     if (!aicpu_so_path_.empty()) {
@@ -946,6 +986,10 @@ int DeviceRunner::finalize() {
         pmu_collector_.finalize(nullptr, free_cb, &mem_alloc_);
     }
 
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+    }
+
     // Kernel binaries are normally released by validate_runtime_impl on the
     // legacy run() path. The prepared-callable path intentionally leaves
     // them resident across runs and relies on finalize() to reclaim them;
@@ -1196,5 +1240,26 @@ int DeviceRunner::init_pmu(
     }
 
     kernel_args_.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
+    return 0;
+}
+
+int DeviceRunner::init_dep_gen(int num_threads, const std::string &submit_trace_path, int /*device_id*/) {
+    auto alloc_cb = [](size_t size, void *user_data) -> void * {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->alloc(size);
+    };
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
+    // Sim shares an address space with the AICPU thread, so register_cb is
+    // not needed (mirrors PMU's nullptr in sim).
+    int rc = dep_gen_collector_.init(num_threads, submit_trace_path, alloc_cb, nullptr, free_cb, &mem_alloc_, -1);
+    if (rc != 0) {
+        return rc;
+    }
+
+    kernel_args_.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
 }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -54,6 +54,7 @@
 #include "host/l2_perf_collector.h"
 #include "host/tensor_dump_collector.h"
 #include "host/pmu_collector.h"
+#include "host/dep_gen_collector.h"
 #include "runtime.h"
 
 /**
@@ -160,6 +161,7 @@ public:
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
+    void set_dep_gen_enabled(bool enable) { enable_dep_gen_ = enable; }
     // Severity floor (0=DEBUG..4=NUL) and INFO verbosity threshold (0..9).
     // Pushed in by the Python layer via run_runtime() and propagated to AICPU
     // through KernelArgs.
@@ -322,6 +324,8 @@ private:
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_reg_addrs_func_)(uint64_t){nullptr};
     void (*set_pmu_enabled_func_)(bool){nullptr};
+    void (*set_platform_dep_gen_base_func_)(uint64_t){nullptr};
+    void (*set_dep_gen_enabled_func_)(bool){nullptr};
     void (*set_log_level_func_)(int){nullptr};
     void (*set_log_info_v_func_)(int){nullptr};
     std::string aicpu_so_path_;
@@ -334,6 +338,8 @@ private:
     TensorDumpCollector dump_collector_;
     // PMU collector (independent of profiling pipeline)
     PmuCollector pmu_collector_;
+    // dep_gen collector — captures orchestrator submit_task inputs for offline replay
+    DepGenCollector dep_gen_collector_;
 
     // Private helper methods
     int ensure_device_initialized(
@@ -368,6 +374,8 @@ private:
     int init_tensor_dump(Runtime &runtime, int device_id);
 
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+
+    int init_dep_gen(int num_threads, const std::string &submit_trace_path, int device_id);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use
@@ -375,6 +383,7 @@ private:
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
+    bool enable_dep_gen_{false};
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                  // diagnostic artifact root directory
     int log_level_{1};                                             // 0=DEBUG..4=NUL; default INFO

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -293,7 +293,8 @@ int prepare_callable(
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
+    const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
@@ -334,6 +335,7 @@ int run_prepared(
         runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
         runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
         runner->set_pmu_enabled(enable_pmu);
+        runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_output_prefix(output_prefix);
 
         std::vector<uint8_t> aicpu_vec;

--- a/src/a2a3/platform/src/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/dep_gen_collector_aicpu.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector_aicpu.cpp
+ * @brief AICPU-side dep_gen capture implementation
+ *
+ * Single-instance: dep_gen captures the orchestrator's submit_task stream,
+ * so there is one BufferState and one current_buf — no per-core arrays.
+ *
+ * Buffer switching (SPSC):
+ *   - Host pushes free DepGenBuffers via free_queue.
+ *   - AICPU pops when current buffer fills; pushes full buffer to per-thread
+ *     ready_queue (indexed by orch_thread_idx).
+ *   - On free_queue empty or ready_queue full: overwrite current buffer
+ *     (record dropped_record_count, keep AICPU alive). Host reads dropped
+ *     at finalize to decide whether to emit deps.json.
+ */
+
+#include "aicpu/dep_gen_collector_aicpu.h"
+
+#include <cstring>
+
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+
+static uint64_t g_platform_dep_gen_base = 0;
+static bool g_enable_dep_gen = false;
+
+// File-local cached state for the single dep_gen instance (the orchestrator).
+static DepGenDataHeader *s_dep_gen_header = nullptr;
+static DepGenBufferState *s_dep_gen_state = nullptr;
+static int s_orch_thread_idx = -1;  // set via dep_gen_aicpu_set_orch_thread_idx
+
+extern "C" void set_platform_dep_gen_base(uint64_t dep_gen_data_base) { g_platform_dep_gen_base = dep_gen_data_base; }
+
+extern "C" uint64_t get_platform_dep_gen_base() { return g_platform_dep_gen_base; }
+
+extern "C" void set_dep_gen_enabled(bool enable) { g_enable_dep_gen = enable; }
+
+extern "C" bool is_dep_gen_enabled() { return g_enable_dep_gen; }
+
+void dep_gen_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
+
+// ---------------------------------------------------------------------------
+// Internal: enqueue full buffer to per-thread ready_queue
+// ---------------------------------------------------------------------------
+
+static int enqueue_dep_gen_ready_buffer(uint64_t buffer_ptr, uint32_t buffer_seq) {
+    if (s_orch_thread_idx < 0 || s_orch_thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
+        return -1;
+    }
+    int q = s_orch_thread_idx;
+    uint32_t capacity = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
+    uint32_t current_tail = s_dep_gen_header->queue_tails[q];
+    uint32_t current_head = s_dep_gen_header->queue_heads[q];
+
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;  // Queue full
+    }
+
+    s_dep_gen_header->queues[q][current_tail].instance_index = 0;
+    s_dep_gen_header->queues[q][current_tail].buffer_ptr = buffer_ptr;
+    s_dep_gen_header->queues[q][current_tail].buffer_seq = buffer_seq;
+    s_dep_gen_header->queue_tails[q] = next_tail;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: switch the current buffer
+// ---------------------------------------------------------------------------
+
+static void dep_gen_switch_buffer() {
+    if (s_dep_gen_state == nullptr) {
+        return;
+    }
+    DepGenBuffer *full_buf = reinterpret_cast<DepGenBuffer *>(s_dep_gen_state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = s_dep_gen_state->free_queue.head;
+    uint32_t tail = s_dep_gen_state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep
+        // the orch loop alive; account every record we drop.
+        LOG_WARN("dep_gen: no free buffer, overwriting current (dropped %u records)", full_buf->count);
+        s_dep_gen_state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    uint32_t seq = s_dep_gen_state->current_buf_seq;
+    int rc = enqueue_dep_gen_ready_buffer(s_dep_gen_state->current_buf_ptr, seq);
+    if (rc != 0) {
+        LOG_ERROR("dep_gen: failed to enqueue full buffer (ready_queue full), %u records dropped", full_buf->count);
+        s_dep_gen_state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = s_dep_gen_state->free_queue.buffer_ptrs[head % PLATFORM_DEP_GEN_SLOT_COUNT];
+    rmb();
+    s_dep_gen_state->free_queue.head = head + 1;
+    s_dep_gen_state->current_buf_ptr = new_buf_ptr;
+    s_dep_gen_state->current_buf_seq = seq + 1;
+    wmb();
+
+    DepGenBuffer *new_buf = reinterpret_cast<DepGenBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+void dep_gen_aicpu_init() {
+    void *base = reinterpret_cast<void *>(get_platform_dep_gen_base());
+    if (base == nullptr) {
+        LOG_ERROR("dep_gen_aicpu_init: dep_gen_data_base is NULL");
+        return;
+    }
+    s_dep_gen_header = get_dep_gen_header(base);
+    s_dep_gen_state = get_dep_gen_buffer_state(base, /*instance_index=*/0);
+
+    rmb();
+    uint32_t head = s_dep_gen_state->free_queue.head;
+    uint32_t tail = s_dep_gen_state->free_queue.tail;
+
+    if (head != tail) {
+        uint64_t buf_ptr = s_dep_gen_state->free_queue.buffer_ptrs[head % PLATFORM_DEP_GEN_SLOT_COUNT];
+        rmb();
+        s_dep_gen_state->free_queue.head = head + 1;
+        s_dep_gen_state->current_buf_ptr = buf_ptr;
+        s_dep_gen_state->current_buf_seq = 0;
+        wmb();
+        DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(buf_ptr);
+        buf->count = 0;
+        LOG_INFO_V0("dep_gen: popped initial buffer addr=0x%lx", buf_ptr);
+    } else {
+        LOG_ERROR("dep_gen: free_queue empty during init");
+        s_dep_gen_state->current_buf_ptr = 0;
+    }
+    wmb();
+}
+
+void dep_gen_aicpu_record_submit(
+    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw
+) {
+    if (!g_enable_dep_gen || s_dep_gen_state == nullptr) {
+        return;
+    }
+
+    // Account every attempted record so total == collected + dropped on host.
+    s_dep_gen_state->total_record_count += 1;
+
+    rmb();
+    uint64_t cur_ptr = s_dep_gen_state->current_buf_ptr;
+    if (cur_ptr == 0) {
+        s_dep_gen_state->dropped_record_count += 1;
+        wmb();
+        return;
+    }
+    DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(cur_ptr);
+
+    if (buf->count >= static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
+        dep_gen_switch_buffer();
+        rmb();
+        cur_ptr = s_dep_gen_state->current_buf_ptr;
+        if (cur_ptr == 0) {
+            s_dep_gen_state->dropped_record_count += 1;
+            wmb();
+            return;
+        }
+        buf = reinterpret_cast<DepGenBuffer *>(cur_ptr);
+    }
+
+    uint32_t idx = buf->count;
+    DepGenRecord *rec = &buf->records[idx];
+
+    rec->task_id = task_id_raw;
+    // Cast the enum to uint32_t before the ternary so Linux GCC's -Wextra
+    // does not warn about "enumerated and non-enumerated type in conditional".
+    rec->flags = in_manual_scope ? static_cast<uint32_t>(DEP_GEN_FLAG_IN_MANUAL_SCOPE) : 0u;
+
+    int tc = tensor_count;
+    if (tc < 0) {
+        tc = 0;
+    } else if (tc > CORE_MAX_TENSOR_ARGS) {
+        // The runtime's Arg also caps at CORE_MAX_TENSOR_ARGS, so this should
+        // never trip; clamp defensively to keep the writer crash-free.
+        LOG_ERROR("dep_gen: tensor_count %d > CORE_MAX_TENSOR_ARGS (%d), truncating", tc, CORE_MAX_TENSOR_ARGS);
+        tc = CORE_MAX_TENSOR_ARGS;
+    }
+    rec->tensor_count = static_cast<uint16_t>(tc);
+
+    int dc = explicit_dep_count;
+    if (dc < 0) {
+        dc = 0;
+    } else if (dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
+        LOG_ERROR(
+            "dep_gen: explicit_dep_count %d > DEP_GEN_MAX_EXPLICIT_DEPS (%d), truncating", dc, DEP_GEN_MAX_EXPLICIT_DEPS
+        );
+        dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+    }
+    rec->explicit_dep_count = static_cast<uint16_t>(dc);
+
+    // explicit_deps (tail of the entry, packed; replay reads only the first dc entries)
+    if (dc > 0 && explicit_deps_raw != nullptr) {
+        memcpy(rec->explicit_deps, explicit_deps_raw, static_cast<size_t>(dc) * sizeof(uint64_t));
+    }
+
+    // arg_types
+    if (tc > 0 && arg_types != nullptr) {
+        memcpy(rec->arg_types, arg_types, static_cast<size_t>(tc));
+    }
+
+    // tensors[]: per-slot 128-byte blob (or zero if pointer is null — OUTPUT slot)
+    if (tc > 0) {
+        if (tensor_ptrs == nullptr) {
+            memset(rec->tensors, 0, static_cast<size_t>(tc) * DEP_GEN_TENSOR_SIZE);
+        } else {
+            for (int i = 0; i < tc; i++) {
+                if (tensor_ptrs[i] == nullptr) {
+                    memset(rec->tensors[i], 0, DEP_GEN_TENSOR_SIZE);
+                } else {
+                    memcpy(rec->tensors[i], tensor_ptrs[i], DEP_GEN_TENSOR_SIZE);
+                }
+            }
+        }
+    }
+
+    buf->count = idx + 1;
+    wmb();
+}
+
+void dep_gen_aicpu_flush() {
+    if (s_dep_gen_header == nullptr || s_dep_gen_state == nullptr) {
+        return;
+    }
+
+    rmb();
+    uint64_t buf_ptr = s_dep_gen_state->current_buf_ptr;
+    if (buf_ptr == 0) {
+        return;
+    }
+    DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(buf_ptr);
+    if (buf->count == 0) {
+        return;
+    }
+
+    uint32_t seq = s_dep_gen_state->current_buf_seq;
+    int rc = enqueue_dep_gen_ready_buffer(buf_ptr, seq);
+    if (rc == 0) {
+        LOG_INFO_V0("dep_gen: flushed buffer with %u records", buf->count);
+        s_dep_gen_state->current_buf_ptr = 0;
+        wmb();
+    } else {
+        LOG_ERROR("dep_gen: flush failed (ready_queue full), %u records dropped", buf->count);
+        s_dep_gen_state->dropped_record_count += buf->count;
+        buf->count = 0;
+        s_dep_gen_state->current_buf_ptr = 0;
+        wmb();
+    }
+}
+
+void dep_gen_aicpu_finalize() {
+    // No HW state to restore (unlike PMU). Reset file-local cache for cleanliness
+    // — the next init re-resolves these from the (potentially new) base anyway.
+    s_dep_gen_header = nullptr;
+    s_dep_gen_state = nullptr;
+    s_orch_thread_idx = -1;
+}

--- a/src/a2a3/platform/src/host/dep_gen_collector.cpp
+++ b/src/a2a3/platform/src/host/dep_gen_collector.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector.cpp
+ * @brief Host-side dep_gen collector. The mgmt-thread + buffer-pool machinery
+ *        lives in profiling_common::BufferPoolManager parameterized by
+ *        DepGenModule (host/dep_gen_collector.h); this file owns the
+ *        per-buffer on_buffer_collected callback (raw binary append) and the
+ *        device-side cross-check.
+ */
+
+#include "host/dep_gen_collector.h"
+
+#include <cassert>
+#include <cstring>
+#include <unordered_set>
+
+#include "common/memory_barrier.h"
+#include "common/unified_log.h"
+
+DepGenCollector::~DepGenCollector() { stop(); }
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+int DepGenCollector::init(
+    int num_threads, const std::string &submit_trace_path, DepGenAllocCallback alloc_cb,
+    DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb, void *user_data, int device_id
+) {
+    if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
+        LOG_ERROR("DepGenCollector::init: invalid arguments");
+        return -1;
+    }
+
+    num_threads_ = num_threads;
+    submit_trace_path_ = submit_trace_path;
+    buffers_registered_ = (register_cb != nullptr);
+    total_collected_ = 0;
+    execution_complete_.store(false, std::memory_order_release);
+    if (out_file_.is_open()) {
+        out_file_.close();
+    }
+
+    // ---- Allocate shared header + buffer-state region ----
+    // dep_gen is single-instance: just one DepGenBufferState after the header.
+    const int num_instances = 1;
+    shm_size_ = calc_dep_gen_shm_size(num_instances);
+    shm_dev_ = alloc_cb(shm_size_, user_data);
+    if (shm_dev_ == nullptr) {
+        LOG_ERROR("DepGenCollector: failed to allocate dep_gen shared memory (%zu bytes)", shm_size_);
+        return -1;
+    }
+
+    if (register_cb != nullptr) {
+        int rc = register_cb(shm_dev_, shm_size_, device_id, &shm_host_);
+        if (rc != 0) {
+            LOG_ERROR("DepGenCollector: halHostRegister for dep_gen SHM failed: %d", rc);
+            free_cb(shm_dev_, user_data);
+            shm_dev_ = nullptr;
+            return rc;
+        }
+        shm_registered_ = true;
+    } else {
+        shm_host_ = shm_dev_;
+    }
+    std::memset(shm_host_, 0, shm_size_);
+
+    DepGenDataHeader *hdr = get_dep_gen_header(shm_host_);
+    hdr->num_instances = static_cast<uint32_t>(num_instances);
+
+    // ---- Allocate DepGenBuffers, populate free_queue + recycled pool ----
+    const size_t buf_size = sizeof(DepGenBuffer);
+    DepGenBufferState *state = dep_gen_state(0);
+
+    for (int b = 0; b < PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE; b++) {
+        void *dev_ptr = alloc_cb(buf_size, user_data);
+        if (dev_ptr == nullptr) {
+            LOG_ERROR("DepGenCollector: failed to allocate DepGenBuffer b=%d", b);
+            return -1;
+        }
+
+        void *host_ptr = dev_ptr;
+        if (register_cb != nullptr) {
+            int rc = register_cb(dev_ptr, buf_size, device_id, &host_ptr);
+            if (rc != 0) {
+                LOG_ERROR("DepGenCollector: halHostRegister for DepGenBuffer b=%d failed: %d", b, rc);
+                free_cb(dev_ptr, user_data);
+                return rc;
+            }
+        }
+        std::memset(host_ptr, 0, buf_size);
+
+        manager_.register_mapping(dev_ptr, host_ptr);
+
+        if (b < PLATFORM_DEP_GEN_SLOT_COUNT) {
+            uint32_t tail = state->free_queue.tail;
+            assert(tail - state->free_queue.head < PLATFORM_DEP_GEN_SLOT_COUNT && "free_queue overflow on init");
+            state->free_queue.buffer_ptrs[tail % PLATFORM_DEP_GEN_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
+            wmb();
+            state->free_queue.tail = tail + 1;
+            wmb();
+        } else {
+            manager_.push_recycled(0, dev_ptr);
+        }
+    }
+
+    initialized_ = true;
+    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_host_, device_id);
+
+    LOG_INFO_V0(
+        "DepGen collector initialized: %d threads, SHM=0x%lx, out=%s (opened on first record)", num_threads,
+        reinterpret_cast<unsigned long>(shm_dev_), submit_trace_path_.c_str()
+    );
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Binary output
+// ---------------------------------------------------------------------------
+
+void DepGenCollector::ensure_out_open_unlocked() {
+    if (out_file_.is_open()) return;
+    out_file_.open(submit_trace_path_, std::ios::out | std::ios::binary | std::ios::trunc);
+    if (!out_file_.is_open()) {
+        LOG_ERROR("DepGenCollector: failed to open submit trace file: %s", submit_trace_path_.c_str());
+    }
+}
+
+void DepGenCollector::write_buffer(const void *buf_host_ptr) {
+    const DepGenBuffer *buf = reinterpret_cast<const DepGenBuffer *>(buf_host_ptr);
+    uint32_t n = buf->count;
+    if (n > static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
+        n = static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER);
+    }
+    if (n == 0) return;
+
+    std::scoped_lock lock(out_mutex_);
+    ensure_out_open_unlocked();
+    if (!out_file_.is_open()) return;
+    out_file_.write(
+        reinterpret_cast<const char *>(buf->records), static_cast<std::streamsize>(n) * sizeof(DepGenRecord)
+    );
+    total_collected_ += n;
+    out_file_.flush();
+}
+
+// ---------------------------------------------------------------------------
+// ProfilerBase callback
+// ---------------------------------------------------------------------------
+
+void DepGenCollector::on_buffer_collected(const DepGenReadyBufferInfo &info) { write_buffer(info.host_buffer_ptr); }
+
+// ---------------------------------------------------------------------------
+// reconcile_counters
+// ---------------------------------------------------------------------------
+
+bool DepGenCollector::reconcile_counters() {
+    if (shm_host_ == nullptr) return false;
+
+    rmb();
+
+    bool clean = true;
+
+    DepGenBufferState *state = dep_gen_state(0);
+    uint64_t buf_dev = state->current_buf_ptr;
+    if (buf_dev != 0) {
+        void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_dev));
+        if (host_ptr != nullptr) {
+            uint32_t count = reinterpret_cast<const DepGenBuffer *>(host_ptr)->count;
+            if (count != 0) {
+                LOG_ERROR(
+                    "dep_gen reconcile: un-flushed buffer (current_buf_ptr=0x%lx, count=%u) — device flush failed",
+                    static_cast<unsigned long>(buf_dev), count
+                );
+                clean = false;
+            }
+        }
+    }
+
+    uint64_t total_device = state->total_record_count;
+    uint64_t dropped_device = state->dropped_record_count;
+
+    if (dropped_device > 0) {
+        LOG_WARN(
+            "dep_gen reconcile: %lu records dropped on device side (free_queue empty or ready_queue full). "
+            "Increase PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE / PLATFORM_DEP_GEN_READYQUEUE_SIZE if frequent. "
+            "deps.json will NOT be emitted for this run (incomplete graph).",
+            static_cast<unsigned long>(dropped_device)
+        );
+        clean = false;
+    }
+    if (total_collected_ + dropped_device != total_device) {
+        LOG_WARN(
+            "dep_gen reconcile: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu, "
+            "silent_loss=%ld)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device),
+            static_cast<long>(total_device) - static_cast<long>(total_collected_ + dropped_device)
+        );
+        clean = false;
+    } else {
+        LOG_INFO_V0(
+            "dep_gen reconcile: counts match (collected=%lu, dropped=%lu, device_total=%lu)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device)
+        );
+    }
+
+    return clean;
+}
+
+// ---------------------------------------------------------------------------
+// finalize
+// ---------------------------------------------------------------------------
+
+void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, DepGenFreeCallback free_cb, void *user_data) {
+    if (!initialized_) return;
+
+    stop();
+
+    if (out_file_.is_open()) {
+        out_file_.close();
+    }
+
+    // Same pattern as PmuCollector: walk owned buffers, then the free_queue
+    // and current_buf_ptr, releasing each unique device pointer once.
+    auto release_buf = [&](void *p) {
+        if (buffers_registered_ && unregister_cb != nullptr) {
+            unregister_cb(p, device_id_);
+        }
+        if (free_cb != nullptr) {
+            free_cb(p, user_data);
+        }
+    };
+    manager_.release_owned_buffers(release_buf);
+
+    if (shm_host_ != nullptr) {
+        std::unordered_set<void *> already_freed;
+        auto release_unique = [&](void *p) {
+            if (p == nullptr || !already_freed.insert(p).second) return;
+            release_buf(p);
+        };
+        DepGenBufferState *state = dep_gen_state(0);
+        release_unique(reinterpret_cast<void *>(state->current_buf_ptr));
+        state->current_buf_ptr = 0;
+        rmb();
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t queued = tail - head;
+        if (queued > PLATFORM_DEP_GEN_SLOT_COUNT) queued = PLATFORM_DEP_GEN_SLOT_COUNT;
+        for (uint32_t i = 0; i < queued; i++) {
+            uint32_t slot = (head + i) % PLATFORM_DEP_GEN_SLOT_COUNT;
+            release_unique(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+            state->free_queue.buffer_ptrs[slot] = 0;
+        }
+        state->free_queue.head = tail;
+    }
+    manager_.clear_mappings();
+
+    if (shm_dev_ != nullptr) {
+        if (shm_registered_ && unregister_cb != nullptr) {
+            unregister_cb(shm_dev_, device_id_);
+        }
+        if (free_cb != nullptr) {
+            free_cb(shm_dev_, user_data);
+        }
+        shm_dev_ = nullptr;
+        shm_host_ = nullptr;
+    }
+
+    initialized_ = false;
+    buffers_registered_ = false;
+    shm_registered_ = false;
+    shm_size_ = 0;
+    total_collected_ = 0;
+    clear_memory_context();
+    LOG_INFO_V0("DepGen collector finalized");
+}

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -37,6 +37,7 @@
 // Performance profiling headers
 #include "aicpu/l2_perf_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
+#include "aicpu/dep_gen_collector_aicpu.h"
 #include "common/l2_perf_profiling.h"
 #include "common/unified_log.h"
 
@@ -508,6 +509,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 #endif
 
+            // dep_gen plugs into the orchestrator thread (single-instance subsystem):
+            // set the per-thread queue index and pop the initial buffer before any
+            // submit_task can fire inside orch_func_.
+            if (is_dep_gen_enabled()) {
+                dep_gen_aicpu_set_orch_thread_idx(thread_idx);
+                dep_gen_aicpu_init();
+            }
+
 #if PTO2_PROFILING
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
@@ -518,6 +527,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             rt_scope_begin(rt);
             (*p_func)(*orch_args_cached_);
             rt_scope_end(rt);
+
+            // Flush the (potentially partially-filled) DepGenBuffer so the host
+            // collector can pick it up before this orchestrator thread joins.
+            if (is_dep_gen_enabled()) {
+                dep_gen_aicpu_flush();
+            }
 #if PTO2_PROFILING
             uint64_t orch_cycle_end = get_sys_cnt_aicpu();
             (void)orch_cycle_end;
@@ -714,6 +729,9 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
+
+    // Clear dep_gen file-local bookkeeping. No-op when dep_gen is disabled.
+    dep_gen_aicpu_finalize();
 
     LOG_INFO_V0("DeInit: Runtime execution state reset");
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -26,6 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "aicpu/dep_gen_collector_aicpu.h"
+#include "common/dep_gen.h"
 #include "common/unified_log.h"
 #include "pto_dep_compute.h"
 #include "pto_runtime2_types.h"
@@ -33,6 +35,25 @@
 #include "pto_tensormap.h"
 #include "pto_types.h"
 #include "tensor.h"
+
+// Verify the captured Tensor blob size in DepGenRecord matches the runtime
+// Tensor layout. The platform header defines DEP_GEN_TENSOR_SIZE without
+// including runtime/tensor.h, so this check lives at the orch callsite.
+static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot size out of sync with sizeof(Tensor)");
+static_assert(
+    PTO2_MAX_EXPLICIT_DEPS == DEP_GEN_MAX_EXPLICIT_DEPS,
+    "DepGenRecord::explicit_deps array length out of sync with PTO2_MAX_EXPLICIT_DEPS"
+);
+
+// Weak fallbacks: dep_gen_collector_aicpu.cpp provides the strong symbols in
+// AICPU builds. Host builds (host_build_graph runtime, future dep_gen replay)
+// link these no-op stubs so the runtime translation unit is self-contained.
+// Visibility is hidden so the HOST .so doesn't export them into the global
+// dynamic symbol table where they'd shadow the AICPU .so's strong symbols
+// (same pattern as get_sys_cnt_aicpu / l2_perf_aicpu_record_orch_phase below).
+extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
+__attribute__((weak, visibility("hidden"))) void
+dep_gen_aicpu_record_submit(uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *) {}
 
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
@@ -580,6 +601,27 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
     result.set_task_id(task_id);
+
+    // dep_gen capture point: snapshot the orch submit_task inputs while the
+    // tensormap is still in its pre-lookup state for this task. Replay reads
+    // these records offline to reconstruct the complete dep graph, sidestepping
+    // the race window in L2PerfRecord::fanout[] where an early-finishing
+    // producer's record gets sealed before later-submitted consumers can
+    // register themselves.
+    if (is_dep_gen_enabled()) {
+        const void *tensor_ptrs[MAX_TENSOR_ARGS];
+        const int tc = args.tensor_count();
+        for (int i = 0; i < tc; i++) {
+            // OUTPUT slots carry create_info (not yet a Tensor); skip them —
+            // they have no producer to look up and replay's per-tensor loop
+            // also skips OUTPUT.
+            tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : args.tensor(i).ptr;
+        }
+        dep_gen_aicpu_record_submit(
+            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, reinterpret_cast<const uint8_t *>(args.tag_data()),
+            static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data())
+        );
+    }
 
     PTO2FaninBuilder fanin_builder(orch->rings[ring_id].fanin_pool);
 

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -352,7 +352,8 @@ int prepare_callable(
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int /*enable_dep_gen*/,
+    const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -290,7 +290,8 @@ int prepare_callable(
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int /*enable_dep_gen*/,
+    const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -11,9 +11,9 @@
 
 /**
  * CallConfig — per-NEXT_LEVEL-task config. Carries execution knobs
- * (block_dim, aicpu_thread_num) plus the three parallel diagnostics
+ * (block_dim, aicpu_thread_num) plus the four parallel diagnostics
  * sub-features under the profiling umbrella: `enable_l2_swimlane` (swimlane),
- * `enable_dump_tensor`, and `enable_pmu`.
+ * `enable_dump_tensor`, `enable_pmu`, and `enable_dep_gen`.
  *
  * Lives here (rather than chip_worker.h) so distributed task slot state
  * can store it directly without pulling in the full ChipWorker header
@@ -25,10 +25,11 @@
  * across compilers (sizeof(bool) is implementation-defined).
  *
  * `output_prefix` is a NUL-terminated directory path under which all
- * diagnostic artifacts (l2_perf_records.json / tensor_dump/ / pmu.csv) are
- * written. The caller is responsible for filling it whenever any diagnostic
- * flag is enabled — `validate()` enforces this contract at every submit/run
- * entry point so the runtime never has to invent a path.
+ * diagnostic artifacts (l2_perf_records.json / tensor_dump/ / pmu.csv /
+ * submit_trace.bin) are written. The caller is responsible for filling it
+ * whenever any diagnostic flag is enabled — `validate()` enforces this
+ * contract at every submit/run entry point so the runtime never has to
+ * invent a path.
  */
 
 #pragma once
@@ -44,10 +45,11 @@ struct CallConfig {
     int32_t enable_l2_swimlane = 0;
     int32_t enable_dump_tensor = 0;
     int32_t enable_pmu = 0;  // 0 = disabled; >0 = enabled, value selects event type
+    int32_t enable_dep_gen = 0;
     char output_prefix[1024] = {};
 
     bool diagnostics_any() const noexcept {
-        return enable_l2_swimlane != 0 || enable_dump_tensor != 0 || enable_pmu != 0;
+        return enable_l2_swimlane != 0 || enable_dump_tensor != 0 || enable_pmu != 0 || enable_dep_gen != 0;
     }
 
     bool output_prefix_set() const noexcept { return output_prefix[0] != '\0'; }
@@ -59,10 +61,10 @@ struct CallConfig {
         if (diagnostics_any() && !output_prefix_set()) {
             throw std::invalid_argument(
                 "CallConfig: output_prefix must be set whenever any of "
-                "enable_l2_swimlane / enable_dump_tensor / enable_pmu is enabled"
+                "enable_l2_swimlane / enable_dump_tensor / enable_pmu / enable_dep_gen is enabled"
             );
         }
     }
 };
 #pragma pack(pop)
-static_assert(sizeof(CallConfig) == 5 * sizeof(int32_t) + 1024, "CallConfig wire layout drift");
+static_assert(sizeof(CallConfig) == 6 * sizeof(int32_t) + 1024, "CallConfig wire layout drift");

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -328,7 +328,7 @@ void ChipWorker::run_prepared(int32_t callable_id, const void *args, const CallC
     int rc = run_prepared_fn_(
         device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, device_id_, aicpu_binary_.data(),
         aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(), config.enable_l2_swimlane,
-        config.enable_dump_tensor, config.enable_pmu, config.output_prefix
+        config.enable_dump_tensor, config.enable_pmu, config.enable_dep_gen, config.output_prefix
     );
     if (rc != 0) {
         throw std::runtime_error("run_prepared failed with code " + std::to_string(rc));

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -112,7 +112,7 @@ private:
         int (*)(void *, int32_t, const void *, int, const uint8_t *, size_t, const uint8_t *, size_t);
     using RunPreparedFn = int (*)(
         void *, void *, int32_t, const void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t, int,
-        int, int, const char *
+        int, int, int, const char *
     );
     using UnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -165,7 +165,8 @@ int prepare_callable(
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
+    const char *output_prefix
 );
 
 /**

--- a/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -106,6 +106,7 @@ class TestPreparedCallableHbg(SceneTestCase):
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         params = case.get("params", {})

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""dep_gen capture sim test.
+
+Re-runs the ``vector_example`` orchestration with ``--enable-dep-gen`` and
+asserts that ``<output_prefix>/submit_trace.bin`` was produced with the
+expected size for the 5 ``submit_task`` calls the orchestration issues. This
+validates the device_runner wiring for the dep_gen sub-feature on a2a3sim
+(host collector, AICPU writer, kernel_args.dep_gen_data_base hand-off).
+
+Pytest entry: rely on the standard ``--enable-dep-gen`` CLI option from
+``conftest.py``. Standalone entry: also requires ``--enable-dep-gen`` so the
+trace path exists when post-run verification runs.
+
+Compute correctness is delegated to the upstream ``vector_example`` test —
+this case re-uses the same orchestration to keep coverage focused on the
+capture pipeline.
+"""
+
+import struct
+import sys
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+KERNELS_BASE = "../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
+
+# Matches struct DepGenRecord in src/a2a3/platform/include/common/dep_gen.h:
+#   8 (task_id) + 4 (flags) + 2 (tensor_count) + 2 (explicit_dep_count)
+#   + 16*8 (explicit_deps) + 16 (arg_types) + 16 (_pad0) + 16*128 (tensors)
+#   = 2240 bytes, aligned(64).
+_DEP_GEN_RECORD_SIZE = 2240
+# example_orchestration.cpp issues 5 submit_task calls (t0..t4).
+_EXPECTED_SUBMIT_COUNT = 5
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestDepGenCapture(SceneTestCase):
+    """Vector example, run with dep_gen enabled, then verify submit_trace.bin."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a2a3sim"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    def _post_validate(self, case):
+        """Hook invoked after the case ran when --enable-dep-gen is in effect.
+
+        Locates the per-case output_prefix directory and asserts the
+        ``submit_trace.bin`` file has size == 5 * sizeof(DepGenRecord).
+        """
+        case_name = case["name"]
+        safe_label = _sanitize_for_filename(f"TestDepGenCapture_{case_name}")
+        outputs = _outputs_dir()
+        matches = sorted(outputs.glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        assert matches, f"no output prefix under {outputs} matching {safe_label}_*"
+        trace = matches[-1] / "submit_trace.bin"
+        assert trace.exists(), f"submit_trace.bin not produced under {matches[-1]}"
+
+        size = trace.stat().st_size
+        expected = _EXPECTED_SUBMIT_COUNT * _DEP_GEN_RECORD_SIZE
+        assert size == expected, (
+            f"submit_trace.bin size {size} != expected {expected} "
+            f"({_EXPECTED_SUBMIT_COUNT} records * {_DEP_GEN_RECORD_SIZE} B per record)"
+        )
+
+        # Spot-check first record's tensor_count to confirm bytes are real:
+        # t0 (kernel_add) has 3 args (a, b, c=output) -> tensor_count == 3.
+        with trace.open("rb") as f:
+            header = f.read(16)
+        _task_id, _flags, tensor_count, _expl = struct.unpack("=QIHH", header)
+        assert tensor_count == 3, f"first record tensor_count={tensor_count}, expected 3"
+
+
+def _post_run_verify():
+    """Iterate all cases and run _post_validate. Used by standalone main."""
+    inst = TestDepGenCapture()
+    for case in TestDepGenCapture.CASES:
+        inst._post_validate(case)
+
+
+if __name__ == "__main__":
+    # The standalone entry exits with 0/1 from inside SceneTestCase.run_module,
+    # so the verification has to happen *before* the exit, or we need to catch
+    # the SystemExit and only do verification on success. Easier: catch.
+    enable_dep_gen = "--enable-dep-gen" in sys.argv
+    try:
+        SceneTestCase.run_module(__name__)
+    except SystemExit as e:
+        if e.code not in (0, None):
+            raise
+        if enable_dep_gen:
+            _post_run_verify()
+            print("[dep_gen_capture] post-run verification PASSED")
+        sys.exit(0)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -107,6 +107,7 @@ class TestPreparedCallable(SceneTestCase):
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         params = case.get("params", {})

--- a/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -95,6 +95,7 @@ class TestPreparedCallableHbgA5(SceneTestCase):
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         params = case.get("params", {})

--- a/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -108,6 +108,7 @@ class TestPreparedCallable(SceneTestCase):
         enable_l2_swimlane=False,
         enable_dump_tensor=False,
         enable_pmu=0,
+        enable_dep_gen=False,
         output_prefix="",
     ):
         params = case.get("params", {})


### PR DESCRIPTION
## Summary

Capture every `Orchestrator::submit_task` call into a streaming
`SubmitTrace` ring on the a2a3 `tensormap_and_ringbuffer` runtime, drained
by a host collector to `submit_trace.bin`. Phase 1 of replacing #500 — the
host-side offline replay that reconstructs `deps.json` from these records
ships in a follow-up PR; this PR is intentionally scoped to the capture
path so it can land independently and be reviewed in isolation.

Motivation: today's swimlane `L2PerfRecord::fanout[]` is filled at the
producer's completion-record commit moment, so a fast producer that
finishes before a later consumer is submitted has its record sealed
without the new edge — those dep edges are silently lost. Capturing the
orch's submit-time inputs and replaying offline reconstructs the complete
logical graph because the replay can run with no eviction.

## What lands in this PR

- **Device structs** — `src/a2a3/platform/include/common/dep_gen.h`:
  `DepGenRecord` (2240 B per submit: task_id, flags, arg_types[16],
  explicit_deps[16], tensors[16][128] as opaque blobs). Plus the
  PMU/L2Perf-style SPSC buffer family (FreeQueue / BufferState /
  ReadyQueueEntry / DataHeader). Single-instance (orch is one AICPU
  thread).
- **AICPU writer** —
  `src/a2a3/platform/{include/aicpu,src/aicpu}/dep_gen_collector_aicpu.{h,cpp}`:
  all-primitive interface (raw uint64 task_id, void* per-Tensor blob,
  uint64* explicit_deps) so the platform header stays runtime-agnostic.
  `submit_task` entry calls `dep_gen_aicpu_record_submit` gated on
  `is_dep_gen_enabled()`. Orch callsite static_asserts
  `sizeof(Tensor) == DEP_GEN_TENSOR_SIZE` and
  `PTO2_MAX_EXPLICIT_DEPS == DEP_GEN_MAX_EXPLICIT_DEPS`. Weak fallbacks
  let host builds link without the AICPU strong symbols.
- **Host collector** —
  `src/a2a3/platform/{include/host,src/host}/dep_gen_collector.{h,cpp}`:
  `DepGenModule` trait + `DepGenCollector : ProfilerBase<...>`, so the
  mgmt thread / buffer-pool manager / poll loop come from the unified
  profiling framework (#714). `on_buffer_collected` appends `DepGenRecord`
  values to `submit_trace.bin`; `reconcile_counters` cross-checks
  `collected + dropped == device_total` and returns clean/dirty so the
  future replay step can skip `deps.json` on incomplete traces.
- **Device runner wiring** (`sim` + `onboard`): `DepGenCollector` field,
  `set_dep_gen_enabled()` setter, `init_dep_gen()` helper,
  `kernel_args.dep_gen_data_base` plumbed through to AICPU, RAII cleanup,
  end-of-run flush + reconcile, `make_dep_gen_path()` helper.
- **AICPU lifecycle**: `set_platform_dep_gen_base` /
  `set_dep_gen_enabled` / `dep_gen_aicpu_set_orch_thread_idx` /
  `dep_gen_aicpu_init` / `dep_gen_aicpu_flush` /
  `dep_gen_aicpu_finalize` hooked alongside the existing PMU calls.
- **CallConfig + Python**: `enable_dep_gen` int32 flag, nanobind Python
  property (bool), `conftest.py` and `scene_test.py` `--enable-dep-gen`
  CLI option threaded through `run_class_cases` / `_run_and_validate` /
  `_build_config`. `--rounds > 1` disables capture (matches the
  `--enable-l2-swimlane` pattern).
- **a2a3sim test** —
  `tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py`:
  re-uses the `vector_example` orchestration (5 `submit_task` calls), runs
  with `--enable-dep-gen`, then asserts `submit_trace.bin` size equals
  `5 * sizeof(DepGenRecord)` and spot-checks the first record's
  `tensor_count == 3`.

## What does NOT land in this PR

- Host-side offline replay → `deps.json`
- `swimlane_converter.py` integration that prefers `deps.json` over the
  in-record `fanout[]`
- a5 port (the a5 profiling framework is the pre-#714 layout and needs
  separate wiring)

These follow in subsequent PRs once the capture path is reviewed.

## Testing

- [x] `pre-commit run` (clang-format, clang-tidy, cpplint, ruff,
      pyright) all pass
- [x] a2a3sim `spmd_sync_start` baseline (no `--enable-dep-gen`)
      PASSED — wiring does not perturb the default path
- [x] a2a3sim `dep_gen_capture` (with `--enable-dep-gen`) PASSED,
      post-run verification PASSED (`submit_trace.bin` has exactly
      5 records totalling 11200 bytes)
- [ ] Linux CI green

## Notes

- `profiler_base.h` had to gain a one-line
  `// NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)`
  + comment: the new `dep_gen_collector.cpp` is the first translation
  unit in this checkout to pull the header into pre-commit's clang-tidy
  scope. Existing PmuCollector / L2PerfCollector use the same public
  ctor pattern; making it `protected` would force every derived class
  to declare `friend ProfilerBase` solely for ctor visibility.