### PR TITLE
Feat: dummy_task — dep-only task that bypasses AICore dispatch

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -195,7 +195,7 @@ dependencies).
 | Shared-mem layout | `src/a2a3/platform/include/common/dep_gen.h` | `DepGenRecord` (2240 B, cache-line aligned) + SPSC ring + per-thread ready queue |
 | AICPU writer | `src/a2a3/platform/{include,src}/aicpu/dep_gen_collector_aicpu.{h,cpp}` | Single-instance write path; weak-fallback exported to host build |
 | Host collector | `src/a2a3/platform/{include/host,src/host}/dep_gen_collector.{h,cpp}` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector |
-| Capture call site | `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()` |
+| Capture call site | `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. Dep-only tasks land in the record stream with valid tensor/dep info but no kernel_id field (the schema does not carry kernel_id), so replay treats them as ordinary dep nodes — viewers do not currently distinguish dummy from real tasks. |
 | Replay | `src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.{h,cpp}` | Pure CPU; runs `compute_task_fanin` + `register_task_outputs` against a host `PTO2TensorMap` |
 | Device-runner hookup | `src/a2a3/platform/{onboard,sim}/host/device_runner.cpp` | post-`reconcile_counters` calls `dep_gen_replay_emit_deps_json(records.data(), records.size(), deps_path, nullptr)` |
 | Viewer | `simpler_setup/tools/deps_to_graph.py` | `deps.json` → pan/zoom HTML |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -136,6 +136,7 @@ typedef struct PTO2RuntimeOps {
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
 } PTO2RuntimeOps;
 
 /**
@@ -231,6 +232,21 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg 
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt_submit_task(mk, args);
+}
+
+/**
+ * Submit a dependency-only task. Accepts the same Arg shape as rt_submit_task
+ * (inputs, outputs, inouts, explicit_deps, scalars) but does not run any
+ * AICore kernel. The task still participates in the dependency graph: it
+ * waits on its fanin and notifies its fanout. Useful as a synchronization
+ * barrier or as a placeholder producer for tests / dep-graph wiring.
+ */
+static inline TaskOutputTensors rt_submit_dummy_task(const Arg &args) {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
+    return rt->ops->submit_dummy_task(rt, args);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -528,69 +528,18 @@ void PTO2OrchestratorState::end_scope() {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
-    auto *orch = this;
+
+// Shared body for submit_task / submit_dummy_task. Caller has already validated
+// args.has_error, decided active_mask (empty for dummy), and resolved the per-slot
+// kernel_ids (all INVALID_KERNEL_ID for dummy). Performs tensormap sync, fanin
+// computation (explicit_deps + auto), output registration, slot init, and pushes
+// to the scheduler wiring queue.
+static TaskOutputTensors submit_task_common(
+    PTO2OrchestratorState *orch, const Arg &args, ActiveMask active_mask, int32_t aic_kernel_id, int32_t aiv0_kernel_id,
+    int32_t aiv1_kernel_id
+) {
     CYCLE_COUNT_START();
-
     TaskOutputTensors result;
-
-    // Orchestration API should short-circuit after fatal, but keep this entry
-    // robust as a no-op in case a caller reaches it directly.
-    if (orch->fatal) {
-        return result;
-    }
-
-    // Validate Arg construction (errors recorded by add_input/add_output/etc.)
-    if (args.has_error) {
-        LOG_ERROR("========================================");
-        LOG_ERROR("FATAL: Invalid Arg Detected!");
-        LOG_ERROR("========================================");
-        LOG_ERROR("Error: %s", args.error_msg ? args.error_msg : "(unknown)");
-        LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
-        LOG_ERROR("This is a bug in the orchestration code.");
-        LOG_ERROR("========================================");
-        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
-        return result;
-    }
-    always_assert(orch->scheduler != nullptr);
-    // === Validate submit inputs ===
-    ActiveMask active_mask = mixed_kernels.to_active_mask();
-    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
-
-    int16_t block_num = args.launch_spec.block_num();
-    always_assert(block_num >= 1 && "block_num must be >= 1");
-
-    // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
-    // it to the aiv0 slot.  This guarantees the dispatch path can always use
-    // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
-    // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
-    // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
-    MixedKernels normalized = mixed_kernels;
-    bool has_aic = active_mask.has_mask(PTO2_SUBTASK_MASK_AIC);
-    bool has_aiv0 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV0);
-    bool has_aiv1 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV1);
-    if (!has_aic && has_aiv1 && !has_aiv0) {
-        normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
-        normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
-        active_mask = normalized.to_active_mask();
-    }
-
-    // Encode require_sync_start into active_mask bit 3 (only meaningful for tasks with block_num > 1)
-    if (block_num > 1 && args.launch_spec.require_sync_start()) {
-        // Deadlock check: block_num >= total available slots of the required type.
-        // For MIX/AIC: limit is total_cluster_count (one AIC per cluster).
-        // For AIV:     limit is total_aiv_count.
-        PTO2ResourceShape shape = active_mask.to_shape();
-        int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
-        if (limit > 0 && block_num > limit) {
-            report_fatal(
-                PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
-                "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
-            );
-            return result;
-        }
-        active_mask.set_sync_start();
-    }
     PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
     if (!prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
@@ -660,7 +609,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         PTO2TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
-            report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
+            orch->report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
             return result;
         }
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];
@@ -703,9 +652,9 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
     task.task_id = task_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = normalized.aic_kernel_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = aic_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = aiv0_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = aiv1_kernel_id;
     task.packed_buffer_base = prepared.alloc_result.packed_base;
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
@@ -753,6 +702,99 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     g_orch_submit_idx++;
 #endif
     return result;
+}
+
+TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    auto *orch = this;
+
+    // Orchestration API should short-circuit after fatal, but keep this entry
+    // robust as a no-op in case a caller reaches it directly.
+    if (orch->fatal) {
+        return TaskOutputTensors{};
+    }
+
+    // Validate Arg construction (errors recorded by add_input/add_output/etc.)
+    if (args.has_error) {
+        LOG_ERROR("========================================");
+        LOG_ERROR("FATAL: Invalid Arg Detected!");
+        LOG_ERROR("========================================");
+        LOG_ERROR("Error: %s", args.error_msg ? args.error_msg : "(unknown)");
+        LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
+        LOG_ERROR("This is a bug in the orchestration code.");
+        LOG_ERROR("========================================");
+        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
+        return TaskOutputTensors{};
+    }
+    always_assert(orch->scheduler != nullptr);
+    // === Validate submit inputs ===
+    ActiveMask active_mask = mixed_kernels.to_active_mask();
+    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
+
+    int16_t block_num = args.launch_spec.block_num();
+    always_assert(block_num >= 1 && "block_num must be >= 1");
+
+    // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
+    // it to the aiv0 slot.  This guarantees the dispatch path can always use
+    // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
+    // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
+    // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
+    MixedKernels normalized = mixed_kernels;
+    bool has_aic = active_mask.has_mask(PTO2_SUBTASK_MASK_AIC);
+    bool has_aiv0 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV0);
+    bool has_aiv1 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV1);
+    if (!has_aic && has_aiv1 && !has_aiv0) {
+        normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
+        normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
+        active_mask = normalized.to_active_mask();
+    }
+
+    // Encode require_sync_start into active_mask bit 3 (only meaningful for tasks with block_num > 1)
+    if (block_num > 1 && args.launch_spec.require_sync_start()) {
+        // Deadlock check: block_num >= total available slots of the required type.
+        // For MIX/AIC: limit is total_cluster_count (one AIC per cluster).
+        // For AIV:     limit is total_aiv_count.
+        PTO2ResourceShape shape = active_mask.to_shape();
+        int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
+        if (limit > 0 && block_num > limit) {
+            report_fatal(
+                PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
+                "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
+            );
+            return TaskOutputTensors{};
+        }
+        active_mask.set_sync_start();
+    }
+
+    return submit_task_common(
+        orch, args, active_mask, normalized.aic_kernel_id, normalized.aiv0_kernel_id, normalized.aiv1_kernel_id
+    );
+}
+
+// Submit a dependency-only task: full dependency graph participation
+// (tensormap lookup/insert, explicit_deps, manual_dep, manual_scope) but no
+// AICore dispatch. Empty active_mask routes the slot to the DUMMY ready
+// bucket; dispatch loop short-circuits to completion. Accepts the same Arg
+// shape as submit_task; scalars are permitted but never consumed.
+TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const Arg &args) {
+    auto *orch = this;
+
+    if (orch->fatal) {
+        return TaskOutputTensors{};
+    }
+
+    if (args.has_error) {
+        LOG_ERROR("========================================");
+        LOG_ERROR("FATAL: Invalid Arg in submit_dummy_task!");
+        LOG_ERROR("========================================");
+        LOG_ERROR("Error: %s", args.error_msg ? args.error_msg : "(unknown)");
+        LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
+        LOG_ERROR("========================================");
+        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
+        return TaskOutputTensors{};
+    }
+    always_assert(orch->scheduler != nullptr);
+
+    return submit_task_common(orch, args, ActiveMask{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID);
 }
 
 TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const Arg &args) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -126,6 +126,7 @@ struct PTO2OrchestratorState {
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
     void end_scope();
     TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors submit_dummy_task(const Arg &args);
     TaskOutputTensors alloc_tensors(const Arg &args);
     void mark_done();
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -46,6 +46,10 @@ static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
+static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const Arg &args) {
+    return rt->orchestrator.submit_dummy_task(args);
+}
+
 void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
@@ -241,6 +245,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .get_tensor_data = get_tensor_data,
     .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
+    .submit_dummy_task = submit_dummy_task_impl,
 };
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -88,6 +88,7 @@ struct PTO2RuntimeOps {
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
 };
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -51,13 +51,21 @@ inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all 
  * requires a fully-idle cluster (1 AIC + 2 AIV).  The actual cores used
  * are determined at dispatch time by active_mask — unused cores in the
  * cluster remain idle and available for single-core tasks.
+ *
+ * DUMMY is a synthetic shape for dep-only tasks (no AICore dispatch). Tasks
+ * with an empty core_mask route to a dedicated DUMMY ready queue and are
+ * completed inline by the scheduler dispatch loop, bypassing core allocation.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC = 0,  // Single AIC
-    AIV = 1,  // Single AIV
-    MIX = 2,  // Full cluster (dispatch uses active_mask)
+    AIC = 0,    // Single AIC
+    AIV = 1,    // Single AIV
+    MIX = 2,    // Full cluster (dispatch uses active_mask)
+    DUMMY = 3,  // Dependency-only (no AICore dispatch)
 };
 
+// Number of *dispatchable* resource shapes (AIC, AIV, MIX). DUMMY does not
+// allocate a per-shape ready_queue entry / local buffer — it lives in a
+// dedicated queue inside PTO2SchedulerState.
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
 
 /**
@@ -79,6 +87,7 @@ public:
 
     PTO2ResourceShape to_shape() const {
         uint8_t cmask = core_mask();
+        if (cmask == 0) return PTO2ResourceShape::DUMMY;
         int bit_count = __builtin_popcount(cmask);
         if (bit_count >= 2) return PTO2ResourceShape::MIX;
         if (cmask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -170,6 +170,17 @@ bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_poo
         }
     }
 
+    // Initialize the DUMMY (dep-only task) ready queue.
+    if (!ready_queue_init(&sched->dummy_ready_queue, PTO2_READY_QUEUE_SIZE)) {
+        for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+            ready_queue_destroy(&sched->ready_queues[i]);
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            sched->ring_sched_states[r].destroy();
+        }
+        return false;
+    }
+
     // Initialize per-ring wiring queues and dep pools (exclusively managed by scheduler thread 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         PTO2DepListEntry *dep_entries =
@@ -181,6 +192,7 @@ bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_poo
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 ready_queue_destroy(&sched->ready_queues[i]);
             }
+            ready_queue_destroy(&sched->dummy_ready_queue);
             sched->wiring.queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
@@ -198,6 +210,7 @@ bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_poo
         for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
             ready_queue_destroy(&sched->ready_queues[i]);
         }
+        ready_queue_destroy(&sched->dummy_ready_queue);
         for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
             sched->ring_sched_states[rr].destroy();
         }
@@ -223,6 +236,7 @@ void PTO2SchedulerState::destroy() {
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         ready_queue_destroy(&sched->ready_queues[i]);
     }
+    ready_queue_destroy(&sched->dummy_ready_queue);
 }
 
 // =============================================================================
@@ -261,6 +275,7 @@ void PTO2SchedulerState::print_queues() {
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         LOG_INFO_V0("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
+    LOG_INFO_V0("  DUMMY: count=%" PRIu64, sched->dummy_ready_queue.size());
 
     LOG_INFO_V0("====================");
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -565,6 +565,10 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
+    // Dependency-only tasks (active_mask is empty, shape == DUMMY). Drained by
+    // the dispatch loop and completed inline -- never goes to AICore.
+    PTO2ReadyQueue dummy_ready_queue;
+
     // Wiring subsystem — groups all wiring-related state for cache-line isolation.
     //
     // Three cache-line regions by writer:
@@ -655,6 +659,20 @@ struct PTO2SchedulerState {
         return wired;
     }
 
+    // Route a ready slot to the right global queue. Dummy tasks (empty
+    // active_mask) live in dummy_ready_queue; everything else goes to the
+    // per-shape ready_queues[]. Used by paths that do not have a thread-local
+    // ready buffer (e.g. wiring). See push_ready_routed_local for the
+    // dispatch-time fast path.
+    void push_ready_routed(PTO2TaskSlotState *slot_state) {
+        PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+        if (shape == PTO2ResourceShape::DUMMY) {
+            dummy_ready_queue.push(slot_state);
+        } else {
+            ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+        }
+    }
+
     /**
      * Wire fanout edges for a single task. Sets fanin_count, acquires each
      * producer's fanout_lock, allocates dep_pool entries for live producers,
@@ -680,11 +698,11 @@ struct PTO2SchedulerState {
             int32_t init_rc = early_finished + 1;
             int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
             if (new_rc >= ws->fanin_count) {
-                ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
+                push_ready_routed(ws);
             }
         } else {
             ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
-            ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
+            push_ready_routed(ws);
         }
 
         ws->dep_pool_mark = rss.dep_pool.top;
@@ -775,8 +793,12 @@ struct PTO2SchedulerState {
         if (new_refcount == slot_state.fanin_count) {
             // Local-first: try per-CoreType thread-local buffer before global queue
             // Route by active_mask: AIC-containing tasks → buf[0], AIV-only → buf[1]
+            // DUMMY shape is out of range for local_bufs (sized PTO2_NUM_RESOURCE_SHAPES);
+            // dummy slots bypass the local fast path and go straight to dummy_ready_queue.
             PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-            if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
+            if (shape == PTO2ResourceShape::DUMMY) {
+                dummy_ready_queue.push(&slot_state);
+            } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                 ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
             }
             return true;
@@ -798,9 +820,14 @@ struct PTO2SchedulerState {
                     expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
                 )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
-                // Local-first: try per-CoreType thread-local buffer before global queue
+                // Local-first: try per-CoreType thread-local buffer before global queue.
+                // Dummy slots bypass local_bufs (out-of-range for PTO2_NUM_RESOURCE_SHAPES)
+                // and go straight to dummy_ready_queue; use the profiling-aware push so
+                // atomic_count / push_wait stay consistent with the non-dummy path.
                 PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-                if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
+                if (shape == PTO2ResourceShape::DUMMY) {
+                    dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
+                } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                     ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
                 }
                 return true;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -44,6 +44,8 @@ const char *SchedulerContext::shape_name(PTO2ResourceShape shape) {
         return "AIV";
     case PTO2ResourceShape::MIX:
         return "MIX";
+    case PTO2ResourceShape::DUMMY:
+        return "DUMMY";
     }
     return "UNKNOWN";
 }
@@ -490,6 +492,49 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
         CYCLE_COUNT_LAP(l2_perf.sched_wiring_cycle);
 #endif
+
+        // Phase 3b: Drain dummy ready queue (thread 0 only).
+        //
+        // Dependency-only tasks bypass AICore dispatch: they go through the
+        // scheduler so fanin/fanout edges stay consistent, but completion is
+        // signalled inline here. Pinned to thread 0 to avoid cross-thread
+        // races and to keep cache hot near the wiring drain above.
+        if (thread_idx == 0) {
+            constexpr int DUMMY_DRAIN_BATCH = 16;
+            PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
+            for (int di = 0; di < dummy_got; di++) {
+                PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
+#if PTO2_SCHED_PROFILING
+                sched_->on_mixed_task_complete(dummy_slot, thread_idx, local_bufs);
+#else
+                sched_->on_mixed_task_complete(dummy_slot, local_bufs);
+#endif
+                // Dummy tasks have no subtasks to retire and no fanout pre-conditions
+                // beyond their own producers; release self-reference so the slot can
+                // reach CONSUMED once all consumers drain.
+                deferred_release_slot_states[deferred_release_count++] = &dummy_slot;
+                if (deferred_release_count >= PTO2_DEFERRED_RELEASE_CAP) {
+                    while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+                        int32_t fe = sched_->on_task_release(
+                            *deferred_release_slot_states[--deferred_release_count], thread_idx
+                        );
+                        l2_perf.fanin_edges_total += fe;
+                        if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
+#else
+                        sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+#endif
+                    }
+                }
+                int32_t prev = completed_tasks_.fetch_add(1, std::memory_order_relaxed);
+                last_progress_count = prev + 1;
+                cur_thread_completed++;
+            }
+            if (dummy_got > 0) {
+                made_progress = true;
+            }
+        }
 
         // Phase 4: Two-phase dispatch (idle then pending)
         const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -211,6 +211,10 @@ public:
             return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
         case PTO2ResourceShape::MIX:
             return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
+        case PTO2ResourceShape::DUMMY:
+            // DUMMY tasks never reach the core-tracker dispatch path; they are
+            // completed inline by resolve_and_dispatch via dummy_ready_queue.
+            return BitStates(0ULL);
         }
         return BitStates(0ULL);
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -136,6 +136,7 @@ typedef struct PTO2RuntimeOps {
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
 } PTO2RuntimeOps;
 
 /**
@@ -231,6 +232,21 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg 
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt_submit_task(mk, args);
+}
+
+/**
+ * Submit a dependency-only task. Accepts the same Arg shape as rt_submit_task
+ * (inputs, outputs, inouts, explicit_deps, scalars) but does not run any
+ * AICore kernel. The task still participates in the dependency graph: it
+ * waits on its fanin and notifies its fanout. Useful as a synchronization
+ * barrier or as a placeholder producer for tests / dep-graph wiring.
+ */
+static inline TaskOutputTensors rt_submit_dummy_task(const Arg &args) {
+    PTO2Runtime *rt = current_runtime();
+    if (rt->ops->is_fatal(rt)) {
+        return TaskOutputTensors{};
+    }
+    return rt->ops->submit_dummy_task(rt, args);
 }
 
 static inline void rt_scope_begin(PTO2ScopeMode mode = PTO2ScopeMode::AUTO) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -507,69 +507,18 @@ void PTO2OrchestratorState::end_scope() {
 // =============================================================================
 // Task Submission
 // =============================================================================
-TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
-    auto *orch = this;
+
+// Shared body for submit_task / submit_dummy_task. Caller has already validated
+// args.has_error, decided active_mask (empty for dummy), and resolved the per-slot
+// kernel_ids (all INVALID_KERNEL_ID for dummy). Performs tensormap sync, fanin
+// computation (explicit_deps + auto), output registration, slot init, and pushes
+// to the scheduler wiring queue.
+static TaskOutputTensors submit_task_common(
+    PTO2OrchestratorState *orch, const Arg &args, ActiveMask active_mask, int32_t aic_kernel_id, int32_t aiv0_kernel_id,
+    int32_t aiv1_kernel_id
+) {
     CYCLE_COUNT_START();
-
     TaskOutputTensors result;
-
-    // Orchestration API should short-circuit after fatal, but keep this entry
-    // robust as a no-op in case a caller reaches it directly.
-    if (orch->fatal) {
-        return result;
-    }
-
-    // Validate Arg construction (errors recorded by add_input/add_output/etc.)
-    if (args.has_error) {
-        LOG_ERROR("========================================");
-        LOG_ERROR("FATAL: Invalid Arg Detected!");
-        LOG_ERROR("========================================");
-        LOG_ERROR("Error: %s", args.error_msg ? args.error_msg : "(unknown)");
-        LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
-        LOG_ERROR("This is a bug in the orchestration code.");
-        LOG_ERROR("========================================");
-        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
-        return result;
-    }
-    always_assert(orch->scheduler != nullptr);
-    // === Validate submit inputs ===
-    ActiveMask active_mask = mixed_kernels.to_active_mask();
-    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
-
-    int16_t block_num = args.launch_spec.core_num();
-    always_assert(block_num >= 1 && "block_num must be >= 1");
-
-    // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
-    // it to the aiv0 slot.  This guarantees the dispatch path can always use
-    // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
-    // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
-    // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
-    MixedKernels normalized = mixed_kernels;
-    bool has_aic = active_mask.has_mask(PTO2_SUBTASK_MASK_AIC);
-    bool has_aiv0 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV0);
-    bool has_aiv1 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV1);
-    if (!has_aic && has_aiv1 && !has_aiv0) {
-        normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
-        normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
-        active_mask = normalized.to_active_mask();
-    }
-
-    // Encode require_sync_start into active_mask bit 3 (only meaningful for tasks with block_num > 1)
-    if (block_num > 1 && args.launch_spec.require_sync_start()) {
-        // Deadlock check: block_num >= total available slots of the required type.
-        // For MIX/AIC: limit is total_cluster_count (one AIC per cluster).
-        // For AIV:     limit is total_aiv_count.
-        PTO2ResourceShape shape = active_mask.to_shape();
-        int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
-        if (limit > 0 && block_num > limit) {
-            report_fatal(
-                PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
-                "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
-            );
-            return result;
-        }
-        active_mask.set_sync_start();
-    }
     PTO2OutputLayout layout = calculate_output_layout(args);
     PTO2PreparedTask prepared;
     if (!prepare_task(orch, args, layout.total_output_size, active_mask, &prepared)) {
@@ -606,7 +555,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         PTO2TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
-            report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
+            orch->report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
             return result;
         }
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];
@@ -652,9 +601,9 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     // evicted by TensorMap lookup/insert cache pressure.
     __builtin_prefetch(&task, 1, 1);
     task.task_id = task_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = normalized.aic_kernel_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = normalized.aiv0_kernel_id;
-    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = normalized.aiv1_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIC)] = aic_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV0)] = aiv0_kernel_id;
+    task.kernel_id[static_cast<int>(PTO2SubtaskSlot::AIV1)] = aiv1_kernel_id;
     task.packed_buffer_base = prepared.alloc_result.packed_base;
     task.packed_buffer_end = prepared.alloc_result.packed_end;
 
@@ -702,6 +651,99 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
     g_orch_submit_idx++;
 #endif
     return result;
+}
+
+TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+    auto *orch = this;
+
+    // Orchestration API should short-circuit after fatal, but keep this entry
+    // robust as a no-op in case a caller reaches it directly.
+    if (orch->fatal) {
+        return TaskOutputTensors{};
+    }
+
+    // Validate Arg construction (errors recorded by add_input/add_output/etc.)
+    if (args.has_error) {
+        LOG_ERROR("========================================");
+        LOG_ERROR("FATAL: Invalid Arg Detected!");
+        LOG_ERROR("========================================");
+        LOG_ERROR("Error: %s", args.error_msg ? args.error_msg : "(unknown)");
+        LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
+        LOG_ERROR("This is a bug in the orchestration code.");
+        LOG_ERROR("========================================");
+        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
+        return TaskOutputTensors{};
+    }
+    always_assert(orch->scheduler != nullptr);
+    // === Validate submit inputs ===
+    ActiveMask active_mask = mixed_kernels.to_active_mask();
+    always_assert(static_cast<bool>(active_mask) && "MixedKernels must have at least one active slot");
+
+    int16_t block_num = args.launch_spec.core_num();
+    always_assert(block_num >= 1 && "block_num must be >= 1");
+
+    // Normalize single-AIV tasks: if only aiv1 is set (no aic, no aiv0), move
+    // it to the aiv0 slot.  This guarantees the dispatch path can always use
+    // PTO2SubtaskSlot::AIV0 for single-AIV shapes without inspecting active_mask.
+    // Mixed tasks (AIC+AIV) keep their original AIV identity so the correct
+    // hardware channel (AIV0→AIC vs AIV1→AIC) is used at dispatch time.
+    MixedKernels normalized = mixed_kernels;
+    bool has_aic = active_mask.has_mask(PTO2_SUBTASK_MASK_AIC);
+    bool has_aiv0 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV0);
+    bool has_aiv1 = active_mask.has_mask(PTO2_SUBTASK_MASK_AIV1);
+    if (!has_aic && has_aiv1 && !has_aiv0) {
+        normalized.aiv0_kernel_id = normalized.aiv1_kernel_id;
+        normalized.aiv1_kernel_id = INVALID_KERNEL_ID;
+        active_mask = normalized.to_active_mask();
+    }
+
+    // Encode require_sync_start into active_mask bit 3 (only meaningful for tasks with block_num > 1)
+    if (block_num > 1 && args.launch_spec.require_sync_start()) {
+        // Deadlock check: block_num >= total available slots of the required type.
+        // For MIX/AIC: limit is total_cluster_count (one AIC per cluster).
+        // For AIV:     limit is total_aiv_count.
+        PTO2ResourceShape shape = active_mask.to_shape();
+        int32_t limit = (shape == PTO2ResourceShape::AIV) ? orch->total_aiv_count : orch->total_cluster_count;
+        if (limit > 0 && block_num > limit) {
+            report_fatal(
+                PTO2_ERROR_REQUIRE_SYNC_START_INVALID, __FUNCTION__,
+                "require_sync_start block_num=%d > limit=%d (deadlock guaranteed)", block_num, limit
+            );
+            return TaskOutputTensors{};
+        }
+        active_mask.set_sync_start();
+    }
+
+    return submit_task_common(
+        orch, args, active_mask, normalized.aic_kernel_id, normalized.aiv0_kernel_id, normalized.aiv1_kernel_id
+    );
+}
+
+// Submit a dependency-only task: full dependency graph participation
+// (tensormap lookup/insert, explicit_deps, manual_dep, manual_scope) but no
+// AICore dispatch. Empty active_mask routes the slot to the DUMMY ready
+// bucket; dispatch loop short-circuits to completion. Accepts the same Arg
+// shape as submit_task; scalars are permitted but never consumed.
+TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const Arg &args) {
+    auto *orch = this;
+
+    if (orch->fatal) {
+        return TaskOutputTensors{};
+    }
+
+    if (args.has_error) {
+        LOG_ERROR("========================================");
+        LOG_ERROR("FATAL: Invalid Arg in submit_dummy_task!");
+        LOG_ERROR("========================================");
+        LOG_ERROR("Error: %s", args.error_msg ? args.error_msg : "(unknown)");
+        LOG_ERROR("  tensor_count: %d, scalar_count: %d", args.tensor_count(), args.scalar_count());
+        LOG_ERROR("========================================");
+        orch_mark_fatal(orch, PTO2_ERROR_INVALID_ARGS);
+        return TaskOutputTensors{};
+    }
+    always_assert(orch->scheduler != nullptr);
+
+    return submit_task_common(orch, args, ActiveMask{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID);
 }
 
 TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const Arg &args) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -126,6 +126,7 @@ struct PTO2OrchestratorState {
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
     void end_scope();
     TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors submit_dummy_task(const Arg &args);
     TaskOutputTensors alloc_tensors(const Arg &args);
     void mark_done();
 };

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -46,6 +46,10 @@ static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
+static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const Arg &args) {
+    return rt->orchestrator.submit_dummy_task(args);
+}
+
 void rt_scope_begin(PTO2Runtime *rt) {
     PTO2ScopeMode mode = rt->pending_scope_mode;
     rt->pending_scope_mode = PTO2ScopeMode::AUTO;
@@ -241,6 +245,7 @@ static const PTO2RuntimeOps s_runtime_ops = {
     .get_tensor_data = get_tensor_data,
     .set_tensor_data = set_tensor_data,
     .alloc_tensors = alloc_tensors_impl,
+    .submit_dummy_task = submit_dummy_task_impl,
 };
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -88,6 +88,7 @@ struct PTO2RuntimeOps {
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
     TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
 };
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -51,13 +51,21 @@ inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all 
  * requires a fully-idle cluster (1 AIC + 2 AIV).  The actual cores used
  * are determined at dispatch time by active_mask — unused cores in the
  * cluster remain idle and available for single-core tasks.
+ *
+ * DUMMY is a synthetic shape for dep-only tasks (no AICore dispatch). Tasks
+ * with an empty core_mask route to a dedicated DUMMY ready queue and are
+ * completed inline by the scheduler dispatch loop, bypassing core allocation.
  */
 enum class PTO2ResourceShape : uint8_t {
-    AIC = 0,  // Single AIC
-    AIV = 1,  // Single AIV
-    MIX = 2,  // Full cluster (dispatch uses active_mask)
+    AIC = 0,    // Single AIC
+    AIV = 1,    // Single AIV
+    MIX = 2,    // Full cluster (dispatch uses active_mask)
+    DUMMY = 3,  // Dependency-only (no AICore dispatch)
 };
 
+// Number of *dispatchable* resource shapes (AIC, AIV, MIX). DUMMY does not
+// allocate a per-shape ready_queue entry / local buffer — it lives in a
+// dedicated queue inside PTO2SchedulerState.
 inline constexpr int32_t PTO2_NUM_RESOURCE_SHAPES = 3;
 
 /**
@@ -79,6 +87,7 @@ public:
 
     PTO2ResourceShape to_shape() const {
         uint8_t cmask = core_mask();
+        if (cmask == 0) return PTO2ResourceShape::DUMMY;
         int bit_count = __builtin_popcount(cmask);
         if (bit_count >= 2) return PTO2ResourceShape::MIX;
         if (cmask & PTO2_SUBTASK_MASK_AIC) return PTO2ResourceShape::AIC;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -170,6 +170,17 @@ bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_poo
         }
     }
 
+    // Initialize the DUMMY (dep-only task) ready queue.
+    if (!ready_queue_init(&sched->dummy_ready_queue, PTO2_READY_QUEUE_SIZE)) {
+        for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
+            ready_queue_destroy(&sched->ready_queues[i]);
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            sched->ring_sched_states[r].destroy();
+        }
+        return false;
+    }
+
     // Initialize per-ring wiring queues and dep pools (exclusively managed by scheduler thread 0)
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         PTO2DepListEntry *dep_entries =
@@ -181,6 +192,7 @@ bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_poo
             for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
                 ready_queue_destroy(&sched->ready_queues[i]);
             }
+            ready_queue_destroy(&sched->dummy_ready_queue);
             sched->wiring.queue.destroy();
             for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
                 sched->ring_sched_states[rr].destroy();
@@ -198,6 +210,7 @@ bool PTO2SchedulerState::init(PTO2SharedMemoryHeader *sm_header, int32_t dep_poo
         for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
             ready_queue_destroy(&sched->ready_queues[i]);
         }
+        ready_queue_destroy(&sched->dummy_ready_queue);
         for (int rr = 0; rr < PTO2_MAX_RING_DEPTH; rr++) {
             sched->ring_sched_states[rr].destroy();
         }
@@ -223,6 +236,7 @@ void PTO2SchedulerState::destroy() {
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         ready_queue_destroy(&sched->ready_queues[i]);
     }
+    ready_queue_destroy(&sched->dummy_ready_queue);
 }
 
 // =============================================================================
@@ -261,6 +275,7 @@ void PTO2SchedulerState::print_queues() {
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         LOG_INFO_V0("  %s: count=%" PRIu64, shape_names[i], sched->ready_queues[i].size());
     }
+    LOG_INFO_V0("  DUMMY: count=%" PRIu64, sched->dummy_ready_queue.size());
 
     LOG_INFO_V0("====================");
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -565,6 +565,10 @@ struct PTO2SchedulerState {
     // Ready queues remain global (scheduling is ring-agnostic)
     PTO2ReadyQueue ready_queues[PTO2_NUM_RESOURCE_SHAPES];
 
+    // Dependency-only tasks (active_mask is empty, shape == DUMMY). Drained by
+    // the dispatch loop and completed inline -- never goes to AICore.
+    PTO2ReadyQueue dummy_ready_queue;
+
     // Wiring subsystem — groups all wiring-related state for cache-line isolation.
     //
     // Three cache-line regions by writer:
@@ -655,6 +659,20 @@ struct PTO2SchedulerState {
         return wired;
     }
 
+    // Route a ready slot to the right global queue. Dummy tasks (empty
+    // active_mask) live in dummy_ready_queue; everything else goes to the
+    // per-shape ready_queues[]. Used by paths that do not have a thread-local
+    // ready buffer (e.g. wiring). See push_ready_routed_local for the
+    // dispatch-time fast path.
+    void push_ready_routed(PTO2TaskSlotState *slot_state) {
+        PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+        if (shape == PTO2ResourceShape::DUMMY) {
+            dummy_ready_queue.push(slot_state);
+        } else {
+            ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+        }
+    }
+
     /**
      * Wire fanout edges for a single task. Sets fanin_count, acquires each
      * producer's fanout_lock, allocates dep_pool entries for live producers,
@@ -680,11 +698,11 @@ struct PTO2SchedulerState {
             int32_t init_rc = early_finished + 1;
             int32_t new_rc = ws->fanin_refcount.fetch_add(init_rc, std::memory_order_acq_rel) + init_rc;
             if (new_rc >= ws->fanin_count) {
-                ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
+                push_ready_routed(ws);
             }
         } else {
             ws->fanin_refcount.fetch_add(1, std::memory_order_acq_rel);
-            ready_queues[static_cast<int32_t>(ws->active_mask.to_shape())].push(ws);
+            push_ready_routed(ws);
         }
 
         ws->dep_pool_mark = rss.dep_pool.top;
@@ -775,8 +793,12 @@ struct PTO2SchedulerState {
         if (new_refcount == slot_state.fanin_count) {
             // Local-first: try per-CoreType thread-local buffer before global queue
             // Route by active_mask: AIC-containing tasks → buf[0], AIV-only → buf[1]
+            // DUMMY shape is out of range for local_bufs (sized PTO2_NUM_RESOURCE_SHAPES);
+            // dummy slots bypass the local fast path and go straight to dummy_ready_queue.
             PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-            if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
+            if (shape == PTO2ResourceShape::DUMMY) {
+                dummy_ready_queue.push(&slot_state);
+            } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                 ready_queues[static_cast<int32_t>(shape)].push(&slot_state);
             }
             return true;
@@ -798,9 +820,14 @@ struct PTO2SchedulerState {
                     expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
                 )) {
                 atomic_count += 1;  // CAS(task_state PENDING→READY)
-                // Local-first: try per-CoreType thread-local buffer before global queue
+                // Local-first: try per-CoreType thread-local buffer before global queue.
+                // Dummy slots bypass local_bufs (out-of-range for PTO2_NUM_RESOURCE_SHAPES)
+                // and go straight to dummy_ready_queue; use the profiling-aware push so
+                // atomic_count / push_wait stay consistent with the non-dummy path.
                 PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-                if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
+                if (shape == PTO2ResourceShape::DUMMY) {
+                    dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
+                } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
                     ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
                 }
                 return true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -44,6 +44,8 @@ const char *SchedulerContext::shape_name(PTO2ResourceShape shape) {
         return "AIV";
     case PTO2ResourceShape::MIX:
         return "MIX";
+    case PTO2ResourceShape::DUMMY:
+        return "DUMMY";
     }
     return "UNKNOWN";
 }
@@ -509,6 +511,49 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
         CYCLE_COUNT_LAP(l2_perf.sched_wiring_cycle);
 #endif
+
+        // Phase 3b: Drain dummy ready queue (thread 0 only).
+        //
+        // Dependency-only tasks bypass AICore dispatch: they go through the
+        // scheduler so fanin/fanout edges stay consistent, but completion is
+        // signalled inline here. Pinned to thread 0 to avoid cross-thread
+        // races and to keep cache hot near the wiring drain above.
+        if (thread_idx == 0) {
+            constexpr int DUMMY_DRAIN_BATCH = 16;
+            PTO2TaskSlotState *dummy_batch[DUMMY_DRAIN_BATCH];
+            int dummy_got = sched_->dummy_ready_queue.pop_batch(dummy_batch, DUMMY_DRAIN_BATCH);
+            for (int di = 0; di < dummy_got; di++) {
+                PTO2TaskSlotState &dummy_slot = *dummy_batch[di];
+#if PTO2_SCHED_PROFILING
+                sched_->on_mixed_task_complete(dummy_slot, thread_idx, local_bufs);
+#else
+                sched_->on_mixed_task_complete(dummy_slot, local_bufs);
+#endif
+                // Dummy tasks have no subtasks to retire and no fanout pre-conditions
+                // beyond their own producers; release self-reference so the slot can
+                // reach CONSUMED once all consumers drain.
+                deferred_release_slot_states[deferred_release_count++] = &dummy_slot;
+                if (deferred_release_count >= PTO2_DEFERRED_RELEASE_CAP) {
+                    while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+                        int32_t fe = sched_->on_task_release(
+                            *deferred_release_slot_states[--deferred_release_count], thread_idx
+                        );
+                        l2_perf.fanin_edges_total += fe;
+                        if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
+#else
+                        sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+#endif
+                    }
+                }
+                int32_t prev = completed_tasks_.fetch_add(1, std::memory_order_relaxed);
+                last_progress_count = prev + 1;
+                cur_thread_completed++;
+            }
+            if (dummy_got > 0) {
+                made_progress = true;
+            }
+        }
 
         // Phase 4: Two-phase dispatch (idle then pending)
         const PTO2ResourceShape *dispatch_order = get_dispatch_order(thread_idx);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -213,6 +213,10 @@ public:
             return ((core_states_ >> 1) | (core_states_ >> 2)) & aic_mask_;
         case PTO2ResourceShape::MIX:
             return (core_states_ >> 1) & (core_states_ >> 2) & core_states_ & aic_mask_;
+        case PTO2ResourceShape::DUMMY:
+            // DUMMY tasks never reach the core-tracker dispatch path; they are
+            // completed inline by resolve_and_dispatch via dummy_ready_queue.
+            return BitStates(0ULL);
         }
         return BitStates(0ULL);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_copy_first.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_copy_first.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Consumer kernel for the dummy_task scene tests: copies args[0][0] -> args[1][0].
+ *
+ * If the dummy_task in the middle of the chain has correctly waited on the
+ * producer and notified this consumer, args[1][0] will equal the producer's
+ * sentinel (42.0f). If the dependency chain broke or the dummy somehow ran a
+ * kernel that clobbered args[0], the value will differ.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *in_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+
+    __gm__ float *in = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = in[0];
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_write_const.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_write_const.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Writes a fixed sentinel (42.0f) to args[0][0]. Used as the producer in the
+ * dummy_task scene tests so a downstream consumer can verify the dependency
+ * chain (producer -> ... -> dummy -> consumer) propagates the value intact.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 42.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * dummy_task orchestration scenes.
+ *
+ * Each case is selected via params["case"] in the orchestration scalar slot.
+ *
+ *   case=1: Single dummy via auto tensormap dep.
+ *     producer (kernel_write_const) writes X[0] = 42.0
+ *     dummy_T INOUTs X (no kernel)        // becomes new producer in tensormap
+ *     consumer (kernel_copy_first) X -> Y
+ *     expect Y[0] = 42.0
+ *
+ *   case=2: Long dummy chain (N dummies between producer and consumer).
+ *     producer writes X[0] = 42.0
+ *     dummy_T1 .. dummy_TN each INOUT X    // chained through tensormap
+ *     consumer copies X -> Y
+ *     expect Y[0] = 42.0 (no dummy runs a kernel; X must be undisturbed)
+ *
+ *   case=3: Dummy as many-to-one barrier via explicit add_dep.
+ *     producer_A writes X[0] = 42.0
+ *     producer_B writes W[0] = 7.0
+ *     dummy_T explicit add_dep(A.id, B.id)  // no tensor args, pure barrier
+ *     consumer explicit add_dep(dummy.id), copies X -> Y
+ *     expect Y[0] = 42.0 (consumer waits on dummy which waits on A+B)
+ *
+ * Args layout: [X, Y, W]
+ *   - X: producer A writes; consumer reads
+ *   - Y: consumer writes; host checks
+ *   - W: producer B writes (case 3 only); ignored by consumer
+ *
+ * Scalar:  case selector
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+
+static constexpr int32_t LONG_CHAIN_DUMMIES = 4;
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,  // 3 tensors + 1 case scalar
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
+    Tensor ext_W = from_tensor_arg(orch_args.tensor(2));
+
+    uint64_t case_id = orch_args.scalar(0);
+    LOG_INFO_V0("[dummy_task_orch] case_id=%llu", static_cast<unsigned long long>(case_id));
+
+    if (case_id == 1) {
+        // producer writes X
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_aic_task(FUNC_WRITE_CONST, args);
+        }
+        // dummy_T INOUTs X (becomes new producer)
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_dummy_task(args);
+        }
+        // consumer reads X -> writes Y
+        {
+            Arg args;
+            args.add_input(ext_X);
+            args.add_inout(ext_Y);
+            rt_submit_aic_task(FUNC_COPY_FIRST, args);
+        }
+    } else if (case_id == 2) {
+        // producer writes X
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_aic_task(FUNC_WRITE_CONST, args);
+        }
+        // long dummy chain
+        for (int32_t i = 0; i < LONG_CHAIN_DUMMIES; i++) {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_dummy_task(args);
+        }
+        // consumer
+        {
+            Arg args;
+            args.add_input(ext_X);
+            args.add_inout(ext_Y);
+            rt_submit_aic_task(FUNC_COPY_FIRST, args);
+        }
+    } else if (case_id == 3) {
+        // producer A writes X, producer B writes W
+        PTO2TaskId a_id;
+        PTO2TaskId b_id;
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            a_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        }
+        {
+            Arg args;
+            args.add_inout(ext_W);
+            b_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        }
+        // dummy barrier on A + B (no tensor args, only explicit deps)
+        PTO2TaskId dummy_id;
+        {
+            Arg args;
+            args.add_dep(a_id, b_id);
+            dummy_id = rt_submit_dummy_task(args).task_id();
+        }
+        // consumer: explicit dep on dummy, reads X
+        {
+            Arg args;
+            args.add_dep(dummy_id);
+            args.add_input(ext_X);
+            args.add_inout(ext_Y);
+            rt_submit_aic_task(FUNC_COPY_FIRST, args);
+        }
+    } else {
+        rt_report_fatal(PTO2_ERROR_INVALID_ARGS, "unsupported case_id=%llu", static_cast<unsigned long long>(case_id));
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""dummy_task: verify dep-only tasks block consumers and never run a kernel.
+
+The orchestration submits one of three scenes, controlled by params["case"]:
+
+  case=1 (single dummy via tensormap INOUT):
+    producer writes X[0]=42.0 -> dummy_T INOUTs X -> consumer copies X to Y.
+    Y[0] must equal 42.0. If dummy somehow ran a kernel it would zero or
+    corrupt the buffer; the value 42.0 in Y proves both ordering and the
+    no-op nature of dummy_task.
+
+  case=2 (long dummy chain):
+    Same as case 1, but with LONG_CHAIN_DUMMIES dummies between producer
+    and consumer. Looks after the dummy_ready_queue + dispatch-loop drain
+    when several dummies sit on the critical path back-to-back.
+
+  case=3 (explicit add_dep barrier):
+    Two independent producers (writing X and W); a dummy_T uses
+    add_dep(A, B) as a many-to-one barrier; the consumer add_deps on dummy
+    and reads X. Verifies dummy_task participates in explicit_dep wiring.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+SENTINEL = 42.0
+INIT_VAL = -1.0  # so unmodified Y is distinguishable from the sentinel
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestDummyTask(SceneTestCase):
+    """dummy_task: dep-only tasks must block consumers and never run a kernel."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/dummy_task_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": "kernels/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": "kernels/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "SingleDummyAutoDep",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"case": 1},
+        },
+        {
+            "name": "LongDummyChain",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"case": 2},
+        },
+        {
+            "name": "DummyExplicitDepBarrier",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"case": 3},
+        },
+    ]
+
+    def generate_args(self, params):
+        x = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        y = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        w = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        return TaskArgsBuilder(
+            Tensor("x", x),
+            Tensor("y", y),
+            Tensor("w", w),
+            Scalar("case", int(params["case"])),
+        )
+
+    def compute_golden(self, args, params):
+        # The producer (kernel_write_const) writes 42.0 to X[0]; the consumer
+        # (kernel_copy_first) copies X[0] -> Y[0]. Any dummy_task in the chain
+        # is a pure barrier and does NOT touch the buffer, so X[0] / Y[0]
+        # must equal SENTINEL on the host side regardless of case.
+        args.x[0] = SENTINEL
+        args.y[0] = SENTINEL
+        if params["case"] == 3:
+            # case 3 has a second producer writing W
+            args.w[0] = SENTINEL
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_copy_first.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_copy_first.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Consumer kernel for the dummy_task scene tests: copies args[0][0] -> args[1][0].
+ *
+ * If the dummy_task in the middle of the chain has correctly waited on the
+ * producer and notified this consumer, args[1][0] will equal the producer's
+ * sentinel (42.0f). If the dependency chain broke or the dummy somehow ran a
+ * kernel that clobbered args[0], the value will differ.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *in_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+
+    __gm__ float *in = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = in[0];
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_write_const.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/aic/kernel_write_const.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Writes a fixed sentinel (42.0f) to args[0][0]. Used as the producer in the
+ * dummy_task scene tests so a downstream consumer can verify the dependency
+ * chain (producer -> ... -> dummy -> consumer) propagates the value intact.
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    out[0] = 42.0f;
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * dummy_task orchestration scenes.
+ *
+ * Each case is selected via params["case"] in the orchestration scalar slot.
+ *
+ *   case=1: Single dummy via auto tensormap dep.
+ *     producer (kernel_write_const) writes X[0] = 42.0
+ *     dummy_T INOUTs X (no kernel)        // becomes new producer in tensormap
+ *     consumer (kernel_copy_first) X -> Y
+ *     expect Y[0] = 42.0
+ *
+ *   case=2: Long dummy chain (N dummies between producer and consumer).
+ *     producer writes X[0] = 42.0
+ *     dummy_T1 .. dummy_TN each INOUT X    // chained through tensormap
+ *     consumer copies X -> Y
+ *     expect Y[0] = 42.0 (no dummy runs a kernel; X must be undisturbed)
+ *
+ *   case=3: Dummy as many-to-one barrier via explicit add_dep.
+ *     producer_A writes X[0] = 42.0
+ *     producer_B writes W[0] = 7.0
+ *     dummy_T explicit add_dep(A.id, B.id)  // no tensor args, pure barrier
+ *     consumer explicit add_dep(dummy.id), copies X -> Y
+ *     expect Y[0] = 42.0 (consumer waits on dummy which waits on A+B)
+ *
+ * Args layout: [X, Y, W]
+ *   - X: producer A writes; consumer reads
+ *   - Y: consumer writes; host checks
+ *   - W: producer B writes (case 3 only); ignored by consumer
+ *
+ * Scalar:  case selector
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+
+static constexpr int32_t LONG_CHAIN_DUMMIES = 4;
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 4,  // 3 tensors + 1 case scalar
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
+    Tensor ext_W = from_tensor_arg(orch_args.tensor(2));
+
+    uint64_t case_id = orch_args.scalar(0);
+    LOG_INFO_V0("[dummy_task_orch] case_id=%llu", static_cast<unsigned long long>(case_id));
+
+    if (case_id == 1) {
+        // producer writes X
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_aic_task(FUNC_WRITE_CONST, args);
+        }
+        // dummy_T INOUTs X (becomes new producer)
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_dummy_task(args);
+        }
+        // consumer reads X -> writes Y
+        {
+            Arg args;
+            args.add_input(ext_X);
+            args.add_inout(ext_Y);
+            rt_submit_aic_task(FUNC_COPY_FIRST, args);
+        }
+    } else if (case_id == 2) {
+        // producer writes X
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_aic_task(FUNC_WRITE_CONST, args);
+        }
+        // long dummy chain
+        for (int32_t i = 0; i < LONG_CHAIN_DUMMIES; i++) {
+            Arg args;
+            args.add_inout(ext_X);
+            rt_submit_dummy_task(args);
+        }
+        // consumer
+        {
+            Arg args;
+            args.add_input(ext_X);
+            args.add_inout(ext_Y);
+            rt_submit_aic_task(FUNC_COPY_FIRST, args);
+        }
+    } else if (case_id == 3) {
+        // producer A writes X, producer B writes W
+        PTO2TaskId a_id;
+        PTO2TaskId b_id;
+        {
+            Arg args;
+            args.add_inout(ext_X);
+            a_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        }
+        {
+            Arg args;
+            args.add_inout(ext_W);
+            b_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        }
+        // dummy barrier on A + B (no tensor args, only explicit deps)
+        PTO2TaskId dummy_id;
+        {
+            Arg args;
+            args.add_dep(a_id, b_id);
+            dummy_id = rt_submit_dummy_task(args).task_id();
+        }
+        // consumer: explicit dep on dummy, reads X
+        {
+            Arg args;
+            args.add_dep(dummy_id);
+            args.add_input(ext_X);
+            args.add_inout(ext_Y);
+            rt_submit_aic_task(FUNC_COPY_FIRST, args);
+        }
+    } else {
+        rt_report_fatal(PTO2_ERROR_INVALID_ARGS, "unsupported case_id=%llu", static_cast<unsigned long long>(case_id));
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""dummy_task: verify dep-only tasks block consumers and never run a kernel.
+
+The orchestration submits one of three scenes, controlled by params["case"]:
+
+  case=1 (single dummy via tensormap INOUT):
+    producer writes X[0]=42.0 -> dummy_T INOUTs X -> consumer copies X to Y.
+    Y[0] must equal 42.0. If dummy somehow ran a kernel it would zero or
+    corrupt the buffer; the value 42.0 in Y proves both ordering and the
+    no-op nature of dummy_task.
+
+  case=2 (long dummy chain):
+    Same as case 1, but with LONG_CHAIN_DUMMIES dummies between producer
+    and consumer. Looks after the dummy_ready_queue + dispatch-loop drain
+    when several dummies sit on the critical path back-to-back.
+
+  case=3 (explicit add_dep barrier):
+    Two independent producers (writing X and W); a dummy_T uses
+    add_dep(A, B) as a many-to-one barrier; the consumer add_deps on dummy
+    and reads X. Verifies dummy_task participates in explicit_dep wiring.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+SENTINEL = 42.0
+INIT_VAL = -1.0  # so unmodified Y is distinguishable from the sentinel
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestDummyTask(SceneTestCase):
+    """dummy_task: dep-only tasks must block consumers and never run a kernel."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/dummy_task_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": "kernels/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": "kernels/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "SingleDummyAutoDep",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"case": 1},
+        },
+        {
+            "name": "LongDummyChain",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"case": 2},
+        },
+        {
+            "name": "DummyExplicitDepBarrier",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"case": 3},
+        },
+    ]
+
+    def generate_args(self, params):
+        x = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        y = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        w = torch.full((16,), INIT_VAL, dtype=torch.float32)
+        return TaskArgsBuilder(
+            Tensor("x", x),
+            Tensor("y", y),
+            Tensor("w", w),
+            Scalar("case", int(params["case"])),
+        )
+
+    def compute_golden(self, args, params):
+        # The producer (kernel_write_const) writes 42.0 to X[0]; the consumer
+        # (kernel_copy_first) copies X[0] -> Y[0]. Any dummy_task in the chain
+        # is a pure barrier and does NOT touch the buffer, so X[0] / Y[0]
+        # must equal SENTINEL on the host side regardless of case.
+        args.x[0] = SENTINEL
+        args.y[0] = SENTINEL
+        if params["case"] == 3:
+            # case 3 has a second producer writing W
+            args.w[0] = SENTINEL
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
Adds a new submit_dummy_task() entry alongside submit_task/alloc_tensors. A dummy task participates fully in the dependency graph (tensormap deps, explicit add_dep, manual_scope, manual_dep tensor flags) but never runs a kernel — useful as a synchronization barrier or a placeholder producer in the dep graph.

Mechanics:
- New PTO2ResourceShape::DUMMY; ActiveMask::to_shape() returns it when core_mask is empty.
- Slots with empty active_mask route to a dedicated dummy_ready_queue (sibling of ready_queues[shape]), avoiding the per-shape tracker / core-allocation hot path that doesn't apply to dep-only work.
- Dispatch loop adds a Phase 3b (thread 0 only) that drains the queue and inline-completes each dummy via on_mixed_task_complete — fanout notify is identical to a real task's, just without dispatch_block.
- submit_task body factored into submit_task_common(); submit_task and submit_dummy_task both call through the helper so manual-dep semantics (explicit_deps, manual_scope, tensor->manual_dep) are inherited unchanged.

Scene tests cover three cases on a2a3 + a5: auto tensormap dep with a single dummy in the chain, a long dummy chain (4 dummies back-to-back), and a many-to-one explicit-dep barrier. Each verifies the producer sentinel propagates intact to the consumer — proves dummy ordering is correct and that no kernel runs in the dummy slot.