### PR TITLE
fix(examples): correct swapped SF/PV callable names in a2a3 paged_attention tests

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py
@@ -38,14 +38,14 @@ class TestPagedAttention(SceneTestCase):
             },
             {
                 "func_id": 1,
-                "name": "PV",
+                "name": "SF",
                 "source": "kernels/aiv/aiv_softmax_prepare.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 2,
-                "name": "SF",
+                "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.OUT],

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention.py
@@ -38,14 +38,14 @@ class TestPagedAttentionManualScope(SceneTestCase):
             },
             {
                 "func_id": 1,
-                "name": "PV",
+                "name": "SF",
                 "source": "kernels/aiv/aiv_softmax_prepare.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 2,
-                "name": "SF",
+                "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.OUT],

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py
@@ -38,14 +38,14 @@ class TestBatchPagedAttention(SceneTestCase):
             },
             {
                 "func_id": 1,
-                "name": "PV",
+                "name": "SF",
                 "source": "kernels/aiv/aiv_softmax_prepare.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 2,
-                "name": "SF",
+                "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.OUT],

--- a/tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py
@@ -43,14 +43,14 @@ class TestMultiRoundPagedAttention(SceneTestCase):
             },
             {
                 "func_id": 1,
-                "name": "PV",
+                "name": "SF",
                 "source": f"{_PA_KERNELS}/aiv/aiv_softmax_prepare.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 2,
-                "name": "SF",
+                "name": "PV",
                 "source": f"{_PA_KERNELS}/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.OUT],

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -38,14 +38,14 @@ class TestPagedAttentionUnroll(SceneTestCase):
             },
             {
                 "func_id": 1,
-                "name": "PV",
+                "name": "SF",
                 "source": "kernels/aiv/aiv_softmax_prepare.cpp",
                 "core_type": "aiv",
                 "signature": [D.IN, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 2,
-                "name": "SF",
+                "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
                 "signature": [D.IN, D.IN, D.OUT],


### PR DESCRIPTION
## Summary

In five a2a3 paged-attention test files the `CALLABLE["incores"]` `name` fields
for `func_id` 1 and 2 were swapped: the `aiv_softmax_prepare.cpp` callable was
named `"PV"` and the `aic_pv_matmul.cpp` callable was named `"SF"`.

`func_id` / `source` / `core_type` / `signature` were all correct, so kernel
dispatch was unaffected. But `deps_to_graph.py` labels dep-graph nodes by the
callable `name`, so the generated graphs rendered the SF and PV nodes (and
their AIC/AIV shapes) swapped — making it look like the orchestration built
`QK -> PV -> SF` when the code actually builds `QK -> SF -> PV`.

Swapped the names back in:
- `examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py`
- `examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention.py`
- `tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/test_batch_paged_attention.py`
- `tests/st/a2a3/tensormap_and_ringbuffer/multi_round_paged_attention/test_multi_round_paged_attention.py`
- `tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py`

The a2a3 `paged_attention_unroll_manual_scope` test and all a5 variants were
already correct and are untouched.

## Testing
- [ ] Simulation tests pass
- [ ] Hardware tests pass (if applicable)