### PR TITLE
fix(examples): drop redundant UP deps in paged_attention manual_scope orchs

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -238,16 +238,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    params_up.add_dep(sf_outs.task_id());
+                    // UP reads SF's mi/li, but SF -> PV -> UP already orders it; only the PV edge is explicit.
                     params_up.add_dep(pv_outs.task_id());
-                    if (is_first) {
-                        params_up.add_dep(alloc_task);
-                    }
                     if (prev_update_task.is_valid()) {
                         params_up.add_dep(prev_update_task);
-                        if (is_last) {
-                            params_up.add_dep(alloc_task);
-                        }
+                    }
+                    // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
+                    if (is_last) {
+                        params_up.add_dep(alloc_task);
                     }
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -278,14 +278,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
                     params_up.add_dep(pv_outs.task_id());
-                    if (is_first) {
-                        params_up.add_dep(alloc_outs.task_id());
-                    }
                     if (!is_first) {
                         params_up.add_dep(pre_task_id);
-                        if (is_last) {
-                            params_up.add_dep(alloc_outs.task_id());
-                        }
+                    }
+                    // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
+                    if (is_last) {
+                        params_up.add_dep(alloc_outs.task_id());
                     }
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -238,14 +238,12 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
                     params_up.add_dep(pv_outs.task_id());
-                    if (is_first) {
-                        params_up.add_dep(alloc_task);
-                    }
                     if (prev_update_task.is_valid()) {
                         params_up.add_dep(prev_update_task);
-                        if (is_last) {
-                            params_up.add_dep(alloc_task);
-                        }
+                    }
+                    // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
+                    if (is_last) {
+                        params_up.add_dep(alloc_task);
                     }
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -268,14 +268,12 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
                     params_up.add_dep(pv_outs.task_id());
-                    if (is_first) {
-                        params_up.add_dep(alloc_outs.task_id());
-                    }
                     if (prev_update_task.is_valid()) {
                         params_up.add_dep(prev_update_task);
-                        if (is_last) {
-                            params_up.add_dep(alloc_outs.task_id());
-                        }
+                    }
+                    // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
+                    if (is_last) {
+                        params_up.add_dep(alloc_outs.task_id());
                     }
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);


### PR DESCRIPTION
## Summary

Two transitively-implied edges were cluttering the dep graph of the
manual-scope `paged_attention` orchestrations:

1. **`SF → UP`** — only in `a2a3/.../paged_attention_manual_scope`.
   `ONLINE_UPDATE` already depends on `PV_MATMUL`, which depends on
   `SOFTMAX_PREPARE`, so `SF → PV → UP` already orders UP after SF. The
   explicit `params_up.add_dep(sf_outs.task_id())` was pure redundancy.

2. **`alloc → UP_first`** — in all four manual_scope orchs (a2a3/a5 ×
   `paged_attention_manual_scope` / `paged_attention_unroll_manual_scope`).
   The hidden `alloc_tensors` task completes *inline* in the orchestrator
   before any consumer is submitted (`task_state = PTO2_TASK_COMPLETED`), so
   the alloc dep is never an ordering constraint — it only tells the ring
   buffer to keep the scratch tensors (`oi`/`li_update`/`mi_update`) alive
   until their last consumer. The UP chain (`UP_0 → UP_1 → … → UP_last`)
   makes `UP_last` the final consumer, so a single `alloc → UP_last` edge
   suffices; the extra `alloc → UP_first` edge is redundant. Restructured so
   the alloc dep attaches to the last UP — which also covers the single-block
   case (`first == last`).

`alloc → UP_last` is **kept** — removing it entirely would let the ring
recycle the scratch buffers while UP is still using them.

The non-manual `paged_attention` / `paged_attention_unroll` examples use
auto same-scope dependency wiring and are untouched.

## Testing
- [x] `pytest examples/.../paged_attention_manual_scope --platform a2a3sim --enable-dep-gen --enable-l2-swimlane --require-pto-isa` — `1 passed`; `deps.json` drops 16 → 12 edges (per block: `QK → SF → PV → UP`, plus the prev-UP chain and `alloc → UP_last`). Golden comparison unchanged.
- [ ] CI: a2a3/a5 sim + onboard scene tests (cover the unroll/a5 variants, which only got the `alloc → UP_first` removal — same mechanical change).