### PR TITLE
Sim: support L3 worker communication examples

### DIFF
--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -10,7 +10,7 @@
 """End-to-end distributed allreduce — symmetric 4-phase pattern.
 
 Each rank owns a private input/output tensor; cross-rank communication happens
-strictly inside the kernel, via a HCCL window scratch slot:
+strictly inside the kernel, via a communication window scratch slot:
 
   Phase 1 stage-in      input → my scratch slot (HCCL window)
   Phase 2 device barrier signal matrix cross-rank sync via TNOTIFY/TWAIT
@@ -21,14 +21,11 @@ input / output are plain per-rank ``torch.share_memory_()`` tensors — the
 parent writes inputs before ``init()`` and reads outputs after ``run()``, and
 the framework's TaskArgs path handles H2D / D2H automatically (same as
 ``multi_chip_dispatch``).  Only ``scratch`` uses the chip bootstrap path
-because window buffers can only exist after HCCL ``comm_alloc_windows`` has
+because window buffers can only exist after ``comm_alloc_windows`` has
 run — that's what ``chip_bootstrap_configs`` is for.
 
-Hardware only.  The sim backend's CommRemotePtr uses a different addressing
-scheme; sim support is out of scope for this demo.
-
 Run:
-    python examples/workers/l3/allreduce_distributed/main.py -d 0-1
+    python examples/workers/l3/allreduce_distributed/main.py -p a2a3sim -d 0-1
 """
 
 from __future__ import annotations
@@ -87,7 +84,7 @@ def parse_device_range(spec: str) -> list[int]:
     return ids
 
 
-def build_chip_callable(platform: str) -> ChipCallable:
+def build_chip_callable(platform: str, pto_isa_commit: str | None) -> ChipCallable:
     """Compile the AIV allreduce kernel + its C++ orchestration shim.
 
     The orchestration forwards three Tensor args (input / output / scratch)
@@ -96,7 +93,7 @@ def build_chip_callable(platform: str) -> ChipCallable:
     """
     kc = KernelCompiler(platform=platform)
     runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
     include_dirs = kc.get_orchestration_include_dirs(runtime)
 
     # The kernel resolves CommContext from "platform_comm/comm_context.h",
@@ -109,7 +106,8 @@ def build_chip_callable(platform: str) -> ChipCallable:
         pto_isa_root=pto_isa_root,
         extra_include_dirs=kernel_include_dirs,
     )
-    kernel_bytes = extract_text_section(kernel_bytes)
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
 
     orch_bytes = kc.compile_orchestration(
         runtime_name=runtime,
@@ -132,11 +130,16 @@ def expected_output(nranks: int) -> list[float]:
     return [float(nranks * i + 100 * nranks * (nranks - 1) // 2) for i in range(ALLREDUCE_COUNT)]
 
 
-def run(device_ids: list[int]) -> int:
+def run(
+    device_ids: list[int],
+    platform: str = "a2a3",
+    pto_isa_commit: str | None = None,
+    build: bool = False,
+) -> int:
     """Core logic — callable from both CLI and pytest."""
     nranks = len(device_ids)
-    # HCCL may round up; only needs to hold SCRATCH_NBYTES.  A 4 KB floor
-    # keeps us clear of any HCCL minimum-window-size quirks.
+    # Backends may round up; only needs to hold SCRATCH_NBYTES.  A 4 KB floor
+    # keeps us clear of minimum-window-size quirks.
     window_size = max(SCRATCH_NBYTES, 4 * 1024)
 
     rootinfo_path = f"/tmp/pto_allreduce_distributed_rootinfo_{os.getpid()}.bin"
@@ -145,7 +148,7 @@ def run(device_ids: list[int]) -> int:
     except FileNotFoundError:
         pass
 
-    print(f"[allreduce] devices={device_ids} nranks={nranks}")
+    print(f"[allreduce] platform={platform} devices={device_ids} nranks={nranks}")
 
     # --- Per-rank host tensors (input/output) via torch.share_memory_().
     # share_memory_() moves the storage into an mmap region that forked
@@ -159,8 +162,8 @@ def run(device_ids: list[int]) -> int:
     ]
     host_outputs = [torch.zeros(ALLREDUCE_COUNT, dtype=torch.float32).share_memory_() for _ in range(nranks)]
 
-    # --- Scratch bootstrap: one window buffer per chip.  The window only
-    # exists after HCCL comm_alloc_windows has run, so allocating scratch
+    # --- Scratch bootstrap: one window buffer per chip.  The window exists
+    # only after comm_alloc_windows has run, so allocating scratch
     # during bootstrap is the natural lifecycle — no TaskArgs equivalent
     # covers it.  No host staging is needed for scratch.
     cfgs = [
@@ -184,20 +187,21 @@ def run(device_ids: list[int]) -> int:
     ]
 
     print("[allreduce] compiling kernels...")
-    chip_callable = build_chip_callable("a2a3")
+    chip_callable = build_chip_callable(platform, pto_isa_commit)
 
     worker = Worker(
         level=3,
-        platform="a2a3",
+        platform=platform,
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
         chip_bootstrap_configs=cfgs,
+        build=build,
     )
     chip_cid = worker.register(chip_callable)
 
     try:
-        print("[allreduce] init worker (forks chip children + bootstraps HCCL)...")
+        print("[allreduce] init worker (forks chip children + bootstraps comm backend)...")
         worker.init()
 
         contexts: list[ChipContext] = worker.chip_contexts
@@ -258,9 +262,16 @@ def run(device_ids: list[int]) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
+    parser.add_argument(
+        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
+    )
+    parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
-    return run(parse_device_range(cli.device))
+    return run(
+        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
+    )
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -6,17 +6,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Hardware ST for examples/workers/l3/allreduce_distributed."""
+"""ST for examples/workers/l3/allreduce_distributed."""
 
 import pytest
 
 from .main import run
 
 
-@pytest.mark.requires_hardware
-@pytest.mark.platforms(["a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
-def test_allreduce_distributed(st_device_ids):
-    rc = run([int(d) for d in st_device_ids])
+def test_allreduce_distributed(st_device_ids, st_platform):
+    rc = run([int(d) for d in st_device_ids], platform=st_platform)
     assert rc == 0

--- a/examples/workers/l3/ep_dispatch_combine/kernels/aiv/combine.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/aiv/combine.cpp
@@ -40,15 +40,6 @@
  * in the window.
  */
 
-#include <cstdint>
-#include <pto/pto-inst.hpp>
-#include "pto/comm/comm_types.hpp"
-#include "pto/comm/pto_comm_inst.hpp"
-#include "platform_comm/comm_context.h"
-#include "tensor.h"
-
-using namespace pto;
-
 #ifndef __gm__
 #define __gm__
 #endif
@@ -56,6 +47,16 @@ using namespace pto;
 #ifndef __aicore__
 #define __aicore__ [aicore]
 #endif
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+using namespace pto;
 
 // Demo dimensions — must match dispatch.cpp / main.py.
 static constexpr int N = 2;
@@ -159,9 +160,15 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
                 __gm__ bfloat16_t *dst_row_local = routed_y_buf_local + r * D;
                 __gm__ bfloat16_t *dst_row_remote = CommRemotePtr(comm_ctx, dst_row_local, dst);
 
+#if defined(__CPU_SIM)
+                for (int i = 0; i < D; ++i) {
+                    dst_row_remote[i] = src_row[i];
+                }
+#else
                 RowBfG src_g(src_row);
                 RowBfG dst_g(dst_row_remote);
                 pto::comm::TPUT(dst_g, src_g, push_tile);
+#endif
             }
         }
     }

--- a/examples/workers/l3/ep_dispatch_combine/kernels/aiv/dispatch.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/aiv/dispatch.cpp
@@ -49,15 +49,6 @@
  *     this configuration; the L*R = 128 scalar stores are negligible.
  */
 
-#include <cstdint>
-#include <pto/pto-inst.hpp>
-#include "pto/comm/comm_types.hpp"
-#include "pto/comm/pto_comm_inst.hpp"
-#include "platform_comm/comm_context.h"
-#include "tensor.h"
-
-using namespace pto;
-
 #ifndef __gm__
 #define __gm__
 #endif
@@ -65,6 +56,16 @@ using namespace pto;
 #ifndef __aicore__
 #define __aicore__ [aicore]
 #endif
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+using namespace pto;
 
 // Demo dimensions — must match main.py.
 static constexpr int N = 2;
@@ -365,27 +366,45 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         __gm__ bfloat16_t *x_dst_local = recv_x_local + row * D;
         __gm__ bfloat16_t *x_dst_remote = CommRemotePtr(comm_ctx, x_dst_local, dst);
 
+#if defined(__CPU_SIM)
+        for (int i = 0; i < D; ++i) {
+            x_dst_remote[i] = x_src[i];
+        }
+#else
         XGlobal x_src_g(x_src);
         XGlobal x_dst_g(x_dst_remote);
         pto::comm::TPUT(x_dst_g, x_src_g, x_tile);
+#endif
 
         // Channel 2: weight (FP32, 1xW_PAD); host pre-packed [w, 0, …, 0]
         __gm__ float *w_src = w_padded + r * W_PAD;
         __gm__ float *w_dst_local = recv_w_local + row * W_PAD;
         __gm__ float *w_dst_remote = CommRemotePtr(comm_ctx, w_dst_local, dst);
 
+#if defined(__CPU_SIM)
+        for (int i = 0; i < W_PAD; ++i) {
+            w_dst_remote[i] = w_src[i];
+        }
+#else
         WGlobal w_src_g(w_src);
         WGlobal w_dst_g(w_dst_remote);
         pto::comm::TPUT(w_dst_g, w_src_g, w_tile);
+#endif
 
         // Channel 3: idx (INT32, 1xIDX_PAD); host pre-packed [r, 0, …, 0]
         __gm__ int32_t *idx_src = idx_padded + r * IDX_PAD;
         __gm__ int32_t *idx_dst_local = recv_idx_local + row * IDX_PAD;
         __gm__ int32_t *idx_dst_remote = CommRemotePtr(comm_ctx, idx_dst_local, dst);
 
+#if defined(__CPU_SIM)
+        for (int i = 0; i < IDX_PAD; ++i) {
+            idx_dst_remote[i] = idx_src[i];
+        }
+#else
         IGlobal idx_src_g(idx_src);
         IGlobal idx_dst_g(idx_dst_remote);
         pto::comm::TPUT(idx_dst_g, idx_src_g, idx_tile);
+#endif
     }
     pipe_barrier(PIPE_ALL);
 

--- a/examples/workers/l3/ep_dispatch_combine/kernels/aiv/local_expert.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/aiv/local_expert.cpp
@@ -30,13 +30,6 @@
  * happens once per row at `cast(x*w, bf16)`.
  */
 
-#include <cstdint>
-#include <pto/pto-inst.hpp>
-#include "platform_comm/comm_context.h"
-#include "tensor.h"
-
-using namespace pto;
-
 #ifndef __gm__
 #define __gm__
 #endif
@@ -44,6 +37,14 @@ using namespace pto;
 #ifndef __aicore__
 #define __aicore__ [aicore]
 #endif
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+using namespace pto;
 
 // Demo dimensions — must match dispatch.cpp / main.py.
 static constexpr int L = 4;

--- a/examples/workers/l3/ep_dispatch_combine/main.py
+++ b/examples/workers/l3/ep_dispatch_combine/main.py
@@ -49,9 +49,9 @@ Type/shape contract:
   - ``recv_count_out`` is [L, 1] INT32 emitted by dispatch's prefix_sum
     phase.
 
-Hardware only. Run:
+Run:
 
-    python examples/workers/l3/ep_dispatch_combine/main.py -d 0-1
+    python examples/workers/l3/ep_dispatch_combine/main.py -p a2a3sim -d 0-1
 """
 
 from __future__ import annotations
@@ -130,14 +130,14 @@ def parse_device_range(spec: str) -> list[int]:
     return ids
 
 
-def build_chip_callable(platform: str) -> ChipCallable:
+def build_chip_callable(platform: str, pto_isa_commit: str | None) -> ChipCallable:
     """Compile the dispatch / local_expert / combine AIV kernels + their
     shared C++ orchestration shim into a single ChipCallable with three
     child callables.
     """
     kc = KernelCompiler(platform=platform)
     runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
     include_dirs = kc.get_orchestration_include_dirs(runtime)
     kernel_include_dirs = list(include_dirs) + [str(kc.project_root / "src" / "common")]
 
@@ -148,7 +148,9 @@ def build_chip_callable(platform: str) -> ChipCallable:
             pto_isa_root=pto_isa_root,
             extra_include_dirs=kernel_include_dirs,
         )
-        return extract_text_section(b)
+        if not platform.endswith("sim"):
+            b = extract_text_section(b)
+        return b
 
     dispatch_bin = compile_aiv("dispatch.cpp")
     local_expert_bin = compile_aiv("local_expert.cpp")
@@ -414,7 +416,12 @@ def _verify_routed_y(
     return ok
 
 
-def run(device_ids: list[int]) -> int:
+def run(
+    device_ids: list[int],
+    platform: str = "a2a3",
+    pto_isa_commit: str | None = None,
+    build: bool = False,
+) -> int:
     """Core logic — callable from CLI and pytest."""
     nranks = len(device_ids)
     assert nranks == N_RANKS
@@ -427,7 +434,7 @@ def run(device_ids: list[int]) -> int:
     except FileNotFoundError:
         pass
 
-    print(f"[ep_dispatch] devices={device_ids} nranks={nranks}")
+    print(f"[ep_dispatch] platform={platform} devices={device_ids} nranks={nranks}")
 
     # x_norm[r, t, d] = r*100 + t*10 + d  →  max value = 1*100 + 7*10 + 63 = 233.
     # All values are integers ≤ 256, so they fit BF16 exactly (8-bit mantissa
@@ -498,15 +505,16 @@ def run(device_ids: list[int]) -> int:
     ]
 
     print("[ep_dispatch] compiling kernels...")
-    chip_callable = build_chip_callable("a2a3")
+    chip_callable = build_chip_callable(platform, pto_isa_commit)
 
     worker = Worker(
         level=3,
-        platform="a2a3",
+        platform=platform,
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
         chip_bootstrap_configs=cfgs,
+        build=build,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -581,8 +589,15 @@ def run(device_ids: list[int]) -> int:
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
+    parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
+    parser.add_argument(
+        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
+    )
+    parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
-    return run(parse_device_range(cli.device))
+    return run(
+        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
+    )
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/ep_dispatch_combine/test_ep_dispatch_combine.py
+++ b/examples/workers/l3/ep_dispatch_combine/test_ep_dispatch_combine.py
@@ -6,17 +6,16 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Hardware ST for examples/workers/l3/ep_dispatch_combine."""
+"""ST for examples/workers/l3/ep_dispatch_combine."""
 
 import pytest
 
 from .main import run
 
 
-@pytest.mark.requires_hardware
-@pytest.mark.platforms(["a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
-def test_ep_dispatch_combine(st_device_ids):
-    rc = run([int(d) for d in st_device_ids])
+def test_ep_dispatch_combine(st_device_ids, st_platform):
+    rc = run([int(d) for d in st_device_ids], platform=st_platform)
     assert rc == 0

--- a/examples/workers/l3/ffn_tp_parallel/kernels/aic/kernel_local_linear.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/aic/kernel_local_linear.cpp
@@ -21,16 +21,6 @@
  *   tensor(2) = partial_local OUTPUT_EXISTING (M x N, per-rank device mem)
  */
 
-#include <cstdint>
-
-#include <pto/common/constants.hpp>
-#include <pto/common/pto_tile.hpp>
-#include <pto/pto-inst.hpp>
-
-#include "tensor.h"
-
-using namespace pto;
-
 #ifndef __gm__
 #define __gm__
 #endif
@@ -38,6 +28,16 @@ using namespace pto;
 #ifndef __aicore__
 #define __aicore__ [aicore]
 #endif
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
 
 template <typename T>
 AICORE constexpr inline T CeilAlign(T num_1, T num_2) {

--- a/examples/workers/l3/ffn_tp_parallel/kernels/aiv/kernel_allreduce_sum.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/aiv/kernel_allreduce_sum.cpp
@@ -31,18 +31,6 @@
  *   scalar(1) = CommContext device pointer
  */
 
-#include <cstdint>
-
-#include <pto/comm/comm_types.hpp>
-#include <pto/comm/pto_comm_inst.hpp>
-#include <pto/common/pto_tile.hpp>
-#include <pto/pto-inst.hpp>
-
-#include "platform_comm/comm_context.h"
-#include "tensor.h"
-
-using namespace pto;
-
 #ifndef __gm__
 #define __gm__
 #endif
@@ -50,6 +38,18 @@ using namespace pto;
 #ifndef __aicore__
 #define __aicore__ [aicore]
 #endif
+
+#include <cstdint>
+
+#include <pto/pto-inst.hpp>
+#include <pto/comm/comm_types.hpp>
+#include <pto/comm/pto_comm_inst.hpp>
+#include <pto/common/pto_tile.hpp>
+
+#include "platform_comm/comm_context.h"
+#include "tensor.h"
+
+using namespace pto;
 
 static constexpr int kRows = 64;
 static constexpr int kCols = 64;
@@ -107,8 +107,14 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         }
         __gm__ float *remote_mailbox_base = CommRemotePtr(comm_ctx, mailbox_ptr, peer);
         __gm__ float *remote_slot_ptr = remote_mailbox_base + my_rank * kElemsPerPartial;
+#if defined(__CPU_SIM)
+        for (int i = 0; i < kElemsPerPartial; ++i) {
+            remote_slot_ptr[i] = partial_local_ptr[i];
+        }
+#else
         MatrixGlobal remote_slot(remote_slot_ptr);
         pto::comm::TPUT(remote_slot, partial_local_global, staging_tile);
+#endif
     }
     pipe_barrier(PIPE_ALL);
 

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -18,11 +18,11 @@ partial_local is a per-rank torch.share_memory_() tensor; it is the OUTPUT of
 stage 1 and the INPUT of stage 2.  Because both submits see the same
 ``buffer.addr``, the framework's TensorMap discovers the producer/consumer
 edge automatically — no manual barriers in Python.  Cross-rank exchange in
-stage 2 still goes through a per-chip ``scratch`` HCCL-window buffer (laid
+stage 2 still goes through a per-chip communication-window ``scratch`` buffer (laid
 out as ``[mailbox: nranks * M*N floats | signal tail: nranks int32 slots]``).
 
-Hardware only.  Run:
-    python examples/workers/l3/ffn_tp_parallel/main.py -d 0-1
+Run:
+    python examples/workers/l3/ffn_tp_parallel/main.py -p a2a3sim -d 0-1
 """
 
 from __future__ import annotations
@@ -79,10 +79,10 @@ def parse_device_range(spec: str) -> list[int]:
     return ids
 
 
-def _kernel_compiler(platform: str) -> tuple[KernelCompiler, str, list[str], list[str]]:
+def _kernel_compiler(platform: str, pto_isa_commit: str | None) -> tuple[KernelCompiler, str, list[str], list[str]]:
     kc = KernelCompiler(platform=platform)
     runtime = "tensormap_and_ringbuffer"
-    pto_isa_root = ensure_pto_isa_root(clone_protocol="https")
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
     include_dirs = kc.get_orchestration_include_dirs(runtime)
     # The allreduce_sum kernel resolves CommContext from
     # "platform_comm/comm_context.h" under src/common/.
@@ -90,9 +90,9 @@ def _kernel_compiler(platform: str) -> tuple[KernelCompiler, str, list[str], lis
     return kc, pto_isa_root, list(include_dirs), kernel_include_dirs
 
 
-def build_ffn_local_callable(platform: str) -> ChipCallable:
+def build_ffn_local_callable(platform: str, pto_isa_commit: str | None) -> ChipCallable:
     """AIC matmul: x_shard @ w_shard -> partial_local."""
-    kc, pto_isa_root, _, kernel_include_dirs = _kernel_compiler(platform)
+    kc, pto_isa_root, _, kernel_include_dirs = _kernel_compiler(platform, pto_isa_commit)
     runtime = "tensormap_and_ringbuffer"
 
     kernel_bytes = kc.compile_incore(
@@ -101,7 +101,8 @@ def build_ffn_local_callable(platform: str) -> ChipCallable:
         pto_isa_root=pto_isa_root,
         extra_include_dirs=kernel_include_dirs,
     )
-    kernel_bytes = extract_text_section(kernel_bytes)
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
 
     orch_bytes = kc.compile_orchestration(
         runtime_name=runtime,
@@ -119,9 +120,9 @@ def build_ffn_local_callable(platform: str) -> ChipCallable:
     )
 
 
-def build_allreduce_sum_callable(platform: str) -> ChipCallable:
+def build_allreduce_sum_callable(platform: str, pto_isa_commit: str | None) -> ChipCallable:
     """AIV cross-rank sum (4-phase publish/notify/wait/accumulate)."""
-    kc, pto_isa_root, _, kernel_include_dirs = _kernel_compiler(platform)
+    kc, pto_isa_root, _, kernel_include_dirs = _kernel_compiler(platform, pto_isa_commit)
     runtime = "tensormap_and_ringbuffer"
 
     kernel_bytes = kc.compile_incore(
@@ -130,7 +131,8 @@ def build_allreduce_sum_callable(platform: str) -> ChipCallable:
         pto_isa_root=pto_isa_root,
         extra_include_dirs=kernel_include_dirs,
     )
-    kernel_bytes = extract_text_section(kernel_bytes)
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
 
     orch_bytes = kc.compile_orchestration(
         runtime_name=runtime,
@@ -155,7 +157,12 @@ def make_rank_inputs(rank: int) -> tuple[torch.Tensor, torch.Tensor]:
     return x, w
 
 
-def run(device_ids: list[int]) -> int:
+def run(
+    device_ids: list[int],
+    platform: str = "a2a3",
+    pto_isa_commit: str | None = None,
+    build: bool = False,
+) -> int:
     nranks = len(device_ids)
     # scratch = mailbox(nranks * M*N floats) + signal tail (nranks int32).
     scratch_count = nranks * M * N
@@ -168,7 +175,7 @@ def run(device_ids: list[int]) -> int:
     except FileNotFoundError:
         pass
 
-    print(f"[ffn_tp_parallel] devices={device_ids} nranks={nranks} M={M} K={K} N={N}")
+    print(f"[ffn_tp_parallel] platform={platform} devices={device_ids} nranks={nranks} M={M} K={K} N={N}")
 
     # Per-rank host tensors via torch.share_memory_(): inputs, partial_local
     # (stage1 output / stage2 input), and final y (stage2 output).
@@ -198,22 +205,23 @@ def run(device_ids: list[int]) -> int:
     ]
 
     print("[ffn_tp_parallel] compiling kernels...")
-    ffn_local_cc = build_ffn_local_callable("a2a3")
-    allreduce_cc = build_allreduce_sum_callable("a2a3")
+    ffn_local_cc = build_ffn_local_callable(platform, pto_isa_commit)
+    allreduce_cc = build_allreduce_sum_callable(platform, pto_isa_commit)
 
     worker = Worker(
         level=3,
-        platform="a2a3",
+        platform=platform,
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
         chip_bootstrap_configs=cfgs,
+        build=build,
     )
     ffn_cid = worker.register(ffn_local_cc)
     allreduce_cid = worker.register(allreduce_cc)
 
     try:
-        print("[ffn_tp_parallel] init worker (forks chip children + bootstraps HCCL)...")
+        print("[ffn_tp_parallel] init worker (forks chip children + bootstraps comm backend)...")
         worker.init()
 
         contexts: list[ChipContext] = worker.chip_contexts
@@ -294,9 +302,16 @@ def run(device_ids: list[int]) -> int:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
+    parser.add_argument(
+        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
+    )
+    parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
-    return run(parse_device_range(cli.device))
+    return run(
+        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
+    )
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/ffn_tp_parallel/test_ffn_tp_parallel.py
+++ b/examples/workers/l3/ffn_tp_parallel/test_ffn_tp_parallel.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Hardware ST for examples/workers/l3/ffn_tp_parallel."""
+"""ST for examples/workers/l3/ffn_tp_parallel."""
 
 import os
 from importlib.machinery import SourceFileLoader
@@ -17,10 +17,9 @@ _main = SourceFileLoader("ffn_tp_parallel_main", os.path.join(os.path.dirname(__
 run = _main.run
 
 
-@pytest.mark.requires_hardware
-@pytest.mark.platforms(["a2a3"])
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
-def test_ffn_tp_parallel(st_device_ids):
-    rc = run([int(d) for d in st_device_ids])
+def test_ffn_tp_parallel(st_device_ids, st_platform):
+    rc = run([int(d) for d in st_device_ids], platform=st_platform)
     assert rc == 0


### PR DESCRIPTION
  ## Summary

  - Parameterize L3 worker communication examples by `--platform` so the same code can run on onboard and sim backends.
  - Enable `allreduce_distributed`, `ffn_tp_parallel`, and `ep_dispatch_combine` pytest entry points for `a2a3sim` and `a5sim`.
  - Add CPU-sim copy fallbacks around current PTO-ISA `TPUT` behavior while preserving the onboard `TPUT` path.

  ## Testing

  - `python -m pytest -q examples/workers/l3/allreduce_distributed/test_allreduce.py examples/workers/l3/ffn_tp_parallel/test_ffn_tp_parallel.py
  examples/workers/l3/ep_dispatch_combine/test_ep_dispatch_combine.py --platform a2a3sim --runtime tensormap_and_ringbuffer --device 0-1`
    - `3 passed, 1 warning`
  - `python -m pytest -q examples/workers/l3/allreduce_distributed/test_allreduce.py examples/workers/l3/ffn_tp_parallel/test_ffn_tp_parallel.py
  examples/workers/l3/ep_dispatch_combine/test_ep_dispatch_combine.py --platform a5sim --runtime tensormap_and_ringbuffer --device 0-1`
    - `3 passed, 1 warning`

  ## Notes

  - Hardware/onboard `TPUT` paths are unchanged.
  - `a5` onboard is not added to the test markers because it was not previously supported by these tests and was not validated here.
  - Existing `aicpu_orchestration_config` dlsym log noise is not changed in this PR; that is a separate cleanup.