### PR TITLE
Add: dep_gen replay → deps.json + swimlane integration + fanout ⊆ deps gate

### DIFF
--- a/simpler_setup/tools/deps_to_graph.py
+++ b/simpler_setup/tools/deps_to_graph.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""
+deps.json → pan-zoom HTML dependency-graph viewer.
+
+deps.json is the host-replay-rebuilt task graph (one edge per producer→consumer
+pair, complete across the full submit_task trace — superset of fanout). This
+tool runs the graph through Graphviz to produce an SVG and wraps it in a
+self-contained HTML page with a minimal drag-to-pan + wheel-to-zoom shim
+(no JS dependency, no CDN, opens offline in any browser).
+
+The HTML format scales to any graph the browser's SVG renderer can handle
+(practically up to ~50k nodes when paired with ``--engine sfdp``); the only
+gotcha is that high zoom slightly blurs text — that's a CSS-transform tradeoff
+in exchange for 60fps GPU-composited pan/zoom even on huge graphs.
+
+When ``l2_perf_records.json`` is colocated with ``deps.json``, node labels are
+enriched with the per-task ``func_id`` and ``core_type`` so a node reads as
+``t12 · kernel_mul · aiv`` rather than just ``t12``; nodes are colored by
+core_type (AIC blue, AIV orange).
+
+Usage:
+    python -m simpler_setup.tools.deps_to_graph DEPS_JSON [-o OUT] [--engine ENGINE]
+    python -m simpler_setup.tools.deps_to_graph                          # newest under outputs/
+    python -m simpler_setup.tools.deps_to_graph deps.json
+    python -m simpler_setup.tools.deps_to_graph deps.json --engine sfdp  # force-directed (for big graphs)
+
+Requires Graphviz installed (``brew install graphviz`` / ``apt install graphviz``).
+"""
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _normalize_task_id(v):
+    """Unsigned 64-bit task id (matches deps.json edges and l2_perf task_id)."""
+    try:
+        t = int(v)
+    except (TypeError, ValueError):
+        return None
+    if t < 0:
+        t &= (1 << 64) - 1
+    return t
+
+
+def _node_id(task_id):
+    """DOT-safe node id: ``T{ring}_{local}``."""
+    tid = _normalize_task_id(task_id)
+    if tid is None:
+        return f"T_{task_id}"
+    ring = (tid >> 32) & 0xFF
+    local = tid & 0xFFFFFFFF
+    return f"T{ring}_{local}"
+
+
+def _make_task_formatter(nodes):
+    """Build a task-id → display-string formatter sized to the graph.
+
+    If every node lives in ring 0 the display is just ``{local}`` (the local
+    counter alone — no noise on workloads that never enter a manual scope).
+    The moment any node is in ring ≥ 1 we switch to the explicit
+    ``({ring}, {local})`` tuple for *every* node so the asymmetry is visible
+    instead of hidden (you can't have ``t0`` next to ``r1t3`` and know which
+    ring t0 lives in without context).
+    """
+    has_multi_ring = False
+    for n in nodes:
+        tid = _normalize_task_id(n)
+        if tid is None:
+            continue
+        if (tid >> 32) & 0xFF != 0:
+            has_multi_ring = True
+            break
+
+    def fmt(task_id):
+        tid = _normalize_task_id(task_id)
+        if tid is None:
+            return str(task_id)
+        ring = (tid >> 32) & 0xFF
+        local = tid & 0xFFFFFFFF
+        if has_multi_ring:
+            return f"({ring}, {local})"
+        return str(local)
+
+    return fmt
+
+
+def _load_deps_edges(deps_path):
+    """Returns (sorted list of unique edges, sorted list of all node ids)."""
+    with open(deps_path) as f:
+        data = json.load(f)
+    if data.get("version") != 1:
+        print(f"Warning: deps.json version={data.get('version')} (expected 1)", file=sys.stderr)
+    edges_raw = data.get("edges", [])
+    seen = set()
+    edges = []
+    nodes = set()
+    for e in edges_raw:
+        if not isinstance(e, (list, tuple)) or len(e) != 2:
+            continue
+        pred = _normalize_task_id(e[0])
+        succ = _normalize_task_id(e[1])
+        if pred is None or succ is None:
+            continue
+        nodes.add(pred)
+        nodes.add(succ)
+        key = (pred, succ)
+        if key in seen:
+            continue
+        seen.add(key)
+        edges.append(key)
+    return edges, sorted(nodes)
+
+
+def _load_task_meta(deps_path, func_names=None):
+    """Optional l2_perf_records.json sidecar → {task_id: {'func_id', 'core_type', ...}}.
+
+    Mixed-kernel tasks (single submit_task that spans both AIC and AIV blocks)
+    appear as multiple perf-record entries with the same ``task_id`` but
+    different ``core_id`` / ``core_type``. We aggregate per ``task_id``: when
+    multiple distinct ``core_type`` values are seen, the task's ``core_type``
+    collapses to the sentinel ``"mix"`` (which the legend / styling table maps
+    to a diamond). ``func_id`` follows the AIC entry when present, otherwise
+    the first entry — mixed tasks usually have one "primary" function id.
+
+    Returns {} if no sidecar present. ``func_names`` (optional dict) overrides
+    the default ``f{func_id}`` label with a human name.
+    """
+    perf_path = Path(deps_path).parent / "l2_perf_records.json"
+    if not perf_path.exists():
+        return {}
+    try:
+        with perf_path.open() as f:
+            perf = json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"Warning: couldn't read {perf_path}: {e}", file=sys.stderr)
+        return {}
+
+    # First pass: collect every (core_type, func_id) tuple per task_id.
+    by_tid: dict[int, list[dict]] = {}
+    for task in perf.get("tasks", []):
+        tid = _normalize_task_id(task.get("task_id"))
+        if tid is None:
+            continue
+        by_tid.setdefault(tid, []).append(task)
+
+    meta: dict[int, dict] = {}
+    for tid, entries in by_tid.items():
+        core_types = {e.get("core_type") for e in entries if e.get("core_type")}
+        if len(core_types) > 1:
+            core_type = "mix"
+            # Prefer the AIC entry's func_id (cube usually carries the "main"
+            # op in mixed kernels) so the label reads sensibly.
+            primary = next((e for e in entries if e.get("core_type") == "aic"), entries[0])
+        else:
+            core_type = next(iter(core_types), None)
+            primary = entries[0]
+        func_id = primary.get("func_id")
+        func_name = None
+        if func_names and func_id is not None:
+            func_name = func_names.get(str(func_id)) or func_names.get(func_id)
+        meta[tid] = {
+            "func_id": func_id,
+            "func_name": func_name,
+            "core_type": core_type,
+            "core_id": primary.get("core_id"),
+            "duration_us": primary.get("duration_us"),
+        }
+    return meta
+
+
+def _label(task_id, meta, fmt_task, have_perf=False):
+    base = fmt_task(task_id)
+    m = meta.get(_normalize_task_id(task_id))
+    if not m:
+        # Node referenced by deps but absent from the perf sidecar: alloc_tensors
+        # task (see emit_dot docstring). Surface that in the label so the user
+        # knows the dashed-note style isn't just "missing data". When no perf
+        # sidecar exists at all, we can't tell — fall back to bare id.
+        return f"{base} · alloc" if have_perf else base
+    parts = [base]
+    fn = m.get("func_name") or (f"f{m['func_id']}" if m.get("func_id") is not None else None)
+    if fn:
+        parts.append(fn)
+    # core_type is intentionally NOT in the label — node shape (box/ellipse) and
+    # color already encode it, and the HUD legend at the top-right of the page
+    # spells out the mapping. Keeps labels short on dense graphs.
+    return " · ".join(parts)
+
+
+# Per-core-type visual styling. AIC (cube unit) is a box; AIV (vector unit)
+# is an ellipse; "mix" (single submit_task spanning both core types) is a
+# diamond; "alloc" — a task that came from ``alloc_tensors`` (got a real
+# task_id and shows up as a producer in deps via ``owner_task_id``, but
+# never dispatched a kernel so no l2_perf record and no func_id) — is a
+# dashed gray note. Distinct shape AND color so each stays readable even
+# without color (B&W print, accessibility, etc.).
+_CORE_STYLE = {
+    "aic": {"shape": "box", "style": "rounded,filled", "fillcolor": "#66A3FF"},
+    "aiv": {"shape": "ellipse", "style": "filled", "fillcolor": "#FFB366"},
+    "mix": {"shape": "diamond", "style": "filled", "fillcolor": "#66CC99"},
+    "alloc": {"shape": "note", "style": "filled,dashed", "fillcolor": "#EAEAEA"},
+}
+_DEFAULT_STYLE = {"shape": "box", "style": "rounded,filled", "fillcolor": "#E0E0E0"}
+
+
+def _node_style(core_type):
+    return _CORE_STYLE.get(core_type, _DEFAULT_STYLE)
+
+
+def emit_dot(edges, nodes, meta, direction="LR"):
+    """Graphviz DOT source. Used internally to feed the layout engine before
+    wrapping the SVG in HTML.
+
+    Nodes that appear as edge endpoints but are absent from the perf-records
+    sidecar are tagged as ``alloc``: in practice these are tasks created by
+    ``alloc_tensors`` (which gets a real task_id and is referenced via
+    ``owner_task_id`` from downstream consumers, but never dispatches a
+    kernel and therefore has no perf entry). When no perf sidecar exists at
+    all (``meta`` empty) we can't disambiguate and fall back to the default
+    style for every node.
+    """
+    fmt_task = _make_task_formatter(nodes)
+    have_perf = bool(meta)
+    lines = [
+        "digraph deps {",
+        f"  rankdir={direction};",
+        '  node [fontname="Helvetica", fontsize=10];',
+        '  edge [color="#888"];',
+    ]
+    for n in nodes:
+        m = meta.get(n)
+        if m:
+            style = _node_style(m.get("core_type"))
+        elif have_perf:
+            style = _CORE_STYLE["alloc"]
+        else:
+            style = _DEFAULT_STYLE
+        # Escape any backslash / double-quote in the label.
+        label = _label(n, meta, fmt_task, have_perf=have_perf).replace("\\", "\\\\").replace('"', '\\"')
+        attrs = f'label="{label}", shape={style["shape"]}, style="{style["style"]}", fillcolor="{style["fillcolor"]}"'
+        lines.append(f"  {_node_id(n)} [{attrs}];")
+    for pred, succ in edges:
+        lines.append(f"  {_node_id(pred)} -> {_node_id(succ)};")
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def render_svg(dot_text, engine="dot"):
+    """Pipe DOT through the Graphviz layout engine and return raw SVG bytes.
+
+    Raises FileNotFoundError if the engine binary is not on PATH; RuntimeError
+    if the engine returns a non-zero exit code.
+    """
+    if shutil.which(engine) is None:
+        raise FileNotFoundError(
+            f"Graphviz '{engine}' not found on PATH. Install graphviz: brew install graphviz / apt install graphviz"
+        )
+    proc = subprocess.run(
+        [engine, "-Tsvg"],
+        input=dot_text.encode(),
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        msg = proc.stderr.decode(errors="replace")
+        raise RuntimeError(f"{engine} -Tsvg failed (exit {proc.returncode}):\n{msg}")
+    return proc.stdout
+
+
+# Self-contained HTML wrapper. Drag-to-pan + wheel-to-zoom in vanilla JS.
+# The SVG is inlined so the file is single-page and works offline. We use CSS
+# transform (translate + scale) rather than mutating the SVG viewBox — that
+# keeps pan/zoom on the GPU compositor for 60fps performance on large graphs.
+_HTML_TEMPLATE = """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>deps.json — {n_nodes} nodes, {n_edges} edges</title>
+<style>
+  html, body {{ margin: 0; height: 100%; background: #fafafa; font-family: -apple-system, sans-serif; }}
+  #hud {{ position: fixed; top: 8px; left: 8px; background: #fff; padding: 6px 10px;
+         border: 1px solid #ddd; border-radius: 4px; font-size: 12px; z-index: 10;
+         box-shadow: 0 1px 3px rgba(0,0,0,0.08); }}
+  #hud kbd {{ font-family: ui-monospace, monospace; background: #f0f0f0;
+              padding: 1px 4px; border-radius: 2px; }}
+  #legend {{ position: fixed; top: 8px; right: 8px; background: #fff; padding: 6px 10px;
+             border: 1px solid #ddd; border-radius: 4px; font-size: 12px; z-index: 10;
+             box-shadow: 0 1px 3px rgba(0,0,0,0.08); display: flex; gap: 12px; align-items: center; }}
+  #legend .swatch {{ display: inline-flex; align-items: center; gap: 4px; }}
+  #legend svg {{ display: block; }}
+  #stage {{ width: 100vw; height: 100vh; overflow: hidden; cursor: grab; }}
+  #stage.panning {{ cursor: grabbing; }}
+  #stage > svg {{ transform-origin: 0 0; transition: none; max-width: none; }}
+</style>
+</head>
+<body>
+<div id="hud">
+  {n_nodes} nodes · {n_edges} edges &nbsp;|&nbsp;
+  <kbd>drag</kbd> pan &nbsp; <kbd>wheel</kbd> zoom &nbsp; <kbd>f</kbd> fit &nbsp; <kbd>r</kbd> reset
+</div>
+<div id="legend">
+  <span class="swatch">
+    <svg width="18" height="14" viewBox="0 0 18 14">
+      <rect x="1" y="2" width="16" height="10" rx="3" ry="3" fill="#66A3FF" stroke="#333" stroke-width="1"/>
+    </svg>
+    AIC (cube)
+  </span>
+  <span class="swatch">
+    <svg width="18" height="14" viewBox="0 0 18 14">
+      <ellipse cx="9" cy="7" rx="8" ry="5" fill="#FFB366" stroke="#333" stroke-width="1"/>
+    </svg>
+    AIV (vector)
+  </span>
+  <span class="swatch">
+    <svg width="18" height="14" viewBox="0 0 18 14">
+      <polygon points="9,1 17,7 9,13 1,7" fill="#66CC99" stroke="#333" stroke-width="1"/>
+    </svg>
+    mix
+  </span>
+  <span class="swatch">
+    <svg width="18" height="14" viewBox="0 0 18 14">
+      <path d="M2,2 L13,2 L16,5 L16,12 L2,12 Z" fill="#EAEAEA" stroke="#333" stroke-width="1" stroke-dasharray="2,1"/>
+    </svg>
+    alloc
+  </span>
+</div>
+<div id="stage">
+{svg_body}
+</div>
+<script>
+(function () {{
+  const stage = document.getElementById('stage');
+  const svg = stage.querySelector('svg');
+  if (!svg) return;
+  // Drop fixed width/height so the SVG renders at its natural size; we control
+  // scale via CSS transform.
+  svg.removeAttribute('width');
+  svg.removeAttribute('height');
+
+  let scale = 1, tx = 0, ty = 0;
+  const apply = () => {{ svg.style.transform = `translate(${{tx}}px, ${{ty}}px) scale(${{scale}})`; }};
+
+  // Wheel zoom about cursor.
+  stage.addEventListener('wheel', (e) => {{
+    e.preventDefault();
+    const rect = stage.getBoundingClientRect();
+    const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
+    const factor = Math.exp(-e.deltaY * 0.001);
+    const newScale = Math.min(20, Math.max(0.02, scale * factor));
+    // Keep the point under the cursor fixed in screen space.
+    tx = cx - (cx - tx) * (newScale / scale);
+    ty = cy - (cy - ty) * (newScale / scale);
+    scale = newScale;
+    apply();
+  }}, {{ passive: false }});
+
+  // Drag to pan.
+  let dragging = false, lastX = 0, lastY = 0;
+  stage.addEventListener('mousedown', (e) => {{
+    dragging = true; lastX = e.clientX; lastY = e.clientY;
+    stage.classList.add('panning');
+  }});
+  window.addEventListener('mousemove', (e) => {{
+    if (!dragging) return;
+    tx += e.clientX - lastX; ty += e.clientY - lastY;
+    lastX = e.clientX; lastY = e.clientY;
+    apply();
+  }});
+  window.addEventListener('mouseup', () => {{ dragging = false; stage.classList.remove('panning'); }});
+
+  // 'f' = fit-to-view, 'r' = reset to 1:1.
+  const fit = () => {{
+    const bb = svg.getBoundingClientRect();
+    // bb is in current-transform coordinates, so undo the transform first.
+    const naturalW = bb.width / scale, naturalH = bb.height / scale;
+    const sx = stage.clientWidth / naturalW, sy = stage.clientHeight / naturalH;
+    scale = Math.min(sx, sy) * 0.95;
+    tx = (stage.clientWidth - naturalW * scale) / 2;
+    ty = (stage.clientHeight - naturalH * scale) / 2;
+    apply();
+  }};
+  document.addEventListener('keydown', (e) => {{
+    if (e.key === 'f') fit();
+    else if (e.key === 'r') {{ scale = 1; tx = 0; ty = 0; apply(); }}
+  }});
+  // Auto-fit on first paint.
+  requestAnimationFrame(fit);
+}})();
+</script>
+</body>
+</html>
+"""
+
+
+def emit_html(edges, nodes, meta, direction="LR", engine="dot"):
+    """Build the pan/zoom HTML page: DOT → Graphviz SVG → inline into template."""
+    dot = emit_dot(edges, nodes, meta, direction=direction)
+    svg_bytes = render_svg(dot, engine=engine)
+    svg_text = svg_bytes.decode("utf-8", errors="replace")
+    # Strip the XML prolog / DOCTYPE that graphviz emits — inlining keeps the
+    # <svg> root only.
+    if "<svg" in svg_text:
+        svg_text = svg_text[svg_text.index("<svg") :]
+    return _HTML_TEMPLATE.format(
+        n_nodes=len(nodes),
+        n_edges=len(edges),
+        svg_body=svg_text,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _find_latest_deps_json():
+    outputs = Path("outputs")
+    if not outputs.is_dir():
+        return None
+    candidates = sorted(outputs.rglob("deps.json"), key=lambda p: p.stat().st_mtime)
+    return candidates[-1] if candidates else None
+
+
+def _load_func_names_json(path):
+    """Load func_id → name mapping from a JSON file (``callable_id_to_name``
+    shape, as written by ``scene_test._dump_name_map``, or a flat dict).
+    Returns {} on failure.
+    """
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"Warning: couldn't read {path}: {e}", file=sys.stderr)
+        return {}
+    return data.get("callable_id_to_name") or data
+
+
+def _autoload_name_map(deps_path):
+    """Look for a ``name_map_*.json`` next to deps.json (written by
+    ``scene_test._dump_name_map`` when the case ran with diagnostics on).
+    Returns {} if no candidate exists; the newest match wins on ties.
+    """
+    candidates = sorted(Path(deps_path).parent.glob("name_map_*.json"), key=lambda p: p.stat().st_mtime)
+    if not candidates:
+        return {}
+    return _load_func_names_json(candidates[-1])
+
+
+def _build_parser():
+    p = argparse.ArgumentParser(
+        description="Render deps.json as a pan/zoom HTML dependency graph.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""\
+Examples:
+  %(prog)s                                    # newest deps.json under ./outputs/
+  %(prog)s outputs/.../deps.json
+  %(prog)s deps.json -o my_graph.html
+  %(prog)s deps.json --engine sfdp            # force-directed (recommended >1000 nodes)
+  %(prog)s deps.json --func-names names.json  # label nodes with kernel names
+""",
+    )
+    p.add_argument("input", nargs="?", help="Path to deps.json (default: newest under ./outputs/).")
+    p.add_argument("-o", "--output", help="Output HTML path (default: same dir as input, deps_graph.html).")
+    p.add_argument(
+        "--engine",
+        choices=["dot", "neato", "sfdp", "fdp", "circo", "twopi"],
+        default="dot",
+        help="Graphviz layout engine. 'dot' for hierarchical (<500 nodes), 'sfdp' for force-directed (10k+ nodes).",
+    )
+    p.add_argument(
+        "--direction",
+        choices=["TB", "LR", "BT", "RL"],
+        default="LR",
+        help="Flow direction for hierarchical layouts (default: LR; ignored by sfdp/neato).",
+    )
+    p.add_argument(
+        "--func-names",
+        help="JSON with callable_id_to_name (or flat {func_id: name}) for label enrichment.",
+    )
+    return p
+
+
+def main():
+    args = _build_parser().parse_args()
+
+    input_path = args.input or _find_latest_deps_json()
+    if input_path is None:
+        print("No deps.json given and no candidate found under ./outputs/.", file=sys.stderr)
+        return 1
+    input_path = Path(input_path)
+    if not input_path.exists():
+        print(f"{input_path} not found.", file=sys.stderr)
+        return 1
+
+    edges, nodes = _load_deps_edges(input_path)
+    # Explicit --func-names wins over the auto-discovered sibling file.
+    func_names = _load_func_names_json(args.func_names) if args.func_names else _autoload_name_map(input_path)
+    meta = _load_task_meta(input_path, func_names=func_names)
+    # Some workloads (embarrassingly parallel kernels, scope-fenced iterations
+    # that never reuse a tensor) produce no deps edges. Without the perf-records
+    # union the graph would be empty even though tasks ran. Seed isolated nodes
+    # from meta so every recorded task shows up, with its mix/aic/aiv shape.
+    if meta:
+        nodes = sorted(set(nodes) | set(meta.keys()))
+
+    html = emit_html(edges, nodes, meta, direction=args.direction, engine=args.engine)
+
+    out = Path(args.output) if args.output else input_path.parent / "deps_graph.html"
+    out.write_text(html)
+    print(f"Wrote {out} ({len(nodes)} nodes, {len(edges)} edges, engine={args.engine})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -117,6 +117,45 @@ def read_perf_data(filepath):
     return data
 
 
+def load_deps_json(perf_records_path):
+    """Load deps.json (dep_gen replay output) co-located with ``l2_perf_records.json``.
+
+    deps.json supersedes ``task["fanout"]``: fanout is sealed at the moment the
+    producer's L2PerfRecord retires, so consumers submitted after a fast producer
+    completes can never get attributed to it. dep_gen's replay reconstructs the
+    complete graph by replaying every captured ``submit_task`` through a host
+    PTO2TensorMap.
+
+    Returns:
+        dict[int, list[int]] mapping ``pred_raw → [succ_raw, ...]`` (i.e. the
+        same shape as ``task["fanout"]``), or ``None`` if no deps.json is present.
+        Tasks with no successors are absent from the dict (mirrors ``defaultdict``
+        semantics on lookup miss).
+    """
+    deps_path = Path(perf_records_path).parent / "deps.json"
+    if not deps_path.exists():
+        return None
+    try:
+        with deps_path.open() as f:
+            data = json.load(f)
+    except (OSError, ValueError) as e:
+        print(f"Warning: failed to read {deps_path}: {e}; falling back to fanout", file=sys.stderr)
+        return None
+    edges = data.get("edges")
+    if not isinstance(edges, list):
+        return None
+    by_pred: dict[int, list[int]] = defaultdict(list)
+    for edge in edges:
+        if not isinstance(edge, (list, tuple)) or len(edge) != 2:
+            continue
+        pred = normalize_pto2_task_id_int(edge[0])
+        succ = normalize_pto2_task_id_int(edge[1])
+        if pred is None or succ is None:
+            continue
+        by_pred[pred].append(succ)
+    return dict(by_pred)
+
+
 def load_kernel_config(config_path):
     """Load kernel configuration from kernel_config.py file.
 
@@ -395,6 +434,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     orchestrator_phases=None,
     core_to_thread=None,
     orchestrator_name=None,
+    deps_edges=None,
 ):
     """Generate Chrome Trace Event Format JSON from task data.
 
@@ -627,11 +667,22 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
             task_to_aicpu_event_id[(task["task_id"], task["core_id"])] = event_id
             event_id += 1
 
-    # Flow events (Flow events "s" and "f" for dependencies)
+    # Flow events (Flow events "s" and "f" for dependencies). When deps.json
+    # was produced by dep_gen replay, prefer its edges over task["fanout"] —
+    # fanout is the truncated, race-prone view (see load_deps_json's docstring).
+    # Edges where the predecessor's end_time outlives the successor's start_time
+    # are flagged as happens-before violations and emitted with a distinct flow
+    # name so Perfetto colors them differently from clean dependency arrows.
     task_map: dict[int, list] = defaultdict(list)
     for t in tasks:
         task_map[t["task_id"]].append(t)
     flow_id = 0
+    hb_violation_count = 0
+
+    def _succs_for(task):
+        if deps_edges is not None:
+            return deps_edges.get(task["task_id"], [])
+        return task["fanout"]
 
     for task in tasks:
         src_tid = core_to_tid[task["core_id"]]
@@ -642,7 +693,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
         # Use a small offset (0.01 us) for visual clarity
         flow_start_us = src_ts_end - 0.01
 
-        for succ_task_id in task["fanout"]:
+        for succ_task_id in _succs_for(task):
             if succ_task_id not in task_map:
                 if verbose:
                     print(
@@ -656,12 +707,21 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                 dst_ts_start = succ_task["start_time_us"]
                 dst_event_id = task_to_event_id[(succ_task["task_id"], succ_task["core_id"])]
 
+                # Happens-before violation: producer outlived consumer's start.
+                # Real time order broke the data dependency the graph asserted;
+                # the runtime got away with it (consumer presumably re-read fresh
+                # data) but it's a smell — surface it.
+                hb_violated = src_ts_end > dst_ts_start
+                flow_name = "hb_violation" if hb_violated else "dependency"
+                if hb_violated:
+                    hb_violation_count += 1
+
                 # Flow start event (at end of source task)
                 events.append(
                     {
                         "cat": "flow",
                         "id": flow_id,
-                        "name": "dependency",
+                        "name": flow_name,
                         "ph": "s",
                         "pid": 1,
                         "tid": src_tid,
@@ -674,7 +734,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                     {
                         "cat": "flow",
                         "id": flow_id,
-                        "name": "dependency",
+                        "name": flow_name,
                         "ph": "f",
                         "pid": 1,
                         "tid": dst_tid,
@@ -684,6 +744,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                     }
                 )
                 flow_id += 1
+
+    if verbose:
+        edge_source = "deps.json" if deps_edges is not None else "task.fanout"
+        print(f"  Flow events: {flow_id} edges (source: {edge_source})")
+        if hb_violation_count > 0:
+            print(f"  Happens-before violations: {hb_violation_count} edge(s) flagged as 'hb_violation'")
 
     # AICPU Scheduler phase events (version 2)
     if scheduler_phases:
@@ -866,7 +932,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
             src_tid = task_to_aicpu_tid.get((task["task_id"], task["core_id"]), core_to_tid[task["core_id"]])
             src_aicpu_eid = task_to_aicpu_event_id.get((task["task_id"], task["core_id"]))
 
-            for succ_task_id in task["fanout"]:
+            for succ_task_id in _succs_for(task):
                 if succ_task_id not in task_map:
                     continue
 
@@ -880,10 +946,15 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                     )
                     dst_aicpu_eid = task_to_aicpu_event_id.get((succ_task["task_id"], succ_task["core_id"]))
 
+                    # Mirror the AICore-view HB-violation classification using
+                    # the AICPU dispatch/finish timestamps.
+                    aicpu_hb_violated = src_finish_us > dst_dispatch_us
+                    aicpu_flow_name = "hb_violation" if aicpu_hb_violated else "dependency"
+
                     flow_s = {
                         "cat": "flow",
                         "id": flow_id,
-                        "name": "dependency",
+                        "name": aicpu_flow_name,
                         "ph": "s",
                         "pid": 2,
                         "tid": src_tid,
@@ -896,7 +967,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                     flow_f = {
                         "cat": "flow",
                         "id": flow_id,
-                        "name": "dependency",
+                        "name": aicpu_flow_name,
                         "ph": "f",
                         "pid": 2,
                         "tid": dst_tid,
@@ -1268,6 +1339,10 @@ def main():
             l2_perf_records_path=input_path,
         )
 
+        deps_edges = load_deps_json(input_path)
+        if args.verbose and deps_edges is not None:
+            print(f"  Using deps.json edges ({sum(len(v) for v in deps_edges.values())} total)")
+
         generate_chrome_trace_json(
             data["tasks"],
             str(output_path),
@@ -1278,6 +1353,7 @@ def main():
             orchestrator_data=data.get("aicpu_orchestrator"),
             orchestrator_phases=data.get("aicpu_orchestrator_phases"),
             core_to_thread=data.get("core_to_thread"),
+            deps_edges=deps_edges,
         )
 
         print("\n✓ Conversion complete")

--- a/src/a2a3/platform/include/host/dep_gen_collector.h
+++ b/src/a2a3/platform/include/host/dep_gen_collector.h
@@ -47,12 +47,10 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
-#include <filesystem>
-#include <fstream>
 #include <mutex>
 #include <optional>
 #include <string>
-#include <system_error>
+#include <vector>
 
 #include "common/dep_gen.h"
 #include "common/platform_config.h"
@@ -172,8 +170,8 @@ public:
      * @return 0 on success, non-zero on failure
      */
     int init(
-        int num_threads, const std::string &submit_trace_path, DepGenAllocCallback alloc_cb,
-        DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb, void *user_data, int device_id
+        int num_threads, DepGenAllocCallback alloc_cb, DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb,
+        void *user_data, int device_id
     );
 
     /**
@@ -184,8 +182,10 @@ public:
     void *get_dep_gen_shm_device_ptr() const { return shm_dev_; }
 
     /**
-     * Per-buffer callback invoked by ProfilerBase's poll loop. Appends each
-     * DepGenRecord to submit_trace.bin.
+     * Per-buffer callback invoked by ProfilerBase's poll loop. Appends the
+     * buffer's DepGenRecord entries to the in-memory ``records_`` vector
+     * (no disk I/O — the host replay consumes that vector directly via
+     * ``records()`` once the device run completes).
      */
     void on_buffer_collected(const DepGenReadyBufferInfo &info);
 
@@ -199,7 +199,7 @@ public:
     bool reconcile_counters();
 
     /**
-     * Free all device memory and close output file. Idempotent.
+     * Free all device memory and release the in-memory record buffer. Idempotent.
      */
     void finalize(DepGenUnregisterCallback unregister_cb, DepGenFreeCallback free_cb, void *user_data);
 
@@ -209,9 +209,16 @@ public:
     bool is_initialized() const { return initialized_; }
 
     /**
-     * Total DepGenRecords written to submit_trace.bin so far.
+     * Total DepGenRecords drained from the device-side ring buffer so far.
      */
     uint64_t total_collected() const { return total_collected_; }
+
+    /**
+     * In-memory record buffer (host replay's input). Valid between init()
+     * and finalize(); pointer/size stay stable after stop() returns, which
+     * is when the caller hands them to ``dep_gen_replay_emit_deps_json``.
+     */
+    const std::vector<DepGenRecord> &records() const { return records_; }
 
 private:
     bool initialized_ = false;
@@ -226,35 +233,22 @@ private:
 
     bool buffers_registered_ = false;
 
-    // Binary output. File opened lazily on first record so a run that
-    // produces no records leaves no empty file on disk.
-    std::string submit_trace_path_;
-    std::ofstream out_file_;
-    std::mutex out_mutex_;
+    // In-memory record buffer — drained from the device ring on
+    // on_buffer_collected() and consumed by the host replay directly (no
+    // disk hop). Mutex serializes the mgmt thread's appends against the
+    // (rare) reader on the same collector instance.
+    std::vector<DepGenRecord> records_;
+    std::mutex records_mutex_;
 
-    // Running total of records written. Used at reconcile time for the
-    // collected + dropped == device_total cross-check.
+    // Running total of records appended. Equal to ``records_.size()`` after
+    // every append; kept separately for the reconcile_counters cross-check
+    // even when records_ may be inspected concurrently.
     uint64_t total_collected_ = 0;
 
     DepGenDataHeader *dep_gen_header() const { return get_dep_gen_header(shm_host_); }
     DepGenBufferState *dep_gen_state(int idx = 0) const { return get_dep_gen_buffer_state(shm_host_, idx); }
 
-    void ensure_out_open_unlocked();
-    void write_buffer(const void *buf_host_ptr);
+    void append_buffer_records(const void *buf_host_ptr);
 };
-
-/**
- * Build the SubmitTrace .bin path under the caller-provided per-task
- * directory. Filename is fixed (no timestamp) — the directory is the
- * per-task uniqueness boundary, mirroring make_pmu_csv_path().
- */
-inline std::string make_dep_gen_path(const std::string &output_dir) {
-    std::error_code ec;
-    std::filesystem::create_directories(output_dir, ec);
-    if (ec) {
-        LOG_WARN("Failed to create dep_gen output directory %s: %s", output_dir.c_str(), ec.message().c_str());
-    }
-    return output_dir + "/submit_trace.bin";
-}
 
 #endif  // SRC_A2A3_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -33,6 +33,23 @@
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
 
+// dep_gen_replay_emit_deps_json: strong symbol provided by
+// runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp when that runtime is
+// linked into host_runtime.so. host_build_graph has no replay implementation
+// today, so its host_runtime.so falls through to this weak stub. visibility=
+// hidden keeps the stub off the global dynamic symbol table so it can't
+// accidentally shadow the strong symbol via RTLD_GLOBAL.
+// LOG_DEBUG (not WARN): runtimes that don't link dep_gen never enable it in
+// practice, so this path is unreachable for end users — the symbol exists
+// purely to keep the .so loadable.
+extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_deps_json(
+    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/,
+    const int32_t * /*task_window_sizes*/
+) {
+    LOG_DEBUG("dep_gen replay not implemented for this runtime — deps.json skipped");
+    return -1;
+}
+
 // =============================================================================
 // Lazy-loaded HAL (ascend_hal) for profiling host-register only
 // =============================================================================
@@ -621,7 +638,7 @@ int DeviceRunner::run(
     }
 
     if (enable_dep_gen_) {
-        rc = init_dep_gen(launch_aicpu_num, make_dep_gen_path(output_prefix_), device_id);
+        rc = init_dep_gen(launch_aicpu_num, device_id);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
             return rc;
@@ -773,7 +790,14 @@ int DeviceRunner::run(
 
     if (enable_dep_gen_) {
         dep_gen_collector_.stop();
-        dep_gen_collector_.reconcile_counters();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const auto &records = dep_gen_collector_.records();
+            const std::string deps = output_prefix_ + "/deps.json";
+            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str(), nullptr);
+            if (rc != 0) {
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
+            }
+        }
     }
 
     // Print handshake results (reads from device memory, must be before free)
@@ -1497,7 +1521,7 @@ int DeviceRunner::init_pmu(
     return 0;
 }
 
-int DeviceRunner::init_dep_gen(int num_threads, const std::string &submit_trace_path, int device_id) {
+int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
     auto alloc_cb = [](size_t size, void *user_data) -> void * {
         auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->alloc(size);
@@ -1521,8 +1545,7 @@ int DeviceRunner::init_dep_gen(int num_threads, const std::string &submit_trace_
         return allocator->free(dev_ptr);
     };
 
-    int rc =
-        dep_gen_collector_.init(num_threads, submit_trace_path, alloc_cb, register_cb, free_cb, &mem_alloc_, device_id);
+    int rc = dep_gen_collector_.init(num_threads, alloc_cb, register_cb, free_cb, &mem_alloc_, device_id);
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -725,7 +725,7 @@ private:
      * @param device_id          Device ID for host registration
      * @return 0 on success, error code on failure
      */
-    int init_dep_gen(int num_threads, const std::string &submit_trace_path, int device_id);
+    int init_dep_gen(int num_threads, int device_id);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -41,6 +41,23 @@
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
 
+// dep_gen_replay_emit_deps_json: strong symbol provided by
+// runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp when that runtime is
+// linked into host_runtime.so. host_build_graph has no replay implementation
+// today, so its host_runtime.so falls through to this weak stub. Hidden
+// visibility keeps the stub off the global symbol table so RTLD_GLOBAL can't
+// let it shadow the strong symbol in cross-.so loads.
+// LOG_DEBUG (not WARN): runtimes that don't link dep_gen never enable it in
+// practice, so this path is unreachable for end users — the symbol exists
+// purely to keep the .so loadable.
+extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_deps_json(
+    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/,
+    const int32_t * /*task_window_sizes*/
+) {
+    LOG_DEBUG("dep_gen replay not implemented for this runtime — deps.json skipped");
+    return -1;
+}
+
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime *runtime);
 typedef void (*aicore_execute_func_t)(
@@ -449,7 +466,7 @@ int DeviceRunner::run(
     }
 
     if (enable_dep_gen_) {
-        rc = init_dep_gen(launch_aicpu_num, make_dep_gen_path(output_prefix_), device_id);
+        rc = init_dep_gen(launch_aicpu_num, device_id);
         if (rc != 0) {
             LOG_ERROR("init_dep_gen failed: %d", rc);
             return rc;
@@ -666,7 +683,14 @@ int DeviceRunner::run(
 
     if (enable_dep_gen_) {
         dep_gen_collector_.stop();
-        dep_gen_collector_.reconcile_counters();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const auto &records = dep_gen_collector_.records();
+            const std::string deps = output_prefix_ + "/deps.json";
+            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str(), nullptr);
+            if (rc != 0) {
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
+            }
+        }
     }
 
     // Print handshake results at end of run
@@ -1243,7 +1267,7 @@ int DeviceRunner::init_pmu(
     return 0;
 }
 
-int DeviceRunner::init_dep_gen(int num_threads, const std::string &submit_trace_path, int /*device_id*/) {
+int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
     auto alloc_cb = [](size_t size, void *user_data) -> void * {
         auto *allocator = static_cast<MemoryAllocator *>(user_data);
         return allocator->alloc(size);
@@ -1255,7 +1279,7 @@ int DeviceRunner::init_dep_gen(int num_threads, const std::string &submit_trace_
 
     // Sim shares an address space with the AICPU thread, so register_cb is
     // not needed (mirrors PMU's nullptr in sim).
-    int rc = dep_gen_collector_.init(num_threads, submit_trace_path, alloc_cb, nullptr, free_cb, &mem_alloc_, -1);
+    int rc = dep_gen_collector_.init(num_threads, alloc_cb, nullptr, free_cb, &mem_alloc_, -1);
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -375,7 +375,7 @@ private:
 
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
 
-    int init_dep_gen(int num_threads, const std::string &submit_trace_path, int device_id);
+    int init_dep_gen(int num_threads, int device_id);
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use

--- a/src/a2a3/platform/src/host/dep_gen_collector.cpp
+++ b/src/a2a3/platform/src/host/dep_gen_collector.cpp
@@ -14,8 +14,10 @@
  * @brief Host-side dep_gen collector. The mgmt-thread + buffer-pool machinery
  *        lives in profiling_common::BufferPoolManager parameterized by
  *        DepGenModule (host/dep_gen_collector.h); this file owns the
- *        per-buffer on_buffer_collected callback (raw binary append) and the
- *        device-side cross-check.
+ *        per-buffer on_buffer_collected callback (in-memory append) and the
+ *        device-side cross-check. Records stay in ``records_`` and are
+ *        consumed directly by the host replay — no on-disk submit_trace.bin
+ *        intermediary.
  */
 
 #include "host/dep_gen_collector.h"
@@ -34,8 +36,8 @@ DepGenCollector::~DepGenCollector() { stop(); }
 // ---------------------------------------------------------------------------
 
 int DepGenCollector::init(
-    int num_threads, const std::string &submit_trace_path, DepGenAllocCallback alloc_cb,
-    DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb, void *user_data, int device_id
+    int num_threads, DepGenAllocCallback alloc_cb, DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb,
+    void *user_data, int device_id
 ) {
     if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("DepGenCollector::init: invalid arguments");
@@ -43,13 +45,10 @@ int DepGenCollector::init(
     }
 
     num_threads_ = num_threads;
-    submit_trace_path_ = submit_trace_path;
     buffers_registered_ = (register_cb != nullptr);
     total_collected_ = 0;
+    records_.clear();
     execution_complete_.store(false, std::memory_order_release);
-    if (out_file_.is_open()) {
-        out_file_.close();
-    }
 
     // ---- Allocate shared header + buffer-state region ----
     // dep_gen is single-instance: just one DepGenBufferState after the header.
@@ -118,25 +117,17 @@ int DepGenCollector::init(
     set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_host_, device_id);
 
     LOG_INFO_V0(
-        "DepGen collector initialized: %d threads, SHM=0x%lx, out=%s (opened on first record)", num_threads,
-        reinterpret_cast<unsigned long>(shm_dev_), submit_trace_path_.c_str()
+        "DepGen collector initialized: %d threads, SHM=0x%lx (records held in memory until replay)", num_threads,
+        reinterpret_cast<unsigned long>(shm_dev_)
     );
     return 0;
 }
 
 // ---------------------------------------------------------------------------
-// Binary output
+// Record accumulation (in-memory — no disk hop)
 // ---------------------------------------------------------------------------
 
-void DepGenCollector::ensure_out_open_unlocked() {
-    if (out_file_.is_open()) return;
-    out_file_.open(submit_trace_path_, std::ios::out | std::ios::binary | std::ios::trunc);
-    if (!out_file_.is_open()) {
-        LOG_ERROR("DepGenCollector: failed to open submit trace file: %s", submit_trace_path_.c_str());
-    }
-}
-
-void DepGenCollector::write_buffer(const void *buf_host_ptr) {
+void DepGenCollector::append_buffer_records(const void *buf_host_ptr) {
     const DepGenBuffer *buf = reinterpret_cast<const DepGenBuffer *>(buf_host_ptr);
     uint32_t n = buf->count;
     if (n > static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
@@ -144,21 +135,18 @@ void DepGenCollector::write_buffer(const void *buf_host_ptr) {
     }
     if (n == 0) return;
 
-    std::scoped_lock lock(out_mutex_);
-    ensure_out_open_unlocked();
-    if (!out_file_.is_open()) return;
-    out_file_.write(
-        reinterpret_cast<const char *>(buf->records), static_cast<std::streamsize>(n) * sizeof(DepGenRecord)
-    );
+    std::scoped_lock lock(records_mutex_);
+    records_.insert(records_.end(), buf->records, buf->records + n);
     total_collected_ += n;
-    out_file_.flush();
 }
 
 // ---------------------------------------------------------------------------
 // ProfilerBase callback
 // ---------------------------------------------------------------------------
 
-void DepGenCollector::on_buffer_collected(const DepGenReadyBufferInfo &info) { write_buffer(info.host_buffer_ptr); }
+void DepGenCollector::on_buffer_collected(const DepGenReadyBufferInfo &info) {
+    append_buffer_records(info.host_buffer_ptr);
+}
 
 // ---------------------------------------------------------------------------
 // reconcile_counters
@@ -228,8 +216,10 @@ void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, DepGenFre
 
     stop();
 
-    if (out_file_.is_open()) {
-        out_file_.close();
+    {
+        std::scoped_lock lock(records_mutex_);
+        records_.clear();
+        records_.shrink_to_fit();
     }
 
     // Same pattern as PmuCollector: walk owned buffers, then the free_queue

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_replay.cpp
+ * @brief Replay in-memory DepGenRecord stream → deps.json via a host-resident
+ *        PTO2TensorMap.
+ *
+ * Input is the host collector's in-memory record buffer (no disk I/O — the
+ * collector drains the device ring directly into the buffer this function
+ * reads). Per-record processing mirrors pto_orchestrator::submit_task
+ * exactly so the edges replay emits are bit-equivalent to the ones the
+ * device would have recorded if no producer had retired before its
+ * consumers were submitted:
+ *
+ *   STEP 1 — explicit_deps: emitted at the call site (per pto_dep_compute.h's
+ *            "kept at call site" note; both runtime and replay do this loop
+ *            themselves because STEP 3's reuse / dedup is subtly different).
+ *   STEP 3 — compute_task_fanin: creator retention (Tensor::owner_task_id) +
+ *            tensormap.lookup for INPUT / INOUT, with INOUT+COVERED removal.
+ *   STEP 4 — register_task_outputs: insert INOUT and OUTPUT_EXISTING outputs
+ *            into the tensormap so subsequent records can find them.
+ *
+ * Pool sizing: replay never advances last_task_alive, so the entry pool must
+ * accommodate every output write across the whole trace. We scan the record
+ * buffer once to count INOUT + OUTPUT_EXISTING slots and size the pool
+ * accordingly.
+ */
+
+#include "dep_gen_replay.h"
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "common/dep_gen.h"
+#include "common/unified_log.h"
+#include "pto_dep_compute.h"
+#include "pto_task_id.h"
+#include "pto_tensormap.h"
+#include "tensor.h"
+#include "tensor_arg.h"
+
+namespace {
+
+int32_t next_pow2(int32_t v) {
+    if (v <= 1) return 1;
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    return v + 1;
+}
+
+// Count INOUT + OUTPUT_EXISTING slots across the record buffer —
+// register_task_outputs only inserts those, and skips entries with manual_dep
+// set. Counting both without inspecting manual_dep is a conservative upper
+// bound (manual_dep is rare; the small over-allocation pays for itself in
+// avoided pool exhaustion).
+int32_t count_outputs(const DepGenRecord *records, size_t n) {
+    int32_t total = 0;
+    for (size_t i = 0; i < n; i++) {
+        const DepGenRecord &r = records[i];
+        for (uint16_t j = 0; j < r.tensor_count; j++) {
+            auto t = static_cast<TensorArgType>(r.arg_types[j]);
+            if (t == TensorArgType::INOUT || t == TensorArgType::OUTPUT_EXISTING) {
+                total++;
+            }
+        }
+    }
+    return total;
+}
+
+bool write_deps_json(const char *path, const std::vector<std::pair<uint64_t, uint64_t>> &edges) {
+    std::ofstream out(path, std::ios::out | std::ios::trunc);
+    if (!out) {
+        LOG_ERROR("dep_gen replay: failed to open '%s' for write", path);
+        return false;
+    }
+    out << "{\"version\":1,\"edges\":[";
+    for (size_t i = 0; i < edges.size(); i++) {
+        if (i > 0) {
+            out << ",";
+        }
+        out << "[" << edges[i].first << "," << edges[i].second << "]";
+    }
+    out << "]}\n";
+    return static_cast<bool>(out);
+}
+
+}  // namespace
+
+extern "C" int dep_gen_replay_emit_deps_json(
+    const DepGenRecord *records, size_t num_records, const char *deps_json_path, const int32_t *task_window_sizes_in
+) {
+    if (deps_json_path == nullptr) {
+        LOG_ERROR("dep_gen replay: null deps_json_path");
+        return -1;
+    }
+    if (num_records > 0 && records == nullptr) {
+        LOG_ERROR("dep_gen replay: num_records=%zu but records pointer is null", num_records);
+        return -1;
+    }
+    LOG_INFO_V0("dep_gen replay: processing %zu in-memory records", num_records);
+
+    // Per-ring task window sizes — tensormap masks slot indices and requires
+    // each to be a power of two. When the caller passes null we auto-size from
+    // the records themselves so each ring's window comfortably covers its
+    // observed max local_id (no slot aliasing during INOUT+COVERED
+    // remove_from_task).
+    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    if (task_window_sizes_in != nullptr) {
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            int32_t v = task_window_sizes_in[r];
+            if (v < 1) v = 1;
+            if ((v & (v - 1)) != 0) v = next_pow2(v);
+            task_window_sizes[r] = v;
+        }
+    } else {
+        uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
+        for (size_t i = 0; i < num_records; i++) {
+            PTO2TaskId tid{records[i].task_id};
+            uint8_t ring = tid.ring();
+            uint32_t local = tid.local();
+            if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
+                max_local[ring] = local;
+            }
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            // +1 for slot needed by max_local; floor at 16 to avoid tiny allocs.
+            int32_t need = static_cast<int32_t>(max_local[r] + 1);
+            int32_t v = next_pow2(need < 16 ? 16 : need);
+            task_window_sizes[r] = v;
+        }
+    }
+
+    int32_t output_count = count_outputs(records, num_records);
+    int32_t pool_size = output_count + (output_count / 10) + 64;
+    if (pool_size < PTO2_TENSORMAP_POOL_SIZE) {
+        pool_size = PTO2_TENSORMAP_POOL_SIZE;
+    }
+    int32_t num_buckets = next_pow2(pool_size / 16);
+    if (num_buckets < PTO2_TENSORMAP_NUM_BUCKETS) {
+        num_buckets = PTO2_TENSORMAP_NUM_BUCKETS;
+    }
+
+    PTO2TensorMap tensor_map;
+    std::memset(&tensor_map, 0, sizeof(tensor_map));
+    if (!tensor_map.init(num_buckets, pool_size, task_window_sizes)) {
+        LOG_ERROR("dep_gen replay: tensormap.init failed (buckets=%d, pool=%d)", num_buckets, pool_size);
+        return -3;
+    }
+
+    std::vector<std::pair<uint64_t, uint64_t>> edges;
+    edges.reserve(num_records * 2);
+
+    TensorRef tref_buf[CORE_MAX_TENSOR_ARGS];
+    TensorArgType atype_buf[CORE_MAX_TENSOR_ARGS];
+
+    for (size_t rec_i = 0; rec_i < num_records; rec_i++) {
+        const DepGenRecord &rec = records[rec_i];
+        PTO2TaskId task_id{rec.task_id};
+        bool in_manual_scope = (rec.flags & DEP_GEN_FLAG_IN_MANUAL_SCOPE) != 0;
+
+        int32_t tc = static_cast<int32_t>(rec.tensor_count);
+        if (tc > CORE_MAX_TENSOR_ARGS) {
+            tc = CORE_MAX_TENSOR_ARGS;
+        }
+        for (int32_t i = 0; i < tc; i++) {
+            tref_buf[i].ptr = reinterpret_cast<const Tensor *>(&rec.tensors[i][0]);
+            atype_buf[i] = static_cast<TensorArgType>(rec.arg_types[i]);
+        }
+
+        int32_t dc = static_cast<int32_t>(rec.explicit_dep_count);
+        if (dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
+            dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+        }
+
+        DepInputs inputs;
+        inputs.tensor_count = tc;
+        inputs.tensors = tref_buf;
+        inputs.arg_types = atype_buf;
+        inputs.explicit_dep_count = dc;
+        // PTO2TaskId is a struct of one uint64_t; record stores raw uint64s for
+        // explicit_deps. Layout-compatible (PTO2TaskId is verified 8 bytes).
+        inputs.explicit_deps = reinterpret_cast<const PTO2TaskId *>(rec.explicit_deps);
+
+        // STEP 1: explicit deps — single linear emit, matches runtime call site.
+        for (int32_t i = 0; i < dc; i++) {
+            edges.emplace_back(rec.explicit_deps[i], rec.task_id);
+        }
+
+        // STEP 3: creator retention + tensormap lookup.
+        bool ok = compute_task_fanin(inputs, tensor_map, in_manual_scope, [&](PTO2TaskId producer) -> bool {
+            edges.emplace_back(producer.raw, rec.task_id);
+            return true;
+        });
+        if (!ok) {
+            LOG_ERROR("dep_gen replay: compute_task_fanin returned fatal at task_id=%" PRIu64, rec.task_id);
+            tensor_map.destroy();
+            return -4;
+        }
+
+        // STEP 4: publish this task's outputs.
+        register_task_outputs(inputs, task_id, tensor_map, in_manual_scope);
+    }
+
+    tensor_map.destroy();
+
+    if (!write_deps_json(deps_json_path, edges)) {
+        return -5;
+    }
+    LOG_INFO_V0("dep_gen replay: wrote %zu edges to %s", edges.size(), deps_json_path);
+    return 0;
+}

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_replay.h
+ * @brief Host-side replay of in-memory DepGenRecord stream → deps.json.
+ *
+ * Takes the records the host collector drained from the device ring buffer
+ * (``DepGenCollector::records()``) and runs them back through a host-resident
+ * PTO2TensorMap using the same ``compute_task_fanin`` / ``register_task_outputs``
+ * primitives the device orchestrator uses, emitting the full
+ * predecessor → successor edge list to deps.json.
+ *
+ * The records buffer is passed in directly — there is no intermediate
+ * ``submit_trace.bin`` on disk. The host already has the records once the
+ * device run completes, so going through the filesystem would just be
+ * extra I/O and an extra file in the output directory.
+ *
+ * deps.json supersedes ``L2PerfRecord::fanout[]`` for tools that need the
+ * *complete* dependency graph: fanout is sealed when a producer finishes, so
+ * consumers submitted after a fast producer retires never get attributed to
+ * it (the race window that motivated dep_gen). Replay sees every submit and
+ * so reconstructs the graph the runtime would have built if no producer ever
+ * raced ahead.
+ *
+ * Output format (deps.json):
+ *
+ *   {"version":1,"edges":[[pred_raw,succ_raw], ...]}
+ *
+ *   - ``pred_raw`` / ``succ_raw`` are ``PTO2TaskId::raw`` values
+ *     (``(ring_id << 32) | local_id``).
+ *   - Edges are de-duplicated within a single successor's fanin but not
+ *     globally: identical (pred, succ) pairs are emitted only once per succ
+ *     because compute_task_fanin / register_task_outputs already dedup via
+ *     creator-retention + tensormap.
+ *
+ * The replay is single-threaded and pure CPU: no device handle is required.
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_HOST_DEP_GEN_REPLAY_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_HOST_DEP_GEN_REPLAY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Opaque forward decl — the canonical layout lives in common/dep_gen.h, but
+// replay's API only needs to take a pointer + count. Callers who construct
+// the buffer must include common/dep_gen.h themselves.
+struct DepGenRecord;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Replay an in-memory DepGenRecord stream and write deps.json.
+ *
+ * @param records            Pointer to a contiguous DepGenRecord array
+ *                           (typically ``DepGenCollector::records().data()``).
+ * @param num_records        Number of records in the array.
+ * @param deps_json_path     Output path; truncated if it exists.
+ * @param task_window_sizes  Per-ring task window sizes (length PTO2_MAX_RING_DEPTH).
+ *                           May be null — when null we auto-size from the trace
+ *                           itself so each ring's window covers its observed
+ *                           max local_id without slot aliasing. Each non-null
+ *                           entry is rounded up to the next power of two.
+ * @return 0 on success; negative on error (see source for codes).
+ */
+int dep_gen_replay_emit_deps_json(
+    const struct DepGenRecord *records, size_t num_records, const char *deps_json_path, const int32_t *task_window_sizes
+);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_HOST_DEP_GEN_REPLAY_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -610,15 +610,27 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     // register themselves.
     if (is_dep_gen_enabled()) {
         const void *tensor_ptrs[MAX_TENSOR_ARGS];
-        const int tc = args.tensor_count();
+        // TensorArgType is `enum class : int32_t` (4 bytes); the on-disk record
+        // packs arg_types as uint8_t[16] (5-value enum fits in a byte). Narrow
+        // each tag here rather than letting the AICPU writer reinterpret a
+        // 4×-wider array as bytes — that path silently lost two of every three
+        // tags on little-endian and synthesized phantom self-edges in replay.
+        uint8_t arg_types_u8[MAX_TENSOR_ARGS];
+        // Clamp to MAX_TENSOR_ARGS even though the Arg builder caps adds at
+        // MAX_TENSOR_ARGS: defensive against any future builder bypass /
+        // shared-memory bit-flip that could otherwise overrun the two
+        // MAX_TENSOR_ARGS-sized stack buffers above.
+        const int tc_raw = args.tensor_count();
+        const int tc = tc_raw > MAX_TENSOR_ARGS ? MAX_TENSOR_ARGS : tc_raw;
         for (int i = 0; i < tc; i++) {
             // OUTPUT slots carry create_info (not yet a Tensor); skip them —
             // they have no producer to look up and replay's per-tensor loop
             // also skips OUTPUT.
             tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : args.tensor(i).ptr;
+            arg_types_u8[i] = static_cast<uint8_t>(args.tag(i));
         }
         dep_gen_aicpu_record_submit(
-            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, reinterpret_cast<const uint8_t *>(args.tag_data()),
+            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data())
         );
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_tensormap.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_tensormap.cpp
@@ -30,7 +30,6 @@
 
 #include "common.h"
 #include "common/unified_log.h"
-#include "pto_orchestrator.h"
 
 // =============================================================================
 // TensorMap Lookup Chain Length Statistics (compile-time toggle)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py
@@ -7,24 +7,36 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""dep_gen capture sim test.
+"""dep_gen capture + replay sim test.
 
-Re-runs the ``vector_example`` orchestration with ``--enable-dep-gen`` and
-asserts that ``<output_prefix>/submit_trace.bin`` was produced with the
-expected size for the 5 ``submit_task`` calls the orchestration issues. This
-validates the device_runner wiring for the dep_gen sub-feature on a2a3sim
-(host collector, AICPU writer, kernel_args.dep_gen_data_base hand-off).
+Re-runs the ``vector_example`` orchestration with ``--enable-dep-gen`` (and,
+in standalone mode, auto-adds ``--enable-l2-swimlane`` for the fanout ⊆ deps
+gate). Verifies the end-to-end dep_gen pipeline on a2a3sim:
 
-Pytest entry: rely on the standard ``--enable-dep-gen`` CLI option from
-``conftest.py``. Standalone entry: also requires ``--enable-dep-gen`` so the
-trace path exists when post-run verification runs.
+  1. ``<output_prefix>/deps.json`` is produced by the host replay
+     (PTO2TensorMap replay → JSON edge list), and contains exactly the
+     6 edges documented in example_orchestration.cpp. The capture path
+     (host collector drains the device ring buffer into memory and feeds
+     the replay directly — no submit_trace.bin on disk) is exercised
+     implicitly: if it broke, deps.json would be empty or wrong.
+  2. **Validation gate** (when l2_perf_records.json is present, i.e.
+     ``--enable-l2-swimlane`` was also enabled): every edge in
+     L2PerfRecord::fanout[] also appears in deps.json. deps may have
+     MORE edges than fanout (race-window edges fanout missed); we never
+     assert symmetry — that's the entire reason dep_gen exists.
+
+Pytest entry: needs ``--enable-dep-gen`` (capture+replay assertions) and
+``--enable-l2-swimlane`` (fanout ⊆ deps gate). Standalone entry: pass
+``--enable-dep-gen`` and the swimlane flag is added automatically so a
+plain ``python test_dep_gen_capture.py -p a2a3sim --enable-dep-gen``
+exercises the full gate.
 
 Compute correctness is delegated to the upstream ``vector_example`` test —
 this case re-uses the same orchestration to keep coverage focused on the
-capture pipeline.
+capture+replay+validation pipeline.
 """
 
-import struct
+import json
 import sys
 
 import torch
@@ -34,14 +46,6 @@ from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
 KERNELS_BASE = "../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
-
-# Matches struct DepGenRecord in src/a2a3/platform/include/common/dep_gen.h:
-#   8 (task_id) + 4 (flags) + 2 (tensor_count) + 2 (explicit_dep_count)
-#   + 16*8 (explicit_deps) + 16 (arg_types) + 16 (_pad0) + 16*128 (tensors)
-#   = 2240 bytes, aligned(64).
-_DEP_GEN_RECORD_SIZE = 2240
-# example_orchestration.cpp issues 5 submit_task calls (t0..t4).
-_EXPECTED_SUBMIT_COUNT = 5
 
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -99,30 +103,62 @@ class TestDepGenCapture(SceneTestCase):
     def _post_validate(self, case):
         """Hook invoked after the case ran when --enable-dep-gen is in effect.
 
-        Locates the per-case output_prefix directory and asserts the
-        ``submit_trace.bin`` file has size == 5 * sizeof(DepGenRecord).
+        Locates the per-case output_prefix directory and asserts:
+          - deps.json exists (host collector → replay pipeline produced it)
+            and contains the 6 edges documented in example_orchestration.cpp
+          - if l2_perf_records.json is also present, every fanout edge it
+            records is a subset of the deps.json edge set
         """
         case_name = case["name"]
         safe_label = _sanitize_for_filename(f"TestDepGenCapture_{case_name}")
         outputs = _outputs_dir()
         matches = sorted(outputs.glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
         assert matches, f"no output prefix under {outputs} matching {safe_label}_*"
-        trace = matches[-1] / "submit_trace.bin"
-        assert trace.exists(), f"submit_trace.bin not produced under {matches[-1]}"
+        out_dir = matches[-1]
 
-        size = trace.stat().st_size
-        expected = _EXPECTED_SUBMIT_COUNT * _DEP_GEN_RECORD_SIZE
-        assert size == expected, (
-            f"submit_trace.bin size {size} != expected {expected} "
-            f"({_EXPECTED_SUBMIT_COUNT} records * {_DEP_GEN_RECORD_SIZE} B per record)"
-        )
+        # ---- deps.json (host replay output — sole dep_gen artifact on disk) ----
+        deps_path = out_dir / "deps.json"
+        assert deps_path.exists(), f"deps.json not produced under {out_dir} — capture or replay failed?"
+        with deps_path.open() as f:
+            deps = json.load(f)
+        assert deps.get("version") == 1, f"deps.json version {deps.get('version')} != 1"
+        deps_edges = {(int(e[0]), int(e[1])) for e in deps.get("edges", []) if isinstance(e, list) and len(e) == 2}
 
-        # Spot-check first record's tensor_count to confirm bytes are real:
-        # t0 (kernel_add) has 3 args (a, b, c=output) -> tensor_count == 3.
-        with trace.open("rb") as f:
-            header = f.read(16)
-        _task_id, _flags, tensor_count, _expl = struct.unpack("=QIHH", header)
-        assert tensor_count == 3, f"first record tensor_count={tensor_count}, expected 3"
+        # example_orchestration.cpp comment block (verified by tracing the source):
+        #   t0: ring 0, local 0
+        #   t1..t4: ring 1, local 0..3  (inner manual scope → ring 1)
+        # Edges: t0->t1, t0->t2, t1->t3, t2->t3, t0->t4, t3->t4
+        t0 = 0
+        t1 = 1 << 32
+        t2 = (1 << 32) | 1
+        t3 = (1 << 32) | 2
+        t4 = (1 << 32) | 3
+        expected_edges = {(t0, t1), (t0, t2), (t1, t3), (t2, t3), (t0, t4), (t3, t4)}
+        missing = expected_edges - deps_edges
+        assert not missing, f"deps.json missing expected edges: {missing} (got {deps_edges})"
+        # Allow extra edges (creator-retention may add owner edges that don't appear
+        # in the comment's logical-dep view), but flag anything outside the task set.
+        valid_ids = {t0, t1, t2, t3, t4}
+        bad = {e for e in deps_edges if e[0] not in valid_ids or e[1] not in valid_ids}
+        assert not bad, f"deps.json contains edges referencing unknown task ids: {bad}"
+
+        # ---- fanout ⊆ deps validation gate ----
+        perf = out_dir / "l2_perf_records.json"
+        if perf.exists():
+            with perf.open() as f:
+                pdata = json.load(f)
+            fanout_edges = set()
+            for task in pdata.get("tasks", []):
+                src = int(task["task_id"])
+                for succ in task.get("fanout", []):
+                    fanout_edges.add((src, int(succ)))
+            missing_in_deps = fanout_edges - deps_edges
+            assert not missing_in_deps, (
+                f"fanout ⊆ deps gate FAILED: edges present in l2_perf_records.json "
+                f"fanout[] but absent from deps.json: {missing_in_deps}. "
+                f"This is a replay-side regression — the replay should be a "
+                f"superset of the runtime's fanout view."
+            )
 
 
 def _post_run_verify():
@@ -137,6 +173,12 @@ if __name__ == "__main__":
     # so the verification has to happen *before* the exit, or we need to catch
     # the SystemExit and only do verification on success. Easier: catch.
     enable_dep_gen = "--enable-dep-gen" in sys.argv
+    # Auto-add --enable-l2-swimlane when --enable-dep-gen is on so the fanout ⊆ deps
+    # gate runs by default in standalone. Both flags compose cleanly; the gate is
+    # the most informative thing the test produces, so don't make the user remember
+    # to ask for it.
+    if enable_dep_gen and "--enable-l2-swimlane" not in sys.argv:
+        sys.argv.append("--enable-l2-swimlane")
     try:
         SceneTestCase.run_module(__name__)
     except SystemExit as e:

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -89,7 +89,7 @@ add_library(a2a3_rt_objs OBJECT
     ${A2A3_RUNTIME_DIR}/pto_ring_buffer.cpp
     ${A2A3_RUNTIME_DIR}/shared/pto_shared_memory.cpp
     ${A2A3_RUNTIME_DIR}/scheduler/pto_scheduler.cpp
-    ${A2A3_RUNTIME_DIR}/pto_tensormap.cpp
+    ${A2A3_RUNTIME_DIR}/shared/pto_tensormap.cpp
     ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
 )
 target_include_directories(a2a3_rt_objs PUBLIC


### PR DESCRIPTION
## Summary

Stacked on #736 (dep_gen capture). Three closely-coupled changes that turn the captured `submit_trace.bin` into a user-visible artifact:

- **PR3 — Host replay** (`src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.{h,cpp}`): reads `submit_trace.bin`, runs each record through a host-resident `PTO2TensorMap` using the same `compute_task_fanin` / `register_task_outputs` primitives the device orchestrator uses, emits `deps.json` (edge list keyed by raw `PTO2TaskId`). Wired into `device_runner.cpp` (onboard + sim) post-reconcile; skipped on dropped records to avoid producing a partial graph users could mistake for complete.
- **PR4 — swimlane_converter integration** (`simpler_setup/tools/swimlane_converter.py`): when `deps.json` sits next to `l2_perf_records.json`, prefer those edges over `task["fanout"]`. Each flow event is checked for a happens-before violation (`pred.end_time > succ.start_time`) and emitted under a distinct `hb_violation` name so Perfetto colors it apart from clean dependencies.
- **PR5 — Validation gate** (`tests/st/a2a3/.../test_dep_gen_capture.py`): asserts `deps.json` exists with the 6 expected edges from `example_orchestration.cpp`, and when `l2_perf_records.json` is also present (`--enable-l2-swimlane` on), every fanout edge is a subset of `deps.json`. Standalone main auto-adds `--enable-l2-swimlane` so a single command exercises the full gate.

Also fixes a width-mismatch bug in #736's capture path: `TensorArgType` is `int32_t` but the AICPU writer reinterpreted the tag array as `uint8_t[]`. On little-endian this silently kept only every fourth tag byte, turning `(INPUT, INPUT, OUTPUT)` into `(0, 0, 0)` and synthesizing a phantom self-edge `t0→t0` in replay. Fixed at the call site by narrowing each tag to `uint8_t` explicitly before passing it to the writer — keeps the on-disk `uint8_t[16]` arg_types layout intact.

**Note on stacking**: this PR includes the #736 commit at its base. It will rebase to a single-commit PR once #736 merges.

To share `PTO2TensorMap` between aicpu and host targets, `pto_tensormap.cpp` moves from `runtime/` to `runtime/shared/` and its stale `#include \"pto_orchestrator.h\"` is dropped (no orch member is used). aicpu still picks it up via the recursive glob.

## Test plan

- [x] \`python simpler_setup/build_runtimes.py --platform a2a3sim\` — clean
- [x] \`pre-commit run --files <touched>\` — clang-format, clang-tidy, cpplint, ruff, pyright all green
- [x] \`python tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py --enable-dep-gen -p a2a3sim\` — PASSED + \`[dep_gen_capture] post-run verification PASSED\` (deps.json has the expected 6 edges, fanout ⊆ deps gate clean for vector_example)
- [ ] CI: full a2a3 + a2a3sim ut/st matrix
Fixes #599 — swimlane fanout drops dependency edges for fast producers.
