### PR TITLE
Refactor: move RTLD_GLOBAL SO preload + simpler_log_init from C++ ChipWorker::init to Python

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -113,7 +113,7 @@ runner.finalize();
 ### Layer 2: C API (`src/common/worker/pto_runtime_c_api.h`)
 
 ```c
-// libsimpler_log.so (RTLD_GLOBAL, loaded first):
+// libsimpler_log.so (RTLD_GLOBAL, loaded first by the Python wrapper):
 simpler_log_init(log_level, log_info_v);              // seed HostLogger once
 
 // host_runtime.so (RTLD_LOCAL, loaded after):
@@ -137,8 +137,7 @@ destroy_device_context(ctx);
 from simpler.task_interface import ChipWorker, ChipCallable, ChipStorageTaskArgs, CallConfig
 
 worker = ChipWorker()
-worker.init(host_lib_path, aicpu_path, aicore_path, simpler_log_lib_path,
-            device_id, sim_context_lib_path="")
+worker.init(device_id=0, bins=bins)   # bins = RuntimeBuilder(platform).get_binaries(...)
 
 config = CallConfig()
 config.block_dim = 24
@@ -179,17 +178,19 @@ Python test_*.py (SceneTestCase)
   ├─→ KernelCompiler(platform).compile_orchestration(runtime, source) → orch .so
   │
   └─→ ChipWorker()
-       └─→ init(host_path, aicpu_path, aicore_path, simpler_log_path, device_id)
-            ├─→ dlopen(libsimpler_log.so) RTLD_GLOBAL
+       └─→ init(device_id, bins)                          # Python wrapper
+            ├─→ ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)   # once per process
             ├─→ simpler_log_init(log_level, log_info_v) → HostLogger seeded
-            ├─→ dlopen(host.so) → resolve C API symbols via dlsym
-            ├─→ create_device_context() → DeviceContextHandle
-            └─→ simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
-                 ├─→ DeviceRunner::attach_current_thread(device_id)
-                 │    ├─→ rtSetDevice(device_id) on onboard
-                 │    └─→ pto_cpu_sim_bind+acquire on sim
-                 ├─→ DeviceRunner::set_executors(aicpu, aicore)
-                 └─→ (onboard) dlog_setlevel(HostLogger.level())
+            ├─→ ctypes.CDLL(libcpu_sim_context.so, RTLD_GLOBAL)  # sim only, once
+            └─→ _ChipWorker.init(host_path, aicpu_path, aicore_path, device_id)  # C++
+                 ├─→ dlopen(host.so, RTLD_LOCAL) → resolve C API symbols via dlsym
+                 ├─→ create_device_context() → DeviceContextHandle
+                 └─→ simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
+                      ├─→ DeviceRunner::attach_current_thread(device_id)
+                      │    ├─→ rtSetDevice(device_id) on onboard
+                      │    └─→ pto_cpu_sim_bind+acquire on sim
+                      ├─→ DeviceRunner::set_executors(aicpu, aicore)
+                      └─→ (onboard) dlog_setlevel(HostLogger.level())
 ```
 
 ### 2. Initialization Phase

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -258,19 +258,21 @@ different tasks have different configurations.
 ### Simulation (in-process, per-task)
 
 ```text
-ChipWorker.init(host_path, aicpu_path, aicore_path, simpler_log_path, device_id)
-  dlopen(libsimpler_log.so, RTLD_GLOBAL)
-  simpler_log_init(log_level, log_info_v)    seeds HostLogger before host_runtime
-  dlopen(host_runtime.so, RTLD_LOCAL)
-  dlsym: create_device_context, destroy_device_context, simpler_init,
-         get_runtime_size, prepare_callable, run_prepared, unregister_callable,
-         finalize_device
-  create_device_context() → DeviceContextHandle
-  simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
-    DeviceRunner::attach_current_thread(device_id)
-      pto_cpu_sim_bind_device(device_id)
-      pto_cpu_sim_acquire_device(device_id)
-    DeviceRunner::set_executors(aicpu, aicore)         binaries owned by runner
+ChipWorker.init(device_id, bins)                       # Python wrapper
+  ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)          # once per process
+  simpler_log_init(log_level, log_info_v)              seeds HostLogger before host_runtime
+  ctypes.CDLL(libcpu_sim_context.so, RTLD_GLOBAL)      # sim only, once per process
+  _ChipWorker.init(host_path, aicpu_path, aicore_path, device_id)   # C++
+    dlopen(host_runtime.so, RTLD_LOCAL)
+    dlsym: create_device_context, destroy_device_context, simpler_init,
+           get_runtime_size, prepare_callable, run_prepared, unregister_callable,
+           finalize_device
+    create_device_context() → DeviceContextHandle
+    simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
+      DeviceRunner::attach_current_thread(device_id)
+        pto_cpu_sim_bind_device(device_id)
+        pto_cpu_sim_acquire_device(device_id)
+      DeviceRunner::set_executors(aicpu, aicore)       binaries owned by runner
 
 ChipWorker.run(cid, args, config)
   run_prepared(ctx, buf, cid, args, block_dim, aicpu_thread_num, …)
@@ -297,32 +299,33 @@ ChipWorker.finalize()
 ```text
 device_worker_main(device_id)
   for each runtime_group:
-    ChipWorker.init(host_path, aicpu_path, aicore_path, simpler_log_path, device_id)
-      dlopen(libsimpler_log.so, RTLD_GLOBAL)
+    ChipWorker.init(device_id, bins)                    # Python wrapper
+      ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)       # once per process
       simpler_log_init(log_level, log_info_v)
-      dlopen(host_runtime.so, RTLD_LOCAL)
-      create_device_context()
-      simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
-        DeviceRunner::attach_current_thread(device_id)  rtSetDevice()
-        DeviceRunner::set_executors(aicpu, aicore)
-        dlog_setlevel(HostLogger.level())               sync CANN dlog
+      _ChipWorker.init(host_path, aicpu_path, aicore_path, device_id)   # C++
+        dlopen(host_runtime.so, RTLD_LOCAL)
+        create_device_context()
+        simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
+          DeviceRunner::attach_current_thread(device_id)  rtSetDevice()
+          DeviceRunner::set_executors(aicpu, aicore)
+          dlog_setlevel(HostLogger.level())               sync CANN dlog
 
     for each callable:
-      ChipWorker.prepare_callable(cid, callable)
-        prepare_callable(ctx, cid, callable)
-          upload child kernels, copy orch SO to device buffer
-      for each launch with that cid:
-        ChipWorker.run(cid, args, config)
-          run_prepared(ctx, buf, cid, args, block_dim, aicpu_thread_num, …)
-            new (buf) Runtime()
-            bind_prepared_callable_to_runtime()
-            bind_prepared_to_runtime_impl()  rtMalloc, rtMemcpy to device
-            DeviceRunner::run()
-              ensure_binaries_loaded()       rtMemcpy AICPU SO to HBM (once)
-              rtAicpuKernelLaunchExWithArgs() launch on device
-              rtStreamSynchronize()          wait for completion
-              launch_aicore_kernel()         rtRegisterAllKernel + rtKernelLaunch
-            validate_runtime_impl()          rtMemcpy results back to host
+        ChipWorker.prepare_callable(cid, callable)
+          prepare_callable(ctx, cid, callable)
+            upload child kernels, copy orch SO to device buffer
+        for each launch with that cid:
+          ChipWorker.run(cid, args, config)
+            run_prepared(ctx, buf, cid, args, block_dim, aicpu_thread_num, …)
+              new (buf) Runtime()
+              bind_prepared_callable_to_runtime()
+              bind_prepared_to_runtime_impl()  rtMalloc, rtMemcpy to device
+              DeviceRunner::run()
+                ensure_binaries_loaded()       rtMemcpy AICPU SO to HBM (once)
+                rtAicpuKernelLaunchExWithArgs() launch on device
+                rtStreamSynchronize()          wait for completion
+                launch_aicore_kernel()         rtRegisterAllKernel + rtKernelLaunch
+              validate_runtime_impl()          rtMemcpy results back to host
 
     ChipWorker.finalize()
       finalize_device(ctx)                     rtDeviceReset()

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -14,19 +14,20 @@ Python: logging.getLogger("simpler").setLevel(N)
                   │
                   ▼  Worker.init() snapshots level once, splits into (severity, info_v)
                   │
-       ChipWorker.init(host_lib, aicpu, aicore, simpler_log_lib, sim_ctx_lib, sev, v)
+       ChipWorker.init(device_id, bins, sev, v)            ◀── Python wrapper
                   │
-       1. dlopen libsimpler_log.so   RTLD_GLOBAL  ◀── one HostLogger per process
+       1. ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)  ◀── one HostLogger per process
        2. simpler_log_init(sev, v)   ──→ HostLogger.set_level/set_info_v
                                      (seeds HostLogger BEFORE any host_runtime /
                                       sim_context / aicore SO is dlopen'd, so
                                       any LOG_* macro firing during dlopen-time
                                       constructors already sees the right filter)
-       3. dlopen libcpu_sim_context  RTLD_GLOBAL  (sim only)
-       4. dlopen libhost_runtime.so  RTLD_LOCAL   ──→ undefined HostLogger /
-                                                       unified_log_* symbols
-                                                       resolve via (1)
-       5. simpler_init(ctx, device_id, aicpu*, aicore*)
+       3. ctypes.CDLL(libcpu_sim_context.so, RTLD_GLOBAL)  (sim only)
+       4. _ChipWorker.init(host_lib, aicpu, aicore, device_id)   ◀── C++
+            ├─ dlopen libhost_runtime.so  RTLD_LOCAL   ──→ undefined HostLogger /
+            │                                              unified_log_* symbols
+            │                                              resolve via (1)
+            └─ simpler_init(ctx, device_id, aicpu*, aicore*)
                                      ──→ attach thread + transfer executor binaries
                                      ──→ (onboard) dlog_setlevel(HostLogger.level())
 
@@ -147,26 +148,34 @@ The host log code lives in **one** `.so` (`libsimpler_log.so`) at
 toolchain is sufficient). Every other `.so` that calls `LOG_*` resolves the
 symbols against this single instance via `RTLD_GLOBAL` load order.
 
-### Load order — `ChipWorker::init`
+### Load order — `ChipWorker.init` (Python wrapper) → `_ChipWorker.init` (C++)
+
+```python
+# python/simpler/task_interface.py — ChipWorker.init(device_id, bins, sev, v)
+_preload_global(bins.simpler_log_path)              # 1: ctypes.CDLL(RTLD_GLOBAL)
+log_handle.simpler_log_init(sev, v)                 # 2: seed HostLogger BEFORE
+                                                    #    any consumer SO is opened
+if bins.sim_context_path:
+    _preload_global(bins.sim_context_path)          # 3: ctypes.CDLL(RTLD_GLOBAL), sim only
+self._impl.init(host_path, aicpu_path, aicore_path, device_id)   # 4: C++ _ChipWorker.init
+```
 
 ```cpp
-void ChipWorker::init(host_lib_path, aicpu_path, aicore_path,
-                      simpler_log_lib_path, sim_context_lib_path, sev, v) {
-    ensure_simpler_log_loaded(simpler_log_lib_path);    // 1: RTLD_NOW | RTLD_GLOBAL
-    simpler_log_init_fn(sev, v);                        // 2: seed HostLogger BEFORE
-                                                        //    any consumer SO is opened
-    if (!sim_context_lib_path.empty())
-        ensure_sim_context_loaded(sim_context_lib_path);// 3: RTLD_NOW | RTLD_GLOBAL
-    handle = dlopen(host_lib_path, RTLD_NOW | RTLD_LOCAL); // 4: undefined HostLogger /
-                                                           //    unified_log_* resolve
-                                                           //    via (1)
-    simpler_init_fn(device_ctx, device_id,
-                    aicpu_bytes, aicpu_size,
-                    aicore_bytes, aicore_size);            // 5: attach thread +
-                                                           //    transfer binaries +
-                                                           //    (onboard) sync dlog
-}
+// src/common/worker/chip_worker.cpp — _ChipWorker.init(...)
+handle = dlopen(host_lib_path, RTLD_NOW | RTLD_LOCAL);  // 4a: undefined HostLogger /
+                                                        //     unified_log_* resolve via (1)
+simpler_init_fn(device_ctx, device_id,
+                aicpu_bytes, aicpu_size,
+                aicore_bytes, aicore_size);             // 4b: attach thread +
+                                                        //     transfer binaries +
+                                                        //     (onboard) sync dlog
 ```
+
+`_preload_global` keeps a process-wide `path → ctypes.CDLL` registry so the
+RTLD_GLOBAL load happens exactly once per path (mirrors the old C++
+`std::once_flag`). `_task_interface.so` itself has no undefined `HostLogger`
+symbols, so the preload only has to precede `_ChipWorker.init`, not module
+import.
 
 Each `.so` that needs the host symbols is built **without** compiling
 `host_log.cpp` / `unified_log_host.cpp`. On macOS this requires
@@ -228,8 +237,9 @@ CANN's level enum has no INFO sub-tiers.
 | ----- | ------ | ------ |
 | Python import | `_log.py` registers `V0..V9` / `NUL` with `logging.addLevelName`; sets `simpler` logger to V5 if untouched | `python/simpler/_log.py` |
 | `Worker.init()` | reads `simpler` logger's effective level, splits via `_split_threshold(t) → (sev, info_v)` | `python/simpler/_log.py:get_current_config()` |
-| `ChipWorker.init()` | dlopen libsimpler_log → `simpler_log_init(sev,v)` (seeds HostLogger) → dlopen libsim_context → libhost_runtime → `simpler_init` | `src/common/worker/chip_worker.cpp` |
+| `ChipWorker.init()` (Python) | `ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)` → `simpler_log_init(sev,v)` (seeds HostLogger) → `ctypes.CDLL(libcpu_sim_context.so, RTLD_GLOBAL)` (sim) → `_ChipWorker.init` | `python/simpler/task_interface.py` |
 | `simpler_log_init` | `HostLogger.set_level/set_info_v` — only writer of log filter | `src/common/log/host_log.cpp` |
+| `_ChipWorker.init()` (C++) | `dlopen(host_runtime.so, RTLD_LOCAL)` → dlsym → `simpler_init` | `src/common/worker/chip_worker.cpp` |
 | `simpler_init` (per platform) | attach thread, transfer executor binaries to runner; (onboard) `dlog_setlevel(HostLogger.level())` | `src/{arch}/platform/{onboard,sim}/host/pto_runtime_c_api.cpp` |
 | Per kernel launch | runner reads `HostLogger.level() / info_v()` directly, writes into `KernelArgs`; AICPU `kernel.cpp` calls `set_log_level/set_log_info_v` on entry | `src/{arch}/platform/onboard/aicpu/kernel.cpp` |
 
@@ -252,8 +262,9 @@ the same pattern (one process-global copy, sim builds only).
 | Output path | — | `build/lib/libsimpler_log.so` |
 | Path resolution at runtime | `simpler_setup/runtime_builder.py` | `RuntimeBinaries.simpler_log_path` |
 
-`Worker.init()` reads `binaries.simpler_log_path` from `RuntimeBinaries` and
-threads it through `ChipWorker.init(..., simpler_log_lib_path, ...)`.
+`ChipWorker.init(device_id, bins)` reads `bins.simpler_log_path` (and, on sim,
+`bins.sim_context_path`) from `RuntimeBinaries` and `ctypes.CDLL(..., mode=
+RTLD_GLOBAL)`s them before handing off to the C++ `_ChipWorker.init`.
 
 ## Where to look for what
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -627,8 +627,7 @@ NB_MODULE(_task_interface, m) {
         .def(nb::init<>())
         .def(
             "init", &ChipWorker::init, nb::arg("host_lib_path"), nb::arg("aicpu_path"), nb::arg("aicore_path"),
-            nb::arg("simpler_log_lib_path"), nb::arg("device_id"), nb::arg("sim_context_lib_path") = "",
-            nb::arg("log_level") = 1, nb::arg("log_info_v") = 5
+            nb::arg("device_id")
         )
         .def("finalize", &ChipWorker::finalize)
         .def(

--- a/python/simpler/__init__.py
+++ b/python/simpler/__init__.py
@@ -8,12 +8,13 @@
 # -----------------------------------------------------------------------------------------------------------
 """Simpler runtime — public Python surface.
 
-Host-side log filter setup is performed via libsimpler_log.so's
-`simpler_log_init` C entry (seeding the process-wide HostLogger); CANN dlog
-bootstrap is performed by the platform SO's `simpler_init` reading off that
-same HostLogger. Both are driven once from `ChipWorker::init()` with the
-snapshot of the `simpler` Python logger level. No Python-side ctypes /
-dlopen is needed here.
+Host-side log filter setup happens in `ChipWorker.init` (see
+`simpler.task_interface`): it `ctypes.CDLL`s libsimpler_log.so RTLD_GLOBAL,
+calls its `simpler_log_init` C entry to seed the process-wide HostLogger, then
+hands off to the C++ `_ChipWorker.init` which dlopens host_runtime.so (whose
+`simpler_init` reads CANN dlog config off that same HostLogger, onboard only).
+The level forwarded is a one-shot snapshot of the `simpler` Python logger.
+Nothing log-related needs to happen at import time here.
 """
 
 # Importing _log auto-configures the simpler logger to V5 if unset.

--- a/python/simpler/_log.py
+++ b/python/simpler/_log.py
@@ -22,10 +22,11 @@ severity and INFO sub-verbosity:
 
 C++ side uses two axes (severity enum, info_v int) — `_split_threshold()`
 converts the Python integer into that pair, which `Worker.init()` forwards
-to `ChipWorker::init(..., log_level, log_info_v)` once. `ChipWorker::init`
-calls libsimpler_log.so's `simpler_log_init()` to seed the process-wide
-HostLogger; from then on the platform SO reads back through
-`HostLogger::get_instance()` (populating `KernelArgs.log_level` /
+to `ChipWorker.init(device_id, bins, log_level, log_info_v)` once. The Python
+`ChipWorker.init` wrapper `ctypes.CDLL`s libsimpler_log.so RTLD_GLOBAL and
+calls its `simpler_log_init()` to seed the process-wide HostLogger before the
+C++ side dlopens host_runtime.so; from then on the platform SO reads back
+through `HostLogger::get_instance()` (populating `KernelArgs.log_level` /
 `log_info_v` and, onboard only, syncing CANN dlog inside `simpler_init`).
 
 This module configures the "simpler" logger at import so that an unconfigured

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -20,6 +20,7 @@ Usage:
 """
 
 import ctypes
+import os
 from dataclasses import dataclass, field
 from multiprocessing.shared_memory import SharedMemory
 from typing import Optional
@@ -227,6 +228,27 @@ class ChipContext:
     buffer_ptrs: dict[str, int]
 
 
+# Process-wide RTLD_GLOBAL preload registry. host_runtime.so resolves its
+# undefined HostLogger / unified_log_* (and, on sim, sim_context_*) symbols
+# against these globals, so they must be loaded — exactly once — before any
+# host_runtime.so dlopen. Keyed by path; mirrors the C++ side's old
+# std::once_flag semantics. Never closed.
+_preloaded_globals: dict[str, ctypes.CDLL] = {}
+
+
+def _preload_global(path: str) -> ctypes.CDLL:
+    """dlopen `path` with RTLD_NOW | RTLD_GLOBAL, idempotently (one CDLL per path).
+
+    Eager resolution (RTLD_NOW) mirrors the previous C++ dlopen flags and
+    surfaces any missing-symbol problem at load time rather than first use.
+    """
+    handle = _preloaded_globals.get(path)
+    if handle is None:
+        handle = ctypes.CDLL(path, mode=os.RTLD_NOW | os.RTLD_GLOBAL)
+        _preloaded_globals[path] = handle
+    return handle
+
+
 class ChipWorker:
     """Unified execution interface wrapping the host runtime C API.
 
@@ -253,6 +275,14 @@ class ChipWorker:
         Can only be called once — the runtime and device cannot be changed
         after init.
 
+        Performs the process-wide RTLD_GLOBAL bootstrap (libsimpler_log.so,
+        plus libcpu_sim_context.so on sim platforms) and seeds the HostLogger
+        via ``simpler_log_init`` *before* the C++ ``_ChipWorker.init`` dlopens
+        host_runtime.so — host_runtime.so resolves its undefined HostLogger /
+        unified_log_* (and, on sim, sim_context_*) symbols against those
+        globals, and any LOG_* macro firing during its dlopen-time
+        constructors must already see the right filter.
+
         Args:
             device_id: NPU device ID to attach the calling thread to.
             bins: A `simpler_setup.runtime_builder.RuntimeBinaries` (or any
@@ -275,15 +305,28 @@ class ChipWorker:
                 log_level = sev
             if log_info_v is None:
                 log_info_v = info_v
+
+        # 1. libsimpler_log.so — RTLD_GLOBAL singleton, before host_runtime.so.
+        if not bins.simpler_log_path:
+            raise ValueError("ChipWorker.init: bins.simpler_log_path is required")
+        log_handle = _preload_global(str(bins.simpler_log_path))
+        log_handle.simpler_log_init.argtypes = [ctypes.c_int, ctypes.c_int]
+        log_handle.simpler_log_init.restype = ctypes.c_int
+        rc = log_handle.simpler_log_init(int(log_level), int(log_info_v))
+        if rc != 0:
+            raise RuntimeError(f"simpler_log_init failed with code {rc}")
+
+        # 2. libcpu_sim_context.so — sim platforms only (host_runtime.so's sim
+        #    variant resolves sim_context_set_* / pto_sim_get_* against it).
+        if bins.sim_context_path:
+            _preload_global(str(bins.sim_context_path))
+
+        # 3. host_runtime.so is dlopen'd RTLD_LOCAL inside _impl.init.
         self._impl.init(
             str(bins.host_path),
             str(bins.aicpu_path),
             str(bins.aicore_path),
-            str(bins.simpler_log_path),
             int(device_id),
-            str(bins.sim_context_path) if bins.sim_context_path else "",
-            log_level,
-            log_info_v,
         )
 
     def finalize(self):

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -14,7 +14,6 @@
 #include <dlfcn.h>
 
 #include <fstream>
-#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <thread>
@@ -35,46 +34,6 @@ T load_symbol(void *handle, const char *name) {
         throw std::runtime_error(msg);
     }
     return reinterpret_cast<T>(sym);
-}
-
-// Process-wide singleton: libcpu_sim_context.so is loaded once with
-// RTLD_GLOBAL so that host_runtime.so can resolve sim_context_set_* and
-// pto_sim_get_* symbols at runtime.  Never dlclosed.
-std::once_flag g_sim_context_once;
-void *g_sim_context_handle = nullptr;
-
-void ensure_sim_context_loaded(const std::string &path) {
-    std::call_once(g_sim_context_once, [&]() {
-        dlerror();
-        g_sim_context_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
-        if (!g_sim_context_handle) {
-            std::string err = "dlopen sim_context failed: ";
-            const char *msg = dlerror();
-            err += msg ? msg : "unknown error";
-            throw std::runtime_error(err);
-        }
-    });
-}
-
-// Process-wide singleton: libsimpler_log.so is loaded once with RTLD_GLOBAL
-// so every consumer .so (host_runtime, cpu_sim_context, the binding, sim
-// AICore) shares one HostLogger across the process.  Must be loaded BEFORE
-// any consumer that has unresolved HostLogger / unified_log_* symbols.
-// Never dlclosed.
-std::once_flag g_simpler_log_once;
-void *g_simpler_log_handle = nullptr;
-
-void ensure_simpler_log_loaded(const std::string &path) {
-    std::call_once(g_simpler_log_once, [&]() {
-        dlerror();
-        g_simpler_log_handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
-        if (!g_simpler_log_handle) {
-            std::string err = "dlopen simpler_log failed: ";
-            const char *msg = dlerror();
-            err += msg ? msg : "unknown error";
-            throw std::runtime_error(err);
-        }
-    });
 }
 
 std::vector<uint8_t> read_binary_file(const std::string &path) {
@@ -99,9 +58,7 @@ std::vector<uint8_t> read_binary_file(const std::string &path) {
 ChipWorker::~ChipWorker() { finalize(); }
 
 void ChipWorker::init(
-    const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path,
-    const std::string &simpler_log_lib_path, int device_id, const std::string &sim_context_lib_path, int log_level,
-    int log_info_v
+    const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path, int device_id
 ) {
     if (finalized_) {
         throw std::runtime_error("ChipWorker already finalized; cannot reinitialize");
@@ -113,32 +70,12 @@ void ChipWorker::init(
         throw std::runtime_error("ChipWorker::init requires a non-negative device_id");
     }
 
-    // Load libsimpler_log FIRST with RTLD_GLOBAL so that subsequent host_runtime
-    // / cpu_sim_context / sim aicore .so loads can resolve their HostLogger and
-    // unified_log_* references against the single process-wide instance.
-    if (simpler_log_lib_path.empty()) {
-        throw std::runtime_error("ChipWorker::init requires simpler_log_lib_path");
-    }
-    ensure_simpler_log_loaded(simpler_log_lib_path);
-
-    // Seed the process-wide HostLogger BEFORE host_runtime.so is dlopen'd, so
-    // any LOG_* macro firing during host_runtime's dlopen-time constructors
-    // already sees the user's chosen filter rather than the C++ static init
-    // default. simpler_log_init lives in libsimpler_log.so.
-    simpler_log_init_fn_ = load_symbol<SimplerLogInitFn>(g_simpler_log_handle, "simpler_log_init");
-    int log_rc = simpler_log_init_fn_(log_level, log_info_v);
-    if (log_rc != 0) {
-        simpler_log_init_fn_ = nullptr;
-        throw std::runtime_error("simpler_log_init failed with code " + std::to_string(log_rc));
-    }
-
-    // Load the sim context SO with RTLD_GLOBAL (once per process) so that
-    // PTO ISA TPUSH/TPOP can resolve pto_sim_get_subblock_id and
-    // pto_sim_get_pipe_shared_state via dlsym(RTLD_DEFAULT).
-    if (!sim_context_lib_path.empty()) {
-        ensure_sim_context_loaded(sim_context_lib_path);
-    }
-
+    // libsimpler_log.so (RTLD_GLOBAL, with HostLogger already seeded via
+    // simpler_log_init) and — on sim — libcpu_sim_context.so (RTLD_GLOBAL) must
+    // already be loaded by the caller; host_runtime.so resolves its undefined
+    // HostLogger / unified_log_* (and, on sim, sim_context_*) symbols against
+    // those globals. The Python `ChipWorker` wrapper does this preload.
+    //
     // Host runtime SO is loaded with RTLD_LOCAL so that different runtimes'
     // identically-named symbols (simpler_init, prepare_callable,
     // run_prepared, etc.) do not collide when switching runtimes within the
@@ -331,7 +268,6 @@ void ChipWorker::finalize() {
     comm_get_window_size_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
-    simpler_log_init_fn_ = nullptr;
     runtime_buf_.clear();
     initialized_ = false;
     device_id_ = -1;

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -32,14 +32,15 @@ public:
     /// calling thread to `device_id`. Can only be called once per lifetime —
     /// the runtime and device cannot be changed after init.
     ///
-    /// `log_level` (0=DEBUG..4=NUL) and `log_info_v` (0..9) are pushed into
-    /// HostLogger + runner state and (onboard) into CANN dlog at this point;
-    /// they reflect the user's `simpler` Python logger at Worker.init() time
-    /// and are then fixed for this ChipWorker's lifetime.
+    /// The process-wide RTLD_GLOBAL bootstrap loads (libsimpler_log.so, and on
+    /// sim libcpu_sim_context.so — plus seeding HostLogger via simpler_log_init)
+    /// are the caller's responsibility and must already have happened before
+    /// this call: host_runtime.so resolves its undefined HostLogger /
+    /// unified_log_* (and, on sim, sim_context_*) symbols against those
+    /// globals. The Python `ChipWorker` wrapper does this with `ctypes.CDLL(...,
+    /// mode=RTLD_GLOBAL)`.
     void init(
-        const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path,
-        const std::string &simpler_log_lib_path, int device_id, const std::string &sim_context_lib_path = "",
-        int log_level = 1, int log_info_v = 5
+        const std::string &host_lib_path, const std::string &aicpu_path, const std::string &aicore_path, int device_id
     );
 
     /// Tear down everything: device resources and runtime library.
@@ -107,9 +108,6 @@ private:
     using CopyToDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using CopyFromDeviceCtxFn = int (*)(void *, void *, const void *, size_t);
     using GetRuntimeSizeFn = size_t (*)();
-    // From libsimpler_log.so. Called with (log_level, log_info_v) to seed the
-    // process-wide HostLogger before host_runtime.so is even opened.
-    using SimplerLogInitFn = int (*)(int, int);
     // From host_runtime.so. Single platform-side init that does (a) thread
     // attach + device-id record, (b) executor binary takeover, (c) onboard
     // CANN dlog sync. Reads the current log level off HostLogger itself.
@@ -137,7 +135,6 @@ private:
     CopyToDeviceCtxFn copy_to_device_ctx_fn_ = nullptr;
     CopyFromDeviceCtxFn copy_from_device_ctx_fn_ = nullptr;
     GetRuntimeSizeFn get_runtime_size_fn_ = nullptr;
-    SimplerLogInitFn simpler_log_init_fn_ = nullptr;  // resolved from libsimpler_log.so
     SimplerInitFn simpler_init_fn_ = nullptr;
     PrepareCallableFn prepare_callable_fn_ = nullptr;
     RunPreparedFn run_prepared_fn_ = nullptr;

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -77,21 +77,17 @@ class TestChipWorkerStateMachine:
         worker = _ChipWorker()
         worker.finalize()
         with pytest.raises(RuntimeError, match="finalized"):
-            worker.init(
-                "/nonexistent/libfoo.so", "/dev/null", "/dev/null", "/nonexistent/libsimpler_log.so", device_id=0
-            )
+            worker.init("/nonexistent/libfoo.so", "/dev/null", "/dev/null", device_id=0)
 
     def test_init_with_nonexistent_lib_raises(self):
         worker = _ChipWorker()
         with pytest.raises(RuntimeError, match="dlopen"):
-            worker.init(
-                "/nonexistent/libfoo.so", "/dev/null", "/dev/null", "/nonexistent/libsimpler_log.so", device_id=0
-            )
+            worker.init("/nonexistent/libfoo.so", "/dev/null", "/dev/null", device_id=0)
 
     def test_init_with_negative_device_id_raises(self):
         worker = _ChipWorker()
         with pytest.raises(RuntimeError, match="device_id"):
-            worker.init("/nonexistent/libfoo.so", "/dev/null", "/dev/null", "/nonexistent/libsimpler_log.so", -1)
+            worker.init("/nonexistent/libfoo.so", "/dev/null", "/dev/null", -1)
 
     def test_prepare_callable_before_init_raises(self):
         from _task_interface import ChipCallable  # noqa: PLC0415


### PR DESCRIPTION
## Summary

Continues the API-narrowing theme of #723 / #735. `ChipWorker::init` was the last place in C++ doing process-wide SO bootstrap (dlopen `libsimpler_log.so` + on sim `libcpu_sim_context.so` with `RTLD_GLOBAL`, plus calling `simpler_log_init` to seed HostLogger). That moves up into the Python `ChipWorker` wrapper, shrinking the C++ init signature from 8 args to 4:

```diff
- void init(host_lib, aicpu, aicore, simpler_log_lib, device_id, sim_context_lib = "", log_level = 1, log_info_v = 5);
+ void init(host_lib, aicpu, aicore, device_id);
```

### Why it's safe

`_task_interface.so` has no undefined `HostLogger` / `unified_log_*` symbols — `chip_worker.cpp` reaches `host_runtime.so` purely via `dlsym`, and the binding code doesn't log. So the `RTLD_GLOBAL` preload only has to precede the `_ChipWorker.init` dlopen of `host_runtime.so`, not module import. The Python wrapper does:

1. `ctypes.CDLL(bins.simpler_log_path, mode=RTLD_GLOBAL)` — once per process
2. `<handle>.simpler_log_init(log_level, log_info_v)` — seed HostLogger
3. on sim: `ctypes.CDLL(bins.sim_context_path, mode=RTLD_GLOBAL)`
4. `self._impl.init(host_path, aicpu_path, aicore_path, device_id)`

A module-level `_preloaded_globals: dict[str, ctypes.CDLL]` makes the loads idempotent per path (Python counterpart of the old `std::once_flag`). The `ChipWorker.init` wrapper's public signature `(device_id, bins, log_level=None, log_info_v=None)` is unchanged, so no caller updates.

### Changes

- `src/common/worker/chip_worker.{h,cpp}` — drop the 4 init params; remove the `g_simpler_log_*` / `g_sim_context_*` globals, `ensure_*_loaded()` helpers, `SimplerLogInitFn` typedef + `simpler_log_init_fn_` member, the `simpler_log_init` call, and the now-unused `<mutex>` include.
- `python/bindings/task_interface.cpp` — `_ChipWorker.init` def is now 4 args.
- `python/simpler/task_interface.py` — `_preloaded_globals` registry + `_preload_global()`; `ChipWorker.init` does the preload + `simpler_log_init` via ctypes, then the 4-arg `_impl.init`.
- `tests/ut/py/test_chip_worker.py` — the three `_ChipWorker.init(...)` fault-path tests drop the `/nonexistent/libsimpler_log.so` arg.
- Docs (`chip-level-arch`, `dynamic-linking`, `logging`, `python/simpler/__init__.py`, `python/simpler/_log.py`) — init-flow ASCII art / load-order / config-flow table now show the preload in the Python wrapper.

## Testing

- [x] `pip install --no-build-isolation -e .` (all 4 host_runtime.so + libsimpler_log compile)
- [x] `pytest tests/ut/py` — 119 passed, 7 skipped (torch-missing tests excluded as before)
- [x] `examples/workers/l2/{hello_worker, worker_malloc}` on `a2a3sim` and `a5sim`
- [ ] Onboard ut + st (runs in CI on Linux)