### PR TITLE
Fix: finalize diagnostics collectors per run() so reused Workers can re-init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,11 +217,10 @@ jobs:
           fi
           exit $rc
 
-      # DFX per-feature smokes — default pytest above passes no --enable-* flag,
-      # so each capture pipeline gets its own fresh pytest invocation here.
-      # Separate processes side-step the L2PerfCollector dup-init guard
-      # (shm_host_ != nullptr) that the shared L2 worker pool would otherwise
-      # trip across consecutive tests in one session.
+      # DFX per-feature smokes — the default pytest above passes no --enable-*
+      # flag, so each capture pipeline gets its own invocation here. Kept as
+      # separate steps so a failing capture pipeline is attributed to its own
+      # CI step rather than buried in a combined run.
       - name: dep_gen smoke
         run: |
           pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -635,19 +635,12 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
+    // On any exit from run() — success or early error — release the diagnostics
+    // collectors' shared memory. They are only re-initialized per run(), so a
+    // Worker reused across runs (e.g. a pytest session-scoped worker pool) would
+    // otherwise re-enter init_l2_perf() with stale state still allocated.
     auto perf_cleanup = RAIIScopeGuard([this]() {
-        if (l2_perf_collector_.is_initialized()) {
-            l2_perf_collector_.stop();
-        }
-        if (dump_collector_.is_initialized()) {
-            dump_collector_.stop();
-        }
-        if (pmu_collector_.is_initialized()) {
-            pmu_collector_.stop();
-        }
-        if (dep_gen_collector_.is_initialized()) {
-            dep_gen_collector_.stop();
-        }
+        finalize_collectors();
     });
 
     LOG_INFO_V0("=== Initialize runtime args ===");
@@ -1152,74 +1145,9 @@ int DeviceRunner::finalize() {
     aicpu_seen_callable_ids_.clear();
     aicpu_dlopen_total_ = 0;
 
-    // Cleanup performance profiling
-    if (l2_perf_collector_.is_initialized()) {
-        auto unregister_cb = [](void *dev_ptr, int device_id) -> int {
-            HalHostUnregisterFn fn = get_halHostUnregister();
-            if (fn != nullptr) {
-                return fn(dev_ptr, device_id);
-            }
-            return 0;
-        };
-
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            auto *allocator = static_cast<MemoryAllocator *>(user_data);
-            return allocator->free(dev_ptr);
-        };
-
-        l2_perf_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
-    }
-
-    if (dump_collector_.is_initialized()) {
-        auto unregister_cb = [](void *dev_ptr, int device_id) -> int {
-            HalHostUnregisterFn fn = get_halHostUnregister();
-            if (fn != nullptr) {
-                return fn(dev_ptr, device_id);
-            }
-            return 0;
-        };
-
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            auto *allocator = static_cast<MemoryAllocator *>(user_data);
-            return allocator->free(dev_ptr);
-        };
-
-        dump_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
-    }
-
-    if (pmu_collector_.is_initialized()) {
-        auto unregister_cb = [](void *dev_ptr, int device_id) -> int {
-            HalHostUnregisterFn fn = get_halHostUnregister();
-            if (fn != nullptr) {
-                return fn(dev_ptr, device_id);
-            }
-            return 0;
-        };
-
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            auto *allocator = static_cast<MemoryAllocator *>(user_data);
-            return allocator->free(dev_ptr);
-        };
-
-        pmu_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
-    }
-
-    if (dep_gen_collector_.is_initialized()) {
-        auto unregister_cb = [](void *dev_ptr, int device_id) -> int {
-            HalHostUnregisterFn fn = get_halHostUnregister();
-            if (fn != nullptr) {
-                return fn(dev_ptr, device_id);
-            }
-            return 0;
-        };
-
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            auto *allocator = static_cast<MemoryAllocator *>(user_data);
-            return allocator->free(dev_ptr);
-        };
-
-        dep_gen_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
-    }
+    // Cleanup performance profiling. Normally already done by run()'s
+    // perf_cleanup guard; this is the backstop for the no-run-since-init case.
+    finalize_collectors();
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
     mem_alloc_.finalize();
@@ -1545,4 +1473,31 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
 
     kernel_args_.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
+}
+
+void DeviceRunner::finalize_collectors() {
+    auto unregister_cb = [](void *dev_ptr, int device_id) -> int {
+        HalHostUnregisterFn fn = get_halHostUnregister();
+        if (fn != nullptr) {
+            return fn(dev_ptr, device_id);
+        }
+        return 0;
+    };
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
+    if (l2_perf_collector_.is_initialized()) {
+        l2_perf_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+    }
+    if (dump_collector_.is_initialized()) {
+        dump_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+    }
+    if (pmu_collector_.is_initialized()) {
+        pmu_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+    }
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+    }
 }

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -731,6 +731,18 @@ private:
      * @return 0 on success, error code on failure
      */
     int init_dep_gen(int num_threads, int device_id);
+
+    /**
+     * Finalize whichever diagnostics collectors are currently initialized,
+     * releasing their device/host shared memory back to mem_alloc_.
+     *
+     * Idempotent and safe to call multiple times: each collector's finalize()
+     * early-outs once its shm has been released. Invoked both at the end of
+     * every run() (so a Worker reused across runs starts each run with the
+     * collectors in a pristine, re-initializable state) and from finalize()
+     * as a backstop before mem_alloc_.finalize().
+     */
+    void finalize_collectors();
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -465,19 +465,12 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
+    // On any exit from run() — success or early error — release the diagnostics
+    // collectors' shared memory. They are only re-initialized per run(), so a
+    // Worker reused across runs (e.g. a pytest session-scoped worker pool) would
+    // otherwise re-enter init_l2_perf() with stale state still allocated.
     auto perf_cleanup = RAIIScopeGuard([this]() {
-        if (l2_perf_collector_.is_initialized()) {
-            l2_perf_collector_.stop();
-        }
-        if (dump_collector_.is_initialized()) {
-            dump_collector_.stop();
-        }
-        if (pmu_collector_.is_initialized()) {
-            pmu_collector_.stop();
-        }
-        if (dep_gen_collector_.is_initialized()) {
-            dep_gen_collector_.stop();
-        }
+        finalize_collectors();
     });
 
     // Allocate simulated register blocks for all AICore cores
@@ -979,27 +972,9 @@ int DeviceRunner::finalize() {
         return 0;
     }
 
-    // Cleanup performance profiling — free through MemoryAllocator so finalize() can audit.
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
-    };
-
-    if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize(nullptr, free_cb, &mem_alloc_);
-    }
-
-    if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize(nullptr, free_cb, &mem_alloc_);
-    }
-
-    if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize(nullptr, free_cb, &mem_alloc_);
-    }
-
-    if (dep_gen_collector_.is_initialized()) {
-        dep_gen_collector_.finalize(nullptr, free_cb, &mem_alloc_);
-    }
+    // Cleanup performance profiling. Normally already done by run()'s
+    // perf_cleanup guard; this is the backstop for the no-run-since-init case.
+    finalize_collectors();
 
     // Kernel binaries are normally released by validate_runtime_impl on the
     // legacy run() path. The prepared-callable path intentionally leaves
@@ -1273,4 +1248,26 @@ int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
 
     kernel_args_.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
+}
+
+void DeviceRunner::finalize_collectors() {
+    // Free through MemoryAllocator so finalize() can audit. Sim shares an
+    // address space with the AICPU thread, so no host unregister is needed.
+    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
+        auto *allocator = static_cast<MemoryAllocator *>(user_data);
+        return allocator->free(dev_ptr);
+    };
+
+    if (l2_perf_collector_.is_initialized()) {
+        l2_perf_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+    }
+    if (dump_collector_.is_initialized()) {
+        dump_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+    }
+    if (pmu_collector_.is_initialized()) {
+        pmu_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+    }
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+    }
 }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -383,6 +383,16 @@ private:
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
 
     int init_dep_gen(int num_threads, int device_id);
+
+    /**
+     * Finalize whichever diagnostics collectors are currently initialized,
+     * releasing their shared memory back to mem_alloc_. Idempotent: each
+     * collector's finalize() early-outs once its shm has been released.
+     * Invoked at the end of every run() so a Worker reused across runs starts
+     * each run with the collectors re-initializable, and from finalize() as a
+     * backstop before mem_alloc_.finalize().
+     */
+    void finalize_collectors();
     // Enablement for the three diagnostics sub-features. Written by the c_api
     // entry point via set_enable_*() before run(), read inside run() and its
     // helpers. Moved off Runtime / run() args so all three sub-features use

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -924,6 +924,11 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     }
 
     perf_shared_mem_dev_ = nullptr;
+    // shm_host_ aliases freed device/host memory now; null it so is_initialized()
+    // reports false, the dtor's "destroyed without finalize()" warning stays
+    // quiet, and a re-entrant finalize() / re-init hits the early-out instead of
+    // walking freed buffer state. Mirrors PMU/DepGen/TensorDump collectors.
+    shm_host_ = nullptr;
     was_registered_ = false;
     collected_perf_records_.clear();
     collected_phase_records_.clear();


### PR DESCRIPTION
## Summary

`L2PerfCollector::initialize()` returned `-1` (`"already initialized"`) when re-entered on a `DeviceRunner` that survives across runs — e.g. the session-scoped L2 worker pool reused by consecutive scene tests. `run()`'s `perf_cleanup` guard only `stop()`'d the collectors; `finalize()` ran solely from `DeviceRunner::finalize()` at Worker close, so the per-run shared memory was never released between runs. The second test in a process that used a profiler flag then failed with `run_prepared failed with code -1`. The other three collectors (PMU / dep_gen / tensor_dump) silently leaked their shm and double-allocated in the same scenario.

- **`l2_perf_collector.cpp`** — `finalize()` now nulls `shm_host_` in its reset block, so `is_initialized()` reports false afterwards, the dtor's `"destroyed without finalize()"` warning stays quiet, and a re-entrant `finalize()`/re-init hits the early-out instead of walking freed buffer state. This brings it in line with the PMU/dep_gen/tensor_dump collectors, which already did this.
- **`device_runner.{cpp,h}` (onboard + sim)** — add `DeviceRunner::finalize_collectors()`: idempotent, finalizes whichever of the four collectors are currently initialized. `run()`'s `perf_cleanup` RAII guard now calls it (releasing per-run shm on every exit path), and `DeviceRunner::finalize()` calls it as a backstop. Replaces ~70 lines of duplicated unregister/free lambda blocks on the onboard side.
- **`ci.yml`** — drop the now-stale comment claiming the dfx smoke steps run in separate processes to side-step the dup-init guard; they stay separate purely for per-pipeline failure attribution.

## Testing

- [x] Simulation tests pass — all four dfx smokes (`l2_swimlane` + `dep_gen` + `pmu` + `tensor_dump`) now pass in a **single** `pytest` invocation with every profiler flag enabled (`--enable-l2-swimlane --enable-dep-gen --enable-pmu 2 --dump-tensor`), the exact scenario that previously failed. Sim runtime compiled clean via `pip install --no-build-isolation -e .`.
- [ ] Hardware tests — onboard `device_runner.cpp` half not buildable locally on macOS; relies on CI's onboard dfx job. Changes are symmetric to the sim side.