### PR TITLE
fix(ci): fail fast on PTO-ISA clone failure; never leave a half-clone behind

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,12 +207,12 @@ jobs:
       - name: Run pytest scene tests (a2a3sim)
         run: |
           set +e
-          pytest examples tests/st --platform a2a3sim --device 0-15 -v --pto-session-timeout 600 --clone-protocol https
+          pytest examples tests/st --platform a2a3sim --device 0-15 -v --pto-session-timeout 600 --clone-protocol https --require-pto-isa
           rc=$?
           if [ $rc -ne 0 ]; then
             echo "pytest failed with rc=$rc; retrying with pinned PTO-ISA commit"
             pytest examples tests/st --platform a2a3sim --device 0-15 -v \
-              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https
+              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https --require-pto-isa
             rc=$?
           fi
           exit $rc
@@ -265,12 +265,12 @@ jobs:
       - name: Run pytest scene tests (a5sim)
         run: |
           set +e
-          pytest examples tests/st --platform a5sim --device 0-15 -v --pto-session-timeout 600 --clone-protocol https
+          pytest examples tests/st --platform a5sim --device 0-15 -v --pto-session-timeout 600 --clone-protocol https --require-pto-isa
           rc=$?
           if [ $rc -ne 0 ]; then
             echo "pytest failed with rc=$rc; retrying with pinned PTO-ISA commit"
             pytest examples tests/st --platform a5sim --device 0-15 -v \
-              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https
+              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https --require-pto-isa
             rc=$?
           fi
           exit $rc
@@ -336,12 +336,12 @@ jobs:
         run: |
           set +e
           source .venv/bin/activate
-          python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v --pto-session-timeout 600 --clone-protocol https
+          python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v --pto-session-timeout 600 --clone-protocol https --require-pto-isa
           rc=$?
           if [ $rc -ne 0 ]; then
             echo "pytest failed with rc=$rc; retrying with pinned PTO-ISA commit"
             python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v \
-              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https
+              --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https --require-pto-isa
             rc=$?
           fi
           exit $rc
@@ -456,5 +456,5 @@ jobs:
         run: |
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "s,e='${DEVICE_RANGE}'.split('-'); print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --clone-protocol https"
+          PYTEST="python -m pytest examples tests/st --platform a5 --device ${DEVICE_RANGE} -v --clone-protocol https --require-pto-isa"
           task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "set +e; $PYTEST --pto-session-timeout 1200; rc=\$?; if [ \$rc -ne 0 ]; then echo \"pytest failed with rc=\$rc; retrying with pinned PTO-ISA commit\"; $PYTEST --pto-session-timeout 1200 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https; rc=\$?; fi; exit \$rc"

--- a/conftest.py
+++ b/conftest.py
@@ -173,6 +173,15 @@ def pytest_addoption(parser):
         choices=["ssh", "https"],
         help="Protocol for cloning pto-isa when --pto-isa-commit is set",
     )
+    parser.addoption(
+        "--require-pto-isa",
+        action="store_true",
+        default=False,
+        help="Abort the session immediately if PTO-ISA can't be resolved/cloned, "
+        "instead of deferring to the per-test lazy path. CI scene-test jobs pass "
+        "this so a transient clone failure fails fast rather than fanning out into "
+        "device subprocesses that each re-clone into a poisoned directory.",
+    )
     # Distinct from pytest-timeout's per-test --timeout (which `.[test]` pulls
     # in on the a2a3 hardware runner); this is session-level.
     parser.addoption(
@@ -294,6 +303,10 @@ def pytest_configure(config):
     # need PTO-ISA (e.g. pytest tests/ut on a runner without SSH keys) must not
     # be aborted when the eager clone fails. If an actual scene test later needs
     # PTO-ISA, scene_test.py's lazy path will re-raise the original error.
+    #
+    # --require-pto-isa flips that: callers that know PTO-ISA is mandatory
+    # (CI scene-test jobs) want the session to die here rather than fan out
+    # into device subprocesses that each re-attempt the clone.
     try:
         root = ensure_pto_isa_root(
             verbose=True,
@@ -302,6 +315,8 @@ def pytest_configure(config):
             update_if_exists=True,
         )
     except OSError as e:
+        if config.getoption("--require-pto-isa"):
+            pytest.exit(f"PTO-ISA required but unavailable: {e}", returncode=pytest.ExitCode.USAGE_ERROR)
         print(f"[pytest] PTO-ISA pre-clone skipped: {e}", file=sys.stderr)
         root = None
     if root:

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -22,6 +22,7 @@ Lock file under build/ serializes concurrent clones from parallel processes.
 import fcntl
 import logging
 import os
+import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
@@ -79,6 +80,30 @@ def _run_git(
     )
 
 
+def _discard_incomplete_clone(target: Path, verbose: bool) -> None:
+    """Remove `target` if it exists but isn't a usable clone.
+
+    A timed-out or aborted ``git clone`` leaves a non-empty directory behind;
+    a later attempt then fails with "destination path already exists and is
+    not an empty directory" — poisoning every retry and every parallel device
+    subprocess that re-attempts the clone. Clearing it keeps the failure local
+    to the one attempt that hit the transient error.
+
+    Handles whatever is squatting on the path: a real directory, a plain file,
+    or a (possibly broken) symlink — ``git clone`` rejects all three, but
+    ``Path.exists()`` is False for a broken symlink and ``shutil.rmtree``
+    refuses non-directories, so check ``lexists`` and unlink non-dirs.
+    """
+    if not (target.exists() or target.is_symlink()) or _is_cloned(target):
+        return
+    if verbose:
+        logger.warning(f"Removing incomplete pto-isa clone at {target}")
+    if target.is_dir() and not target.is_symlink():
+        shutil.rmtree(target, ignore_errors=True)
+    else:
+        target.unlink(missing_ok=True)
+
+
 def _clone(target: Path, commit: Optional[str], clone_protocol: str, verbose: bool) -> bool:
     """Clone PTO-ISA to `target`, optionally at `commit`. Returns True on success."""
     if not _is_git_available():
@@ -93,6 +118,10 @@ def _clone(target: Path, commit: Optional[str], clone_protocol: str, verbose: bo
             logger.warning(f"Failed to create clone parent dir: {e}")
         return False
 
+    # Clear any half-clone left by a previous failed attempt (this run or an
+    # earlier one) so `git clone` doesn't refuse a non-empty target.
+    _discard_incomplete_clone(target, verbose)
+
     repo_url = _repo_url(clone_protocol)
     logger.info(f"Cloning pto-isa to {target} (first run, may take up to a minute)...")
 
@@ -101,6 +130,7 @@ def _clone(target: Path, commit: Optional[str], clone_protocol: str, verbose: bo
         if result.returncode != 0:
             if verbose:
                 logger.warning(f"Failed to clone pto-isa:\n{result.stderr}")
+            _discard_incomplete_clone(target, verbose)
             return False
 
         if commit:
@@ -117,10 +147,12 @@ def _clone(target: Path, commit: Optional[str], clone_protocol: str, verbose: bo
     except subprocess.TimeoutExpired:
         if verbose:
             logger.warning("Clone operation timed out")
+        _discard_incomplete_clone(target, verbose)
         return False
     except Exception as e:  # noqa: BLE001
         if verbose:
             logger.warning(f"Failed to clone pto-isa: {e}")
+        _discard_incomplete_clone(target, verbose)
         return False
 
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -499,12 +499,18 @@ def _build_output_prefix(case_label: str) -> Path:
     under that root with fixed filenames. Two cases of the same name run in
     the same second is not a contemplated scenario (parallel xdist runs differ
     by class+method).
+
+    The directory is created here: the dep_gen host replay (and any other
+    writer) ``fopen``s ``<prefix>/<file>`` directly without an mkdir of its
+    own, so the prefix must exist before the runtime call.
     """
     from datetime import datetime  # noqa: PLC0415
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     safe_label = _sanitize_for_filename(case_label)
-    return _outputs_dir() / f"{safe_label}_{timestamp}"
+    prefix = _outputs_dir() / f"{safe_label}_{timestamp}"
+    prefix.mkdir(parents=True, exist_ok=True)
+    return prefix
 
 
 def _get_device_log_dir(device_id) -> Path:


### PR DESCRIPTION
## Summary

A transient PTO-ISA clone failure (e.g. a `git clone` timeout) on the scene-test
CI jobs currently cascades far worse than the one failure warrants:

1. `conftest.py`'s session pre-clone swallows the error ("an optimization, not a
   requirement") and lets the run continue.
2. The dispatcher then fans out into per-device subprocesses, each of which
   re-runs `pytest_configure` → re-attempts the clone.
3. The timed-out clone left a non-empty `build/pto-isa/` behind, so every
   re-attempt fails with `destination path already exists and is not an empty
   directory` — and `scene_test.py`'s lazy fallback fails the same way. One
   transient hiccup turns into a fully red job.

This PR makes the failure local and the response fail-fast:

- **`conftest.py`** — new `--require-pto-isa` flag. When set and the pre-clone
  can't resolve PTO-ISA, `pytest_configure` aborts the session (`pytest.exit`)
  instead of deferring to the lazy path. CI scene-test jobs (a2a3/a5 sim +
  onboard, initial + pinned-retry invocations) pass it; `tests/ut` and offline
  developer runs are untouched (no flag → current soft behavior).
- **`simpler_setup/pto_isa.py`** — `_clone` removes an incomplete clone
  directory both before cloning and after a failed/timed-out attempt, so a
  half-clone from one transient failure can't poison every subsequent retry and
  parallel subprocess. A valid clone (has `include/`) is never removed.
- **`simpler_setup/scene_test.py`** — `_build_output_prefix` now `mkdir`s the
  per-case `outputs/<case>_<ts>/` directory. The dep_gen host replay `fopen`s
  `<prefix>/deps.json` directly without its own mkdir, so previously
  `--enable-dep-gen` without `--enable-l2-swimlane` produced
  `write_deps_json: failed to open ... for write` / `dep_gen replay failed (-5)`.

## Testing
- [x] `pytest examples/.../paged_attention_manual_scope --platform a2a3sim --enable-dep-gen --require-pto-isa` — passes; `deps.json` produced (previously needed `--enable-l2-swimlane` too).
- [x] `_discard_incomplete_clone` unit-checked: removes a non-empty dir lacking `include/`, preserves a valid clone.
- [ ] CI: a2a3/a5 sim + onboard scene-test jobs