### PR TITLE
Refactor: single-shot upload_chip_callable_buffer for ChipCallable

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -207,7 +207,8 @@ worker.run(callable, args, CallConfig(block_dim, aicpu_thread_num))
   │
   └─→ run_runtime(ctx, runtime, callable, args, ...)
        │
-       ├─→ Upload kernel binaries (upload_kernel_binary per func_id)
+       ├─→ Upload the entire ChipCallable buffer (upload_chip_callable_buffer)
+       │      then fill func_id_to_addr_[fid] = chip_dev + storage_offset + child_offset(i)
        ├─→ Allocate device tensors via MemoryAllocator
        ├─→ Copy input data to device
        ├─→ Build task graph with dependencies

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -230,7 +230,13 @@ compiler = KernelCompiler(platform="a2a3sim")
 kernel_binary = compiler.compile_incore("path/to/kernel.cpp", core_type="aiv")
 ```
 
-The compiled binary is then uploaded via `DeviceRunner::upload_kernel_binary(func_id, bin_data, bin_size)`, which loads it into device memory and returns the function address for task dispatch.
+The compiled binaries are packed into a `ChipCallable` (orch SO + each
+child `CoreCallable`) and uploaded as a single blob via
+`DeviceRunner::upload_chip_callable_buffer(callable)`, which fixes up each
+child's `resolved_addr_`, H2Ds once, and returns the device address of the
+ChipCallable header. The caller then derives each child's device address
+from that header plus the child's recorded offset and writes it into
+`Runtime::func_id_to_addr_[]` for AICPU dispatch.
 
 ## Features
 

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -20,9 +20,9 @@ Python process (ChipWorker)
     |     |
     |     +-- dlopen(aicore_sim_XXXXXX, RTLD_NOW | RTLD_LOCAL)   ← AICore SO (temp file)
     |
-    +-- DeviceRunner::upload_kernel_binary()
+    +-- DeviceRunner::upload_chip_callable_buffer()
           |
-          +-- dlopen(kernel_<func_id>_XXXXXX, RTLD_NOW | RTLD_LOCAL)  ← kernel SOs (temp file, per func_id)
+          +-- for each child: dlopen(kernel_<func_id>_XXXXXX, RTLD_NOW | RTLD_LOCAL)  ← kernel SOs (temp file, per child)
 ```
 
 ### Onboard

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -32,6 +32,7 @@
 #include "callable.h"
 #include "callable_protocol.h"
 #include "utils/elf_build_id.h"
+#include "utils/fnv1a_64.h"
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
 
@@ -583,8 +584,10 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
     }
 
-    // Set function_bin_addr for all tasks: func_id_to_addr_[] stores CoreCallable
-    // device address; compute binary code address using compile-time offset
+    // Set function_bin_addr for all tasks: Runtime::func_id_to_addr_[] stores
+    // a CoreCallable device address; the binary code address is one
+    // compile-time offset further in. The dispatch path then reads
+    // resolved_addr_ from the on-device CoreCallable header.
     LOG_DEBUG("Setting function_bin_addr for Tasks");
     for (int i = 0; i < runtime.get_task_count(); i++) {
         Task *task = runtime.get_task(i);
@@ -1089,28 +1092,18 @@ int DeviceRunner::finalize() {
     // Cleanup AICPU SO
     so_info_.finalize();
 
-    // Kernel binaries are normally released by validate_runtime_impl on the
-    // legacy run() path. The prepared-callable path intentionally leaves
-    // them resident across runs (shared by func_id) and relies on
-    // finalize() to reclaim them; that is not a leak. Emit at DEBUG so the
-    // legacy regression signal is preserved for callers that never went
-    // through prepare_callable.
-    if (!func_id_to_addr_.empty()) {
-        const bool prepared_path_used = prepared_callable_path_used_;
-        if (prepared_path_used) {
-            LOG_DEBUG("finalize() releasing %zu kernel binaries staged by prepare_callable", func_id_to_addr_.size());
-        } else {
-            LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)", func_id_to_addr_.size());
-        }
-        for (const auto &pair : func_id_to_addr_) {
-            void *gm_addr = reinterpret_cast<void *>(pair.second);
-            mem_alloc_.free(gm_addr);
-            LOG_DEBUG("Freed kernel binary: func_id=%d, addr=0x%lx", pair.first, pair.second);
-        }
-    }
-    func_id_to_addr_.clear();
-    func_id_to_hash_.clear();
     binaries_loaded_ = false;
+
+    // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
+    // Pool semantics mirror per-fid binaries: never freed until finalize.
+    for (auto &kv : chip_callable_buffers_) {
+        mem_alloc_.free(reinterpret_cast<void *>(kv.second.chip_dev));
+        LOG_DEBUG(
+            "Freed chip callable buffer: chip_dev=0x%lx, size=%zu, hash=0x%lx", kv.second.chip_dev,
+            kv.second.total_size, kv.first
+        );
+    }
+    chip_callable_buffers_.clear();
 
     // Release the cached orchestration SO buffer.
     if (dev_orch_so_buffer_ != nullptr) {
@@ -1246,89 +1239,76 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args) {
 }
 
 // =============================================================================
-// Kernel Binary Upload (returns device address for caller to store in Runtime)
+// Chip Callable Buffer Upload (returns device address of ChipCallable header)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
-    if (bin_data == nullptr || bin_size == 0) {
-        LOG_ERROR("Invalid kernel binary data");
+uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable) {
+    if (callable == nullptr || callable->child_count() == 0) {
         return 0;
     }
-
-    // Run context (streams) must be prepared first.
     if (stream_aicpu_ == nullptr) {
-        LOG_ERROR("Run context not prepared before upload_kernel_binary()");
+        LOG_ERROR("Run context not prepared before upload_chip_callable_buffer()");
         return 0;
     }
 
-    // Return cached callable address if already uploaded *and* the new bytes
-    // match. With the prepared-callable path, multiple ChipCallables share a
-    // single ChipWorker (and DeviceRunner) and can pick distinct kernel
-    // binaries for the same func_id. Naively reusing the cached entry hands
-    // the AICore the previous callable's kernel: dispatch never completes
-    // the new task and the AICPU spins forever.
-    const uint64_t new_hash = simpler::common::utils::elf_build_id_64(bin_data, bin_size);
-    auto it = func_id_to_addr_.find(func_id);
-    if (it != func_id_to_addr_.end()) {
-        auto hash_it = func_id_to_hash_.find(func_id);
-        if (hash_it != func_id_to_hash_.end() && hash_it->second == new_hash) {
-            LOG_INFO_V0("Kernel func_id=%d already uploaded (matching hash), returning cached address", func_id);
-            return it->second;
-        }
-        LOG_INFO_V0("Kernel func_id=%d binary changed, evicting cached entry", func_id);
-        mem_alloc_.free(reinterpret_cast<void *>(it->second));
-        func_id_to_addr_.erase(it);
-        func_id_to_hash_.erase(func_id);
+    // Compute total ChipCallable buffer size from contents (header + storage_
+    // used). Mirrors make_callable<>()'s layout math.
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    size_t storage_used = static_cast<size_t>(callable->binary_size());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const CoreCallable &c = callable->child(i);
+        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
+        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
+        if (end > storage_used) storage_used = end;
+    }
+    const size_t total_size = kHeaderSize + storage_used;
+
+    // Content-hash dedup: identical bytes → return cached chip_dev.
+    const auto *raw_bytes = reinterpret_cast<const uint8_t *>(callable);
+    const uint64_t hash = simpler::common::utils::fnv1a_64(raw_bytes, total_size);
+    auto it = chip_callable_buffers_.find(hash);
+    if (it != chip_callable_buffers_.end()) {
+        LOG_DEBUG(
+            "Chip callable dedup hit: chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev, it->second.total_size,
+            hash
+        );
+        return it->second.chip_dev;
     }
 
-    LOG_DEBUG("Uploading kernel binary: func_id=%d, size=%zu bytes", func_id, bin_size);
-
-    // Allocate device GM memory for kernel binary
-    void *gm_addr = mem_alloc_.alloc(bin_size);
+    void *gm_addr = mem_alloc_.alloc(total_size);
     if (gm_addr == nullptr) {
-        LOG_ERROR("Failed to allocate device GM memory for kernel func_id=%d", func_id);
+        LOG_ERROR("Failed to allocate device GM for ChipCallable buffer (size=%zu)", total_size);
         return 0;
     }
+    const uint64_t chip_dev = reinterpret_cast<uint64_t>(gm_addr);
+    assert((chip_dev & (CALLABLE_ALIGN - 1)) == 0 && "device alloc must be CALLABLE_ALIGN-byte aligned");
 
-    // Set resolved_addr_ in host buffer before copying to device:
-    // AICPU will read this field to get the binary code address for dispatch
-    uint64_t callable_addr = reinterpret_cast<uint64_t>(gm_addr);
-    assert((callable_addr & (CALLABLE_ALIGN - 1)) == 0 && "device alloc must be CALLABLE_ALIGN-byte aligned");
-    uint64_t binary_code_addr = callable_addr + CoreCallable::binary_data_offset();
-    // Write resolved_addr_ into the host-side buffer (the field lives at a fixed offset)
-    CoreCallable *host_callable = reinterpret_cast<CoreCallable *>(const_cast<uint8_t *>(bin_data));
-    host_callable->set_resolved_addr(binary_code_addr);
+    // Build a host scratch with each child's resolved_addr_ fixed up to the
+    // device-side address of that child's binary code (so the AICPU dispatch
+    // path's `reinterpret_cast<CoreCallable*>(addr)->resolved_addr()` lands
+    // on the right device offset).
+    std::vector<uint8_t> scratch(total_size);
+    std::memcpy(scratch.data(), raw_bytes, total_size);
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch.data() + kHeaderSize + off);
+        uint64_t child_dev = chip_dev + kHeaderSize + off;
+        child_in_scratch->set_resolved_addr(child_dev + CoreCallable::binary_data_offset());
+    }
 
-    // Copy the full CoreCallable (header + binary) to device
-    int rc = rtMemcpy(gm_addr, bin_size, bin_data, bin_size, RT_MEMCPY_HOST_TO_DEVICE);
+    int rc = rtMemcpy(gm_addr, total_size, scratch.data(), total_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
-        LOG_ERROR("rtMemcpy to device failed: %d", rc);
+        LOG_ERROR("rtMemcpy chip callable H2D failed: %d", rc);
         mem_alloc_.free(gm_addr);
         return 0;
     }
 
-    func_id_to_addr_[func_id] = callable_addr;
-    func_id_to_hash_[func_id] = new_hash;
-
-    LOG_DEBUG("  func_id=%d -> callable_addr=0x%lx, binary_code_addr=0x%lx", func_id, callable_addr, binary_code_addr);
-
-    return callable_addr;
-}
-
-void DeviceRunner::remove_kernel_binary(int func_id) {
-    auto it = func_id_to_addr_.find(func_id);
-    if (it == func_id_to_addr_.end()) {
-        return;
-    }
-
-    uint64_t function_bin_addr = it->second;
-    void *gm_addr = reinterpret_cast<void *>(function_bin_addr);
-
-    mem_alloc_.free(gm_addr);
-    func_id_to_addr_.erase(it);
-    func_id_to_hash_.erase(func_id);
-
-    LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
+    chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, total_size});
+    LOG_DEBUG(
+        "Uploaded chip callable: chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, total_size,
+        callable->child_count(), hash
+    );
+    return chip_dev;
 }
 
 int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -975,7 +975,6 @@ int DeviceRunner::register_prepared_callable(
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     return 0;
 }
 
@@ -1004,7 +1003,6 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
     return 0;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -37,6 +37,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "callable.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_perf_profiling.h"
@@ -334,35 +335,27 @@ public:
     int launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args);
 
     /**
-     * Upload a kernel binary to device memory
+     * Upload an entire ChipCallable buffer to device memory in one shot.
+     * Walks child_offsets_ to compute total byte size, allocates device GM
+     * once, fixes up each child's resolved_addr_ in an internal host scratch
+     * (= device-side address of that child's binary code), H2D's once, and
+     * returns the device-side address of the ChipCallable header.
      *
-     * IMPORTANT: prepare_run_context() must be called before this function.
-     * Kernels are immediately copied to device memory.
+     * Pool-managed: identical buffer bytes (FNV-1a 64-bit content hash) hit
+     * the dedup cache and return the cached chip_dev without reallocating.
+     * All chip buffers are bulk-freed in finalize() — there is no explicit
+     * free API, mirroring the per-fid binary pool semantics.
      *
-     * Receives pre-extracted .text section binary data,
-     * allocates device GM memory, copies the binary to device,
-     * and returns the device GM address. The caller is responsible
-     * for storing this address (typically in Runtime::func_id_to_addr_[]).
+     * Callers compute child addresses as
+     *     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+     * and write them to Runtime::func_id_to_addr_[fid] via
+     * Runtime::set_function_bin_addr().
      *
-     * If the kernel is already uploaded (same func_id), returns the
-     * cached address without re-uploading.
-     *
-     * @param func_id   Function identifier (0, 1, 2, ...) for caching
-     * @param bin_data  Kernel .text section binary data
-     * @param bin_size  Size of binary data in bytes
-     * @return Device GM address of kernel on success, 0 on error
+     * @param callable  Host-side ChipCallable pointer.
+     * @return Device GM address of the ChipCallable header, or 0 on failure
+     *         (also returns 0 when callable->child_count() == 0).
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
-
-    /**
-     * Remove a kernel binary from device memory
-     *
-     * Frees the device memory allocated for the kernel and removes the
-     * cached entry. This should be called during per-case cleanup.
-     *
-     * @param func_id   Function identifier to remove
-     */
-    void remove_kernel_binary(int func_id);
+    uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
 
     /**
      * Attach the current host thread to the target device.
@@ -549,12 +542,20 @@ private:
     DeviceArgs device_args_;
 
     // Kernel binary management
-    bool binaries_loaded_{false};              // true after AICPU SO loaded
-    std::map<int, uint64_t> func_id_to_addr_;  // func_id -> function_bin_addr (device GM)
-    // Parallel hash map for upload_kernel_binary() to detect when the same
-    // func_id is re-uploaded with different binary bytes (different
-    // ChipCallable sharing the same func_id under the per-callable_id path).
-    std::map<int, uint64_t> func_id_to_hash_;
+    bool binaries_loaded_{false};  // true after AICPU SO loaded
+
+    // Chip-callable buffer pool. Keyed by FNV-1a 64-bit content hash of the
+    // ChipCallable bytes. Each entry owns one device GM allocation holding
+    // the entire ChipCallable buffer (header + storage_, with each child's
+    // resolved_addr_ fixed up to its post-H2D device address). Pool-managed:
+    // identical buffer bytes share one entry across cids; the map is bulk-
+    // freed in finalize(). No explicit free API (mirrors per-fid binary pool
+    // semantics today).
+    struct ChipCallableBuffer {
+        uint64_t chip_dev{0};  // device GM address of the ChipCallable header
+        size_t total_size{0};  // byte size of the device allocation
+    };
+    std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
     // Orchestration SO cache. `cached_orch_so_hash_ == 0` means "no cache".
     // The device buffer grows monotonically — cache miss with a larger SO

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -605,15 +605,6 @@ private:
     // register_prepared_callable_host_orch call; never decremented). Same
     // re-prepare semantics as aicpu_dlopen_total_, but for hbg variants.
     size_t host_dlopen_total_{0};
-    // Sticky flag: prepare_callable was called at least once in this
-    // DeviceRunner's lifetime. unregister_prepared_callable clears the
-    // per-cid kernel maps, so we cannot rely on map contents at finalize()
-    // to distinguish a legacy-path leak from a kernel legitimately staged
-    // by prepare_callable (which is owned until finalize by design).
-    // Assumes the legacy non-prepared run path is retired; if it is ever
-    // reintroduced, revisit whether this distinction still holds.
-    bool prepared_callable_path_used_{false};
-
     // ACL lifecycle (process-wide). aclInit must run exactly once; ensure_acl_ready
     // gates it behind this flag. finalize() drives aclFinalize only if we observed
     // acl_ready_, so runtimes that never ask for ACL (e.g. pure rt-layer) stay unaffected.

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -92,18 +92,12 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
-static uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
+static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
-        return current_runner()->upload_kernel_binary(func_id, bin_data, bin_size);
+        return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
     } catch (...) {
         return 0;
     }
-}
-
-static void remove_kernel_binary_wrapper(int func_id) {
-    try {
-        current_runner()->remove_kernel_binary(func_id);
-    } catch (...) {}
 }
 
 /* ===========================================================================
@@ -272,8 +266,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
         if (rc != 0) {
@@ -346,8 +339,7 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         // Restore kernel addrs + orch symbol names + active_callable_id
         rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -882,7 +882,6 @@ int DeviceRunner::register_prepared_callable(
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     return 0;
 }
 
@@ -911,7 +910,6 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
     return 0;
@@ -1073,12 +1071,18 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
     auto *scratch = new uint8_t[total_size];
     std::memcpy(scratch, raw_bytes, total_size);
 
-    // dlopen each child binary, dlsym kernel_entry, register pto-sim hooks,
-    // and patch the child's resolved_addr_ to the resulting function pointer.
-    // On any failure mid-loop, dlclose all opened handles + free scratch.
+    // Per-child dlopen + dlsym kernel_entry + register pto-sim hooks, then
+    // patch the child's resolved_addr_ to the function pointer. A scope guard
+    // owns scratch and any dlopen'd handles until the success path dismisses
+    // it; every early return unwinds cleanly.
     std::vector<void *> dlopen_handles;
     dlopen_handles.reserve(callable->child_count());
-    bool ok = true;
+    auto cleanup = RAIIScopeGuard([&]() {
+        for (void *h : dlopen_handles)
+            dlclose(h);
+        delete[] scratch;
+    });
+
     for (int32_t i = 0; i < callable->child_count(); ++i) {
         const uint32_t off = callable->child_offset(i);
         auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch + kHeaderSize + off);
@@ -1091,24 +1095,21 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
                 reinterpret_cast<const uint8_t *>(kernel_binary), kernel_size, &tmpfile
             )) {
             LOG_ERROR("Failed to create temp file for child kernel #%d", i);
-            ok = false;
-            break;
+            return 0;
         }
 
         void *handle = dlopen(tmpfile.c_str(), RTLD_NOW | RTLD_LOCAL);
         std::remove(tmpfile.c_str());
         if (!handle) {
             LOG_ERROR("dlopen failed for child kernel #%d: %s", i, dlerror());
-            ok = false;
-            break;
+            return 0;
         }
+        dlopen_handles.push_back(handle);
 
         void *func = dlsym(handle, "kernel_entry");
         if (!func) {
             LOG_ERROR("dlsym failed for child kernel #%d 'kernel_entry': %s", i, dlerror());
-            dlclose(handle);
-            ok = false;
-            break;
+            return 0;
         }
 
         auto register_hooks = reinterpret_cast<void (*)(void *, void *)>(dlsym(handle, "pto_sim_register_hooks"));
@@ -1120,16 +1121,9 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
         }
 
         child_in_scratch->set_resolved_addr(reinterpret_cast<uint64_t>(func));
-        dlopen_handles.push_back(handle);
     }
 
-    if (!ok) {
-        for (void *h : dlopen_handles)
-            dlclose(h);
-        delete[] scratch;
-        return 0;
-    }
-
+    cleanup.dismiss();
     const uint64_t chip_dev = reinterpret_cast<uint64_t>(scratch);
     chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, scratch, total_size, std::move(dlopen_handles)});
     LOG_DEBUG(

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -38,6 +38,7 @@
 #include "callable.h"
 #include "callable_protocol.h"
 #include "utils/elf_build_id.h"
+#include "utils/fnv1a_64.h"
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
 
@@ -409,8 +410,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
     }
 
-    // Set function_bin_addr for each task: func_id_to_addr_[] stores CoreCallable
-    // host address; dereference resolved_addr_ for the dlsym function pointer
+    // Set function_bin_addr for each task: Runtime::func_id_to_addr_[] stores
+    // a CoreCallable host address (chip buffer + offset); dereference
+    // resolved_addr_ for the dlsym function pointer.
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");
     for (int i = 0; i < runtime.get_task_count(); i++) {
         Task *task = runtime.get_task(i);
@@ -976,27 +978,19 @@ int DeviceRunner::finalize() {
     // perf_cleanup guard; this is the backstop for the no-run-since-init case.
     finalize_collectors();
 
-    // Kernel binaries are normally released by validate_runtime_impl on the
-    // legacy run() path. The prepared-callable path intentionally leaves
-    // them resident across runs and relies on finalize() to reclaim them;
-    // that is not a leak.
-    if (!func_id_to_addr_.empty()) {
-        const bool prepared_path_used = prepared_callable_path_used_;
-        if (prepared_path_used) {
-            LOG_DEBUG("finalize() releasing %zu kernel binaries staged by prepare_callable", func_id_to_addr_.size());
-        } else {
-            LOG_ERROR("finalize() called with %zu kernel binaries still cached", func_id_to_addr_.size());
+    // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
+    // Pool semantics mirror per-fid binaries: never freed until finalize.
+    for (auto &kv : chip_callable_buffers_) {
+        for (void *h : kv.second.dlopen_handles) {
+            if (h != nullptr) dlclose(h);
         }
-        for (auto &pair : func_id_to_addr_) {
-            MappedKernel &kernel = pair.second;
-            if (kernel.dl_handle != nullptr) {
-                dlclose(kernel.dl_handle);
-                LOG_DEBUG("Closed kernel: func_id=%d", pair.first);
-            }
-            delete[] kernel.callable_buf;
-        }
+        delete[] kv.second.host_scratch;
+        LOG_DEBUG(
+            "Freed chip callable buffer (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", kv.second.chip_dev,
+            kv.second.total_size, kv.first
+        );
     }
-    func_id_to_addr_.clear();
+    chip_callable_buffers_.clear();
 
     // Release cached orchestration SO buffer.
     if (dev_orch_so_buffer_ != nullptr) {
@@ -1045,116 +1039,104 @@ int DeviceRunner::finalize() {
 }
 
 // =============================================================================
-// Kernel Binary Upload (returns function address for caller to store in Runtime)
+// Chip Callable Buffer Upload (returns host address of ChipCallable header)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
-    if (bin_data == nullptr || bin_size == 0) {
-        LOG_ERROR("Invalid kernel data");
+uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable) {
+    if (callable == nullptr || callable->child_count() == 0) {
         return 0;
     }
 
-    // Return cached callable address if already uploaded *and* the new bytes
-    // match. With the prepared-callable path, multiple ChipCallables share a
-    // single ChipWorker (and hence DeviceRunner) and can pick distinct
-    // kernel binaries for the same func_id.  Naively reusing the cached
-    // entry hands the AICore the previous callable's kernel and segfaults
-    // at dispatch.
-    auto it = func_id_to_addr_.find(func_id);
-    if (it != func_id_to_addr_.end()) {
-        const auto &cached_callable = *reinterpret_cast<const CoreCallable *>(it->second.callable_buf);
-        const auto *new_callable = reinterpret_cast<const CoreCallable *>(bin_data);
-        if (cached_callable.binary_size() == new_callable->binary_size() &&
-            std::memcmp(cached_callable.binary_data(), new_callable->binary_data(), new_callable->binary_size()) == 0) {
-            LOG_INFO_V0("Kernel func_id=%d already uploaded (matching bytes), returning cached address", func_id);
-            return reinterpret_cast<uint64_t>(it->second.callable_buf);
-        }
-        LOG_INFO_V0("Kernel func_id=%d binary changed, evicting cached entry", func_id);
-        if (it->second.dl_handle != nullptr) dlclose(it->second.dl_handle);
-        delete[] it->second.callable_buf;
-        func_id_to_addr_.erase(it);
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    size_t storage_used = static_cast<size_t>(callable->binary_size());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const CoreCallable &c = callable->child(i);
+        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
+        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
+        if (end > storage_used) storage_used = end;
     }
+    const size_t total_size = kHeaderSize + storage_used;
 
-    // Extract binary from CoreCallable envelope
-    const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(bin_data);
-    const void *kernel_binary = callable->binary_data();
-    size_t kernel_size = callable->binary_size();
-
-    // 1. Generate temp file path
-    std::string tmpfile;
-    if (!create_temp_so_file(
-            "/tmp/kernel_" + std::to_string(func_id) + "_XXXXXX", reinterpret_cast<const uint8_t *>(kernel_binary),
-            kernel_size, &tmpfile
-        )) {
-        LOG_ERROR("Failed to create temp file for kernel func_id=%d", func_id);
-        return 0;
-    }
-
-    LOG_DEBUG("Uploading kernel .so: %s (size=%zu bytes)", tmpfile.c_str(), kernel_size);
-
-    // 3. dlopen to load .so (RTLD_NOW ensures all symbols resolved immediately)
-    void *handle = dlopen(tmpfile.c_str(), RTLD_NOW | RTLD_LOCAL);
-
-    // 4. Remove temp file immediately (.so is already in memory)
-    std::remove(tmpfile.c_str());
-
-    if (!handle) {
-        LOG_ERROR("dlopen failed: %s", dlerror());
-        return 0;
-    }
-
-    // 5. dlsym to get kernel function address (unified entry point: "kernel_entry")
-    void *func = dlsym(handle, "kernel_entry");
-    if (!func) {
-        LOG_ERROR("dlsym failed for 'kernel_entry': %s", dlerror());
-        dlclose(handle);
-        return 0;
-    }
-
-    // 6. Inject pto-isa simulation hooks into the kernel SO.
-    //    Each kernel SO has its own copy of the inline static function pointers
-    //    in cpu_stub.hpp, so every SO must be registered after dlopen.
-    auto register_hooks = reinterpret_cast<void (*)(void *, void *)>(dlsym(handle, "pto_sim_register_hooks"));
-    if (register_hooks != nullptr) {
-        register_hooks(
-            reinterpret_cast<void *>(pto_sim_get_subblock_id), reinterpret_cast<void *>(pto_sim_get_pipe_shared_state)
+    const auto *raw_bytes = reinterpret_cast<const uint8_t *>(callable);
+    const uint64_t hash = simpler::common::utils::fnv1a_64(raw_bytes, total_size);
+    auto it = chip_callable_buffers_.find(hash);
+    if (it != chip_callable_buffers_.end()) {
+        LOG_DEBUG(
+            "Chip callable dedup hit (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev,
+            it->second.total_size, hash
         );
+        return it->second.chip_dev;
     }
 
-    // 6. Create host-memory copy of CoreCallable with resolved_addr_ = func_ptr
-    uint8_t *copy = new uint8_t[bin_size];
-    std::memcpy(copy, bin_data, bin_size);
-    CoreCallable *callable_copy = reinterpret_cast<CoreCallable *>(copy);
-    callable_copy->set_resolved_addr(reinterpret_cast<uint64_t>(func));
+    // Allocate host scratch (host == device in sim). Plain new[] keeps
+    // ChipCallableBuffer::host_scratch ownership symmetric with finalize().
+    auto *scratch = new uint8_t[total_size];
+    std::memcpy(scratch, raw_bytes, total_size);
 
-    // 7. Store mapping info for cleanup
-    MappedKernel kernel;
-    kernel.dl_handle = handle;
-    kernel.callable_buf = copy;
-    func_id_to_addr_[func_id] = kernel;
+    // dlopen each child binary, dlsym kernel_entry, register pto-sim hooks,
+    // and patch the child's resolved_addr_ to the resulting function pointer.
+    // On any failure mid-loop, dlclose all opened handles + free scratch.
+    std::vector<void *> dlopen_handles;
+    dlopen_handles.reserve(callable->child_count());
+    bool ok = true;
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch + kHeaderSize + off);
+        const void *kernel_binary = child_in_scratch->binary_data();
+        size_t kernel_size = static_cast<size_t>(child_in_scratch->binary_size());
 
+        std::string tmpfile;
+        if (!create_temp_so_file(
+                "/tmp/kernel_" + std::to_string(callable->child_func_id(i)) + "_XXXXXX",
+                reinterpret_cast<const uint8_t *>(kernel_binary), kernel_size, &tmpfile
+            )) {
+            LOG_ERROR("Failed to create temp file for child kernel #%d", i);
+            ok = false;
+            break;
+        }
+
+        void *handle = dlopen(tmpfile.c_str(), RTLD_NOW | RTLD_LOCAL);
+        std::remove(tmpfile.c_str());
+        if (!handle) {
+            LOG_ERROR("dlopen failed for child kernel #%d: %s", i, dlerror());
+            ok = false;
+            break;
+        }
+
+        void *func = dlsym(handle, "kernel_entry");
+        if (!func) {
+            LOG_ERROR("dlsym failed for child kernel #%d 'kernel_entry': %s", i, dlerror());
+            dlclose(handle);
+            ok = false;
+            break;
+        }
+
+        auto register_hooks = reinterpret_cast<void (*)(void *, void *)>(dlsym(handle, "pto_sim_register_hooks"));
+        if (register_hooks != nullptr) {
+            register_hooks(
+                reinterpret_cast<void *>(pto_sim_get_subblock_id),
+                reinterpret_cast<void *>(pto_sim_get_pipe_shared_state)
+            );
+        }
+
+        child_in_scratch->set_resolved_addr(reinterpret_cast<uint64_t>(func));
+        dlopen_handles.push_back(handle);
+    }
+
+    if (!ok) {
+        for (void *h : dlopen_handles)
+            dlclose(h);
+        delete[] scratch;
+        return 0;
+    }
+
+    const uint64_t chip_dev = reinterpret_cast<uint64_t>(scratch);
+    chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, scratch, total_size, std::move(dlopen_handles)});
     LOG_DEBUG(
-        "Registered kernel (dlopen): func_id=%d -> callable=0x%lx, func_addr=0x%lx, handle=%p", func_id,
-        reinterpret_cast<uint64_t>(copy), reinterpret_cast<uint64_t>(func), handle
+        "Uploaded chip callable (sim): chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, total_size,
+        callable->child_count(), hash
     );
-
-    return reinterpret_cast<uint64_t>(copy);
-}
-
-void DeviceRunner::remove_kernel_binary(int func_id) {
-    auto it = func_id_to_addr_.find(func_id);
-    if (it == func_id_to_addr_.end()) {
-        return;
-    }
-
-    MappedKernel &kernel = it->second;
-    if (kernel.dl_handle != nullptr) {
-        dlclose(kernel.dl_handle);
-        LOG_DEBUG("Removed kernel binary (dlclose): func_id=%d, handle=%p", func_id, kernel.dl_handle);
-    }
-    delete[] kernel.callable_buf;
-
-    func_id_to_addr_.erase(it);
+    return chip_dev;
 }
 
 // =============================================================================

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -296,15 +296,6 @@ private:
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;
     size_t aicpu_dlopen_total_{0};
     size_t host_dlopen_total_{0};
-    // Sticky flag: prepare_callable was called at least once in this
-    // DeviceRunner's lifetime. unregister_prepared_callable clears the
-    // per-cid kernel maps, so we cannot rely on map contents at finalize()
-    // to distinguish a legacy-path leak from a kernel legitimately staged
-    // by prepare_callable (which is owned until finalize by design).
-    // Assumes the legacy non-prepared run path is retired; if it is ever
-    // reintroduced, revisit whether this distinction still holds.
-    bool prepared_callable_path_used_{false};
-
     // AICPU executor SO: load-once, matching onboard's binaries_loaded_ pattern.
     // The aicpu_executor g_aicpu_executor static lives inside the dlopen'd DSO;
     // reloading it destroys orch_so_handle_ and breaks the orch-SO cache-hit path.

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -43,6 +43,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "callable.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
@@ -56,17 +57,6 @@
 #include "host/pmu_collector.h"
 #include "host/dep_gen_collector.h"
 #include "runtime.h"
-
-/**
- * Mapped kernel binary loaded via dlopen
- *
- * Stores dlopen handle and function pointer address. This enables
- * proper handling of external symbols (e.g., std::exp) via PLT/GOT.
- */
-struct MappedKernel {
-    void *dl_handle{nullptr};        // dlopen handle
-    uint8_t *callable_buf{nullptr};  // host-memory copy of CoreCallable (owns memory)
-};
 
 /**
  * Device runner for simulated kernel execution
@@ -210,31 +200,21 @@ public:
     int finalize();
 
     /**
-     * Upload a kernel binary and return the function address
+     * Upload an entire ChipCallable buffer (sim path).
      *
-     * Loads the complete kernel .so via dlopen, enabling proper handling
-     * of external symbols (e.g., std::exp, std::log) via PLT/GOT.
-     * Uses dlsym to resolve the unified entry point "kernel_entry".
+     * Copies the ChipCallable buffer into an internal host scratch (host /
+     * device memory is unified in sim), dlopens each child binary as a temp
+     * .so to obtain its function pointer, and writes that pointer into the
+     * child's resolved_addr_ field. Returns the host address of the scratch
+     * (= chip_dev) so callers can compute child addresses as
+     *     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+     * and store them via runtime->set_function_bin_addr(fid, child_dev).
      *
-     * If the kernel is already uploaded (same func_id), returns the
-     * cached address without re-uploading.
-     *
-     * @param func_id      Function identifier (for caching)
-     * @param bin_data     Complete kernel .so binary data
-     * @param bin_size     Size of binary data in bytes
-     * @return Function pointer address on success, 0 on error
+     * Pool-managed by content hash (FNV-1a 64-bit); identical bytes return
+     * the cached buffer. All chip buffers + their dlopen handles are bulk-
+     * freed in finalize(). Returns 0 on failure or when child_count() == 0.
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
-
-    /**
-     * Remove a kernel binary from memory
-     *
-     * Closes the dlopen handle and removes the cached entry.
-     * This should be called during per-case cleanup.
-     *
-     * @param func_id   Function identifier to remove
-     */
-    void remove_kernel_binary(int func_id);
+    uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
 
     int register_prepared_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
@@ -273,8 +253,18 @@ private:
     // Simulation state (no actual device resources)
     KernelArgs kernel_args_;
 
-    // Kernel binary mapping (func_id -> executable memory)
-    std::map<int, MappedKernel> func_id_to_addr_;
+    // Chip-callable buffer pool (sim path). Keyed by FNV-1a 64-bit content
+    // hash of the ChipCallable bytes. Each entry owns a host scratch holding
+    // the ChipCallable with each child's resolved_addr_ fixed up to the
+    // dlopen'd function pointer; chip_dev == (uint64_t)host_scratch. The
+    // dlopen handles in `dlopen_handles` are bulk-dlclose'd in finalize().
+    struct ChipCallableBuffer {
+        uint64_t chip_dev{0};  // (uint64_t)host_scratch
+        uint8_t *host_scratch{nullptr};
+        size_t total_size{0};
+        std::vector<void *> dlopen_handles;
+    };
+    std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
     // Orchestration SO cache (host-resident in sim; see onboard for shape).
     uint64_t cached_orch_so_hash_{0};

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -88,18 +88,12 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
-static uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
+static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
-        return current_runner()->upload_kernel_binary(func_id, bin_data, bin_size);
+        return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
     } catch (...) {
         return 0;
     }
-}
-
-static void remove_kernel_binary_wrapper(int func_id) {
-    try {
-        current_runner()->remove_kernel_binary(func_id);
-    } catch (...) {}
 }
 
 /* ===========================================================================
@@ -253,8 +247,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         int rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
         if (rc != 0) {
@@ -313,8 +306,7 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);
         if (rc != 0) {

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,12 +9,12 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 - `Runtime` owns the task table, handshake buffers, and host-side device APIs. See `src/runtime/host_build_graph/runtime/runtime.h`.
 - `Task` is a fixed-size record that stores `func_id`, argument array, `fanin`, `fanout`, `core_type`, and `function_bin_addr`.
 - `Handshake` is the shared per-core control block used by AICPU and AICore for dispatch and completion.
-- `HostApi` provides device memory ops used by host orchestration (`device_malloc`, `copy_to_device`, `upload_kernel_binary`, etc.).
+- `HostApi` provides device memory ops used by host orchestration (`device_malloc`, `copy_to_device`, `upload_chip_callable_buffer`, etc.).
 
 ## Build And Init Flow
 
 1. Python tooling compiles kernels and orchestration into shared objects.
-2. `init_runtime_impl` loads the orchestration SO from bytes, resolves the entry symbol, and registers kernel binaries with the platform uploader. The resulting GM addresses are stored by `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
+2. `prepare_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and stores it in `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
 3. The orchestration function runs on the host and builds the graph. It allocates device buffers, copies input data to device, records output buffers with `record_tensor_pair(runtime, ...)`, adds tasks via `add_task(runtime, ...)`, and adds dependency edges via `add_successor(runtime, ...)`.
 4. The populated `Runtime` is copied to device memory by the platform layer. AICPU then runs the executor with this Runtime snapshot.
 

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -480,8 +480,7 @@ int validate_runtime_impl(Runtime *runtime) {
     // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
     // The underlying chip-callable device buffer is pool-managed by
     // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
-    // PR #710 introduced.
+    // DeviceRunner::finalize().
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -294,25 +294,28 @@ int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
         return -1;
     }
 
-    // Register kernel binaries from ChipCallable children
+    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
+    // computes total size from contents, allocates device GM once, fixes up
+    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
+    // and returns the device-side address of the ChipCallable header.
+    // Callers then compute child device addresses via offset arithmetic and
+    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
     if (callable->child_count() > 0) {
         LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
+        if (chip_dev == 0) {
+            LOG_ERROR("Failed to upload ChipCallable buffer");
+            return -1;
+        }
+        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
             if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
                 LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
                 return -1;
             }
-            const auto &kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                func_id, reinterpret_cast<const uint8_t *>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size()
-            );
-            if (addr == 0) {
-                LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
-                return -1;
-            }
-            runtime->set_function_bin_addr(func_id, addr);
+            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
+            runtime->set_function_bin_addr(func_id, child_dev);
         }
     }
 
@@ -474,15 +477,18 @@ int validate_runtime_impl(Runtime *runtime) {
     }
     LOG_INFO_V0("Freed %d device tensors", tensor_pair_count);
 
-    // Cleanup kernel binaries
+    // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
+    // The underlying chip-callable device buffer is pool-managed by
+    // DeviceRunner (keyed by content hash) and bulk-freed in
+    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
+    // PR #710 introduced.
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->host_api.remove_kernel_binary(func_id);
         runtime->set_function_bin_addr(func_id, 0);
     }
     if (kernel_count > 0) {
-        LOG_INFO_V0("Freed %d kernel binaries", kernel_count);
+        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
     }
     runtime->clear_registered_kernels();
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -138,8 +138,19 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
-    void (*remove_kernel_binary)(int func_id);
+    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
+    // `const ChipCallable *` (declared void* to avoid pulling task_interface
+    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
+    // total byte size, allocates device GM once, fixes up each child's
+    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
+    // dlopen function pointer), H2D's once, and returns the device-side
+    // address of the ChipCallable header. Pool-managed: identical buffer
+    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
+    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
+    // child_count() == 0. Caller computes child addrs as
+    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
+    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -79,7 +79,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 | `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
 | `memory_allocator.cpp` | Wraps `malloc`/`free` |
 | `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
-| `upload_kernel_binary` | `dlopen` kernel SO, `dlsym` entry point |
+| `upload_chip_callable_buffer` | Copy ChipCallable bytes to a host scratch, `dlopen` each child SO, `dlsym` "kernel_entry", patch the scratch's `resolved_addr_` with the function pointer |
 
 ### 2.3 Platform Constants (`platform_config.h`)
 
@@ -614,9 +614,16 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 ### 10.1 Kernel Binary Loading
 
 1. **Host** compiles each kernel source (`.cpp`) into a binary (`.o` or `.so`)
-2. `host_api.upload_kernel_binary(func_id, binary, size)` uploads to GM
-3. The returned GM address is stored in `Runtime.func_id_to_addr_[func_id]`
-4. When dispatching, the scheduler copies this address into `PTO2DispatchPayload.function_bin_addr`
+   and packs all children into a single `ChipCallable` buffer alongside the
+   orchestration SO.
+2. `host_api.upload_chip_callable_buffer(callable)` H2Ds the whole buffer
+   once and returns the device address of the ChipCallable header.
+3. For each child, host computes
+   `chip_dev + offsetof(ChipCallable, storage_) + callable->child_offset(i)`
+   and stores it in `Runtime.func_id_to_addr_[child_func_id(i)]`.
+4. When dispatching, the scheduler reads `func_id_to_addr_[fid]`, casts to
+   `const CoreCallable*`, reads `resolved_addr_`, and copies that into
+   `PTO2DispatchPayload.function_bin_addr`.
 
 ### 10.2 Orchestration SO Loading
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -413,9 +413,8 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
     // The underlying chip-callable device buffer is pool-managed by
     // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
-    // PR #710 introduced. The prepared-callable path also relies on this:
-    // re-running the same callable repeatedly should not re-upload.
+    // DeviceRunner::finalize(); re-running the same callable repeatedly
+    // should not re-upload.
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -112,25 +112,28 @@ extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *calla
         return -1;
     }
 
-    // Register kernel binaries from ChipCallable children
+    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
+    // computes total size from contents, allocates device GM once, fixes up
+    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
+    // and returns the device-side address of the ChipCallable header.
+    // Callers then compute child device addresses via offset arithmetic and
+    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
     if (callable->child_count() > 0) {
         LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
+        if (chip_dev == 0) {
+            LOG_ERROR("Failed to upload ChipCallable buffer");
+            return -1;
+        }
+        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
             if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
                 LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
                 return -1;
             }
-            const auto &kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                func_id, reinterpret_cast<const uint8_t *>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size()
-            );
-            if (addr == 0) {
-                LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
-                return -1;
-            }
-            runtime->set_function_bin_addr(func_id, addr);
+            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
+            runtime->set_function_bin_addr(func_id, child_dev);
         }
     }
 
@@ -407,15 +410,19 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     }
     LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);
 
-    // Cleanup kernel binaries
+    // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
+    // The underlying chip-callable device buffer is pool-managed by
+    // DeviceRunner (keyed by content hash) and bulk-freed in
+    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
+    // PR #710 introduced. The prepared-callable path also relies on this:
+    // re-running the same callable repeatedly should not re-upload.
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->host_api.remove_kernel_binary(func_id);
         runtime->set_function_bin_addr(func_id, 0);
     }
     if (kernel_count > 0) {
-        LOG_INFO_V0("Freed %d kernel binaries", kernel_count);
+        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
     }
     runtime->clear_registered_kernels();
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -118,8 +118,19 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
-    void (*remove_kernel_binary)(int func_id);
+    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
+    // `const ChipCallable *` (declared void* to avoid pulling task_interface
+    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
+    // total byte size, allocates device GM once, fixes up each child's
+    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
+    // dlopen function pointer), H2D's once, and returns the device-side
+    // address of the ChipCallable header. Pool-managed: identical buffer
+    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
+    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
+    // child_count() == 0. Caller computes child addrs as
+    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
+    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -751,7 +751,6 @@ int DeviceRunner::register_prepared_callable(
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     return 0;
 }
 
@@ -780,7 +779,6 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
     return 0;

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -30,6 +30,7 @@
 #include "callable.h"
 #include "callable_protocol.h"
 #include "utils/elf_build_id.h"
+#include "utils/fnv1a_64.h"
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
 
@@ -372,8 +373,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         runtime.workers[i].l2_perf_records_addr = static_cast<uint64_t>(0);
     }
 
-    // Set function_bin_addr for all tasks: func_id_to_addr_[] stores CoreCallable
-    // device address; compute binary code address using compile-time offset
+    // Set function_bin_addr for all tasks: Runtime::func_id_to_addr_[] stores
+    // a CoreCallable device address; the binary code address is one
+    // compile-time offset further in.
     LOG_DEBUG("Setting function_bin_addr for Tasks");
     for (int i = 0; i < runtime.get_task_count(); i++) {
         Task *task = runtime.get_task(i);
@@ -862,28 +864,18 @@ int DeviceRunner::finalize() {
     // Cleanup AICPU SO
     so_info_.finalize();
 
-    // Kernel binaries are normally released by validate_runtime_impl on the
-    // legacy run() path. The prepared-callable path intentionally leaves
-    // them resident across runs (shared by func_id) and relies on
-    // finalize() to reclaim them; that is not a leak. Emit at DEBUG so the
-    // legacy regression signal is preserved for callers that never went
-    // through prepare_callable.
-    if (!func_id_to_addr_.empty()) {
-        const bool prepared_path_used = prepared_callable_path_used_;
-        if (prepared_path_used) {
-            LOG_DEBUG("finalize() releasing %zu kernel binaries staged by prepare_callable", func_id_to_addr_.size());
-        } else {
-            LOG_ERROR("finalize() called with %zu kernel binaries still cached (memory leak)", func_id_to_addr_.size());
-        }
-        for (const auto &pair : func_id_to_addr_) {
-            void *gm_addr = reinterpret_cast<void *>(pair.second);
-            mem_alloc_.free(gm_addr);
-            LOG_DEBUG("Freed kernel binary: func_id=%d, addr=0x%lx", pair.first, pair.second);
-        }
-    }
-    func_id_to_addr_.clear();
-    func_id_to_hash_.clear();
     binaries_loaded_ = false;
+
+    // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
+    // Pool semantics mirror per-fid binaries: never freed until finalize.
+    for (auto &kv : chip_callable_buffers_) {
+        mem_alloc_.free(reinterpret_cast<void *>(kv.second.chip_dev));
+        LOG_DEBUG(
+            "Freed chip callable buffer: chip_dev=0x%lx, size=%zu, hash=0x%lx", kv.second.chip_dev,
+            kv.second.total_size, kv.first
+        );
+    }
+    chip_callable_buffers_.clear();
 
     if (dev_orch_so_buffer_ != nullptr) {
         mem_alloc_.free(dev_orch_so_buffer_);
@@ -1028,89 +1020,69 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
 }
 
 // =============================================================================
-// Kernel Binary Upload (returns device address for caller to store in Runtime)
+// Chip Callable Buffer Upload (returns device address of ChipCallable header)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
-    if (bin_data == nullptr || bin_size == 0) {
-        LOG_ERROR("Invalid kernel binary data");
+uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable) {
+    if (callable == nullptr || callable->child_count() == 0) {
         return 0;
     }
-
-    // Run context (streams) must be prepared first.
     if (stream_aicpu_ == nullptr) {
-        LOG_ERROR("Run context not prepared before upload_kernel_binary()");
+        LOG_ERROR("Run context not prepared before upload_chip_callable_buffer()");
         return 0;
     }
 
-    // Return cached callable address if already uploaded *and* the new bytes
-    // match. With the prepared-callable path, multiple ChipCallables share a
-    // single ChipWorker (and DeviceRunner) and can pick distinct kernel
-    // binaries for the same func_id. Naively reusing the cached entry hands
-    // the AICore the previous callable's kernel: dispatch never completes
-    // the new task and the AICPU spins forever.
-    const uint64_t new_hash = simpler::common::utils::elf_build_id_64(bin_data, bin_size);
-    auto it = func_id_to_addr_.find(func_id);
-    if (it != func_id_to_addr_.end()) {
-        auto hash_it = func_id_to_hash_.find(func_id);
-        if (hash_it != func_id_to_hash_.end() && hash_it->second == new_hash) {
-            LOG_INFO_V0("Kernel func_id=%d already uploaded (matching hash), returning cached address", func_id);
-            return it->second;
-        }
-        LOG_INFO_V0("Kernel func_id=%d binary changed, evicting cached entry", func_id);
-        mem_alloc_.free(reinterpret_cast<void *>(it->second));
-        func_id_to_addr_.erase(it);
-        func_id_to_hash_.erase(func_id);
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    size_t storage_used = static_cast<size_t>(callable->binary_size());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const CoreCallable &c = callable->child(i);
+        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
+        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
+        if (end > storage_used) storage_used = end;
+    }
+    const size_t total_size = kHeaderSize + storage_used;
+
+    const auto *raw_bytes = reinterpret_cast<const uint8_t *>(callable);
+    const uint64_t hash = simpler::common::utils::fnv1a_64(raw_bytes, total_size);
+    auto it = chip_callable_buffers_.find(hash);
+    if (it != chip_callable_buffers_.end()) {
+        LOG_DEBUG(
+            "Chip callable dedup hit: chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev, it->second.total_size,
+            hash
+        );
+        return it->second.chip_dev;
     }
 
-    LOG_DEBUG("Uploading kernel binary: func_id=%d, size=%zu bytes", func_id, bin_size);
-
-    // Allocate device GM memory for kernel binary
-    void *gm_addr = mem_alloc_.alloc(bin_size);
+    void *gm_addr = mem_alloc_.alloc(total_size);
     if (gm_addr == nullptr) {
-        LOG_ERROR("Failed to allocate device GM memory for kernel func_id=%d", func_id);
+        LOG_ERROR("Failed to allocate device GM for ChipCallable buffer (size=%zu)", total_size);
         return 0;
     }
+    const uint64_t chip_dev = reinterpret_cast<uint64_t>(gm_addr);
+    assert((chip_dev & (CALLABLE_ALIGN - 1)) == 0 && "device alloc must be CALLABLE_ALIGN-byte aligned");
 
-    // Set resolved_addr_ in host buffer before copying to device:
-    // AICPU will read this field to get the binary code address for dispatch
-    uint64_t callable_addr = reinterpret_cast<uint64_t>(gm_addr);
-    assert((callable_addr & (CALLABLE_ALIGN - 1)) == 0 && "device alloc must be CALLABLE_ALIGN-byte aligned");
-    uint64_t binary_code_addr = callable_addr + CoreCallable::binary_data_offset();
-    // Write resolved_addr_ into the host-side buffer (the field lives at a fixed offset)
-    CoreCallable *host_callable = reinterpret_cast<CoreCallable *>(const_cast<uint8_t *>(bin_data));
-    host_callable->set_resolved_addr(binary_code_addr);
+    std::vector<uint8_t> scratch(total_size);
+    std::memcpy(scratch.data(), raw_bytes, total_size);
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch.data() + kHeaderSize + off);
+        uint64_t child_dev = chip_dev + kHeaderSize + off;
+        child_in_scratch->set_resolved_addr(child_dev + CoreCallable::binary_data_offset());
+    }
 
-    // Copy the full CoreCallable (header + binary) to device
-    int rc = rtMemcpy(gm_addr, bin_size, bin_data, bin_size, RT_MEMCPY_HOST_TO_DEVICE);
+    int rc = rtMemcpy(gm_addr, total_size, scratch.data(), total_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
-        LOG_ERROR("rtMemcpy to device failed: %d", rc);
+        LOG_ERROR("rtMemcpy chip callable H2D failed: %d", rc);
         mem_alloc_.free(gm_addr);
         return 0;
     }
 
-    func_id_to_addr_[func_id] = callable_addr;
-    func_id_to_hash_[func_id] = new_hash;
-
-    LOG_DEBUG("  func_id=%d -> callable_addr=0x%lx, binary_code_addr=0x%lx", func_id, callable_addr, binary_code_addr);
-
-    return callable_addr;
-}
-
-void DeviceRunner::remove_kernel_binary(int func_id) {
-    auto it = func_id_to_addr_.find(func_id);
-    if (it == func_id_to_addr_.end()) {
-        return;
-    }
-
-    uint64_t function_bin_addr = it->second;
-    void *gm_addr = reinterpret_cast<void *>(function_bin_addr);
-
-    mem_alloc_.free(gm_addr);
-    func_id_to_addr_.erase(it);
-    func_id_to_hash_.erase(func_id);
-
-    LOG_DEBUG("Removed kernel binary: func_id=%d, addr=0x%lx", func_id, function_bin_addr);
+    chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, total_size});
+    LOG_DEBUG(
+        "Uploaded chip callable: chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, total_size,
+        callable->child_count(), hash
+    );
+    return chip_dev;
 }
 
 int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -37,6 +37,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "callable.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_perf_profiling.h"
@@ -318,35 +319,22 @@ public:
     int launch_aicore_kernel(rtStream_t stream, Runtime *runtime);
 
     /**
-     * Upload a kernel binary to device memory
+     * Upload an entire ChipCallable buffer to device memory in one shot.
      *
-     * IMPORTANT: prepare_run_context() must be called before this function.
-     * Kernels are immediately copied to device memory.
+     * Walks child_offsets_ to compute total byte size, allocates device GM
+     * once, fixes up each child's resolved_addr_ in an internal host scratch
+     * (= device-side address of that child's binary code), H2D's once, and
+     * returns the device-side address of the ChipCallable header.
      *
-     * Receives pre-extracted .text section binary data,
-     * allocates device GM memory, copies the binary to device,
-     * and returns the device GM address. The caller is responsible
-     * for storing this address (typically in Runtime::func_id_to_addr_[]).
+     * Pool-managed: identical buffer bytes (FNV-1a 64-bit content hash) hit
+     * the dedup cache and return the cached chip_dev without reallocating.
+     * All chip buffers are bulk-freed in finalize() — there is no explicit
+     * free API, mirroring the per-fid binary pool semantics.
      *
-     * If the kernel is already uploaded (same func_id), returns the
-     * cached address without re-uploading.
-     *
-     * @param func_id   Function identifier (0, 1, 2, ...) for caching
-     * @param bin_data  Kernel .text section binary data
-     * @param bin_size  Size of binary data in bytes
-     * @return Device GM address of kernel on success, 0 on error
+     * @return Device GM address of the ChipCallable header, or 0 on failure
+     *         (also returns 0 when callable->child_count() == 0).
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
-
-    /**
-     * Remove a kernel binary from device memory
-     *
-     * Frees the device memory allocated for the kernel and removes the
-     * cached entry. This should be called during per-case cleanup.
-     *
-     * @param func_id   Function identifier to remove
-     */
-    void remove_kernel_binary(int func_id);
+    uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
 
     /**
      * Attach the current host thread to the target device.
@@ -465,9 +453,20 @@ private:
     DeviceArgs device_args_;
 
     // Kernel binary management
-    bool binaries_loaded_{false};              // true after AICPU SO loaded
-    std::map<int, uint64_t> func_id_to_addr_;  // func_id -> function_bin_addr (device GM)
-    std::map<int, uint64_t> func_id_to_hash_;  // func_id -> elf_build_id_64(bin_data)
+    bool binaries_loaded_{false};  // true after AICPU SO loaded
+
+    // Chip-callable buffer pool. Keyed by FNV-1a 64-bit content hash of the
+    // ChipCallable bytes. Each entry owns one device GM allocation holding
+    // the entire ChipCallable buffer (header + storage_, with each child's
+    // resolved_addr_ fixed up to its post-H2D device address). Pool-managed:
+    // identical buffer bytes share one entry across cids; the map is bulk-
+    // freed in finalize(). No explicit free API (mirrors per-fid binary pool
+    // semantics today).
+    struct ChipCallableBuffer {
+        uint64_t chip_dev{0};
+        size_t total_size{0};
+    };
+    std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
     // Orchestration SO cache (host-tracked, device-resident).
     uint64_t cached_orch_so_hash_{0};

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -502,15 +502,6 @@ private:
     size_t aicpu_dlopen_total_{0};
     // Monotonic host-side dlopen counter for hbg variants.
     size_t host_dlopen_total_{0};
-    // Sticky flag: prepare_callable was called at least once in this
-    // DeviceRunner's lifetime. unregister_prepared_callable clears the
-    // per-cid kernel maps, so we cannot rely on map contents at finalize()
-    // to distinguish a legacy-path leak from a kernel legitimately staged
-    // by prepare_callable (which is owned until finalize by design).
-    // Assumes the legacy non-prepared run path is retired; if it is ever
-    // reintroduced, revisit whether this distinction still holds.
-    bool prepared_callable_path_used_{false};
-
     // Performance profiling
     L2PerfCollector l2_perf_collector_;
 

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -92,18 +92,12 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
-static uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
+static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
-        return current_runner()->upload_kernel_binary(func_id, bin_data, bin_size);
+        return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
     } catch (...) {
         return 0;
     }
-}
-
-static void remove_kernel_binary_wrapper(int func_id) {
-    try {
-        current_runner()->remove_kernel_binary(func_id);
-    } catch (...) {}
 }
 
 /* ===========================================================================
@@ -300,8 +294,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
         if (rc != 0) {
@@ -370,8 +363,7 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         // Restore kernel addrs + orch symbol names + active_callable_id
         rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -798,7 +798,6 @@ int DeviceRunner::register_prepared_callable(
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     return 0;
 }
 
@@ -827,7 +826,6 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
     prepared_callables_.emplace(callable_id, std::move(state));
-    prepared_callable_path_used_ = true;
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
     return 0;
@@ -1013,9 +1011,18 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
     auto *scratch = new uint8_t[total_size];
     std::memcpy(scratch, raw_bytes, total_size);
 
+    // Per-child dlopen + dlsym kernel_entry + register pto-sim hooks, then
+    // patch the child's resolved_addr_ to the function pointer. A scope guard
+    // owns scratch and any dlopen'd handles until the success path dismisses
+    // it; every early return unwinds cleanly.
     std::vector<void *> dlopen_handles;
     dlopen_handles.reserve(callable->child_count());
-    bool ok = true;
+    auto cleanup = RAIIScopeGuard([&]() {
+        for (void *h : dlopen_handles)
+            dlclose(h);
+        delete[] scratch;
+    });
+
     for (int32_t i = 0; i < callable->child_count(); ++i) {
         const uint32_t off = callable->child_offset(i);
         auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch + kHeaderSize + off);
@@ -1028,24 +1035,21 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
                 reinterpret_cast<const uint8_t *>(kernel_binary), kernel_size, &tmpfile
             )) {
             LOG_ERROR("Failed to create temp file for child kernel #%d", i);
-            ok = false;
-            break;
+            return 0;
         }
 
         void *handle = dlopen(tmpfile.c_str(), RTLD_NOW | RTLD_LOCAL);
         std::remove(tmpfile.c_str());
         if (!handle) {
             LOG_ERROR("dlopen failed for child kernel #%d: %s", i, dlerror());
-            ok = false;
-            break;
+            return 0;
         }
+        dlopen_handles.push_back(handle);
 
         void *func = dlsym(handle, "kernel_entry");
         if (!func) {
             LOG_ERROR("dlsym failed for child kernel #%d 'kernel_entry': %s", i, dlerror());
-            dlclose(handle);
-            ok = false;
-            break;
+            return 0;
         }
 
         auto register_hooks = reinterpret_cast<void (*)(void *, void *)>(dlsym(handle, "pto_sim_register_hooks"));
@@ -1057,16 +1061,9 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
         }
 
         child_in_scratch->set_resolved_addr(reinterpret_cast<uint64_t>(func));
-        dlopen_handles.push_back(handle);
     }
 
-    if (!ok) {
-        for (void *h : dlopen_handles)
-            dlclose(h);
-        delete[] scratch;
-        return 0;
-    }
-
+    cleanup.dismiss();
     const uint64_t chip_dev = reinterpret_cast<uint64_t>(scratch);
     chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, scratch, total_size, std::move(dlopen_handles)});
     LOG_DEBUG(

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -38,6 +38,7 @@
 #include "callable.h"
 #include "callable_protocol.h"
 #include "utils/elf_build_id.h"
+#include "utils/fnv1a_64.h"
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
 
@@ -365,8 +366,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
     }
 
-    // Set function_bin_addr for each task: func_id_to_addr_[] stores CoreCallable
-    // host address; dereference resolved_addr_ for the dlsym function pointer
+    // Set function_bin_addr for each task: Runtime::func_id_to_addr_[] stores
+    // a CoreCallable host address (chip buffer + offset); dereference
+    // resolved_addr_ for the dlsym function pointer.
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");
     for (int i = 0; i < runtime.get_task_count(); i++) {
         Task *task = runtime.get_task(i);
@@ -918,27 +920,19 @@ int DeviceRunner::finalize() {
         pmu_collector_.finalize(nullptr, free_cb, nullptr);
     }
 
-    // Kernel binaries are normally released by validate_runtime_impl on the
-    // legacy run() path. The prepared-callable path intentionally leaves
-    // them resident across runs and relies on finalize() to reclaim them;
-    // that is not a leak.
-    if (!func_id_to_addr_.empty()) {
-        const bool prepared_path_used = prepared_callable_path_used_;
-        if (prepared_path_used) {
-            LOG_DEBUG("finalize() releasing %zu kernel binaries staged by prepare_callable", func_id_to_addr_.size());
-        } else {
-            LOG_ERROR("finalize() called with %zu kernel binaries still cached", func_id_to_addr_.size());
+    // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
+    // Pool semantics mirror per-fid binaries: never freed until finalize.
+    for (auto &kv : chip_callable_buffers_) {
+        for (void *h : kv.second.dlopen_handles) {
+            if (h != nullptr) dlclose(h);
         }
-        for (auto &pair : func_id_to_addr_) {
-            MappedKernel &kernel = pair.second;
-            if (kernel.dl_handle != nullptr) {
-                dlclose(kernel.dl_handle);
-                LOG_DEBUG("Closed kernel: func_id=%d", pair.first);
-            }
-            delete[] kernel.callable_buf;
-        }
+        delete[] kv.second.host_scratch;
+        LOG_DEBUG(
+            "Freed chip callable buffer (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", kv.second.chip_dev,
+            kv.second.total_size, kv.first
+        );
     }
-    func_id_to_addr_.clear();
+    chip_callable_buffers_.clear();
 
     // Release cached orchestration SO buffer.
     if (dev_orch_so_buffer_ != nullptr) {
@@ -987,116 +981,99 @@ int DeviceRunner::finalize() {
 }
 
 // =============================================================================
-// Kernel Binary Upload (returns function address for caller to store in Runtime)
+// Chip Callable Buffer Upload (returns host address of ChipCallable header)
 // =============================================================================
 
-uint64_t DeviceRunner::upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size) {
-    if (bin_data == nullptr || bin_size == 0) {
-        LOG_ERROR("Invalid kernel data");
+uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable) {
+    if (callable == nullptr || callable->child_count() == 0) {
         return 0;
     }
 
-    // Return cached callable address if already uploaded *and* the new bytes
-    // match. With the prepared-callable path, multiple ChipCallables share a
-    // single ChipWorker (and hence DeviceRunner) and can pick distinct
-    // kernel binaries for the same func_id.  Naively reusing the cached
-    // entry hands the AICore the previous callable's kernel and segfaults
-    // at dispatch.
-    auto it = func_id_to_addr_.find(func_id);
-    if (it != func_id_to_addr_.end()) {
-        const auto &cached_callable = *reinterpret_cast<const CoreCallable *>(it->second.callable_buf);
-        const auto *new_callable = reinterpret_cast<const CoreCallable *>(bin_data);
-        if (cached_callable.binary_size() == new_callable->binary_size() &&
-            std::memcmp(cached_callable.binary_data(), new_callable->binary_data(), new_callable->binary_size()) == 0) {
-            LOG_INFO_V0("Kernel func_id=%d already uploaded (matching bytes), returning cached address", func_id);
-            return reinterpret_cast<uint64_t>(it->second.callable_buf);
-        }
-        LOG_INFO_V0("Kernel func_id=%d binary changed, evicting cached entry", func_id);
-        if (it->second.dl_handle != nullptr) dlclose(it->second.dl_handle);
-        delete[] it->second.callable_buf;
-        func_id_to_addr_.erase(it);
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    size_t storage_used = static_cast<size_t>(callable->binary_size());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const CoreCallable &c = callable->child(i);
+        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
+        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
+        if (end > storage_used) storage_used = end;
     }
+    const size_t total_size = kHeaderSize + storage_used;
 
-    // Extract binary from CoreCallable envelope
-    const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(bin_data);
-    const void *kernel_binary = callable->binary_data();
-    size_t kernel_size = callable->binary_size();
-
-    // 1. Generate temp file path
-    std::string tmpfile;
-    if (!create_temp_so_file(
-            "/tmp/kernel_" + std::to_string(func_id) + "_XXXXXX", reinterpret_cast<const uint8_t *>(kernel_binary),
-            kernel_size, &tmpfile
-        )) {
-        LOG_ERROR("Failed to create temp file for kernel func_id=%d", func_id);
-        return 0;
-    }
-
-    LOG_DEBUG("Uploading kernel .so: %s (size=%zu bytes)", tmpfile.c_str(), kernel_size);
-
-    // 3. dlopen to load .so (RTLD_NOW ensures all symbols resolved immediately)
-    void *handle = dlopen(tmpfile.c_str(), RTLD_NOW | RTLD_LOCAL);
-
-    // 4. Remove temp file immediately (.so is already in memory)
-    std::remove(tmpfile.c_str());
-
-    if (!handle) {
-        LOG_ERROR("dlopen failed: %s", dlerror());
-        return 0;
-    }
-
-    // 5. dlsym to get kernel function address (unified entry point: "kernel_entry")
-    void *func = dlsym(handle, "kernel_entry");
-    if (!func) {
-        LOG_ERROR("dlsym failed for 'kernel_entry': %s", dlerror());
-        dlclose(handle);
-        return 0;
-    }
-
-    // 6. Inject pto-isa simulation hooks into the kernel SO.
-    //    Each kernel SO has its own copy of the inline static function pointers
-    //    in cpu_stub.hpp, so every SO must be registered after dlopen.
-    auto register_hooks = reinterpret_cast<void (*)(void *, void *)>(dlsym(handle, "pto_sim_register_hooks"));
-    if (register_hooks != nullptr) {
-        register_hooks(
-            reinterpret_cast<void *>(pto_sim_get_subblock_id), reinterpret_cast<void *>(pto_sim_get_pipe_shared_state)
+    const auto *raw_bytes = reinterpret_cast<const uint8_t *>(callable);
+    const uint64_t hash = simpler::common::utils::fnv1a_64(raw_bytes, total_size);
+    auto it = chip_callable_buffers_.find(hash);
+    if (it != chip_callable_buffers_.end()) {
+        LOG_DEBUG(
+            "Chip callable dedup hit (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev,
+            it->second.total_size, hash
         );
+        return it->second.chip_dev;
     }
 
-    // 6. Create host-memory copy of CoreCallable with resolved_addr_ = func_ptr
-    uint8_t *copy = new uint8_t[bin_size];
-    std::memcpy(copy, bin_data, bin_size);
-    CoreCallable *callable_copy = reinterpret_cast<CoreCallable *>(copy);
-    callable_copy->set_resolved_addr(reinterpret_cast<uint64_t>(func));
+    auto *scratch = new uint8_t[total_size];
+    std::memcpy(scratch, raw_bytes, total_size);
 
-    // 7. Store mapping info for cleanup
-    MappedKernel kernel;
-    kernel.dl_handle = handle;
-    kernel.callable_buf = copy;
-    func_id_to_addr_[func_id] = kernel;
+    std::vector<void *> dlopen_handles;
+    dlopen_handles.reserve(callable->child_count());
+    bool ok = true;
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch + kHeaderSize + off);
+        const void *kernel_binary = child_in_scratch->binary_data();
+        size_t kernel_size = static_cast<size_t>(child_in_scratch->binary_size());
 
+        std::string tmpfile;
+        if (!create_temp_so_file(
+                "/tmp/kernel_" + std::to_string(callable->child_func_id(i)) + "_XXXXXX",
+                reinterpret_cast<const uint8_t *>(kernel_binary), kernel_size, &tmpfile
+            )) {
+            LOG_ERROR("Failed to create temp file for child kernel #%d", i);
+            ok = false;
+            break;
+        }
+
+        void *handle = dlopen(tmpfile.c_str(), RTLD_NOW | RTLD_LOCAL);
+        std::remove(tmpfile.c_str());
+        if (!handle) {
+            LOG_ERROR("dlopen failed for child kernel #%d: %s", i, dlerror());
+            ok = false;
+            break;
+        }
+
+        void *func = dlsym(handle, "kernel_entry");
+        if (!func) {
+            LOG_ERROR("dlsym failed for child kernel #%d 'kernel_entry': %s", i, dlerror());
+            dlclose(handle);
+            ok = false;
+            break;
+        }
+
+        auto register_hooks = reinterpret_cast<void (*)(void *, void *)>(dlsym(handle, "pto_sim_register_hooks"));
+        if (register_hooks != nullptr) {
+            register_hooks(
+                reinterpret_cast<void *>(pto_sim_get_subblock_id),
+                reinterpret_cast<void *>(pto_sim_get_pipe_shared_state)
+            );
+        }
+
+        child_in_scratch->set_resolved_addr(reinterpret_cast<uint64_t>(func));
+        dlopen_handles.push_back(handle);
+    }
+
+    if (!ok) {
+        for (void *h : dlopen_handles)
+            dlclose(h);
+        delete[] scratch;
+        return 0;
+    }
+
+    const uint64_t chip_dev = reinterpret_cast<uint64_t>(scratch);
+    chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, scratch, total_size, std::move(dlopen_handles)});
     LOG_DEBUG(
-        "Registered kernel (dlopen): func_id=%d -> callable=0x%lx, func_addr=0x%lx, handle=%p", func_id,
-        reinterpret_cast<uint64_t>(copy), reinterpret_cast<uint64_t>(func), handle
+        "Uploaded chip callable (sim): chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, total_size,
+        callable->child_count(), hash
     );
-
-    return reinterpret_cast<uint64_t>(copy);
-}
-
-void DeviceRunner::remove_kernel_binary(int func_id) {
-    auto it = func_id_to_addr_.find(func_id);
-    if (it == func_id_to_addr_.end()) {
-        return;
-    }
-
-    MappedKernel &kernel = it->second;
-    if (kernel.dl_handle != nullptr) {
-        dlclose(kernel.dl_handle);
-        LOG_DEBUG("Removed kernel binary (dlclose): func_id=%d, handle=%p", func_id, kernel.dl_handle);
-    }
-    delete[] kernel.callable_buf;
-
-    func_id_to_addr_.erase(it);
+    return chip_dev;
 }
 
 // =============================================================================

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -41,6 +41,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "callable.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
@@ -53,17 +54,6 @@
 #include "host/pmu_collector.h"
 #include "host/tensor_dump_collector.h"
 #include "runtime.h"
-
-/**
- * Mapped kernel binary loaded via dlopen
- *
- * Stores dlopen handle and function pointer address. This enables
- * proper handling of external symbols (e.g., std::exp) via PLT/GOT.
- */
-struct MappedKernel {
-    void *dl_handle{nullptr};        // dlopen handle
-    uint8_t *callable_buf{nullptr};  // host-memory copy of CoreCallable (owns memory)
-};
 
 /**
  * Device runner for simulated kernel execution
@@ -205,31 +195,13 @@ public:
     int finalize();
 
     /**
-     * Upload a kernel binary and return the function address
-     *
-     * Loads the complete kernel .so via dlopen, enabling proper handling
-     * of external symbols (e.g., std::exp, std::log) via PLT/GOT.
-     * Uses dlsym to resolve the unified entry point "kernel_entry".
-     *
-     * If the kernel is already uploaded (same func_id), returns the
-     * cached address without re-uploading.
-     *
-     * @param func_id      Function identifier (for caching)
-     * @param bin_data     Complete kernel .so binary data
-     * @param bin_size     Size of binary data in bytes
-     * @return Function pointer address on success, 0 on error
+     * Upload an entire ChipCallable buffer (sim path). See a2a3 sim
+     * device_runner.h for the full contract. Returns the host scratch
+     * address (== chip_dev in sim since host/device memory is unified);
+     * caller computes per-child addrs via
+     *     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i).
      */
-    uint64_t upload_kernel_binary(int func_id, const uint8_t *bin_data, size_t bin_size);
-
-    /**
-     * Remove a kernel binary from memory
-     *
-     * Closes the dlopen handle and removes the cached entry.
-     * This should be called during per-case cleanup.
-     *
-     * @param func_id   Function identifier to remove
-     */
-    void remove_kernel_binary(int func_id);
+    uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
 
     /**
      * Stage a per-callable_id orchestration SO and its supporting metadata.
@@ -281,8 +253,16 @@ private:
     // Simulation state (no actual device resources)
     KernelArgs kernel_args_;
 
-    // Kernel binary mapping (func_id -> executable memory)
-    std::map<int, MappedKernel> func_id_to_addr_;
+    // Chip-callable buffer pool (sim path). Keyed by FNV-1a 64-bit content
+    // hash; each entry owns the host scratch + dlopen handles needed for the
+    // children embedded in that buffer. Bulk-freed in finalize().
+    struct ChipCallableBuffer {
+        uint64_t chip_dev{0};  // (uint64_t)host_scratch
+        uint8_t *host_scratch{nullptr};
+        size_t total_size{0};
+        std::vector<void *> dlopen_handles;
+    };
+    std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
     // Orchestration SO cache (host-resident in sim).
     uint64_t cached_orch_so_hash_{0};

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -294,15 +294,6 @@ private:
     std::unordered_set<int32_t> aicpu_seen_callable_ids_;
     size_t aicpu_dlopen_total_{0};
     size_t host_dlopen_total_{0};
-    // Sticky flag: prepare_callable was called at least once in this
-    // DeviceRunner's lifetime. unregister_prepared_callable clears the
-    // per-cid kernel maps, so we cannot rely on map contents at finalize()
-    // to distinguish a legacy-path leak from a kernel legitimately staged
-    // by prepare_callable (which is owned until finalize by design).
-    // Assumes the legacy non-prepared run path is retired; if it is ever
-    // reintroduced, revisit whether this distinction still holds.
-    bool prepared_callable_path_used_{false};
-
     // Runtime pointer for print_handshake_results
     Runtime *last_runtime_{nullptr};
 

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -88,18 +88,12 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
-static uint64_t upload_kernel_binary_wrapper(int func_id, const uint8_t *bin_data, size_t bin_size) {
+static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
-        return current_runner()->upload_kernel_binary(func_id, bin_data, bin_size);
+        return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
     } catch (...) {
         return 0;
     }
-}
-
-static void remove_kernel_binary_wrapper(int func_id) {
-    try {
-        current_runner()->remove_kernel_binary(func_id);
-    } catch (...) {}
 }
 
 /* ===========================================================================
@@ -250,8 +244,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         int rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
         if (rc != 0) {
@@ -310,8 +303,7 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_kernel_binary = upload_kernel_binary_wrapper;
-        r->host_api.remove_kernel_binary = remove_kernel_binary_wrapper;
+        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);
         if (rc != 0) {

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -9,12 +9,12 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 - `Runtime` owns the task table, handshake buffers, and host-side device APIs. See `src/runtime/host_build_graph/runtime/runtime.h`.
 - `Task` is a fixed-size record that stores `func_id`, argument array, `fanin`, `fanout`, `core_type`, and `function_bin_addr`.
 - `Handshake` is the shared per-core control block used by AICPU and AICore for dispatch and completion.
-- `HostApi` provides device memory ops used by host orchestration (`device_malloc`, `copy_to_device`, `upload_kernel_binary`, etc.).
+- `HostApi` provides device memory ops used by host orchestration (`device_malloc`, `copy_to_device`, `upload_chip_callable_buffer`, etc.).
 
 ## Build And Init Flow
 
 1. Python tooling compiles kernels and orchestration into shared objects.
-2. `init_runtime_impl` loads the orchestration SO from bytes, resolves the entry symbol, and registers kernel binaries with the platform uploader. The resulting GM addresses are stored by `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
+2. `prepare_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and stores it in `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
 3. The orchestration function runs on the host and builds the graph. It allocates device buffers, copies input data to device, records output buffers with `record_tensor_pair(runtime, ...)`, adds tasks via `add_task(runtime, ...)`, and adds dependency edges via `add_successor(runtime, ...)`.
 4. The populated `Runtime` is copied to device memory by the platform layer. AICPU then runs the executor with this Runtime snapshot.
 

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -480,8 +480,7 @@ int validate_runtime_impl(Runtime *runtime) {
     // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
     // The underlying chip-callable device buffer is pool-managed by
     // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
-    // PR #710 introduced.
+    // DeviceRunner::finalize().
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -294,25 +294,28 @@ int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
         return -1;
     }
 
-    // Register kernel binaries from ChipCallable children
+    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
+    // computes total size from contents, allocates device GM once, fixes up
+    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
+    // and returns the device-side address of the ChipCallable header.
+    // Callers then compute child device addresses via offset arithmetic and
+    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
     if (callable->child_count() > 0) {
         LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
+        if (chip_dev == 0) {
+            LOG_ERROR("Failed to upload ChipCallable buffer");
+            return -1;
+        }
+        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
             if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
                 LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
                 return -1;
             }
-            const auto &kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                func_id, reinterpret_cast<const uint8_t *>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size()
-            );
-            if (addr == 0) {
-                LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
-                return -1;
-            }
-            runtime->set_function_bin_addr(func_id, addr);
+            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
+            runtime->set_function_bin_addr(func_id, child_dev);
         }
     }
 
@@ -474,15 +477,18 @@ int validate_runtime_impl(Runtime *runtime) {
     }
     LOG_INFO_V0("Freed %d device tensors", tensor_pair_count);
 
-    // Cleanup kernel binaries
+    // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
+    // The underlying chip-callable device buffer is pool-managed by
+    // DeviceRunner (keyed by content hash) and bulk-freed in
+    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
+    // PR #710 introduced.
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->host_api.remove_kernel_binary(func_id);
         runtime->set_function_bin_addr(func_id, 0);
     }
     if (kernel_count > 0) {
-        LOG_INFO_V0("Freed %d kernel binaries", kernel_count);
+        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
     }
     runtime->clear_registered_kernels();
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -152,8 +152,19 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
-    void (*remove_kernel_binary)(int func_id);
+    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
+    // `const ChipCallable *` (declared void* to avoid pulling task_interface
+    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
+    // total byte size, allocates device GM once, fixes up each child's
+    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
+    // dlopen function pointer), H2D's once, and returns the device-side
+    // address of the ChipCallable header. Pool-managed: identical buffer
+    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
+    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
+    // child_count() == 0. Caller computes child addrs as
+    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
+    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -79,7 +79,7 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 | `device_runner.cpp` | Uses `std::thread` to simulate AICPU/AICore |
 | `memory_allocator.cpp` | Wraps `malloc`/`free` |
 | `aicore/kernel.cpp` | `aicore_execute_wrapper` sets `g_sim_reg_base` per core |
-| `upload_kernel_binary` | `dlopen` kernel SO, `dlsym` entry point |
+| `upload_chip_callable_buffer` | Copy ChipCallable bytes to a host scratch, `dlopen` each child SO, `dlsym` "kernel_entry", patch the scratch's `resolved_addr_` with the function pointer |
 
 ### 2.3 Platform Constants (`platform_config.h`)
 
@@ -614,9 +614,16 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 ### 10.1 Kernel Binary Loading
 
 1. **Host** compiles each kernel source (`.cpp`) into a binary (`.o` or `.so`)
-2. `host_api.upload_kernel_binary(func_id, binary, size)` uploads to GM
-3. The returned GM address is stored in `Runtime.func_id_to_addr_[func_id]`
-4. When dispatching, the scheduler copies this address into `PTO2DispatchPayload.function_bin_addr`
+   and packs all children into a single `ChipCallable` buffer alongside the
+   orchestration SO.
+2. `host_api.upload_chip_callable_buffer(callable)` H2Ds the whole buffer
+   once and returns the device address of the ChipCallable header.
+3. For each child, host computes
+   `chip_dev + offsetof(ChipCallable, storage_) + callable->child_offset(i)`
+   and stores it in `Runtime.func_id_to_addr_[child_func_id(i)]`.
+4. When dispatching, the scheduler reads `func_id_to_addr_[fid]`, casts to
+   `const CoreCallable*`, reads `resolved_addr_`, and copies that into
+   `PTO2DispatchPayload.function_bin_addr`.
 
 ### 10.2 Orchestration SO Loading
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -413,8 +413,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
     // The underlying chip-callable device buffer is pool-managed by
     // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
-    // PR #710 introduced.
+    // DeviceRunner::finalize().
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -112,25 +112,28 @@ extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *calla
         return -1;
     }
 
-    // Register kernel binaries from ChipCallable children
+    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
+    // computes total size from contents, allocates device GM once, fixes up
+    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
+    // and returns the device-side address of the ChipCallable header.
+    // Callers then compute child device addresses via offset arithmetic and
+    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
     if (callable->child_count() > 0) {
         LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
+        if (chip_dev == 0) {
+            LOG_ERROR("Failed to upload ChipCallable buffer");
+            return -1;
+        }
+        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
         for (int32_t i = 0; i < callable->child_count(); i++) {
             int func_id = callable->child_func_id(i);
             if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
                 LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
                 return -1;
             }
-            const auto &kernel = callable->child(i);
-            uint64_t addr = runtime->host_api.upload_kernel_binary(
-                func_id, reinterpret_cast<const uint8_t *>(&kernel),
-                CoreCallable::binary_data_offset() + kernel.binary_size()
-            );
-            if (addr == 0) {
-                LOG_ERROR("Failed to upload kernel binary for func_id=%d", func_id);
-                return -1;
-            }
-            runtime->set_function_bin_addr(func_id, addr);
+            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
+            runtime->set_function_bin_addr(func_id, child_dev);
         }
     }
 
@@ -407,15 +410,18 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     }
     LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);
 
-    // Cleanup kernel binaries
+    // Clear the per-run dispatch-table entries staged by prepare_callable_impl.
+    // The underlying chip-callable device buffer is pool-managed by
+    // DeviceRunner (keyed by content hash) and bulk-freed in
+    // DeviceRunner::finalize(), mirroring the per-fid binary pool semantics
+    // PR #710 introduced.
     int kernel_count = runtime->get_registered_kernel_count();
     for (int i = 0; i < kernel_count; i++) {
         int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->host_api.remove_kernel_binary(func_id);
         runtime->set_function_bin_addr(func_id, 0);
     }
     if (kernel_count > 0) {
-        LOG_INFO_V0("Freed %d kernel binaries", kernel_count);
+        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
     }
     runtime->clear_registered_kernels();
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -132,8 +132,19 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    uint64_t (*upload_kernel_binary)(int func_id, const uint8_t *bin_data, size_t bin_size);
-    void (*remove_kernel_binary)(int func_id);
+    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
+    // `const ChipCallable *` (declared void* to avoid pulling task_interface
+    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
+    // total byte size, allocates device GM once, fixes up each child's
+    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
+    // dlopen function pointer), H2D's once, and returns the device-side
+    // address of the ChipCallable header. Pool-managed: identical buffer
+    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
+    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
+    // child_count() == 0. Caller computes child addrs as
+    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
+    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**

--- a/src/common/utils/elf_build_id.h
+++ b/src/common/utils/elf_build_id.h
@@ -27,6 +27,8 @@
 #include <cstdint>
 #include <cstring>
 
+#include "fnv1a_64.h"
+
 // <elf.h> is Linux-only. On other platforms (macOS, Windows) we embed the
 // minimal subset of ELF64 types needed by this header.
 #if defined(__linux__)
@@ -89,26 +91,11 @@ struct Elf64_Nhdr {
 
 namespace simpler::common::utils {
 
-namespace detail {
-
-inline uint64_t fnv1a_64(const void *data, std::size_t len) {
-    constexpr uint64_t kPrime = 0x00000100000001b3ULL;
-    uint64_t h = 0xcbf29ce484222325ULL;
-    const auto *p = static_cast<const uint8_t *>(data);
-    for (std::size_t i = 0; i < len; ++i) {
-        h ^= p[i];
-        h *= kPrime;
-    }
-    return h;
-}
-
-}  // namespace detail
-
 // Returns a 64-bit identifier derived from the ELF64 GNU Build-ID. Falls
 // back to FNV-1a over the whole buffer when no Build-ID is available.
 inline uint64_t elf_build_id_64(const void *data, std::size_t len) {
     if (data == nullptr || len < sizeof(Elf64_Ehdr)) {
-        return detail::fnv1a_64(data, len);
+        return fnv1a_64(data, len);
     }
     const auto *base = static_cast<const uint8_t *>(data);
     Elf64_Ehdr ehdr{};
@@ -117,15 +104,15 @@ inline uint64_t elf_build_id_64(const void *data, std::size_t len) {
     // Validate ELF magic and 64-bit class; otherwise fall back.
     if (ehdr.e_ident[EI_MAG0] != ELFMAG0 || ehdr.e_ident[EI_MAG1] != ELFMAG1 || ehdr.e_ident[EI_MAG2] != ELFMAG2 ||
         ehdr.e_ident[EI_MAG3] != ELFMAG3 || ehdr.e_ident[EI_CLASS] != ELFCLASS64) {
-        return detail::fnv1a_64(data, len);
+        return fnv1a_64(data, len);
     }
     if (ehdr.e_phoff == 0 || ehdr.e_phentsize < sizeof(Elf64_Phdr)) {
-        return detail::fnv1a_64(data, len);
+        return fnv1a_64(data, len);
     }
     // Guard against truncated / malformed inputs.
     std::size_t phdr_end = ehdr.e_phoff + static_cast<std::size_t>(ehdr.e_phnum) * ehdr.e_phentsize;
     if (phdr_end > len) {
-        return detail::fnv1a_64(data, len);
+        return fnv1a_64(data, len);
     }
 
     for (std::size_t i = 0; i < ehdr.e_phnum; ++i) {
@@ -160,7 +147,7 @@ inline uint64_t elf_build_id_64(const void *data, std::size_t len) {
         }
     }
     // No Build-ID found; the SO was likely linked without --build-id.
-    return detail::fnv1a_64(data, len);
+    return fnv1a_64(data, len);
 }
 
 }  // namespace simpler::common::utils

--- a/src/common/utils/fnv1a_64.h
+++ b/src/common/utils/fnv1a_64.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SIMPLER_COMMON_UTILS_FNV1A_64_H_
+#define SIMPLER_COMMON_UTILS_FNV1A_64_H_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace simpler::common::utils {
+
+// FNV-1a 64-bit content hash. Deterministic, allocation-free, ~µs / MB.
+// Used as a generic content-keyed dedup key (ChipCallable buffer hashing in
+// DeviceRunner, ELF Build-ID fallback in elf_build_id.h, etc.).
+inline uint64_t fnv1a_64(const void *data, std::size_t len) {
+    constexpr uint64_t kPrime = 0x00000100000001b3ULL;
+    uint64_t h = 0xcbf29ce484222325ULL;
+    const auto *p = static_cast<const uint8_t *>(data);
+    for (std::size_t i = 0; i < len; ++i) {
+        h ^= p[i];
+        h *= kPrime;
+    }
+    return h;
+}
+
+}  // namespace simpler::common::utils
+
+#endif  // SIMPLER_COMMON_UTILS_FNV1A_64_H_

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -240,6 +240,26 @@ add_hierarchical_test(test_scheduler  hierarchical/test_scheduler.cpp)
 # ---------------------------------------------------------------------------
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
 
+# Contract test for upload_chip_callable_buffer caller-buffer immutability.
+# Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),
+# so it can't use add_task_interface_test as-is.
+add_executable(test_chip_callable_upload_immutable
+    types/test_chip_callable_upload_immutable.cpp
+)
+target_include_directories(test_chip_callable_upload_immutable PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+)
+target_compile_options(test_chip_callable_upload_immutable PRIVATE -D_GLIBCXX_USE_CXX11_ABI=0)
+target_link_libraries(test_chip_callable_upload_immutable PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_chip_callable_upload_immutable COMMAND test_chip_callable_upload_immutable)
+set_tests_properties(test_chip_callable_upload_immutable PROPERTIES LABELS "no_hardware")
+
 # ---------------------------------------------------------------------------
 # Common utilities tests (src/common/utils/)
 # ---------------------------------------------------------------------------

--- a/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
+++ b/tests/ut/cpp/types/test_chip_callable_upload_immutable.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Contract test for DeviceRunner::upload_chip_callable_buffer.
+//
+// The previous per-fid `upload_kernel_binary` path mutated the caller's
+// ChipCallable buffer in-place via const_cast to fill resolved_addr_; the
+// new single-shot upload path stages a host scratch instead and leaves the
+// caller bytes untouched. That invariant is load-bearing: chip-child
+// processes share the ChipCallable buffer through COW pages, so any
+// in-place write triggers a private copy (onboard) or rewrites bytes still
+// shared with the parent (sim).
+//
+// This test pins the contract: any compliant implementation must
+//   (1) compute total_size from header + max(binary_size, child_offset +
+//       binary_data_offset + binary_size over children),
+//   (2) leave the caller buffer bytewise identical after the call,
+//   (3) write each child's fix-up address to the scratch only.
+//
+// The test reproduces the upload-side arithmetic locally so it does not
+// require linking a full DeviceRunner. If a future implementation moves
+// the fix-up back into the caller buffer, item (2) will fail here.
+
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "callable.h"
+#include "utils/fnv1a_64.h"
+
+namespace {
+
+// Build a ChipCallable with two trivial CoreCallable children. Returns the
+// owning byte buffer; the ChipCallable* aliases its data().
+std::vector<uint8_t> build_test_chip_callable() {
+    // Two leaf kernels with arbitrary fake binaries.
+    constexpr int kCoreSig = 2;
+    ArgDirection core_sig[kCoreSig] = {ArgDirection::IN, ArgDirection::OUT};
+
+    const uint8_t kernel0[] = {0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04};
+    const uint8_t kernel1[] = {0xca, 0xfe, 0xba, 0xbe, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a};
+
+    auto core0 = make_callable<CORE_MAX_TENSOR_ARGS>(core_sig, kCoreSig, kernel0, sizeof(kernel0));
+    auto core1 = make_callable<CORE_MAX_TENSOR_ARGS>(core_sig, kCoreSig, kernel1, sizeof(kernel1));
+
+    const uint8_t fake_orch_so[] = {0x7f, 'E', 'L', 'F', 0xaa, 0xbb};
+    int32_t child_ids[2] = {5, 7};
+    std::vector<uint8_t> children[2] = {std::move(core0), std::move(core1)};
+
+    return make_callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>(
+        nullptr, 0, "orch_fn", fake_orch_so, sizeof(fake_orch_so), child_ids, children, 2, "cfg_name"
+    );
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Caller buffer must be bytewise identical before and after the upload-side
+// arithmetic — this is the core anti-COW invariant.
+// ---------------------------------------------------------------------------
+TEST(ChipCallableUploadImmutable, CallerBufferUnchangedAfterScratchFixup) {
+    auto chip_buf = build_test_chip_callable();
+    const auto *callable = reinterpret_cast<const ChipCallable *>(chip_buf.data());
+    ASSERT_EQ(callable->child_count(), 2);
+
+    // Recompute total_size exactly as DeviceRunner::upload_chip_callable_buffer does.
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    size_t storage_used = static_cast<size_t>(callable->binary_size());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const CoreCallable &c = callable->child(i);
+        size_t end = static_cast<size_t>(callable->child_offset(i)) + CoreCallable::binary_data_offset() +
+                     static_cast<size_t>(c.binary_size());
+        if (end > storage_used) storage_used = end;
+    }
+    const size_t total_size = kHeaderSize + storage_used;
+    ASSERT_LE(total_size, chip_buf.size()) << "Computed total_size must fit inside the make_callable allocation";
+
+    // Hash the caller buffer *before* the upload-side fix-up.
+    const uint64_t caller_hash_before = simpler::common::utils::fnv1a_64(chip_buf.data(), chip_buf.size());
+
+    // Mirror onboard's fix-up path: copy to scratch, patch each child's
+    // resolved_addr_ to a synthetic device address, never touch the caller.
+    std::vector<uint8_t> scratch(total_size);
+    std::memcpy(scratch.data(), chip_buf.data(), total_size);
+    constexpr uint64_t kFakeChipDev = 0x10000ULL;
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch.data() + kHeaderSize + off);
+        const uint64_t child_dev = kFakeChipDev + kHeaderSize + off;
+        child_in_scratch->set_resolved_addr(child_dev + CoreCallable::binary_data_offset());
+    }
+
+    // (1) Caller bytes unchanged.
+    const uint64_t caller_hash_after = simpler::common::utils::fnv1a_64(chip_buf.data(), chip_buf.size());
+    EXPECT_EQ(caller_hash_before, caller_hash_after) << "Upload must not mutate the caller's ChipCallable buffer";
+
+    // (2) Caller-side resolved_addr_ on every child must still be the
+    //     initial value written by make_callable. If a future implementation
+    //     reintroduces in-place const_cast, this is the assertion that fires.
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        EXPECT_EQ(callable->child(i).resolved_addr(), 0u)
+            << "child " << i << " resolved_addr_ on caller side must be untouched";
+    }
+
+    // (3) Scratch-side resolved_addr_ matches the documented formula.
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        const auto *child_in_scratch = reinterpret_cast<const CoreCallable *>(scratch.data() + kHeaderSize + off);
+        const uint64_t expected = kFakeChipDev + kHeaderSize + off + CoreCallable::binary_data_offset();
+        EXPECT_EQ(child_in_scratch->resolved_addr(), expected) << "child " << i << " scratch resolved_addr_ mismatch";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Each child's recorded offset must land on a CALLABLE_ALIGN boundary in
+// storage_. make_callable enforces this; upload arithmetic relies on it.
+// ---------------------------------------------------------------------------
+TEST(ChipCallableUploadImmutable, ChildOffsetsAreCallableAligned) {
+    auto chip_buf = build_test_chip_callable();
+    const auto *callable = reinterpret_cast<const ChipCallable *>(chip_buf.data());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        EXPECT_EQ(callable->child_offset(i) % CALLABLE_ALIGN, 0u)
+            << "child_offset(" << i << ") = " << callable->child_offset(i)
+            << " is not a multiple of CALLABLE_ALIGN=" << CALLABLE_ALIGN;
+    }
+}


### PR DESCRIPTION
## Summary

Replaces per-fid `upload_kernel_binary` + `remove_kernel_binary` with a
single `upload_chip_callable_buffer(callable)` HostApi call. The 4
runtime variants (a2a3 / a5 × tensormap_and_ringbuffer / host_build_graph)
all now upload the entire `ChipCallable` buffer in one shot; child
dispatch addresses are derived by offset arithmetic and written into
`Runtime::func_id_to_addr_[]` for AICPU dispatch.

Pool-managed: identical buffer bytes (FNV-1a 64-bit content hash) hit
the dedup cache; chip buffers are bulk-freed in
DeviceRunner::finalize().

### Key changes

- New `HostApi::upload_chip_callable_buffer(const void *callable)`
  function pointer; backed by `DeviceRunner::upload_chip_callable_buffer`
  in all 4 platform implementations (onboard / sim × a2a3 / a5).
- New shared helper `src/common/utils/fnv1a_64.h` (extracted from
  `elf_build_id.h`'s detail namespace) for content-keyed dedup.
- `prepare_callable_impl` in 4 `runtime_maker.cpp` files swapped from a
  per-child upload loop to:

      chip_dev = host_api.upload_chip_callable_buffer(callable);
      for (i in callable->child_count())
          runtime->set_function_bin_addr(
              callable->child_func_id(i),
              chip_dev + offsetof(ChipCallable, storage_)
                       + callable->child_offset(i));

- `validate_runtime_impl` legacy per-fid free loop reduced to set-to-0
  + `clear_registered_kernels`; chip buffer is reclaimed by `finalize`.
- Removed: `HostApi::upload_kernel_binary` / `remove_kernel_binary` fn
  ptrs and their wrappers, `DeviceRunner::upload_kernel_binary` /
  `remove_kernel_binary` methods, `DeviceRunner::func_id_to_addr_`
  internal map, `DeviceRunner::func_id_to_hash_` ELF-Build-ID eviction
  tracker.
- AICPU side untouched: `Runtime::func_id_to_addr_[RUNTIME_MAX_FUNC_ID]`
  still feeds dispatch / completion / tensor_dump readers, just now
  pointing into the chip buffer instead of one allocation per fid.

### Trade-off: dedup granularity widens from per-fid to per-buffer

The old `upload_kernel_binary` path keyed dedup on `(func_id, elf-build-id
of the kernel .text)`. Two `ChipCallable`s that pick distinct orchestration
SOs but share a kernel for the same `func_id` would reuse the same device
GM allocation for that kernel.

The new `upload_chip_callable_buffer` path keys dedup on the **entire**
ChipCallable buffer's FNV-1a 64-bit content hash. Two callables that share
every kernel but differ in any orch byte (or in `child_offsets_` / sig /
name fields) now miss the dedup cache and each gets its own full-buffer
device allocation. Kernels are no longer deduplicated across callables.

In current use this is intentional: under the prepared-callable path each
`callable_id` is registered exactly once and stays resident until
`finalize()`, so the cache only fires for legitimate re-uploads of the
same callable. The cross-callable kernel-sharing case the old key
optimised is not exercised today. If it becomes load-bearing later, the
fix is to switch back to per-child dedup inside this function — caller
contract is unaffected.

### Side-effect bug fix

The previous code mutated the caller's `ChipCallable` buffer in-place
via `const_cast` to fill `resolved_addr_`. That broke COW page sharing
in forked chip-child processes (L3+), and in sim it wrote host-process-
local dlopen function pointers into bytes that were COW-shared with the
parent. The new code uses an internal scratch and leaves the caller
buffer read-only.

## Testing

- [x] 8 `host_runtime.so` libraries link cleanly (a2a3/a5 × onboard/sim
  × trb/hbg).
- [x] `a2a3sim` and `a5sim` `tensormap_and_ringbuffer/vector_example`
  smoke tests pass.
- [x] `a2a3sim` `tensormap_and_ringbuffer/prepared_callable` (6 cases)
  pass.
- [x] `a2a3sim` `host_build_graph/prepared_callable` (`test_run`) +
  `host_build_graph/vector_example` pass.
- [x] `tests/ut/py/test_chip_worker.py` (13 cases) pass.
- [ ] Hardware (onboard) tests — not run locally.