### PR TITLE
Fix: set L3 worker orchestration config symbols

### DIFF
--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -122,6 +122,7 @@ def build_chip_callable(platform: str) -> ChipCallable:
     return ChipCallable.build(
         signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
         func_name="allreduce_orchestration",
+        config_name="allreduce_orchestration_config",
         binary=orch_bytes,
         children=[(0, core_callable)],
     )

--- a/examples/workers/l3/ep_dispatch_combine/main.py
+++ b/examples/workers/l3/ep_dispatch_combine/main.py
@@ -203,6 +203,7 @@ def build_chip_callable(platform: str) -> ChipCallable:
     return ChipCallable.build(
         signature=sig_orch,
         func_name="ep_dispatch_combine_orchestration",
+        config_name="ep_dispatch_combine_orchestration_config",
         binary=orch_bytes,
         children=[
             (0, CoreCallable.build(signature=sig_dispatch, binary=dispatch_bin)),

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -114,6 +114,7 @@ def build_ffn_local_callable(platform: str) -> ChipCallable:
     return ChipCallable.build(
         signature=[ArgDirection.IN, ArgDirection.IN, ArgDirection.OUT],
         func_name="ffn_local_orchestration",
+        config_name="ffn_local_orchestration_config",
         binary=orch_bytes,
         children=[(0, core_callable)],
     )
@@ -143,6 +144,7 @@ def build_allreduce_sum_callable(platform: str) -> ChipCallable:
     return ChipCallable.build(
         signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
         func_name="allreduce_sum_orchestration",
+        config_name="allreduce_sum_orchestration_config",
         binary=orch_bytes,
         children=[(1, core_callable)],
     )


### PR DESCRIPTION
  ## Summary

  - Pass explicit orchestration config symbol names for the L3 worker examples.
  - Prevent the tensormap runtime from falling back to `aicpu_orchestration_config` and emitting a non-fatal dlsym error.

  ## Testing

  - `python -m py_compile examples/workers/l3/allreduce_distributed/main.py examples/workers/l3/ffn_tp_parallel/main.py examples/workers/l3/ep_dispatch_combine/main.py`
  - `task-submit --device 11,12 --run "cd /data/fangjingzhi/simpler_comm && source .venv/bin/activate && ASCEND_PROCESS_LOG_PATH=/data/fangjingzhi/simpler/device_logs
  ASCEND_GLOBAL_LOG_LEVEL=0 python examples/workers/l3/allreduce_distributed/main.py -d 11-12"`
    - `all ranks matched golden`
    - verified no `dlsym failed for config symbol` / `aicpu_orchestration_config` appears in the saved output