### PR TITLE
Refactor: hoist executor blobs to simpler_init; trim prepare/run ABI

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -236,17 +236,17 @@ std::thread DeviceRunner::create_thread(std::function<void()> fn) {
     });
 }
 
-int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+int DeviceRunner::load_executor_blobs(
+    const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
 ) {
-    // First attach the current thread and create fresh run-scoped streams
-    int rc = prepare_run_context(device_id);
-    if (rc != 0) {
-        return rc;
+    if (aicpu_blob == nullptr || aicpu_blob_size == 0 || aicore_blob == nullptr || aicore_blob_size == 0) {
+        LOG_ERROR("load_executor_blobs: blobs must be non-empty");
+        return -1;
     }
-
-    // Then ensure binaries are loaded
-    return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
+    // Take owning copies into the runner so the caller may drop its buffer.
+    aicpu_so_binary_.assign(aicpu_blob, aicpu_blob + aicpu_blob_size);
+    aicore_kernel_binary_.assign(aicore_blob, aicore_blob + aicore_blob_size);
+    return ensure_binaries_loaded();
 }
 
 int DeviceRunner::attach_current_thread(int device_id) {
@@ -395,15 +395,10 @@ void DeviceRunner::release_run_context() {
     }
 }
 
-int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-) {
-    // Check if already loaded
+int DeviceRunner::ensure_binaries_loaded() {
+    // Already loaded — idempotent no-op. The runner-owned vectors are the
+    // source of truth; the caller cannot ask us to replace them mid-life.
     if (binaries_loaded_) {
-        // Just update kernel binary if different
-        if (aicore_kernel_binary_ != aicore_kernel_binary) {
-            aicore_kernel_binary_ = aicore_kernel_binary;
-        }
         return 0;
     }
 
@@ -413,10 +408,11 @@ int DeviceRunner::ensure_binaries_loaded(
         return -1;
     }
 
-    aicore_kernel_binary_ = aicore_kernel_binary;
-
-    // Load AICPU SO
-    int rc = so_info_.init(aicpu_so_binary, mem_alloc_);
+    // Load AICPU SO from the runner-owned vector populated by
+    // `load_executor_blobs`. so_info_.init copies into device GM, so we keep
+    // aicpu_so_binary_ as host-side reference (for hash comparison and
+    // future reload paths) without further H2D traffic.
+    int rc = so_info_.init(aicpu_so_binary_, mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("AicpuSoInfo::init failed: %d", rc);
         return rc;
@@ -453,10 +449,7 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
-int DeviceRunner::run(
-    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
-) {
+int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -493,14 +486,15 @@ int DeviceRunner::run(
         }
     }
 
-    // Ensure device is initialized (lazy initialization)
-    int rc = ensure_device_initialized(device_id, aicpu_so_binary, aicore_kernel_binary);
-    if (rc != 0) {
-        LOG_ERROR("ensure_device_initialized failed: %d", rc);
-        return rc;
+    // Caller (the C ABI entry point) must have done `prepare_run_context()` +
+    // `load_executor_blobs()` at `simpler_init`. We only sanity-check here.
+    if (!binaries_loaded_) {
+        LOG_ERROR("DeviceRunner::run: executor blobs not loaded; call simpler_init first");
+        return -1;
     }
 
     // Calculate execution parameters
+    int rc = 0;
     block_dim_ = block_dim;
 
     int num_aicore = block_dim * cores_per_blockdim_;
@@ -533,7 +527,7 @@ int DeviceRunner::run(
 
     // Get AICore register addresses for register-based task dispatch
     rc = init_aicore_register_addresses(
-        &kernel_args_.args.regs, static_cast<uint64_t>(device_id), mem_alloc_, AicoreRegKind::Ctrl
+        &kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_, AicoreRegKind::Ctrl
     );
     if (rc != 0) {
         LOG_ERROR("init_aicore_register_addresses(Ctrl) failed: %d", rc);
@@ -543,7 +537,7 @@ int DeviceRunner::run(
     // Get AICore PMU register addresses (distinct MMIO page from AIC_CTRL).
     if (enable_pmu_) {
         rc = init_aicore_register_addresses(
-            &kernel_args_.args.pmu_reg_addrs, static_cast<uint64_t>(device_id), mem_alloc_, AicoreRegKind::Pmu
+            &kernel_args_.args.pmu_reg_addrs, static_cast<uint64_t>(device_id_), mem_alloc_, AicoreRegKind::Pmu
         );
         if (rc != 0) {
             LOG_ERROR("init_aicore_register_addresses(Pmu) failed: %d", rc);
@@ -593,7 +587,7 @@ int DeviceRunner::run(
 
     // Initialize per-subsystem shared memory.
     if (enable_l2_swimlane_) {
-        rc = init_l2_perf(num_aicore, device_id);
+        rc = init_l2_perf(num_aicore, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf failed: %d", rc);
             return rc;
@@ -602,7 +596,7 @@ int DeviceRunner::run(
 
     if (enable_dump_tensor_) {
         // Initialize tensor dump (independent from profiling)
-        rc = init_tensor_dump(runtime, device_id);
+        rc = init_tensor_dump(runtime, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
@@ -610,7 +604,7 @@ int DeviceRunner::run(
     }
 
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id);
+        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -235,27 +235,46 @@ public:
      * Execute a runtime
      *
      * This method:
-     * 1. Initializes device if not already done (lazy initialization)
-     * 2. Initializes worker handshake buffers in the runtime based on block_dim
-     * 3. Transfers runtime to device memory
-     * 4. Launches AICPU init kernel
-     * 5. Launches AICPU main kernel
-     * 6. Launches AICore kernel
-     * 7. Synchronizes streams
-     * 8. Cleans up runtime memory
+     * 1. Initializes worker handshake buffers in the runtime based on block_dim
+     * 2. Transfers runtime to device memory
+     * 3. Launches AICPU init kernel
+     * 4. Launches AICPU main kernel
+     * 5. Launches AICore kernel
+     * 6. Synchronizes streams
+     * 7. Cleans up runtime memory
      *
-     * @param runtime             Runtime to execute (will be modified to
-     * initialize workers)
-     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param device_id            Device ID (0-15)
-     * @param aicpu_so_binary       Binary data of AICPU shared object
-     * @param aicore_kernel_binary  Binary data of AICore kernel
-     * @param launch_aicpu_num      Number of AICPU instances (default: 1)
+     * The caller must have already attached the current thread via
+     * `prepare_run_context()` and the executor blobs must have been loaded
+     * via `load_executor_blobs()` (both done once at `simpler_init`).
+     *
+     * @param runtime         Runtime to execute (will be modified to
+     *                        initialize workers)
+     * @param block_dim       Number of blocks (1 block = 1 AIC + 2 AIV)
+     * @param launch_aicpu_num Number of AICPU instances (default: 1)
      * @return 0 on success, error code on failure
      */
-    int
-    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1);
+
+    /**
+     * Bound device id (set by `attach_current_thread` / `simpler_init`).
+     * Returns -1 before init.
+     */
+    int device_id() const noexcept { return device_id_; }
+
+    /**
+     * Load AICPU SO + AICore kernel blobs into the runner once. Idempotent:
+     * subsequent calls with the same content are no-ops; calls with
+     * differing AICore bytes refresh the cached vector but never re-init
+     * AicpuSoInfo (AICPU SO load is treated as immutable for the runner's
+     * lifetime).
+     *
+     * Requires `prepare_run_context()` to have created the streams.
+     *
+     * @return 0 on success, error code on failure.
+     */
+    int load_executor_blobs(
+        const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+    );
 
     /**
      * Enablement setters for the three diagnostics sub-features. Called by
@@ -524,6 +543,11 @@ private:
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results in destructor
+    // Runner-owned copies of the executor blobs. Populated once by
+    // `load_executor_blobs()` (called from `simpler_init`); read every run.
+    // The AICPU SO is also handed off to `so_info_` (device GM); this host
+    // copy is kept for hash comparison on potential re-loads only.
+    std::vector<uint8_t> aicpu_so_binary_;
     std::vector<uint8_t> aicore_kernel_binary_;
 
     // Memory management
@@ -611,37 +635,12 @@ private:
     PmuCollector pmu_collector_;
 
     /**
-     * Ensure device is initialized (lazy initialization)
-     *
-     * Checks if device is already initialized. If not, performs:
-     * - Attach the current thread to the device
-     * - Create AICPU and AICore streams
-     * - Load AICPU SO to device memory
-     * - Initialize device args
-     *
-     * @param device_id            Device ID (0-15)
-     * @param aicpu_so_binary       Binary data of AICPU shared object
-     * @param aicore_kernel_binary  Binary data of AICore kernel
-     * @return 0 on success, error code on failure
+     * Internal: load AICPU SO + AICore kernel from already-cached host-side
+     * vectors `aicpu_so_binary_` / `aicore_kernel_binary_`. Called from
+     * `load_executor_blobs` once the caller has populated those members.
+     * Requires `prepare_run_context()` to have created the streams.
      */
-    int ensure_device_initialized(
-        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
-
-    /**
-     * Load AICPU SO and initialize device args
-     *
-     * Called by run() after prepare_run_context(). Performs:
-     * - Load AICPU SO to device memory
-     * - Initialize device args
-     *
-     * @param aicpu_so_binary       Binary data of AICPU shared object
-     * @param aicore_kernel_binary  Binary data of AICore kernel
-     * @return 0 on success, error code on failure
-     */
-    int ensure_binaries_loaded(
-        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
+    int ensure_binaries_loaded();
 
     /**
      * Populate runtime.{dev_orch_so_addr_, dev_orch_so_size_} from

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -208,16 +208,29 @@ void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, si
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 
-int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_info_v) {
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, int log_level, int log_info_v, const uint8_t *aicpu_blob,
+    size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+) {
     if (ctx == NULL) return -1;
+    if (aicpu_blob == NULL || aicpu_blob_size == 0 || aicore_blob == NULL || aicore_blob_size == 0) return -1;
 
-    // Attach FIRST so that an attach failure does not leave process-wide side
-    // effects (CANN dlog level, HostLogger singleton) mutated. Subsequent
-    // logger writes only happen on the success path.
+    // Attach + create streams FIRST so that an attach failure does not leave
+    // process-wide side effects (CANN dlog level, HostLogger singleton)
+    // mutated. The streams are required by AicpuSoInfo::init below, so
+    // prepare_run_context (which attach + creates streams) must precede
+    // load_executor_blobs.
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
     int rc;
     try {
-        rc = runner->attach_current_thread(device_id);
+        rc = runner->prepare_run_context(device_id);
+    } catch (...) {
+        return -1;
+    }
+    if (rc != 0) return rc;
+
+    try {
+        rc = runner->load_executor_blobs(aicpu_blob, aicpu_blob_size, aicore_blob, aicore_blob_size);
     } catch (...) {
         return -1;
     }
@@ -241,19 +254,9 @@ int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_
  * Per-callable_id preparation
  * =========================================================================== */
 
-int prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, int device_id, const uint8_t *aicpu_binary,
-    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size
-) {
+int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
     if (ctx == NULL || callable == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
-
-    // AICPU/AICore executor binaries are only consumed by run()/run_prepared();
-    // prepare_callable just uploads kernel + orch SO state.
-    (void)aicpu_binary;
-    (void)aicpu_size;
-    (void)aicore_binary;
-    (void)aicore_size;
 
     pthread_once(&g_runner_key_once, create_runner_key);
     pthread_setspecific(g_runner_key, ctx);
@@ -262,7 +265,9 @@ int prepare_callable(
     });
 
     try {
-        int rc = runner->prepare_run_context(device_id);
+        // Re-attach the caller's thread (idempotent on the same device_id);
+        // forked chip-child loops hit this on first prepare_callable.
+        int rc = runner->prepare_run_context(runner->device_id());
         if (rc != 0) return rc;
         auto run_context_guard = RAIIScopeGuard([runner]() {
             runner->release_run_context();
@@ -321,8 +326,7 @@ int prepare_callable(
 
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
@@ -339,7 +343,7 @@ int run_prepared(
     });
 
     try {
-        int rc = runner->prepare_run_context(device_id);
+        int rc = runner->prepare_run_context(runner->device_id());
         if (rc != 0) return rc;
         auto run_context_guard = RAIIScopeGuard([runner]() {
             runner->release_run_context();
@@ -374,9 +378,7 @@ int run_prepared(
         runner->set_pmu_enabled(enable_pmu);
         runner->set_output_prefix(output_prefix);
 
-        std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
-        std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
+        rc = runner->run(*r, block_dim, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -135,23 +135,26 @@ int DeviceRunner::attach_current_thread(int device_id) {
     return 0;
 }
 
-int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+int DeviceRunner::load_executor_blobs(
+    const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
 ) {
-    int rc = attach_current_thread(device_id);
-    if (rc != 0) return rc;
-    return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
+    if (aicpu_blob == nullptr || aicpu_blob_size == 0 || aicore_blob == nullptr || aicore_blob_size == 0) {
+        LOG_ERROR("load_executor_blobs: blobs must be non-empty");
+        return -1;
+    }
+    // Take owning copies so the caller can drop its buffer immediately.
+    aicpu_so_binary_.assign(aicpu_blob, aicpu_blob + aicpu_blob_size);
+    aicore_kernel_binary_.assign(aicore_blob, aicore_blob + aicore_blob_size);
+    return ensure_binaries_loaded();
 }
 
-int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-) {
+int DeviceRunner::ensure_binaries_loaded() {
     // AICPU .so: load-once, matching onboard's binaries_loaded_ pattern.
     // Keeping the DSO alive across runs preserves g_aicpu_executor state
     // (orch_so_handle_ etc.), which is required for the orch-SO cache-hit path.
-    if (!aicpu_so_loaded_ && !aicpu_so_binary.empty()) {
+    if (!aicpu_so_loaded_ && !aicpu_so_binary_.empty()) {
         if (!create_temp_so_file(
-                "/tmp/aicpu_sim_XXXXXX", aicpu_so_binary.data(), aicpu_so_binary.size(), &aicpu_so_path_
+                "/tmp/aicpu_sim_XXXXXX", aicpu_so_binary_.data(), aicpu_so_binary_.size(), &aicpu_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICPU SO");
             return -1;
@@ -243,9 +246,9 @@ int DeviceRunner::ensure_binaries_loaded(
     }
 
     // Write AICore binary to temp file and dlopen
-    if (!aicore_kernel_binary.empty()) {
+    if (!aicore_kernel_binary_.empty()) {
         if (!create_temp_so_file(
-                "/tmp/aicore_sim_XXXXXX", aicore_kernel_binary.data(), aicore_kernel_binary.size(), &aicore_so_path_
+                "/tmp/aicore_sim_XXXXXX", aicore_kernel_binary_.data(), aicore_kernel_binary_.size(), &aicore_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICore SO");
             return -1;
@@ -300,10 +303,7 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return 0;
 }
 
-int DeviceRunner::run(
-    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
-) {
+int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     clear_cpu_sim_shared_storage();
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
@@ -341,14 +341,15 @@ int DeviceRunner::run(
         }
     }
 
-    // Ensure device is initialized
-    int rc = ensure_device_initialized(device_id, aicpu_so_binary, aicore_kernel_binary);
-    if (rc != 0) {
-        LOG_ERROR("ensure_device_initialized failed: %d", rc);
-        return rc;
+    // Caller (the C ABI entry point) must have done `attach_current_thread()` +
+    // `load_executor_blobs()` at `simpler_init`.
+    if (!aicpu_so_loaded_) {
+        LOG_ERROR("DeviceRunner::run: executor blobs not loaded; call simpler_init first");
+        return -1;
     }
 
     // Calculate execution parameters
+    int rc = 0;
     block_dim_ = block_dim;
     int num_aicore = block_dim * cores_per_blockdim_;
 
@@ -408,7 +409,7 @@ int DeviceRunner::run(
 
     // Initialize per-subsystem shared memory.
     if (enable_l2_swimlane_) {
-        rc = init_l2_perf(num_aicore, device_id);
+        rc = init_l2_perf(num_aicore, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf failed: %d", rc);
             return rc;
@@ -417,7 +418,7 @@ int DeviceRunner::run(
 
     if (enable_dump_tensor_) {
         // Initialize tensor dump (independent from profiling)
-        rc = init_tensor_dump(runtime, device_id);
+        rc = init_tensor_dump(runtime, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
@@ -425,7 +426,7 @@ int DeviceRunner::run(
     }
 
     if (enable_pmu_) {
-        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id);
+        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_pmu failed: %d", rc);
             return rc;
@@ -634,20 +635,11 @@ int DeviceRunner::run(
     // Print handshake results at end of run
     print_handshake_results();
 
-    // Close AICore kernel .so now while the process is healthy.
-    // AICPU .so is kept alive (load-once) so that g_aicpu_executor state
-    // (orch_so_handle_ etc.) survives across runs for the orch-SO cache-hit path.
-    // It will be closed in finalize() / unload_executor_binaries().
-    if (aicore_so_handle_ != nullptr) {
-        dlclose(aicore_so_handle_);
-        aicore_so_handle_ = nullptr;
-        aicore_execute_func_ = nullptr;
-    }
-    if (!aicore_so_path_.empty()) {
-        std::remove(aicore_so_path_.c_str());
-        aicore_so_path_.clear();
-    }
-
+    // AICore + AICPU .so are kept alive for the runner's lifetime; they are
+    // loaded once by `simpler_init`'s `load_executor_blobs` and closed in
+    // `unload_executor_binaries` (via finalize). The orch SO cache-hit path
+    // relies on g_aicpu_executor state surviving across runs, and under the
+    // post-#710 ABI the AICore blob no longer varies per run.
     return 0;
 }
 

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -129,24 +129,33 @@ public:
     /**
      * Execute a runtime using threads
      *
-     * This method simulates the complete execution:
-     * 1. Initializes worker handshake buffers
-     * 2. Sets function_bin_addr for all tasks
-     * 3. Launches AICPU threads
-     * 4. Launches AICore threads
-     * 5. Waits for all threads to complete
+     * The caller must have already attached the current thread via
+     * `prepare_run_context()` and loaded the executor blobs via
+     * `load_executor_blobs()` (both done once at `simpler_init`).
      *
-     * @param runtime              Runtime to execute
-     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param device_id            Device ID (ignored in simulation)
-     * @param aicpu_so_binary      AICPU binary (ignored in simulation)
-     * @param aicore_kernel_binary AICore binary (ignored in simulation)
-     * @param launch_aicpu_num     Number of AICPU threads
+     * @param runtime          Runtime to execute
+     * @param block_dim        Number of blocks (1 block = 1 AIC + 2 AIV)
+     * @param launch_aicpu_num Number of AICPU threads
      * @return 0 on success
      */
-    int
-    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1);
+
+    /**
+     * Bound device id (set by `attach_current_thread` / `simpler_init`).
+     * Returns -1 before init.
+     */
+    int device_id() const noexcept { return device_id_; }
+
+    /**
+     * Load the AICPU/AICore executor blobs once (called from `simpler_init`).
+     * On sim, the executor binaries are read from disk paths inside the
+     * loader; the blobs supplied here are kept as runner-owned reference
+     * copies (matching the onboard contract) so the caller can drop its
+     * buffer after `simpler_init` returns.
+     */
+    int load_executor_blobs(
+        const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+    );
 
     /**
      * Enablement setters for the three diagnostics sub-features. Called by
@@ -254,6 +263,15 @@ private:
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};
 
+    // Runner-owned copies of the executor blobs, populated once by
+    // `load_executor_blobs()` (from `simpler_init`). Sim writes these to
+    // /tmp + dlopens and then unlinks; the vectors remain as the canonical
+    // host-side reference so that any future re-load path (e.g. after
+    // unload_executor_binaries) has a single source of truth without
+    // re-routing through the caller.
+    std::vector<uint8_t> aicpu_so_binary_;
+    std::vector<uint8_t> aicore_kernel_binary_;
+
     // Memory management
     MemoryAllocator mem_alloc_;
 
@@ -335,13 +353,10 @@ private:
     // PMU collector (independent of profiling pipeline)
     PmuCollector pmu_collector_;
 
-    // Private helper methods
-    int ensure_device_initialized(
-        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
-    int ensure_binaries_loaded(
-        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
+    // Internal: load executor SOs from already-cached host-side vectors
+    // `aicpu_so_binary_` / `aicore_kernel_binary_`. Called from
+    // `load_executor_blobs()`.
+    int ensure_binaries_loaded();
     void unload_executor_binaries();
 
     /**

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -200,8 +200,12 @@ void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, si
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 
-int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_info_v) {
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, int log_level, int log_info_v, const uint8_t *aicpu_blob,
+    size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+) {
     if (ctx == NULL) return -1;
+    if (aicpu_blob == NULL || aicpu_blob_size == 0 || aicore_blob == NULL || aicore_blob_size == 0) return -1;
 
     // Attach FIRST so that an attach failure (e.g. invalid device_id) does not
     // leave the process-wide HostLogger singleton mutated.
@@ -209,6 +213,13 @@ int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_
     int rc;
     try {
         rc = runner->attach_current_thread(device_id);
+    } catch (...) {
+        return -1;
+    }
+    if (rc != 0) return rc;
+
+    try {
+        rc = runner->load_executor_blobs(aicpu_blob, aicpu_blob_size, aicore_blob, aicore_blob_size);
     } catch (...) {
         return -1;
     }
@@ -226,18 +237,9 @@ int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_
  * Per-callable_id preparation
  * =========================================================================== */
 
-int prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, int device_id, const uint8_t *aicpu_binary,
-    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size
-) {
+int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
     if (ctx == NULL || callable == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
-
-    (void)aicpu_binary;
-    (void)aicpu_size;
-    (void)aicore_binary;
-    (void)aicore_size;
-    (void)device_id;
 
     pthread_once(&g_runner_key_once, create_runner_key);
     pthread_setspecific(g_runner_key, ctx);
@@ -292,8 +294,7 @@ int prepare_callable(
 
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
@@ -336,15 +337,7 @@ int run_prepared(
         runner->set_pmu_enabled(enable_pmu);
         runner->set_output_prefix(output_prefix);
 
-        std::vector<uint8_t> aicpu_vec;
-        std::vector<uint8_t> aicore_vec;
-        if (aicpu_binary != NULL && aicpu_size > 0) {
-            aicpu_vec.assign(aicpu_binary, aicpu_binary + aicpu_size);
-        }
-        if (aicore_binary != NULL && aicore_size > 0) {
-            aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
-        }
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
+        rc = runner->run(*r, block_dim, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -155,17 +155,16 @@ std::thread DeviceRunner::create_thread(std::function<void()> fn) {
     });
 }
 
-int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+int DeviceRunner::load_executor_blobs(
+    const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
 ) {
-    // First attach the current thread and create fresh run-scoped streams
-    int rc = prepare_run_context(device_id);
-    if (rc != 0) {
-        return rc;
+    if (aicpu_blob == nullptr || aicpu_blob_size == 0 || aicore_blob == nullptr || aicore_blob_size == 0) {
+        LOG_ERROR("load_executor_blobs: blobs must be non-empty");
+        return -1;
     }
-
-    // Then ensure binaries are loaded
-    return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
+    aicpu_so_binary_.assign(aicpu_blob, aicpu_blob + aicpu_blob_size);
+    aicore_kernel_binary_.assign(aicore_blob, aicore_blob + aicore_blob_size);
+    return ensure_binaries_loaded();
 }
 
 int DeviceRunner::attach_current_thread(int device_id) {
@@ -234,15 +233,10 @@ void DeviceRunner::release_run_context() {
     }
 }
 
-int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-) {
-    // Check if already loaded
+int DeviceRunner::ensure_binaries_loaded() {
+    // Already loaded — idempotent no-op. The runner-owned vectors are the
+    // source of truth.
     if (binaries_loaded_) {
-        // Just update kernel binary if different
-        if (aicore_kernel_binary_ != aicore_kernel_binary) {
-            aicore_kernel_binary_ = aicore_kernel_binary;
-        }
         return 0;
     }
 
@@ -252,10 +246,9 @@ int DeviceRunner::ensure_binaries_loaded(
         return -1;
     }
 
-    aicore_kernel_binary_ = aicore_kernel_binary;
-
-    // Load AICPU SO
-    int rc = so_info_.init(aicpu_so_binary, mem_alloc_);
+    // Load AICPU SO from the runner-owned vector populated by
+    // `load_executor_blobs`.
+    int rc = so_info_.init(aicpu_so_binary_, mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("AicpuSoInfo::init failed: %d", rc);
         return rc;
@@ -292,10 +285,7 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
-int DeviceRunner::run(
-    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
-) {
+int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
@@ -332,11 +322,11 @@ int DeviceRunner::run(
     }
 
     // Ensure device is initialized (lazy initialization)
-    int rc = ensure_device_initialized(device_id, aicpu_so_binary, aicore_kernel_binary);
-    if (rc != 0) {
-        LOG_ERROR("ensure_device_initialized failed: %d", rc);
-        return rc;
+    if (!binaries_loaded_) {
+        LOG_ERROR("DeviceRunner::run: executor blobs not loaded; call simpler_init first");
+        return -1;
     }
+    int rc = 0;
 
     // Calculate execution parameters
     block_dim_ = block_dim;
@@ -353,7 +343,7 @@ int DeviceRunner::run(
     runtime.sche_cpu_num = launch_aicpu_num;
 
     // Get AICore register addresses for register-based task dispatch
-    rc = init_aicore_register_addresses(&kernel_args_.args.regs, static_cast<uint64_t>(device_id), mem_alloc_);
+    rc = init_aicore_register_addresses(&kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("init_aicore_register_addresses failed: %d", rc);
         return rc;
@@ -409,7 +399,7 @@ int DeviceRunner::run(
 
     // Initialize performance profiling if enabled
     if (enable_l2_swimlane_) {
-        rc = init_l2_perf_collection(num_aicore, device_id);
+        rc = init_l2_perf_collection(num_aicore, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
@@ -422,7 +412,7 @@ int DeviceRunner::run(
 
     // Initialize tensor dump if enabled
     if (enable_dump_tensor_) {
-        rc = init_tensor_dump(runtime, num_aicore, device_id);
+        rc = init_tensor_dump(runtime, num_aicore, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
@@ -432,7 +422,7 @@ int DeviceRunner::run(
 
     if (enable_pmu_) {
         rc = init_pmu_buffers(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_
         );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -209,28 +209,24 @@ public:
     /**
      * Execute a runtime
      *
-     * This method:
-     * 1. Initializes device if not already done (lazy initialization)
-     * 2. Initializes worker handshake buffers in the runtime based on block_dim
-     * 3. Transfers runtime to device memory
-     * 4. Launches AICPU init kernel
-     * 5. Launches AICPU main kernel
-     * 6. Launches AICore kernel
-     * 7. Synchronizes streams
-     * 8. Cleans up runtime memory
+     * Caller must have done `prepare_run_context()` and `load_executor_blobs()`
+     * once at `simpler_init`; this entry only performs per-task setup + launch.
      *
-     * @param runtime             Runtime to execute (will be modified to
-     * initialize workers)
-     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param device_id            Device ID (0-15)
-     * @param aicpu_so_binary       Binary data of AICPU shared object
-     * @param aicore_kernel_binary  Binary data of AICore kernel
-     * @param launch_aicpu_num      Number of AICPU instances (default: 1)
+     * @param runtime         Runtime to execute
+     * @param block_dim       Number of blocks
+     * @param launch_aicpu_num Number of AICPU instances (default: 1)
      * @return 0 on success, error code on failure
      */
-    int
-    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1);
+
+    /// Bound device id (set by `attach_current_thread` / `simpler_init`).
+    /// Returns -1 before init.
+    int device_id() const noexcept { return device_id_; }
+
+    /// Load AICPU SO + AICore kernel blobs into the runner once. Idempotent.
+    int load_executor_blobs(
+        const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+    );
 
     /**
      * Enablement setters for the three diagnostics sub-features. Called by
@@ -442,6 +438,9 @@ private:
     int block_dim_{0};
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};  // Stored for print_handshake_results in destructor
+    // Runner-owned copies of the executor blobs, populated once by
+    // `load_executor_blobs()` (from `simpler_init`); read every run.
+    std::vector<uint8_t> aicpu_so_binary_;
     std::vector<uint8_t> aicore_kernel_binary_;
 
     // Memory management
@@ -521,24 +520,12 @@ private:
      * @param aicore_kernel_binary  Binary data of AICore kernel
      * @return 0 on success, error code on failure
      */
-    int ensure_device_initialized(
-        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
-
     /**
-     * Load AICPU SO and initialize device args
-     *
-     * Called by run() after prepare_run_context(). Performs:
-     * - Load AICPU SO to device memory
-     * - Initialize device args
-     *
-     * @param aicpu_so_binary       Binary data of AICPU shared object
-     * @param aicore_kernel_binary  Binary data of AICore kernel
-     * @return 0 on success, error code on failure
+     * Internal: load AICPU SO + AICore kernel from cached host-side vectors
+     * `aicpu_so_binary_` / `aicore_kernel_binary_`. Called from
+     * `load_executor_blobs()` once the caller has populated those members.
      */
-    int ensure_binaries_loaded(
-        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
+    int ensure_binaries_loaded();
 
     /**
      * Stage the orchestration SO into a device-resident buffer (with hash

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -240,16 +240,27 @@ void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, si
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 
-int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_info_v) {
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, int log_level, int log_info_v, const uint8_t *aicpu_blob,
+    size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+) {
     if (ctx == NULL) return -1;
+    if (aicpu_blob == NULL || aicpu_blob_size == 0 || aicore_blob == NULL || aicore_blob_size == 0) return -1;
 
-    // Attach FIRST so that an attach failure does not leave process-wide side
-    // effects (CANN dlog level, HostLogger singleton) mutated. Subsequent
-    // logger writes only happen on the success path.
+    // Attach + create streams FIRST; AicpuSoInfo::init below requires
+    // stream_aicpu_ to exist, so prepare_run_context must precede the
+    // load_executor_blobs call.
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
     int rc;
     try {
-        rc = runner->attach_current_thread(device_id);
+        rc = runner->prepare_run_context(device_id);
+    } catch (...) {
+        return -1;
+    }
+    if (rc != 0) return rc;
+
+    try {
+        rc = runner->load_executor_blobs(aicpu_blob, aicpu_blob_size, aicore_blob, aicore_blob_size);
     } catch (...) {
         return -1;
     }
@@ -275,19 +286,9 @@ int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_
  * Per-callable_id preparation
  * =========================================================================== */
 
-int prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, int device_id, const uint8_t *aicpu_binary,
-    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size
-) {
+int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
     if (ctx == NULL || callable == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
-
-    // AICPU/AICore executor binaries are only consumed by run()/run_prepared();
-    // prepare_callable just uploads kernel + orch SO state.
-    (void)aicpu_binary;
-    (void)aicpu_size;
-    (void)aicore_binary;
-    (void)aicore_size;
 
     pthread_once(&g_runner_key_once, create_runner_key);
     pthread_setspecific(g_runner_key, ctx);
@@ -296,7 +297,8 @@ int prepare_callable(
     });
 
     try {
-        int rc = runner->prepare_run_context(device_id);
+        // Re-attach the caller's thread (idempotent on same device_id).
+        int rc = runner->prepare_run_context(runner->device_id());
         if (rc != 0) return rc;
         auto run_context_guard = RAIIScopeGuard([runner]() {
             runner->release_run_context();
@@ -351,8 +353,7 @@ int prepare_callable(
 
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
@@ -369,7 +370,7 @@ int run_prepared(
     });
 
     try {
-        int rc = runner->prepare_run_context(device_id);
+        int rc = runner->prepare_run_context(runner->device_id());
         if (rc != 0) return rc;
         auto run_context_guard = RAIIScopeGuard([runner]() {
             runner->release_run_context();
@@ -404,9 +405,7 @@ int run_prepared(
         runner->set_pmu_enabled(enable_pmu);
         runner->set_output_prefix(output_prefix);
 
-        std::vector<uint8_t> aicpu_vec(aicpu_binary, aicpu_binary + aicpu_size);
-        std::vector<uint8_t> aicore_vec(aicore_binary, aicore_binary + aicore_size);
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
+        rc = runner->run(*r, block_dim, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -127,23 +127,25 @@ int DeviceRunner::attach_current_thread(int device_id) {
     return 0;
 }
 
-int DeviceRunner::ensure_device_initialized(
-    int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
+int DeviceRunner::load_executor_blobs(
+    const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
 ) {
-    int rc = attach_current_thread(device_id);
-    if (rc != 0) return rc;
-    return ensure_binaries_loaded(aicpu_so_binary, aicore_kernel_binary);
+    if (aicpu_blob == nullptr || aicpu_blob_size == 0 || aicore_blob == nullptr || aicore_blob_size == 0) {
+        LOG_ERROR("load_executor_blobs: blobs must be non-empty");
+        return -1;
+    }
+    aicpu_so_binary_.assign(aicpu_blob, aicpu_blob + aicpu_blob_size);
+    aicore_kernel_binary_.assign(aicore_blob, aicore_blob + aicore_blob_size);
+    return ensure_binaries_loaded();
 }
 
-int DeviceRunner::ensure_binaries_loaded(
-    const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-) {
+int DeviceRunner::ensure_binaries_loaded() {
     // AICPU .so: load-once, matching onboard's binaries_loaded_ pattern.
     // Keeping the DSO alive across runs preserves g_aicpu_executor state
     // (orch_so_handle_ etc.), which is required for the orch-SO cache-hit path.
-    if (!aicpu_so_loaded_ && !aicpu_so_binary.empty()) {
+    if (!aicpu_so_loaded_ && !aicpu_so_binary_.empty()) {
         if (!create_temp_so_file(
-                "/tmp/aicpu_sim_XXXXXX", aicpu_so_binary.data(), aicpu_so_binary.size(), &aicpu_so_path_
+                "/tmp/aicpu_sim_XXXXXX", aicpu_so_binary_.data(), aicpu_so_binary_.size(), &aicpu_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICPU SO");
             return -1;
@@ -230,9 +232,9 @@ int DeviceRunner::ensure_binaries_loaded(
     }
 
     // Write AICore binary to temp file and dlopen
-    if (!aicore_kernel_binary.empty()) {
+    if (!aicore_kernel_binary_.empty()) {
         if (!create_temp_so_file(
-                "/tmp/aicore_sim_XXXXXX", aicore_kernel_binary.data(), aicore_kernel_binary.size(), &aicore_so_path_
+                "/tmp/aicore_sim_XXXXXX", aicore_kernel_binary_.data(), aicore_kernel_binary_.size(), &aicore_so_path_
             )) {
             LOG_ERROR("Failed to create temp file for AICore SO");
             return -1;
@@ -288,10 +290,7 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return 0;
 }
 
-int DeviceRunner::run(
-    Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-    const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num
-) {
+int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     clear_cpu_sim_shared_storage();
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
@@ -329,12 +328,11 @@ int DeviceRunner::run(
         }
     }
 
-    // Ensure device is initialized
-    int rc = ensure_device_initialized(device_id, aicpu_so_binary, aicore_kernel_binary);
-    if (rc != 0) {
-        LOG_ERROR("ensure_device_initialized failed: %d", rc);
-        return rc;
+    if (!aicpu_so_loaded_) {
+        LOG_ERROR("DeviceRunner::run: executor blobs not loaded; call simpler_init first");
+        return -1;
     }
+    int rc = 0;
 
     // Calculate execution parameters
     block_dim_ = block_dim;
@@ -396,7 +394,7 @@ int DeviceRunner::run(
 
     // Initialize performance profiling if enabled
     if (enable_l2_swimlane_) {
-        rc = init_l2_perf_collection(num_aicore, device_id);
+        rc = init_l2_perf_collection(num_aicore, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_perf_collection failed: %d", rc);
             return rc;
@@ -409,7 +407,7 @@ int DeviceRunner::run(
 
     if (enable_dump_tensor_) {
         // Initialize tensor dump (independent from profiling)
-        rc = init_tensor_dump(runtime, num_aicore, device_id);
+        rc = init_tensor_dump(runtime, num_aicore, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
@@ -419,7 +417,7 @@ int DeviceRunner::run(
 
     if (enable_pmu_) {
         rc = init_pmu_buffers(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id
+            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_
         );
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
@@ -612,20 +610,10 @@ int DeviceRunner::run(
     // Print handshake results at end of run
     print_handshake_results();
 
-    // Close AICore kernel .so now while the process is healthy.
-    // AICPU .so is kept alive (load-once) so that g_aicpu_executor state
-    // (orch_so_handle_ etc.) survives across runs for the orch-SO cache-hit path.
-    // It will be closed in finalize() / unload_executor_binaries().
-    if (aicore_so_handle_ != nullptr) {
-        dlclose(aicore_so_handle_);
-        aicore_so_handle_ = nullptr;
-        aicore_execute_func_ = nullptr;
-    }
-    if (!aicore_so_path_.empty()) {
-        std::remove(aicore_so_path_.c_str());
-        aicore_so_path_.clear();
-    }
-
+    // AICore + AICPU .so are kept alive for the runner's lifetime; they are
+    // loaded once by `simpler_init`'s `load_executor_blobs` and closed in
+    // `unload_executor_binaries` (via finalize). Under the post-#710 ABI the
+    // AICore blob no longer varies per run, so per-run dlclose is wasted work.
     return 0;
 }
 

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -127,24 +127,23 @@ public:
     /**
      * Execute a runtime using threads
      *
-     * This method simulates the complete execution:
-     * 1. Initializes worker handshake buffers
-     * 2. Sets function_bin_addr for all tasks
-     * 3. Launches AICPU threads
-     * 4. Launches AICore threads
-     * 5. Waits for all threads to complete
+     * Caller must have done `attach_current_thread()` and
+     * `load_executor_blobs()` once at `simpler_init`.
      *
-     * @param runtime              Runtime to execute
-     * @param block_dim            Number of blocks (1 block = 1 AIC + 2 AIV)
-     * @param device_id            Device ID (ignored in simulation)
-     * @param aicpu_so_binary      AICPU binary (ignored in simulation)
-     * @param aicore_kernel_binary AICore binary (ignored in simulation)
-     * @param launch_aicpu_num     Number of AICPU threads
+     * @param runtime          Runtime to execute
+     * @param block_dim        Number of blocks (1 block = 1 AIC + 2 AIV)
+     * @param launch_aicpu_num Number of AICPU threads
      * @return 0 on success
      */
-    int
-    run(Runtime &runtime, int block_dim, int device_id, const std::vector<uint8_t> &aicpu_so_binary,
-        const std::vector<uint8_t> &aicore_kernel_binary, int launch_aicpu_num = 1);
+    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1);
+
+    /// Bound device id (set by `attach_current_thread` / `simpler_init`).
+    int device_id() const noexcept { return device_id_; }
+
+    /// Load AICPU SO + AICore kernel blobs into the runner once.
+    int load_executor_blobs(
+        const uint8_t *aicpu_blob, size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+    );
 
     /**
      * Enablement setters for the three diagnostics sub-features. Called by
@@ -264,6 +263,11 @@ private:
     int cores_per_blockdim_{PLATFORM_CORES_PER_BLOCKDIM};
     int worker_count_{0};
 
+    // Runner-owned copies of the executor blobs, populated once by
+    // `load_executor_blobs()` (from `simpler_init`).
+    std::vector<uint8_t> aicpu_so_binary_;
+    std::vector<uint8_t> aicore_kernel_binary_;
+
     // Memory management
     MemoryAllocator mem_alloc_;
 
@@ -335,13 +339,9 @@ private:
     // PMU profiling (per-task AICore hardware counters)
     PmuCollector pmu_collector_;
 
-    // Private helper methods
-    int ensure_device_initialized(
-        int device_id, const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
-    int ensure_binaries_loaded(
-        const std::vector<uint8_t> &aicpu_so_binary, const std::vector<uint8_t> &aicore_kernel_binary
-    );
+    // Internal: load executor SOs from cached host-side vectors
+    // `aicpu_so_binary_` / `aicore_kernel_binary_`.
+    int ensure_binaries_loaded();
     void unload_executor_binaries();
 
     /**

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -200,8 +200,12 @@ void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, si
     r->record_tensor_pair(host_ptr, dev_ptr, size);
 }
 
-int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_info_v) {
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, int log_level, int log_info_v, const uint8_t *aicpu_blob,
+    size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+) {
     if (ctx == NULL) return -1;
+    if (aicpu_blob == NULL || aicpu_blob_size == 0 || aicore_blob == NULL || aicore_blob_size == 0) return -1;
 
     // Attach FIRST so that an attach failure (e.g. invalid device_id) does not
     // leave the process-wide HostLogger singleton mutated.
@@ -209,6 +213,13 @@ int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_
     int rc;
     try {
         rc = runner->attach_current_thread(device_id);
+    } catch (...) {
+        return -1;
+    }
+    if (rc != 0) return rc;
+
+    try {
+        rc = runner->load_executor_blobs(aicpu_blob, aicpu_blob_size, aicore_blob, aicore_blob_size);
     } catch (...) {
         return -1;
     }
@@ -225,18 +236,9 @@ int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_
  * Per-callable_id preparation
  * =========================================================================== */
 
-int prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, int device_id, const uint8_t *aicpu_binary,
-    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size
-) {
+int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable) {
     if (ctx == NULL || callable == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
-
-    (void)aicpu_binary;
-    (void)aicpu_size;
-    (void)aicore_binary;
-    (void)aicore_size;
-    (void)device_id;
 
     pthread_once(&g_runner_key_once, create_runner_key);
     pthread_setspecific(g_runner_key, ctx);
@@ -289,8 +291,7 @@ int prepare_callable(
 
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
 ) {
     if (ctx == NULL || runtime == NULL) return -1;
     DeviceRunner *runner = static_cast<DeviceRunner *>(ctx);
@@ -333,15 +334,7 @@ int run_prepared(
         runner->set_pmu_enabled(enable_pmu);
         runner->set_output_prefix(output_prefix);
 
-        std::vector<uint8_t> aicpu_vec;
-        std::vector<uint8_t> aicore_vec;
-        if (aicpu_binary != NULL && aicpu_size > 0) {
-            aicpu_vec.assign(aicpu_binary, aicpu_binary + aicpu_size);
-        }
-        if (aicore_binary != NULL && aicore_size > 0) {
-            aicore_vec.assign(aicore_binary, aicore_binary + aicore_size);
-        }
-        rc = runner->run(*r, block_dim, device_id, aicpu_vec, aicore_vec, aicpu_thread_num);
+        rc = runner->run(*r, block_dim, aicpu_thread_num);
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -194,11 +194,16 @@ void ChipWorker::init(
     runtime_buf_.resize(get_runtime_size_fn_());
 
     // One-shot platform-side init: attach the calling thread to `device_id`
-    // (rtSetDevice on onboard, sim bind+acquire on sim) and push the user's
-    // simpler-logger choice into HostLogger + runner state (and CANN dlog
-    // onboard). Subsequent device-ops re-attach their caller threads
-    // idempotently against the recorded device id.
-    int init_rc = simpler_init_fn_(device_ctx_, device_id, log_level, log_info_v);
+    // (rtSetDevice on onboard, sim bind+acquire on sim), hand the executor
+    // blobs over to the DeviceRunner (which copies them and keeps them for
+    // the lifetime of the runtime), and push the user's simpler-logger
+    // choice into HostLogger + runner state (and CANN dlog onboard).
+    // Subsequent device-ops re-attach their caller threads idempotently
+    // against the recorded device id.
+    int init_rc = simpler_init_fn_(
+        device_ctx_, device_id, log_level, log_info_v, aicpu_binary_.data(), aicpu_binary_.size(),
+        aicore_binary_.data(), aicore_binary_.size()
+    );
     if (init_rc != 0) {
         // Symmetric teardown: drop the device context, clear all dlsym'd
         // function pointers, dlclose, and discard cached binaries so the
@@ -303,10 +308,7 @@ void ChipWorker::prepare_callable(int32_t callable_id, const void *callable) {
     if (callable == nullptr) {
         throw std::runtime_error("prepare_callable: callable must not be null");
     }
-    int rc = prepare_callable_fn_(
-        device_ctx_, callable_id, callable, device_id_, aicpu_binary_.data(), aicpu_binary_.size(),
-        aicore_binary_.data(), aicore_binary_.size()
-    );
+    int rc = prepare_callable_fn_(device_ctx_, callable_id, callable);
     if (rc != 0) {
         throw std::runtime_error("prepare_callable failed with code " + std::to_string(rc));
     }
@@ -326,8 +328,7 @@ void ChipWorker::run_prepared(int32_t callable_id, const void *args, const CallC
     void *rt = runtime_buf_.data();
 
     int rc = run_prepared_fn_(
-        device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, device_id_, aicpu_binary_.data(),
-        aicpu_binary_.size(), aicore_binary_.data(), aicore_binary_.size(), config.enable_l2_swimlane,
+        device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, config.enable_l2_swimlane,
         config.enable_dump_tensor, config.enable_pmu, config.output_prefix
     );
     if (rc != 0) {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -107,13 +107,9 @@ private:
     using CopyToDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using CopyFromDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using GetRuntimeSizeFn = size_t (*)();
-    using SimplerInitFn = int (*)(void *, int, int, int);
-    using PrepareCallableFn =
-        int (*)(void *, int32_t, const void *, int, const uint8_t *, size_t, const uint8_t *, size_t);
-    using RunPreparedFn = int (*)(
-        void *, void *, int32_t, const void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t, int,
-        int, int, const char *
-    );
+    using SimplerInitFn = int (*)(void *, int, int, int, const uint8_t *, size_t, const uint8_t *, size_t);
+    using PrepareCallableFn = int (*)(void *, int32_t, const void *);
+    using RunPreparedFn = int (*)(void *, void *, int32_t, const void *, int, int, int, int, int, const char *);
     using UnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);
     using FinalizeDeviceFn = int (*)(void *);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -82,14 +82,23 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
 
 /**
  * One-shot platform-side init. Called once by ChipWorker::init() right
- * after dlopen, before any other entry. Two responsibilities:
+ * after dlopen, before any other entry. Three responsibilities:
  *
  *   1. Attach the calling thread to `device_id` (rtSetDevice on onboard,
  *      pto_cpu_sim_bind_device + pto_cpu_sim_acquire_device on sim) and
  *      record the device id on the DeviceRunner so subsequent device-ops
- *      can re-attach their own caller threads idempotently.
+ *      can re-attach their own caller threads idempotently. Also creates
+ *      the per-runner streams so binary load can proceed in the same call.
  *
- *   2. Push the user's chosen severity + INFO verbosity into HostLogger
+ *   2. Copy the AICPU/AICore executor blobs into the DeviceRunner
+ *      (one-shot H2D + AicpuSoInfo init). The blobs are raw byte buffers
+ *      already loaded into host memory by the caller (typically the
+ *      ChipWorker reading `aicpu.so` / `aicore_kernel.bin` from disk). The
+ *      caller may release its own buffer immediately after `simpler_init`
+ *      returns; every subsequent `run_prepared` reuses the runner-owned
+ *      copies.
+ *
+ *   3. Push the user's chosen severity + INFO verbosity into HostLogger
  *      and into runner state (which run_prepared later forwards to AICPU
  *      via KernelArgs).
  *
@@ -102,9 +111,12 @@ int copy_from_device_ctx(DeviceContextHandle ctx, void *host_ptr, const void *de
  * `log_level` is CANN-aligned: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL.
  * `log_info_v` ∈ [0, 9]; only meaningful when severity is INFO.
  *
- * Returns 0 on success, negative on attach failure.
+ * Returns 0 on success, negative on attach / stream / binary-load failure.
  */
-int simpler_init(DeviceContextHandle ctx, int device_id, int log_level, int log_info_v);
+int simpler_init(
+    DeviceContextHandle ctx, int device_id, int log_level, int log_info_v, const uint8_t *aicpu_blob,
+    size_t aicpu_blob_size, const uint8_t *aicore_blob, size_t aicore_blob_size
+);
 
 /**
  * Release all device resources held by the context.
@@ -133,22 +145,13 @@ int finalize_device(DeviceContextHandle ctx);
  * copies the orchestration SO bytes into a device-resident buffer keyed by
  * the SO's ELF Build-ID hash (so two callable_ids with identical SO share
  * one buffer). Subsequent `run_prepared(callable_id, ...)` calls reuse this
- * state.
- *
- * The `device_id`, `aicpu_binary` / `aicpu_size`, `aicore_binary` /
- * `aicore_size` parameters are accepted to keep the signature aligned with
- * `run_prepared` so codegen layers can share a single forwarding shim; the
- * current implementations ignore them (kernel upload uses the ChipCallable
- * payload, and the AICPU / AICore executor binaries are already loaded at
- * `simpler_init`).
+ * state. The device and executor binaries were bound at `simpler_init`; no
+ * per-call binary or device_id is needed.
  *
  * @return 0 on success, negative on error (NULL ctx, callable_id out of
  *         range, or upload/copy failure).
  */
-int prepare_callable(
-    DeviceContextHandle ctx, int32_t callable_id, const void *callable, int device_id, const uint8_t *aicpu_binary,
-    size_t aicpu_size, const uint8_t *aicore_binary, size_t aicore_size
-);
+int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *callable);
 
 /**
  * Launch a callable previously staged via `prepare_callable`.
@@ -158,14 +161,14 @@ int prepare_callable(
  * kernels or re-copying the orch SO. The AICPU side dispatches via
  * `orch_so_table_[callable_id]` (see runtime.h::set_active_callable_id). The
  * first run for a given callable_id sets `register_new_callable_id_` so the
- * AICPU does its one-time dlopen.
+ * AICPU does its one-time dlopen. The device and executor binaries were
+ * bound at `simpler_init`; this entry only carries per-task state.
  *
  * @return 0 on success, negative on error (no prep state, NULL ctx, etc.).
  */
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size, const uint8_t *aicore_binary,
-    size_t aicore_size, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
+    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, const char *output_prefix
 );
 
 /**


### PR DESCRIPTION
## Summary

The AICPU/AICore executor binaries used to ride along on every
`prepare_callable` and `run_prepared` call across the C ABI boundary,
even though `DeviceRunner` already cached them after the first
`ensure_binaries_loaded`. `prepare_callable` on all four platforms had
the parameters but `(void)`'d them out; `run_prepared` rebuilt
`std::vector` copies on every launch only to hand them to a runner that
already knew the bytes. The parameter list invited readers to think the
device or executors might change per call when they cannot.

This PR consolidates the executor blobs on `simpler_init` and drops
them from `prepare_callable` / `run_prepared`. `device_id` is also
dropped from the per-call entries; the runner records it at init and
exposes it via `device_id()` for any re-attach the chip-child process
needs.

## Changes

- **`pto_runtime_c_api.h`**: `simpler_init` takes `aicpu_blob` /
  `aicore_blob` (raw ptr+size); `prepare_callable` and `run_prepared`
  lose binary + `device_id` parameters; doxygen rewritten to describe
  the load-once contract.
- **`DeviceRunner` (4 variants)**: `run()` / `ensure_binaries_loaded()`
  shed their binary parameters in favor of new `aicpu_so_binary_` /
  `aicore_kernel_binary_` members populated by `load_executor_blobs()`,
  which `simpler_init` invokes once. `ensure_device_initialized`
  retired (its `prepare_run_context` + `ensure_binaries_loaded` split
  is now done explicitly in the C ABI entry). Added `device_id()`
  accessor.
- **a2a3/a5 sim runners**: drop the per-run `dlclose` of the AICore
  SO; the blob is fixed for the runner's lifetime under the new ABI so
  the load-once contract matches onboard.
- **`pto_runtime_c_api.cpp` (4 variants)**: `simpler_init` now drives
  `prepare_run_context` + `load_executor_blobs`; `prepare_callable`
  and `run_prepared` re-attach via `runner->device_id()` instead of
  taking a fresh `device_id` arg, and `run_prepared` no longer
  constructs the `std::vector` copies that fed the old `runner->run`
  signature.
- **`ChipWorker`**: `SimplerInitFn` / `PrepareCallableFn` /
  `RunPreparedFn` typedefs track the new ABI; `init()` forwards the
  cached binaries into `simpler_init`; `prepare_callable` /
  `run_prepared` stop forwarding them.

## Test plan

- [x] `pre-commit` clean (clang-format / clang-tidy / cpplint)
- [x] `pytest tests/ut/py` — 226 passed, 3 hw-skipped
- [x] `pytest tests/st/{a2a3,a5}/{tensormap_and_ringbuffer,host_build_graph}/prepared_callable --platform {a2a3sim,a5sim}` — all 21 cases pass
- [ ] Hardware ST run (onboard)

## Notes

Follow-up to #710. No API change visible to Python callers — `Worker`,
`ChipWorker`, and the nanobind bindings keep identical signatures; the
ABI tightening happens entirely below `ChipWorker::init`.