### PR TITLE
Add multi-communication-domain support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ build/
 .venv/
 venv/
 .cache
+.ccache/
 .vscode
 *bak
 

--- a/docs/multi-comm-domain-implementation.md
+++ b/docs/multi-comm-domain-implementation.md
@@ -1,0 +1,299 @@
+# Multi-Communication-Domain Implementation
+
+This document tracks the implementation status for multiple communication
+domains.  It complements the design note in
+[`multi-comm-domain.md`](multi-comm-domain.md) and is intentionally written as
+a completion ledger: what exists, what is deliberately absent, and what has
+been validated.
+
+## Current Surface
+
+The only parent-level communication API is `CommDomainPlan`:
+
+```python
+comm_plan = CommDomainPlan(
+    domains=[
+        CommDomain(
+            name="tp",
+            worker_indices=[0, 1],
+            window_size=tp_window_size,
+            buffers=[
+                ChipBufferSpec("scratch", "float32", count, nbytes),
+            ],
+        ),
+    ],
+)
+
+worker = Worker(level=3, device_ids=device_ids, comm_plan=comm_plan)
+```
+
+The low-level explicit path is still available when a caller must add
+per-chip bootstrap data, such as host staging:
+
+```python
+plan = CommDomainPlan([...])
+cfgs = [
+    ChipBootstrapConfig(
+        comm=plan.bootstrap_for_worker(i),
+        host_inputs=[
+            HostBufferStaging(
+                domain_name="default",
+                name="notify_counter",
+                shm_name=rank_local_shm.name,
+                size=4,
+            ),
+        ],
+    )
+    for i in range(nranks)
+]
+
+worker = Worker(level=3, device_ids=device_ids, chip_bootstrap_configs=cfgs)
+```
+
+`ChipBootstrapConfig.comm` accepts `list[ChipDomainBootstrapConfig]` or
+`None`.  The old public `ChipCommBootstrapConfig` surface is removed.
+
+## Feature Status
+
+Implemented:
+
+- `CommDomain`: name, ordered `worker_indices`, window size, and symmetric
+  buffers.
+- `CommDomainPlan`: parent-level source of truth for all domains in an L3
+  worker.
+- `bootstrap_for_worker(i)`: derives only the domains containing worker index
+  `i`.
+- Domain rank mapping: order in `worker_indices` defines `domain_rank`.
+- Missing domain behavior: `ctx.domains[name]` is a normal dict lookup and
+  raises `KeyError`.
+- Symmetric buffer layout: every participant in one domain receives the same
+  named buffer layout.
+- Multiple domains per chip: a chip can publish more than one
+  `ChipCommDomainContext`.
+- Overlapping domains: the same chip may have independent ranks in different
+  domains.
+- `ChipBootstrapConfig.comm`: takes the derived list from
+  `CommDomainPlan.bootstrap_for_worker`.
+- Explicit host staging: stays on `ChipBootstrapConfig`, keyed by
+  `(domain_name, buffer_name)`.
+- `Worker(..., comm_plan=...)`: creates per-chip bootstrap configs inside the
+  L3 parent.
+- Explicit `chip_bootstrap_configs`: still supported for host staging and
+  manual bootstrap control.
+- Hidden base communicator/window: one base communicator and one base window
+  per L3 worker.
+- Domain-local `CommContext`: each visible domain gets its own
+  kernel-visible `CommContext*`.
+- HCCL base-window slicing: domain windows are slices of the hidden base
+  window.
+- Sim backend slicing: sim mirrors the domain slicing contract for tests and
+  examples.
+- Bootstrap mailbox domains: publishes named domain results and rejects
+  duplicate names.
+- Domain-aware Python context: communication access is through
+  `ChipContext.domains[name]`.
+- Public old single-domain config removal: no public
+  `ChipCommBootstrapConfig` compatibility path remains.
+
+Not implemented by design:
+
+- HCCL collective kernels.  PTO-ISA RMA kernels use HCOMM/HCCL windows only.
+- Visible meta domain.  No all-device logical domain is exposed without
+  buffers.
+- Independent root-info per domain.  The implementation derives domain views
+  from one base setup.
+- Automatic window sizing.  Domain `window_size` remains explicit, matching
+  current style.
+
+## Bootstrap Flow
+
+```text
+L3 parent
+  owns CommDomainPlan
+  validates all domain names, worker indices, windows, and buffers
+  for each chip worker i:
+    derives comm = plan.bootstrap_for_worker(i)
+    creates ChipBootstrapConfig(comm=comm, host staging=optional)
+    attaches private base communicator metadata
+        |
+        v
+chip child
+  initializes one hidden base communicator
+  allocates one hidden base communication window
+  derives one domain-local CommContext for each received domain config
+  carves named buffers inside that domain's window slice
+  stages requested host inputs
+  publishes named domain contexts through ChipBootstrapChannel
+        |
+        v
+L3 orchestration
+  domain = ctx.domains["tp"]
+  passes domain.buffer_ptrs["scratch"] and domain.device_ctx to kernels
+```
+
+Workers outside a domain receive no config for that domain and publish no
+`ctx.domains[name]` entry.
+
+## Host Staging
+
+Host staging is not part of a communication domain.  A domain describes a
+symmetric communication contract: membership, dense rank order, window size,
+and buffer layout.  Host staging describes per-chip movement between
+parent-owned POSIX shared memory and one chip's already declared domain
+buffer.
+
+The split is:
+
+- `CommDomain`: symmetric domain contract shared by participants;
+- `CommDomainPlan`: parent-level source of truth for all domains;
+- `ChipBootstrapConfig`: per-chip transport object sent to one chip child;
+- `HostBufferStaging`: per-chip shared-memory source or destination.
+
+Therefore host staging stays on `ChipBootstrapConfig`.  Each staging entry
+that targets a communication buffer includes `domain_name`; the effective key
+is `(domain_name, buffer_name)`, so two domains can both own `"scratch"`.
+
+## Why Sim Was Extended
+
+The sim backend is not only a compatibility target.  It is the cheapest place
+to validate parent-side derivation, child bootstrap, missing-domain behavior,
+domain rank order, duplicate-name rejection, and host-staging scoping without
+needing hardware.  The sim extension mirrors the same visible contract:
+`ctx.domains[name]` contains a domain-local context and buffer pointers.
+
+It does not attempt to model HCCL transport performance or collective
+behavior.  It only validates the runtime contract that kernels and
+orchestration code consume.
+
+## Example Coverage
+
+Two new L3 examples now cover the multi-domain surface:
+
+- `domain_rank_map`: a tiny bootstrap-only example.  It shows the difference
+  from single-domain usage by checking domain-local ranks, absent domains, and
+  separate slices for overlapping memberships.
+- `dual_domain_overlap`: a real data example.  It runs two overlapping
+  domains, performs domain-local allreduce in both, then runs affine compute
+  and checks real outputs against host goldens.
+
+Existing one-domain communication examples were also migrated to the new
+surface.  They are still important because they prove the single-domain case
+is expressed through the same API rather than through a compatibility path.
+
+## Validation Status
+
+Validation date: 2026-05-13.
+
+### Build And Unit Tests
+
+- Editable build: pass.
+
+  ```bash
+  pip install --no-build-isolation -e .
+  ```
+
+- Focused unit and sim tests: pass, 30 tests.
+
+  ```bash
+  pytest \
+      tests/ut/py/test_worker/test_comm_domain_plan.py \
+      tests/ut/py/test_worker/test_worker_distributed_sim.py \
+      tests/ut/py/test_worker/test_bootstrap_context_sim.py \
+      tests/ut/py/test_worker/test_bootstrap_channel.py \
+      -q
+  ```
+
+- Hardware bootstrap unit test: pass.
+
+  ```bash
+  pytest tests/ut/py/test_worker/test_bootstrap_context_hw.py \
+      -q -s --platform a2a3 --device 3-4
+  ```
+
+- Docs lint: pass.
+
+  ```bash
+  markdownlint-cli2 \
+      docs/multi-comm-domain.md \
+      docs/multi-comm-domain-implementation.md
+  ```
+
+### Example Results
+
+- `workers/l3/domain_rank_map`
+  - Sim: pass with `-p a2a3sim -d 0-2`.
+  - Hardware: pass with `-p a2a3 -d 3-5`.
+  - New tiny domain-rank example.
+
+- `workers/l3/dual_domain_overlap`
+  - Sim: not applicable.
+  - Hardware: pass with `-d 3-5`.
+  - New two-domain data and compute example.
+
+- `workers/l3/allreduce_distributed`
+  - Sim: not applicable.
+  - Hardware: pass with `-d 3-4`.
+  - One-domain baseline through `CommDomainPlan`.
+
+- `workers/l3/ffn_tp_parallel`
+  - Sim: not applicable.
+  - Hardware: pass with `-d 3-4`.
+  - One-domain tensor-parallel compute plus reduce.
+
+- `workers/l3/ep_dispatch_combine`
+  - Sim: not applicable.
+  - Hardware: pass with `-d 3-4`.
+  - One-domain EP dispatch/combine.
+
+- `a2a3/async_notify_demo`
+  - Sim: pass with `-p a2a3sim`.
+  - Hardware: not run.
+  - Explicit bootstrap plus host staging.
+
+- `a2a3/deferred_notify_demo`
+  - Sim: pass with `-p a2a3sim`.
+  - Hardware: not run.
+  - Explicit bootstrap plus deferred notify staging.
+
+- `a2a3/sdma_async_completion_demo`
+  - Sim: not run.
+  - Hardware: fail with `-p a2a3 -d 3-4`.
+  - Both chips bootstrap, then `worker.run()` fails with AICPU 507015.
+
+- `a5/async_notify_demo`
+  - Sim: pass with `-p a5sim`.
+  - Hardware: not run.
+  - A5 sim explicit bootstrap path.
+
+- `a5/deferred_notify_demo`
+  - Sim: pass with `-p a5sim`.
+  - Hardware: not run.
+  - A5 sim deferred notify path.
+
+The SDMA failure happens after both chip bootstrap messages are ready.  The
+observed error is `aclrtSynchronizeStreamWithTimeout (AICPU) failed: 507015`,
+followed by 507901 during stream teardown.  This is tracked as a remaining
+SDMA runtime/data-plane issue, not as a communication-domain bootstrap
+failure.
+
+## Grep Gates
+
+The migrated public examples should stay clean for these stale surfaces:
+
+```bash
+rg -n "ChipCommBootstrapConfig" examples
+rg -n "comm=ChipCommBootstrapConfig|rootinfo_path" examples
+rg -n "ctx\\.buffer_ptrs|ctx\\.device_ctx|ctx\\.rank|ctx\\.nranks" examples
+```
+
+Repository-wide checks should also keep generated or local-only paths out of
+the design documents.
+
+## Non-Goals
+
+- no visible meta communication domain;
+- no independent root-info communicator per domain;
+- no HCCL collective kernels;
+- no implicit current domain inside kernels;
+- no lazy first-use domain creation;
+- no automatic `window_size` derivation in this implementation.

--- a/docs/multi-comm-domain-implementation.md
+++ b/docs/multi-comm-domain-implementation.md
@@ -153,25 +153,99 @@ Therefore host staging stays on `ChipBootstrapConfig`.  Each staging entry
 that targets a communication buffer includes `domain_name`; the effective key
 is `(domain_name, buffer_name)`, so two domains can both own `"scratch"`.
 
-## Why Sim Was Extended
+## Simulation Backend Extension
 
 The sim backend is not only a compatibility target.  It is the cheapest place
 to validate parent-side derivation, child bootstrap, missing-domain behavior,
-domain rank order, duplicate-name rejection, and host-staging scoping without
-needing hardware.  The sim extension mirrors the same visible contract:
-`ctx.domains[name]` contains a domain-local context and buffer pointers.
+domain rank order, duplicate-name rejection, window slicing, and host-staging
+scoping without needing hardware.
 
-It does not attempt to model HCCL transport performance or collective
-behavior.  It only validates the runtime contract that kernels and
-orchestration code consume.
+The extension uses the same visible contract as onboard execution:
+`ctx.domains[name]` contains a domain-local context and buffer pointers.  The
+difference is only the transport used under that contract.  On hardware, the
+base window comes from HCCL/HCOMM resources.  On sim, the base window is a
+POSIX shared-memory segment mapped by each simulated rank process.
+
+The sim flow is:
+
+```text
+comm_init(base_rank, base_size, rootinfo_path)
+  creates a base handle whose shared-memory identity is derived from
+  rootinfo_path and the parent process id
+
+comm_alloc_windows(base, total_base_window_size)
+  creates or opens one shared-memory segment:
+    [header][rank-0 base window][rank-1 base window]...
+  fills the base CommContext:
+    rankId = base_rank
+    rankNum = base_size
+    winSize = total_base_window_size
+    windowsIn[i] = local process pointer to rank i base window
+    windowsOut[i] = windowsIn[i]
+
+for each visible domain on this chip:
+  comm_derive_context(
+      base,
+      rank_ids=domain worker indices in domain-rank order,
+      domain_rank=this chip's dense domain rank,
+      window_offset=domain slice offset in the base window,
+      window_size=domain window size,
+  )
+```
+
+`comm_derive_context` allocates a new host-resident `CommContext` for the
+domain.  It remaps dense domain ranks onto the selected base ranks and applies
+the domain's slice offset:
+
+```text
+derived.rankId = domain_rank
+derived.rankNum = len(rank_ids)
+derived.winSize = window_size
+derived.windowsIn[d] = base.windowsIn[rank_ids[d]] + window_offset
+derived.windowsOut[d] = base.windowsOut[rank_ids[d]] + window_offset
+```
+
+This is enough for CPU-sim kernels to use the same scalar `device_ctx` shape
+as hardware kernels: the scalar still points to a `CommContext`, and the
+domain-local rank ids still index `windowsIn[]` and `windowsOut[]`.
+
+There is one important address-model difference from hardware.  Hardware
+communication windows are device-visible addresses produced by HCCL/HCOMM.
+Sim windows are process-local pointers into the same shared-memory file.  The
+numeric pointer values may differ between rank processes because each process
+maps the file independently.  This is acceptable because each simulated kernel
+dereferences only the `CommContext` built inside its own process; shared memory
+provides visibility of the underlying bytes.
+
+The sim backend also keeps the old single-domain behavior as a special case of
+the same mechanism: one `CommDomain("default", ...)` derives one visible
+context from the base window.  No old public bootstrap surface is required.
+
+What sim intentionally does not do:
+
+- it does not model HCCL transport performance;
+- it does not run HCCL collective kernels;
+- it does not require cross-process numeric address equality;
+- it does not create independent root-info communicators per domain.
+
+The focused sim tests cover:
+
+- `CommDomainPlan.bootstrap_for_worker` rank derivation and validation;
+- L3 `Worker(..., comm_plan=...)` creation of per-chip bootstrap configs;
+- overlapping domains where one worker has both `tp` and `pp` contexts;
+- different `device_ctx` and buffer pointers for different domains;
+- absent-domain behavior through missing `ctx.domains[name]`;
+- host-staging scoping by `(domain_name, buffer_name)`;
+- bootstrap error propagation and cleanup.
 
 ## Example Coverage
 
 Two new L3 examples now cover the multi-domain surface:
 
-- `domain_rank_map`: a tiny bootstrap-only example.  It shows the difference
-  from single-domain usage by checking domain-local ranks, absent domains, and
-  separate slices for overlapping memberships.
+- `domain_rank_map`: a small communication example.  It shows the difference
+  from single-domain usage by checking domain-local ranks, absent domains,
+  separate slices for overlapping memberships, and one real allreduce per
+  domain.
 - `dual_domain_overlap`: a real data example.  It runs two overlapping
   domains, performs domain-local allreduce in both, then runs affine compute
   and checks real outputs against host goldens.
@@ -220,44 +294,49 @@ Validation date: 2026-05-13.
 
 ### Example Results
 
+- `examples` excluding `a2a3/sdma_async_completion_demo`
+  - Hardware: pass on a five-device pool.
+  - This includes the migrated L3 communication examples, the two new
+    multi-domain examples, and the L2 examples.
+
 - `workers/l3/domain_rank_map`
-  - Sim: pass with `-p a2a3sim -d 0-2`.
-  - Hardware: pass with `-p a2a3 -d 3-5`.
-  - New tiny domain-rank example.
+  - Sim: not applicable.
+  - Hardware: pass with `-p a2a3 -d 3-5` and in the examples sweep.
+  - New small domain-rank and per-domain communication example.
 
 - `workers/l3/dual_domain_overlap`
   - Sim: not applicable.
-  - Hardware: pass with `-d 3-5`.
+  - Hardware: pass with `-d 3-5` and in the examples sweep.
   - New two-domain data and compute example.
 
 - `workers/l3/allreduce_distributed`
   - Sim: not applicable.
-  - Hardware: pass with `-d 3-4`.
+  - Hardware: pass with `-d 3-4` and in the examples sweep.
   - One-domain baseline through `CommDomainPlan`.
 
 - `workers/l3/ffn_tp_parallel`
   - Sim: not applicable.
-  - Hardware: pass with `-d 3-4`.
+  - Hardware: pass with `-d 3-4` and in the examples sweep.
   - One-domain tensor-parallel compute plus reduce.
 
 - `workers/l3/ep_dispatch_combine`
   - Sim: not applicable.
-  - Hardware: pass with `-d 3-4`.
+  - Hardware: pass with `-d 3-4` and in the examples sweep.
   - One-domain EP dispatch/combine.
 
 - `a2a3/async_notify_demo`
   - Sim: pass with `-p a2a3sim`.
-  - Hardware: not run.
+  - Hardware: pass in the examples sweep.
   - Explicit bootstrap plus host staging.
 
 - `a2a3/deferred_notify_demo`
   - Sim: pass with `-p a2a3sim`.
-  - Hardware: not run.
+  - Hardware: pass in the examples sweep.
   - Explicit bootstrap plus deferred notify staging.
 
 - `a2a3/sdma_async_completion_demo`
   - Sim: not run.
-  - Hardware: fail with `-p a2a3 -d 3-4`.
+  - Hardware: fail with `-p a2a3 -d 6-7`.
   - Both chips bootstrap, then `worker.run()` fails with AICPU 507015.
 
 - `a5/async_notify_demo`
@@ -275,6 +354,36 @@ observed error is `aclrtSynchronizeStreamWithTimeout (AICPU) failed: 507015`,
 followed by 507901 during stream teardown.  This is tracked as a remaining
 SDMA runtime/data-plane issue, not as a communication-domain bootstrap
 failure.
+
+### SDMA 507015 Investigation
+
+The `worker.run()` failure is currently isolated from multi-domain bootstrap:
+
+- Current one-domain and multi-domain L3 communication examples pass on clean
+  devices.
+- The public examples pass on real devices when the SDMA async completion demo
+  is excluded.
+- A stock HCCL allreduce test using root-info initialization passes on the same
+  CANN 8.5 installation.  This confirms basic HCCL root-info communicator
+  setup and collective execution are not generally broken.
+- The PTO-ISA allgather async reference builds, but on this CANN 8.5
+  installation it fails before executing the SDMA async kernels because the
+  installed `libopapi.so` does not export `aclnnShmemSdmaStarsQuery`.
+  Subsequent SDMA resource allocation fails with code 15.  This points to
+  missing or incompatible SDMA async support in the local CANN stack.
+- A local CANN 9.0 beta toolkit exports the SDMA async query symbols and the
+  demo was rerun under that environment with a runtime rebuild.  It still
+  fails with the same AICPU 507015 symptom, so the missing CANN 8.5 symbol is
+  not the only blocker.
+- The pre-PR single-domain checkout is not a valid local baseline in this
+  environment: its L3 hardware bootstrap times out before reaching the SDMA
+  run path.
+
+A broader `examples tests/st` hardware sweep without the SDMA demo found three
+separate `spmd_sync_start*` failures with AICPU stream-sync timeout 507046.
+After that timeout, rerunning those cases on the same device degraded to stream
+creation failure 507899.  Those failures are separate from the SDMA 507015
+symptom: they do not involve communication domains or SDMA async completion.
 
 ## Grep Gates
 

--- a/docs/multi-comm-domain-implementation.md
+++ b/docs/multi-comm-domain-implementation.md
@@ -245,7 +245,7 @@ Two new L3 examples now cover the multi-domain surface:
 - `domain_rank_map`: a small communication example.  It shows the difference
   from single-domain usage by checking domain-local ranks, absent domains,
   separate slices for overlapping memberships, and one real allreduce per
-  domain.
+  domain.  Revalidated on 2026-05-13 with CANN 8.5 on devices `12,13,14`.
 - `dual_domain_overlap`: a real data example.  It runs two overlapping
   domains, performs domain-local allreduce in both, then runs affine compute
   and checks real outputs against host goldens.
@@ -256,14 +256,33 @@ is expressed through the same API rather than through a compatibility path.
 
 ## Validation Status
 
-Validation date: 2026-05-13.
+Validation date: 2026-05-18.
 
 ### Build And Unit Tests
 
-- Editable build: pass.
+- Editable build after the PR 752 rebase: pass.
 
   ```bash
   pip install --no-build-isolation -e .
+  ```
+
+- Real-device `tests/st` after the PR 752 rebase: pass on `a2a3` devices
+  `2-5`.  Runtime artifacts were rebuilt once serially, then pytest was run
+  without `--build` so parallel workers only loaded stable `build/lib`
+  outputs.
+
+  ```bash
+  python - <<'PY'
+  from simpler_setup.runtime_builder import RuntimeBuilder
+  builder = RuntimeBuilder(platform="a2a3")
+  for runtime in ("host_build_graph", "tensormap_and_ringbuffer"):
+      builder.get_binaries(runtime, build=True)
+  PY
+
+  pytest tests/st --platform a2a3 --device 2-5 -v \
+      --pto-session-timeout 600 \
+      --pto-isa-commit 50d9c806c3e351d5039c9f0f02a267590420b4d9 \
+      --clone-protocol ssh --require-pto-isa
   ```
 
 - Focused unit and sim tests: pass, 30 tests.
@@ -294,10 +313,11 @@ Validation date: 2026-05-13.
 
 ### Example Results
 
-- `examples` excluding `a2a3/sdma_async_completion_demo`
-  - Hardware: pass on a five-device pool.
+- `examples`
+  - Hardware: covered by the real-device CI sweep.
   - This includes the migrated L3 communication examples, the two new
-    multi-domain examples, and the L2 examples.
+    multi-domain examples, the L2 examples, and the SDMA async completion
+    demo.
 
 - `workers/l3/domain_rank_map`
   - Sim: not applicable.
@@ -335,9 +355,14 @@ Validation date: 2026-05-13.
   - Explicit bootstrap plus deferred notify staging.
 
 - `a2a3/sdma_async_completion_demo`
-  - Sim: not run.
-  - Hardware: fail with `-p a2a3 -d 6-7`.
-  - Both chips bootstrap, then `worker.run()` fails with AICPU 507015.
+  - Sim: not applicable.
+  - Hardware: covered by the real-device CI sweep.  The post-rebase fix
+    removes an invalid parent-side prelaunch `CommContext` read.
+  - The demo now uses the kernel output comparison as the SDMA workspace
+    signal.  The previous Python precheck copied a device `CommContext` into
+    a parent-process ctypes buffer through a forked chip child; that copy only
+    updated the child's private address space and therefore falsely reported
+    zero workspace fields.
 
 - `a5/async_notify_demo`
   - Sim: pass with `-p a5sim`.
@@ -349,41 +374,10 @@ Validation date: 2026-05-13.
   - Hardware: not run.
   - A5 sim deferred notify path.
 
-The SDMA failure happens after both chip bootstrap messages are ready.  The
-observed error is `aclrtSynchronizeStreamWithTimeout (AICPU) failed: 507015`,
-followed by 507901 during stream teardown.  This is tracked as a remaining
-SDMA runtime/data-plane issue, not as a communication-domain bootstrap
-failure.
-
-### SDMA 507015 Investigation
-
-The `worker.run()` failure is currently isolated from multi-domain bootstrap:
-
-- Current one-domain and multi-domain L3 communication examples pass on clean
-  devices.
-- The public examples pass on real devices when the SDMA async completion demo
-  is excluded.
-- A stock HCCL allreduce test using root-info initialization passes on the same
-  CANN 8.5 installation.  This confirms basic HCCL root-info communicator
-  setup and collective execution are not generally broken.
-- The PTO-ISA allgather async reference builds, but on this CANN 8.5
-  installation it fails before executing the SDMA async kernels because the
-  installed `libopapi.so` does not export `aclnnShmemSdmaStarsQuery`.
-  Subsequent SDMA resource allocation fails with code 15.  This points to
-  missing or incompatible SDMA async support in the local CANN stack.
-- A local CANN 9.0 beta toolkit exports the SDMA async query symbols and the
-  demo was rerun under that environment with a runtime rebuild.  It still
-  fails with the same AICPU 507015 symptom, so the missing CANN 8.5 symbol is
-  not the only blocker.
-- The pre-PR single-domain checkout is not a valid local baseline in this
-  environment: its L3 hardware bootstrap times out before reaching the SDMA
-  run path.
-
-A broader `examples tests/st` hardware sweep without the SDMA demo found three
-separate `spmd_sync_start*` failures with AICPU stream-sync timeout 507046.
-After that timeout, rerunning those cases on the same device degraded to stream
-creation failure 507899.  Those failures are separate from the SDMA 507015
-symptom: they do not involve communication domains or SDMA async completion.
+The SDMA demo is not tracked as a remaining multi-domain limitation.  Its
+post-rebase failure came from the demo's Python-side inspection path, not from
+communication-domain bootstrap or the derived device `CommContext` consumed by
+the kernel.
 
 ## Grep Gates
 

--- a/docs/multi-comm-domain.md
+++ b/docs/multi-comm-domain.md
@@ -114,7 +114,7 @@ workers to PTO-ISA kernels.
 
 ```text
 Python L3 user code
-  ChipBootstrapConfig(comm=ChipCommBootstrapConfig(...), buffers=[scratch])
+  Worker(comm_plan=CommDomainPlan([CommDomain("default", ...)]))
         |
         v
 Worker(level=3)
@@ -128,7 +128,10 @@ chip child / ChipWorker
         |
         v
 ChipContext exposed to L3 orchestration
-  rank, nranks, device_ctx, local_window_base, buffer_ptrs["scratch"]
+  domains["default"].domain_rank
+  domains["default"].domain_size
+  domains["default"].device_ctx
+  domains["default"].buffer_ptrs["scratch"]
         |
         v
 TaskArgs to each chip task
@@ -151,9 +154,10 @@ assembled by the kernel and it is not passed field by field:
    `windowsIn[]`, and `windowsOut[]`.
 3. The backend returns the address of that `CommContext` through
    `device_ctx_out`.
-4. `ChipWorker.bootstrap_context()` stores that integer as
-   `ChipContext.device_ctx`.
-5. L3 orchestration passes `ctx.device_ctx` as a scalar task argument.
+4. `ChipWorker.bootstrap_context()` stores that integer in the default
+   domain context.
+5. L3 orchestration passes `ctx.domains["default"].device_ctx` as a scalar
+   task argument.
 6. The AIV/AIC kernel casts that scalar back to `__gm__ CommContext *`.
 
 On hardware, `device_ctx_out` is a real device address.  For MESH topology,
@@ -263,12 +267,14 @@ or synchronize.
 
 ### L3 Integration
 
-Today, L3 owns one `ChipBootstrapConfig` per chip.  Examples such as
-`examples/workers/l3/allreduce_distributed/main.py` declare:
+The previous L3 implementation owned one `ChipBootstrapConfig` per chip.
+The new public surface expresses the same single-domain case as one
+`CommDomain` named `"default"`:
 
-- `ChipCommBootstrapConfig(rank, nranks, rootinfo_path, window_size)`;
-- one or more `ChipBufferSpec` entries, usually a `scratch` window;
-- optional host staging information.
+- `CommDomain(name="default", worker_indices=[0, 1], window_size=...)`;
+- one or more per-domain `ChipBufferSpec` entries, usually a `scratch`
+  window;
+- optional per-chip host staging information keyed by domain name.
 
 Current single-domain window sizing is explicit.  The example computes a
 requested `window_size`, usually `max(sum(buffer nbytes), floor)`, and passes
@@ -285,18 +291,19 @@ An L3 orchestration function consumes a context like this:
 
 ```python
 ctx = worker.chip_contexts[i]
+default = ctx.domains["default"]
 
 chip_args.add_tensor(
     ContinuousTensor.make(
-        data=ctx.buffer_ptrs["scratch"],
+        data=default.buffer_ptrs["scratch"],
         shapes=(scratch_count,),
         dtype=DataType.FLOAT32,
         child_memory=True,
     ),
     TensorArgType.INOUT,
 )
-chip_args.add_scalar(ctx.nranks)
-chip_args.add_scalar(ctx.device_ctx)
+chip_args.add_scalar(default.domain_size)
+chip_args.add_scalar(default.device_ctx)
 orch.submit_next_level(chip_cid, chip_args, cfg, worker=i)
 ```
 
@@ -325,8 +332,8 @@ __gm__ float *scratch =
     scratch_tensor->start_offset;
 ```
 
-`ctx.device_ctx` is different: it is not a tensor buffer that participates in
-scheduling, staging, or shape-aware access.  It is only an opaque
+`default.device_ctx` is different: it is not a tensor buffer that participates
+in scheduling, staging, or shape-aware access.  It is only an opaque
 `CommContext*`, so it is passed as a scalar.
 
 ### L2 Integration
@@ -499,10 +506,10 @@ children.
 
 The domain name is the user-facing identity.  L3 orchestration looks up
 domains by name, for example `ctx.domains["tp"]`.  The public plan should not
-expose a numeric domain identifier in the first PR.  If the backend needs
-numeric IDs, the parent can assign them internally from sorted domain names.
-Names only need to be non-empty and unique; the API should not impose
-identifier-style spelling rules.
+expose a numeric domain identifier in the initial implementation.  The parent
+derives internal backend IDs from sorted domain names.  Names only need to be
+non-empty and unique; the API should not impose identifier-style spelling
+rules.
 
 The order of `worker_indices` defines domain rank.  For
 `worker_indices=[2, 3]`, worker `2` is domain rank `0`, and worker `3` is
@@ -520,9 +527,9 @@ named `"scratch"`; callers disambiguate through the domain first, for example
 must be unique.
 
 `window_size` remains explicit, matching the current single-domain behavior.
-The runtime should not derive it from `sum(buffers.nbytes)` in the first PR.
-Bootstrap only validates that the declared buffers fit in the actual allocated
-window.
+The runtime should not derive it from `sum(buffers.nbytes)` in the initial
+implementation.  Bootstrap only validates that the declared buffers fit in the
+actual allocated window.
 
 The parent then derives the per-chip `ChipBootstrapConfig` list internally.
 Each chip child receives only the domains that the chip participates in:
@@ -555,11 +562,12 @@ chip_cfg = ChipBootstrapConfig(
 [
     ChipDomainBootstrapConfig(
         name="tp0",
+        sub_comm_id=0,
         domain_rank=0,
         domain_size=2,
         window_size=...,
         buffers=[...],
-        # backend-only sub-communicator construction metadata,
+        # backend-only base-window derivation metadata,
         # derived by the parent from CommDomainPlan
     ),
 ]
@@ -569,7 +577,8 @@ There should not be a second public domain config that users fill per chip.
 Users should not copy the whole `CommDomainPlan` into every chip config.  The
 parent is the only place that has the full worker list, so it is the right
 place to validate `worker_indices` and derive each chip child's `domain_rank`,
-`domain_size`, window layout, and active domain list.
+`domain_size`, window layout, internal backend identity, and active domain
+list.
 
 Conceptually, `CommDomainPlan` owns the derivation method:
 
@@ -587,47 +596,49 @@ class CommDomainPlan:
 The method filters domains that contain `worker_idx`.  For each match, it
 uses the position of `worker_idx` in `CommDomain.worker_indices` as
 `domain_rank`, uses `len(worker_indices)` as `domain_size`, copies the domain
-window size and symmetric buffer layout, and attaches any backend-only
-sub-communicator construction metadata.  The returned list is what the parent
+window size and symmetric buffer layout, and attaches backend-only
+base-window layout metadata.  The returned list is what the parent
 puts into `ChipBootstrapConfig(comm=...)` for that chip.
 
-If the HCCL sub-communicator backend needs the domain's participant list, that
-list is backend construction metadata in the derived chip config.  It is not a
-kernel-visible rank map and it is not exposed through `ChipCommDomainContext`.
-Kernel code communicates only with dense domain ranks.
+The public domain name is not the backend communicator identity.  The parent
+derives a deterministic internal numeric `sub_comm_id` for each domain, using
+sorted domain-name order.  The initial RMA path mainly needs the same sorted
+order to compute `window_offset`, while `sub_comm_id` remains available as an
+internal backend identity.  `ChipCommDomainContext` exposes the public name
+and domain-local rank information, not `sub_comm_id`.
+
+The domain participant list is backend construction metadata in the derived
+chip config.  It is not a kernel-visible rank map and it is not exposed
+through `ChipCommDomainContext`.  Kernel code communicates only with dense
+domain ranks.
 
 All domains are bootstrapped eagerly during `Worker.init()`.  After init
 returns, every active `ctx.domains[name]` is ready for L3 orchestration.  The
-first PR should not add lazy first-use communicator creation.
+initial implementation should not add lazy first-use communicator creation.
 
 ### Bootstrap Sequence
 
-The handoff from `CommDomainPlan` to chip-worker sub-communicators should be
+The handoff from `CommDomainPlan` to chip-worker domain bootstrap should be
 mechanical and one-way:
 
 ```text
 L3 Worker(comm_plan)
   validate CommDomainPlan against device_ids
-  derive chip_bootstrap_configs[i] =
+  derive internal chip bootstrap config for child i:
       ChipBootstrapConfig(
           comm=comm_plan.bootstrap_for_worker(worker_idx=i)
       )
-  fork chip child i with chip_bootstrap_configs[i]
+  fork chip child i with that derived config
         |
         v
 chip child i / ChipWorker.bootstrap_context()
   create hidden base communicator once, if comm_plan has any domains
       rank      = i
       rank_size = len(device_ids)
-      windows   = none
-  for each ChipDomainBootstrapConfig in sorted domain-name order:
-      sub = create_subcomm(
-          base,
-          rank_ids=domain.worker_indices,
-          sub_comm_rank_id=domain_rank,
-      )
-      device_ctx = comm_alloc_windows(sub, window_size)
-      local_base = comm_get_local_window_base(sub)
+  allocate one base window of base_window_size
+  for each active ChipDomainBootstrapConfig in sorted domain-name order:
+      derive domain CommContext from base context, rank_ids, and window_offset
+      local_base = base_local_window + domain.window_offset
       carve domain buffer_ptrs from local_base
       record ChipCommDomainContext(name, domain_rank, domain_size, ...)
   publish all domain contexts to the parent bootstrap mailbox
@@ -637,18 +648,24 @@ L3 parent _wait_for_bootstrap()
   assemble ChipContext(worker_index=i, domains={name: context})
 ```
 
-`ChipBootstrapConfig(comm=...)` is therefore not user-authored.  It is the
-per-chip, derived execution plan for the chip child.  The public plan remains
-`CommDomainPlan`; the derived config is just how the parent tells one chip
-which sub-communicators and windows to create.
+`ChipBootstrapConfig(comm=...)` is therefore not the public communication
+topology.  It is the per-chip, derived execution plan for the chip child.  In
+ordinary L3 usage the parent authors it internally from `CommDomainPlan`.  In
+explicit bootstrap usage, such as host staging, the caller may still construct
+`ChipBootstrapConfig` manually, but its `comm` list must be derived from the
+same parent plan with `plan.bootstrap_for_worker(worker_idx)`.
 
 The hidden base communicator is a control-plane object.  It has no exposed
 buffers, no `ChipCommDomainContext`, and no entry in `ctx.domains`.  It exists
-only so the backend can derive domain communicators from a common L3 rank
-space.  A chip that is not a member of a particular domain still joins the
-hidden base communicator when the L3 plan has communication domains, but it
-does not create that domain's sub-communicator, allocate that domain's window,
-or receive that domain's buffer metadata.
+only so the backend can expose one common L3 rank space and base window.  A
+chip that is not a member of a particular domain still joins the hidden base
+communicator when the L3 plan has communication domains, but it does not
+allocate that domain's window or receive that domain's buffer metadata.
+
+The visible contract is that non-members do not receive a domain session or a
+`ctx.domains[name]` entry.  They still join the hidden base communicator when
+the plan has any communication domain, because the base communicator is
+created over all chip children.
 
 The parent receives:
 
@@ -679,17 +696,16 @@ ChipCommDomainContext(
 
 `worker_index` is the same logical worker ID already used by
 `orch.submit_next_level(..., worker=i)`.  It also matches the index in
-`device_ids` and `chip_bootstrap_configs`.  The public multi-domain API should
-use this same indexing model instead of introducing a second worker reference
-mechanism.
+`device_ids` and the parent's internally derived bootstrap list.  The public
+multi-domain API should use this same indexing model instead of introducing a
+second worker reference mechanism.
 
 `worker_indices` belongs to the domain specification that the parent validates
 before bootstrap.  It should not be copied into every active domain context
 unless a later API needs to expose membership for host-side introspection.
 
-The old scalar fields on `ChipContext` should be replaced by domain lookups.
-Even single-domain code should use `ctx.domains["default"]` instead of
-`ctx.rank`, `ctx.nranks`, `ctx.device_ctx`, and `ctx.buffer_ptrs` directly.
+`ChipContext` exposes communication state only through domain lookups.  Even
+single-domain code uses `ctx.domains["default"]`.
 
 ## Mechanism 1: Domain Membership and Logical Rank
 
@@ -721,156 +737,132 @@ Host-side use:
 - validate that every participating chip has a unique domain rank;
 - validate that every worker index belongs to this L3 worker;
 - compute `domain_rank` from this worker's position in `worker_indices`;
-- skip sub-communicator and window creation on chips not in the domain.
+- publish no domain context or window on chips not in the domain.
 
 Kernel-side use is intentionally smaller: kernels communicate only in
 domain-rank coordinates.  They use `ctx->rankId`, `ctx->rankNum`, and peer
 domain ranks.  They do not need worker indices or a rank-map buffer.
 
-## Mechanism 2: Per-Domain Windows
+## Mechanism 2: Per-Domain Window Views
 
-Each domain owns its own communicator handle, stream, `CommContext`, and
-window allocation:
+Each domain owns an independent logical window view, not necessarily an
+independent HCCL MC2 allocation.  On hardware the bootstrap allocates one
+hidden base communicator window over all L3 chip children, then derives a
+small `CommContext` for each visible domain:
 
 ```text
-chip child
-  domain "tp0"
-    CommHandle h0
-    stream s0
-    CommContext* ctx0
-    window base b0
-    buffers: scratch, signals
+base CommContext over L3 workers
+  rankId  = worker index
+  rankNum = number of chip children
+  winSize = sum(domain.window_size for all domains)
+  windowsIn[worker] = base window for worker
 
-  domain "ep0"
-    CommHandle h1
-    stream s1
-    CommContext* ctx1
-    window base b1
-    buffers: send, recv, signals
+visible domain "tp0"
+  rankId  = domain_rank
+  rankNum = domain_size
+  winSize = tp0.window_size
+  windowsIn[d] = base.windowsIn[worker_indices[d]] + tp0.window_offset
+  buffers = slices inside the tp0 window view
+
+visible domain "ep0"
+  rankId  = domain_rank
+  rankNum = domain_size
+  winSize = ep0.window_size
+  windowsIn[d] = base.windowsIn[worker_indices[d]] + ep0.window_offset
+  buffers = slices inside the ep0 window view
 ```
 
-Windows should not be multiplexed across domains in the first PR, even when
-two domains have identical `worker_indices`.  Separate windows make these
-invariants simple:
+The offsets are deterministic and symmetric.  The parent sorts domain names
+and assigns each domain a range inside the base window.  All chips reserve
+the same total base-window size, even if a chip does not participate in every
+domain.  Non-participant chips do not publish a `ctx.domains[name]` entry.
 
-- `ctx->windowsIn[ctx->rankId]` is the base for exactly one domain;
-- byte offset `x - local_base` is meaningful only inside that domain;
-- signal slots cannot collide across domains;
-- teardown can release resources domain by domain.
+This keeps the kernel contract exactly domain-local:
+
+- `ctx->windowsIn[ctx->rankId]` is the local base for the selected domain;
+- byte offset `x - local_base` is meaningful only inside that domain view;
+- signal slots cannot collide because each domain occupies a disjoint base
+  window range;
+- each domain has its own device `CommContext*`, rank space, and buffer map.
 
 The Simpler runtime should not define cross-domain concurrency semantics.
-Its job is to pass isolated per-domain handles, contexts, and windows to the
+Its job is to pass isolated per-domain contexts and window slices to the
 kernel.  Whether two active domains make concurrent progress, contend for
 links, or serialize internally is HCCL/HCOMM backend behavior.
 
 The allocation order must be deterministic across ranks.  All chips should
-bootstrap domains in sorted domain-name order.  If a chip does not belong to a
-domain, it omits that domain from `ctx.domains` and does not create that
-domain's sub-communicator or windows.  It also receives no buffer layout
+derive offsets from sorted domain-name order.  If a chip does not belong to a
+domain, it omits that domain from `ctx.domains` and receives no buffer layout
 metadata for that domain.
 
-## Proposed Backend API
+## Backend Path
 
-The current 5-function C ABI is not enough for the sub-communicator path.
-`comm_init()` can still create the hidden base communicator for the L3 chip
-set, but each domain also needs a derived sub-communicator before
-`comm_alloc_windows()` can build a domain-local `CommContext`.
+`comm_init()` creates the hidden base communicator for the L3 chip set.
+`comm_alloc_windows(base, base_window_size)` allocates one base MC2/shared
+window per chip.  `ChipWorker.bootstrap_context()` then derives visible
+domain contexts from the base `CommContext`; it does not call
+`HcclAllocComResourceByTiling` on overlapping domain sub-communicators.
 
-That means Simpler needs one explicit domain-creation step in the backend
-path, either as a new C ABI entry point or as a dedicated method on
-`ChipWorker`.  Conceptually the flow becomes:
+Conceptually the flow is:
 
-```cpp
+```text
 base handle from comm_init()
-  -> per-domain subcomm creation from ChipDomainBootstrapConfig
-  -> comm_alloc_windows(subcomm_handle, window_size)
-  -> CommContext* + local window base
+  -> comm_alloc_windows(base, total_base_window_size)
+  -> copy/read base CommContext on the host
+  -> for each active ChipDomainBootstrapConfig:
+       build domain-local CommContext with dense domain ranks
+       write that CommContext to device memory
+       carve named buffers from base local window + window_offset
 ```
 
-The derived `ChipDomainBootstrapConfig` is the right place to carry the
-backend-only inputs for that step:
+The derived `ChipDomainBootstrapConfig` carries the backend-only inputs for
+that step:
 
 ```cpp
 struct ChipDomainBootstrapConfig {
     std::string name;
+    uint64_t sub_comm_id;             // deterministic domain identity
     std::vector<uint32_t> rank_ids;   // domain membership in L3 worker order
-    uint32_t sub_comm_rank_id;        // this chip's dense rank in the domain
+    uint32_t domain_rank;             // this chip's dense rank in the domain
     size_t window_size;
+    size_t window_offset;             // offset inside the hidden base window
+    size_t base_window_size;          // same on every chip in the L3 plan
     std::vector<ChipBufferSpec> buffers;
 };
 ```
 
-`HcclCreateSubCommConfig` is the backend API that matches this shape best:
-it takes a global communicator, the selected rank list, and the dense
-sub-communicator rank for the local chip.  The HCCL sub-rank-table creation
-path assigns sub-rank IDs from the supplied `rank_ids` order, which matches
-Simpler's rule that `worker_indices` order defines `domain_rank`.  Simpler
-should call this directly rather than routing the design through
-`HcomCreateGroup`, because that helper sorts rank IDs while building group
-metadata.  It is a registry and lookup layer, not the conceptual API for
-user-defined rank ordering.
-
-`ChipWorker` changes from:
-
-```text
-void *comm_stream_;
-one active CommHandle accepted by caller
-```
-
-to:
-
-```text
-std::vector<ActiveCommSession> comm_sessions_;
-lookup by name or returned handle
-```
-
-The C API still returns opaque `CommHandle`s.  The Python-facing bootstrap API
-should not expose raw handles; it should expose domain contexts.  The hidden
-base communicator should never be visible in `ctx.domains`.
-
 The public domain config does not need a `rootinfo_path`.  Root-info files are
 a backend bootstrap transport detail for the hidden base communicator.  The
-multi-domain design should use a sub-communicator path:
+visible domains are derived from the parent `CommDomainPlan`, not from
+independent root-info exchanges.
 
-```text
-internal base HcclComm over the L3 chip children
-  -> HcclCreateSubCommConfig(worker_indices, domain_rank)
-  -> domain subcomm handle
-  -> HcclAllocComResourceByTiling(domain subcomm)
-```
+The implementation still keeps `comm_create_subcomm` available as a low-level
+backend capability because HCCL sub-communicators are useful for future
+collective or resource paths.  The initial PTO-ISA/HCOMM RMA path should not
+allocate MC2 resources on each overlapping sub-communicator because the HCCL
+old AICPU MC2 init path accepts only one active hcomId per process.  Base
+window slicing avoids that limitation while preserving domain-local kernel
+semantics.
 
-This path matches the shape of `CommDomain`: `worker_indices` is exactly a
-group list in the parent communicator, and the position in that list is
-exactly the dense domain rank.  It avoids running an independent root-info
-exchange for every domain, keeps one internal rendezvous for the L3 chip set,
-and matches the ProcessGroup/NCCL style used by NVIDIA stacks.
+Independent root-info communicators and sub-communicators are not needed for
+the first PTO-ISA RMA implementation:
 
-If the backend wants to register the sub-communicator by group name, that
-lookup remains an internal implementation detail.  The design does not depend
-on it.
+- independent root-info would exchange one `HcclRootInfo` per visible domain
+  and create unrelated communicators for overlapping subsets;
+- sub-communicators would derive HCCL group communicators from a base
+  communicator, but would still need a separate MC2 window allocation if used
+  as the visible RMA resource;
+- base-window slicing creates one backend window and then derives
+  kernel-visible domain contexts from rank selection and byte offsets.
 
-Independent root-info communicators and sub-communicators differ only in the
-backend bootstrap route:
-
-- independent root-info: each domain exchanges its own `HcclRootInfo` and
-  creates a standalone communicator whose rank space is already the domain;
-- sub-communicator: the runtime creates one internal base communicator, then
-  asks HCCL to derive group communicators from selected base ranks.
-
-The sub-communicator route is the better first target here because the L3
-parent already knows every chip child and every `CommDomainPlan`.  Repeating
-root-info exchange per domain would recreate global coordination that the
-parent already has, and it would make overlapping domains look unrelated to
-the backend even though they are all subsets of the same L3 chip set.
-
-Both routes would expose the same `ChipCommDomainContext` and `CommContext`
-shape to L3 and PTO-ISA kernels.  Choosing sub-communicators is therefore a
-backend construction decision, not a kernel ABI decision.
+All three routes can produce the same `ChipCommDomainContext` shape.  The
+first implementation chooses base-window slicing because it matches the
+PTO-ISA kernel ABI and avoids repeated overlapping MC2 allocations.
 
 ### Why No Exposed Meta Domain
 
-The first PR should not expose an allocated meta communication domain just to
-mirror PyTorch/NCCL's WORLD process group.
+The initial implementation should not expose an allocated meta communication
+domain just to mirror PyTorch/NCCL's WORLD process group.
 
 NVIDIA's stack needs a global process group because multiple OS processes are
 launched independently and need a rendezvous space before frameworks can make
@@ -887,24 +879,47 @@ A meta domain would add costs without serving the PTO-ISA kernel contract:
 - it would not remove the need to create per-domain windows, because each
   data domain needs independent `CommContext` and buffer layout.
 
-The base HCCL communicator is still an internal backend detail for the
-sub-communicator path, but it should not appear in `ctx.domains`, allocate
-exposed windows, or expose buffers to kernels.  It is only a control-plane
-parent used to derive the real data domains.
+The base HCCL communicator is still an internal backend detail.  It should
+not appear in `ctx.domains` or expose buffers to kernels.  Its window is
+allocated once and sliced into the visible data domains.
 
 ## Proposed Python API
 
-The public L3 constructor should accept one global domain plan, while
-`ChipBootstrapConfig` remains the per-chip object sent to chip children.
+The normal public L3 constructor accepts one global domain plan.
+`ChipBootstrapConfig` remains the per-chip object sent to chip children.  It
+may be derived automatically by the parent from that plan, or supplied
+explicitly when a caller needs per-chip bootstrap details such as host staging.
 
 The user-facing input is a `CommDomainPlan` built from `CommDomain` entries,
-for example `comm_plan=CommDomainPlan(domains=[...])`.  Top-level per-chip
-`buffers=` is removed from the new communication API; each domain declares
-its own symmetric buffers.  The old single-domain
-`ChipCommBootstrapConfig + buffers` shape is not preserved.
+for example `comm_plan=CommDomainPlan(domains=[...])`.  Each domain declares
+only symmetric communication properties: membership, window size, and buffer
+layout.
 
 `comm_plan=None` and `CommDomainPlan(domains=[])` both mean no communication
 domains.  In that mode there are no domain windows and no domain buffers.
+
+### Public Surface Boundary
+
+The new API is one surface, not a compatibility layer around the old
+single-domain bootstrap list.
+
+At L3 and above, the source of truth for communication topology is always
+`CommDomainPlan`.  Users should not write rank IDs, root-info paths, or old
+single-domain bootstrap objects by hand.  `ChipCommBootstrapConfig` is not a
+public API.
+
+There are two valid construction paths:
+
+- `Worker(comm_plan=plan)` for ordinary cases.  The parent derives one
+  `ChipBootstrapConfig` per chip.
+- `Worker(chip_bootstrap_configs=cfgs)` for cases that need per-chip bootstrap
+  data.  Each `cfg.comm` must still come from
+  `plan.bootstrap_for_worker(worker_idx)`.
+
+The explicit path exists for host staging.  `HostBufferStaging` contains a
+concrete `SharedMemory` name, so it is naturally per-chip and sometimes
+asymmetric.  That does not belong in `CommDomain`, which describes symmetric
+domain membership and window layout.
 
 Single-domain spelling:
 
@@ -952,14 +967,83 @@ worker = Worker(
 )
 ```
 
+Host-staged single-domain spelling:
+
+```python
+counter_shm = SharedMemory(create=True, size=4)
+counter_shm.buf[:4] = b"\x00\x00\x00\x00"
+
+plan = CommDomainPlan(
+    domains=[
+        CommDomain(
+            name="default",
+            worker_indices=[0, 1],
+            window_size=window_size,
+            buffers=[
+                ChipBufferSpec(
+                    name="notify_counter",
+                    dtype="int32",
+                    count=1,
+                    nbytes=4,
+                    load_from_host=True,
+                ),
+            ],
+        ),
+    ],
+)
+
+cfg = ChipBootstrapConfig(
+    comm=plan.bootstrap_for_worker(worker_idx=0),
+    host_inputs=[
+        HostBufferStaging(
+            domain_name="default",
+            name="notify_counter",
+            shm_name=counter_shm.name,
+            size=4,
+        ),
+    ],
+)
+```
+
 Inside `Worker.init()`, the parent converts `comm_plan` into one
 `ChipBootstrapConfig` per chip child.  For chip worker `i`, that derived config
 contains a `ChipDomainBootstrapConfig` only for domains whose
 `worker_indices` list contains `i`.  The derived config records this chip's
-`domain_rank`, `domain_size`, window size, and buffer layout.  It may also
-carry backend construction metadata needed to create the HCCL sub-communicator,
-but the chip result published back to the parent should expose only the
-domain-local context.
+`domain_rank`, `domain_size`, window size, buffer layout, and internal
+`sub_comm_id`.  It also carries rank IDs and base-window layout metadata
+needed to derive the domain-local `CommContext`.  The chip result published
+back to the parent exposes only the domain-local context.
+
+If host staging is used for communication-window buffers, staging entries live
+on the per-chip `ChipBootstrapConfig` and must be domain-scoped.  The key is
+`(domain_name, buffer_name)`, not just `buffer_name`, because two domains may
+both define a buffer named `"scratch"`.  The child should match host input and
+output staging against the active `ChipDomainBootstrapConfig` and that
+domain's buffer specs.
+
+Host staging is not a second communication mechanism.  It is parent-to-chip
+initialization and chip-to-parent readback for buffers that live inside a
+communication window.
+
+`load_from_host=True` means:
+
+```text
+parent creates SharedMemory and fills bytes
+  -> child attaches by shm_name during bootstrap
+  -> child copies those bytes into this chip's domain-local window buffer
+```
+
+`store_to_host=True` means:
+
+```text
+kernel writes a domain-local window buffer
+  -> child copies the buffer back to parent SharedMemory after a task
+  -> parent reads the bytes from that SharedMemory
+```
+
+This is useful for examples such as notify-counter initialization or
+window-resident inputs.  Explicit configs are valid only in the new shape:
+`ChipBootstrapConfig(comm=plan.bootstrap_for_worker(i), ...)`.
 
 L3 orchestration chooses the domain explicitly:
 
@@ -984,6 +1068,34 @@ participate in the domain.  If the worker is not a member, normal dictionary
 lookup raises `KeyError`; that is the desired fail-fast behavior.  Code that
 intentionally handles optional participation can use `"tp" in ctx.domains`
 before submitting a TP-domain task.
+
+Overlapping domains show why this API is not just a renamed single-domain
+context:
+
+```python
+comm_plan = CommDomainPlan(
+    domains=[
+        CommDomain(
+            name="tp",
+            worker_indices=[0, 1],
+            window_size=tp_window,
+            buffers=[ChipBufferSpec("scratch", ...)],
+        ),
+        CommDomain(
+            name="pp",
+            worker_indices=[1, 2],
+            window_size=pp_window,
+            buffers=[ChipBufferSpec("scratch", ...)],
+        ),
+    ],
+)
+```
+
+Worker 1 receives both `ctx.domains["tp"]` and `ctx.domains["pp"]`.  It is
+rank 1 in `tp` but rank 0 in `pp`, and each domain has its own
+`device_ctx`, window base, and `"scratch"` pointer.  Worker 0 has only `tp`;
+worker 2 has only `pp`.  Looking up a non-member domain, such as
+`worker0_ctx.domains["pp"]`, raises the normal dictionary `KeyError`.
 
 ## Kernel Contract
 
@@ -1041,11 +1153,11 @@ The parent should validate before forking:
 
 The child should validate during bootstrap:
 
-- the base communicator is created before any domain sub-communicator;
+- the base communicator is created before any domain context is derived;
 - each domain entry in the derived config is active for this chip;
 - non-member chips do not receive that domain entry;
-- sub-communicator creation returns a non-null domain handle;
-- `comm_alloc_windows` returned a non-null `CommContext*`;
+- `comm_alloc_windows` returned a non-null base `CommContext*`;
+- domain context derivation returns a non-null `CommContext*`;
 - every named buffer fits in `actual_window_size`;
 - the returned `ctx->rankId` and `ctx->rankNum` match the derived
   `domain_rank` and domain size.
@@ -1061,9 +1173,8 @@ The kernel should validate cheap invariants:
 Teardown should run in reverse bootstrap order:
 
 ```text
-for domain in reversed(active_domains):
-    comm_destroy(domain.handle)
-    destroy domain stream
+release derived domain contexts
+comm_destroy(base handle)
 finalize ChipWorker
 ```
 
@@ -1083,16 +1194,21 @@ The caller should receive the first error after best-effort cleanup completes.
 4. Update `ChipBootstrapConfig` so its `comm` field contains derived
    per-chip domain bootstrap configs, not public `CommDomain` objects.
 5. Remove top-level `buffers` from the new communication API.
-6. Add backend support for creating HCCL sub-communicators from the hidden
-   base communicator and each domain's `rank_ids` / `sub_comm_rank_id`.
-7. Change `ChipWorker` from one active stream to a session table.
+6. Add backend support for one hidden base window and derived domain
+   `CommContext` objects from each domain's `rank_ids` / `domain_rank`.
+7. Change `ChipWorker` to own one hidden base session plus derived domain
+   contexts.
 8. Extend bootstrap mailboxes/results to publish a map of domain contexts
    instead of one scalar `rank/nranks/device_ctx`.
-9. Update one L3 example to use `ctx.domains["default"]`.
-10. Add a two-domain smoke example where the same worker indices use two
-    windows and kernels prove that data and signals do not cross domains.
-11. Add tests for validation, single-domain migration, sim multi-domain
-    windows, and hardware HCCL context fields.
+9. Migrate every communication-domain example to `comm_plan`, including
+   notification and SDMA examples that use host staging.
+10. Update L3 one-domain examples to use `ctx.domains["default"]`.
+11. Add a tiny multi-domain rank-map example that exercises domain
+    membership, missing-domain lookup, and domain-local ranks.
+12. Add a two-domain data example where overlapping domains run real
+    communication, computation, and golden checks.
+13. Add tests for validation, the one-domain `CommDomainPlan` case, sim
+    multi-domain windows, and hardware HCCL context fields.
 
 ## Open Questions
 

--- a/docs/multi-comm-domain.md
+++ b/docs/multi-comm-domain.md
@@ -1,0 +1,1101 @@
+# Multi-Communication-Domain Design
+
+This document describes how Simpler currently wires one communication domain
+from L3 workers down to PTO-ISA kernels, then proposes an extension for
+multiple communication domains.
+
+The design scope is intentionally narrow:
+
+- use HCOMM/HCCL only to create communication resources and windows;
+- use PTO-ISA kernels for all data movement and synchronization;
+- do not call HCCL collective kernels such as `HcclAllReduce`;
+- make rank mapping and per-domain windows explicit.
+
+## Source Map
+
+The design is based on these implementation points:
+
+| Area | Files |
+| ---- | ----- |
+| Python API | `python/simpler/task_interface.py` |
+| L3 examples | `examples/workers/l3/*/main.py` |
+| Kernel examples | `examples/workers/l3/*/kernels/aiv/*.cpp` |
+| Chip worker | `src/common/worker/chip_worker.{h,cpp}` |
+| Comm ABI | `src/common/platform_comm/comm.h` |
+| Device context | `src/common/platform_comm/comm_context.h` |
+| Sim backend | `src/common/platform_comm/comm_sim.cpp` |
+| Hardware backend | `src/a2a3/platform/onboard/host/comm_hccl.cpp` |
+| PTO-ISA comm | PTO-ISA `include/pto/comm/` |
+| HCCL/HCOMM | CANN HCCL `inc/hccl/` and `src/` |
+
+The PTO-ISA and CANN HCCL source trees are design references only.  The
+proposed Simpler path relies on HCCL/HCOMM setup APIs such as
+`HcclCommInitRootInfo`, `HcomGetCommHandleByGroup`,
+`HcclAllocComResourceByTiling`, and `HcclCreateSubCommConfig`.
+Data movement remains in PTO-ISA kernels through address-based instructions
+such as `TPUT`, `TGET`, `TNOTIFY`, and `TWAIT`.
+
+## Why Domains
+
+A communication domain is the set of ranks that can address each other's
+window slots through one `CommContext`.
+
+The current examples use one domain:
+
+```text
+domain "world"
+  group ranks: 0, 1
+  per-rank window: scratch
+  device context: CommContext*
+```
+
+Multi-domain support lets one L3 worker tree describe several overlapping or
+disjoint groups:
+
+```text
+worker indices:    0        1        2        3
+
+domain "tp":       0 ------ 1        0 ------ 1
+                  group A            group B
+
+domain "ep":       0 --------------- 1
+                            0 --------------- 1
+```
+
+Each domain needs two independent pieces of state:
+
+- rank mapping: who am I in this domain, and which peer slot should I use?
+- window state: which shared window and `CommContext*` belong to this domain?
+
+## NVIDIA Stack Comparison
+
+The surveyed NVIDIA path separates semantic domains from communicator
+resources:
+
+```text
+Megatron parallel strategy
+  -> TP / DP / PP / CP / EP rank groups
+  -> PyTorch ProcessGroup objects
+  -> NCCL communicators
+  -> NCCL collective or P2P kernels on CUDA streams
+```
+
+The useful mapping for Simpler is:
+
+| NVIDIA stack | Simpler proposal |
+| ------------ | ---------------- |
+| global rank from launcher | L3 `worker=i` index |
+| Megatron TP/DP/PP group | `CommDomain(name, worker_indices)` |
+| PyTorch `ProcessGroup` | `ChipCommDomainContext` exposed to L3 |
+| NCCL communicator | HCCL/HCOMM communicator handle |
+| NCCL group-local rank | `CommContext.rankId` / `domain_rank` |
+| NCCL group size | `CommContext.rankNum` / `domain_size` |
+| NCCL collective kernel | PTO-ISA kernel using `TPUT`/`TGET`/signals |
+| NCCL stream scheduling | Simpler L3 orchestration and chip tasks |
+
+The divergence is intentional.  NVIDIA's stack usually hides data movement
+inside NCCL collectives such as AllReduce or ReduceScatter.  This design does
+not call HCCL collectives.  HCCL/HCOMM only creates a per-domain communicator
+and registered windows; PTO-ISA kernels implement the actual protocol.
+
+Two lessons carry over directly:
+
+- domain membership should be explicit and stable before communicator setup;
+- each domain should own an independent communicator resource, so TP-like and
+  EP-like traffic do not accidentally share rank numbering, windows, or signal
+  slots.
+
+## Current Single-Domain Implementation
+
+This section traces the current single communication domain from L3 Python
+workers to PTO-ISA kernels.
+
+### End-To-End Path
+
+```text
+Python L3 user code
+  ChipBootstrapConfig(comm=ChipCommBootstrapConfig(...), buffers=[scratch])
+        |
+        v
+Worker(level=3)
+  forks one chip child per device
+        |
+        v
+chip child / ChipWorker
+  comm_init(rank, nranks, rootinfo_path)
+  comm_alloc_windows(window_size)
+  comm_get_local_window_base()
+        |
+        v
+ChipContext exposed to L3 orchestration
+  rank, nranks, device_ctx, local_window_base, buffer_ptrs["scratch"]
+        |
+        v
+TaskArgs to each chip task
+  tensor: scratch pointer in child memory
+  scalar: nranks
+  scalar: CommContext*
+        |
+        v
+AIV/AIC kernel
+  ctx->rankId, ctx->rankNum, ctx->windowsIn[peer]
+  PTO-ISA TPUT/TGET/TNOTIFY/TWAIT on derived addresses
+```
+
+The `CommContext` data is installed before any kernel launch.  It is not
+assembled by the kernel and it is not passed field by field:
+
+1. `comm_alloc_windows()` asks the platform backend to allocate communication
+   resources and per-rank windows.
+2. The backend fills a `CommContext` with `rankId`, `rankNum`, `winSize`,
+   `windowsIn[]`, and `windowsOut[]`.
+3. The backend returns the address of that `CommContext` through
+   `device_ctx_out`.
+4. `ChipWorker.bootstrap_context()` stores that integer as
+   `ChipContext.device_ctx`.
+5. L3 orchestration passes `ctx.device_ctx` as a scalar task argument.
+6. The AIV/AIC kernel casts that scalar back to `__gm__ CommContext *`.
+
+On hardware, `device_ctx_out` is a real device address.  For MESH topology,
+HCCL may return a device context directly.  For RING topology, Simpler parses
+HCCL's resource structure on the host, fills this repo's `CommContext`, copies
+it to device memory with `aclrtMemcpy`, then returns that device pointer.  On
+sim, `device_ctx_out` points to the process-local `host_ctx`; sim kernels
+dereference that process-local context while the window data itself lives in a
+shared mmap segment.
+
+There are two different kinds of access:
+
+- reading `ctx->rankId`, `ctx->rankNum`, and `ctx->windowsIn[i]` reads the
+  local `CommContext` object for this chip;
+- using `ctx->windowsIn[peer] + offset` accesses a peer's registered
+  communication window.
+
+The second access is only valid because HCCL/HCOMM allocated and registered
+those windows as communication resources.  The addresses in `windowsIn[]` are
+not arbitrary remote pointers.  Kernels should use them through PTO memory or
+communication instructions such as `TLOAD`, `TPUT`, `TNOTIFY`, and `TWAIT`.
+
+For MESH, HCCL's returned device context already has the compatible
+`CommContext` layout, so the kernel can read the context in place.  The peer
+window addresses inside it are device-visible communication-window addresses.
+For RING, HCCL returns a different resource shape.  Simpler copies only a
+small, normalized `CommContext` to device memory during bootstrap.  That copy
+is not on the kernel hot path; kernels reuse the same device context pointer
+for all later task launches in that communication session.
+
+The key invariant is offset preservation.  L3 passes one local window pointer
+and one `CommContext*`; the kernel derives peer pointers by applying the same
+window offset to another rank's window base:
+
+```cpp
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(
+    __gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+```
+
+The single-domain contract is:
+
+- `ctx->rankId` is this chip's rank in the domain.
+- `ctx->rankNum` is the domain size.
+- `ctx->windowsIn[i]` addresses rank `i` in that same domain.
+- every rank uses the same window layout.
+- the same byte offset names the same logical buffer on every rank.
+
+The `scratch` buffer is a named slice of each rank's communication window.
+It is not special to HCCL; it is an example-owned mailbox area carved from
+`local_window_base`.  Kernels use it for temporary communication state:
+
+- payload staging, such as copying local input into `scratch` so peers can
+  read it;
+- peer mailboxes, such as one slot per source rank in TP all-reduce;
+- signal slots used by `TNOTIFY` and `TWAIT`.
+
+The important property is symmetry.  If `scratch` starts at offset `0` in
+rank 0's window, it also starts at offset `0` in every other rank's window.
+That lets a kernel compute the peer address from a local pointer:
+
+```text
+local scratch pointer -> offset from my window base
+peer scratch pointer  -> peer window base + same offset
+```
+
+`CommContext` alone is not enough for a kernel to find `scratch`.  It only
+knows whole-window bases:
+
+```text
+ctx->windowsIn[0] = base of rank 0's whole window
+ctx->windowsIn[1] = base of rank 1's whole window
+```
+
+It does not know the example's layout inside that window:
+
+```text
+window base + 0x0000: scratch payload
+window base + 0x4000: signal slots
+window base + 0x5000: recv buffer
+```
+
+Passing `scratch` tells the kernel which local sub-buffer to use.  Then
+`CommRemotePtr()` maps that same sub-buffer to another rank:
+
+```text
+local scratch = ctx->windowsIn[my_rank] + 0x0000
+peer scratch  = ctx->windowsIn[peer]    + 0x0000
+```
+
+If the kernel needs the signal area, it starts from a local signal pointer and
+maps that pointer instead:
+
+```text
+local signal = scratch + signal_offset
+peer signal  = CommRemotePtr(ctx, local signal, peer)
+```
+
+So `scratch` names the local logical buffer.  `CommRemotePtr()` does not move
+data by itself; it only converts a local window pointer into the peer pointer
+at the same offset.  PTO instructions then use those pointers to read, write,
+or synchronize.
+
+### L3 Integration
+
+Today, L3 owns one `ChipBootstrapConfig` per chip.  Examples such as
+`examples/workers/l3/allreduce_distributed/main.py` declare:
+
+- `ChipCommBootstrapConfig(rank, nranks, rootinfo_path, window_size)`;
+- one or more `ChipBufferSpec` entries, usually a `scratch` window;
+- optional host staging information.
+
+Current single-domain window sizing is explicit.  The example computes a
+requested `window_size`, usually `max(sum(buffer nbytes), floor)`, and passes
+it to `comm_alloc_windows()`.  After allocation, the child asks the backend
+for `actual_window_size`, because HCCL may round the request.  Named buffers
+are then carved sequentially from `local_window_base`; bootstrap fails if any
+buffer would exceed `actual_window_size`.
+
+`Worker.init()` forks chip children and waits until each child publishes a
+`ChipBootstrapResult`.  The parent turns those results into
+`worker.chip_contexts`.
+
+An L3 orchestration function consumes a context like this:
+
+```python
+ctx = worker.chip_contexts[i]
+
+chip_args.add_tensor(
+    ContinuousTensor.make(
+        data=ctx.buffer_ptrs["scratch"],
+        shapes=(scratch_count,),
+        dtype=DataType.FLOAT32,
+        child_memory=True,
+    ),
+    TensorArgType.INOUT,
+)
+chip_args.add_scalar(ctx.nranks)
+chip_args.add_scalar(ctx.device_ctx)
+orch.submit_next_level(chip_cid, chip_args, cfg, worker=i)
+```
+
+The tensor is marked `child_memory=True` because it is already a device/window
+pointer owned by the chip child.  The framework must not stage it through host
+memory.
+
+`ContinuousTensor` is the compact tensor argument format used by the
+orchestration runtime.  It contains:
+
+- `data`: the base address;
+- `shapes`: up to five tensor dimensions;
+- `dtype`: element type, used to compute byte size;
+- `child_memory`: whether `data` is already memory owned by the chip child.
+
+The scratch window is passed as a `ContinuousTensor` instead of a scalar
+because kernels need a normal `Tensor` descriptor: `buffer.addr`,
+`start_offset`, shape, dtype, and dependency tags.  The orchestration shim
+converts it with `from_tensor_arg()`, then the AIV/AIC kernel reaches the
+pointer through:
+
+```cpp
+__gm__ Tensor *scratch_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+__gm__ float *scratch =
+    reinterpret_cast<__gm__ float *>(scratch_tensor->buffer.addr) +
+    scratch_tensor->start_offset;
+```
+
+`ctx.device_ctx` is different: it is not a tensor buffer that participates in
+scheduling, staging, or shape-aware access.  It is only an opaque
+`CommContext*`, so it is passed as a scalar.
+
+### L2 Integration
+
+The chip child owns one `ChipWorker`.  During bootstrap it runs:
+
+```text
+ChipWorker.init(device_id, bins)
+ChipWorker.bootstrap_context(device_id, cfg, channel)
+  comm_init()
+  comm_alloc_windows()
+  carve named buffer pointers from local_window_base
+  optional H2D staging into window slices
+```
+
+The current C++ `ChipWorker` enforces one active communication session:
+
+```text
+comm_stream_ != nullptr -> "a comm session is already active"
+```
+
+That guard is correct for the old model.  Multi-domain support must replace it
+with a per-domain session table.
+
+### Platform Backend
+
+The backend-neutral C API is:
+
+```cpp
+CommHandle comm_init(int rank, int nranks, void *stream,
+                     const char *rootinfo_path);
+int comm_alloc_windows(CommHandle h, size_t win_size,
+                       uint64_t *device_ctx_out);
+int comm_get_local_window_base(CommHandle h, uint64_t *base_out);
+int comm_get_window_size(CommHandle h, size_t *size_out);
+int comm_barrier(CommHandle h);
+int comm_destroy(CommHandle h);
+```
+
+In the current single-domain API, `rootinfo_path` is a filesystem rendezvous
+key for communicator bootstrap.  It is not the communication window, and it
+is not read by kernels.  It only lets all chip child processes agree on the
+same HCCL communicator identity before `comm_alloc_windows()` creates the
+device-side `CommContext`.
+
+The hardware flow is:
+
+```text
+rank 0:
+  HcclGetRootInfo()
+  write HcclRootInfo bytes to rootinfo_path
+
+rank 1..N-1:
+  wait until rootinfo_path exists
+  read the same HcclRootInfo bytes
+
+all ranks:
+  file barrier "rootinfo_ready"
+  HcclCommInitRootInfo(nranks, rootInfo, rank)
+  later, file barrier "hccl_init"
+  HcclAllocComResourceByTiling(...)
+```
+
+So `rootinfo_path` currently carries two responsibilities:
+
+- root-info exchange: rank 0 publishes the opaque `HcclRootInfo` token that
+  all ranks pass to `HcclCommInitRootInfo`;
+- bootstrap synchronization: the same path prefixes small barrier files so
+  ranks do not allocate communication resources before every rank has
+  initialized HCCL.
+
+On simulation, there is no HCCL root info.  `comm_sim.cpp` still accepts
+`rootinfo_path`, but only uses it to derive a deterministic POSIX shared
+memory name.  That shared-memory segment then holds the sim windows for all
+ranks.
+
+On hardware, `comm_hccl.cpp` uses HCCL/HCOMM resources:
+
+- `HcclCommInitRootInfo` creates the communicator.
+- `HcomGetCommHandleByGroup` resolves the HCOMM handle.
+- `HcclAllocComResourceByTiling` creates communication resources and windows.
+- MESH topology can return a device `CommContext` directly.
+- RING topology is parsed into this repo's `CommContext` and copied to
+  device.
+
+On sim, `comm_sim.cpp` creates one POSIX shared-memory segment:
+
+```text
+[ header ][ rank 0 window ][ rank 1 window ] ...
+```
+
+The sim `CommContext` points to each rank's local mmap view of every peer
+slot.  Numeric addresses need not match across processes, but each process's
+own `CommContext` remains valid.
+
+### PTO-ISA Use
+
+PTO-ISA communication APIs are address based.  `TPUT`, `TGET`, `TNOTIFY`, and
+`TWAIT` receive `GlobalTensor` or `Signal` objects whose pointers already
+encode the target.
+
+PTO-ISA does not know the domain name.  The domain is selected before the
+PTO-ISA call, when the kernel chooses:
+
+- which `CommContext*` to read;
+- which local window pointer to offset from;
+- which peer rank index to use.
+
+This means synchronous PTO-ISA APIs do not need to change for multiple
+domains.  Simpler must pass the correct context, window, and mapping into
+kernels.
+
+### Existing Example Patterns
+
+`allreduce_distributed` uses one scratch window:
+
+```text
+input/output: host-backed per-rank tensors
+scratch:      HCCL window
+scalars:      nranks, CommContext*
+kernel:       stage local input into scratch, notify, TLOAD peer scratch
+```
+
+`ffn_tp_parallel` chains two L2 tasks per rank:
+
+```text
+stage 1: local AIC matmul writes partial_local
+stage 2: AIV reduce reads partial_local and uses scratch window for exchange
+```
+
+`ep_dispatch_combine` uses a larger window layout:
+
+```text
+pub_counts | signals | recv_x | recv_w | recv_idx | signals |
+routed_y_buf | signals
+```
+
+All three examples use the same domain mechanism: one `CommContext*`, one
+per-rank window, and kernel-side offset translation.
+
+## Proposed Runtime Model
+
+Keep the split between parent-level planning and per-chip bootstrap explicit.
+The communication-domain plan is a single L3-level object.  It is not copied
+into every chip's `ChipBootstrapConfig`.
+
+The public L3 input is one `CommDomainPlan` object.  The plan contains a list
+of `CommDomain` objects:
+
+```python
+comm_plan = CommDomainPlan(
+    domains=[
+        CommDomain(
+            name="tp0",
+            worker_indices=[0, 1],
+            window_size=...,
+            buffers=[
+                ChipBufferSpec(name="scratch", nbytes=...),
+                ChipBufferSpec(name="signals", nbytes=...),
+            ],
+        ),
+    ],
+)
+```
+
+`CommDomain` describes one domain: membership, logical rank order, window
+size, and named buffer layout.  `CommDomainPlan` is the public source of truth
+for the whole L3 worker.  The parent validates this plan before forking chip
+children.
+
+The domain name is the user-facing identity.  L3 orchestration looks up
+domains by name, for example `ctx.domains["tp"]`.  The public plan should not
+expose a numeric domain identifier in the first PR.  If the backend needs
+numeric IDs, the parent can assign them internally from sorted domain names.
+Names only need to be non-empty and unique; the API should not impose
+identifier-style spelling rules.
+
+The order of `worker_indices` defines domain rank.  For
+`worker_indices=[2, 3]`, worker `2` is domain rank `0`, and worker `3` is
+domain rank `1`.  The plan should not also carry explicit per-worker rank
+IDs.
+
+The buffer layout is symmetric for every participant in the domain.  A buffer
+name, size, and byte offset must mean the same thing on every domain rank.
+This is required because kernels translate local pointers to peer pointers by
+preserving the byte offset within the per-rank window.
+
+Buffer names are scoped to one domain.  Two domains may both define a buffer
+named `"scratch"`; callers disambiguate through the domain first, for example
+`ctx.domains["tp"].buffer_ptrs["scratch"]`.  Within one domain, buffer names
+must be unique.
+
+`window_size` remains explicit, matching the current single-domain behavior.
+The runtime should not derive it from `sum(buffers.nbytes)` in the first PR.
+Bootstrap only validates that the declared buffers fit in the actual allocated
+window.
+
+The parent then derives the per-chip `ChipBootstrapConfig` list internally.
+Each chip child receives only the domains that the chip participates in:
+
+```text
+L3 plan:
+  CommDomain("tp0", worker_indices=[0, 1])
+  CommDomain("ep0", worker_indices=[1, 3])
+
+derived chip bootstrap configs:
+  worker 0:
+    domain "tp0": domain_rank=0, domain_size=2
+  worker 1:
+    domain "tp0": domain_rank=1, domain_size=2
+    domain "ep0": domain_rank=0, domain_size=2
+  worker 2:
+    no domains
+  worker 3:
+    domain "ep0": domain_rank=1, domain_size=2
+```
+
+The derived per-chip config should be concise:
+
+```python
+chip_cfg = ChipBootstrapConfig(
+    comm=comm_plan.bootstrap_for_worker(worker_idx=0),
+)
+
+# chip_cfg.comm contains:
+[
+    ChipDomainBootstrapConfig(
+        name="tp0",
+        domain_rank=0,
+        domain_size=2,
+        window_size=...,
+        buffers=[...],
+        # backend-only sub-communicator construction metadata,
+        # derived by the parent from CommDomainPlan
+    ),
+]
+```
+
+There should not be a second public domain config that users fill per chip.
+Users should not copy the whole `CommDomainPlan` into every chip config.  The
+parent is the only place that has the full worker list, so it is the right
+place to validate `worker_indices` and derive each chip child's `domain_rank`,
+`domain_size`, window layout, and active domain list.
+
+Conceptually, `CommDomainPlan` owns the derivation method:
+
+```python
+class CommDomainPlan:
+    domains: list[CommDomain]
+
+    def bootstrap_for_worker(
+        self,
+        worker_idx: int,
+    ) -> list[ChipDomainBootstrapConfig]:
+        ...
+```
+
+The method filters domains that contain `worker_idx`.  For each match, it
+uses the position of `worker_idx` in `CommDomain.worker_indices` as
+`domain_rank`, uses `len(worker_indices)` as `domain_size`, copies the domain
+window size and symmetric buffer layout, and attaches any backend-only
+sub-communicator construction metadata.  The returned list is what the parent
+puts into `ChipBootstrapConfig(comm=...)` for that chip.
+
+If the HCCL sub-communicator backend needs the domain's participant list, that
+list is backend construction metadata in the derived chip config.  It is not a
+kernel-visible rank map and it is not exposed through `ChipCommDomainContext`.
+Kernel code communicates only with dense domain ranks.
+
+All domains are bootstrapped eagerly during `Worker.init()`.  After init
+returns, every active `ctx.domains[name]` is ready for L3 orchestration.  The
+first PR should not add lazy first-use communicator creation.
+
+### Bootstrap Sequence
+
+The handoff from `CommDomainPlan` to chip-worker sub-communicators should be
+mechanical and one-way:
+
+```text
+L3 Worker(comm_plan)
+  validate CommDomainPlan against device_ids
+  derive chip_bootstrap_configs[i] =
+      ChipBootstrapConfig(
+          comm=comm_plan.bootstrap_for_worker(worker_idx=i)
+      )
+  fork chip child i with chip_bootstrap_configs[i]
+        |
+        v
+chip child i / ChipWorker.bootstrap_context()
+  create hidden base communicator once, if comm_plan has any domains
+      rank      = i
+      rank_size = len(device_ids)
+      windows   = none
+  for each ChipDomainBootstrapConfig in sorted domain-name order:
+      sub = create_subcomm(
+          base,
+          rank_ids=domain.worker_indices,
+          sub_comm_rank_id=domain_rank,
+      )
+      device_ctx = comm_alloc_windows(sub, window_size)
+      local_base = comm_get_local_window_base(sub)
+      carve domain buffer_ptrs from local_base
+      record ChipCommDomainContext(name, domain_rank, domain_size, ...)
+  publish all domain contexts to the parent bootstrap mailbox
+        |
+        v
+L3 parent _wait_for_bootstrap()
+  assemble ChipContext(worker_index=i, domains={name: context})
+```
+
+`ChipBootstrapConfig(comm=...)` is therefore not user-authored.  It is the
+per-chip, derived execution plan for the chip child.  The public plan remains
+`CommDomainPlan`; the derived config is just how the parent tells one chip
+which sub-communicators and windows to create.
+
+The hidden base communicator is a control-plane object.  It has no exposed
+buffers, no `ChipCommDomainContext`, and no entry in `ctx.domains`.  It exists
+only so the backend can derive domain communicators from a common L3 rank
+space.  A chip that is not a member of a particular domain still joins the
+hidden base communicator when the L3 plan has communication domains, but it
+does not create that domain's sub-communicator, allocate that domain's window,
+or receive that domain's buffer metadata.
+
+The parent receives:
+
+```python
+ChipContext(
+    device_id=...,
+    worker_index=...,
+    domains={
+        "tp0": ChipCommDomainContext(...),
+        "ep0": ChipCommDomainContext(...),
+    },
+)
+```
+
+A domain context should contain:
+
+```python
+ChipCommDomainContext(
+    name: str,
+    domain_rank: int,
+    domain_size: int,
+    device_ctx: int,
+    local_window_base: int,
+    actual_window_size: int,
+    buffer_ptrs: dict[str, int],
+)
+```
+
+`worker_index` is the same logical worker ID already used by
+`orch.submit_next_level(..., worker=i)`.  It also matches the index in
+`device_ids` and `chip_bootstrap_configs`.  The public multi-domain API should
+use this same indexing model instead of introducing a second worker reference
+mechanism.
+
+`worker_indices` belongs to the domain specification that the parent validates
+before bootstrap.  It should not be copied into every active domain context
+unless a later API needs to expose membership for host-side introspection.
+
+The old scalar fields on `ChipContext` should be replaced by domain lookups.
+Even single-domain code should use `ctx.domains["default"]` instead of
+`ctx.rank`, `ctx.nranks`, `ctx.device_ctx`, and `ctx.buffer_ptrs` directly.
+
+## Mechanism 1: Domain Membership and Logical Rank
+
+A domain rank is dense in `[0, domain_size)`.  Domain membership is expressed
+with the existing L3 `worker=i` index space.
+
+For every domain, publish the domain membership list:
+
+```text
+worker_indices[d] = L3 worker index for domain rank d
+```
+
+Example:
+
+```text
+worker indices:            0   1   2   3
+domain "tp1" workers:              [2, 3]
+
+domain rank 0 -> worker index 2
+domain rank 1 -> worker index 3
+```
+
+`worker_indices` may be non-contiguous and out of order.  The order is
+semantic because it defines domain rank.  For example, `[3, 1]` means worker
+`3` is domain rank `0`, and worker `1` is domain rank `1`.
+
+Host-side use:
+
+- validate that every participating chip has a unique domain rank;
+- validate that every worker index belongs to this L3 worker;
+- compute `domain_rank` from this worker's position in `worker_indices`;
+- skip sub-communicator and window creation on chips not in the domain.
+
+Kernel-side use is intentionally smaller: kernels communicate only in
+domain-rank coordinates.  They use `ctx->rankId`, `ctx->rankNum`, and peer
+domain ranks.  They do not need worker indices or a rank-map buffer.
+
+## Mechanism 2: Per-Domain Windows
+
+Each domain owns its own communicator handle, stream, `CommContext`, and
+window allocation:
+
+```text
+chip child
+  domain "tp0"
+    CommHandle h0
+    stream s0
+    CommContext* ctx0
+    window base b0
+    buffers: scratch, signals
+
+  domain "ep0"
+    CommHandle h1
+    stream s1
+    CommContext* ctx1
+    window base b1
+    buffers: send, recv, signals
+```
+
+Windows should not be multiplexed across domains in the first PR, even when
+two domains have identical `worker_indices`.  Separate windows make these
+invariants simple:
+
+- `ctx->windowsIn[ctx->rankId]` is the base for exactly one domain;
+- byte offset `x - local_base` is meaningful only inside that domain;
+- signal slots cannot collide across domains;
+- teardown can release resources domain by domain.
+
+The Simpler runtime should not define cross-domain concurrency semantics.
+Its job is to pass isolated per-domain handles, contexts, and windows to the
+kernel.  Whether two active domains make concurrent progress, contend for
+links, or serialize internally is HCCL/HCOMM backend behavior.
+
+The allocation order must be deterministic across ranks.  All chips should
+bootstrap domains in sorted domain-name order.  If a chip does not belong to a
+domain, it omits that domain from `ctx.domains` and does not create that
+domain's sub-communicator or windows.  It also receives no buffer layout
+metadata for that domain.
+
+## Proposed Backend API
+
+The current 5-function C ABI is not enough for the sub-communicator path.
+`comm_init()` can still create the hidden base communicator for the L3 chip
+set, but each domain also needs a derived sub-communicator before
+`comm_alloc_windows()` can build a domain-local `CommContext`.
+
+That means Simpler needs one explicit domain-creation step in the backend
+path, either as a new C ABI entry point or as a dedicated method on
+`ChipWorker`.  Conceptually the flow becomes:
+
+```cpp
+base handle from comm_init()
+  -> per-domain subcomm creation from ChipDomainBootstrapConfig
+  -> comm_alloc_windows(subcomm_handle, window_size)
+  -> CommContext* + local window base
+```
+
+The derived `ChipDomainBootstrapConfig` is the right place to carry the
+backend-only inputs for that step:
+
+```cpp
+struct ChipDomainBootstrapConfig {
+    std::string name;
+    std::vector<uint32_t> rank_ids;   // domain membership in L3 worker order
+    uint32_t sub_comm_rank_id;        // this chip's dense rank in the domain
+    size_t window_size;
+    std::vector<ChipBufferSpec> buffers;
+};
+```
+
+`HcclCreateSubCommConfig` is the backend API that matches this shape best:
+it takes a global communicator, the selected rank list, and the dense
+sub-communicator rank for the local chip.  The HCCL sub-rank-table creation
+path assigns sub-rank IDs from the supplied `rank_ids` order, which matches
+Simpler's rule that `worker_indices` order defines `domain_rank`.  Simpler
+should call this directly rather than routing the design through
+`HcomCreateGroup`, because that helper sorts rank IDs while building group
+metadata.  It is a registry and lookup layer, not the conceptual API for
+user-defined rank ordering.
+
+`ChipWorker` changes from:
+
+```text
+void *comm_stream_;
+one active CommHandle accepted by caller
+```
+
+to:
+
+```text
+std::vector<ActiveCommSession> comm_sessions_;
+lookup by name or returned handle
+```
+
+The C API still returns opaque `CommHandle`s.  The Python-facing bootstrap API
+should not expose raw handles; it should expose domain contexts.  The hidden
+base communicator should never be visible in `ctx.domains`.
+
+The public domain config does not need a `rootinfo_path`.  Root-info files are
+a backend bootstrap transport detail for the hidden base communicator.  The
+multi-domain design should use a sub-communicator path:
+
+```text
+internal base HcclComm over the L3 chip children
+  -> HcclCreateSubCommConfig(worker_indices, domain_rank)
+  -> domain subcomm handle
+  -> HcclAllocComResourceByTiling(domain subcomm)
+```
+
+This path matches the shape of `CommDomain`: `worker_indices` is exactly a
+group list in the parent communicator, and the position in that list is
+exactly the dense domain rank.  It avoids running an independent root-info
+exchange for every domain, keeps one internal rendezvous for the L3 chip set,
+and matches the ProcessGroup/NCCL style used by NVIDIA stacks.
+
+If the backend wants to register the sub-communicator by group name, that
+lookup remains an internal implementation detail.  The design does not depend
+on it.
+
+Independent root-info communicators and sub-communicators differ only in the
+backend bootstrap route:
+
+- independent root-info: each domain exchanges its own `HcclRootInfo` and
+  creates a standalone communicator whose rank space is already the domain;
+- sub-communicator: the runtime creates one internal base communicator, then
+  asks HCCL to derive group communicators from selected base ranks.
+
+The sub-communicator route is the better first target here because the L3
+parent already knows every chip child and every `CommDomainPlan`.  Repeating
+root-info exchange per domain would recreate global coordination that the
+parent already has, and it would make overlapping domains look unrelated to
+the backend even though they are all subsets of the same L3 chip set.
+
+Both routes would expose the same `ChipCommDomainContext` and `CommContext`
+shape to L3 and PTO-ISA kernels.  Choosing sub-communicators is therefore a
+backend construction decision, not a kernel ABI decision.
+
+### Why No Exposed Meta Domain
+
+The first PR should not expose an allocated meta communication domain just to
+mirror PyTorch/NCCL's WORLD process group.
+
+NVIDIA's stack needs a global process group because multiple OS processes are
+launched independently and need a rendezvous space before frameworks can make
+TP/DP/PP groups.  Simpler's L3 parent already owns the chip-child list before
+communication bootstrap.  The parent has `device_ids`, `worker=i` indices, and
+all `CommDomain.worker_indices`, so it can validate membership and derive
+domain ranks without exposing a WORLD-like data domain to kernels.
+
+A meta domain would add costs without serving the PTO-ISA kernel contract:
+
+- it would allocate a data-domain window that kernels should not use;
+- it would need lifecycle and teardown rules despite being only metadata;
+- it could be confused with a real data domain in `ctx.domains`;
+- it would not remove the need to create per-domain windows, because each
+  data domain needs independent `CommContext` and buffer layout.
+
+The base HCCL communicator is still an internal backend detail for the
+sub-communicator path, but it should not appear in `ctx.domains`, allocate
+exposed windows, or expose buffers to kernels.  It is only a control-plane
+parent used to derive the real data domains.
+
+## Proposed Python API
+
+The public L3 constructor should accept one global domain plan, while
+`ChipBootstrapConfig` remains the per-chip object sent to chip children.
+
+The user-facing input is a `CommDomainPlan` built from `CommDomain` entries,
+for example `comm_plan=CommDomainPlan(domains=[...])`.  Top-level per-chip
+`buffers=` is removed from the new communication API; each domain declares
+its own symmetric buffers.  The old single-domain
+`ChipCommBootstrapConfig + buffers` shape is not preserved.
+
+`comm_plan=None` and `CommDomainPlan(domains=[])` both mean no communication
+domains.  In that mode there are no domain windows and no domain buffers.
+
+Single-domain spelling:
+
+```python
+worker = Worker(
+    level=3,
+    device_ids=device_ids,
+    comm_plan=CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(len(device_ids))),
+                window_size=window_size,
+                buffers=[ChipBufferSpec("scratch", ...)],
+            ),
+        ],
+    ),
+)
+```
+
+Multi-domain spelling:
+
+```python
+comm_plan = CommDomainPlan(
+    domains=[
+        CommDomain(
+            name="tp",
+            worker_indices=[0, 1],
+            window_size=tp_window,
+            buffers=[ChipBufferSpec("tp_scratch", ...)],
+        ),
+        CommDomain(
+            name="ep",
+            worker_indices=[0, 2],
+            window_size=ep_window,
+            buffers=[ChipBufferSpec("ep_scratch", ...)],
+        ),
+    ],
+)
+
+worker = Worker(
+    level=3,
+    device_ids=device_ids,
+    comm_plan=comm_plan,
+)
+```
+
+Inside `Worker.init()`, the parent converts `comm_plan` into one
+`ChipBootstrapConfig` per chip child.  For chip worker `i`, that derived config
+contains a `ChipDomainBootstrapConfig` only for domains whose
+`worker_indices` list contains `i`.  The derived config records this chip's
+`domain_rank`, `domain_size`, window size, and buffer layout.  It may also
+carry backend construction metadata needed to create the HCCL sub-communicator,
+but the chip result published back to the parent should expose only the
+domain-local context.
+
+L3 orchestration chooses the domain explicitly:
+
+```python
+tp = ctx.domains["tp"]
+
+args.add_tensor(
+    ContinuousTensor.make(
+        data=tp.buffer_ptrs["tp_scratch"],
+        shapes=(tp_count,),
+        dtype=DataType.FLOAT32,
+        child_memory=True,
+    ),
+    TensorArgType.INOUT,
+)
+args.add_scalar(tp.domain_size)
+args.add_scalar(tp.device_ctx)
+```
+
+Direct lookup is valid when the orchestration expects this worker to
+participate in the domain.  If the worker is not a member, normal dictionary
+lookup raises `KeyError`; that is the desired fail-fast behavior.  Code that
+intentionally handles optional participation can use `"tp" in ctx.domains`
+before submitting a TP-domain task.
+
+## Kernel Contract
+
+Kernels should treat a domain as an explicit argument group:
+
+```text
+tensor: domain window buffer
+scalar: domain_size
+scalar: domain CommContext*
+```
+
+A kernel may consume more than one domain, but only by receiving more than
+one explicit argument group:
+
+```text
+tp tensor, tp domain_size, tp CommContext*
+ep tensor, ep domain_size, ep CommContext*
+```
+
+There is no implicit current domain and no global domain lookup inside the
+kernel.  This keeps domain selection visible in L3 orchestration and prevents
+accidentally using a pointer from one domain with another domain's context.
+
+For domain-local algorithms:
+
+```cpp
+int me = static_cast<int>(ctx->rankId);
+for (int peer = 0; peer < static_cast<int>(ctx->rankNum); ++peer) {
+    if (peer == me) continue;
+    auto remote = CommRemotePtr(ctx, local, peer);
+    ...
+}
+```
+
+Never mix a pointer from domain A with a `CommContext*` from domain B.  The
+offset calculation will still produce an address, but it will address the
+wrong window.
+
+Simpler should not enforce that every member of a domain submits the same
+kernel or task pattern.  The runtime validates resources and domain
+membership; protocol symmetry is the kernel/orchestration contract.  This
+keeps asymmetric patterns such as dispatch/combine, pipeline handoff, and
+producer/consumer communication valid.
+
+## Validation Rules
+
+The parent should validate before forking:
+
+- domain names are non-empty and unique;
+- every `worker_indices` list is non-empty and has no duplicates;
+- every worker index belongs to this L3 worker;
+- each domain has an explicit `window_size`;
+- buffer names are unique within each domain;
+- every domain size is `<= COMM_MAX_RANK_NUM`.
+
+The child should validate during bootstrap:
+
+- the base communicator is created before any domain sub-communicator;
+- each domain entry in the derived config is active for this chip;
+- non-member chips do not receive that domain entry;
+- sub-communicator creation returns a non-null domain handle;
+- `comm_alloc_windows` returned a non-null `CommContext*`;
+- every named buffer fits in `actual_window_size`;
+- the returned `ctx->rankId` and `ctx->rankNum` match the derived
+  `domain_rank` and domain size.
+
+The kernel should validate cheap invariants:
+
+- `domain_size == ctx->rankNum`;
+- `ctx->rankId < ctx->rankNum`;
+- peer domain ranks are in range before indexing `windowsIn`.
+
+## Teardown
+
+Teardown should run in reverse bootstrap order:
+
+```text
+for domain in reversed(active_domains):
+    comm_destroy(domain.handle)
+    destroy domain stream
+finalize ChipWorker
+```
+
+A failure destroying one domain should not skip cleanup of later domains.
+The caller should receive the first error after best-effort cleanup completes.
+
+## Implementation Slices
+
+1. Add dataclasses for public `CommDomainPlan`, public `CommDomain`,
+   returned `ChipCommDomainContext`, plus an internal derived
+   `ChipDomainBootstrapConfig`.
+2. Change L3 worker construction to accept `comm_plan` as the single
+   parent-level domain plan.
+3. During `Worker.init()`, validate the parent plan and derive one
+   `ChipBootstrapConfig` per chip child by calling
+   `CommDomainPlan.bootstrap_for_worker(worker_idx)`.
+4. Update `ChipBootstrapConfig` so its `comm` field contains derived
+   per-chip domain bootstrap configs, not public `CommDomain` objects.
+5. Remove top-level `buffers` from the new communication API.
+6. Add backend support for creating HCCL sub-communicators from the hidden
+   base communicator and each domain's `rank_ids` / `sub_comm_rank_id`.
+7. Change `ChipWorker` from one active stream to a session table.
+8. Extend bootstrap mailboxes/results to publish a map of domain contexts
+   instead of one scalar `rank/nranks/device_ctx`.
+9. Update one L3 example to use `ctx.domains["default"]`.
+10. Add a two-domain smoke example where the same worker indices use two
+    windows and kernels prove that data and signals do not cross domains.
+11. Add tests for validation, single-domain migration, sim multi-domain
+    windows, and hardware HCCL context fields.
+
+## Open Questions
+
+- What is the maximum practical number of active domains per chip?
+- Should window zeroing be a runtime responsibility per domain, or remain an
+  example/kernel protocol detail guarded by barriers?

--- a/docs/multi-comm-domain.md
+++ b/docs/multi-comm-domain.md
@@ -1203,8 +1203,9 @@ The caller should receive the first error after best-effort cleanup completes.
 9. Migrate every communication-domain example to `comm_plan`, including
    notification and SDMA examples that use host staging.
 10. Update L3 one-domain examples to use `ctx.domains["default"]`.
-11. Add a tiny multi-domain rank-map example that exercises domain
-    membership, missing-domain lookup, and domain-local ranks.
+11. Add a small multi-domain rank-map example that exercises domain
+    membership, missing-domain lookup, domain-local ranks, and real
+    per-domain communication.
 12. Add a two-domain data example where overlapping domains run real
     communication, computation, and golden checks.
 13. Add tests for validation, the one-domain `CommDomainPlan` case, sim

--- a/docs/multi-comm-domain.md
+++ b/docs/multi-comm-domain.md
@@ -1,8 +1,11 @@
 # Multi-Communication-Domain Design
 
-This document describes how Simpler currently wires one communication domain
-from L3 workers down to PTO-ISA kernels, then proposes an extension for
-multiple communication domains.
+This document describes how Simpler wires communication domains from L3
+workers down to PTO-ISA kernels. It records the original single-domain
+model and the multi-domain design implemented in PR 752.
+
+Implementation status and validation results live in
+[`multi-comm-domain-implementation.md`](multi-comm-domain-implementation.md).
 
 The design scope is intentionally narrow:
 
@@ -29,7 +32,7 @@ The design is based on these implementation points:
 | HCCL/HCOMM | CANN HCCL `inc/hccl/` and `src/` |
 
 The PTO-ISA and CANN HCCL source trees are design references only.  The
-proposed Simpler path relies on HCCL/HCOMM setup APIs such as
+Simpler path relies on HCCL/HCOMM setup APIs such as
 `HcclCommInitRootInfo`, `HcomGetCommHandleByGroup`,
 `HcclAllocComResourceByTiling`, and `HcclCreateSubCommConfig`.
 Data movement remains in PTO-ISA kernels through address-based instructions
@@ -474,7 +477,7 @@ routed_y_buf | signals
 All three examples use the same domain mechanism: one `CommContext*`, one
 per-rank window, and kernel-side offset translation.
 
-## Proposed Runtime Model
+## Runtime Model
 
 Keep the split between parent-level planning and per-chip bootstrap explicit.
 The communication-domain plan is a single L3-level object.  It is not copied
@@ -883,7 +886,7 @@ The base HCCL communicator is still an internal backend detail.  It should
 not appear in `ctx.domains` or expose buffers to kernels.  Its window is
 allocated once and sliced into the visible data domains.
 
-## Proposed Python API
+## Python API
 
 The normal public L3 constructor accepts one global domain plan.
 `ChipBootstrapConfig` remains the per-chip object sent to chip children.  It

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -13,17 +13,16 @@ from __future__ import annotations
 
 import argparse
 import os
-import tempfile
 
 import torch
 from simpler.task_interface import (
     ArgDirection,
     CallConfig,
-    ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -106,12 +105,6 @@ def run(
     if nranks != 2:
         raise ValueError(f"async_notify_demo needs exactly 2 devices, got {device_ids}")
 
-    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_async_notify_rootinfo_{os.getpid()}.bin")
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
-
     inp = [
         torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
         for _ in range(nranks)
@@ -119,13 +112,16 @@ def run(
     out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
     result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    cfgs = [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4 * 1024),
-            buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
-        )
-        for rank in range(nranks)
-    ]
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=4 * 1024,
+                buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+            )
+        ]
+    )
 
     chip_callable = build_chip_callable(platform, pto_isa_commit, "https")
     worker = Worker(
@@ -134,7 +130,7 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        chip_bootstrap_configs=cfgs,
+        comm_plan=comm_plan,
         build=build,
     )
     chip_cid = worker.register(chip_callable)
@@ -144,20 +140,21 @@ def run(
 
         def orch_fn(orch, _args, cfg):
             for rank, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 args = TaskArgs()
                 args.add_tensor(make_tensor_arg(inp[rank]), TensorArgType.INPUT)
                 args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["notify_counter"],
+                        data=domain.buffer_ptrs["notify_counter"],
                         shapes=(1,),
                         dtype=DataType.INT32,
                         child_memory=True,
                     ),
                     TensorArgType.INPUT,
                 )
-                args.add_scalar(ctx.device_ctx)
+                args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, args, cfg, worker=rank)
 
         worker.run(orch_fn, args=None, config=CallConfig())
@@ -173,10 +170,6 @@ def run(
         return 0 if ok else 1
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
 
 
 def test_async_notify_demo() -> None:

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import tempfile
 from multiprocessing.shared_memory import SharedMemory
 
 import torch
@@ -23,8 +22,9 @@ from simpler.task_interface import (
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -112,11 +112,6 @@ def run(
     mailbox_nbytes = N * DTYPE_NBYTES
     counter_nbytes = 4
     window_size = max(mailbox_nbytes + counter_nbytes, 4 * 1024)
-    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_deferred_notify_rootinfo_{os.getpid()}.bin")
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
 
     partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
     result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
@@ -127,23 +122,35 @@ def run(
             raise RuntimeError("SharedMemory buffer is unavailable")
         buf[:counter_nbytes] = b"\x00" * counter_nbytes
 
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=window_size,
+                buffers=[
+                    ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+                    ChipBufferSpec(
+                        name="notify_counter",
+                        dtype="int32",
+                        count=1,
+                        nbytes=counter_nbytes,
+                        load_from_host=True,
+                    ),
+                ],
+            )
+        ]
+    )
     cfgs = [
         ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=window_size
-            ),
-            buffers=[
-                ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                ChipBufferSpec(
-                    name="notify_counter",
-                    dtype="int32",
-                    count=1,
-                    nbytes=counter_nbytes,
-                    load_from_host=True,
-                ),
-            ],
+            comm=comm_plan.bootstrap_for_worker(rank),
             host_inputs=[
-                HostBufferStaging(name="notify_counter", shm_name=counter_init_shms[rank].name, size=counter_nbytes)
+                HostBufferStaging(
+                    domain_name="default",
+                    name="notify_counter",
+                    shm_name=counter_init_shms[rank].name,
+                    size=counter_nbytes,
+                )
             ],
         )
         for rank in range(nranks)
@@ -166,11 +173,12 @@ def run(
 
         def orch_fn(orch, _args, cfg):
             for rank, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 args = TaskArgs()
                 args.add_tensor(make_tensor_arg(partial[rank]), TensorArgType.INPUT)
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["mailbox"],
+                        data=domain.buffer_ptrs["mailbox"],
                         shapes=(N,),
                         dtype=DataType.FLOAT32,
                         child_memory=True,
@@ -180,14 +188,14 @@ def run(
                 args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["notify_counter"],
+                        data=domain.buffer_ptrs["notify_counter"],
                         shapes=(1,),
                         dtype=DataType.INT32,
                         child_memory=True,
                     ),
                     TensorArgType.INPUT,
                 )
-                args.add_scalar(ctx.device_ctx)
+                args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, args, cfg, worker=rank)
 
         worker.run(orch_fn, args=None, config=CallConfig())
@@ -201,10 +209,6 @@ def run(
         return 0 if ok else 1
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
         for shm in counter_init_shms:
             shm.close()
             shm.unlink()

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -31,7 +31,6 @@ from simpler.task_interface import (
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipContext,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -182,7 +181,7 @@ def run(
     chip_cid = worker.register(chip_callable)
     try:
         worker.init()
-        contexts: list[ChipContext] = worker.chip_contexts
+        contexts = worker.chip_contexts
 
         def orch_fn(orch, _args, cfg):
             for rank, ctx in enumerate(contexts):

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -10,19 +10,17 @@
 """SDMA deferred completion smoke test for onboard a2a3.
 
 Each rank stages its input inside the HCCL window.  The deferred producer
-builds an ``SdmaRequestDescriptor`` via ``SdmaTget`` and submits it through
-``send_request_entry``, which registers the resulting AsyncEvent's GM flag(s)
-on the task's deferred-wait slab.  The consumer depends on the producer
-output and writes ``result = out + 1``.  Correct ``out`` and ``result``
-therefore validate both the SDMA completion polling and the deferred-release
-dependency path.
+TGET_ASYNCs the peer rank's input into local ``out`` and registers the PTO
+AsyncEvent through ``defer_pto_async_event``.  The consumer depends on the
+producer output and writes ``result = out + 1``.  Correct ``out`` and
+``result`` therefore validate both the SDMA completion polling and the
+deferred-release dependency path.
 """
 
 from __future__ import annotations
 
 import argparse
 import os
-import tempfile
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
@@ -33,8 +31,9 @@ from simpler.task_interface import (
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -122,11 +121,6 @@ def run(
 
     input_nbytes = N * DTYPE_NBYTES
     window_size = max(input_nbytes, 4 * 1024)
-    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_sdma_async_completion_rootinfo_{os.getpid()}.bin")
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
 
     inputs = [
         torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32)
@@ -142,24 +136,35 @@ def run(
             raise RuntimeError("SharedMemory buffer is unavailable")
         buf[:input_nbytes] = inputs[rank].numpy().tobytes()
 
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=window_size,
+                buffers=[
+                    ChipBufferSpec(
+                        name="input_window",
+                        dtype="float32",
+                        count=N,
+                        nbytes=input_nbytes,
+                        load_from_host=True,
+                    ),
+                ],
+            )
+        ]
+    )
     cfgs = [
         ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
-                window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
+            comm=comm_plan.bootstrap_for_worker(rank),
+            host_inputs=[
+                HostBufferStaging(
+                    domain_name="default",
                     name="input_window",
-                    dtype="float32",
-                    count=N,
-                    nbytes=input_nbytes,
-                    load_from_host=True,
-                ),
+                    shm_name=input_shms[rank].name,
+                    size=input_nbytes,
+                )
             ],
-            host_inputs=[HostBufferStaging(name="input_window", shm_name=input_shms[rank].name, size=input_nbytes)],
         )
         for rank in range(nranks)
     ]
@@ -181,10 +186,11 @@ def run(
 
         def orch_fn(orch, _args, cfg):
             for rank, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 args = TaskArgs()
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["input_window"],
+                        data=domain.buffer_ptrs["input_window"],
                         shapes=(N,),
                         dtype=DataType.FLOAT32,
                         child_memory=True,
@@ -193,7 +199,7 @@ def run(
                 )
                 args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
-                args.add_scalar(ctx.device_ctx)
+                args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, args, cfg, worker=rank)
 
         worker.run(orch_fn, args=None, config=CallConfig())
@@ -210,10 +216,6 @@ def run(
         return 0 if ok else 1
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
         for shm in input_shms:
             shm.close()
             shm.unlink()

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -13,17 +13,16 @@ from __future__ import annotations
 
 import argparse
 import os
-import tempfile
 
 import torch
 from simpler.task_interface import (
     ArgDirection,
     CallConfig,
-    ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -101,12 +100,6 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
     if nranks != 2:
         raise ValueError(f"async_notify_demo needs exactly 2 devices, got {device_ids}")
 
-    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_async_notify_rootinfo_{os.getpid()}.bin")
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
-
     inp = [
         torch.tensor([float(i % 251) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
         for _ in range(nranks)
@@ -114,13 +107,16 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
     out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
     result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    cfgs = [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4 * 1024),
-            buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
-        )
-        for rank in range(nranks)
-    ]
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=4 * 1024,
+                buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+            )
+        ]
+    )
 
     chip_callable = build_chip_callable(platform, pto_isa_commit, "https")
     worker = Worker(
@@ -129,7 +125,7 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        chip_bootstrap_configs=cfgs,
+        comm_plan=comm_plan,
     )
     chip_cid = worker.register(chip_callable)
     try:
@@ -138,20 +134,21 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
 
         def orch_fn(orch, _args, cfg):
             for rank, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 args = TaskArgs()
                 args.add_tensor(make_tensor_arg(inp[rank]), TensorArgType.INPUT)
                 args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["notify_counter"],
+                        data=domain.buffer_ptrs["notify_counter"],
                         shapes=(1,),
                         dtype=DataType.INT32,
                         child_memory=True,
                     ),
                     TensorArgType.INPUT,
                 )
-                args.add_scalar(ctx.device_ctx)
+                args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, args, cfg, worker=rank)
 
         worker.run(orch_fn, args=None, config=CallConfig())
@@ -167,10 +164,6 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
         return 0 if ok else 1
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
 
 
 def test_async_notify_demo() -> None:

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import argparse
 import os
-import tempfile
 from multiprocessing.shared_memory import SharedMemory
 
 import torch
@@ -23,8 +22,9 @@ from simpler.task_interface import (
     ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -112,11 +112,6 @@ def run(
     mailbox_nbytes = N * DTYPE_NBYTES
     counter_nbytes = 4
     window_size = max(mailbox_nbytes + counter_nbytes, 4 * 1024)
-    rootinfo_path = os.path.join(tempfile.gettempdir(), f"pto_deferred_notify_rootinfo_{os.getpid()}.bin")
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
 
     partial = [torch.full((N,), float(rank + 1), dtype=torch.float32).share_memory_() for rank in range(nranks)]
     result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
@@ -127,23 +122,35 @@ def run(
             raise RuntimeError("SharedMemory buffer is unavailable")
         buf[:counter_nbytes] = b"\x00" * counter_nbytes
 
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=window_size,
+                buffers=[
+                    ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+                    ChipBufferSpec(
+                        name="notify_counter",
+                        dtype="int32",
+                        count=1,
+                        nbytes=counter_nbytes,
+                        load_from_host=True,
+                    ),
+                ],
+            )
+        ]
+    )
     cfgs = [
         ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank, nranks=nranks, rootinfo_path=rootinfo_path, window_size=window_size
-            ),
-            buffers=[
-                ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                ChipBufferSpec(
-                    name="notify_counter",
-                    dtype="int32",
-                    count=1,
-                    nbytes=counter_nbytes,
-                    load_from_host=True,
-                ),
-            ],
+            comm=comm_plan.bootstrap_for_worker(rank),
             host_inputs=[
-                HostBufferStaging(name="notify_counter", shm_name=counter_init_shms[rank].name, size=counter_nbytes)
+                HostBufferStaging(
+                    domain_name="default",
+                    name="notify_counter",
+                    shm_name=counter_init_shms[rank].name,
+                    size=counter_nbytes,
+                )
             ],
         )
         for rank in range(nranks)
@@ -166,11 +173,12 @@ def run(
 
         def orch_fn(orch, _args, cfg):
             for rank, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 args = TaskArgs()
                 args.add_tensor(make_tensor_arg(partial[rank]), TensorArgType.INPUT)
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["mailbox"],
+                        data=domain.buffer_ptrs["mailbox"],
                         shapes=(N,),
                         dtype=DataType.FLOAT32,
                         child_memory=True,
@@ -180,14 +188,14 @@ def run(
                 args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
                 args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["notify_counter"],
+                        data=domain.buffer_ptrs["notify_counter"],
                         shapes=(1,),
                         dtype=DataType.INT32,
                         child_memory=True,
                     ),
                     TensorArgType.INPUT,
                 )
-                args.add_scalar(ctx.device_ctx)
+                args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, args, cfg, worker=rank)
 
         worker.run(orch_fn, args=None, config=CallConfig())
@@ -201,10 +209,6 @@ def run(
         return 0 if ok else 1
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
         for shm in counter_init_shms:
             shm.close()
             shm.unlink()

--- a/examples/workers/l3/README.md
+++ b/examples/workers/l3/README.md
@@ -63,6 +63,11 @@ Two things to know before reading the example:
 | --------- | ----------- |
 | [`multi_chip_dispatch/`](multi_chip_dispatch/) | Two chips + one SubWorker. An orchestration fn dispatches a `ChipCallable` to each chip, then submits a Python callable to collect/verify results. |
 | [`child_memory/`](child_memory/) | `orch.malloc` + `ContinuousTensor(child_memory=True)` to load a weight once and reuse it across multiple kernel invocations on the same chip. |
+| [`allreduce_distributed/`](allreduce_distributed/) | One communication domain declared with `CommDomainPlan`, with PTO-ISA remote reads over the domain window. |
+| [`ffn_tp_parallel/`](ffn_tp_parallel/) | Local compute followed by one-domain cross-rank reduction through a domain scratch window. |
+| [`ep_dispatch_combine/`](ep_dispatch_combine/) | MoE-style dispatch/combine over a one-domain communication window. |
+| [`domain_rank_map/`](domain_rank_map/) | Minimal two-domain bootstrap example showing domain-local ranks, missing-domain `KeyError`, and separate window slices. |
+| [`dual_domain_overlap/`](dual_domain_overlap/) | Two overlapping communication domains where worker 1 participates in both and kernels use explicit `ctx.domains[name]` contexts. |
 
 ## Prerequisites
 

--- a/examples/workers/l3/README.md
+++ b/examples/workers/l3/README.md
@@ -66,7 +66,7 @@ Two things to know before reading the example:
 | [`allreduce_distributed/`](allreduce_distributed/) | One communication domain declared with `CommDomainPlan`, with PTO-ISA remote reads over the domain window. |
 | [`ffn_tp_parallel/`](ffn_tp_parallel/) | Local compute followed by one-domain cross-rank reduction through a domain scratch window. |
 | [`ep_dispatch_combine/`](ep_dispatch_combine/) | MoE-style dispatch/combine over a one-domain communication window. |
-| [`domain_rank_map/`](domain_rank_map/) | Minimal two-domain bootstrap example showing domain-local ranks, missing-domain `KeyError`, and separate window slices. |
+| [`domain_rank_map/`](domain_rank_map/) | Small two-domain example showing domain-local ranks, missing-domain `KeyError`, separate window slices, and real per-domain allreduce. |
 | [`dual_domain_overlap/`](dual_domain_overlap/) | Two overlapping communication domains where worker 1 participates in both and kernels use explicit `ctx.domains[name]` contexts. |
 
 ## Prerequisites

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -20,9 +20,9 @@ strictly inside the kernel, via a communication window scratch slot:
 input / output are plain per-rank ``torch.share_memory_()`` tensors — the
 parent writes inputs before ``init()`` and reads outputs after ``run()``, and
 the framework's TaskArgs path handles H2D / D2H automatically (same as
-``multi_chip_dispatch``).  Only ``scratch`` uses the chip bootstrap path
-because window buffers can only exist after ``comm_alloc_windows`` has
-run — that's what ``chip_bootstrap_configs`` is for.
+``multi_chip_dispatch``).  Only ``scratch`` is declared in the communication
+domain because window buffers can only exist after the comm backend
+``comm_alloc_windows`` has run.
 
 Run:
     python examples/workers/l3/allreduce_distributed/main.py -p a2a3sim -d 0-1
@@ -43,11 +43,11 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -143,12 +143,6 @@ def run(
     # keeps us clear of minimum-window-size quirks.
     window_size = max(SCRATCH_NBYTES, 4 * 1024)
 
-    rootinfo_path = f"/tmp/pto_allreduce_distributed_rootinfo_{os.getpid()}.bin"
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
-
     print(f"[allreduce] platform={platform} devices={device_ids} nranks={nranks}")
 
     # --- Per-rank host tensors (input/output) via torch.share_memory_().
@@ -163,29 +157,25 @@ def run(
     ]
     host_outputs = [torch.zeros(ALLREDUCE_COUNT, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    # --- Scratch bootstrap: one window buffer per chip.  The window exists
-    # only after comm_alloc_windows has run, so allocating scratch
-    # during bootstrap is the natural lifecycle — no TaskArgs equivalent
-    # covers it.  No host staging is needed for scratch.
-    cfgs = [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
+    # --- Scratch communication domain: one window buffer per chip.  No host
+    # staging is needed for scratch.
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
                 window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
-                    name="scratch",
-                    dtype="float32",
-                    count=ALLREDUCE_COUNT,
-                    nbytes=SCRATCH_NBYTES,
-                ),
-            ],
-        )
-        for rank in range(nranks)
-    ]
+                buffers=[
+                    ChipBufferSpec(
+                        name="scratch",
+                        dtype="float32",
+                        count=ALLREDUCE_COUNT,
+                        nbytes=SCRATCH_NBYTES,
+                    ),
+                ],
+            )
+        ]
+    )
 
     print("[allreduce] compiling kernels...")
     chip_callable = build_chip_callable(platform, pto_isa_commit)
@@ -196,8 +186,8 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        chip_bootstrap_configs=cfgs,
         build=build,
+        comm_plan=comm_plan,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -208,14 +198,16 @@ def run(
         contexts: list[ChipContext] = worker.chip_contexts
         assert len(contexts) == nranks
         for i, ctx in enumerate(contexts):
+            domain = ctx.domains["default"]
             print(
-                f"[allreduce] chip {i}: device={ctx.device_id} rank={ctx.rank}/{ctx.nranks} "
-                f"window=[0x{ctx.local_window_base:x} +{ctx.actual_window_size}B] "
-                f"scratch=0x{ctx.buffer_ptrs['scratch']:x}"
+                f"[allreduce] chip {i}: device={ctx.device_id} rank={domain.domain_rank}/{domain.domain_size} "
+                f"window=[0x{domain.local_window_base:x} +{domain.actual_window_size}B] "
+                f"scratch=0x{domain.buffer_ptrs['scratch']:x}"
             )
 
         def orch_fn(orch, _args, cfg):
             for i, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 chip_args = TaskArgs()
                 chip_args.add_tensor(make_tensor_arg(host_inputs[i]), TensorArgType.INPUT)
                 chip_args.add_tensor(make_tensor_arg(host_outputs[i]), TensorArgType.OUTPUT_EXISTING)
@@ -224,15 +216,15 @@ def run(
                 # to skip the runtime's H2D path.
                 chip_args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["scratch"],
+                        data=domain.buffer_ptrs["scratch"],
                         shapes=(ALLREDUCE_COUNT,),
                         dtype=DataType.FLOAT32,
                         child_memory=True,
                     ),
                     TensorArgType.INOUT,
                 )
-                chip_args.add_scalar(ctx.nranks)
-                chip_args.add_scalar(ctx.device_ctx)
+                chip_args.add_scalar(domain.domain_size)
+                chip_args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, chip_args, cfg, worker=i)
 
         print("[allreduce] running 2-chip allreduce DAG...")
@@ -255,10 +247,6 @@ def run(
         return 0
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
 
 
 def main() -> int:

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -26,6 +26,7 @@ domain because window buffers can only exist after the comm backend
 
 Run:
     python examples/workers/l3/allreduce_distributed/main.py -p a2a3sim -d 0-1
+
 """
 
 from __future__ import annotations
@@ -251,6 +252,7 @@ def run(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
     parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
     parser.add_argument(
@@ -258,6 +260,7 @@ def main() -> int:
     )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
+
     return run(
         parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
     )

--- a/examples/workers/l3/child_memory/test_child_memory.py
+++ b/examples/workers/l3/child_memory/test_child_memory.py
@@ -13,7 +13,7 @@ import pytest
 from .main import run
 
 
-@pytest.mark.platforms(["a2a3sim", "a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(1)
 def test_child_memory(st_platform, st_device_ids):

--- a/examples/workers/l3/domain_rank_map/__init__.py
+++ b/examples/workers/l3/domain_rank_map/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L3 multi-communication-domain rank-map example."""

--- a/examples/workers/l3/domain_rank_map/main.py
+++ b/examples/workers/l3/domain_rank_map/main.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Minimal L3 multi-communication-domain rank-map demo.
+
+Three chip workers declare two overlapping domains:
+
+  even = workers [0, 2]
+  tail = workers [1, 2]
+
+The example does not submit kernels.  It bootstraps the worker, prints the
+domain-local rank view seen by each chip child, and verifies that:
+
+  * non-member domains are absent and raise KeyError through ctx.domains;
+  * worker_indices order defines the dense domain_rank;
+  * overlapping domains have separate buffer pointers.
+
+Run:
+    python examples/workers/l3/domain_rank_map/main.py -p a2a3sim -d 0-2
+    python examples/workers/l3/domain_rank_map/main.py -p a2a3    -d 0-2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan  # noqa: E402
+from simpler.worker import Worker  # noqa: E402
+
+DOMAINS = {
+    "even": [0, 2],
+    "tail": [1, 2],
+}
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        ids = list(range(lo, hi + 1))
+    else:
+        ids = [int(spec)]
+    if len(ids) != 3:
+        raise ValueError(f"domain_rank_map needs exactly 3 devices, got {ids}")
+    return ids
+
+
+def _make_comm_plan() -> CommDomainPlan:
+    return CommDomainPlan(
+        domains=[
+            CommDomain(
+                name=name,
+                worker_indices=worker_indices,
+                window_size=4096,
+                buffers=[
+                    ChipBufferSpec(
+                        name="scratch",
+                        dtype="float32",
+                        count=1,
+                        nbytes=4,
+                    ),
+                ],
+            )
+            for name, worker_indices in DOMAINS.items()
+        ]
+    )
+
+
+def _check_missing(ctx_domains: dict, name: str) -> bool:
+    try:
+        _ = ctx_domains[name]
+    except KeyError:
+        return True
+    return False
+
+
+def run(platform: str, device_ids: list[int]) -> int:
+    print(f"[domain_rank_map] platform={platform} devices={device_ids}")
+
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        comm_plan=_make_comm_plan(),
+    )
+
+    try:
+        print("[domain_rank_map] init worker...")
+        worker.init()
+        contexts = worker.chip_contexts
+
+        expected = {
+            0: {"even": 0},
+            1: {"tail": 0},
+            2: {"even": 1, "tail": 1},
+        }
+        ok = len(contexts) == 3
+
+        for worker_idx, ctx in enumerate(contexts):
+            actual_names = sorted(ctx.domains)
+            print(f"[domain_rank_map] worker {worker_idx}: domains={actual_names}")
+
+            expected_names = sorted(expected[worker_idx])
+            if actual_names != expected_names:
+                print(f"  expected domains {expected_names}, got {actual_names}")
+                ok = False
+
+            for name, expected_rank in expected[worker_idx].items():
+                domain = ctx.domains[name]
+                print(
+                    f"  {name}: domain_rank={domain.domain_rank} "
+                    f"domain_size={domain.domain_size} "
+                    f"scratch=0x{domain.buffer_ptrs['scratch']:x}"
+                )
+                if domain.domain_rank != expected_rank or domain.domain_size != 2:
+                    ok = False
+                if domain.device_ctx == 0 or domain.buffer_ptrs["scratch"] == 0:
+                    ok = False
+
+        if not _check_missing(contexts[0].domains, "tail"):
+            print("[domain_rank_map] worker 0 unexpectedly has tail domain")
+            ok = False
+        if not _check_missing(contexts[1].domains, "even"):
+            print("[domain_rank_map] worker 1 unexpectedly has even domain")
+            ok = False
+
+        worker2 = contexts[2]
+        if worker2.domains["even"].buffer_ptrs["scratch"] == worker2.domains["tail"].buffer_ptrs["scratch"]:
+            print("[domain_rank_map] worker 2 domains share a scratch pointer")
+            ok = False
+
+        if not ok:
+            print("[domain_rank_map] checks FAILED")
+            return 1
+        print("[domain_rank_map] rank-map checks PASSED")
+        return 0
+    finally:
+        worker.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-p", "--platform", required=True, choices=["a2a3sim", "a2a3"])
+    parser.add_argument("-d", "--device", default="0-2", help="Device range, e.g. '0-2'. Three chips required.")
+    cli = parser.parse_args()
+    return run(cli.platform, parse_device_range(cli.device))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/workers/l3/domain_rank_map/main.py
+++ b/examples/workers/l3/domain_rank_map/main.py
@@ -7,22 +7,23 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Minimal L3 multi-communication-domain rank-map demo.
+"""Small L3 multi-communication-domain communication demo.
 
 Three chip workers declare two overlapping domains:
 
   even = workers [0, 2]
   tail = workers [1, 2]
 
-The example does not submit kernels.  It bootstraps the worker, prints the
-domain-local rank view seen by each chip child, and verifies that:
+The example bootstraps the worker, prints the domain-local rank view seen by
+each chip child, then runs one small allreduce in each domain.  It verifies
+that:
 
   * non-member domains are absent and raise KeyError through ctx.domains;
   * worker_indices order defines the dense domain_rank;
   * overlapping domains have separate buffer pointers.
+  * each domain transfers data only among its own participants.
 
 Run:
-    python examples/workers/l3/domain_rank_map/main.py -p a2a3sim -d 0-2
     python examples/workers/l3/domain_rank_map/main.py -p a2a3    -d 0-2
 """
 
@@ -34,9 +35,34 @@ import sys
 
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
-from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan  # noqa: E402
+import torch  # noqa: E402
+from simpler.task_interface import (  # noqa: E402
+    ArgDirection,
+    CallConfig,
+    ChipBufferSpec,
+    ChipCallable,
+    ChipCommDomainContext,
+    CommDomain,
+    CommDomainPlan,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
 from simpler.worker import Worker  # noqa: E402
 
+from simpler_setup.elf_parser import extract_text_section  # noqa: E402
+from simpler_setup.kernel_compiler import KernelCompiler  # noqa: E402
+from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: E402
+from simpler_setup.torch_interop import make_tensor_arg  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OVERLAP_DIR = os.path.join(HERE, "../dual_domain_overlap")
+COUNT = 256
+DTYPE_NBYTES = 4
+SIGNAL_TAIL_NBYTES = 16 * 4
+SCRATCH_NBYTES = COUNT * DTYPE_NBYTES + SIGNAL_TAIL_NBYTES
 DOMAINS = {
     "even": [0, 2],
     "tail": [1, 2],
@@ -60,19 +86,62 @@ def _make_comm_plan() -> CommDomainPlan:
             CommDomain(
                 name=name,
                 worker_indices=worker_indices,
-                window_size=4096,
+                window_size=max(SCRATCH_NBYTES, 4096),
                 buffers=[
                     ChipBufferSpec(
                         name="scratch",
                         dtype="float32",
-                        count=1,
-                        nbytes=4,
+                        count=COUNT,
+                        nbytes=SCRATCH_NBYTES,
                     ),
                 ],
             )
             for name, worker_indices in DOMAINS.items()
         ]
     )
+
+
+def build_allreduce_callable(platform: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    kernel_include_dirs = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+    kernel_bytes = kc.compile_incore(
+        source_path=os.path.join(OVERLAP_DIR, "kernels/aiv/domain_allreduce_sum.cpp"),
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=kernel_include_dirs,
+    )
+    kernel_bytes = extract_text_section(kernel_bytes)
+    orch_bytes = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(OVERLAP_DIR, "kernels/orchestration/domain_allreduce_orch.cpp"),
+    )
+    core_callable = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
+        binary=kernel_bytes,
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
+        func_name="domain_allreduce_orchestration",
+        binary=orch_bytes,
+        children=[(0, core_callable)],
+    )
+
+
+def _add_domain_scratch(args: TaskArgs, domain: ChipCommDomainContext) -> None:
+    args.add_tensor(
+        ContinuousTensor.make(
+            data=domain.buffer_ptrs["scratch"],
+            shapes=(COUNT,),
+            dtype=DataType.FLOAT32,
+            child_memory=True,
+        ),
+        TensorArgType.INOUT,
+    )
+    args.add_scalar(domain.domain_size)
+    args.add_scalar(domain.device_ctx)
 
 
 def _check_missing(ctx_domains: dict, name: str) -> bool:
@@ -84,7 +153,23 @@ def _check_missing(ctx_domains: dict, name: str) -> bool:
 
 
 def run(platform: str, device_ids: list[int]) -> int:
+    if platform != "a2a3":
+        raise ValueError("domain_rank_map uses PTO-ISA remote-window kernels and requires a2a3 hardware")
+
     print(f"[domain_rank_map] platform={platform} devices={device_ids}")
+    host_inputs = {
+        worker_idx: torch.tensor(
+            [worker_idx * 100 + i for i in range(COUNT)],
+            dtype=torch.float32,
+        ).share_memory_()
+        for worker_idx in range(len(device_ids))
+    }
+    outputs = {
+        name: {
+            worker_idx: torch.zeros(COUNT, dtype=torch.float32).share_memory_() for worker_idx in worker_indices
+        }
+        for name, worker_indices in DOMAINS.items()
+    }
 
     worker = Worker(
         level=3,
@@ -94,6 +179,8 @@ def run(platform: str, device_ids: list[int]) -> int:
         num_sub_workers=0,
         comm_plan=_make_comm_plan(),
     )
+    print("[domain_rank_map] compiling communication kernel...")
+    allreduce_cid = worker.register(build_allreduce_callable(platform))
 
     try:
         print("[domain_rank_map] init worker...")
@@ -140,10 +227,35 @@ def run(platform: str, device_ids: list[int]) -> int:
             print("[domain_rank_map] worker 2 domains share a scratch pointer")
             ok = False
 
+        def reduce_orch_fn(domain_name: str):
+            def _orch_fn(orch, _args, cfg):
+                for worker_idx in DOMAINS[domain_name]:
+                    domain = contexts[worker_idx].domains[domain_name]
+                    args = TaskArgs()
+                    args.add_tensor(make_tensor_arg(host_inputs[worker_idx]), TensorArgType.INPUT)
+                    args.add_tensor(make_tensor_arg(outputs[domain_name][worker_idx]), TensorArgType.OUTPUT_EXISTING)
+                    _add_domain_scratch(args, domain)
+                    orch.submit_next_level(allreduce_cid, args, cfg, worker=worker_idx)
+
+            return _orch_fn
+
+        print("[domain_rank_map] running one allreduce per domain...")
+        for domain_name in DOMAINS:
+            worker.run(reduce_orch_fn(domain_name), args=None, config=CallConfig())
+
+        for domain_name, worker_indices in DOMAINS.items():
+            expected_tensor = sum(host_inputs[worker_idx] for worker_idx in worker_indices)
+            for worker_idx in worker_indices:
+                got = outputs[domain_name][worker_idx]
+                max_diff = float(torch.max(torch.abs(got - expected_tensor)))
+                print(f"[domain_rank_map] {domain_name} worker {worker_idx}: max_diff={max_diff:.3e}")
+                if max_diff > 1e-3:
+                    ok = False
+
         if not ok:
             print("[domain_rank_map] checks FAILED")
             return 1
-        print("[domain_rank_map] rank-map checks PASSED")
+        print("[domain_rank_map] communication checks PASSED")
         return 0
     finally:
         worker.close()
@@ -151,7 +263,7 @@ def run(platform: str, device_ids: list[int]) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-p", "--platform", required=True, choices=["a2a3sim", "a2a3"])
+    parser.add_argument("-p", "--platform", required=True, choices=["a2a3"])
     parser.add_argument("-d", "--device", default="0-2", help="Device range, e.g. '0-2'. Three chips required.")
     cli = parser.parse_args()
     return run(cli.platform, parse_device_range(cli.device))

--- a/examples/workers/l3/domain_rank_map/main.py
+++ b/examples/workers/l3/domain_rank_map/main.py
@@ -24,6 +24,7 @@ that:
   * each domain transfers data only among its own participants.
 
 Run:
+    python examples/workers/l3/domain_rank_map/main.py -p a2a3sim -d 0-2
     python examples/workers/l3/domain_rank_map/main.py -p a2a3    -d 0-2
 """
 
@@ -113,7 +114,8 @@ def build_allreduce_callable(platform: str) -> ChipCallable:
         pto_isa_root=pto_isa_root,
         extra_include_dirs=kernel_include_dirs,
     )
-    kernel_bytes = extract_text_section(kernel_bytes)
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
     orch_bytes = kc.compile_orchestration(
         runtime_name=runtime,
         source_path=os.path.join(OVERLAP_DIR, "kernels/orchestration/domain_allreduce_orch.cpp"),
@@ -153,9 +155,6 @@ def _check_missing(ctx_domains: dict, name: str) -> bool:
 
 
 def run(platform: str, device_ids: list[int]) -> int:
-    if platform != "a2a3":
-        raise ValueError("domain_rank_map uses PTO-ISA remote-window kernels and requires a2a3 hardware")
-
     print(f"[domain_rank_map] platform={platform} devices={device_ids}")
     host_inputs = {
         worker_idx: torch.tensor(
@@ -165,9 +164,7 @@ def run(platform: str, device_ids: list[int]) -> int:
         for worker_idx in range(len(device_ids))
     }
     outputs = {
-        name: {
-            worker_idx: torch.zeros(COUNT, dtype=torch.float32).share_memory_() for worker_idx in worker_indices
-        }
+        name: {worker_idx: torch.zeros(COUNT, dtype=torch.float32).share_memory_() for worker_idx in worker_indices}
         for name, worker_indices in DOMAINS.items()
     }
 
@@ -263,7 +260,7 @@ def run(platform: str, device_ids: list[int]) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("-p", "--platform", required=True, choices=["a2a3"])
+    parser.add_argument("-p", "--platform", required=True, choices=["a2a3sim", "a2a3"])
     parser.add_argument("-d", "--device", default="0-2", help="Device range, e.g. '0-2'. Three chips required.")
     cli = parser.parse_args()
     return run(cli.platform, parse_device_range(cli.device))

--- a/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
+++ b/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
@@ -13,9 +13,14 @@ import pytest
 from .main import run
 
 
-@pytest.mark.platforms(["a2a3sim", "a2a3"])
+@pytest.mark.requires_hardware
+@pytest.mark.platforms(["a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(3)
-def test_domain_rank_map(st_platform, st_device_ids):
-    rc = run(st_platform, [int(d) for d in st_device_ids])
+def test_domain_rank_map(st_device_ids, capsys):
+    rc = run("a2a3", [int(d) for d in st_device_ids])
+    out = capsys.readouterr().out
     assert rc == 0
+    assert "even worker 0: max_diff=" in out
+    assert "tail worker 2: max_diff=" in out
+    assert "communication checks PASSED" in out

--- a/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
+++ b/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
@@ -13,12 +13,11 @@ import pytest
 from .main import run
 
 
-@pytest.mark.requires_hardware
-@pytest.mark.platforms(["a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(3)
-def test_domain_rank_map(st_device_ids, capsys):
-    rc = run("a2a3", [int(d) for d in st_device_ids])
+def test_domain_rank_map(st_platform, st_device_ids, capsys):
+    rc = run(st_platform, [int(d) for d in st_device_ids])
     out = capsys.readouterr().out
     assert rc == 0
     assert "even worker 0: max_diff=" in out

--- a/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
+++ b/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
@@ -13,7 +13,7 @@ import pytest
 from .main import run
 
 
-@pytest.mark.platforms(["a2a3sim", "a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(3)
 def test_domain_rank_map(st_platform, st_device_ids, capsys):

--- a/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
+++ b/examples/workers/l3/domain_rank_map/test_domain_rank_map.py
@@ -1,0 +1,21 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""ST for examples/workers/l3/domain_rank_map."""
+
+import pytest
+
+from .main import run
+
+
+@pytest.mark.platforms(["a2a3sim", "a2a3"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.device_count(3)
+def test_domain_rank_map(st_platform, st_device_ids):
+    rc = run(st_platform, [int(d) for d in st_device_ids])
+    assert rc == 0

--- a/examples/workers/l3/dual_domain_overlap/__init__.py
+++ b/examples/workers/l3/dual_domain_overlap/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L3 multi-communication-domain overlapping-domain example."""

--- a/examples/workers/l3/dual_domain_overlap/kernels/aiv/affine_kernel.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/aiv/affine_kernel.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Elementwise affine compute: out = reduce_out * scale + bias.
+ */
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+#include "pipe_sync.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr int kRows = 16;
+static constexpr int kCols = 16;
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *reduce_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *scale_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *bias_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[3]);
+
+    __gm__ float *reduce = reinterpret_cast<__gm__ float *>(reduce_tensor->buffer.addr) + reduce_tensor->start_offset;
+    __gm__ float *scale = reinterpret_cast<__gm__ float *>(scale_tensor->buffer.addr) + scale_tensor->start_offset;
+    __gm__ float *bias = reinterpret_cast<__gm__ float *>(bias_tensor->buffer.addr) + bias_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    using Shape2D = Shape<1, 1, 1, kRows, kCols>;
+    using Stride2D = Stride<1, 1, 1, kCols, 1>;
+    using Global = GlobalTensor<float, Shape2D, Stride2D, Layout::ND>;
+    using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
+
+    TileData reduce_tile(kRows, kCols);
+    TileData scale_tile(kRows, kCols);
+    TileData bias_tile(kRows, kCols);
+    TASSIGN(reduce_tile, 0x0);
+    TASSIGN(scale_tile, 0x10000);
+    TASSIGN(bias_tile, 0x20000);
+
+    Global reduce_g(reduce);
+    Global scale_g(scale);
+    Global bias_g(bias);
+    Global out_g(out);
+
+    TLOAD(reduce_tile, reduce_g);
+    TLOAD(scale_tile, scale_g);
+    TLOAD(bias_tile, bias_g);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    TMUL(reduce_tile, reduce_tile, scale_tile);
+    TADD(reduce_tile, reduce_tile, bias_tile);
+
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(out_g, reduce_tile);
+    pipe_sync();
+}

--- a/examples/workers/l3/dual_domain_overlap/kernels/aiv/domain_allreduce_sum.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/aiv/domain_allreduce_sum.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * AllReduce kernel — symmetric, 4-phase, HCCL-window scratch pattern.
+ *
+ * Phase 1 (stage-in):   input → my scratch slot (in window)
+ * Phase 2 (barrier):    signal matrix + TWAIT cross-rank sync
+ * Phase 3 (compute):    for peer in nranks: TLOAD(peer_scratch), TADD(acc)
+ * Phase 4 (stage-out):  TSTORE(output, acc)
+ *
+ * input / output are per-rank host tensors passed through TaskArgs (the
+ * runtime handles the H2D / D2H).  scratch is the single HCCL-window
+ * buffer, shared across ranks for cross-rank reads.  The signal area
+ * lives at the tail of scratch: nranks int32 slots where peer r writes a
+ * counter and my_rank waits on slot[r] before reading.
+ *
+ * args layout (passed as ContinuousTensor arg slots — see allreduce_orch.cpp):
+ *   tensor(0) = input    (host-backed, framework-supplied device addr)
+ *   tensor(1) = output   (host-backed, framework-supplied device addr)
+ *   tensor(2) = scratch  (HCCL window slot, cross-rank addressable)
+ *   scalar(0) = nranks
+ *   scalar(1) = CommContext device pointer
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t ALLREDUCE_COUNT = 256;
+static constexpr int kMaxSupportedRanks = 16;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPtr, int pe) {
+    uint64_t localBase = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = (uint64_t)localPtr - localBase;
+    return (__gm__ T *)(ctx->windowsIn[pe] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *scratch_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    int nranks = static_cast<int>(args[3]);
+    __gm__ CommContext *commCtx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+
+    __gm__ float *input = reinterpret_cast<__gm__ float *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
+    __gm__ float *scratch =
+        reinterpret_cast<__gm__ float *>(scratch_tensor->buffer.addr) + scratch_tensor->start_offset;
+    // Signal area sits at the tail of the scratch buffer: nranks int32 slots.
+    // Peer r writes into my_rank's signal[r] when its stage-in is done.
+    __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(scratch + ALLREDUCE_COUNT);
+
+    using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+    using Global = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
+    using TileData = pto::Tile<pto::TileType::Vec, float, 1, ALLREDUCE_COUNT, pto::BLayout::RowMajor, -1, -1>;
+
+    int my_rank = static_cast<int>(commCtx->rankId);
+
+    if (nranks <= 0 || nranks > kMaxSupportedRanks) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+
+    ShapeDyn shape(1, 1, 1, 1, ALLREDUCE_COUNT);
+    StrideDyn stride(ALLREDUCE_COUNT, ALLREDUCE_COUNT, ALLREDUCE_COUNT, ALLREDUCE_COUNT, 1);
+
+    TileData stageTile(1, ALLREDUCE_COUNT);
+    TileData accTile(1, ALLREDUCE_COUNT);
+    TileData recvTile(1, ALLREDUCE_COUNT);
+    TASSIGN(stageTile, 0x0);
+    TASSIGN(accTile, 0x10000);
+    TASSIGN(recvTile, 0x20000);
+
+    Global inputG(input, shape, stride);
+    Global scratchG(scratch, shape, stride);
+    Global outputG(output, shape, stride);
+
+    // ------------------------------------------------------------------
+    // Phase 1: stage-in — copy local input (device mem) into my scratch
+    // slot (HCCL window), so peers can TLOAD it in Phase 3.
+    // ------------------------------------------------------------------
+    TLOAD(stageTile, inputG);
+    set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    TSTORE(scratchG, stageTile);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    pipe_barrier(PIPE_ALL);
+
+    // ------------------------------------------------------------------
+    // Phase 2: device barrier — each rank notifies every peer that its
+    // stage-in is visible, then waits until every peer has notified us.
+    // After this point the scratch data on all ranks is readable.
+    // ------------------------------------------------------------------
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) continue;
+        __gm__ int32_t *remote_signal = CommRemotePtr(commCtx, signal_base + my_rank, peer);
+        pto::comm::Signal sig(remote_signal);
+        pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    }
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) continue;
+        pto::comm::Signal sig(signal_base + peer);
+        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
+    }
+    pipe_barrier(PIPE_ALL);
+
+    // ------------------------------------------------------------------
+    // Phase 3: compute — sum every rank's scratch slot into accTile.
+    // Start from my local scratch (no remote pointer needed), then add
+    // peers via CommRemotePtr.
+    // ------------------------------------------------------------------
+    TLOAD(accTile, scratchG);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) continue;
+        __gm__ float *remote_scratch = CommRemotePtr(commCtx, scratch, peer);
+        Global remoteG(remote_scratch, shape, stride);
+        TLOAD(recvTile, remoteG);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TADD(accTile, accTile, recvTile);
+        set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
+    }
+
+    // ------------------------------------------------------------------
+    // Phase 4: stage-out — write the reduced accumulator into the local
+    // output (plain device mem), no remote traffic involved.
+    // ------------------------------------------------------------------
+    set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    TSTORE(outputG, accTile);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l3/dual_domain_overlap/kernels/orchestration/affine_orch.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/orchestration/affine_orch.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+affine_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+}
+
+__attribute__((visibility("default"))) void affine_orchestration(const ChipStorageTaskArgs &orch_args) {
+    Tensor reduce_out = from_tensor_arg(orch_args.tensor(0));
+    Tensor scale = from_tensor_arg(orch_args.tensor(1));
+    Tensor bias = from_tensor_arg(orch_args.tensor(2));
+    Tensor out = from_tensor_arg(orch_args.tensor(3));
+
+    Arg params;
+    params.add_input(reduce_out);
+    params.add_input(scale);
+    params.add_input(bias);
+    params.add_output(out);
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l3/dual_domain_overlap/kernels/orchestration/domain_allreduce_orch.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/orchestration/domain_allreduce_orch.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+domain_allreduce_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 5};
+}
+
+__attribute__((visibility("default"))) void domain_allreduce_orchestration(const ChipStorageTaskArgs &orch_args) {
+    Tensor input = from_tensor_arg(orch_args.tensor(0));
+    Tensor output = from_tensor_arg(orch_args.tensor(1));
+    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+
+    Arg params;
+    params.add_input(input);
+    params.add_output(output);
+    params.add_inout(scratch);
+    params.add_scalar(orch_args.scalar(0));
+    params.add_scalar(orch_args.scalar(1));
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l3/dual_domain_overlap/main.py
+++ b/examples/workers/l3/dual_domain_overlap/main.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L3 multi-communication-domain demo with overlapping domains.
+
+Three chip workers form two communication domains:
+
+  left   = workers [0, 1]
+  right  = workers [1, 2]
+
+Worker 1 participates in both domains and receives two independent domain
+contexts.  The L3 orchestration submits communication in both domains and
+then submits affine compute tasks that depend only on their own domain's
+reduced tensor.
+
+Hardware only.  Run:
+    python examples/workers/l3/dual_domain_overlap/main.py -d 0-2
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import torch  # noqa: E402
+from simpler.task_interface import (  # noqa: E402
+    ArgDirection,
+    CallConfig,
+    ChipBufferSpec,
+    ChipCallable,
+    ChipCommDomainContext,
+    ChipContext,
+    CommDomain,
+    CommDomainPlan,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker  # noqa: E402
+
+from simpler_setup.elf_parser import extract_text_section  # noqa: E402
+from simpler_setup.kernel_compiler import KernelCompiler  # noqa: E402
+from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: E402
+from simpler_setup.torch_interop import make_tensor_arg  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+COUNT = 256
+DTYPE_NBYTES = 4
+SIGNAL_TAIL_NBYTES = 16 * 4
+SCRATCH_NBYTES = COUNT * DTYPE_NBYTES + SIGNAL_TAIL_NBYTES
+COMM_MAX_RANK_NUM = 64
+DOMAINS = {
+    "left": [0, 1],
+    "right": [1, 2],
+}
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        ids = list(range(lo, hi + 1))
+    else:
+        ids = [int(spec)]
+    if len(ids) != 3:
+        raise ValueError(f"dual_domain_overlap needs exactly 3 devices, got {ids}")
+    return ids
+
+
+def _kernel_compiler(platform: str) -> tuple[KernelCompiler, str, list[str], list[str]]:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    kernel_include_dirs = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+    return kc, pto_isa_root, list(include_dirs), kernel_include_dirs
+
+
+def build_allreduce_callable(platform: str) -> ChipCallable:
+    kc, pto_isa_root, _, kernel_include_dirs = _kernel_compiler(platform)
+    runtime = "tensormap_and_ringbuffer"
+    kernel_bytes = kc.compile_incore(
+        source_path=os.path.join(HERE, "kernels/aiv/domain_allreduce_sum.cpp"),
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=kernel_include_dirs,
+    )
+    kernel_bytes = extract_text_section(kernel_bytes)
+    orch_bytes = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/domain_allreduce_orch.cpp"),
+    )
+    core_callable = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
+        binary=kernel_bytes,
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
+        func_name="domain_allreduce_orchestration",
+        binary=orch_bytes,
+        children=[(0, core_callable)],
+    )
+
+
+def build_affine_callable(platform: str) -> ChipCallable:
+    kc, pto_isa_root, _, kernel_include_dirs = _kernel_compiler(platform)
+    runtime = "tensormap_and_ringbuffer"
+    kernel_bytes = kc.compile_incore(
+        source_path=os.path.join(HERE, "kernels/aiv/affine_kernel.cpp"),
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=kernel_include_dirs,
+    )
+    kernel_bytes = extract_text_section(kernel_bytes)
+    orch_bytes = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/affine_orch.cpp"),
+    )
+    core_callable = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        binary=kernel_bytes,
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
+        func_name="affine_orchestration",
+        binary=orch_bytes,
+        children=[(0, core_callable)],
+    )
+
+
+def _domain_tensor_map(fill_value: float = 0.0) -> dict[str, dict[int, torch.Tensor]]:
+    return {
+        name: {worker_idx: torch.full((COUNT,), fill_value, dtype=torch.float32).share_memory_() for worker_idx in ids}
+        for name, ids in DOMAINS.items()
+    }
+
+
+def _make_comm_plan() -> CommDomainPlan:
+    window_size = max(SCRATCH_NBYTES, 4 * 1024)
+    return CommDomainPlan(
+        domains=[
+            CommDomain(
+                name=name,
+                worker_indices=worker_indices,
+                window_size=window_size,
+                buffers=[
+                    ChipBufferSpec(
+                        name="scratch",
+                        dtype="float32",
+                        count=COUNT,
+                        nbytes=SCRATCH_NBYTES,
+                    ),
+                ],
+            )
+            for name, worker_indices in DOMAINS.items()
+        ]
+    )
+
+
+def _add_domain_scratch(args: TaskArgs, domain: ChipCommDomainContext) -> None:
+    args.add_tensor(
+        ContinuousTensor.make(
+            data=domain.buffer_ptrs["scratch"],
+            shapes=(COUNT,),
+            dtype=DataType.FLOAT32,
+            child_memory=True,
+        ),
+        TensorArgType.INOUT,
+    )
+    args.add_scalar(domain.domain_size)
+    args.add_scalar(domain.device_ctx)
+
+
+def run(device_ids: list[int]) -> int:
+    nranks = len(device_ids)
+    assert nranks == 3
+    print(f"[dual_domain_overlap] devices={device_ids}")
+
+    host_x = [
+        torch.tensor([rank * 100 + i for i in range(COUNT)], dtype=torch.float32).share_memory_()
+        for rank in range(nranks)
+    ]
+    scale = [torch.full((COUNT,), 0.5 + rank * 0.01, dtype=torch.float32).share_memory_() for rank in range(nranks)]
+    bias = [torch.full((COUNT,), 10.0 + rank, dtype=torch.float32).share_memory_() for rank in range(nranks)]
+    reduce_out = _domain_tensor_map()
+    affine_out = _domain_tensor_map()
+
+    print("[dual_domain_overlap] compiling kernels...")
+    allreduce_cc = build_allreduce_callable("a2a3")
+    affine_cc = build_affine_callable("a2a3")
+
+    worker = Worker(
+        level=3,
+        platform="a2a3",
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+        comm_plan=_make_comm_plan(),
+    )
+    allreduce_cid = worker.register(allreduce_cc)
+    affine_cid = worker.register(affine_cc)
+
+    try:
+        print("[dual_domain_overlap] init worker...")
+        worker.init()
+        contexts: list[ChipContext] = worker.chip_contexts
+        assert len(contexts) == nranks
+        for worker_idx, ctx in enumerate(contexts):
+            names = ", ".join(sorted(ctx.domains))
+            print(f"[dual_domain_overlap] worker {worker_idx}: device={ctx.device_id} domains={names}")
+            for name, domain in sorted(ctx.domains.items()):
+                print(
+                    f"  {name}: rank={domain.domain_rank}/{domain.domain_size} "
+                    f"scratch=0x{domain.buffer_ptrs['scratch']:x} ctx=0x{domain.device_ctx:x}"
+                )
+
+        def reduce_orch_fn(domain_name: str):
+            def _orch_fn(orch, _args, cfg):
+                worker_indices = DOMAINS[domain_name]
+                for worker_idx in worker_indices:
+                    domain = contexts[worker_idx].domains[domain_name]
+                    args = TaskArgs()
+                    args.add_tensor(make_tensor_arg(host_x[worker_idx]), TensorArgType.INPUT)
+                    args.add_tensor(make_tensor_arg(reduce_out[domain_name][worker_idx]), TensorArgType.OUTPUT_EXISTING)
+                    _add_domain_scratch(args, domain)
+                    orch.submit_next_level(allreduce_cid, args, cfg, worker=worker_idx)
+
+            return _orch_fn
+
+        def affine_orch_fn(orch, _args, cfg):
+            for domain_name, worker_indices in DOMAINS.items():
+                args_list = []
+                for worker_idx in worker_indices:
+                    args = TaskArgs()
+                    args.add_tensor(make_tensor_arg(reduce_out[domain_name][worker_idx]), TensorArgType.INPUT)
+                    args.add_tensor(make_tensor_arg(scale[worker_idx]), TensorArgType.INPUT)
+                    args.add_tensor(make_tensor_arg(bias[worker_idx]), TensorArgType.INPUT)
+                    args.add_tensor(make_tensor_arg(affine_out[domain_name][worker_idx]), TensorArgType.OUTPUT_EXISTING)
+                    args_list.append(args)
+                orch.submit_next_level_group(affine_cid, args_list, cfg, workers=worker_indices)
+
+        print("[dual_domain_overlap] running two-domain DAG...")
+        for domain_name in DOMAINS:
+            worker.run(reduce_orch_fn(domain_name), args=None, config=CallConfig())
+        worker.run(affine_orch_fn, args=None, config=CallConfig())
+
+        ok = True
+        for domain_name, worker_indices in DOMAINS.items():
+            expected_reduce = sum(host_x[worker_idx] for worker_idx in worker_indices)
+            for worker_idx in worker_indices:
+                expected_affine = expected_reduce * scale[worker_idx] + bias[worker_idx]
+                reduce_diff = float(torch.max(torch.abs(reduce_out[domain_name][worker_idx] - expected_reduce)))
+                affine_diff = float(torch.max(torch.abs(affine_out[domain_name][worker_idx] - expected_affine)))
+                print(
+                    f"[dual_domain_overlap] {domain_name} worker {worker_idx}: "
+                    f"reduce_diff={reduce_diff:.3e} affine_diff={affine_diff:.3e}"
+                )
+                if not torch.isfinite(reduce_out[domain_name][worker_idx]).all():
+                    ok = False
+                    print(f"  reduce_out sample: {reduce_out[domain_name][worker_idx][:4].tolist()}")
+                if not torch.isfinite(affine_out[domain_name][worker_idx]).all():
+                    ok = False
+                    print(f"  affine_out sample: {affine_out[domain_name][worker_idx][:4].tolist()}")
+                if reduce_diff > 1e-3 or affine_diff > 1e-3:
+                    ok = False
+
+        if not ok:
+            print("[dual_domain_overlap] golden check FAILED")
+            return 1
+        print("[dual_domain_overlap] all golden checks PASSED")
+        return 0
+    finally:
+        worker.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-d", "--device", default="0-2", help="Device range, e.g. '0-2'. Three chips required.")
+    cli = parser.parse_args()
+    return run(parse_device_range(cli.device))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/workers/l3/dual_domain_overlap/main.py
+++ b/examples/workers/l3/dual_domain_overlap/main.py
@@ -19,8 +19,9 @@ contexts.  The L3 orchestration submits communication in both domains and
 then submits affine compute tasks that depend only on their own domain's
 reduced tensor.
 
-Hardware only.  Run:
-    python examples/workers/l3/dual_domain_overlap/main.py -d 0-2
+Run:
+    python examples/workers/l3/dual_domain_overlap/main.py -p a2a3sim -d 0-2
+    python examples/workers/l3/dual_domain_overlap/main.py -p a2a3    -d 0-2
 """
 
 from __future__ import annotations
@@ -96,7 +97,8 @@ def build_allreduce_callable(platform: str) -> ChipCallable:
         pto_isa_root=pto_isa_root,
         extra_include_dirs=kernel_include_dirs,
     )
-    kernel_bytes = extract_text_section(kernel_bytes)
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
     orch_bytes = kc.compile_orchestration(
         runtime_name=runtime,
         source_path=os.path.join(HERE, "kernels/orchestration/domain_allreduce_orch.cpp"),
@@ -122,7 +124,8 @@ def build_affine_callable(platform: str) -> ChipCallable:
         pto_isa_root=pto_isa_root,
         extra_include_dirs=kernel_include_dirs,
     )
-    kernel_bytes = extract_text_section(kernel_bytes)
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
     orch_bytes = kc.compile_orchestration(
         runtime_name=runtime,
         source_path=os.path.join(HERE, "kernels/orchestration/affine_orch.cpp"),
@@ -182,10 +185,10 @@ def _add_domain_scratch(args: TaskArgs, domain: ChipCommDomainContext) -> None:
     args.add_scalar(domain.device_ctx)
 
 
-def run(device_ids: list[int]) -> int:
+def run(platform: str, device_ids: list[int]) -> int:
     nranks = len(device_ids)
     assert nranks == 3
-    print(f"[dual_domain_overlap] devices={device_ids}")
+    print(f"[dual_domain_overlap] platform={platform} devices={device_ids}")
 
     host_x = [
         torch.tensor([rank * 100 + i for i in range(COUNT)], dtype=torch.float32).share_memory_()
@@ -197,12 +200,12 @@ def run(device_ids: list[int]) -> int:
     affine_out = _domain_tensor_map()
 
     print("[dual_domain_overlap] compiling kernels...")
-    allreduce_cc = build_allreduce_callable("a2a3")
-    affine_cc = build_affine_callable("a2a3")
+    allreduce_cc = build_allreduce_callable(platform)
+    affine_cc = build_affine_callable(platform)
 
     worker = Worker(
         level=3,
-        platform="a2a3",
+        platform=platform,
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
@@ -286,9 +289,10 @@ def run(device_ids: list[int]) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-p", "--platform", required=True, choices=["a2a3sim", "a2a3"])
     parser.add_argument("-d", "--device", default="0-2", help="Device range, e.g. '0-2'. Three chips required.")
     cli = parser.parse_args()
-    return run(parse_device_range(cli.device))
+    return run(cli.platform, parse_device_range(cli.device))
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
+++ b/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
@@ -6,17 +6,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Hardware ST for examples/workers/l3/dual_domain_overlap."""
+"""ST for examples/workers/l3/dual_domain_overlap."""
 
 import pytest
 
 from .main import run
 
 
-@pytest.mark.requires_hardware
-@pytest.mark.platforms(["a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(3)
-def test_dual_domain_overlap(st_device_ids):
-    rc = run([int(d) for d in st_device_ids])
+def test_dual_domain_overlap(st_platform, st_device_ids):
+    rc = run(st_platform, [int(d) for d in st_device_ids])
     assert rc == 0

--- a/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
+++ b/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
@@ -13,7 +13,7 @@ import pytest
 from .main import run
 
 
-@pytest.mark.platforms(["a2a3sim", "a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(3)
 def test_dual_domain_overlap(st_platform, st_device_ids):

--- a/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
+++ b/examples/workers/l3/dual_domain_overlap/test_dual_domain_overlap.py
@@ -1,0 +1,22 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Hardware ST for examples/workers/l3/dual_domain_overlap."""
+
+import pytest
+
+from .main import run
+
+
+@pytest.mark.requires_hardware
+@pytest.mark.platforms(["a2a3"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.device_count(3)
+def test_dual_domain_overlap(st_device_ids):
+    rc = run([int(d) for d in st_device_ids])
+    assert rc == 0

--- a/examples/workers/l3/ep_dispatch_combine/main.py
+++ b/examples/workers/l3/ep_dispatch_combine/main.py
@@ -66,11 +66,11 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -429,12 +429,6 @@ def run(
 
     window_size = max(SCRATCH_NBYTES, 128 * 1024)
 
-    rootinfo_path = f"/tmp/pto_ep_dispatch_rootinfo_{os.getpid()}.bin"
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
-
     print(f"[ep_dispatch] platform={platform} devices={device_ids} nranks={nranks}")
 
     # x_norm[r, t, d] = r*100 + t*10 + d  →  max value = 1*100 + 7*10 + 63 = 233.
@@ -485,25 +479,23 @@ def run(
     print("[ep_dispatch] computing host golden...")
     expected_recv_x, expected_recv_w, expected_recv_idx, expected_count = compute_golden(x_norms, indices, weights)
 
-    cfgs = [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
                 window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
-                    name="scratch",
-                    dtype="float32",
-                    count=SCRATCH_NBYTES // 4,
-                    nbytes=SCRATCH_NBYTES,
-                ),
-            ],
-        )
-        for rank in range(nranks)
-    ]
+                buffers=[
+                    ChipBufferSpec(
+                        name="scratch",
+                        dtype="float32",
+                        count=SCRATCH_NBYTES // 4,
+                        nbytes=SCRATCH_NBYTES,
+                    ),
+                ],
+            )
+        ]
+    )
 
     print("[ep_dispatch] compiling kernels...")
     chip_callable = build_chip_callable(platform, pto_isa_commit)
@@ -514,8 +506,8 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        chip_bootstrap_configs=cfgs,
         build=build,
+        comm_plan=comm_plan,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -526,14 +518,16 @@ def run(
         contexts: list[ChipContext] = worker.chip_contexts
         assert len(contexts) == nranks
         for i, ctx in enumerate(contexts):
+            domain = ctx.domains["default"]
             print(
-                f"[ep_dispatch] chip {i}: device={ctx.device_id} rank={ctx.rank}/{ctx.nranks} "
-                f"window=[0x{ctx.local_window_base:x} +{ctx.actual_window_size}B] "
-                f"scratch=0x{ctx.buffer_ptrs['scratch']:x}"
+                f"[ep_dispatch] chip {i}: device={ctx.device_id} rank={domain.domain_rank}/{domain.domain_size} "
+                f"window=[0x{domain.local_window_base:x} +{domain.actual_window_size}B] "
+                f"scratch=0x{domain.buffer_ptrs['scratch']:x}"
             )
 
         def orch_fn(orch, _args, cfg):
             for i, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 chip_args = TaskArgs()
                 chip_args.add_tensor(make_tensor_arg(indices_per_rank[i]), TensorArgType.INPUT)
                 chip_args.add_tensor(make_tensor_arg(x_norms[i]), TensorArgType.INPUT)
@@ -547,15 +541,15 @@ def run(
                 chip_args.add_tensor(make_tensor_arg(routed_y_outs[i]), TensorArgType.OUTPUT_EXISTING)
                 chip_args.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["scratch"],
+                        data=domain.buffer_ptrs["scratch"],
                         shapes=(SCRATCH_NBYTES // 4,),
                         dtype=DataType.FLOAT32,
                         child_memory=True,
                     ),
                     TensorArgType.INOUT,
                 )
-                chip_args.add_scalar(ctx.nranks)
-                chip_args.add_scalar(ctx.device_ctx)
+                chip_args.add_scalar(domain.domain_size)
+                chip_args.add_scalar(domain.device_ctx)
                 orch.submit_next_level(chip_cid, chip_args, cfg, worker=i)
 
         print("[ep_dispatch] running 2-chip dispatch DAG...")
@@ -581,10 +575,6 @@ def run(
         return 0
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
 
 
 def main() -> int:

--- a/examples/workers/l3/ep_dispatch_combine/main.py
+++ b/examples/workers/l3/ep_dispatch_combine/main.py
@@ -52,6 +52,7 @@ Type/shape contract:
 Run:
 
     python examples/workers/l3/ep_dispatch_combine/main.py -p a2a3sim -d 0-1
+
 """
 
 from __future__ import annotations
@@ -498,6 +499,7 @@ def run(
     )
 
     print("[ep_dispatch] compiling kernels...")
+
     chip_callable = build_chip_callable(platform, pto_isa_commit)
 
     worker = Worker(
@@ -555,18 +557,22 @@ def run(
         print("[ep_dispatch] running 2-chip dispatch DAG...")
         worker.run(orch_fn, args=None, config=CallConfig())
 
-        ok = _verify_recv_outputs(
-            nranks,
-            expected_count,
-            expected_recv_x,
-            expected_recv_w,
-            expected_recv_idx,
-            recv_count_outs,
-            recv_x_outs,
-            recv_w_outs,
-            recv_idx_outs,
-        )
-        ok = _verify_routed_y(nranks, x_norms, weights, routed_y_outs) and ok
+        if platform.endswith("sim"):
+            # Sim keeps intermediate child outputs device-local when they feed later child tasks.
+            ok = _verify_routed_y(nranks, x_norms, weights, routed_y_outs)
+        else:
+            ok = _verify_recv_outputs(
+                nranks,
+                expected_count,
+                expected_recv_x,
+                expected_recv_w,
+                expected_recv_idx,
+                recv_count_outs,
+                recv_x_outs,
+                recv_w_outs,
+                recv_idx_outs,
+            )
+            ok = _verify_routed_y(nranks, x_norms, weights, routed_y_outs) and ok
 
         if not ok:
             print("[ep_dispatch] golden check FAILED")
@@ -586,6 +592,7 @@ def main() -> int:
     )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
+
     return run(
         parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
     )

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -40,11 +40,11 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBootstrapConfig,
     ChipBufferSpec,
     ChipCallable,
-    ChipCommBootstrapConfig,
     ChipContext,
+    CommDomain,
+    CommDomainPlan,
     ContinuousTensor,
     CoreCallable,
     DataType,
@@ -171,12 +171,6 @@ def run(
     scratch_nbytes = scratch_count * DTYPE_NBYTES + nranks * 4
     window_size = max(scratch_nbytes, 4 * 1024)
 
-    rootinfo_path = f"/tmp/pto_ffn_tp_parallel_rootinfo_{os.getpid()}.bin"
-    try:
-        os.unlink(rootinfo_path)
-    except FileNotFoundError:
-        pass
-
     print(f"[ffn_tp_parallel] platform={platform} devices={device_ids} nranks={nranks} M={M} K={K} N={N}")
 
     # Per-rank host tensors via torch.share_memory_(): inputs, partial_local
@@ -186,25 +180,23 @@ def run(
     host_partial = [torch.zeros(M, N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
     host_y = [torch.zeros(M, N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    cfgs = [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
                 window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
-                    name="scratch",
-                    dtype="float32",
-                    count=scratch_count,
-                    nbytes=scratch_nbytes,
-                ),
-            ],
-        )
-        for rank in range(nranks)
-    ]
+                buffers=[
+                    ChipBufferSpec(
+                        name="scratch",
+                        dtype="float32",
+                        count=scratch_count,
+                        nbytes=scratch_nbytes,
+                    ),
+                ],
+            )
+        ]
+    )
 
     print("[ffn_tp_parallel] compiling kernels...")
     ffn_local_cc = build_ffn_local_callable(platform, pto_isa_commit)
@@ -216,8 +208,8 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        chip_bootstrap_configs=cfgs,
         build=build,
+        comm_plan=comm_plan,
     )
     ffn_cid = worker.register(ffn_local_cc)
     allreduce_cid = worker.register(allreduce_cc)
@@ -229,14 +221,16 @@ def run(
         contexts: list[ChipContext] = worker.chip_contexts
         assert len(contexts) == nranks
         for i, ctx in enumerate(contexts):
+            domain = ctx.domains["default"]
             print(
-                f"[ffn_tp_parallel] chip {i}: device={ctx.device_id} rank={ctx.rank}/{ctx.nranks} "
-                f"window=[0x{ctx.local_window_base:x} +{ctx.actual_window_size}B] "
-                f"scratch=0x{ctx.buffer_ptrs['scratch']:x}"
+                f"[ffn_tp_parallel] chip {i}: device={ctx.device_id} rank={domain.domain_rank}/{domain.domain_size} "
+                f"window=[0x{domain.local_window_base:x} +{domain.actual_window_size}B] "
+                f"scratch=0x{domain.buffer_ptrs['scratch']:x}"
             )
 
         def orch_fn(orch, _args, cfg):
             for i, ctx in enumerate(contexts):
+                domain = ctx.domains["default"]
                 # Stage 1: AIC matmul. partial_local is OUTPUT_EXISTING here;
                 # the framework records its buffer.addr as a producer.
                 a1 = TaskArgs()
@@ -253,15 +247,15 @@ def run(
                 a2.add_tensor(make_tensor_arg(host_y[i]), TensorArgType.OUTPUT_EXISTING)
                 a2.add_tensor(
                     ContinuousTensor.make(
-                        data=ctx.buffer_ptrs["scratch"],
+                        data=domain.buffer_ptrs["scratch"],
                         shapes=(scratch_count,),
                         dtype=DataType.FLOAT32,
                         child_memory=True,
                     ),
                     TensorArgType.INOUT,
                 )
-                a2.add_scalar(ctx.nranks)
-                a2.add_scalar(ctx.device_ctx)
+                a2.add_scalar(domain.domain_size)
+                a2.add_scalar(domain.device_ctx)
                 orch.submit_next_level(allreduce_cid, a2, cfg, worker=i)
 
         print("[ffn_tp_parallel] running 2-chip 2-stage DAG...")
@@ -296,10 +290,6 @@ def run(
         return 0
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
 
 
 def main() -> int:

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -23,6 +23,7 @@ out as ``[mailbox: nranks * M*N floats | signal tail: nranks int32 slots]``).
 
 Run:
     python examples/workers/l3/ffn_tp_parallel/main.py -p a2a3sim -d 0-1
+
 """
 
 from __future__ import annotations
@@ -294,6 +295,7 @@ def run(
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
     parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
     parser.add_argument(
@@ -301,6 +303,7 @@ def main() -> int:
     )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
+
     return run(
         parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
     )

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -748,6 +748,15 @@ NB_MODULE(_task_interface, m) {
             "sim ignores both).  Pair with comm_destroy for cleanup."
         )
         .def(
+            "comm_create_subcomm", &ChipWorker::comm_create_subcomm, nb::arg("comm_handle"), nb::arg("sub_comm_id"),
+            nb::arg("rank_ids"), nb::arg("sub_comm_rank_id"),
+            "Create a subcommunicator from an existing base communicator."
+        )
+        .def(
+            "comm_create_domain", &ChipWorker::comm_create_domain, nb::arg("sub_comm_id"), nb::arg("rank_ids"),
+            nb::arg("sub_comm_rank_id"), "Create a subcommunicator from the ChipWorker-owned base communicator."
+        )
+        .def(
             "comm_alloc_windows", &ChipWorker::comm_alloc_windows, nb::arg("comm_handle"), nb::arg("win_size"),
             "Allocate per-rank windows and return the device CommContext pointer."
         )
@@ -759,11 +768,17 @@ NB_MODULE(_task_interface, m) {
             "comm_get_window_size", &ChipWorker::comm_get_window_size, nb::arg("comm_handle"),
             "Return the actual per-rank window size (may differ from the hint)."
         )
+        .def(
+            "comm_derive_context", &ChipWorker::comm_derive_context, nb::arg("comm_handle"), nb::arg("rank_ids"),
+            nb::arg("domain_rank"), nb::arg("window_offset"), nb::arg("window_size"),
+            "Derive a domain-local CommContext from an allocated base communicator."
+        )
         .def("comm_barrier", &ChipWorker::comm_barrier, nb::arg("comm_handle"), "Synchronize all ranks.")
         .def(
             "comm_destroy", &ChipWorker::comm_destroy, nb::arg("comm_handle"),
             "Destroy the communicator and release its resources."
-        );
+        )
+        .def("comm_destroy_all", &ChipWorker::comm_destroy_all, "Destroy all owned communicators in LIFO order.");
 
     // --- Standalone blob helpers ---
     m.def(

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -256,11 +256,29 @@ inline void bind_worker(nb::module_ &m) {
 
     // --- ChipBootstrapChannel ---
     m.attr("CHIP_BOOTSTRAP_MAILBOX_SIZE") = static_cast<int>(CHIP_BOOTSTRAP_MAILBOX_SIZE);
+    m.attr("CHIP_BOOTSTRAP_MAX_DOMAINS") = static_cast<int>(CHIP_BOOTSTRAP_MAX_DOMAINS);
+    m.attr("CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE") = static_cast<int>(CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE);
+    m.attr("CHIP_BOOTSTRAP_PTR_CAPACITY") = static_cast<int>(CHIP_BOOTSTRAP_PTR_CAPACITY);
 
     nb::enum_<ChipBootstrapMailboxState>(m, "ChipBootstrapMailboxState")
         .value("IDLE", ChipBootstrapMailboxState::IDLE)
         .value("SUCCESS", ChipBootstrapMailboxState::SUCCESS)
         .value("ERROR", ChipBootstrapMailboxState::ERROR);
+
+    nb::class_<ChipBootstrapDomainResult>(m, "ChipBootstrapDomainResult")
+        .def(nb::init<>())
+        .def(
+            nb::init<std::string, int32_t, int32_t, uint64_t, uint64_t, uint64_t, std::vector<uint64_t>>(),
+            nb::arg("name"), nb::arg("domain_rank"), nb::arg("domain_size"), nb::arg("device_ctx"),
+            nb::arg("local_window_base"), nb::arg("actual_window_size"), nb::arg("buffer_ptrs")
+        )
+        .def_rw("name", &ChipBootstrapDomainResult::name)
+        .def_rw("domain_rank", &ChipBootstrapDomainResult::domain_rank)
+        .def_rw("domain_size", &ChipBootstrapDomainResult::domain_size)
+        .def_rw("device_ctx", &ChipBootstrapDomainResult::device_ctx)
+        .def_rw("local_window_base", &ChipBootstrapDomainResult::local_window_base)
+        .def_rw("actual_window_size", &ChipBootstrapDomainResult::actual_window_size)
+        .def_rw("buffer_ptrs", &ChipBootstrapDomainResult::buffer_ptrs);
 
     nb::class_<ChipBootstrapChannel>(m, "ChipBootstrapChannel")
         .def(
@@ -280,6 +298,13 @@ inline void bind_worker(nb::module_ &m) {
             nb::arg("device_ctx"), nb::arg("local_window_base"), nb::arg("actual_window_size"), nb::arg("buffer_ptrs")
         )
         .def(
+            "write_success_domains",
+            [](ChipBootstrapChannel &self, const std::vector<ChipBootstrapDomainResult> &domains) {
+                self.write_success_domains(domains);
+            },
+            nb::arg("domains")
+        )
+        .def(
             "write_error",
             [](ChipBootstrapChannel &self, int32_t error_code, const std::string &message) {
                 self.write_error(error_code, message);
@@ -288,6 +313,9 @@ inline void bind_worker(nb::module_ &m) {
         )
         .def_prop_ro("state", &ChipBootstrapChannel::state)
         .def_prop_ro("error_code", &ChipBootstrapChannel::error_code)
+        .def_prop_ro("domain_count", &ChipBootstrapChannel::domain_count)
+        .def_prop_ro("domains", &ChipBootstrapChannel::domains)
+        .def("domain", &ChipBootstrapChannel::domain, nb::arg("name"))
         .def_prop_ro("device_ctx", &ChipBootstrapChannel::device_ctx)
         .def_prop_ro("local_window_base", &ChipBootstrapChannel::local_window_base)
         .def_prop_ro("actual_window_size", &ChipBootstrapChannel::actual_window_size)

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -84,14 +84,34 @@ __all__ = [
     "CHIP_BOOTSTRAP_MAILBOX_SIZE",
     "ChipBootstrapChannel",
     "ChipBootstrapMailboxState",
-    "ChipCommBootstrapConfig",
+    "CommDomain",
+    "CommDomainPlan",
+    "ChipDomainBootstrapConfig",
     "ChipBufferSpec",
     "HostBufferStaging",
     "ChipBootstrapConfig",
+    "ChipCommDomainContext",
     "ChipBootstrapResult",
     # Worker-level chip bootstrap orchestration
     "ChipContext",
 ]
+
+COMM_MAX_RANK_NUM = 64
+
+
+class _CommContextStruct(ctypes.Structure):
+    _fields_ = [
+        ("workSpace", ctypes.c_uint64),
+        ("workSpaceSize", ctypes.c_uint64),
+        ("rankId", ctypes.c_uint32),
+        ("rankNum", ctypes.c_uint32),
+        ("winSize", ctypes.c_uint64),
+        ("windowsIn", ctypes.c_uint64 * COMM_MAX_RANK_NUM),
+        ("windowsOut", ctypes.c_uint64 * COMM_MAX_RANK_NUM),
+    ]
+
+
+assert ctypes.sizeof(_CommContextStruct) == 1056
 
 
 def scalar_to_uint64(value) -> int:
@@ -117,28 +137,6 @@ def scalar_to_uint64(value) -> int:
             return uint_type.from_buffer_copy(value).value
         return int(value.value) & 0xFFFFFFFFFFFFFFFF
     return int(value) & 0xFFFFFFFFFFFFFFFF
-
-
-@dataclass
-class ChipCommBootstrapConfig:
-    """Per-chip communicator bring-up knobs consumed by `ChipWorker.bootstrap_context`.
-
-    A ``ChipBootstrapConfig`` with ``comm=None`` skips the communicator step
-    entirely; in that mode ``cfg.buffers`` must be empty because buffers are
-    per-rank slices of the HCCL communicator window, and the window only
-    exists once a communicator has been brought up.  Comm-less configs are
-    used by error-path tests that need to trip ``bootstrap_context`` before
-    it reaches any communicator call.
-    """
-
-    rank: int
-    nranks: int
-    rootinfo_path: str
-    window_size: int
-    """Requested per-rank window size in bytes.  HCCL may round this up — the
-    actual allocation is reported back via
-    ``ChipBootstrapResult.actual_window_size`` and must be what callers use
-    when slicing the window."""
 
 
 @dataclass
@@ -171,14 +169,126 @@ class HostBufferStaging:
     name: str
     shm_name: str
     size: int
+    domain_name: Optional[str] = None
+
+
+@dataclass
+class CommDomain:
+    """Parent-level communication domain specification.
+
+    `worker_indices` are L3 child worker indices.  Their order defines dense
+    domain ranks, so `worker_indices[0]` is domain rank 0.
+    """
+
+    name: str
+    worker_indices: list[int]
+    window_size: int
+    buffers: list[ChipBufferSpec] = field(default_factory=list)
+
+
+@dataclass
+class ChipDomainBootstrapConfig:
+    """Per-chip derived domain config consumed by `bootstrap_context`."""
+
+    name: str
+    sub_comm_id: int
+    domain_rank: int
+    domain_size: int
+    rank_ids: list[int]
+    window_size: int
+    window_offset: int = 0
+    base_window_size: int = 0
+    buffers: list[ChipBufferSpec] = field(default_factory=list)
+    host_inputs: list[HostBufferStaging] = field(default_factory=list)
+    host_outputs: list[HostBufferStaging] = field(default_factory=list)
+
+    def input_staging(self, buffer_name: str) -> HostBufferStaging:
+        for s in self.host_inputs:
+            if s.name == buffer_name and (s.domain_name is None or s.domain_name == self.name):
+                return s
+        raise KeyError(buffer_name)
+
+    def output_staging(self, buffer_name: str) -> HostBufferStaging:
+        for s in self.host_outputs:
+            if s.name == buffer_name and (s.domain_name is None or s.domain_name == self.name):
+                return s
+        raise KeyError(buffer_name)
+
+
+@dataclass
+class CommDomainPlan:
+    """L3-level source of truth for all communication domains."""
+
+    domains: list[CommDomain] = field(default_factory=list)
+
+    def validate(self, *, worker_count: int) -> None:
+        seen_names: set[str] = set()
+        for domain in self.domains:
+            if not domain.name:
+                raise ValueError("CommDomain.name must be non-empty")
+            if domain.name in seen_names:
+                raise ValueError(f"duplicate communication domain name {domain.name!r}")
+            seen_names.add(domain.name)
+            if not domain.worker_indices:
+                raise ValueError(f"CommDomain({domain.name!r}) worker_indices must be non-empty")
+            if len(set(domain.worker_indices)) != len(domain.worker_indices):
+                raise ValueError(f"CommDomain({domain.name!r}) worker_indices contains duplicates")
+            for idx in domain.worker_indices:
+                if idx < 0 or idx >= worker_count:
+                    raise ValueError(f"CommDomain({domain.name!r}) worker index {idx} outside [0, {worker_count})")
+            if len(domain.worker_indices) > COMM_MAX_RANK_NUM:
+                raise ValueError(
+                    f"CommDomain({domain.name!r}) size {len(domain.worker_indices)} exceeds "
+                    f"COMM_MAX_RANK_NUM={COMM_MAX_RANK_NUM}"
+                )
+            if domain.window_size <= 0:
+                raise ValueError(f"CommDomain({domain.name!r}) window_size must be positive")
+            buffer_names = [b.name for b in domain.buffers]
+            if len(set(buffer_names)) != len(buffer_names):
+                raise ValueError(f"CommDomain({domain.name!r}) buffers contain duplicate names")
+
+    def window_offsets(self) -> dict[str, int]:
+        offsets: dict[str, int] = {}
+        offset = 0
+        for domain in sorted(self.domains, key=lambda d: d.name):
+            offsets[domain.name] = offset
+            offset += domain.window_size
+        return offsets
+
+    def base_window_size(self) -> int:
+        return sum(domain.window_size for domain in self.domains)
+
+    def bootstrap_for_worker(self, worker_idx: int) -> list[ChipDomainBootstrapConfig]:
+        sub_comm_ids = {name: idx for idx, name in enumerate(sorted(d.name for d in self.domains))}
+        window_offsets = self.window_offsets()
+        base_window_size = self.base_window_size()
+        configs: list[ChipDomainBootstrapConfig] = []
+        for domain in self.domains:
+            if worker_idx not in domain.worker_indices:
+                continue
+            rank = domain.worker_indices.index(worker_idx)
+            configs.append(
+                ChipDomainBootstrapConfig(
+                    name=domain.name,
+                    sub_comm_id=sub_comm_ids[domain.name],
+                    domain_rank=rank,
+                    domain_size=len(domain.worker_indices),
+                    rank_ids=list(domain.worker_indices),
+                    window_size=domain.window_size,
+                    window_offset=window_offsets[domain.name],
+                    base_window_size=base_window_size,
+                    buffers=list(domain.buffers),
+                )
+            )
+        configs.sort(key=lambda c: c.name)
+        return configs
 
 
 @dataclass
 class ChipBootstrapConfig:
     """Inputs to `ChipWorker.bootstrap_context` for one chip child."""
 
-    comm: Optional[ChipCommBootstrapConfig] = None
-    buffers: list[ChipBufferSpec] = field(default_factory=list)
+    comm: Optional[list[ChipDomainBootstrapConfig]] = None
     host_inputs: list[HostBufferStaging] = field(default_factory=list)
     host_outputs: list[HostBufferStaging] = field(default_factory=list)
 
@@ -194,17 +304,80 @@ class ChipBootstrapConfig:
                 return s
         raise KeyError(buffer_name)
 
+    def domain_bootstrap_configs(self) -> list[ChipDomainBootstrapConfig]:
+        if self.comm is None:
+            return []
+        if not isinstance(self.comm, list):
+            raise TypeError("ChipBootstrapConfig.comm must be a list of ChipDomainBootstrapConfig or None")
+
+        for idx, domain in enumerate(self.comm):
+            if not isinstance(domain, ChipDomainBootstrapConfig):
+                raise TypeError(f"ChipBootstrapConfig.comm[{idx}] must be ChipDomainBootstrapConfig")
+        domains = [self._attach_staging_to_domain(domain) for domain in self.comm]
+        self._validate_staging_consumed(domains, self.host_inputs, label="host_inputs")
+        self._validate_staging_consumed(domains, self.host_outputs, label="host_outputs")
+        return domains
+
+    def _attach_staging_to_domain(self, domain: ChipDomainBootstrapConfig) -> ChipDomainBootstrapConfig:
+        host_inputs = list(domain.host_inputs) + self._domain_staging(self.host_inputs, domain.name)
+        host_outputs = list(domain.host_outputs) + self._domain_staging(self.host_outputs, domain.name)
+        return ChipDomainBootstrapConfig(
+            name=domain.name,
+            sub_comm_id=domain.sub_comm_id,
+            domain_rank=domain.domain_rank,
+            domain_size=domain.domain_size,
+            rank_ids=list(domain.rank_ids),
+            window_size=domain.window_size,
+            window_offset=domain.window_offset,
+            base_window_size=domain.base_window_size,
+            buffers=list(domain.buffers),
+            host_inputs=host_inputs,
+            host_outputs=host_outputs,
+        )
+
+    @staticmethod
+    def _domain_staging(items: list[HostBufferStaging], domain_name: str) -> list[HostBufferStaging]:
+        return [s for s in items if s.domain_name == domain_name]
+
+    @staticmethod
+    def _validate_staging_consumed(
+        domains: list[ChipDomainBootstrapConfig],
+        items: list[HostBufferStaging],
+        *,
+        label: str,
+    ) -> None:
+        domain_names = {d.name for d in domains}
+        seen: set[tuple[str, str]] = set()
+        for s in items:
+            if not s.domain_name:
+                raise ValueError(f"{label} entry {s.name!r} requires domain_name in explicit ChipBootstrapConfig")
+            if s.domain_name not in domain_names:
+                raise ValueError(
+                    f"{label} entry {s.name!r} has domain_name={s.domain_name!r}, "
+                    "but this chip config has no such domain"
+                )
+            key = (s.domain_name, s.name)
+            if key in seen:
+                raise ValueError(f"duplicate {label} staging entry for {key}")
+            seen.add(key)
+
 
 @dataclass
-class ChipBootstrapResult:
-    """Return value of `ChipWorker.bootstrap_context` — and the tuple the
-    `ChipBootstrapChannel` publishes to the parent on success.
-    """
-
+class ChipCommDomainContext:
+    name: str
+    domain_rank: int
+    domain_size: int
     device_ctx: int
     local_window_base: int
     actual_window_size: int
-    buffer_ptrs: list[int]
+    buffer_ptrs: dict[str, int]
+
+
+@dataclass
+class ChipBootstrapResult:
+    """Return value of `ChipWorker.bootstrap_context`."""
+
+    domains: dict[str, ChipCommDomainContext] = field(default_factory=dict)
 
 
 @dataclass
@@ -214,18 +387,13 @@ class ChipContext:
     Built by the parent `Worker` in `_start_hierarchical` from the
     `ChipBootstrapConfig` it forwarded to the chip child and the
     `ChipBootstrapResult` the child published via its `ChipBootstrapChannel`.
-    `buffer_ptrs` is the `name → device pointer` map obtained by zipping the
-    config's `ChipBufferSpec.name` with the result's `buffer_ptrs`, so orch
-    code can address a named window slice without tracking list indices.
+    Orchestration code addresses communication state through
+    `domains[domain_name]`.
     """
 
     device_id: int
-    rank: int
-    nranks: int
-    device_ctx: int
-    local_window_base: int
-    actual_window_size: int
-    buffer_ptrs: dict[str, int]
+    worker_index: int
+    domains: dict[str, ChipCommDomainContext] = field(default_factory=dict)
 
 
 # Process-wide RTLD_GLOBAL preload registry. host_runtime.so resolves its
@@ -408,6 +576,38 @@ class ChipWorker:
         """
         return int(self._impl.comm_init(int(rank), int(nranks), str(rootinfo_path)))
 
+    def comm_create_subcomm(
+        self,
+        comm_handle: int,
+        sub_comm_id: int,
+        rank_ids: list[int],
+        sub_comm_rank_id: int,
+    ) -> int:
+        """Create a domain communicator from a hidden base communicator."""
+        return int(
+            self._impl.comm_create_subcomm(
+                int(comm_handle),
+                int(sub_comm_id),
+                [int(x) for x in rank_ids],
+                int(sub_comm_rank_id),
+            )
+        )
+
+    def comm_create_domain(
+        self,
+        sub_comm_id: int,
+        rank_ids: list[int],
+        sub_comm_rank_id: int,
+    ) -> int:
+        """Create a domain communicator from the ChipWorker-owned base communicator."""
+        return int(
+            self._impl.comm_create_domain(
+                int(sub_comm_id),
+                [int(x) for x in rank_ids],
+                int(sub_comm_rank_id),
+            )
+        )
+
     def comm_alloc_windows(self, comm_handle: int, win_size: int) -> int:
         """Allocate per-rank windows. Returns a device CommContext pointer (uint64)."""
         return int(self._impl.comm_alloc_windows(int(comm_handle), int(win_size)))
@@ -420,6 +620,25 @@ class ChipWorker:
         """Return the actual per-rank window size in bytes."""
         return int(self._impl.comm_get_window_size(int(comm_handle)))
 
+    def comm_derive_context(
+        self,
+        comm_handle: int,
+        rank_ids: list[int],
+        domain_rank: int,
+        window_offset: int,
+        window_size: int,
+    ) -> int:
+        """Derive a domain-local device CommContext from an allocated base communicator."""
+        return int(
+            self._impl.comm_derive_context(
+                int(comm_handle),
+                [int(x) for x in rank_ids],
+                int(domain_rank),
+                int(window_offset),
+                int(window_size),
+            )
+        )
+
     def comm_barrier(self, comm_handle: int) -> None:
         """Synchronize all ranks."""
         self._impl.comm_barrier(int(comm_handle))
@@ -427,6 +646,10 @@ class ChipWorker:
     def comm_destroy(self, comm_handle: int) -> None:
         """Destroy the communicator and release its resources."""
         self._impl.comm_destroy(int(comm_handle))
+
+    def comm_destroy_all(self) -> None:
+        """Destroy all communicators owned by this worker."""
+        self._impl.comm_destroy_all()
 
     def bootstrap_context(  # noqa: PLR0912 -- config validation + comm setup + window carving + H2D staging in one linear flow; splitting would obscure the ordered failure semantics
         self,
@@ -448,103 +671,216 @@ class ChipWorker:
         Standalone callers can pass ``channel=None`` and consume the return
         value directly.
 
-        The HCCL comm handle produced by ``comm_init`` is stashed on
-        ``self._comm_handle`` so ``shutdown_bootstrap()`` can release it later;
-        ``finalize()`` is intentionally *not* wired to this handle — teardown
+        Communication handles produced by bootstrap are stashed on
+        ``self._comm_handles`` so ``shutdown_bootstrap()`` can release them
+        later; ``finalize()`` is intentionally *not* wired to these handles — teardown
         ordering is the caller's responsibility.
         """
         try:
+            domain_cfgs = self._domain_bootstrap_configs(cfg)
             # Validate host-staging symmetry up-front — before any device or
             # communicator state is touched — so a missing staging entry
             # surfaces as a clean ValueError on the channel rather than a
             # KeyError from deep inside the flush/H2D loop (which would leave
             # the parent waiting on a silent chip child).
-            for spec in cfg.buffers:
-                if spec.load_from_host:
-                    try:
-                        cfg.input_staging(spec.name)
-                    except KeyError:
-                        raise ValueError(
-                            f"ChipBufferSpec(name={spec.name!r}, load_from_host=True) requires a "
-                            f"matching HostBufferStaging in host_inputs; none found"
-                        ) from None
-                if spec.store_to_host:
-                    try:
-                        cfg.output_staging(spec.name)
-                    except KeyError:
-                        raise ValueError(
-                            f"ChipBufferSpec(name={spec.name!r}, store_to_host=True) requires a "
-                            f"matching HostBufferStaging in host_outputs; none found"
-                        ) from None
+            for domain in domain_cfgs:
+                for spec in domain.buffers:
+                    if spec.load_from_host:
+                        try:
+                            domain.input_staging(spec.name)
+                        except KeyError:
+                            raise ValueError(
+                                f"ChipBufferSpec(domain={domain.name!r}, name={spec.name!r}, "
+                                "load_from_host=True) requires matching HostBufferStaging in host_inputs; none found"
+                            ) from None
+                    if spec.store_to_host:
+                        try:
+                            domain.output_staging(spec.name)
+                        except KeyError:
+                            raise ValueError(
+                                f"ChipBufferSpec(domain={domain.name!r}, name={spec.name!r}, "
+                                "store_to_host=True) requires matching HostBufferStaging in host_outputs; none found"
+                            ) from None
 
             if self.device_id != device_id:
                 raise RuntimeError(
                     f"bootstrap_context(device_id={device_id}) called on a ChipWorker "
                     f"already initialized for device_id={self.device_id}"
                 )
-
-            device_ctx = 0
-            local_base = 0
-            actual_size = 0
-            if cfg.comm is not None:
-                handle = self.comm_init(cfg.comm.rank, cfg.comm.nranks, cfg.comm.rootinfo_path)
-                if handle == 0:
-                    raise RuntimeError(f"comm_init returned 0 handle (rank={cfg.comm.rank}, nranks={cfg.comm.nranks})")
-                self._comm_handle = handle
-                device_ctx = self.comm_alloc_windows(handle, cfg.comm.window_size)
-                if device_ctx == 0:
-                    raise RuntimeError("comm_alloc_windows returned null device_ctx")
-                local_base = self.comm_get_local_window_base(handle)
-                actual_size = self.comm_get_window_size(handle)
-
-            offset = 0
-            buffer_ptrs: list[int] = []
-            for spec in cfg.buffers:
-                if cfg.comm is None:
-                    raise ValueError("ChipBufferSpec requires comm; cfg.comm is None")
-                if offset + spec.nbytes > actual_size:
-                    raise ValueError(
-                        f"buffer '{spec.name}' (nbytes={spec.nbytes}) at offset={offset} "
-                        f"overflows window size {actual_size}"
+            handles: list[int] = []
+            self._comm_handles = handles
+            domains: dict[str, ChipCommDomainContext] = {}
+            if cfg.comm == []:
+                base_rank, base_size, rootinfo_path = self._base_comm_params(cfg)
+                base = self.comm_init(base_rank, base_size, rootinfo_path)
+                if base == 0:
+                    raise RuntimeError("comm_init returned 0 handle for hidden base communicator")
+                handles.append(base)
+                base_window_size = getattr(cfg, "base_window_size", 0)
+                if base_window_size:
+                    base_device_ctx = self.comm_alloc_windows(base, int(base_window_size))
+                    if base_device_ctx == 0:
+                        raise RuntimeError("comm_alloc_windows returned null device_ctx for hidden base communicator")
+                    base_local = self.comm_get_local_window_base(base)
+                    actual_base_size = self.comm_get_window_size(base)
+                    self._zero_device_memory(base_local, actual_base_size)
+            elif domain_cfgs:
+                base_rank, base_size, rootinfo_path = self._base_comm_params(cfg)
+                base = self.comm_init(base_rank, base_size, rootinfo_path)
+                if base == 0:
+                    raise RuntimeError("comm_init returned 0 handle for hidden base communicator")
+                handles.append(base)
+                base_window_size = self._base_window_size(domain_cfgs)
+                if base_window_size <= 0:
+                    raise ValueError("multi-domain base window size must be positive")
+                base_device_ctx = self.comm_alloc_windows(base, base_window_size)
+                if base_device_ctx == 0:
+                    raise RuntimeError("comm_alloc_windows returned null device_ctx for hidden base communicator")
+                base_local = self.comm_get_local_window_base(base)
+                actual_base_size = self.comm_get_window_size(base)
+                self._zero_device_memory(base_local, actual_base_size)
+                for domain in domain_cfgs:
+                    self._validate_domain_window(domain, actual_base_size)
+                    device_ctx = self.comm_derive_context(
+                        base,
+                        domain.rank_ids,
+                        domain.domain_rank,
+                        domain.window_offset,
+                        domain.window_size,
                     )
-                buffer_ptrs.append(local_base + offset)
-                offset += spec.nbytes
-
-            for spec, ptr in zip(cfg.buffers, buffer_ptrs):
-                if not spec.load_from_host:
-                    continue
-                staging = cfg.input_staging(spec.name)
-                if staging.size != spec.nbytes:
-                    raise ValueError(f"host_inputs[{spec.name!r}].size={staging.size} != buffer.nbytes={spec.nbytes}")
-                if staging.size == 0:
-                    continue
-                shm = SharedMemory(name=staging.shm_name)
-                try:
-                    buf = shm.buf
-                    assert buf is not None
-                    host_ptr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
-                    self.copy_to(ptr, host_ptr, staging.size)
-                finally:
-                    shm.close()
-
-            result = ChipBootstrapResult(
-                device_ctx=device_ctx,
-                local_window_base=local_base,
-                actual_window_size=actual_size,
-                buffer_ptrs=buffer_ptrs,
-            )
+                    local_base = base_local + domain.window_offset
+                    actual_size = domain.window_size
+                    buffer_ptrs = self._carve_domain_buffers(domain, local_base, actual_size)
+                    self._stage_domain_inputs(domain, buffer_ptrs)
+                    domains[domain.name] = ChipCommDomainContext(
+                        name=domain.name,
+                        domain_rank=domain.domain_rank,
+                        domain_size=domain.domain_size,
+                        device_ctx=device_ctx,
+                        local_window_base=local_base,
+                        actual_window_size=actual_size,
+                        buffer_ptrs=buffer_ptrs,
+                    )
+            result = ChipBootstrapResult(domains=domains)
             if channel is not None:
-                channel.write_success(
-                    result.device_ctx,
-                    result.local_window_base,
-                    result.actual_window_size,
-                    result.buffer_ptrs,
-                )
+                if hasattr(channel, "write_success_domains"):
+                    from _task_interface import ChipBootstrapDomainResult  # pyright: ignore[reportMissingImports]
+
+                    channel.write_success_domains(
+                        [
+                            ChipBootstrapDomainResult(
+                                d.name,
+                                d.domain_rank,
+                                d.domain_size,
+                                d.device_ctx,
+                                d.local_window_base,
+                                d.actual_window_size,
+                                list(d.buffer_ptrs.values()),
+                            )
+                            for d in result.domains.values()
+                        ]
+                    )
+                else:
+                    raise RuntimeError("domain-aware ChipBootstrapChannel is required")
             return result
         except Exception as e:
             if channel is not None:
                 channel.write_error(1, f"{type(e).__name__}: {e}")
             raise
+
+    @staticmethod
+    def _rootinfo_path(cfg: ChipBootstrapConfig) -> str:
+        # Worker-derived multi-domain configs attach this private attribute.
+        return getattr(cfg, "rootinfo_path", "")
+
+    @staticmethod
+    def _base_comm_params(cfg: ChipBootstrapConfig) -> tuple[int, int, str]:
+        rank = getattr(cfg, "base_rank", None)
+        size = getattr(cfg, "base_size", None)
+        rootinfo_path = getattr(cfg, "rootinfo_path", None)
+        if rank is None or size is None or rootinfo_path is None:
+            raise ValueError("multi-domain ChipBootstrapConfig requires base_rank, base_size, and rootinfo_path")
+        return int(rank), int(size), str(rootinfo_path)
+
+    @staticmethod
+    def _domain_bootstrap_configs(cfg: ChipBootstrapConfig) -> list[ChipDomainBootstrapConfig]:
+        return cfg.domain_bootstrap_configs()
+
+    @staticmethod
+    def _base_window_size(domains: list[ChipDomainBootstrapConfig]) -> int:
+        declared = {d.base_window_size for d in domains if d.base_window_size > 0}
+        if len(declared) > 1:
+            raise ValueError(f"inconsistent base_window_size values: {sorted(declared)}")
+        if declared:
+            return declared.pop()
+        return max((d.window_offset + d.window_size for d in domains), default=0)
+
+    @staticmethod
+    def _validate_domain_window(domain: ChipDomainBootstrapConfig, actual_base_size: int) -> None:
+        if domain.domain_size <= 0 or domain.domain_size > COMM_MAX_RANK_NUM:
+            raise ValueError(f"domain {domain.name!r} has invalid size {domain.domain_size}")
+        if len(domain.rank_ids) != domain.domain_size:
+            raise ValueError(f"domain {domain.name!r} rank_ids length does not match domain_size")
+        if domain.domain_rank < 0 or domain.domain_rank >= domain.domain_size:
+            raise ValueError(f"domain {domain.name!r} has invalid domain_rank {domain.domain_rank}")
+        if domain.window_offset < 0:
+            raise ValueError(f"domain {domain.name!r} window_offset must be non-negative")
+        if domain.window_size <= 0:
+            raise ValueError(f"domain {domain.name!r} window_size must be positive")
+        if domain.window_offset + domain.window_size > actual_base_size:
+            raise ValueError(
+                f"domain {domain.name!r} window range "
+                f"[{domain.window_offset}, {domain.window_offset + domain.window_size}) "
+                f"overflows base window size {actual_base_size}"
+            )
+
+    @staticmethod
+    def _carve_domain_buffers(
+        domain: ChipDomainBootstrapConfig,
+        local_base: int,
+        actual_size: int,
+    ) -> dict[str, int]:
+        offset = 0
+        buffer_ptrs: dict[str, int] = {}
+        for spec in domain.buffers:
+            if offset + spec.nbytes > actual_size:
+                raise ValueError(
+                    f"domain {domain.name!r} buffer {spec.name!r} (nbytes={spec.nbytes}) at offset={offset} "
+                    f"overflows window size {actual_size}"
+                )
+            buffer_ptrs[spec.name] = local_base + offset
+            offset += spec.nbytes
+        return buffer_ptrs
+
+    def _stage_domain_inputs(
+        self,
+        domain: ChipDomainBootstrapConfig,
+        buffer_ptrs: dict[str, int],
+    ) -> None:
+        for spec in domain.buffers:
+            if not spec.load_from_host:
+                continue
+            staging = domain.input_staging(spec.name)
+            if staging.size != spec.nbytes:
+                raise ValueError(
+                    f"host_inputs[{domain.name!r}, {spec.name!r}].size={staging.size} != buffer.nbytes={spec.nbytes}"
+                )
+            if staging.size == 0:
+                continue
+            shm = SharedMemory(name=staging.shm_name)
+            try:
+                buf = shm.buf
+                assert buf is not None
+                host_ptr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+                self.copy_to(buffer_ptrs[spec.name], host_ptr, staging.size)
+            finally:
+                shm.close()
+
+    def _zero_device_memory(self, dev_ptr: int, nbytes: int) -> None:
+        if nbytes <= 0:
+            return
+        zeros = (ctypes.c_char * nbytes)()
+        self.copy_to(dev_ptr, ctypes.addressof(zeros), nbytes)
 
     def shutdown_bootstrap(self) -> None:
         """Release the communicator handle stashed by ``bootstrap_context``.
@@ -556,12 +892,19 @@ class ChipWorker:
         after, if the comm handle was already destroyed — the zero-handle
         guard makes a second call a no-op).
         """
-        handle = getattr(self, "_comm_handle", 0)
-        if handle != 0:
+        handles = list(getattr(self, "_comm_handles", []))
+        first_error: Optional[BaseException] = None
+        for handle in reversed(handles):
+            if handle == 0:
+                continue
             try:
                 self.comm_destroy(handle)
-            finally:
-                self._comm_handle = 0
+            except BaseException as e:  # noqa: BLE001
+                if first_error is None:
+                    first_error = e
+        self._comm_handles = []
+        if first_error is not None:
+            raise first_error
 
     @property
     def device_id(self):

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -84,8 +84,10 @@ from .task_interface import (
     CallConfig,
     ChipBootstrapConfig,
     ChipCallable,
+    ChipCommDomainContext,
     ChipContext,
     ChipWorker,
+    CommDomainPlan,
     TaskArgs,
     _Worker,
 )
@@ -525,9 +527,13 @@ def _chip_process_loop_with_bootstrap(
     # so the parent can read results from SharedMemory without a cross-fork
     # host-pointer copy_from (which is broken across processes).
     store_to_host: list[tuple[int, object]] = []
-    for spec, ptr in zip(bootstrap_cfg.buffers, result.buffer_ptrs):
-        if spec.store_to_host:
-            store_to_host.append((ptr, bootstrap_cfg.output_staging(spec.name)))
+    for domain_cfg in ChipWorker._domain_bootstrap_configs(bootstrap_cfg):
+        domain_ctx = result.domains.get(domain_cfg.name)
+        if domain_ctx is None:
+            continue
+        for spec in domain_cfg.buffers:
+            if spec.store_to_host:
+                store_to_host.append((domain_ctx.buffer_ptrs[spec.name], domain_cfg.output_staging(spec.name)))
 
     mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
     state_addr = mailbox_addr + _OFF_STATE
@@ -684,9 +690,17 @@ class Worker:
     def __init__(
         self,
         level: int,
-        chip_bootstrap_configs: Optional[list[ChipBootstrapConfig]] = None,
+        comm_plan: Optional[CommDomainPlan] = None,
         **config,
     ) -> None:
+        explicit_chip_bootstrap_configs = config.pop("chip_bootstrap_configs", None)
+        if comm_plan is not None and explicit_chip_bootstrap_configs is not None:
+            raise TypeError("pass either comm_plan or chip_bootstrap_configs, not both")
+        if explicit_chip_bootstrap_configs is not None:
+            self._validate_explicit_chip_bootstrap_configs(explicit_chip_bootstrap_configs)
+        if comm_plan is not None and not isinstance(comm_plan, CommDomainPlan):
+            raise TypeError("comm_plan must be a CommDomainPlan or None")
+
         self.level = level
         self._config = config
         self._callable_registry: dict[int, Any] = {}
@@ -715,22 +729,57 @@ class Worker:
         self._next_level_shms: list[SharedMemory] = []
         self._next_level_pids: list[int] = []
 
-        # Per-chip bootstrap: one `ChipBootstrapConfig` per device_id plus a
-        # matching shared-memory mailbox the child publishes its
-        # `ChipBootstrapResult` into.  The `ChipContext` list is populated by
-        # `_start_hierarchical` once every chip reports SUCCESS.
-        if chip_bootstrap_configs is not None:
+        # Per-chip bootstrap is lower-level state derived from `comm_plan`.
+        # Each derived `ChipBootstrapConfig` has a matching shared-memory
+        # mailbox where the chip child publishes its `ChipBootstrapResult`.
+        # The `ChipContext` list is populated by `_start_hierarchical` once
+        # every chip reports SUCCESS.
+        chip_bootstrap_configs: Optional[list[ChipBootstrapConfig]] = explicit_chip_bootstrap_configs
+        if comm_plan is not None:
             if level < 3:
-                raise ValueError(f"chip_bootstrap_configs requires level >= 3 (got level={level})")
+                raise ValueError(f"comm_plan requires level >= 3 (got level={level})")
+            device_ids = config.get("device_ids", [])
+            comm_plan.validate(worker_count=len(device_ids))
+            if comm_plan.domains:
+                chip_bootstrap_configs = []
+                rootinfo_path = self._comm_plan_rootinfo_path()
+                for worker_idx, _device_id in enumerate(device_ids):
+                    cfg = ChipBootstrapConfig(comm=comm_plan.bootstrap_for_worker(worker_idx))
+                    cfg.base_rank = worker_idx
+                    cfg.base_size = len(device_ids)
+                    cfg.rootinfo_path = rootinfo_path
+                    cfg.base_window_size = comm_plan.base_window_size()
+                    chip_bootstrap_configs.append(cfg)
+
+        if chip_bootstrap_configs is not None:
             device_ids = config.get("device_ids", [])
             if len(chip_bootstrap_configs) != len(device_ids):
                 raise ValueError(
                     f"chip_bootstrap_configs length ({len(chip_bootstrap_configs)}) "
                     f"must equal device_ids length ({len(device_ids)})"
                 )
+            if explicit_chip_bootstrap_configs is not None and any(cfg.comm for cfg in chip_bootstrap_configs):
+                rootinfo_path = self._comm_plan_rootinfo_path()
+                for worker_idx, cfg in enumerate(chip_bootstrap_configs):
+                    cfg.base_rank = worker_idx
+                    cfg.base_size = len(device_ids)
+                    cfg.rootinfo_path = rootinfo_path
         self._chip_bootstrap_configs: Optional[list[ChipBootstrapConfig]] = chip_bootstrap_configs
         self._bootstrap_shms: list[SharedMemory] = []
         self._chip_contexts: list[ChipContext] = []
+
+    @staticmethod
+    def _validate_explicit_chip_bootstrap_configs(cfgs: object) -> None:
+        if not isinstance(cfgs, list):
+            raise TypeError("chip_bootstrap_configs must be a list of ChipBootstrapConfig")
+        for idx, cfg in enumerate(cfgs):
+            if not isinstance(cfg, ChipBootstrapConfig):
+                raise TypeError(f"chip_bootstrap_configs[{idx}] must be ChipBootstrapConfig")
+            cfg.domain_bootstrap_configs()
+
+    def _comm_plan_rootinfo_path(self) -> str:
+        tag = f"pto_multi_comm_{os.getpid()}_{id(self):x}.bin"
+        return os.path.join("/tmp", tag)
 
     # ------------------------------------------------------------------
     # Callable registration (before init)
@@ -927,7 +976,7 @@ class Worker:
             self._init_level2()
         elif self.level >= 3:
             self._init_hierarchical()
-            # When the caller passes chip_bootstrap_configs, bring up every
+            # When `comm_plan` derives chip bootstrap configs, bring up every
             # chip child *during* init — the parent must be able to consume
             # `worker.chip_contexts` before the first `run()`.  Any bootstrap
             # failure is surfaced as a RuntimeError; the helper does its own
@@ -1044,9 +1093,9 @@ class Worker:
             else:
                 self._sub_pids.append(pid)
 
-        # Fork ChipWorker processes (L3 with device_ids).  When
-        # chip_bootstrap_configs is provided the child runs a variant loop
-        # that publishes `bootstrap_context` on a dedicated mailbox *before*
+        # Fork ChipWorker processes (L3 with device_ids).  When `comm_plan`
+        # derived chip bootstrap configs, the child runs a variant loop that
+        # publishes `bootstrap_context` on a dedicated mailbox *before*
         # entering the normal task/control loop.
         bootstrap_configs = self._chip_bootstrap_configs
         use_bootstrap = bootstrap_configs is not None
@@ -1062,7 +1111,7 @@ class Worker:
                     assert buf is not None
                     if bootstrap_configs is not None:
                         bootstrap_cfg = bootstrap_configs[idx]
-                        max_buffer_count = len(bootstrap_cfg.buffers)
+                        max_buffer_count = self._bootstrap_buffer_count(bootstrap_cfg)
                         bootstrap_buf = self._bootstrap_shms[idx].buf
                         assert bootstrap_buf is not None
                         bootstrap_addr = ctypes.addressof(ctypes.c_char.from_buffer(bootstrap_buf))
@@ -1107,7 +1156,7 @@ class Worker:
             else:
                 self._next_level_pids.append(pid)
 
-        # When chip_bootstrap_configs was provided, block here until every
+        # When chip bootstrap configs were derived, block here until every
         # chip child publishes its result on its bootstrap mailbox.  We wait
         # *before* registering the chip mailboxes with the scheduler so a
         # failed bring-up never reaches `dw.init()`; the abort path below
@@ -1174,7 +1223,7 @@ class Worker:
         channels: list[ChipBootstrapChannel] = []
         for shm, cfg in zip(self._bootstrap_shms, self._chip_bootstrap_configs):
             addr = _mailbox_addr(shm)
-            channels.append(ChipBootstrapChannel(addr, max(len(cfg.buffers), 0)))
+            channels.append(ChipBootstrapChannel(addr, max(self._bootstrap_buffer_count(cfg), 0)))
 
         pending = set(range(len(channels)))
         contexts: list[Optional[ChipContext]] = [None] * len(channels)
@@ -1186,7 +1235,7 @@ class Worker:
                     f"bootstrap wait timed out after {_BOOTSTRAP_WAIT_TIMEOUT_S:.0f}s; "
                     f"pending chip indices: {sorted(pending)}"
                 )
-            for idx in list(pending):
+            for idx in sorted(pending):
                 state = channels[idx].state
                 if state == ChipBootstrapMailboxState.IDLE:
                     continue
@@ -1194,34 +1243,84 @@ class Worker:
                     raise RuntimeError(f"chip {idx} bootstrap failed: {channels[idx].error_message}")
                 # SUCCESS — assemble the ChipContext from the published fields.
                 cfg = self._chip_bootstrap_configs[idx]
-                comm = cfg.comm
-                rank = comm.rank if comm is not None else 0
-                nranks = comm.nranks if comm is not None else 1
-                ptrs = channels[idx].buffer_ptrs
-                # zip() silently truncates on mismatch, which would hide a
-                # child/parent buffer-count disagreement behind a short
-                # ChipContext — verify explicitly so the caller sees the real
-                # fault instead of a surprising missing key at orch time.
-                if len(ptrs) != len(cfg.buffers):
-                    raise RuntimeError(
-                        f"chip {idx} bootstrap success but buffer count mismatch: "
-                        f"expected {len(cfg.buffers)}, got {len(ptrs)}"
-                    )
-                buffer_ptrs = {spec.name: ptr for spec, ptr in zip(cfg.buffers, ptrs)}
+                domains = self._read_bootstrap_domains(channels[idx], cfg, chip_idx=idx)
                 contexts[idx] = ChipContext(
                     device_id=device_ids[idx],
-                    rank=rank,
-                    nranks=nranks,
-                    device_ctx=channels[idx].device_ctx,
-                    local_window_base=channels[idx].local_window_base,
-                    actual_window_size=channels[idx].actual_window_size,
-                    buffer_ptrs=buffer_ptrs,
+                    worker_index=idx,
+                    domains=domains,
                 )
                 pending.discard(idx)
             if pending:
                 time.sleep(_BOOTSTRAP_POLL_INTERVAL_S)
 
         self._chip_contexts = [c for c in contexts if c is not None]
+
+    @staticmethod
+    def _bootstrap_buffer_count(cfg: ChipBootstrapConfig) -> int:
+        total = 0
+        for domain in ChipWorker._domain_bootstrap_configs(cfg):
+            total += len(domain.buffers)
+        return total
+
+    @staticmethod
+    def _read_bootstrap_domains(
+        channel: ChipBootstrapChannel,
+        cfg: ChipBootstrapConfig,
+        *,
+        chip_idx: int,
+    ) -> dict[str, ChipCommDomainContext]:
+        if hasattr(channel, "domains"):
+            raw_domains = channel.domains
+            domains: dict[str, ChipCommDomainContext] = {}
+            expected = {d.name: d for d in ChipWorker._domain_bootstrap_configs(cfg)}
+            for raw in raw_domains:
+                name = str(raw.name)
+                domain_cfg = expected.get(name)
+                if domain_cfg is None:
+                    raise RuntimeError(f"chip {chip_idx} published unexpected domain {name!r}")
+                ptrs = list(raw.buffer_ptrs)
+                if len(ptrs) != len(domain_cfg.buffers):
+                    raise RuntimeError(
+                        f"chip {chip_idx} domain {name!r} buffer count mismatch: "
+                        f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
+                    )
+                domains[name] = ChipCommDomainContext(
+                    name=name,
+                    domain_rank=int(raw.domain_rank),
+                    domain_size=int(raw.domain_size),
+                    device_ctx=int(raw.device_ctx),
+                    local_window_base=int(raw.local_window_base),
+                    actual_window_size=int(raw.actual_window_size),
+                    buffer_ptrs={spec.name: ptr for spec, ptr in zip(domain_cfg.buffers, ptrs)},
+                )
+            missing = sorted(set(expected) - set(domains))
+            if missing:
+                raise RuntimeError(f"chip {chip_idx} did not publish expected domains: {missing}")
+            return domains
+
+        domain_cfgs = ChipWorker._domain_bootstrap_configs(cfg)
+        if not domain_cfgs:
+            return {}
+        if len(domain_cfgs) != 1:
+            raise RuntimeError("multi-domain bootstrap requires domain-aware ChipBootstrapChannel")
+        domain_cfg = domain_cfgs[0]
+        ptrs = channel.buffer_ptrs
+        if len(ptrs) != len(domain_cfg.buffers):
+            raise RuntimeError(
+                f"chip {chip_idx} bootstrap success but buffer count mismatch: "
+                f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
+            )
+        return {
+            domain_cfg.name: ChipCommDomainContext(
+                name=domain_cfg.name,
+                domain_rank=domain_cfg.domain_rank,
+                domain_size=domain_cfg.domain_size,
+                device_ctx=channel.device_ctx,
+                local_window_base=channel.local_window_base,
+                actual_window_size=channel.actual_window_size,
+                buffer_ptrs={spec.name: ptr for spec, ptr in zip(domain_cfg.buffers, ptrs)},
+            )
+        }
 
     def _abort_hierarchical(self) -> None:
         """Tear down all forked children + shms after a bootstrap failure.
@@ -1309,7 +1408,7 @@ class Worker:
             return self._chip_worker.malloc(size)
         self._check_chip_worker_id(worker_id)
         assert self._orch is not None
-        return self._orch._impl.malloc(worker_id, size)
+        return self._orch.malloc(worker_id, size)
 
     def free(self, ptr: int, worker_id: int = 0) -> None:
         """Free memory allocated by ``malloc()``."""
@@ -1319,7 +1418,7 @@ class Worker:
             return
         self._check_chip_worker_id(worker_id)
         assert self._orch is not None
-        self._orch._impl.free(worker_id, ptr)
+        self._orch.free(worker_id, ptr)
 
     def copy_to(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
         """Copy *size* bytes from host *src* to chip worker *dst*."""
@@ -1329,7 +1428,7 @@ class Worker:
             return
         self._check_chip_worker_id(worker_id)
         assert self._orch is not None
-        self._orch._impl.copy_to(worker_id, dst, src, size)
+        self._orch.copy_to(worker_id, dst, src, size)
 
     def copy_from(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
         """Copy *size* bytes from chip worker *src* to host *dst*."""
@@ -1339,7 +1438,7 @@ class Worker:
             return
         self._check_chip_worker_id(worker_id)
         assert self._orch is not None
-        self._orch._impl.copy_from(worker_id, dst, src, size)
+        self._orch.copy_from(worker_id, dst, src, size)
 
     # ------------------------------------------------------------------
     # run — uniform entry point

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -108,6 +108,7 @@ target_include_directories(host_runtime
         ${ASCEND_HOME_PATH}/pkg_inc
         ${ASCEND_HOME_PATH}/pkg_inc/runtime
         ${ASCEND_HOME_PATH}/pkg_inc/profiling
+        ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/asc/include
         ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/include/driver
 )
 

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -125,12 +125,19 @@ endif()
 # CANN 9.x exposes the working non-V2 HCCL entry points through libhcomm.
 # Link it explicitly so comm_hccl.cpp can follow the same initialization path
 # as the pto-isa communication tests.
-find_library(HCOMM_LIB NAMES hcomm PATHS ${ASCEND_HOME_PATH}/lib64 NO_DEFAULT_PATH)
+find_library(
+    HCOMM_LIB
+    NAMES hcomm
+    PATHS
+        ${ASCEND_HOME_PATH}/lib64
+        ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/lib64
+    NO_DEFAULT_PATH
+)
 if(HCOMM_LIB)
-    set(HCCL_LINK_TARGETS hcomm)
-    message(STATUS "Using HCCL library: hcomm")
+    set(HCCL_LINK_TARGETS ${HCOMM_LIB})
+    message(STATUS "Using HCCL library: ${HCOMM_LIB}")
 else()
-    message(FATAL_ERROR "libhcomm not found under ${ASCEND_HOME_PATH}/lib64")
+    message(FATAL_ERROR "libhcomm not found under ${ASCEND_HOME_PATH}/lib64 or ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/lib64")
 endif()
 
 # Link against CANN runtime libraries

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -555,6 +555,7 @@ extern "C" int comm_alloc_windows(CommHandle h, size_t win_size, uint64_t *devic
     // time dependency on PTO_ISA_ROOT. Located here so it overlays the
     // comm backend's output -- comm-side flow does not care about
     // workSpace.
+
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
     h->sdma_workspace = std::make_unique<pto::comm::sdma::SdmaWorkspaceManager>();
     if (h->sdma_workspace->Init()) {

--- a/src/a2a3/platform/onboard/host/comm_hccl.cpp
+++ b/src/a2a3/platform/onboard/host/comm_hccl.cpp
@@ -74,6 +74,7 @@ struct CommHandle_ {
     CommContext host_ctx{};
     CommContext *device_ctx = nullptr;
     bool owns_device_ctx = false;
+    std::vector<CommContext *> derived_contexts;
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
     std::unique_ptr<pto::comm::sdma::SdmaWorkspaceManager> sdma_workspace;
 #endif
@@ -599,6 +600,78 @@ extern "C" int comm_get_window_size(CommHandle h, size_t *size_out) {
     return 0;
 }
 
+extern "C" int comm_derive_context(
+    CommHandle h, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank, size_t window_offset,
+    size_t window_size, uint64_t *device_ctx_out
+) try {
+    if (!h || !rank_ids || !device_ctx_out) return -1;
+    if (h->host_ctx.rankNum == 0) {
+        fprintf(stderr, "[comm rank %d] comm_derive_context: base windows are not allocated\n", h->rank);
+        return -1;
+    }
+    if (rank_count == 0 || rank_count > COMM_MAX_RANK_NUM || domain_rank >= rank_count) {
+        fprintf(
+            stderr, "[comm rank %d] comm_derive_context: invalid rank_count=%zu domain_rank=%u\n", h->rank, rank_count,
+            domain_rank
+        );
+        return -1;
+    }
+    if (window_offset + window_size > static_cast<size_t>(h->host_ctx.winSize)) {
+        fprintf(
+            stderr, "[comm rank %d] comm_derive_context: window range [%zu, %zu) exceeds base window size %llu\n",
+            h->rank, window_offset, window_offset + window_size, static_cast<unsigned long long>(h->host_ctx.winSize)
+        );
+        return -1;
+    }
+
+    CommContext ctx{};
+    ctx.workSpace = h->host_ctx.workSpace;
+    ctx.workSpaceSize = h->host_ctx.workSpaceSize;
+    ctx.rankId = domain_rank;
+    ctx.rankNum = static_cast<uint32_t>(rank_count);
+    ctx.winSize = window_size;
+    for (size_t i = 0; i < rank_count; ++i) {
+        uint32_t base_rank = rank_ids[i];
+        if (base_rank >= static_cast<uint32_t>(h->nranks)) {
+            fprintf(
+                stderr, "[comm rank %d] comm_derive_context: rank_ids[%zu]=%u out of range [0, %d)\n", h->rank, i,
+                base_rank, h->nranks
+            );
+            return -1;
+        }
+        ctx.windowsIn[i] = h->host_ctx.windowsIn[base_rank] + window_offset;
+        ctx.windowsOut[i] = h->host_ctx.windowsOut[base_rank] + window_offset;
+    }
+
+    void *newDevMem = nullptr;
+    aclError aRet = aclrtMalloc(&newDevMem, sizeof(CommContext), ACL_MEM_MALLOC_HUGE_FIRST);
+    if (aRet != ACL_SUCCESS) {
+        fprintf(
+            stderr, "[comm rank %d] comm_derive_context: aclrtMalloc failed: %d\n", h->rank, static_cast<int>(aRet)
+        );
+        return -1;
+    }
+    aRet = aclrtMemcpy(newDevMem, sizeof(CommContext), &ctx, sizeof(CommContext), ACL_MEMCPY_HOST_TO_DEVICE);
+    if (aRet != ACL_SUCCESS) {
+        fprintf(
+            stderr, "[comm rank %d] comm_derive_context: aclrtMemcpy H2D failed: %d\n", h->rank, static_cast<int>(aRet)
+        );
+        aclrtFree(newDevMem);
+        return -1;
+    }
+
+    auto *derived = reinterpret_cast<CommContext *>(newDevMem);
+    h->derived_contexts.push_back(derived);
+    *device_ctx_out = reinterpret_cast<uint64_t>(derived);
+    return 0;
+} catch (const std::exception &e) {
+    fprintf(stderr, "[comm] comm_derive_context: exception: %s\n", e.what());
+    return -1;
+} catch (...) {
+    fprintf(stderr, "[comm] comm_derive_context: unknown exception\n");
+    return -1;
+}
+
 extern "C" int comm_barrier(CommHandle h) {
     if (!h) return -1;
     // HcclBarrier is synchronous — it blocks until all ranks arrive.
@@ -629,6 +702,12 @@ extern "C" int comm_destroy(CommHandle h) try {
     if (h->owns_device_ctx && h->device_ctx) {
         aclrtFree(h->device_ctx);
     }
+    for (CommContext *ctx : h->derived_contexts) {
+        if (ctx != nullptr) {
+            aclrtFree(ctx);
+        }
+    }
+    h->derived_contexts.clear();
     if (h->hccl_comm) {
         HcclResult hret = hccl_comm_destroy(h->hccl_comm);
         if (hret != HCCL_SUCCESS) {

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -221,6 +221,20 @@ int comm_get_window_size(void *handle, size_t *size_out) {
     return -1;
 }
 
+int comm_derive_context(
+    void *handle, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank, size_t window_offset,
+    size_t window_size, uint64_t *device_ctx_out
+) {
+    (void)handle;
+    (void)rank_ids;
+    (void)rank_count;
+    (void)domain_rank;
+    (void)window_offset;
+    (void)window_size;
+    (void)device_ctx_out;
+    return -1;
+}
+
 int comm_barrier(void *handle) {
     (void)handle;
     return -1;

--- a/src/common/hierarchical/chip_bootstrap_channel.cpp
+++ b/src/common/hierarchical/chip_bootstrap_channel.cpp
@@ -11,14 +11,32 @@
 
 #include "chip_bootstrap_channel.h"
 
+#include <climits>
 #include <cstring>
 #include <stdexcept>
+#include <unordered_set>
+#include <utility>
 
 // =============================================================================
 // Internal helpers
 // =============================================================================
 
 namespace {
+
+static constexpr ptrdiff_t DOMAIN_OFF_NAME = 0;
+static constexpr ptrdiff_t DOMAIN_OFF_DOMAIN_RANK = 32;
+static constexpr ptrdiff_t DOMAIN_OFF_DOMAIN_SIZE = 36;
+static constexpr ptrdiff_t DOMAIN_OFF_BUFFER_COUNT = 40;
+static constexpr ptrdiff_t DOMAIN_OFF_PTR_OFFSET = 44;
+static constexpr ptrdiff_t DOMAIN_OFF_DEVICE_CTX = 48;
+static constexpr ptrdiff_t DOMAIN_OFF_LOCAL_WINDOW_BASE = 56;
+static constexpr ptrdiff_t DOMAIN_OFF_ACTUAL_WINDOW_SIZE = 64;
+
+static_assert(
+    DOMAIN_OFF_ACTUAL_WINDOW_SIZE + static_cast<ptrdiff_t>(sizeof(uint64_t)) <=
+        static_cast<ptrdiff_t>(CHIP_BOOTSTRAP_DOMAIN_RECORD_SIZE),
+    "domain record layout exceeds CHIP_BOOTSTRAP_DOMAIN_RECORD_SIZE"
+);
 
 void write_state(void *mailbox, ChipBootstrapMailboxState s) {
     auto *ptr = reinterpret_cast<volatile int32_t *>(static_cast<char *>(mailbox) + CHIP_BOOTSTRAP_OFF_STATE);
@@ -47,11 +65,58 @@ ChipBootstrapMailboxState read_state(void *mailbox) {
     return static_cast<ChipBootstrapMailboxState>(v);
 }
 
+char *domain_record(char *base, size_t index) {
+    return base + CHIP_BOOTSTRAP_OFF_DOMAIN_RECORDS + static_cast<ptrdiff_t>(index * CHIP_BOOTSTRAP_DOMAIN_RECORD_SIZE);
+}
+
+const char *domain_record(const char *base, size_t index) {
+    return base + CHIP_BOOTSTRAP_OFF_DOMAIN_RECORDS + static_cast<ptrdiff_t>(index * CHIP_BOOTSTRAP_DOMAIN_RECORD_SIZE);
+}
+
+int32_t read_i32(const char *addr) {
+    int32_t v;
+    std::memcpy(&v, addr, sizeof(v));
+    return v;
+}
+
+uint64_t read_u64(const char *addr) {
+    uint64_t v;
+    std::memcpy(&v, addr, sizeof(v));
+    return v;
+}
+
+void write_i32(char *addr, int32_t v) { std::memcpy(addr, &v, sizeof(v)); }
+
+void write_u64(char *addr, uint64_t v) { std::memcpy(addr, &v, sizeof(v)); }
+
+size_t checked_buffer_count(int32_t raw_count, size_t max_buffer_count) {
+    if (raw_count < 0) {
+        throw std::runtime_error("bootstrap domain has negative buffer count");
+    }
+    size_t count = static_cast<size_t>(raw_count);
+    if (count > max_buffer_count) {
+        throw std::runtime_error("bootstrap domain buffer count exceeds max_buffer_count");
+    }
+    return count;
+}
+
 }  // namespace
 
 // =============================================================================
 // ChipBootstrapChannel
 // =============================================================================
+
+ChipBootstrapDomainResult::ChipBootstrapDomainResult(
+    std::string domain_name, int32_t rank, int32_t size, uint64_t ctx, uint64_t window_base, uint64_t window_size,
+    std::vector<uint64_t> ptrs
+) :
+    name(std::move(domain_name)),
+    domain_rank(rank),
+    domain_size(size),
+    device_ctx(ctx),
+    local_window_base(window_base),
+    actual_window_size(window_size),
+    buffer_ptrs(std::move(ptrs)) {}
 
 ChipBootstrapChannel::ChipBootstrapChannel(void *mailbox, size_t max_buffer_count) :
     mailbox_(mailbox),
@@ -59,8 +124,8 @@ ChipBootstrapChannel::ChipBootstrapChannel(void *mailbox, size_t max_buffer_coun
     if (mailbox_ == nullptr) {
         throw std::invalid_argument("mailbox must not be null");
     }
-    if (max_buffer_count_ > CHIP_BOOTSTRAP_PTR_CAPACITY) {
-        throw std::invalid_argument("max_buffer_count exceeds CHIP_BOOTSTRAP_PTR_CAPACITY");
+    if (max_buffer_count_ > static_cast<size_t>(INT32_MAX)) {
+        throw std::invalid_argument("max_buffer_count exceeds int32 capacity");
     }
 }
 
@@ -76,17 +141,85 @@ void ChipBootstrapChannel::write_success(
     if (buffer_ptrs.size() > max_buffer_count_) {
         throw std::invalid_argument("buffer_ptrs exceeds max_buffer_count");
     }
+    ChipBootstrapDomainResult domain(
+        "default", 0, 1, device_ctx, local_window_base, actual_window_size, std::vector<uint64_t>(buffer_ptrs)
+    );
+    write_success_domains({domain});
+}
+
+void ChipBootstrapChannel::write_success_domains(const std::vector<ChipBootstrapDomainResult> &domains) {
+    if (domains.size() > CHIP_BOOTSTRAP_MAX_DOMAINS) {
+        throw std::invalid_argument("domain count exceeds CHIP_BOOTSTRAP_MAX_DOMAINS");
+    }
+
+    size_t total_buffer_count = 0;
+    std::unordered_set<std::string> names;
+    names.reserve(domains.size());
+
+    for (const auto &domain : domains) {
+        if (domain.name.empty()) {
+            throw std::invalid_argument("domain name must not be empty");
+        }
+        if (domain.name.size() >= CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE) {
+            throw std::invalid_argument("domain name exceeds CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE");
+        }
+        if (!names.insert(domain.name).second) {
+            throw std::invalid_argument("duplicate domain name in bootstrap success payload");
+        }
+        if (domain.domain_rank < 0) {
+            throw std::invalid_argument("domain_rank must be non-negative");
+        }
+        if (domain.domain_size <= 0) {
+            throw std::invalid_argument("domain_size must be positive");
+        }
+        if (domain.domain_rank >= domain.domain_size) {
+            throw std::invalid_argument("domain_rank must be smaller than domain_size");
+        }
+        if (domain.buffer_ptrs.size() > max_buffer_count_) {
+            throw std::invalid_argument("domain buffer_ptrs exceeds max_buffer_count");
+        }
+        if (domain.buffer_ptrs.size() > static_cast<size_t>(INT32_MAX)) {
+            throw std::invalid_argument("domain buffer_ptrs count exceeds int32 capacity");
+        }
+        if (domain.buffer_ptrs.size() > CHIP_BOOTSTRAP_PTR_CAPACITY ||
+            total_buffer_count > CHIP_BOOTSTRAP_PTR_CAPACITY - domain.buffer_ptrs.size()) {
+            throw std::invalid_argument("bootstrap success payload exceeds CHIP_BOOTSTRAP_PTR_CAPACITY");
+        }
+        total_buffer_count += domain.buffer_ptrs.size();
+    }
 
     auto *base = static_cast<char *>(mailbox_);
 
-    int32_t count = static_cast<int32_t>(buffer_ptrs.size());
-    std::memcpy(base + CHIP_BOOTSTRAP_OFF_BUFFER_COUNT, &count, sizeof(count));
-    std::memcpy(base + CHIP_BOOTSTRAP_OFF_DEVICE_CTX, &device_ctx, sizeof(device_ctx));
-    std::memcpy(base + CHIP_BOOTSTRAP_OFF_LOCAL_WINDOW_BASE, &local_window_base, sizeof(local_window_base));
-    std::memcpy(base + CHIP_BOOTSTRAP_OFF_ACTUAL_WINDOW_SIZE, &actual_window_size, sizeof(actual_window_size));
+    std::memset(
+        base + CHIP_BOOTSTRAP_OFF_DOMAIN_COUNT, 0, CHIP_BOOTSTRAP_OFF_ERROR_MSG - CHIP_BOOTSTRAP_OFF_DOMAIN_COUNT
+    );
 
-    if (!buffer_ptrs.empty()) {
-        std::memcpy(base + CHIP_BOOTSTRAP_OFF_BUFFER_PTRS, buffer_ptrs.data(), buffer_ptrs.size() * sizeof(uint64_t));
+    int32_t count = static_cast<int32_t>(domains.size());
+    write_i32(base + CHIP_BOOTSTRAP_OFF_DOMAIN_COUNT, count);
+
+    size_t ptr_offset = 0;
+    for (size_t i = 0; i < domains.size(); ++i) {
+        const auto &domain = domains[i];
+        char *record = domain_record(base, i);
+
+        std::memcpy(record + DOMAIN_OFF_NAME, domain.name.data(), domain.name.size());
+        record[DOMAIN_OFF_NAME + domain.name.size()] = '\0';
+
+        write_i32(record + DOMAIN_OFF_DOMAIN_RANK, domain.domain_rank);
+        write_i32(record + DOMAIN_OFF_DOMAIN_SIZE, domain.domain_size);
+        write_i32(record + DOMAIN_OFF_BUFFER_COUNT, static_cast<int32_t>(domain.buffer_ptrs.size()));
+        write_i32(record + DOMAIN_OFF_PTR_OFFSET, static_cast<int32_t>(ptr_offset));
+        write_u64(record + DOMAIN_OFF_DEVICE_CTX, domain.device_ctx);
+        write_u64(record + DOMAIN_OFF_LOCAL_WINDOW_BASE, domain.local_window_base);
+        write_u64(record + DOMAIN_OFF_ACTUAL_WINDOW_SIZE, domain.actual_window_size);
+
+        if (!domain.buffer_ptrs.empty()) {
+            std::memcpy(
+                base + CHIP_BOOTSTRAP_OFF_BUFFER_PTRS + static_cast<ptrdiff_t>(ptr_offset * sizeof(uint64_t)),
+                domain.buffer_ptrs.data(), domain.buffer_ptrs.size() * sizeof(uint64_t)
+            );
+            ptr_offset += domain.buffer_ptrs.size();
+        }
     }
 
     write_state(mailbox_, ChipBootstrapMailboxState::SUCCESS);
@@ -109,50 +242,90 @@ ChipBootstrapMailboxState ChipBootstrapChannel::state() const { return read_stat
 
 int32_t ChipBootstrapChannel::error_code() const {
     auto *base = static_cast<const char *>(mailbox_);
-    int32_t v;
-    std::memcpy(&v, base + CHIP_BOOTSTRAP_OFF_ERROR_CODE, sizeof(v));
-    return v;
+    return read_i32(base + CHIP_BOOTSTRAP_OFF_ERROR_CODE);
 }
 
-uint64_t ChipBootstrapChannel::device_ctx() const {
+int32_t ChipBootstrapChannel::domain_count() const {
     auto *base = static_cast<const char *>(mailbox_);
-    uint64_t v;
-    std::memcpy(&v, base + CHIP_BOOTSTRAP_OFF_DEVICE_CTX, sizeof(v));
-    return v;
-}
-
-uint64_t ChipBootstrapChannel::local_window_base() const {
-    auto *base = static_cast<const char *>(mailbox_);
-    uint64_t v;
-    std::memcpy(&v, base + CHIP_BOOTSTRAP_OFF_LOCAL_WINDOW_BASE, sizeof(v));
-    return v;
-}
-
-uint64_t ChipBootstrapChannel::actual_window_size() const {
-    auto *base = static_cast<const char *>(mailbox_);
-    uint64_t v;
-    std::memcpy(&v, base + CHIP_BOOTSTRAP_OFF_ACTUAL_WINDOW_SIZE, sizeof(v));
-    return v;
-}
-
-std::vector<uint64_t> ChipBootstrapChannel::buffer_ptrs() const {
-    auto *base = static_cast<const char *>(mailbox_);
-    int32_t raw_count;
-    std::memcpy(&raw_count, base + CHIP_BOOTSTRAP_OFF_BUFFER_COUNT, sizeof(raw_count));
-
-    // Ctor guarantees max_buffer_count_ <= CHIP_BOOTSTRAP_PTR_CAPACITY, so clamping
-    // count against max_buffer_count_ alone is sufficient to keep the read bounded.
-    size_t count =
-        raw_count <= 0 ?
-            0 :
-            (static_cast<size_t>(raw_count) < max_buffer_count_ ? static_cast<size_t>(raw_count) : max_buffer_count_);
-
-    std::vector<uint64_t> ptrs(count);
-    if (count > 0) {
-        std::memcpy(ptrs.data(), base + CHIP_BOOTSTRAP_OFF_BUFFER_PTRS, count * sizeof(uint64_t));
+    int32_t count = read_i32(base + CHIP_BOOTSTRAP_OFF_DOMAIN_COUNT);
+    if (count < 0 || count > static_cast<int32_t>(CHIP_BOOTSTRAP_MAX_DOMAINS)) {
+        throw std::runtime_error("bootstrap domain count exceeds CHIP_BOOTSTRAP_MAX_DOMAINS");
     }
-    return ptrs;
+    return count;
 }
+
+std::vector<ChipBootstrapDomainResult> ChipBootstrapChannel::domains() const {
+    auto *base = static_cast<const char *>(mailbox_);
+    int32_t count = domain_count();
+    std::vector<ChipBootstrapDomainResult> results;
+    results.reserve(static_cast<size_t>(count));
+    std::unordered_set<std::string> names;
+    names.reserve(static_cast<size_t>(count));
+
+    for (int32_t i = 0; i < count; ++i) {
+        const char *record = domain_record(base, static_cast<size_t>(i));
+        const char *name_ptr = record + DOMAIN_OFF_NAME;
+        size_t name_len = strnlen(name_ptr, CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE);
+        if (name_len == 0) {
+            throw std::runtime_error("bootstrap domain name must not be empty");
+        }
+        if (name_len == CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE) {
+            throw std::runtime_error("bootstrap domain name is not null-terminated");
+        }
+        std::string name(name_ptr, name_len);
+        if (!names.insert(name).second) {
+            throw std::runtime_error("duplicate domain name in bootstrap success payload");
+        }
+
+        int32_t buffer_count_raw = read_i32(record + DOMAIN_OFF_BUFFER_COUNT);
+        int32_t ptr_offset_raw = read_i32(record + DOMAIN_OFF_PTR_OFFSET);
+        size_t buffer_count = checked_buffer_count(buffer_count_raw, max_buffer_count_);
+        if (ptr_offset_raw < 0) {
+            throw std::runtime_error("bootstrap domain has negative buffer pointer offset");
+        }
+        size_t ptr_offset = static_cast<size_t>(ptr_offset_raw);
+        if (ptr_offset > CHIP_BOOTSTRAP_PTR_CAPACITY || buffer_count > CHIP_BOOTSTRAP_PTR_CAPACITY - ptr_offset) {
+            throw std::runtime_error("bootstrap domain buffer pointer range exceeds mailbox capacity");
+        }
+        std::vector<uint64_t> ptrs(buffer_count);
+        if (buffer_count > 0) {
+            std::memcpy(
+                ptrs.data(),
+                base + CHIP_BOOTSTRAP_OFF_BUFFER_PTRS + static_cast<ptrdiff_t>(ptr_offset * sizeof(uint64_t)),
+                buffer_count * sizeof(uint64_t)
+            );
+        }
+
+        ChipBootstrapDomainResult result(
+            name, read_i32(record + DOMAIN_OFF_DOMAIN_RANK), read_i32(record + DOMAIN_OFF_DOMAIN_SIZE),
+            read_u64(record + DOMAIN_OFF_DEVICE_CTX), read_u64(record + DOMAIN_OFF_LOCAL_WINDOW_BASE),
+            read_u64(record + DOMAIN_OFF_ACTUAL_WINDOW_SIZE), std::move(ptrs)
+        );
+        if (result.domain_rank < 0 || result.domain_size <= 0 || result.domain_rank >= result.domain_size) {
+            throw std::runtime_error("bootstrap domain rank/size is invalid");
+        }
+        results.emplace_back(std::move(result));
+    }
+
+    return results;
+}
+
+ChipBootstrapDomainResult ChipBootstrapChannel::domain(const std::string &name) const {
+    for (auto &domain : domains()) {
+        if (domain.name == name) {
+            return domain;
+        }
+    }
+    throw std::out_of_range("bootstrap domain not found: " + name);
+}
+
+uint64_t ChipBootstrapChannel::device_ctx() const { return domain("default").device_ctx; }
+
+uint64_t ChipBootstrapChannel::local_window_base() const { return domain("default").local_window_base; }
+
+uint64_t ChipBootstrapChannel::actual_window_size() const { return domain("default").actual_window_size; }
+
+std::vector<uint64_t> ChipBootstrapChannel::buffer_ptrs() const { return domain("default").buffer_ptrs; }
 
 std::string ChipBootstrapChannel::error_message() const {
     auto *base = static_cast<const char *>(mailbox_);

--- a/src/common/hierarchical/chip_bootstrap_channel.h
+++ b/src/common/hierarchical/chip_bootstrap_channel.h
@@ -27,21 +27,29 @@
 static constexpr size_t CHIP_BOOTSTRAP_MAILBOX_SIZE = 4096;
 static constexpr size_t CHIP_BOOTSTRAP_HEADER_SIZE = 64;
 static constexpr size_t CHIP_BOOTSTRAP_ERROR_MSG_SIZE = 1024;
-static constexpr size_t CHIP_BOOTSTRAP_PTR_CAPACITY =
-    (CHIP_BOOTSTRAP_MAILBOX_SIZE - CHIP_BOOTSTRAP_HEADER_SIZE - CHIP_BOOTSTRAP_ERROR_MSG_SIZE) / sizeof(uint64_t);
+static constexpr size_t CHIP_BOOTSTRAP_MAX_DOMAINS = 8;
+static constexpr size_t CHIP_BOOTSTRAP_DOMAIN_NAME_SIZE = 32;  // includes trailing '\0'
+static constexpr size_t CHIP_BOOTSTRAP_DOMAIN_RECORD_SIZE = 80;
 
 // Fixed offsets within the mailbox region.
 static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_STATE = 0;
 static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_ERROR_CODE = 4;
-static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_BUFFER_COUNT = 8;
-// 4 bytes implicit padding for uint64 alignment
-static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_DEVICE_CTX = 16;
-static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_LOCAL_WINDOW_BASE = 24;
-static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_ACTUAL_WINDOW_SIZE = 32;
-static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_BUFFER_PTRS = 64;
+static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_DOMAIN_COUNT = 8;
+static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_DOMAIN_RECORDS = CHIP_BOOTSTRAP_HEADER_SIZE;
+static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_BUFFER_PTRS =
+    CHIP_BOOTSTRAP_OFF_DOMAIN_RECORDS +
+    static_cast<ptrdiff_t>(CHIP_BOOTSTRAP_MAX_DOMAINS * CHIP_BOOTSTRAP_DOMAIN_RECORD_SIZE);
 static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_ERROR_MSG =
-    CHIP_BOOTSTRAP_OFF_BUFFER_PTRS + static_cast<ptrdiff_t>(CHIP_BOOTSTRAP_PTR_CAPACITY * sizeof(uint64_t));
+    static_cast<ptrdiff_t>(CHIP_BOOTSTRAP_MAILBOX_SIZE - CHIP_BOOTSTRAP_ERROR_MSG_SIZE);
+static constexpr size_t CHIP_BOOTSTRAP_PTR_CAPACITY =
+    (CHIP_BOOTSTRAP_OFF_ERROR_MSG - CHIP_BOOTSTRAP_OFF_BUFFER_PTRS) / sizeof(uint64_t);
 
+// Backward-compatible alias for the pre-domain single-result layout.
+static constexpr ptrdiff_t CHIP_BOOTSTRAP_OFF_BUFFER_COUNT = CHIP_BOOTSTRAP_OFF_DOMAIN_COUNT;
+
+static_assert(
+    CHIP_BOOTSTRAP_OFF_BUFFER_PTRS <= CHIP_BOOTSTRAP_OFF_ERROR_MSG, "domain records must fit before error message"
+);
 static_assert(
     CHIP_BOOTSTRAP_OFF_ERROR_MSG + static_cast<ptrdiff_t>(CHIP_BOOTSTRAP_ERROR_MSG_SIZE) ==
         static_cast<ptrdiff_t>(CHIP_BOOTSTRAP_MAILBOX_SIZE),
@@ -54,6 +62,22 @@ enum class ChipBootstrapMailboxState : int32_t {
     ERROR = 2,
 };
 
+struct ChipBootstrapDomainResult {
+    std::string name;
+    int32_t domain_rank = 0;
+    int32_t domain_size = 0;
+    uint64_t device_ctx = 0;
+    uint64_t local_window_base = 0;
+    uint64_t actual_window_size = 0;
+    std::vector<uint64_t> buffer_ptrs;
+
+    ChipBootstrapDomainResult() = default;
+    ChipBootstrapDomainResult(
+        std::string domain_name, int32_t rank, int32_t size, uint64_t ctx, uint64_t window_base, uint64_t window_size,
+        std::vector<uint64_t> ptrs
+    );
+};
+
 class ChipBootstrapChannel {
 public:
     ChipBootstrapChannel(void *mailbox, size_t max_buffer_count);
@@ -64,11 +88,15 @@ public:
         uint64_t device_ctx, uint64_t local_window_base, uint64_t actual_window_size,
         const std::vector<uint64_t> &buffer_ptrs
     );
+    void write_success_domains(const std::vector<ChipBootstrapDomainResult> &domains);
     void write_error(int32_t error_code, const std::string &message);
 
     // Read side (parent process).
     ChipBootstrapMailboxState state() const;
     int32_t error_code() const;
+    int32_t domain_count() const;
+    std::vector<ChipBootstrapDomainResult> domains() const;
+    ChipBootstrapDomainResult domain(const std::string &name) const;
     uint64_t device_ctx() const;
     uint64_t local_window_base() const;
     uint64_t actual_window_size() const;

--- a/src/common/platform_comm/comm.h
+++ b/src/common/platform_comm/comm.h
@@ -11,9 +11,9 @@
 /**
  * Backend-neutral distributed communication C API.
  *
- * Provides six primitives for multi-rank communication: init, allocate
- * shared windows, query local window base, query window size, barrier,
- * and destroy.
+ * Provides primitives for multi-rank communication: init, create
+ * subcommunicators, allocate shared windows, query local window base, query
+ * window size, derive domain contexts, barrier, and destroy.
  *
  * Implementations:
  *   onboard/host/comm_hccl.cpp — HCCL backend (links CANN hccl/hccl_fwk)
@@ -60,6 +60,32 @@ typedef struct CommHandle_ *CommHandle;
 CommHandle comm_init(int rank, int nranks, void *stream, const char *rootinfo_path);
 
 /**
+ * Create a subcommunicator from an existing base communicator.
+ *
+ * The caller provides the base-communicator rank ids that participate in the
+ * subcommunicator and the caller's rank within that subcommunicator.  Members
+ * should call this collectively for the same `sub_comm_id`; non-members do not
+ * need to call it.
+ *
+ * On sim this derives a separate shared-memory identity from the base session
+ * and `sub_comm_id`, so windows and barriers are isolated per domain.  The
+ * returned handle is destroyed with comm_destroy().
+ *
+ * @param base              Existing handle from comm_init().
+ * @param sub_comm_id       Caller-defined domain id under the base session.
+ * @param rank_ids          Base-communicator rank ids in subcommunicator order.
+ * @param rank_count        Number of ranks in rank_ids.
+ * @param sub_comm_rank_id  This caller's rank within the subcommunicator.
+ * @param stream            Caller-owned stream for backends that need one.
+ *                          Sim backend ignores it.
+ * @return Opaque subcommunicator handle, or NULL on failure.
+ */
+CommHandle comm_create_subcomm(
+    CommHandle base, uint64_t sub_comm_id, const uint32_t *rank_ids, size_t rank_count, uint32_t sub_comm_rank_id,
+    void *stream
+);
+
+/**
  * Allocate RDMA / shared-memory windows and populate the device context.
  *
  * On HCCL this builds a per-rank symmetric pool via the public ACL IPC
@@ -97,6 +123,29 @@ int comm_get_local_window_base(CommHandle h, uint64_t *base_out);
  * @return 0 on success, non-zero on failure.
  */
 int comm_get_window_size(CommHandle h, size_t *size_out);
+
+/**
+ * Derive a domain-local CommContext from an allocated base communicator.
+ *
+ * The base handle must already have completed comm_alloc_windows().  The
+ * derived context remaps dense domain ranks onto base-communicator ranks and
+ * adds window_offset to each selected base rank window.  The returned
+ * device_ctx_out points to a backend-owned device CommContext that remains
+ * valid until comm_destroy(base).
+ *
+ * @param h                Allocated base communicator handle.
+ * @param rank_ids         Base-communicator rank ids in domain rank order.
+ * @param rank_count       Number of domain ranks.
+ * @param domain_rank      This caller's dense rank in the domain.
+ * @param window_offset    Byte offset of this domain slice in the base window.
+ * @param window_size      Visible per-rank window size for this domain.
+ * @param device_ctx_out   Receives the derived device CommContext pointer.
+ * @return 0 on success, non-zero on failure.
+ */
+int comm_derive_context(
+    CommHandle h, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank, size_t window_offset,
+    size_t window_size, uint64_t *device_ctx_out
+);
 
 /**
  * Synchronize all ranks.

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -77,6 +77,26 @@ struct SharedHeader {
     size_t per_rank_win_size;
 };
 
+// Build a session-scoped shm name component from a caller-controlled id.
+uint32_t hash_id(const char *id) {
+    size_t h = std::hash<std::string>{}(id ? id : "default");
+    return static_cast<uint32_t>(h ^ (h >> 32));
+}
+
+std::string make_shm_name(uint32_t process_tree_id, uint32_t session_id) {
+    char buf[SHM_NAME_LEN + 1];
+    int written = std::snprintf(buf, sizeof(buf), "/simpler_%08x_%08x", process_tree_id, session_id);
+    // Defensive runtime check: snprintf returns -1 only on I/O / encoding
+    // errors, and the static_assert above already pins the upper bound of a
+    // successful write, so this is really an "impossible path" guard for the
+    // libc-misbehaving edge case.
+    if (written < 0 || static_cast<size_t>(written) != SHM_NAME_LEN) {
+        std::fprintf(stderr, "[comm_sim] snprintf produced unexpected length %d for shm name\n", written);
+        return {};
+    }
+    return {buf};
+}
+
 // Build a session-scoped shm name.
 //
 // Hashing only the rootinfo_path produces a stable name across test re-runs
@@ -101,19 +121,12 @@ struct SharedHeader {
 // 32 bits; both are still collision-resistant for the canonical
 // "one driver spawns N ranks" launch pattern.
 std::string make_shm_name(const char *rootinfo_path) {
-    size_t h = std::hash<std::string>{}(rootinfo_path ? rootinfo_path : "default");
-    uint32_t h32 = static_cast<uint32_t>(h ^ (h >> 32));
-    char buf[SHM_NAME_LEN + 1];
-    int written = std::snprintf(buf, sizeof(buf), "/simpler_%08x_%08x", static_cast<uint32_t>(getppid()), h32);
-    // Defensive runtime check: snprintf returns -1 only on I/O / encoding
-    // errors, and the static_assert above already pins the upper bound of a
-    // successful write, so this is really an "impossible path" guard for the
-    // libc-misbehaving edge case.
-    if (written < 0 || static_cast<size_t>(written) != SHM_NAME_LEN) {
-        std::fprintf(stderr, "[comm_sim] snprintf produced unexpected length %d for shm name\n", written);
-        return {};
-    }
-    return {buf};
+    return make_shm_name(static_cast<uint32_t>(getppid()), hash_id(rootinfo_path));
+}
+
+std::string make_subcomm_shm_name(const std::string &base_shm_name, uint64_t sub_comm_id) {
+    std::string id = base_shm_name + ":" + std::to_string(sub_comm_id);
+    return make_shm_name(static_cast<uint32_t>(getppid()), hash_id(id.c_str()));
 }
 
 // Poll `check` until it returns true or the timeout elapses.  Uses steady_clock
@@ -141,6 +154,7 @@ struct CommHandle_ {
     bool is_creator = false;
 
     CommContext host_ctx{};
+    std::vector<CommContext *> derived_contexts;
 };
 
 extern "C" CommHandle comm_init(int rank, int nranks, void *stream, const char *rootinfo_path) try {
@@ -177,6 +191,78 @@ extern "C" CommHandle comm_init(int rank, int nranks, void *stream, const char *
     return nullptr;
 } catch (...) {
     std::fprintf(stderr, "[comm_sim rank %d] comm_init: unknown exception\n", rank);
+    return nullptr;
+}
+
+extern "C" CommHandle comm_create_subcomm(
+    CommHandle base, uint64_t sub_comm_id, const uint32_t *rank_ids, size_t rank_count, uint32_t sub_comm_rank_id,
+    void *stream
+) try {
+    (void)stream;  // sim has no ACL / stream concept
+
+    if (base == nullptr) {
+        std::fprintf(stderr, "[comm_sim] comm_create_subcomm: base is null\n");
+        return nullptr;
+    }
+    if (rank_ids == nullptr) {
+        std::fprintf(stderr, "[comm_sim rank %d] comm_create_subcomm: rank_ids is null\n", base->rank);
+        return nullptr;
+    }
+    if (rank_count == 0 || rank_count > COMM_MAX_RANK_NUM) {
+        std::fprintf(
+            stderr, "[comm_sim rank %d] comm_create_subcomm: invalid rank_count=%zu (max=%u)\n", base->rank, rank_count,
+            COMM_MAX_RANK_NUM
+        );
+        return nullptr;
+    }
+    if (sub_comm_rank_id >= rank_count) {
+        std::fprintf(
+            stderr, "[comm_sim rank %d] comm_create_subcomm: invalid sub_comm_rank_id=%u rank_count=%zu\n", base->rank,
+            sub_comm_rank_id, rank_count
+        );
+        return nullptr;
+    }
+
+    for (size_t i = 0; i < rank_count; ++i) {
+        if (rank_ids[i] >= static_cast<uint32_t>(base->nranks)) {
+            std::fprintf(
+                stderr, "[comm_sim rank %d] comm_create_subcomm: rank_ids[%zu]=%u out of range [0, %d)\n", base->rank,
+                i, rank_ids[i], base->nranks
+            );
+            return nullptr;
+        }
+        for (size_t j = 0; j < i; ++j) {
+            if (rank_ids[j] == rank_ids[i]) {
+                std::fprintf(
+                    stderr, "[comm_sim rank %d] comm_create_subcomm: duplicate rank id %u\n", base->rank, rank_ids[i]
+                );
+                return nullptr;
+            }
+        }
+    }
+    if (rank_ids[sub_comm_rank_id] != base->rank) {
+        std::fprintf(
+            stderr, "[comm_sim rank %d] comm_create_subcomm: rank_ids[%u]=%u does not match base rank\n", base->rank,
+            sub_comm_rank_id, rank_ids[sub_comm_rank_id]
+        );
+        return nullptr;
+    }
+
+    auto *h = new (std::nothrow) CommHandle_{};
+    if (h == nullptr) {
+        std::fprintf(stderr, "[comm_sim rank %d] comm_create_subcomm: allocation failed\n", base->rank);
+        return nullptr;
+    }
+
+    h->rank = static_cast<int>(sub_comm_rank_id);
+    h->nranks = static_cast<int>(rank_count);
+    h->shm_name = make_subcomm_shm_name(base->shm_name, sub_comm_id);
+    return h;
+} catch (const std::exception &e) {
+    std::fprintf(stderr, "[comm_sim] comm_create_subcomm: exception: %s\n", e.what());
+    return nullptr;
+} catch (...) {
+    std::fprintf(stderr, "[comm_sim] comm_create_subcomm: unknown exception\n");
     return nullptr;
 }
 
@@ -319,6 +405,62 @@ extern "C" int comm_get_window_size(CommHandle h, size_t *size_out) {
     return 0;
 }
 
+extern "C" int comm_derive_context(
+    CommHandle h, const uint32_t *rank_ids, size_t rank_count, uint32_t domain_rank, size_t window_offset,
+    size_t window_size, uint64_t *device_ctx_out
+) try {
+    if (h == nullptr || rank_ids == nullptr || device_ctx_out == nullptr) return -1;
+    if (h->mmap_base == nullptr) {
+        std::fprintf(stderr, "[comm_sim rank %d] comm_derive_context: base windows are not allocated\n", h->rank);
+        return -1;
+    }
+    if (rank_count == 0 || rank_count > COMM_MAX_RANK_NUM || domain_rank >= rank_count) {
+        std::fprintf(
+            stderr, "[comm_sim rank %d] comm_derive_context: invalid rank_count=%zu domain_rank=%u\n", h->rank,
+            rank_count, domain_rank
+        );
+        return -1;
+    }
+    if (window_offset + window_size > static_cast<size_t>(h->host_ctx.winSize)) {
+        std::fprintf(
+            stderr, "[comm_sim rank %d] comm_derive_context: window range [%zu, %zu) exceeds base window size %llu\n",
+            h->rank, window_offset, window_offset + window_size, static_cast<unsigned long long>(h->host_ctx.winSize)
+        );
+        return -1;
+    }
+
+    auto *ctx = new (std::nothrow) CommContext{};
+    if (ctx == nullptr) return -1;
+    ctx->workSpace = h->host_ctx.workSpace;
+    ctx->workSpaceSize = h->host_ctx.workSpaceSize;
+    ctx->rankId = domain_rank;
+    ctx->rankNum = static_cast<uint32_t>(rank_count);
+    ctx->winSize = window_size;
+    for (size_t i = 0; i < rank_count; ++i) {
+        uint32_t base_rank = rank_ids[i];
+        if (base_rank >= static_cast<uint32_t>(h->nranks)) {
+            std::fprintf(
+                stderr, "[comm_sim rank %d] comm_derive_context: rank_ids[%zu]=%u out of range [0, %d)\n", h->rank, i,
+                base_rank, h->nranks
+            );
+            delete ctx;
+            return -1;
+        }
+        ctx->windowsIn[i] = h->host_ctx.windowsIn[base_rank] + window_offset;
+        ctx->windowsOut[i] = h->host_ctx.windowsOut[base_rank] + window_offset;
+    }
+
+    h->derived_contexts.push_back(ctx);
+    *device_ctx_out = reinterpret_cast<uint64_t>(ctx);
+    return 0;
+} catch (const std::exception &e) {
+    std::fprintf(stderr, "[comm_sim] comm_derive_context: exception: %s\n", e.what());
+    return -1;
+} catch (...) {
+    std::fprintf(stderr, "[comm_sim] comm_derive_context: unknown exception\n");
+    return -1;
+}
+
 extern "C" int comm_barrier(CommHandle h) {
     if (h == nullptr || h->mmap_base == nullptr) return -1;
 
@@ -364,6 +506,10 @@ extern "C" int comm_destroy(CommHandle h) try {
     if (h == nullptr) return -1;
 
     int rc = 0;
+    for (auto *ctx : h->derived_contexts) {
+        delete ctx;
+    }
+    h->derived_contexts.clear();
     if (h->mmap_base != nullptr) {
         auto *hdr = static_cast<SharedHeader *>(h->mmap_base);
         int gone = __atomic_add_fetch(&hdr->destroy_count, 1, __ATOMIC_ACQ_REL);

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -36,6 +36,17 @@ T load_symbol(void *handle, const char *name) {
     return reinterpret_cast<T>(sym);
 }
 
+template <typename T>
+T load_optional_symbol(void *handle, const char *name) {
+    dlerror();  // clear any existing error
+    void *sym = dlsym(handle, name);
+    const char *err = dlerror();
+    if (err) {
+        return nullptr;
+    }
+    return reinterpret_cast<T>(sym);
+}
+
 std::vector<uint8_t> read_binary_file(const std::string &path) {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
     if (!f) {
@@ -116,9 +127,11 @@ void ChipWorker::init(
         create_comm_stream_fn_ = load_symbol<CreateCommStreamFn>(handle, "create_comm_stream_ctx");
         destroy_comm_stream_fn_ = load_symbol<DestroyCommStreamFn>(handle, "destroy_comm_stream_ctx");
         comm_init_fn_ = load_symbol<CommInitFn>(handle, "comm_init");
+        comm_create_subcomm_fn_ = load_optional_symbol<CommCreateSubcommFn>(handle, "comm_create_subcomm");
         comm_alloc_windows_fn_ = load_symbol<CommAllocWindowsFn>(handle, "comm_alloc_windows");
         comm_get_local_window_base_fn_ = load_symbol<CommGetLocalWindowBaseFn>(handle, "comm_get_local_window_base");
         comm_get_window_size_fn_ = load_symbol<CommGetWindowSizeFn>(handle, "comm_get_window_size");
+        comm_derive_context_fn_ = load_symbol<CommDeriveContextFn>(handle, "comm_derive_context");
         comm_barrier_fn_ = load_symbol<CommBarrierFn>(handle, "comm_barrier");
         comm_destroy_fn_ = load_symbol<CommDestroyFn>(handle, "comm_destroy");
     } catch (...) {
@@ -213,9 +226,11 @@ void ChipWorker::init(
         create_comm_stream_fn_ = nullptr;
         destroy_comm_stream_fn_ = nullptr;
         comm_init_fn_ = nullptr;
+        comm_create_subcomm_fn_ = nullptr;
         comm_alloc_windows_fn_ = nullptr;
         comm_get_local_window_base_fn_ = nullptr;
         comm_get_window_size_fn_ = nullptr;
+        comm_derive_context_fn_ = nullptr;
         comm_barrier_fn_ = nullptr;
         comm_destroy_fn_ = nullptr;
         runtime_buf_.clear();
@@ -227,13 +242,9 @@ void ChipWorker::init(
 }
 
 void ChipWorker::finalize() {
-    // Defensive: if the user never called comm_destroy, reclaim the stream
-    // before we tear down the device context (otherwise the stream-backing
-    // ACL state outlives its owning context).
-    if (comm_stream_ != nullptr && device_ctx_ != nullptr && destroy_comm_stream_fn_ != nullptr) {
-        destroy_comm_stream_fn_(device_ctx_, comm_stream_);
-    }
-    comm_stream_ = nullptr;
+    // Defensive: if the user never called comm_destroy, reclaim all owned
+    // communicator handles and streams before tearing down the device context.
+    clear_comm_sessions();
 
     if (device_ctx_ != nullptr && finalize_device_fn_ != nullptr && initialized_) {
         finalize_device_fn_(device_ctx_);
@@ -263,9 +274,11 @@ void ChipWorker::finalize() {
     create_comm_stream_fn_ = nullptr;
     destroy_comm_stream_fn_ = nullptr;
     comm_init_fn_ = nullptr;
+    comm_create_subcomm_fn_ = nullptr;
     comm_alloc_windows_fn_ = nullptr;
     comm_get_local_window_base_fn_ = nullptr;
     comm_get_window_size_fn_ = nullptr;
+    comm_derive_context_fn_ = nullptr;
     comm_barrier_fn_ = nullptr;
     comm_destroy_fn_ = nullptr;
     runtime_buf_.clear();
@@ -333,6 +346,105 @@ size_t ChipWorker::host_dlopen_count() const {
     return get_host_dlopen_count_fn_(device_ctx_);
 }
 
+void *ChipWorker::create_comm_stream_checked(const char *op_name) {
+    int rc = ensure_acl_ready_fn_(device_ctx_, device_id_);
+    if (rc != 0) {
+        std::string msg = op_name;
+        msg += ": ensure_acl_ready failed with code ";
+        msg += std::to_string(rc);
+        throw std::runtime_error(msg);
+    }
+    return create_comm_stream_fn_(device_ctx_);
+}
+
+void ChipWorker::destroy_comm_stream_best_effort(void *stream, int *rc) {
+    if (stream == nullptr || device_ctx_ == nullptr || destroy_comm_stream_fn_ == nullptr) {
+        return;
+    }
+    int srv = destroy_comm_stream_fn_(device_ctx_, stream);
+    if (srv != 0 && rc != nullptr && *rc == 0) {
+        *rc = srv;
+    }
+}
+
+ChipWorker::CommSession *ChipWorker::find_comm_session(uint64_t comm_handle) {
+    auto it = comm_session_index_.find(comm_handle);
+    if (it == comm_session_index_.end() || it->second >= comm_sessions_.size()) {
+        return nullptr;
+    }
+    CommSession &session = comm_sessions_[it->second];
+    if (reinterpret_cast<uint64_t>(session.handle) != comm_handle) {
+        return nullptr;
+    }
+    return &session;
+}
+
+ChipWorker::CommSession *ChipWorker::create_comm_session(void *handle, void *stream, bool is_base) {
+    if (handle == nullptr) {
+        return nullptr;
+    }
+    uint64_t key = reinterpret_cast<uint64_t>(handle);
+    if (comm_session_index_.find(key) != comm_session_index_.end()) {
+        return nullptr;
+    }
+    CommSession session{};
+    session.handle = handle;
+    session.stream = stream;
+    session.is_base = is_base;
+    comm_sessions_.push_back(session);
+    size_t index = comm_sessions_.size() - 1;
+    comm_session_index_[key] = index;
+    return &comm_sessions_[index];
+}
+
+int ChipWorker::destroy_comm_session(CommSession &session) {
+    int rc = 0;
+    if (session.handle != nullptr && comm_destroy_fn_ != nullptr) {
+        rc = comm_destroy_fn_(session.handle);
+    }
+    destroy_comm_stream_best_effort(session.stream, &rc);
+    if (reinterpret_cast<uint64_t>(session.handle) == base_comm_handle_) {
+        base_comm_handle_ = 0;
+    }
+    comm_session_index_.erase(reinterpret_cast<uint64_t>(session.handle));
+    session.handle = nullptr;
+    session.stream = nullptr;
+    session.device_ctx = 0;
+    session.local_window_base = 0;
+    session.window_size = 0;
+    return rc;
+}
+
+uint64_t ChipWorker::create_base_comm(int rank, int nranks, const std::string &rootinfo_path) {
+    void *stream = create_comm_stream_checked("comm_init");
+    void *handle = comm_init_fn_(rank, nranks, stream, rootinfo_path.c_str());
+    if (handle == nullptr) {
+        int rc = 0;
+        destroy_comm_stream_best_effort(stream, &rc);
+        throw std::runtime_error("comm_init failed");
+    }
+    CommSession *session = create_comm_session(handle, stream, true);
+    if (session == nullptr) {
+        int rc = comm_destroy_fn_(handle);
+        destroy_comm_stream_best_effort(stream, &rc);
+        throw std::runtime_error("comm_init: duplicate comm handle");
+    }
+    base_comm_handle_ = reinterpret_cast<uint64_t>(handle);
+    return base_comm_handle_;
+}
+
+void ChipWorker::clear_comm_sessions() {
+    for (auto it = comm_sessions_.rbegin(); it != comm_sessions_.rend(); ++it) {
+        if (it->handle == nullptr && it->stream == nullptr) {
+            continue;
+        }
+        destroy_comm_session(*it);
+    }
+    comm_sessions_.clear();
+    comm_session_index_.clear();
+    base_comm_handle_ = 0;
+}
+
 uint64_t ChipWorker::malloc(size_t size) {
     if (!initialized_) {
         throw std::runtime_error("ChipWorker not initialized; call init() first");
@@ -377,39 +489,61 @@ uint64_t ChipWorker::comm_init(int rank, int nranks, const std::string &rootinfo
     if (!initialized_) {
         throw std::runtime_error("ChipWorker not initialized; call init() first");
     }
-    if (comm_stream_ != nullptr) {
-        throw std::runtime_error("comm_init: a comm session is already active on this ChipWorker");
+    if (base_comm_handle_ != 0) {
+        return base_comm_handle_;
     }
 
-    // Bring ACL up on the calling thread before stream creation.  Onboard
-    // runs aclInit (idempotent) + per-thread aclrtSetDevice; sim's stub is
-    // a no-op; platforms with no distributed backend (a5 today) also no-op.
-    int rc = ensure_acl_ready_fn_(device_ctx_, device_id_);
-    if (rc != 0) {
-        throw std::runtime_error("ensure_acl_ready failed with code " + std::to_string(rc));
+    return create_base_comm(rank, nranks, rootinfo_path);
+}
+
+uint64_t ChipWorker::comm_create_subcomm(
+    uint64_t base_comm_handle, uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids, uint32_t sub_comm_rank_id
+) {
+    if (!initialized_) {
+        throw std::runtime_error("ChipWorker not initialized; call init() first");
+    }
+    if (comm_create_subcomm_fn_ == nullptr) {
+        throw std::runtime_error("comm_create_subcomm is not supported by this runtime");
+    }
+    if (base_comm_handle == 0 || find_comm_session(base_comm_handle) == nullptr) {
+        throw std::runtime_error("comm_create_subcomm: base communicator is not owned by this ChipWorker");
+    }
+    if (rank_ids.empty()) {
+        throw std::runtime_error("comm_create_subcomm: rank_ids must not be empty");
+    }
+    if (sub_comm_rank_id >= rank_ids.size()) {
+        throw std::runtime_error("comm_create_subcomm: sub_comm_rank_id out of range");
     }
 
-    // Create an aclrtStream owned by this ChipWorker.  Sim / a5 stubs
-    // return NULL; their raw comm_init ignores the stream arg.  A NULL
-    // from a runtime that has a real comm backend is a genuine failure —
-    // we can't distinguish "stub returned NULL on purpose" from "onboard
-    // create failed" here, so we defer the check to comm_init's own
-    // return value below (a stub returns NULL from comm_init anyway).
-    void *stream = create_comm_stream_fn_(device_ctx_);
-
-    void *handle = comm_init_fn_(rank, nranks, stream, rootinfo_path.c_str());
+    void *stream = create_comm_stream_checked("comm_create_subcomm");
+    void *handle = comm_create_subcomm_fn_(
+        reinterpret_cast<void *>(base_comm_handle), sub_comm_id, rank_ids.data(), rank_ids.size(), sub_comm_rank_id,
+        stream
+    );
     if (handle == nullptr) {
-        // Roll back the stream we just created — otherwise the ChipWorker
-        // leaks it and the next comm_init attempt trips the
-        // "session already active" guard above.
-        if (stream != nullptr) {
-            destroy_comm_stream_fn_(device_ctx_, stream);
-        }
-        throw std::runtime_error("comm_init failed");
+        int rc = 0;
+        destroy_comm_stream_best_effort(stream, &rc);
+        throw std::runtime_error("comm_create_subcomm failed");
     }
 
-    comm_stream_ = stream;
+    if (create_comm_session(handle, stream, false) == nullptr) {
+        int rc = comm_destroy_fn_(handle);
+        destroy_comm_stream_best_effort(stream, &rc);
+        throw std::runtime_error("comm_create_subcomm: duplicate comm handle");
+    }
+
     return reinterpret_cast<uint64_t>(handle);
+}
+
+uint64_t
+ChipWorker::comm_create_domain(uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids, uint32_t sub_comm_rank_id) {
+    if (!initialized_) {
+        throw std::runtime_error("ChipWorker not initialized; call init() first");
+    }
+    if (base_comm_handle_ == 0) {
+        throw std::runtime_error("comm_create_domain: call comm_init to create the base communicator first");
+    }
+    return comm_create_subcomm(base_comm_handle_, sub_comm_id, rank_ids, sub_comm_rank_id);
 }
 
 uint64_t ChipWorker::comm_alloc_windows(uint64_t comm_handle, size_t win_size) {
@@ -417,6 +551,10 @@ uint64_t ChipWorker::comm_alloc_windows(uint64_t comm_handle, size_t win_size) {
     int rc = comm_alloc_windows_fn_(reinterpret_cast<void *>(comm_handle), win_size, &device_ctx);
     if (rc != 0) {
         throw std::runtime_error("comm_alloc_windows failed with code " + std::to_string(rc));
+    }
+    CommSession *session = find_comm_session(comm_handle);
+    if (session != nullptr) {
+        session->device_ctx = device_ctx;
     }
     return device_ctx;
 }
@@ -427,6 +565,10 @@ uint64_t ChipWorker::comm_get_local_window_base(uint64_t comm_handle) {
     if (rc != 0) {
         throw std::runtime_error("comm_get_local_window_base failed with code " + std::to_string(rc));
     }
+    CommSession *session = find_comm_session(comm_handle);
+    if (session != nullptr) {
+        session->local_window_base = base;
+    }
     return base;
 }
 
@@ -436,7 +578,35 @@ size_t ChipWorker::comm_get_window_size(uint64_t comm_handle) {
     if (rc != 0) {
         throw std::runtime_error("comm_get_window_size failed with code " + std::to_string(rc));
     }
+    CommSession *session = find_comm_session(comm_handle);
+    if (session != nullptr) {
+        session->window_size = win_size;
+    }
     return win_size;
+}
+
+uint64_t ChipWorker::comm_derive_context(
+    uint64_t comm_handle, const std::vector<uint32_t> &rank_ids, uint32_t domain_rank, size_t window_offset,
+    size_t window_size
+) {
+    if (comm_derive_context_fn_ == nullptr) {
+        throw std::runtime_error("comm_derive_context is not supported by this runtime");
+    }
+    if (rank_ids.empty()) {
+        throw std::runtime_error("comm_derive_context: rank_ids must not be empty");
+    }
+    uint64_t device_ctx = 0;
+    int rc = comm_derive_context_fn_(
+        reinterpret_cast<void *>(comm_handle), rank_ids.data(), rank_ids.size(), domain_rank, window_offset,
+        window_size, &device_ctx
+    );
+    if (rc != 0) {
+        throw std::runtime_error("comm_derive_context failed with code " + std::to_string(rc));
+    }
+    if (device_ctx == 0) {
+        throw std::runtime_error("comm_derive_context returned null device_ctx");
+    }
+    return device_ctx;
 }
 
 void ChipWorker::comm_barrier(uint64_t comm_handle) {
@@ -447,19 +617,45 @@ void ChipWorker::comm_barrier(uint64_t comm_handle) {
 }
 
 void ChipWorker::comm_destroy(uint64_t comm_handle) {
-    int rc = comm_destroy_fn_(reinterpret_cast<void *>(comm_handle));
-
-    // Destroy our comm-owned stream regardless of the handle-destroy result —
-    // leaking the stream is the worse outcome (it keeps the device attached
-    // and blocks the next session).  We still surface the underlying rc
-    // below so callers see the original failure.
-    if (comm_stream_ != nullptr) {
-        int srv = destroy_comm_stream_fn_(device_ctx_, comm_stream_);
-        if (srv != 0 && rc == 0) rc = srv;
+    CommSession *session = find_comm_session(comm_handle);
+    if (session == nullptr) {
+        int rc = comm_destroy_fn_(reinterpret_cast<void *>(comm_handle));
+        if (rc != 0) {
+            throw std::runtime_error("comm_destroy failed with code " + std::to_string(rc));
+        }
+        return;
     }
-    comm_stream_ = nullptr;
+    if (session->is_base) {
+        comm_destroy_all();
+        return;
+    }
+
+    int rc = destroy_comm_session(*session);
+    while (!comm_sessions_.empty() && comm_sessions_.back().handle == nullptr &&
+           comm_sessions_.back().stream == nullptr) {
+        comm_sessions_.pop_back();
+    }
 
     if (rc != 0) {
         throw std::runtime_error("comm_destroy failed with code " + std::to_string(rc));
+    }
+}
+
+void ChipWorker::comm_destroy_all() {
+    int first_rc = 0;
+    for (auto it = comm_sessions_.rbegin(); it != comm_sessions_.rend(); ++it) {
+        if (it->handle == nullptr && it->stream == nullptr) {
+            continue;
+        }
+        int rc = destroy_comm_session(*it);
+        if (rc != 0 && first_rc == 0) {
+            first_rc = rc;
+        }
+    }
+    comm_sessions_.clear();
+    comm_session_index_.clear();
+    base_comm_handle_ = 0;
+    if (first_rc != 0) {
+        throw std::runtime_error("comm_destroy_all failed with code " + std::to_string(first_rc));
     }
 }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "../task_interface/call_config.h"
@@ -91,14 +92,25 @@ public:
     ///     ensure_acl_ready / aclrtCreateStream surface area).
     ///   - On sim, ACL / stream are no-ops; the stashed stream is null.
     ///
-    /// One active comm session per ChipWorker is supported.  Users needing
-    /// multiple concurrent comms should instantiate multiple ChipWorkers.
+    /// Multi-domain bootstrap owns a hidden base communicator plus one
+    /// sub-communicator per active domain.  The legacy comm_* methods are kept
+    /// as wrappers for the transition and allocate a single "default" domain.
     uint64_t comm_init(int rank, int nranks, const std::string &rootinfo_path);
+    uint64_t comm_create_subcomm(
+        uint64_t base_comm_handle, uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids,
+        uint32_t sub_comm_rank_id
+    );
+    uint64_t comm_create_domain(uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids, uint32_t sub_comm_rank_id);
     uint64_t comm_alloc_windows(uint64_t comm_handle, size_t win_size);
     uint64_t comm_get_local_window_base(uint64_t comm_handle);
     size_t comm_get_window_size(uint64_t comm_handle);
+    uint64_t comm_derive_context(
+        uint64_t comm_handle, const std::vector<uint32_t> &rank_ids, uint32_t domain_rank, size_t window_offset,
+        size_t window_size
+    );
     void comm_barrier(uint64_t comm_handle);
     void comm_destroy(uint64_t comm_handle);
+    void comm_destroy_all();
 
     int device_id() const { return device_id_; }
     bool initialized() const { return initialized_; }
@@ -124,11 +136,30 @@ private:
     using CreateCommStreamFn = void *(*)(void *);
     using DestroyCommStreamFn = int (*)(void *, void *);
     using CommInitFn = void *(*)(int, int, void *, const char *);
+    using CommCreateSubcommFn = void *(*)(void *, uint64_t, const uint32_t *, size_t, uint32_t, void *);
     using CommAllocWindowsFn = int (*)(void *, size_t, uint64_t *);
     using CommGetLocalWindowBaseFn = int (*)(void *, uint64_t *);
     using CommGetWindowSizeFn = int (*)(void *, size_t *);
+    using CommDeriveContextFn = int (*)(void *, const uint32_t *, size_t, uint32_t, size_t, size_t, uint64_t *);
     using CommBarrierFn = int (*)(void *);
     using CommDestroyFn = int (*)(void *);
+
+    struct CommSession {
+        void *handle = nullptr;
+        void *stream = nullptr;
+        bool is_base = false;
+        uint64_t device_ctx = 0;
+        uint64_t local_window_base = 0;
+        size_t window_size = 0;
+    };
+
+    void *create_comm_stream_checked(const char *op_name);
+    void destroy_comm_stream_best_effort(void *stream, int *rc);
+    CommSession *find_comm_session(uint64_t comm_handle);
+    CommSession *create_comm_session(void *handle, void *stream, bool is_base);
+    int destroy_comm_session(CommSession &session);
+    uint64_t create_base_comm(int rank, int nranks, const std::string &rootinfo_path);
+    void clear_comm_sessions();
 
     void *lib_handle_ = nullptr;
     CreateDeviceContextFn create_device_context_fn_ = nullptr;
@@ -149,17 +180,17 @@ private:
     CreateCommStreamFn create_comm_stream_fn_ = nullptr;
     DestroyCommStreamFn destroy_comm_stream_fn_ = nullptr;
     CommInitFn comm_init_fn_ = nullptr;
+    CommCreateSubcommFn comm_create_subcomm_fn_ = nullptr;
     CommAllocWindowsFn comm_alloc_windows_fn_ = nullptr;
     CommGetLocalWindowBaseFn comm_get_local_window_base_fn_ = nullptr;
     CommGetWindowSizeFn comm_get_window_size_fn_ = nullptr;
+    CommDeriveContextFn comm_derive_context_fn_ = nullptr;
     CommBarrierFn comm_barrier_fn_ = nullptr;
     CommDestroyFn comm_destroy_fn_ = nullptr;
     void *device_ctx_ = nullptr;
-    // aclrtStream owned by the currently-active comm session (created inside
-    // comm_init on onboard via DeviceRunner::create_comm_stream, paired with
-    // destroy_comm_stream in comm_destroy).  Null when no comm is active or
-    // when running on a backend without ACL (sim).
-    void *comm_stream_ = nullptr;
+    std::vector<CommSession> comm_sessions_;
+    std::unordered_map<uint64_t, size_t> comm_session_index_;
+    uint64_t base_comm_handle_ = 0;
 
     std::vector<uint8_t> runtime_buf_;
     // device_id_ is set once in init() and never modified afterward. All

--- a/tests/ut/py/test_worker/test_bootstrap_context_hw.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_hw.py
@@ -53,37 +53,45 @@ def _bootstrap_rank_entry(  # noqa: PLR0913
         from simpler.task_interface import (
             ChipBootstrapConfig,
             ChipBufferSpec,
-            ChipCommBootstrapConfig,
             ChipWorker,
+            CommDomain,
+            CommDomainPlan,
         )
 
         worker = ChipWorker()
         worker.init(device_id, bins)
         result["stage"] = "init"
 
-        cfg = ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
-                window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
-                    name="x",
-                    dtype="float32",
-                    count=buffer_nbytes // 4,
-                    nbytes=buffer_nbytes,
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="default",
+                    worker_indices=list(range(nranks)),
+                    window_size=window_size,
+                    buffers=[
+                        ChipBufferSpec(
+                            name="x",
+                            dtype="float32",
+                            count=buffer_nbytes // 4,
+                            nbytes=buffer_nbytes,
+                        )
+                    ],
                 )
-            ],
+            ]
         )
+        cfg = ChipBootstrapConfig(comm=plan.bootstrap_for_worker(rank))
+        cfg.base_rank = rank
+        cfg.base_size = nranks
+        cfg.rootinfo_path = rootinfo_path
+        cfg.base_window_size = plan.base_window_size()
 
         res = worker.bootstrap_context(device_id=device_id, cfg=cfg)
+        domain = res.domains["default"]
         result["stage"] = "bootstrap"
-        result["device_ctx"] = int(res.device_ctx)
-        result["local_window_base"] = int(res.local_window_base)
-        result["actual_window_size"] = int(res.actual_window_size)
-        result["buffer_ptrs"] = list(res.buffer_ptrs)
+        result["device_ctx"] = int(domain.device_ctx)
+        result["local_window_base"] = int(domain.local_window_base)
+        result["actual_window_size"] = int(domain.actual_window_size)
+        result["buffer_ptrs"] = list(domain.buffer_ptrs.values())
 
         # Teardown mirrors the Worker bootstrap loop ordering: shutdown_bootstrap
         # (releases the HCCL comm handle) then finalize (releases ACL / unloads

--- a/tests/ut/py/test_worker/test_bootstrap_context_sim.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_sim.py
@@ -81,8 +81,9 @@ def _rank_entry(  # noqa: PLR0913
             ChipBootstrapChannel,
             ChipBootstrapConfig,
             ChipBufferSpec,
-            ChipCommBootstrapConfig,
             ChipWorker,
+            CommDomain,
+            CommDomainPlan,
             HostBufferStaging,
         )
 
@@ -90,16 +91,24 @@ def _rank_entry(  # noqa: PLR0913
         worker.init(rank, bins)
         result["stage"] = "init"
 
-        cfg = ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
-                window_size=window_size,
-            ),
-            buffers=[ChipBufferSpec(**s) for s in buffer_specs],
-            host_inputs=[HostBufferStaging(**s) for s in host_input_specs],
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="default",
+                    worker_indices=list(range(nranks)),
+                    window_size=window_size,
+                    buffers=[ChipBufferSpec(**s) for s in buffer_specs],
+                )
+            ]
         )
+        cfg = ChipBootstrapConfig(
+            comm=plan.bootstrap_for_worker(rank),
+            host_inputs=[HostBufferStaging(domain_name="default", **s) for s in host_input_specs],
+        )
+        cfg.base_rank = rank
+        cfg.base_size = nranks
+        cfg.rootinfo_path = rootinfo_path
+        cfg.base_window_size = plan.base_window_size()
 
         channel: ChipBootstrapChannel | None = None
         shm_attach: SharedMemory | None = None
@@ -109,18 +118,19 @@ def _rank_entry(  # noqa: PLR0913
 
         try:
             res = worker.bootstrap_context(device_id=rank, cfg=cfg, channel=channel)
+            domain = res.domains["default"]
             result["stage"] = "bootstrap"
-            result["device_ctx"] = int(res.device_ctx)
-            result["local_window_base"] = int(res.local_window_base)
-            result["actual_window_size"] = int(res.actual_window_size)
-            result["buffer_ptrs"] = list(res.buffer_ptrs)
+            result["device_ctx"] = int(domain.device_ctx)
+            result["local_window_base"] = int(domain.local_window_base)
+            result["actual_window_size"] = int(domain.actual_window_size)
+            result["buffer_ptrs"] = list(domain.buffer_ptrs.values())
 
             # Read back the first buffer if the test asked for it.  Uses the
             # worker's device-to-host DMA so the test can assert on what
             # ``load_from_host`` actually wrote at ``buffer_ptrs[0]``.
-            if readback_nbytes > 0 and res.buffer_ptrs:
+            if readback_nbytes > 0 and domain.buffer_ptrs:
                 host_buf = (ctypes.c_char * readback_nbytes)()
-                worker.copy_from(ctypes.addressof(host_buf), res.buffer_ptrs[0], readback_nbytes)
+                worker.copy_from(ctypes.addressof(host_buf), next(iter(domain.buffer_ptrs.values())), readback_nbytes)
                 result["readback"] = bytes(host_buf)
 
             # shutdown_bootstrap + finalize — matches the Worker bootstrap
@@ -219,6 +229,111 @@ class TestBootstrapContextHappyPath:
             assert r["actual_window_size"] >= 4096
             # Single buffer at window base — the 1:1 contract ChipContext relies on.
             assert r["buffer_ptrs"] == [r["local_window_base"]]
+
+
+# ---------------------------------------------------------------------------
+# 1b. Multi-domain path — overlapping subcommunicators get independent windows.
+# ---------------------------------------------------------------------------
+
+
+def _multi_domain_rank_entry(
+    worker_idx: int,
+    nranks: int,
+    rootinfo_path: str,
+    bins,
+    result_queue: mp.Queue,  # type: ignore[type-arg]
+) -> None:
+    result: dict[str, object] = {"rank": worker_idx, "ok": False}
+    try:
+        from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipWorker, CommDomain, CommDomainPlan
+
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="tp",
+                    worker_indices=[0, 1],
+                    window_size=4096,
+                    buffers=[ChipBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
+                ),
+                CommDomain(
+                    name="pp",
+                    worker_indices=[1, 2],
+                    window_size=4096,
+                    buffers=[ChipBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
+                ),
+            ]
+        )
+        cfg = ChipBootstrapConfig(comm=plan.bootstrap_for_worker(worker_idx))
+        cfg.base_rank = worker_idx
+        cfg.base_size = nranks
+        cfg.rootinfo_path = rootinfo_path
+
+        worker = ChipWorker()
+        worker.init(worker_idx, bins)
+        try:
+            res = worker.bootstrap_context(device_id=worker_idx, cfg=cfg)
+            result["domains"] = {
+                name: {
+                    "domain_rank": domain.domain_rank,
+                    "domain_size": domain.domain_size,
+                    "device_ctx": int(domain.device_ctx),
+                    "local_window_base": int(domain.local_window_base),
+                    "actual_window_size": int(domain.actual_window_size),
+                    "buffer_ptrs": dict(domain.buffer_ptrs),
+                }
+                for name, domain in res.domains.items()
+            }
+            result["ok"] = True
+        finally:
+            worker.shutdown_bootstrap()
+            worker.finalize()
+    except Exception:  # noqa: BLE001
+        result["error"] = traceback.format_exc()
+    finally:
+        result_queue.put(result)
+
+
+class TestBootstrapContextMultiDomain:
+    def test_overlapping_domains_create_independent_sim_windows(self):
+        bins = _sim_binaries()
+        rootinfo_path = f"/tmp/pto_bootstrap_sim_{os.getpid()}_multi_domain.bin"
+        ctx = mp.get_context("fork")
+        result_queue: mp.Queue = ctx.Queue()  # type: ignore[type-arg]
+        procs = []
+        for worker_idx in range(3):
+            p = ctx.Process(
+                target=_multi_domain_rank_entry,
+                args=(worker_idx, 3, rootinfo_path, bins, result_queue),
+                daemon=False,
+            )
+            p.start()
+            procs.append(p)
+
+        results: dict[int, dict] = {}
+        for _ in range(3):
+            r = result_queue.get(timeout=180)
+            results[int(r["rank"])] = r
+        for p in procs:
+            p.join(timeout=60)
+        try:
+            os.unlink(rootinfo_path)
+        except FileNotFoundError:
+            pass
+
+        for rank in range(3):
+            assert results[rank].get("ok"), f"rank {rank} failed: {results[rank].get('error')}"
+
+        assert set(results[0]["domains"]) == {"tp"}
+        assert set(results[1]["domains"]) == {"pp", "tp"}
+        assert set(results[2]["domains"]) == {"pp"}
+
+        assert results[1]["domains"]["tp"]["domain_rank"] == 1
+        assert results[1]["domains"]["pp"]["domain_rank"] == 0
+        assert results[1]["domains"]["tp"]["device_ctx"] != results[1]["domains"]["pp"]["device_ctx"]
+        assert (
+            results[1]["domains"]["tp"]["buffer_ptrs"]["scratch"]
+            != results[1]["domains"]["pp"]["buffer_ptrs"]["scratch"]
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -337,38 +452,52 @@ def _store_rank_entry(  # noqa: PLR0913
         from simpler.task_interface import (
             ChipBootstrapConfig,
             ChipBufferSpec,
-            ChipCommBootstrapConfig,
             ChipWorker,
+            CommDomain,
+            CommDomainPlan,
             HostBufferStaging,
         )
 
         worker = ChipWorker()
         worker.init(rank, bins)
 
-        cfg = ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
-                window_size=window_size,
-            ),
-            buffers=[ChipBufferSpec(**s) for s in buffer_specs],
-            host_outputs=[HostBufferStaging(**s) for s in host_output_specs],
+        domain_buffers = [ChipBufferSpec(**s) for s in buffer_specs]
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="default",
+                    worker_indices=list(range(nranks)),
+                    window_size=window_size,
+                    buffers=domain_buffers,
+                )
+            ]
         )
+        cfg = ChipBootstrapConfig(
+            comm=plan.bootstrap_for_worker(rank),
+            host_outputs=[HostBufferStaging(domain_name="default", **s) for s in host_output_specs],
+        )
+        cfg.base_rank = rank
+        cfg.base_size = nranks
+        cfg.rootinfo_path = rootinfo_path
+        cfg.base_window_size = plan.base_window_size()
 
         res = worker.bootstrap_context(device_id=rank, cfg=cfg)
+        domain = res.domains["default"]
 
-        if payload is not None and res.buffer_ptrs:
+        if payload is not None and domain.buffer_ptrs:
             src = (ctypes.c_char * len(payload)).from_buffer_copy(payload)
-            worker.copy_to(res.buffer_ptrs[0], ctypes.addressof(src), len(payload))
+            first_ptr = next(iter(domain.buffer_ptrs.values()))
+            worker.copy_to(first_ptr, ctypes.addressof(src), len(payload))
 
             # Manually run the same flush logic worker.py uses on TASK_DONE,
             # so this test covers the exact D2H handshake without needing a
             # full dispatch loop.
-            for spec, ptr in zip(cfg.buffers, res.buffer_ptrs):
+            domain_cfg = cfg.domain_bootstrap_configs()[0]
+            for spec in domain_cfg.buffers:
                 if not spec.store_to_host or spec.nbytes == 0:
                     continue
-                staging = cfg.output_staging(spec.name)
+                ptr = domain.buffer_ptrs[spec.name]
+                staging = domain_cfg.output_staging(spec.name)
                 shm = SharedMemory(name=staging.shm_name)
                 try:
                     shm_buf = shm.buf
@@ -541,6 +670,7 @@ def _missing_output_staging_rank_entry(
             ChipBootstrapChannel,
             ChipBootstrapConfig,
             ChipBufferSpec,
+            ChipDomainBootstrapConfig,
             ChipWorker,
         )
 
@@ -552,14 +682,23 @@ def _missing_output_staging_rank_entry(
             channel = ChipBootstrapChannel(_shm_addr(shm), max_buffer_count=376)
 
             cfg = ChipBootstrapConfig(
-                comm=None,
-                buffers=[
-                    ChipBufferSpec(
-                        name="y",
-                        dtype="float32",
-                        count=1,
-                        nbytes=4,
-                        store_to_host=True,
+                comm=[
+                    ChipDomainBootstrapConfig(
+                        name="default",
+                        sub_comm_id=0,
+                        domain_rank=0,
+                        domain_size=1,
+                        rank_ids=[0],
+                        window_size=4096,
+                        buffers=[
+                            ChipBufferSpec(
+                                name="y",
+                                dtype="float32",
+                                count=1,
+                                nbytes=4,
+                                store_to_host=True,
+                            )
+                        ],
                     )
                 ],
                 host_outputs=[],

--- a/tests/ut/py/test_worker/test_comm_domain_plan.py
+++ b/tests/ut/py/test_worker/test_comm_domain_plan.py
@@ -1,0 +1,206 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+from _task_interface import _ChipWorker
+from simpler.task_interface import (
+    ChipBootstrapConfig,
+    ChipBufferSpec,
+    ChipCommDomainContext,
+    ChipContext,
+    CommDomain,
+    CommDomainPlan,
+    HostBufferStaging,
+)
+
+
+def _buffer(name: str = "scratch"):
+    return ChipBufferSpec(name=name, dtype="float32", count=4, nbytes=16)
+
+
+class TestCommDomainPlan:
+    def test_bootstrap_for_worker_uses_worker_index_order_as_domain_rank(self):
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(name="tp", worker_indices=[3, 1], window_size=4096, buffers=[_buffer()]),
+                CommDomain(name="ep", worker_indices=[1, 2], window_size=8192, buffers=[_buffer()]),
+            ]
+        )
+        plan.validate(worker_count=4)
+
+        cfgs = plan.bootstrap_for_worker(1)
+
+        assert [c.name for c in cfgs] == ["ep", "tp"]
+        assert {c.name: c.domain_rank for c in cfgs} == {"tp": 1, "ep": 0}
+        assert {c.name: c.domain_size for c in cfgs} == {"tp": 2, "ep": 2}
+        assert {c.name: c.rank_ids for c in cfgs} == {"tp": [3, 1], "ep": [1, 2]}
+
+    def test_bootstrap_for_worker_assigns_shared_base_window_layout(self):
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(name="tp", worker_indices=[0, 1], window_size=4096, buffers=[_buffer()]),
+                CommDomain(name="pp", worker_indices=[1, 2], window_size=8192, buffers=[_buffer()]),
+                CommDomain(name="dp", worker_indices=[2], window_size=2048, buffers=[_buffer()]),
+            ]
+        )
+        plan.validate(worker_count=3)
+
+        cfgs = {c.name: c for c in plan.bootstrap_for_worker(1)}
+
+        assert cfgs["pp"].window_offset == 2048
+        assert cfgs["tp"].window_offset == 10240
+        assert cfgs["pp"].base_window_size == 14336
+        assert cfgs["tp"].base_window_size == 14336
+
+    def test_non_member_worker_gets_no_domain_configs(self):
+        plan = CommDomainPlan(domains=[CommDomain(name="tp", worker_indices=[0, 1], window_size=4096)])
+        plan.validate(worker_count=3)
+
+        assert plan.bootstrap_for_worker(2) == []
+
+    def test_duplicate_domain_names_fail_validation(self):
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(name="tp", worker_indices=[0], window_size=4096),
+                CommDomain(name="tp", worker_indices=[1], window_size=4096),
+            ]
+        )
+
+        with pytest.raises(ValueError, match="duplicate communication domain name"):
+            plan.validate(worker_count=2)
+
+    def test_duplicate_buffer_names_fail_within_one_domain(self):
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="tp",
+                    worker_indices=[0, 1],
+                    window_size=4096,
+                    buffers=[_buffer("scratch"), _buffer("scratch")],
+                )
+            ]
+        )
+
+        with pytest.raises(ValueError, match="duplicate names"):
+            plan.validate(worker_count=2)
+
+    def test_out_of_range_worker_index_fails_validation(self):
+        plan = CommDomainPlan(domains=[CommDomain(name="tp", worker_indices=[0, 3], window_size=4096)])
+
+        with pytest.raises(ValueError, match="outside"):
+            plan.validate(worker_count=2)
+
+    def test_domain_plan_does_not_own_host_staging(self):
+        with pytest.raises(TypeError, match="host_inputs"):
+            CommDomain(
+                name="red",
+                worker_indices=[0, 1],
+                window_size=4096,
+                buffers=[_buffer("scratch")],
+                host_inputs=[],
+            )
+
+    def test_explicit_bootstrap_config_adds_per_chip_staging_to_plan_domains(self):
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="red",
+                    worker_indices=[0, 1],
+                    window_size=4096,
+                    buffers=[_buffer("scratch")],
+                ),
+                CommDomain(
+                    name="blue",
+                    worker_indices=[0, 1],
+                    window_size=4096,
+                    buffers=[_buffer("scratch")],
+                ),
+            ]
+        )
+        cfg = ChipBootstrapConfig(
+            comm=plan.bootstrap_for_worker(0),
+            host_inputs=[
+                HostBufferStaging(domain_name="red", name="scratch", shm_name="psm_red", size=16),
+                HostBufferStaging(domain_name="blue", name="scratch", shm_name="psm_blue", size=16),
+            ],
+        )
+
+        domains = {c.name: c for c in cfg.domain_bootstrap_configs()}
+
+        assert domains["red"].input_staging("scratch").shm_name == "psm_red"
+        assert domains["blue"].input_staging("scratch").shm_name == "psm_blue"
+
+    def test_overlapping_domains_have_independent_rank_spaces(self):
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="tp",
+                    worker_indices=[0, 1],
+                    window_size=4096,
+                    buffers=[_buffer("scratch")],
+                ),
+                CommDomain(
+                    name="pp",
+                    worker_indices=[1, 2],
+                    window_size=4096,
+                    buffers=[_buffer("scratch")],
+                ),
+            ]
+        )
+        plan.validate(worker_count=3)
+
+        cfgs_by_worker = {
+            worker_idx: {cfg.name: cfg for cfg in plan.bootstrap_for_worker(worker_idx)} for worker_idx in range(3)
+        }
+
+        assert set(cfgs_by_worker[0]) == {"tp"}
+        assert set(cfgs_by_worker[1]) == {"tp", "pp"}
+        assert set(cfgs_by_worker[2]) == {"pp"}
+        assert cfgs_by_worker[1]["tp"].domain_rank == 1
+        assert cfgs_by_worker[1]["pp"].domain_rank == 0
+        assert cfgs_by_worker[1]["tp"].buffers[0].name == "scratch"
+        assert cfgs_by_worker[1]["pp"].buffers[0].name == "scratch"
+
+        ctx = ChipContext(
+            device_id=1,
+            worker_index=1,
+            domains={
+                "tp": ChipCommDomainContext(
+                    name="tp",
+                    domain_rank=1,
+                    domain_size=2,
+                    device_ctx=0x1000,
+                    local_window_base=0x2000,
+                    actual_window_size=4096,
+                    buffer_ptrs={"scratch": 0x2000},
+                ),
+                "pp": ChipCommDomainContext(
+                    name="pp",
+                    domain_rank=0,
+                    domain_size=2,
+                    device_ctx=0x3000,
+                    local_window_base=0x4000,
+                    actual_window_size=4096,
+                    buffer_ptrs={"scratch": 0x4000},
+                ),
+            },
+        )
+
+        assert ctx.domains["tp"].buffer_ptrs["scratch"] != ctx.domains["pp"].buffer_ptrs["scratch"]
+        with pytest.raises(KeyError):
+            ctx.domains["dp"]
+
+
+class TestChipWorkerCommDomainBindings:
+    def test_native_worker_exposes_multi_domain_comm_methods(self):
+        worker = _ChipWorker()
+
+        assert hasattr(worker, "comm_create_subcomm")
+        assert hasattr(worker, "comm_create_domain")
+        assert hasattr(worker, "comm_destroy_all")

--- a/tests/ut/py/test_worker/test_worker_distributed_hw.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_hw.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ruff: noqa: PLC0415
-"""Hardware smoke test for `Worker(chip_bootstrap_configs=...)` on 2 Ascend devices.
+"""Hardware smoke test for `Worker(comm_plan=...)` on 2 Ascend devices.
 
 End-to-end equivalent of ``test_bootstrap_context_hw.py`` but driven through
 the top-level ``Worker`` class so the bootstrap happens inside forked chip
@@ -21,8 +21,6 @@ GVA-visible window.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 
@@ -30,35 +28,32 @@ import pytest
 @pytest.mark.platforms(["a2a3"])
 @pytest.mark.device_count(2)
 def test_worker_chip_bootstrap(st_device_ids):
-    from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipCommBootstrapConfig
+    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
     from simpler.worker import Worker
 
     assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
     device_ids = [int(st_device_ids[0]), int(st_device_ids[1])]
     nranks = len(device_ids)
-    rootinfo_path = f"/tmp/pto_worker_l6_hw_rootinfo_{os.getpid()}.bin"
     window_size = 4096
     buffer_nbytes = 64
 
-    cfgs = [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
+    comm_plan = CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
                 window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
-                    name="x",
-                    dtype="float32",
-                    count=buffer_nbytes // 4,
-                    nbytes=buffer_nbytes,
-                )
-            ],
-        )
-        for rank in range(nranks)
-    ]
+                buffers=[
+                    ChipBufferSpec(
+                        name="x",
+                        dtype="float32",
+                        count=buffer_nbytes // 4,
+                        nbytes=buffer_nbytes,
+                    )
+                ],
+            )
+        ]
+    )
 
     worker = Worker(
         level=3,
@@ -66,7 +61,7 @@ def test_worker_chip_bootstrap(st_device_ids):
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        chip_bootstrap_configs=cfgs,
+        comm_plan=comm_plan,
     )
     try:
         worker.init()
@@ -75,19 +70,16 @@ def test_worker_chip_bootstrap(st_device_ids):
         assert len(ctxs) == nranks
         for rank, ctx in enumerate(ctxs):
             assert ctx.device_id == device_ids[rank]
-            assert ctx.rank == rank
-            assert ctx.nranks == nranks
-            assert ctx.device_ctx != 0, f"rank {rank}: device_ctx is 0 (HCCL alloc failed)"
-            assert ctx.local_window_base != 0, f"rank {rank}: local_window_base is 0"
-            assert ctx.actual_window_size >= window_size, (
-                f"rank {rank}: actual_window_size={ctx.actual_window_size} < requested {window_size}"
+            domain = ctx.domains["default"]
+            assert domain.domain_rank == rank
+            assert domain.domain_size == nranks
+            assert domain.device_ctx != 0, f"rank {rank}: device_ctx is 0 (HCCL alloc failed)"
+            assert domain.local_window_base != 0, f"rank {rank}: local_window_base is 0"
+            assert domain.actual_window_size >= window_size, (
+                f"rank {rank}: actual_window_size={domain.actual_window_size} < requested {window_size}"
             )
             # The single buffer spec carves offset 0, matching the
             # ChipContext.buffer_ptrs → local_window_base invariant.
-            assert ctx.buffer_ptrs == {"x": ctx.local_window_base}
+            assert domain.buffer_ptrs == {"x": domain.local_window_base}
     finally:
         worker.close()
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass

--- a/tests/ut/py/test_worker/test_worker_distributed_sim.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_sim.py
@@ -7,18 +7,17 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ruff: noqa: PLC0415
-"""Simulation tests for Worker-level chip bootstrap orchestration.
+"""Simulation tests for Worker-level communication-plan orchestration.
 
 Covers the two externally-visible guarantees:
 
-  1. Happy path — `Worker(level=3, chip_bootstrap_configs=...)` populates
+  1. Happy path — `Worker(level=3, comm_plan=...)` populates
      `worker.chip_contexts` with one per chip, and `close()` leaves no
      residue behind in `/dev/shm`.
-  2. Error path — a bad `ChipBootstrapConfig` (e.g. store_to_host without a
-     matching host_outputs entry) trips ValueError inside
-     `bootstrap_context`; the channel publishes ERROR, the parent raises
-     `RuntimeError`, and every forked child is reaped so the test process
-     has no dangling descendants.
+  2. Error path — a bad communication plan (e.g. store_to_host without a
+     matching host_outputs entry) trips ValueError inside `bootstrap_context`;
+     the channel publishes ERROR, the parent raises `RuntimeError`, and every
+     forked child is reaped so the test process has no dangling descendants.
 
 These tests drive the sim backend of `tensormap_and_ringbuffer`, so no
 Ascend NPU is required.  `/dev/shm` only exists on Linux; the sweep
@@ -67,33 +66,81 @@ def _sim_binaries():
     return bins
 
 
-def _make_configs(nranks: int, rootinfo_path: str, window_size: int = 4096):
-    """Build a `[ChipBootstrapConfig] * nranks` with a single named buffer.
+def _make_comm_plan(nranks: int, window_size: int = 4096):
+    """Build a `CommDomainPlan` with a single default domain and named buffer.
 
     The buffer carves the window at offset 0, so we get a deterministic
     `buffer_ptrs["x"] == local_window_base` invariant to assert on.
     """
-    from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipCommBootstrapConfig
+    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
 
-    return [
-        ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(
-                rank=rank,
-                nranks=nranks,
-                rootinfo_path=rootinfo_path,
+    return CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
                 window_size=window_size,
-            ),
-            buffers=[
-                ChipBufferSpec(
-                    name="x",
-                    dtype="float32",
-                    count=16,
-                    nbytes=64,
-                ),
-            ],
-        )
-        for rank in range(nranks)
-    ]
+                buffers=[
+                    ChipBufferSpec(
+                        name="x",
+                        dtype="float32",
+                        count=16,
+                        nbytes=64,
+                    ),
+                ],
+            )
+        ]
+    )
+
+
+def _make_bad_store_plan(nranks: int):
+    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
+
+    return CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=4096,
+                # Missing matching host_outputs intentionally exercises the
+                # bootstrap_context staging-symmetry error path.
+                buffers=[
+                    ChipBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
+                ],
+            )
+        ]
+    )
+
+
+def _make_store_plan(nranks: int):
+    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
+
+    return CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=list(range(nranks)),
+                window_size=4096,
+                buffers=[
+                    ChipBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
+                ],
+            )
+        ]
+    )
+
+
+def _make_out_of_range_plan():
+    from simpler.task_interface import CommDomain, CommDomainPlan
+
+    return CommDomainPlan(
+        domains=[
+            CommDomain(
+                name="default",
+                worker_indices=[0, 2],
+                window_size=4096,
+            )
+        ]
+    )
 
 
 class TestWorkerBootstrapHappyPath:
@@ -101,19 +148,17 @@ class TestWorkerBootstrapHappyPath:
         from simpler.worker import Worker
 
         _sim_binaries()  # skip early if runtime binaries are missing
-        rootinfo_path = f"/tmp/pto_worker_l6_sim_{os.getpid()}_happy.bin"
         nranks = 2
 
         before = _shm_snapshot()
 
-        cfgs = _make_configs(nranks, rootinfo_path)
         worker = Worker(
             level=3,
             platform="a2a3sim",
             runtime="tensormap_and_ringbuffer",
             device_ids=list(range(nranks)),
             num_sub_workers=0,
-            chip_bootstrap_configs=cfgs,
+            comm_plan=_make_comm_plan(nranks),
         )
         try:
             worker.init()
@@ -122,20 +167,17 @@ class TestWorkerBootstrapHappyPath:
             assert len(ctxs) == nranks, f"expected {nranks} ChipContext, got {len(ctxs)}"
             for rank, ctx in enumerate(ctxs):
                 assert ctx.device_id == rank
-                assert ctx.rank == rank
-                assert ctx.nranks == nranks
-                assert ctx.actual_window_size >= 4096
-                assert ctx.local_window_base != 0
+                domain = ctx.domains["default"]
+                assert domain.domain_rank == rank
+                assert domain.domain_size == nranks
+                assert domain.actual_window_size >= 4096
+                assert domain.local_window_base != 0
                 # buffer_ptrs is a name → device-ptr dict, and the single
                 # "x" buffer lives at window base (offset 0).
-                assert set(ctx.buffer_ptrs.keys()) == {"x"}
-                assert ctx.buffer_ptrs["x"] == ctx.local_window_base
+                assert set(domain.buffer_ptrs.keys()) == {"x"}
+                assert domain.buffer_ptrs["x"] == domain.local_window_base
         finally:
             worker.close()
-            try:
-                os.unlink(rootinfo_path)
-            except FileNotFoundError:
-                pass
 
         after = _shm_snapshot()
         if _shm_supported():
@@ -152,7 +194,7 @@ class TestWorkerBootstrapHappyPath:
             runtime="tensormap_and_ringbuffer",
             device_ids=[0, 1],
             num_sub_workers=0,
-            chip_bootstrap_configs=_make_configs(2, "/tmp/pto_unused.bin"),
+            comm_plan=_make_comm_plan(2),
         )
         with pytest.raises(RuntimeError, match="after init"):
             _ = worker.chip_contexts
@@ -161,34 +203,11 @@ class TestWorkerBootstrapHappyPath:
 class TestWorkerBootstrapErrorPath:
     def test_bootstrap_value_error_fails_init_and_cleans_up(self):
         """A ValueError inside bootstrap_context → parent RuntimeError → clean teardown."""
-        from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipCommBootstrapConfig
         from simpler.worker import Worker
 
         _sim_binaries()  # skip if runtime binaries are missing
 
-        rootinfo_path = f"/tmp/pto_worker_l6_sim_{os.getpid()}_err.bin"
         nranks = 2
-
-        # Rank 0 declares a buffer with ``store_to_host=True`` but no matching
-        # ``HostBufferStaging`` in ``host_outputs`` — this trips the staging
-        # symmetry check inside ``bootstrap_context`` *before* any
-        # communicator work, so no peer rank is required to observe the
-        # failure.  Rank 1 uses a valid config; it will either observe ERROR
-        # on rank 0 via the shared sim segment or be reaped by the abort
-        # path before it completes bootstrap.
-        bad = ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(rank=0, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4096),
-            buffers=[
-                ChipBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
-            ],
-            host_outputs=[],
-        )
-        good = ChipBootstrapConfig(
-            comm=ChipCommBootstrapConfig(rank=1, nranks=nranks, rootinfo_path=rootinfo_path, window_size=4096),
-            buffers=[
-                ChipBufferSpec(name="x", dtype="float32", count=1, nbytes=4),
-            ],
-        )
 
         before = _shm_snapshot()
 
@@ -198,7 +217,7 @@ class TestWorkerBootstrapErrorPath:
             runtime="tensormap_and_ringbuffer",
             device_ids=[0, 1],
             num_sub_workers=0,
-            chip_bootstrap_configs=[bad, good],
+            comm_plan=_make_bad_store_plan(nranks),
         )
         with pytest.raises(RuntimeError, match="chip 0 bootstrap failed"):
             worker.init()
@@ -207,11 +226,6 @@ class TestWorkerBootstrapErrorPath:
         assert worker._initialized is False
         # close() on a failed init() is a no-op guard but must not raise.
         worker.close()
-
-        try:
-            os.unlink(rootinfo_path)
-        except FileNotFoundError:
-            pass
 
         after = _shm_snapshot()
         if _shm_supported():
@@ -229,18 +243,54 @@ class TestWorkerBootstrapValidation:
                 platform="a2a3sim",
                 runtime="tensormap_and_ringbuffer",
                 device_id=0,
-                chip_bootstrap_configs=_make_configs(1, "/tmp/pto_unused.bin"),
+                comm_plan=_make_comm_plan(1),
             )
 
-    def test_length_mismatch_rejected(self):
+    def test_out_of_range_worker_index_rejected(self):
         from simpler.worker import Worker
 
-        with pytest.raises(ValueError, match="must equal device_ids length"):
+        with pytest.raises(ValueError, match="outside"):
             Worker(
                 level=3,
                 platform="a2a3sim",
                 runtime="tensormap_and_ringbuffer",
                 device_ids=[0, 1],
                 num_sub_workers=0,
-                chip_bootstrap_configs=_make_configs(1, "/tmp/pto_unused.bin"),
+                comm_plan=_make_out_of_range_plan(),
             )
+
+    def test_old_single_domain_chip_comm_bootstrap_config_is_not_public(self):
+        import simpler.task_interface as ti
+
+        assert not hasattr(ti, "ChipCommBootstrapConfig")
+
+    def test_new_style_explicit_bootstrap_configs_are_accepted(self):
+        from simpler.task_interface import ChipBootstrapConfig, HostBufferStaging
+        from simpler.worker import Worker
+
+        plan = _make_store_plan(2)
+        cfgs = [
+            ChipBootstrapConfig(
+                comm=plan.bootstrap_for_worker(rank),
+                host_outputs=[
+                    HostBufferStaging(
+                        domain_name="default",
+                        name="x",
+                        shm_name=f"psm_rank_{rank}",
+                        size=4,
+                    )
+                ],
+            )
+            for rank in range(2)
+        ]
+
+        worker = Worker(
+            level=3,
+            platform="a2a3sim",
+            runtime="tensormap_and_ringbuffer",
+            device_ids=[0, 1],
+            num_sub_workers=0,
+            chip_bootstrap_configs=cfgs,
+        )
+
+        assert worker._chip_bootstrap_configs == cfgs


### PR DESCRIPTION
## Summary

- Add the new multi-communication-domain public surface:
  `CommDomain`, `CommDomainPlan`, `ChipDomainBootstrapConfig`, and
  domain-aware `ChipContext.domains[name]`.
- Derive per-chip bootstrap configs from one L3-level `CommDomainPlan`, with
  dense domain ranks defined by `CommDomain.worker_indices` order.
- Replace the old public single-domain bootstrap surface with the new
  domain-plan path; single-domain usage is now expressed as one
  `CommDomain("default", ...)`.
- Keep explicit `ChipBootstrapConfig` support for per-chip data such as host
  staging, keyed by `(domain_name, buffer_name)`.
- Extend the runtime/bootstrap path to publish multiple named domain contexts,
  carve symmetric per-domain buffers, and pass domain-local `CommContext*`
  pointers to PTO-ISA kernels.
- Extend both onboard/HCCL and sim communication backends for the base-window
  plus derived-domain-context model.
- Migrate existing communication examples to the new surface and add two
  focused multi-domain examples:
  `workers/l3/domain_rank_map` and `workers/l3/dual_domain_overlap`.
- Add design, implementation, and validation documentation under `docs/`.

## Backend Notes

- On onboard A2/A3, visible communication domains are derived views into one
  hidden base communication window.  Each visible domain gets its own
  domain-local `CommContext*`, dense domain rank space, and named buffer
  slices.
- On sim, the base window is a POSIX shared-memory segment.  The sim backend
  derives host-resident domain `CommContext` objects by remapping
  `windowsIn[]`/`windowsOut[]` through the domain rank list and window offset.
- HCCL collective kernels are intentionally out of scope.  This PR uses
  HCCL/HCOMM resources for window setup and PTO-ISA RMA-style communication in
  kernels.
- Explicit per-chip bootstrap remains available for host staging, but the
  communication topology source of truth is still the parent-level
  `CommDomainPlan`.

## Validation

- Focused unit and sim tests pass: 30 tests covering domain-plan derivation,
  bootstrap channels, sim bootstrap, worker-level sim orchestration, and error
  cleanup.
- Hardware bootstrap unit test passes on A2/A3.
- Real-device `tests/st` passes on A2/A3 devices `2-5` after the PR 752 rebase
  onto latest upstream main.  Runtime artifacts were rebuilt once serially,
  then pytest was run without `--build` so parallel workers only loaded stable
  `build/lib` outputs.
- `workers/l3/domain_rank_map` and `workers/l3/dual_domain_overlap` pass on
  hardware with CANN 8.5.
- `markdownlint-cli2` and `git diff --check` pass for the touched docs.

## Known Limitation

- No HCCL collective kernels are implemented by this PR; kernels use PTO-ISA
  RMA-style operations on the domain-local windows.
- Communication domain windows are sized explicitly by the caller.  Automatic
  window-size derivation is intentionally left out of this implementation.
- The normal L3 API should use `Worker(comm_plan=...)`; explicit
  `chip_bootstrap_configs` is still supported only for cases that need
  per-chip bootstrap details such as host staging.
