### PR TITLE
Refactor: hoist _ensure_prepared and unify prepared-callable docs

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -255,6 +255,25 @@ def _sub_worker_loop(buf, registry: dict) -> None:
             break
 
 
+def _ensure_prepared(cw, registry, prepared, cid: int, *, lazy: bool, device_id: int) -> None:
+    if cid in prepared:
+        return
+    callable_obj = registry.get(cid)
+    if callable_obj is None:
+        raise RuntimeError(f"chip_process dev={device_id}: cid {cid} not in registry")
+    if lazy:
+        # Reaching the lazy branch means _CTRL_PREPARE prewarm did not run
+        # for this cid before the first TASK_READY; the child still does
+        # the work, but the resulting H2D + dlopen cost lands on the
+        # first task's latency.  Log so the gap is visible in stderr.
+        sys.stderr.write(
+            f"[chip_process pid={os.getpid()} dev={device_id}] WARN: lazy-prepare cid={cid}; prewarm path missed it\n"
+        )
+        sys.stderr.flush()
+    cw.prepare_callable(cid, callable_obj)
+    prepared.add(cid)
+
+
 def _chip_process_loop(
     buf: memoryview,
     bins,
@@ -303,25 +322,6 @@ def _chip_process_loop(
     # safety net (e.g. registrations that bypassed the prefetch path).
     prepared: set[int] = set()
 
-    def _ensure_prepared(cid: int, *, lazy: bool) -> None:
-        if cid in prepared:
-            return
-        callable_obj = registry.get(cid)
-        if callable_obj is None:
-            raise RuntimeError(f"chip_process dev={device_id}: cid {cid} not in registry")
-        if lazy:
-            # Reaching the lazy branch means _CTRL_PREPARE prewarm did not run
-            # for this cid before the first TASK_READY; the child still does
-            # the work, but the resulting H2D + dlopen cost lands on the
-            # first task's latency.  Log so the gap is visible in stderr.
-            sys.stderr.write(
-                f"[chip_process pid={os.getpid()} dev={device_id}] "
-                f"WARN: lazy-prepare cid={cid}; prewarm path missed it\n"
-            )
-            sys.stderr.flush()
-        cw.prepare_callable(cid, callable_obj)
-        prepared.add(cid)
-
     while True:
         state = _mailbox_load_i32(state_addr)
         if state == _TASK_READY:
@@ -331,7 +331,7 @@ def _chip_process_loop(
             code = 0
             msg = ""
             try:
-                _ensure_prepared(cid, lazy=True)
+                _ensure_prepared(cw, registry, prepared, cid, lazy=True, device_id=device_id)
                 # Hand the mailbox bytes straight to C++ (zero-copy zero-decode):
                 # the blob layout is what `write_blob` already wrote, so re-parsing
                 # it in Python is N×40B of avoidable work and a permanent
@@ -367,7 +367,7 @@ def _chip_process_loop(
                     cw.copy_from(dst, src, n)
                 elif sub_cmd == _CTRL_PREPARE:
                     cid = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
-                    _ensure_prepared(cid, lazy=False)
+                    _ensure_prepared(cw, registry, prepared, cid, lazy=False, device_id=device_id)
             except Exception as e:  # noqa: BLE001
                 code = 1
                 msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
@@ -441,21 +441,6 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
     # `_chip_process_loop`'s `prepared`.
     prepared: set[int] = set()
 
-    def _ensure_prepared(cid: int, *, lazy: bool) -> None:
-        if cid in prepared:
-            return
-        callable_obj = registry.get(cid)
-        if callable_obj is None:
-            raise RuntimeError(f"chip_process dev={device_id}: cid {cid} not in registry")
-        if lazy:
-            sys.stderr.write(
-                f"[chip_process pid={os.getpid()} dev={device_id}] "
-                f"WARN: lazy-prepare cid={cid}; prewarm path missed it\n"
-            )
-            sys.stderr.flush()
-        cw.prepare_callable(cid, callable_obj)
-        prepared.add(cid)
-
     try:
         while True:
             state = _mailbox_load_i32(state_addr)
@@ -466,7 +451,7 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
                 code = 0
                 msg = ""
                 try:
-                    _ensure_prepared(cid, lazy=True)
+                    _ensure_prepared(cw, registry, prepared, cid, lazy=True, device_id=device_id)
                     # Hand the mailbox bytes straight to C++ (zero-copy zero-decode);
                     # see the matching comment in `_chip_process_loop`.
                     cw._impl.run_prepared_from_blob(cid, mailbox_addr + _OFF_ARGS, _MAILBOX_ARGS_CAPACITY, cfg)
@@ -529,7 +514,7 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
                         cw._impl.copy_from(dst, src, n)
                     elif sub_cmd == _CTRL_PREPARE:
                         cid = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
-                        _ensure_prepared(cid, lazy=False)
+                        _ensure_prepared(cw, registry, prepared, cid, lazy=False, device_id=device_id)
                 except Exception as e:  # noqa: BLE001
                     code = 1
                     msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -604,9 +604,13 @@ private:
     // register_prepared_callable_host_orch call; never decremented). Same
     // re-prepare semantics as aicpu_dlopen_total_, but for hbg variants.
     size_t host_dlopen_total_{0};
-    // Sticky flag: prepare_callable was called at least once. Distinguishes
-    // legacy-path "kernel still cached at finalize" leaks from prepared-path
-    // kernels that legitimately live until finalize.
+    // Sticky flag: prepare_callable was called at least once in this
+    // DeviceRunner's lifetime. unregister_prepared_callable clears the
+    // per-cid kernel maps, so we cannot rely on map contents at finalize()
+    // to distinguish a legacy-path leak from a kernel legitimately staged
+    // by prepare_callable (which is owned until finalize by design).
+    // Assumes the legacy non-prepared run path is retired; if it is ever
+    // reintroduced, revisit whether this distinction still holds.
     bool prepared_callable_path_used_{false};
 
     // ACL lifecycle (process-wide). aclInit must run exactly once; ensure_acl_ready

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -307,11 +307,12 @@ private:
     size_t aicpu_dlopen_total_{0};
     size_t host_dlopen_total_{0};
     // Sticky flag: prepare_callable was called at least once in this
-    // DeviceRunner's lifetime. unregister_prepared_callable clears the maps
-    // above, so we cannot use them at finalize() time to decide whether a
-    // remaining func_id_to_addr_ entry is a legacy-path leak or a kernel
-    // legitimately staged by prepare_callable (which is owned until finalize
-    // by design).
+    // DeviceRunner's lifetime. unregister_prepared_callable clears the
+    // per-cid kernel maps, so we cannot rely on map contents at finalize()
+    // to distinguish a legacy-path leak from a kernel legitimately staged
+    // by prepare_callable (which is owned until finalize by design).
+    // Assumes the legacy non-prepared run path is retired; if it is ever
+    // reintroduced, revisit whether this distinction still holds.
     bool prepared_callable_path_used_{false};
 
     // AICPU executor SO: load-once, matching onboard's binaries_loaded_ pattern.

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -503,9 +503,13 @@ private:
     size_t aicpu_dlopen_total_{0};
     // Monotonic host-side dlopen counter for hbg variants.
     size_t host_dlopen_total_{0};
-    // Sticky flag: prepare_callable was called at least once. Lets finalize()
-    // distinguish legacy-path leaks from prepared-path kernels that legitimately
-    // live until finalize.
+    // Sticky flag: prepare_callable was called at least once in this
+    // DeviceRunner's lifetime. unregister_prepared_callable clears the
+    // per-cid kernel maps, so we cannot rely on map contents at finalize()
+    // to distinguish a legacy-path leak from a kernel legitimately staged
+    // by prepare_callable (which is owned until finalize by design).
+    // Assumes the legacy non-prepared run path is retired; if it is ever
+    // reintroduced, revisit whether this distinction still holds.
     bool prepared_callable_path_used_{false};
 
     // Performance profiling

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -314,6 +314,13 @@ private:
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;
     size_t aicpu_dlopen_total_{0};
     size_t host_dlopen_total_{0};
+    // Sticky flag: prepare_callable was called at least once in this
+    // DeviceRunner's lifetime. unregister_prepared_callable clears the
+    // per-cid kernel maps, so we cannot rely on map contents at finalize()
+    // to distinguish a legacy-path leak from a kernel legitimately staged
+    // by prepare_callable (which is owned until finalize by design).
+    // Assumes the legacy non-prepared run path is retired; if it is ever
+    // reintroduced, revisit whether this distinction still holds.
     bool prepared_callable_path_used_{false};
 
     // Runtime pointer for print_handshake_results

--- a/tests/ut/py/test_worker/test_ensure_prepared.py
+++ b/tests/ut/py/test_worker/test_ensure_prepared.py
@@ -1,0 +1,62 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for the module-level ``_ensure_prepared`` helper.
+
+The two chip-child loops both rely on this helper to handle the
+``_CTRL_PREPARE`` prewarm path (``lazy=False``) and the ``_TASK_READY``
+safety-net path (``lazy=True``). The lazy branch is not reachable from a
+normal end-to-end run — it only fires when prewarm was skipped — so it
+must be exercised directly here.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from simpler.worker import _ensure_prepared
+
+
+class TestEnsurePrepared:
+    def test_lazy_warns_and_prepares(self, capsys):
+        cw = MagicMock()
+        callable_obj = object()
+        registry = {7: callable_obj}
+        prepared: set[int] = set()
+
+        _ensure_prepared(cw, registry, prepared, 7, lazy=True, device_id=3)
+
+        cw.prepare_callable.assert_called_once_with(7, callable_obj)
+        assert prepared == {7}
+        err = capsys.readouterr().err
+        assert "WARN: lazy-prepare cid=7" in err
+        assert "dev=3" in err
+
+    def test_eager_does_not_warn(self, capsys):
+        cw = MagicMock()
+        callable_obj = object()
+        registry = {2: callable_obj}
+        prepared: set[int] = set()
+
+        _ensure_prepared(cw, registry, prepared, 2, lazy=False, device_id=0)
+
+        cw.prepare_callable.assert_called_once_with(2, callable_obj)
+        assert prepared == {2}
+        assert capsys.readouterr().err == ""
+
+    def test_already_prepared_short_circuits(self):
+        cw = MagicMock()
+        # cid is already in `prepared`; helper must skip lookup and
+        # prepare_callable entirely.  Pass an empty registry to prove the
+        # lookup never happens (otherwise registry.get would return None
+        # and the helper would raise).
+        _ensure_prepared(cw, {}, {5}, 5, lazy=True, device_id=0)
+        cw.prepare_callable.assert_not_called()
+
+    def test_missing_cid_raises(self):
+        with pytest.raises(RuntimeError, match="cid 9 not in registry"):
+            _ensure_prepared(MagicMock(), {}, set(), 9, lazy=False, device_id=0)


### PR DESCRIPTION
## Summary

- Hoist `_ensure_prepared` out of the two chip-child loops (`_chip_process_loop` / `_chip_process_loop_with_bootstrap`) in `python/simpler/worker.py` into a single module-level helper so the lazy/eager prepare branches stay in sync.
- Add a UT (`tests/ut/py/test_worker/test_ensure_prepared.py`) covering the four cases — lazy warn, eager silent, already-prepared short-circuit, missing-cid raise. The lazy-prewarm fallback path previously had zero coverage.
- Unify the `prepared_callable_path_used_` field comment across all four `device_runner.h` headers (a2a3/a5 × onboard/sim) and note the legacy-path assumption it rests on (no longer reachable, kept as a regression guard).

Clears the remaining follow-up items from PR #710 / #735.

## Test plan

- [x] `pytest tests/ut/py/test_worker` → 70 passed, 1 skipped
- [x] `pre-commit run --files <changed>` → all hooks pass
- [ ] CI green