### PR TITLE
Refactor: pin TaskOutputTensors to a single PTO2_SCOPE and simplify replay

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -45,8 +45,7 @@
 // practice, so this path is unreachable for end users — the symbol exists
 // purely to keep the .so loadable.
 extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_deps_json(
-    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/,
-    const int32_t * /*task_window_sizes*/
+    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/
 ) {
     LOG_DEBUG("dep_gen replay not implemented for this runtime — deps.json skipped");
     return -1;
@@ -787,7 +786,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         if (dep_gen_collector_.reconcile_counters()) {
             const auto &records = dep_gen_collector_.records();
             const std::string deps = make_deps_json_path(output_prefix_);
-            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str(), nullptr);
+            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (rc != 0) {
                 LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
             }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -51,8 +51,7 @@
 // practice, so this path is unreachable for end users — the symbol exists
 // purely to keep the .so loadable.
 extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_deps_json(
-    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/,
-    const int32_t * /*task_window_sizes*/
+    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/
 ) {
     LOG_DEBUG("dep_gen replay not implemented for this runtime — deps.json skipped");
     return -1;
@@ -674,7 +673,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         if (dep_gen_collector_.reconcile_counters()) {
             const auto &records = dep_gen_collector_.records();
             const std::string deps = make_deps_json_path(output_prefix_);
-            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str(), nullptr);
+            int rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
             if (rc != 0) {
                 LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", rc);
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -432,6 +432,51 @@ PTO2_SCOPE(rt) {
 // scope_end: scope reference released from all tasks above
 ```
 
+**Output tensor lifetime — single-scope only.** `submit_task` returns a
+`TaskOutputTensors`, and `get_ref(i)` hands back a `const Tensor&`. Both are
+backed by pointers into the submitting task's `PTO2TaskPayload::tensors[]`,
+which lives in a ring-buffer slot. After `scope_end` the slot becomes
+eligible for reuse; once `advance_ring_pointers` reaches it,
+`reset_for_reuse()` runs and the next `submit_task` overwrites the same
+Tensor storage in place.
+
+Therefore the `TaskOutputTensors` instance, the references it returns, and
+any pointer derived from them MUST NOT outlive the `PTO2_SCOPE` in which
+submit was called. The typical safe pattern is:
+
+```cpp
+PTO2_SCOPE() {
+    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
+    const Tensor &y = outs.get_ref(0);
+    // Use y here and in subsequent submits within the same scope.
+}   // outs and y both go out of scope; no dangling references can escape.
+```
+
+Anti-patterns that compile but silently break:
+
+```cpp
+const Tensor *kept = nullptr;
+PTO2_SCOPE() {
+    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
+    kept = &outs.get_ref(0);          // escapes the scope
+}
+// `kept` still points at a payload slot. After enough submits in later
+// scopes, the slot is reused and `*kept` aliases an unrelated task's
+// tensor — a wrong-tensor read with no runtime diagnostic.
+
+TaskOutputTensors outs;               // declared in outer scope
+PTO2_SCOPE() {
+    outs = rt_submit_aic_task(FUNC_QK, args);
+}
+const Tensor &t = outs.get_ref(0);    // same hazard: outs survives scope
+```
+
+This invariant is intentionally not runtime-checked. A reused slot carries
+a different but valid `owner_task_id`, so an assertion based on
+`owner_task_id` cannot distinguish "still the original task" from
+"silently aliased to a newer task". Treat the rule as a static contract,
+verified by review.
+
 ---
 
 ## 8. Scheduler

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -56,7 +56,7 @@
 
 namespace {
 
-int32_t next_pow2(int32_t v) {
+int32_t ceil_pow2(int32_t v) {
     if (v <= 1) return 1;
     v--;
     v |= v >> 1;
@@ -105,9 +105,8 @@ bool write_deps_json(const char *path, const std::vector<std::pair<uint64_t, uin
 
 }  // namespace
 
-extern "C" int dep_gen_replay_emit_deps_json(
-    const DepGenRecord *records, size_t num_records, const char *deps_json_path, const int32_t *task_window_sizes_in
-) {
+extern "C" int
+dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, const char *deps_json_path) {
     if (deps_json_path == nullptr) {
         LOG_ERROR("dep_gen replay: null deps_json_path");
         return -1;
@@ -119,34 +118,23 @@ extern "C" int dep_gen_replay_emit_deps_json(
     LOG_INFO_V0("dep_gen replay: processing %zu in-memory records", num_records);
 
     // Per-ring task window sizes — tensormap masks slot indices and requires
-    // each to be a power of two. When the caller passes null we auto-size from
-    // the records themselves so each ring's window comfortably covers its
-    // observed max local_id (no slot aliasing during INOUT+COVERED
-    // remove_from_task).
+    // each to be a power of two. Auto-size from the records themselves so each
+    // ring's window comfortably covers its observed max local_id (no slot
+    // aliasing during INOUT+COVERED remove_from_task).
     int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    if (task_window_sizes_in != nullptr) {
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            int32_t v = task_window_sizes_in[r];
-            if (v < 1) v = 1;
-            if ((v & (v - 1)) != 0) v = next_pow2(v);
-            task_window_sizes[r] = v;
+    uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
+    for (size_t i = 0; i < num_records; i++) {
+        PTO2TaskId tid{records[i].task_id};
+        uint8_t ring = tid.ring();
+        uint32_t local = tid.local();
+        if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
+            max_local[ring] = local;
         }
-    } else {
-        uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
-        for (size_t i = 0; i < num_records; i++) {
-            PTO2TaskId tid{records[i].task_id};
-            uint8_t ring = tid.ring();
-            uint32_t local = tid.local();
-            if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
-                max_local[ring] = local;
-            }
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            // +1 for slot needed by max_local; floor at 16 to avoid tiny allocs.
-            int32_t need = static_cast<int32_t>(max_local[r] + 1);
-            int32_t v = next_pow2(need < 16 ? 16 : need);
-            task_window_sizes[r] = v;
-        }
+    }
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        // +1 for slot needed by max_local; floor at 16 to avoid tiny allocs.
+        int32_t need = static_cast<int32_t>(max_local[r] + 1);
+        task_window_sizes[r] = ceil_pow2(need < 16 ? 16 : need);
     }
 
     int32_t output_count = count_outputs(records, num_records);
@@ -154,15 +142,11 @@ extern "C" int dep_gen_replay_emit_deps_json(
     if (pool_size < PTO2_TENSORMAP_POOL_SIZE) {
         pool_size = PTO2_TENSORMAP_POOL_SIZE;
     }
-    int32_t num_buckets = next_pow2(pool_size / 16);
-    if (num_buckets < PTO2_TENSORMAP_NUM_BUCKETS) {
-        num_buckets = PTO2_TENSORMAP_NUM_BUCKETS;
-    }
 
     PTO2TensorMap tensor_map;
     std::memset(&tensor_map, 0, sizeof(tensor_map));
-    if (!tensor_map.init(num_buckets, pool_size, task_window_sizes)) {
-        LOG_ERROR("dep_gen replay: tensormap.init failed (buckets=%d, pool=%d)", num_buckets, pool_size);
+    if (!tensor_map.init(PTO2_TENSORMAP_NUM_BUCKETS, pool_size, task_window_sizes)) {
+        LOG_ERROR("dep_gen replay: tensormap.init failed (buckets=%d, pool=%d)", PTO2_TENSORMAP_NUM_BUCKETS, pool_size);
         return -3;
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -63,20 +63,16 @@ extern "C" {
 /**
  * Replay an in-memory DepGenRecord stream and write deps.json.
  *
+ * Per-ring task window sizes are auto-derived from the trace itself so each
+ * ring's window covers its observed max local_id without slot aliasing.
+ *
  * @param records            Pointer to a contiguous DepGenRecord array
  *                           (typically ``DepGenCollector::records().data()``).
  * @param num_records        Number of records in the array.
  * @param deps_json_path     Output path; truncated if it exists.
- * @param task_window_sizes  Per-ring task window sizes (length PTO2_MAX_RING_DEPTH).
- *                           May be null — when null we auto-size from the trace
- *                           itself so each ring's window covers its observed
- *                           max local_id without slot aliasing. Each non-null
- *                           entry is rounded up to the next power of two.
  * @return 0 on success; negative on error (see source for codes).
  */
-int dep_gen_replay_emit_deps_json(
-    const struct DepGenRecord *records, size_t num_records, const char *deps_json_path, const int32_t *task_window_sizes
-);
+int dep_gen_replay_emit_deps_json(const struct DepGenRecord *records, size_t num_records, const char *deps_json_path);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -684,9 +684,6 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     auto runtime_emit = [&](PTO2TaskId producer_task_id) -> bool {
         PTO2TaskSlotState *prod_state =
             &orch->sm_header->rings[producer_task_id.ring()].get_slot_state_by_task_id(producer_task_id.local());
-        if (prod_state->task == nullptr || prod_state->task->task_id != producer_task_id) {
-            return true;  // producer slot reused for a different task — dep is moot
-        }
         return append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id);
     };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -78,6 +78,23 @@ enum class PTO2ScopeMode : uint8_t {
  *
  * Users must hold a named TaskOutputTensors variable and borrow via get_ref();
  * binding get_ref() on an rvalue is compile-time rejected to prevent dangling.
+ *
+ * LIFETIME — single-scope only:
+ *   Internally this class stores pointers into the submitting task's payload
+ *   (PTO2TaskPayload::tensors[]), which lives in a ring-buffer slot. After
+ *   scope_end the slot becomes eligible for reuse, and a later submit will
+ *   overwrite the same Tensor storage in place. Therefore the
+ *   TaskOutputTensors instance, the const Tensor& returned by get_ref(), and
+ *   any pointer derived from either MUST NOT outlive the PTO2_SCOPE in which
+ *   submit was called — do not move/copy them to outer-scope variables, do
+ *   not capture references by std::reference_wrapper or raw pointers across
+ *   scope boundaries.
+ *
+ *   This invariant is intentionally not enforced at runtime: a reused slot
+ *   simply carries a different but valid owner_task_id, so checking
+ *   owner_task_id cannot distinguish "still mine" from "silently aliased to
+ *   an unrelated task". Misuse manifests as a wrong-tensor read with no
+ *   diagnostic.
  */
 class TaskOutputTensors {
 public:

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -432,6 +432,51 @@ PTO2_SCOPE(rt) {
 // scope_end: scope reference released from all tasks above
 ```
 
+**Output tensor lifetime — single-scope only.** `submit_task` returns a
+`TaskOutputTensors`, and `get_ref(i)` hands back a `const Tensor&`. Both are
+backed by pointers into the submitting task's `PTO2TaskPayload::tensors[]`,
+which lives in a ring-buffer slot. After `scope_end` the slot becomes
+eligible for reuse; once `advance_ring_pointers` reaches it,
+`reset_for_reuse()` runs and the next `submit_task` overwrites the same
+Tensor storage in place.
+
+Therefore the `TaskOutputTensors` instance, the references it returns, and
+any pointer derived from them MUST NOT outlive the `PTO2_SCOPE` in which
+submit was called. The typical safe pattern is:
+
+```cpp
+PTO2_SCOPE() {
+    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
+    const Tensor &y = outs.get_ref(0);
+    // Use y here and in subsequent submits within the same scope.
+}   // outs and y both go out of scope; no dangling references can escape.
+```
+
+Anti-patterns that compile but silently break:
+
+```cpp
+const Tensor *kept = nullptr;
+PTO2_SCOPE() {
+    TaskOutputTensors outs = rt_submit_aic_task(FUNC_QK, args);
+    kept = &outs.get_ref(0);          // escapes the scope
+}
+// `kept` still points at a payload slot. After enough submits in later
+// scopes, the slot is reused and `*kept` aliases an unrelated task's
+// tensor — a wrong-tensor read with no runtime diagnostic.
+
+TaskOutputTensors outs;               // declared in outer scope
+PTO2_SCOPE() {
+    outs = rt_submit_aic_task(FUNC_QK, args);
+}
+const Tensor &t = outs.get_ref(0);    // same hazard: outs survives scope
+```
+
+This invariant is intentionally not runtime-checked. A reused slot carries
+a different but valid `owner_task_id`, so an assertion based on
+`owner_task_id` cannot distinguish "still the original task" from
+"silently aliased to a newer task". Treat the rule as a static contract,
+verified by review.
+
 ---
 
 ## 8. Scheduler

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -80,6 +80,23 @@ enum class PTO2ScopeMode : uint8_t {
  *
  * Users must hold a named TaskOutputTensors variable and borrow via get_ref();
  * binding get_ref() on an rvalue is compile-time rejected to prevent dangling.
+ *
+ * LIFETIME — single-scope only:
+ *   Internally this class stores pointers into the submitting task's payload
+ *   (PTO2TaskPayload::tensors[]), which lives in a ring-buffer slot. After
+ *   scope_end the slot becomes eligible for reuse, and a later submit will
+ *   overwrite the same Tensor storage in place. Therefore the
+ *   TaskOutputTensors instance, the const Tensor& returned by get_ref(), and
+ *   any pointer derived from either MUST NOT outlive the PTO2_SCOPE in which
+ *   submit was called — do not move/copy them to outer-scope variables, do
+ *   not capture references by std::reference_wrapper or raw pointers across
+ *   scope boundaries.
+ *
+ *   This invariant is intentionally not enforced at runtime: a reused slot
+ *   simply carries a different but valid owner_task_id, so checking
+ *   owner_task_id cannot distinguish "still mine" from "silently aliased to
+ *   an unrelated task". Misuse manifests as a wrong-tensor read with no
+ *   diagnostic.
  */
 class TaskOutputTensors {
 public:


### PR DESCRIPTION
## Summary

- **Document the lifetime contract.** `TaskOutputTensors` (and the `const Tensor&` it returns via `get_ref`) must not outlive the `PTO2_SCOPE` in which submit was called. Internally it points into a ring-buffer payload slot that is overwritten by `reset_for_reuse` on a later submit. Added to the class doc in `pto_types.h` and a new section in `RUNTIME_LOGIC.md` on both `a2a3` and `a5`, with the safe pattern plus two compile-but-silently-broken anti-patterns (escaping reference, outer-scope `TaskOutputTensors`). The invariant is intentionally not runtime-checked — a reused slot still carries a valid `owner_task_id`, so any assertion would be defeated. Treat as a static contract verified by review.
- **Drop now-dead defensive code in a2a3 orchestrator.** `runtime_emit` no longer probes `prod_state->task` / `task_id` before `append_fanin_or_fail`. With the lifetime contract above, a consumer cannot legally observe a producer whose slot has been reused — the check was always false on the happy path and only suppressed real fanin emission on misuse.
- **Simplify the `dep_gen_replay` API.** The optional `task_window_sizes` parameter is removed; windows are always auto-derived from the trace's observed max local_id per ring (floored at 16, rounded up to the next power of two). Helper `next_pow2` → `ceil_pow2` to match what it actually computes. Both `a2a3` platform `device_runner`s (onboard and sim) update the weak stub and the live call site accordingly. Replay no longer needs to know the production task-window configuration to produce a correct `deps.json`.
- **a5 scope.** Documentation only; a5 runtime does not yet implement `dep_gen` replay and its orchestrator has no equivalent dead-code path to drop.