### PR TITLE
fix: standalone L2 scene-test runner builds a Worker, not a raw ChipWorker

### DIFF
--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -814,18 +814,18 @@ class SceneTestCase:
     # ------------------------------------------------------------------
 
     @classmethod
-    def _get_binaries(cls, platform, build=False):
-        from .runtime_builder import RuntimeBuilder  # noqa: PLC0415
-
-        return RuntimeBuilder(platform=platform).get_binaries(cls._st_runtime, build=build)
-
-    @classmethod
     def _create_worker(cls, platform, device_id=0, build=False):
-        from simpler.task_interface import ChipWorker  # noqa: PLC0415
+        """Create the L2 Worker for the standalone path.
 
-        bins = cls._get_binaries(platform, build=build)
-        w = ChipWorker()
-        w.init(device_id, bins)
+        Mirrors the ``st_worker`` pytest fixture, which yields a ``Worker``
+        (not a raw ``ChipWorker``) — ``_run_and_validate_l2`` is shared by both
+        paths and calls ``worker.register(...)`` / ``worker.run(cid, ...)``,
+        which only the ``Worker`` wrapper exposes.
+        """
+        from simpler.worker import Worker  # noqa: PLC0415
+
+        w = Worker(level=2, device_id=device_id, platform=platform, runtime=cls._st_runtime, build=build)
+        w.init()
         return w
 
     # ------------------------------------------------------------------
@@ -1430,10 +1430,7 @@ class SceneTestCase:
                             if args.exitfirst:
                                 raise SystemExit(1) from None
             finally:
-                if level == 2:
-                    worker.finalize()
-                else:
-                    worker.close()
+                worker.close()
 
         sys.exit(0 if ok else 1)
 


### PR DESCRIPTION
## Summary

`SceneTestCase._run_and_validate_l2` — shared by the pytest fixture path and the
standalone `python <test>.py -p <platform>` path — calls `worker.register(callable)`
and `worker.run(cid, ...)`, which only the `simpler.worker.Worker` wrapper exposes
(introduced by #710's prepared-callable refactor). The `st_worker` fixture yields a
`Worker`, but `_create_worker` (the standalone path) handed back a raw `ChipWorker`,
so `python examples/.../test_*.py -p a2a3sim` died with:

```
FAILED: 'ChipWorker' object has no attribute 'register'
```

Fix:
- `_create_worker` now builds `Worker(level=2, device_id=..., platform=..., runtime=..., build=...)` + `init()`, mirroring the fixture.
- Drop the now-unused `_get_binaries` classmethod (was only fed into the old raw-`ChipWorker` path; `Worker._init_level2` resolves binaries itself).
- Tear down the standalone worker with `worker.close()` for both levels (it calls the L2 `ChipWorker.finalize()` internally), replacing the level-2-only `worker.finalize()` which only existed on the raw `ChipWorker`.

## Testing
- [x] `python examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention.py -p a2a3sim` — now `PASSED` (previously `FAILED: 'ChipWorker' object has no attribute 'register'`).
- [ ] CI: sim scene tests (which exercise the pytest fixture path, unchanged) + the standalone-runner packaging smoke.