### PR TITLE
Refactor: PTO2 stall + dispatch diagnostic log format

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -11,6 +11,7 @@
 #include "scheduler_context.h"
 
 #include <cinttypes>
+#include <cstdio>
 
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
@@ -124,82 +125,203 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
     return LoopAction::NONE;
 }
 
+// =============================================================================
+// Stall diagnostic log format.
+//
+// Every line is self-contained — when scheduler threads emit concurrently and
+// device_log interleaves their output, each line still carries enough context
+// to identify which thread / iteration / object it belongs to.
+//
+// Prefix on every line:
+//   [STALL thread=N idle_iterations=K] CATEGORY ...
+//
+// All scheduler threads spinning at the same idle rate hit STALL_LOG_INTERVAL
+// together, so lines with the same idle_iterations belong to one diagnostic
+// round; grep "idle_iterations=N" groups one round's output.
+//
+// Categories (and which thread emits them):
+//   SUMMARY  — completed / total counts and scan totals               (thread 0 only)
+//   TASK     — one per non-completed task scanned from shared rings   (thread 0 only)
+//              - state=RUNNING: includes running_on=[...] cross-ref
+//              - state=WAIT:    includes missing_deps=N
+//   CLUSTER  — one per cluster owned by this thread                   (every thread)
+//              - busy slot shows kernel + task_id + cond_reg_state;
+//                ANOMALY suffix when COND register is fin while software
+//                still has the slot marked busy.
+//
+// Reader workflow:
+//   1. grep SUMMARY                          -> overall completion status
+//   2. grep "idle_iterations=N TASK"         -> stuck RUNNING task and which
+//                                               core/thread it is on
+//   3. grep "idle_iterations=N CLUSTER.*task=<id>" -> cross-check via the
+//                                                     cluster line (or just
+//                                                     read running_on in step 2)
+// =============================================================================
+
+namespace {
+
+// Format a core's idle/busy state into a fixed buffer. Used inside CLUSTER lines.
+// Layout (idle):    coreN(idle)
+// Layout (busy):    coreN(busy kernel=K task=T cond_reg_state=ack)
+// Layout (anomaly): coreN(busy kernel=K task=T cond_reg_state=fin ANOMALY)
+//
+// Healthy busy: COND register reports ack (AICore still executing). fin means
+// AICore wrote completion but AICPU hasn't recycled the running slot yet —
+// either a completion-poll bug or the diagnostic raced the recycle.
+void format_core_status(
+    char *buf, size_t buf_size, int32_t core_id, bool idle, const CoreExecState *core_state, uint64_t reg_addr_for_cond
+) {
+    if (idle) {
+        snprintf(buf, buf_size, "core%d(idle)", core_id);
+        return;
+    }
+    int32_t kernel = -1;
+    int64_t task_id_raw = -1;
+    if (core_state && core_state->running_slot_state) {
+        int32_t subslot = static_cast<int32_t>(core_state->running_subslot);
+        kernel = core_state->running_slot_state->task->kernel_id[subslot];
+        task_id_raw = static_cast<int64_t>(core_state->running_slot_state->task->task_id.raw);
+    }
+    uint64_t cond_reg = read_reg(reg_addr_for_cond, RegId::COND);
+    int32_t hw_state = EXTRACT_TASK_STATE(cond_reg);
+    const char *cond_reg_state_str = (hw_state == TASK_ACK_STATE) ? "ack" : "fin";
+    if (hw_state == TASK_ACK_STATE) {
+        snprintf(
+            buf, buf_size, "core%d(busy kernel=%d task=%" PRId64 " cond_reg_state=%s)", core_id, kernel, task_id_raw,
+            cond_reg_state_str
+        );
+    } else {
+        snprintf(
+            buf, buf_size, "core%d(busy kernel=%d task=%" PRId64 " cond_reg_state=%s ANOMALY)", core_id, kernel,
+            task_id_raw, cond_reg_state_str
+        );
+    }
+}
+
+}  // namespace
+
+int32_t SchedulerContext::find_core_owner_thread(int32_t core_id) const {
+    for (int32_t t = 0; t < thread_num_; t++) {
+        const int32_t *ids = core_trackers_[t].core_ids();
+        int32_t n = core_trackers_[t].core_num();
+        for (int32_t i = 0; i < n; i++) {
+            if (ids[i] == core_id) return t;
+        }
+    }
+    return -1;
+}
+
 void SchedulerContext::log_stall_diagnostics(
     int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count
 ) {
-    int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-    LOG_INFO_V9(
-        "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
-        task_count, last_progress_count
-    );
     CoreTracker &tracker = core_trackers_[thread_idx];
-    int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
-        int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
-        for (int32_t si = 0; si < ring_task_count; si++) {
-            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
-            PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
-            int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
-            int32_t fi = slot_state.fanin_count;
-            int32_t kid = slot_state.task->kernel_id[0];
-            if (st >= PTO2_TASK_COMPLETED) continue;
-            if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
-                cnt_inflight++;
-                continue;
-            }
-            if (rc >= fi) {
-                cnt_ready++;
-                if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                    LOG_INFO_V9(
-                        "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
-                        static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
+
+    // T0 owns the shared-ring scan; printing it from other threads would
+    // produce identical TASK lines once per scheduler thread.
+    if (thread_idx == 0) {
+        int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
+            int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
+            submitted_in_ring += ring_task_count;
+            for (int32_t si = 0; si < ring_task_count; si++) {
+                PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+                PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+                int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
+                int32_t fi = slot_state.fanin_count;
+                int32_t kid_aic = slot_state.task->kernel_id[0];
+                int32_t kid_aiv0 = slot_state.task->kernel_id[1];
+                int32_t kid_aiv1 = slot_state.task->kernel_id[2];
+                int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
+                if (st >= PTO2_TASK_COMPLETED) continue;
+                // task_state's intermediate values (READY / RUNNING) are not
+                // written on the non-profiling hot path, so we cannot rely on
+                // them — classify by the ground truth instead: a slot is
+                // RUNNING iff some core has it as running_slot_state. A task
+                // occupies at most 3 cores (one cluster), all under the same
+                // owner thread by construction of assign_cores_to_threads.
+                char running_on[192] = {0};
+                int32_t owner = -1;
+                int32_t pos = 0;
+                bool is_running = false;
+                for (int32_t cid = 0; cid < cores_total_num_ && pos + 32 < (int32_t)sizeof(running_on); cid++) {
+                    if (core_exec_states_[cid].running_slot_state != &slot_state) continue;
+                    is_running = true;
+                    if (owner < 0) owner = find_core_owner_thread(cid);
+                    const char *sname = subslot_name(core_exec_states_[cid].running_subslot);
+                    int32_t written = snprintf(
+                        running_on + pos, sizeof(running_on) - pos, "%score=%d(%s)", pos == 0 ? "" : " ", cid, sname
                     );
+                    if (written > 0) pos += written;
                 }
-            } else {
+
+                if (is_running) {
+                    cnt_running++;
+                    if (cnt_running > STALL_DUMP_READY_MAX) continue;
+                    LOG_INFO_V9(
+                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                        " state=RUNNING fanin_refcount=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] "
+                        "running_on=[owner_thread=%d cores=[%s]]",
+                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, owner, running_on
+                    );
+                    continue;
+                }
+                if (rc >= fi) {
+                    cnt_ready++;
+                    if (cnt_ready > STALL_DUMP_READY_MAX) continue;
+                    LOG_INFO_V9(
+                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                        " state=READY   fanin_refcount=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d]",
+                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1
+                    );
+                    continue;
+                }
                 cnt_waiting++;
-                if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                    LOG_INFO_V9(
-                        "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
-                        static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
-                    );
-                }
+                if (cnt_waiting > STALL_DUMP_WAIT_MAX) continue;
+                LOG_INFO_V9(
+                    "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                    " state=WAIT    fanin_refcount=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] missing_deps=%d",
+                    thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, fi - rc
+                );
             }
         }
-    }
-    LOG_INFO_V9("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
-    int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
-    int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
-    int32_t total_running = aic_running + aiv_running;
-    LOG_INFO_V9(
-        "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running, aiv_running,
-        core_trackers_[thread_idx].core_num()
-    );
-    auto all_running = tracker.get_all_running_cores();
-    int32_t dump_count = 0;
-    int32_t bp;
-    while (dump_count < STALL_DUMP_CORE_MAX && (bp = all_running.pop_first()) >= 0) {
-        dump_count++;
-        int32_t cid = tracker.get_core_id_by_offset(bp);
-        int32_t sw_tid = core_exec_states_[cid].running_reg_task_id;
-        int32_t hw_kernel = -1;
-        if (sw_tid >= 0 && core_exec_states_[cid].running_slot_state) {
-            int32_t diag_slot = static_cast<int32_t>(core_exec_states_[cid].running_subslot);
-            hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
-        }
-        uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
+        int32_t effective_total = task_count > 0 ? task_count : submitted_in_ring;
+        int32_t c = completed_tasks_.load(std::memory_order_relaxed);
         LOG_INFO_V9(
-            "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
-            EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg), sw_tid, hw_kernel
+            "[STALL thread=%d idle_iterations=%d] SUMMARY completed=%d/%d last_progress_iteration=%d "
+            "scan_ready=%d scan_waiting=%d scan_running=%d",
+            thread_idx, idle_iterations, c, effective_total, last_progress_count, cnt_ready, cnt_waiting, cnt_running
         );
     }
+
+    // CLUSTER lines: one per cluster this thread owns.
+    // cluster_id = local_cluster_idx * active_sched_threads_ + thread_idx, matching the
+    // round-robin assignment in assign_cores_to_threads / reassign_cores_for_all_threads.
+    int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : thread_num_;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
+        int32_t aic_id = tracker.get_aic_core_id(offset);
+        int32_t aiv0_id = tracker.get_aiv0_core_id(offset);
+        int32_t aiv1_id = tracker.get_aiv1_core_id(offset);
+        bool aic_idle = tracker.is_aic_core_idle(offset);
+        bool aiv0_idle = tracker.is_aiv0_core_idle(offset);
+        bool aiv1_idle = tracker.is_aiv1_core_idle(offset);
+        int32_t cluster_id = cli * ast + thread_idx;
+        char aic_buf[128], aiv0_buf[128], aiv1_buf[128];
+        format_core_status(
+            aic_buf, sizeof(aic_buf), aic_id, aic_idle, &core_exec_states_[aic_id], core_exec_states_[aic_id].reg_addr
+        );
+        format_core_status(
+            aiv0_buf, sizeof(aiv0_buf), aiv0_id, aiv0_idle, &core_exec_states_[aiv0_id],
+            core_exec_states_[aiv0_id].reg_addr
+        );
+        format_core_status(
+            aiv1_buf, sizeof(aiv1_buf), aiv1_id, aiv1_idle, &core_exec_states_[aiv1_id],
+            core_exec_states_[aiv1_id].reg_addr
+        );
         LOG_INFO_V9(
-            "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
-            tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
-            tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
-            tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
+            "[STALL thread=%d idle_iterations=%d] CLUSTER cluster_id=%d aic=%s aiv0=%s aiv1=%s", thread_idx,
+            idle_iterations, cluster_id, aic_buf, aiv0_buf, aiv1_buf
         );
     }
 }
@@ -211,7 +333,10 @@ int32_t SchedulerContext::handle_timeout_exit(
     uint64_t sched_start_ts
 #endif
 ) {
-    LOG_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+    LOG_ERROR(
+        "[STALL thread=%d idle_iterations=%d] TIMEOUT_EXIT after_idle_iterations=%d", thread_idx, idle_iterations,
+        idle_iterations
+    );
     latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
         emergency_shutdown(runtime);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -200,6 +200,21 @@ private:
     // =========================================================================
 
     static const char *shape_name(PTO2ResourceShape shape);
+
+    // Lower-case rendering of PTO2SubtaskSlot, used by dispatch and stall logs.
+    // Kept lower-case to match the `kernels=[aic:N aiv0:N aiv1:N]` field
+    // convention already established in the stall log family.
+    static inline const char *subslot_name(PTO2SubtaskSlot s) {
+        switch (s) {
+        case PTO2SubtaskSlot::AIC:
+            return "aic";
+        case PTO2SubtaskSlot::AIV0:
+            return "aiv0";
+        case PTO2SubtaskSlot::AIV1:
+            return "aiv1";
+        }
+        return "?";
+    }
     static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx);
 
     int pop_ready_tasks_batch(
@@ -275,6 +290,11 @@ private:
 
     __attribute__((noinline, cold)) void
     log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
+
+    // Reverse lookup: given a global core_id, find which scheduler thread's
+    // tracker owns it. Returns -1 if not found. Linear scan — only used on
+    // the cold diagnostic path.
+    int32_t find_core_owner_thread(int32_t core_id) const;
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
         int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -157,6 +157,15 @@ void SchedulerContext::dispatch_subtask_to_core(
         tracker.change_core_state(core_offset);
     }
 
+    LOG_DEBUG(
+        "Thread %d: Dispatched %s %s task %" PRId64 " kernel_id=[%d,%d,%d] block_idx=%d/total_blocks=%d to"
+        " core_offset=%d core_id=%d reg_task_id=%u",
+        thread_idx, to_pending ? "pending" : "idle", subslot_name(subslot),
+        static_cast<int64_t>(slot_state.task->task_id.raw), slot_state.task->kernel_id[0],
+        slot_state.task->kernel_id[1], slot_state.task->kernel_id[2], slot_state.next_block_idx,
+        slot_state.logical_block_num, core_offset, core_id, reg_task_id
+    );
+
     write_reg(core_exec_state.reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
     tracker.set_pending_occupied(core_offset);
 }
@@ -269,12 +278,6 @@ void SchedulerContext::dispatch_shape(
                 auto core_offset = cores.pop_first();
                 dispatch_block(thread_idx, core_offset, *slot_state, shape, is_pending);
                 slot_state->next_block_idx++;
-                LOG_DEBUG(
-                    "Thread %d: Dispatched %s %s task %" PRId64 " block %d/%d to core_offset %d", thread_idx,
-                    is_pending ? "pending" : "idle", shape_name(shape),
-                    static_cast<int64_t>(slot_state->task->task_id.raw), slot_state->next_block_idx - 1,
-                    slot_state->logical_block_num, core_offset
-                );
             } while (slot_state->next_block_idx < slot_state->logical_block_num && cores.has_value());
 
             if (slot_state->next_block_idx < slot_state->logical_block_num) {
@@ -564,10 +567,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 if (action == LoopAction::BREAK_LOOP) break;
             }
 
-            if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
-                log_stall_diagnostics(thread_idx, task_count, idle_iterations, last_progress_count);
+            if (idle_iterations % STALL_LOG_INTERVAL == 0) {
+                log_stall_diagnostics(thread_idx, total_tasks_, idle_iterations, last_progress_count);
             }
-            if (idle_iterations > MAX_IDLE_ITERATIONS) {
+            if (idle_iterations >= MAX_IDLE_ITERATIONS) {
                 return handle_timeout_exit(
                     thread_idx, header, runtime, idle_iterations
 #if PTO2_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -44,7 +44,7 @@
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 50000;         // LOG_INFO_V9 every N idle iters to debug hang
+constexpr int32_t STALL_LOG_INTERVAL = 400000;        // LOG_INFO_V9 every N idle iters to debug hang
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -11,6 +11,7 @@
 #include "scheduler_context.h"
 
 #include <cinttypes>
+#include <cstdio>
 
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
@@ -124,82 +125,203 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
     return LoopAction::NONE;
 }
 
+// =============================================================================
+// Stall diagnostic log format.
+//
+// Every line is self-contained — when scheduler threads emit concurrently and
+// device_log interleaves their output, each line still carries enough context
+// to identify which thread / iteration / object it belongs to.
+//
+// Prefix on every line:
+//   [STALL thread=N idle_iterations=K] CATEGORY ...
+//
+// All scheduler threads spinning at the same idle rate hit STALL_LOG_INTERVAL
+// together, so lines with the same idle_iterations belong to one diagnostic
+// round; grep "idle_iterations=N" groups one round's output.
+//
+// Categories (and which thread emits them):
+//   SUMMARY  — completed / total counts and scan totals               (thread 0 only)
+//   TASK     — one per non-completed task scanned from shared rings   (thread 0 only)
+//              - state=RUNNING: includes running_on=[...] cross-ref
+//              - state=WAIT:    includes missing_deps=N
+//   CLUSTER  — one per cluster owned by this thread                   (every thread)
+//              - busy slot shows kernel + task_id + cond_reg_state;
+//                ANOMALY suffix when COND register is fin while software
+//                still has the slot marked busy.
+//
+// Reader workflow:
+//   1. grep SUMMARY                          -> overall completion status
+//   2. grep "idle_iterations=N TASK"         -> stuck RUNNING task and which
+//                                               core/thread it is on
+//   3. grep "idle_iterations=N CLUSTER.*task=<id>" -> cross-check via the
+//                                                     cluster line (or just
+//                                                     read running_on in step 2)
+// =============================================================================
+
+namespace {
+
+// Format a core's idle/busy state into a fixed buffer. Used inside CLUSTER lines.
+// Layout (idle):    coreN(idle)
+// Layout (busy):    coreN(busy kernel=K task=T cond_reg_state=ack)
+// Layout (anomaly): coreN(busy kernel=K task=T cond_reg_state=fin ANOMALY)
+//
+// Healthy busy: COND register reports ack (AICore still executing). fin means
+// AICore wrote completion but AICPU hasn't recycled the running slot yet —
+// either a completion-poll bug or the diagnostic raced the recycle.
+void format_core_status(
+    char *buf, size_t buf_size, int32_t core_id, bool idle, const CoreExecState *core_state, uint64_t reg_addr_for_cond
+) {
+    if (idle) {
+        snprintf(buf, buf_size, "core%d(idle)", core_id);
+        return;
+    }
+    int32_t kernel = -1;
+    int64_t task_id_raw = -1;
+    if (core_state && core_state->running_slot_state) {
+        int32_t subslot = static_cast<int32_t>(core_state->running_subslot);
+        kernel = core_state->running_slot_state->task->kernel_id[subslot];
+        task_id_raw = static_cast<int64_t>(core_state->running_slot_state->task->task_id.raw);
+    }
+    uint64_t cond_reg = read_reg(reg_addr_for_cond, RegId::COND);
+    int32_t hw_state = EXTRACT_TASK_STATE(cond_reg);
+    const char *cond_reg_state_str = (hw_state == TASK_ACK_STATE) ? "ack" : "fin";
+    if (hw_state == TASK_ACK_STATE) {
+        snprintf(
+            buf, buf_size, "core%d(busy kernel=%d task=%" PRId64 " cond_reg_state=%s)", core_id, kernel, task_id_raw,
+            cond_reg_state_str
+        );
+    } else {
+        snprintf(
+            buf, buf_size, "core%d(busy kernel=%d task=%" PRId64 " cond_reg_state=%s ANOMALY)", core_id, kernel,
+            task_id_raw, cond_reg_state_str
+        );
+    }
+}
+
+}  // namespace
+
+int32_t SchedulerContext::find_core_owner_thread(int32_t core_id) const {
+    for (int32_t t = 0; t < thread_num_; t++) {
+        const int32_t *ids = core_trackers_[t].core_ids();
+        int32_t n = core_trackers_[t].core_num();
+        for (int32_t i = 0; i < n; i++) {
+            if (ids[i] == core_id) return t;
+        }
+    }
+    return -1;
+}
+
 void SchedulerContext::log_stall_diagnostics(
     int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count
 ) {
-    int32_t c = completed_tasks_.load(std::memory_order_relaxed);
-    LOG_INFO_V9(
-        "PTO2 stall: no progress for %d iterations, completed=%d total=%d (last progress at %d)", idle_iterations, c,
-        task_count, last_progress_count
-    );
     CoreTracker &tracker = core_trackers_[thread_idx];
-    int32_t cnt_ready = 0, cnt_waiting = 0, cnt_inflight = 0;
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
-        int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
-        for (int32_t si = 0; si < ring_task_count; si++) {
-            PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
-            PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
-            int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
-            int32_t fi = slot_state.fanin_count;
-            int32_t kid = slot_state.task->kernel_id[0];
-            if (st >= PTO2_TASK_COMPLETED) continue;
-            if (st == PTO2_TASK_READY || st == PTO2_TASK_RUNNING) {
-                cnt_inflight++;
-                continue;
-            }
-            if (rc >= fi) {
-                cnt_ready++;
-                if (cnt_ready <= STALL_DUMP_READY_MAX) {
-                    LOG_INFO_V9(
-                        "  STUCK-READY  ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
-                        static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
+
+    // T0 owns the shared-ring scan; printing it from other threads would
+    // produce identical TASK lines once per scheduler thread.
+    if (thread_idx == 0) {
+        int32_t cnt_ready = 0, cnt_waiting = 0, cnt_running = 0, submitted_in_ring = 0;
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            PTO2SharedMemoryRingHeader &ring = *sched_->ring_sched_states[r].ring;
+            int32_t ring_task_count = ring.fc.current_task_index.load(std::memory_order_relaxed);
+            submitted_in_ring += ring_task_count;
+            for (int32_t si = 0; si < ring_task_count; si++) {
+                PTO2TaskSlotState &slot_state = ring.get_slot_state_by_task_id(si);
+                PTO2TaskState st = slot_state.task_state.load(std::memory_order_relaxed);
+                int32_t rc = slot_state.fanin_refcount.load(std::memory_order_relaxed);
+                int32_t fi = slot_state.fanin_count;
+                int32_t kid_aic = slot_state.task->kernel_id[0];
+                int32_t kid_aiv0 = slot_state.task->kernel_id[1];
+                int32_t kid_aiv1 = slot_state.task->kernel_id[2];
+                int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
+                if (st >= PTO2_TASK_COMPLETED) continue;
+                // task_state's intermediate values (READY / RUNNING) are not
+                // written on the non-profiling hot path, so we cannot rely on
+                // them — classify by the ground truth instead: a slot is
+                // RUNNING iff some core has it as running_slot_state. A task
+                // occupies at most 3 cores (one cluster), all under the same
+                // owner thread by construction of assign_cores_to_threads.
+                char running_on[192] = {0};
+                int32_t owner = -1;
+                int32_t pos = 0;
+                bool is_running = false;
+                for (int32_t cid = 0; cid < cores_total_num_ && pos + 32 < (int32_t)sizeof(running_on); cid++) {
+                    if (core_exec_states_[cid].running_slot_state != &slot_state) continue;
+                    is_running = true;
+                    if (owner < 0) owner = find_core_owner_thread(cid);
+                    const char *sname = subslot_name(core_exec_states_[cid].running_subslot);
+                    int32_t written = snprintf(
+                        running_on + pos, sizeof(running_on) - pos, "%score=%d(%s)", pos == 0 ? "" : " ", cid, sname
                     );
+                    if (written > 0) pos += written;
                 }
-            } else {
+
+                if (is_running) {
+                    cnt_running++;
+                    if (cnt_running > STALL_DUMP_READY_MAX) continue;
+                    LOG_INFO_V9(
+                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                        " state=RUNNING fanin_refcount=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] "
+                        "running_on=[owner_thread=%d cores=[%s]]",
+                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, owner, running_on
+                    );
+                    continue;
+                }
+                if (rc >= fi) {
+                    cnt_ready++;
+                    if (cnt_ready > STALL_DUMP_READY_MAX) continue;
+                    LOG_INFO_V9(
+                        "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                        " state=READY   fanin_refcount=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d]",
+                        thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1
+                    );
+                    continue;
+                }
                 cnt_waiting++;
-                if (cnt_waiting <= STALL_DUMP_WAIT_MAX) {
-                    LOG_INFO_V9(
-                        "  STUCK-WAIT   ring=%d task_id=%" PRId64 " kernel_id=%d refcount=%d fanin=%d state=%d", r,
-                        static_cast<int64_t>(slot_state.task->task_id.raw), kid, rc, fi, static_cast<int32_t>(st)
-                    );
-                }
+                if (cnt_waiting > STALL_DUMP_WAIT_MAX) continue;
+                LOG_INFO_V9(
+                    "[STALL thread=%d idle_iterations=%d] TASK ring=%d task_id=%" PRId64
+                    " state=WAIT    fanin_refcount=%d/%d kernels=[aic:%d aiv0:%d aiv1:%d] missing_deps=%d",
+                    thread_idx, idle_iterations, r, task_id, rc, fi, kid_aic, kid_aiv0, kid_aiv1, fi - rc
+                );
             }
         }
-    }
-    LOG_INFO_V9("  scan result: stuck_ready=%d stuck_waiting=%d in_flight=%d", cnt_ready, cnt_waiting, cnt_inflight);
-    int32_t aic_running = tracker.get_running_count<CoreType::AIC>();
-    int32_t aiv_running = tracker.get_running_count<CoreType::AIV>();
-    int32_t total_running = aic_running + aiv_running;
-    LOG_INFO_V9(
-        "  thread=%d running_cores=%d (AIC=%d AIV=%d) core_num=%d", thread_idx, total_running, aic_running, aiv_running,
-        core_trackers_[thread_idx].core_num()
-    );
-    auto all_running = tracker.get_all_running_cores();
-    int32_t dump_count = 0;
-    int32_t bp;
-    while (dump_count < STALL_DUMP_CORE_MAX && (bp = all_running.pop_first()) >= 0) {
-        dump_count++;
-        int32_t cid = tracker.get_core_id_by_offset(bp);
-        int32_t sw_tid = core_exec_states_[cid].running_reg_task_id;
-        int32_t hw_kernel = -1;
-        if (sw_tid >= 0 && core_exec_states_[cid].running_slot_state) {
-            int32_t diag_slot = static_cast<int32_t>(core_exec_states_[cid].running_subslot);
-            hw_kernel = core_exec_states_[cid].running_slot_state->task->kernel_id[diag_slot];
-        }
-        uint64_t cond_reg = read_reg(core_exec_states_[cid].reg_addr, RegId::COND);
+        int32_t effective_total = task_count > 0 ? task_count : submitted_in_ring;
+        int32_t c = completed_tasks_.load(std::memory_order_relaxed);
         LOG_INFO_V9(
-            "    core=%d cond=0x%x(state=%d,id=%d) exec_id=%d kernel=%d", cid, static_cast<unsigned>(cond_reg),
-            EXTRACT_TASK_STATE(cond_reg), EXTRACT_TASK_ID(cond_reg), sw_tid, hw_kernel
+            "[STALL thread=%d idle_iterations=%d] SUMMARY completed=%d/%d last_progress_iteration=%d "
+            "scan_ready=%d scan_waiting=%d scan_running=%d",
+            thread_idx, idle_iterations, c, effective_total, last_progress_count, cnt_ready, cnt_waiting, cnt_running
         );
     }
+
+    // CLUSTER lines: one per cluster this thread owns.
+    // cluster_id = local_cluster_idx * active_sched_threads_ + thread_idx, matching the
+    // round-robin assignment in assign_cores_to_threads / reassign_cores_for_all_threads.
+    int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : thread_num_;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
+        int32_t aic_id = tracker.get_aic_core_id(offset);
+        int32_t aiv0_id = tracker.get_aiv0_core_id(offset);
+        int32_t aiv1_id = tracker.get_aiv1_core_id(offset);
+        bool aic_idle = tracker.is_aic_core_idle(offset);
+        bool aiv0_idle = tracker.is_aiv0_core_idle(offset);
+        bool aiv1_idle = tracker.is_aiv1_core_idle(offset);
+        int32_t cluster_id = cli * ast + thread_idx;
+        char aic_buf[128], aiv0_buf[128], aiv1_buf[128];
+        format_core_status(
+            aic_buf, sizeof(aic_buf), aic_id, aic_idle, &core_exec_states_[aic_id], core_exec_states_[aic_id].reg_addr
+        );
+        format_core_status(
+            aiv0_buf, sizeof(aiv0_buf), aiv0_id, aiv0_idle, &core_exec_states_[aiv0_id],
+            core_exec_states_[aiv0_id].reg_addr
+        );
+        format_core_status(
+            aiv1_buf, sizeof(aiv1_buf), aiv1_id, aiv1_idle, &core_exec_states_[aiv1_id],
+            core_exec_states_[aiv1_id].reg_addr
+        );
         LOG_INFO_V9(
-            "    cluster[%d] aic=%d(%s) aiv0=%d(%s) aiv1=%d(%s)", cli, tracker.get_aic_core_id(offset),
-            tracker.is_aic_core_idle(offset) ? "idle" : "busy", tracker.get_aiv0_core_id(offset),
-            tracker.is_aiv0_core_idle(offset) ? "idle" : "busy", tracker.get_aiv1_core_id(offset),
-            tracker.is_aiv1_core_idle(offset) ? "idle" : "busy"
+            "[STALL thread=%d idle_iterations=%d] CLUSTER cluster_id=%d aic=%s aiv0=%s aiv1=%s", thread_idx,
+            idle_iterations, cluster_id, aic_buf, aiv0_buf, aiv1_buf
         );
     }
 }
@@ -211,7 +333,10 @@ int32_t SchedulerContext::handle_timeout_exit(
     uint64_t sched_start_ts
 #endif
 ) {
-    LOG_ERROR("Thread %d: PTO2 timeout after %d idle iterations", thread_idx, idle_iterations);
+    LOG_ERROR(
+        "[STALL thread=%d idle_iterations=%d] TIMEOUT_EXIT after_idle_iterations=%d", thread_idx, idle_iterations,
+        idle_iterations
+    );
     latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
         emergency_shutdown(runtime);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -201,6 +201,21 @@ private:
     // =========================================================================
 
     static const char *shape_name(PTO2ResourceShape shape);
+
+    // Lower-case rendering of PTO2SubtaskSlot, used by dispatch and stall logs.
+    // Kept lower-case to match the `kernels=[aic:N aiv0:N aiv1:N]` field
+    // convention already established in the stall log family.
+    static inline const char *subslot_name(PTO2SubtaskSlot s) {
+        switch (s) {
+        case PTO2SubtaskSlot::AIC:
+            return "aic";
+        case PTO2SubtaskSlot::AIV0:
+            return "aiv0";
+        case PTO2SubtaskSlot::AIV1:
+            return "aiv1";
+        }
+        return "?";
+    }
     static const PTO2ResourceShape *get_dispatch_order(int32_t thread_idx);
 
     int pop_ready_tasks_batch(
@@ -279,6 +294,11 @@ private:
 
     __attribute__((noinline, cold)) void
     log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
+
+    // Reverse lookup: given a global core_id, find which scheduler thread's
+    // tracker owns it. Returns -1 if not found. Linear scan — only used on
+    // the cold diagnostic path.
+    int32_t find_core_owner_thread(int32_t core_id) const;
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
         int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -170,6 +170,15 @@ void SchedulerContext::dispatch_subtask_to_core(
     }
 #endif
 
+    LOG_DEBUG(
+        "Thread %d: Dispatched %s %s task %" PRId64 " kernel_id=[%d,%d,%d] block_idx=%d/total_blocks=%d to"
+        " core_offset=%d core_id=%d reg_task_id=%u",
+        thread_idx, to_pending ? "pending" : "idle", subslot_name(subslot),
+        static_cast<int64_t>(slot_state.task->task_id.raw), slot_state.task->kernel_id[0],
+        slot_state.task->kernel_id[1], slot_state.task->kernel_id[2], slot_state.next_block_idx,
+        slot_state.logical_block_num, core_offset, core_id, reg_task_id
+    );
+
     write_reg(core_exec_state.reg_addr, RegId::DATA_MAIN_BASE, static_cast<uint64_t>(reg_task_id));
     tracker.set_pending_occupied(core_offset);
 }
@@ -286,12 +295,6 @@ void SchedulerContext::dispatch_shape(
                 auto core_offset = cores.pop_first();
                 dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending);
                 slot_state->next_block_idx++;
-                LOG_DEBUG(
-                    "Thread %d: Dispatched %s %s task %" PRId64 " block %d/%d to core_offset %d", thread_idx,
-                    is_pending ? "pending" : "idle", shape_name(shape),
-                    static_cast<int64_t>(slot_state->task->task_id.raw), slot_state->next_block_idx - 1,
-                    slot_state->logical_block_num, core_offset
-                );
             } while (slot_state->next_block_idx < slot_state->logical_block_num && cores.has_value());
 
             if (slot_state->next_block_idx < slot_state->logical_block_num) {
@@ -579,10 +582,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 if (action == LoopAction::BREAK_LOOP) break;
             }
 
-            if (thread_idx == 0 && task_count > 0 && idle_iterations % STALL_LOG_INTERVAL == 0) {
-                log_stall_diagnostics(thread_idx, task_count, idle_iterations, last_progress_count);
+            if (idle_iterations % STALL_LOG_INTERVAL == 0) {
+                log_stall_diagnostics(thread_idx, total_tasks_, idle_iterations, last_progress_count);
             }
-            if (idle_iterations > MAX_IDLE_ITERATIONS) {
+            if (idle_iterations >= MAX_IDLE_ITERATIONS) {
                 return handle_timeout_exit(
                     thread_idx, header, runtime, idle_iterations
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -45,7 +45,7 @@
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 50000;         // LOG_INFO_V9 every N idle iters to debug hang
+constexpr int32_t STALL_LOG_INTERVAL = 400000;        // LOG_INFO_V9 every N idle iters to debug hang
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;


### PR DESCRIPTION
## Summary

Reformat the PTO2 scheduler **stall** diagnostic so multi-thread output is greppable, and re-anchor the **dispatch** `LOG_DEBUG` so each line corresponds 1:1 with a real hardware `write_reg` (carrying `core_id` + `reg_task_id`, joinable with the stall log). No changes to scheduler hot-path behavior — `task_state` semantics on the non-profiling path are preserved exactly.

Mirrored across `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/` and `src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/`.

## Motivation

Two distinct triage holes when a kernel hangs:

1. **Stall log**: every scheduler thread that goes idle hits `STALL_LOG_INTERVAL` together, but only T0 emitted anything, and the lines themselves had no per-line context. Once `device_log` interleaved their output across threads it was impossible to tell which diagnostic round a line belonged to.
2. **Dispatch log**: the `LOG_DEBUG` in `dispatch_shape` only knew `shape` and `core_offset`. For MIX kernels one log line covered three actual hardware dispatches (AIC + AIV0 + AIV1 to one cluster), so "which subtask got stuck" required guessing. `core_offset` is a tracker-internal bit index — it does not match the `core_id` that stall log's `running_on=[cores=[...]]` field reports, and `reg_task_id` was not available at that scope at all, so dispatch lines could not be joined to either stall lines or completion lines.

## Changes

### 1. Stall log format — uniform self-contained lines

Every line now starts with `[STALL thread=N idle_iterations=K] CATEGORY ...`. `grep \"idle_iterations=N\"` groups one round across all threads.

| Category | Emitted by | Contents |
| -------- | ---------- | -------- |
| `SUMMARY` | T0 only | completed / total + scan_ready / scan_waiting / scan_running |
| `TASK`    | T0 only | one per non-completed task; `state=RUNNING` includes `running_on=[owner_thread=... cores=[...]]`; `state=WAIT` includes `missing_deps=N` |
| `CLUSTER` | every thread | one per owned cluster; busy slot shows `kernel`, `task`, `cond_reg_state`; `ANOMALY` suffix when the COND register reports `fin` but the slot is still marked busy in software |

### 2. `state=` derived from ground truth, not `task_state`

`task_state`'s intermediate values (`READY` / `RUNNING`) are intentionally not written on the non-profiling hot path — only `PENDING` / `COMPLETED` / `CONSUMED` are. Reading it would miscategorize.

The new diagnostic scans `core_exec_states_` once per task:

- `state=RUNNING` ⇔ some core has the slot as `running_slot_state`
- `state=READY` ⇔ `fanin_refcount >= fanin_count` and no core is running it
- `state=WAIT` ⇔ otherwise

The same scan produces the `running_on=[...]` cross-reference for free. **Zero new atomics on the scheduler hot path.**

### 3. Per-thread diagnostic emission + interval tuning

- `scheduler_dispatch.cpp`: `log_stall_diagnostics` is invoked from every thread (was T0-only), passing `total_tasks_` instead of the thread-local `task_count`, so per-thread CLUSTER lines reach the log.
- `MAX_IDLE_ITERATIONS` comparison switched from `>` to `>=` to match the `STALL_LOG_INTERVAL` boundary.
- `STALL_LOG_INTERVAL` 50000 → 400000 (one round ~every 10s of idle instead of every 1.25s — matches how long a real hang takes to triage, stops drowning the normal idle period in spam).

### 4. Dispatch log — re-anchored at `dispatch_subtask_to_core`

The `LOG_DEBUG` now fires from `dispatch_subtask_to_core`, **one line per real hardware `write_reg`**. Each line carries:

```
core_offset=N core_id=N reg_task_id=N subslot=aic|aiv0|aiv1
```

- **MIX naturally produces 3 lines per block** (one per AIC/AIV0/AIV1 dispatch), each pinning the specific subtask + core + reg_task_id. The "which subtask hung" question is now answerable from the log alone.
- `core_id` matches the stall log's `running_on=[cores=[...]]` field — dispatch / stall / completion logs can be joined on a common key.
- `reg_task_id` is the same value the AICore reads from `DATA_MAIN_BASE` and writes back on completion — joinable with completion logs and matches HW dump.
- **Zero new function parameters**: `core_id` and `reg_task_id` are already local in `dispatch_subtask_to_core`'s scope.

`subslot_name` is consolidated as a `static inline` on `SchedulerContext` in `scheduler_context.h` — previously stall log had a TU-local copy in `scheduler_cold_path.cpp`, and the new dispatch log would have needed its own. Both call sites now share the header definition. Lower-case (`aic` / `aiv0` / `aiv1`) to match the existing `kernels=[aic:N aiv0:N aiv1:N]` field convention.

## Log Output: Before vs After

### Before (one stall diagnostic round)

\`\`\`text
PTO2 stall: no progress for 50000 iterations, completed=3 total=5 (last progress at 0)
  STUCK-READY  ring=1 task_id=4294967298 kernel_id=-1 refcount=3 fanin=3 state=0
  STUCK-WAIT   ring=1 task_id=4294967299 kernel_id=-1 refcount=2 fanin=3 state=0
  scan result: stuck_ready=1 stuck_waiting=1 in_flight=0
  thread=0 running_cores=0 (AIC=0 AIV=0) core_num=3
    cluster[0] aic=0(idle) aiv0=3(idle) aiv1=4(idle)
\`\`\`

Problems:
- Lines from other threads were silently dropped — only T0 emitted anything.
- `state=0` was reported even for tasks that were actually running on a core, because the old classifier read `task_state` (which non-profiling code never updates past `PENDING`).
- Lines from different rounds shared identical prefixes (`STUCK-READY`, `STUCK-WAIT`, `scan result`) — once `device_log` interleaved scheduler output across threads, you could not tell which line belonged to which round.
- `kernel_id=-1` only showed one slot of the three; if AIV1 was the actually-stuck core, you couldn't tell from the line.
- No back-reference from a stuck task to the core(s) running it.

### After (one stall diagnostic round)

\`\`\`text
[STALL thread=0 idle_iterations=400000] TASK ring=1 task_id=4294967300 state=RUNNING fanin_refcount=4/4 kernels=[aic:-1 aiv0:3 aiv1:-1] running_on=[owner_thread=2 cores=[core=47(aiv0)]]
[STALL thread=0 idle_iterations=400000] TASK ring=1 task_id=4294967305 state=RUNNING fanin_refcount=4/4 kernels=[aic:-1 aiv0:3 aiv1:-1] running_on=[owner_thread=1 cores=[core=45(aiv0)]]
[STALL thread=0 idle_iterations=400000] TASK ring=1 task_id=4294967585 state=READY   fanin_refcount=4/4 kernels=[aic:-1 aiv0:3 aiv1:-1]
[STALL thread=0 idle_iterations=400000] TASK ring=1 task_id=4294967605 state=WAIT    fanin_refcount=3/4 kernels=[aic:-1 aiv0:3 aiv1:-1] missing_deps=1
[STALL thread=0 idle_iterations=400000] SUMMARY completed=716/1280 last_progress_iteration=711 scan_ready=160 scan_waiting=308 scan_running=96
[STALL thread=2 idle_iterations=400000] CLUSTER cluster_id=2 aic=core2(idle) aiv0=core28(busy kernel=3 task=4294967595 cond_reg_state=ack) aiv1=core29(busy kernel=3 task=4294967415 cond_reg_state=ack)
[STALL thread=2 idle_iterations=400000] CLUSTER cluster_id=5 aic=core5(idle) aiv0=core34(busy kernel=3 task=4294967350 cond_reg_state=ack) aiv1=core35(busy kernel=3 task=4294967410 cond_reg_state=ack)
[ERROR] [STALL thread=0 idle_iterations=800000] TIMEOUT_EXIT after_idle_iterations=800000
\`\`\`

Wins:
- Every line is self-contained — interleaved output from T0/T1/T2 is still readable. `grep \"idle_iterations=400000\"` returns exactly one diagnostic round, across all threads.
- `state=RUNNING` lines carry `running_on=[...]` so the stuck task points directly at the core(s) that own it (note tasks 4294967300 and 4294967305 land on different `owner_thread`s — the cross-ref tells you which scheduler thread to look at).
- `state=` is derived from `core_exec_states_` + `refcount`, so it stays accurate without forcing the hot path to maintain extra state.
- `state=WAIT` lines report `missing_deps=N` directly — no more refcount/fanin math by hand.
- `kernels=[aic:_ aiv0:_ aiv1:_]` shows all three subslots, so the AIV-only stuck case is obvious.
- CLUSTER lines from every thread now reach the log, with `cond_reg_state=ack|fin` per busy core (and an `ANOMALY` suffix when HW says fin but SW still thinks the slot is busy).
- TIMEOUT_EXIT uses the same prefix, so a grep for `STALL` finds the death banner too.

### Dispatch log — Before vs After

Before (one MIX block):

\`\`\`text
Thread 0: Dispatched idle MIX task 4294967300 kernel_id=[3,4,5] block_idx=0/total_blocks=1 to core_offset 0
\`\`\`

After (same MIX block — 3 lines, joinable with stall + completion):

\`\`\`text
Thread 0: Dispatched idle aic  task 4294967300 kernel_id=[3,4,5] block_idx=0/total_blocks=1 to core_offset=0 core_id=0  reg_task_id=42
Thread 0: Dispatched idle aiv0 task 4294967300 kernel_id=[3,4,5] block_idx=0/total_blocks=1 to core_offset=1 core_id=24 reg_task_id=17
Thread 0: Dispatched idle aiv1 task 4294967300 kernel_id=[3,4,5] block_idx=0/total_blocks=1 to core_offset=2 core_id=25 reg_task_id=17
\`\`\`

If `task=4294967300` later shows up in stall log as `running_on=[cores=[core=25(aiv1)]]` you immediately know it was AIV1 with `reg_task_id=17` that hung — direct cross-reference, no guessing.

## Test plan

- [x] Local cpp ut: 22/22 passing (including \`TaskStateTest.NonProfilingReadyPathStaysPending\`, which asserts the preserved non-profiling contract)
- [ ] a5sim CI passes
- [ ] a2a3sim CI passes