### PR TITLE
Add: validate block_dim against stream resource limit via aclrtGetStreamResLimit

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -463,41 +463,45 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
+int DeviceRunner::validate_block_dim(rtStream_t stream, int block_dim) {
+    if (block_dim < 1) {
+        LOG_ERROR("block_dim (%d) must be >= 1", block_dim);
+        return -1;
+    }
+
+    uint32_t cube_limit = 0, vector_limit = 0;
+    bool got_limits = (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_CUBE_CORE, &cube_limit) == ACL_ERROR_NONE) &&
+                      (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_VECTOR_CORE, &vector_limit) == ACL_ERROR_NONE) &&
+                      cube_limit > 0 && vector_limit > 0;
+
+    if (got_limits) {
+        int max_bd = static_cast<int>(
+            std::min(cube_limit / PLATFORM_AIC_CORES_PER_BLOCKDIM, vector_limit / PLATFORM_AIV_CORES_PER_BLOCKDIM)
+        );
+        if (block_dim > max_bd) {
+            LOG_ERROR(
+                "block_dim (%d) exceeds available cores (max_block_dim=%d, cube=%u, vector=%u)", block_dim, max_bd,
+                cube_limit, vector_limit
+            );
+            return -1;
+        }
+    } else if (block_dim > PLATFORM_MAX_BLOCKDIM) {
+        // aclrtGetStreamResLimit unavailable (or reported no cores) — fall back
+        // to the static platform capacity so block_dim stays bounded.
+        LOG_ERROR(
+            "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
+            block_dim, PLATFORM_MAX_BLOCKDIM
+        );
+        return -1;
+    }
+    return 0;
+}
+
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
-    }
-
-    // Validate block_dim
-    if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
-        return -1;
-    }
-
-    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
-
-    // Validate even core distribution for initial scheduler threads
-    if (scheduler_thread_num > 0) {
-        if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
-            );
-            return -1;
-        }
-    } else {
-        LOG_INFO_V0(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
-        );
-        // Post-transition: all threads become schedulers
-        if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN(
-                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                "some threads will have different core counts after transition",
-                block_dim, launch_aicpu_num
-            );
-        }
     }
 
     // Ensure device is initialized (lazy initialization)
@@ -507,7 +511,11 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return rc;
     }
 
-    // Calculate execution parameters
+    // Validate block_dim against stream resource limits
+    rc = validate_block_dim(stream_aicore_, block_dim);
+    if (rc != 0) {
+        return rc;
+    }
     block_dim_ = block_dim;
 
     int num_aicore = block_dim * cores_per_blockdim_;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -643,6 +643,14 @@ private:
     int ensure_device_initialized();
 
     /**
+     * Validate block_dim against the stream's CUBE/VECTOR core limits
+     * (aclrtGetStreamResLimit). When that query is unavailable or reports no
+     * cores, falls back to the static PLATFORM_MAX_BLOCKDIM cap.
+     * Returns 0 if block_dim fits, -1 otherwise (or if block_dim < 1).
+     */
+    int validate_block_dim(rtStream_t stream, int block_dim);
+
+    /**
      * Load AICPU SO and initialize device args
      *
      * Called by run() after prepare_run_context(). Reads aicpu_so_binary_ /

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -333,34 +333,14 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return -1;
     }
 
-    // Validate block_dim
+    // Validate block_dim. Sim has no stream resource query, so the static
+    // platform capacity is the bound (mirrors the onboard fallback in
+    // DeviceRunner::validate_block_dim). The scheduler assigns cores to
+    // threads cluster-aligned round-robin, so block_dim need not be evenly
+    // divisible by the scheduler thread count.
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
         LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;
-    }
-
-    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
-
-    // Validate even core distribution for initial scheduler threads
-    if (scheduler_thread_num > 0) {
-        if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
-            );
-            return -1;
-        }
-    } else {
-        LOG_INFO_V0(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
-        );
-        // Post-transition: all threads become schedulers
-        if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN(
-                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                "some threads will have different core counts after transition",
-                block_dim, launch_aicpu_num
-            );
-        }
     }
 
     // Ensure device is initialized

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -17,6 +17,7 @@
 
 #include "device_runner.h"
 
+#include "acl/acl.h"
 #include "host_log.h"
 
 #include <dlfcn.h>
@@ -285,40 +286,44 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
+int DeviceRunner::validate_block_dim(rtStream_t stream, int block_dim) {
+    if (block_dim < 1) {
+        LOG_ERROR("block_dim (%d) must be >= 1", block_dim);
+        return -1;
+    }
+
+    uint32_t cube_limit = 0, vector_limit = 0;
+    bool got_limits = (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_CUBE_CORE, &cube_limit) == ACL_ERROR_NONE) &&
+                      (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_VECTOR_CORE, &vector_limit) == ACL_ERROR_NONE) &&
+                      cube_limit > 0 && vector_limit > 0;
+
+    if (got_limits) {
+        int max_bd = static_cast<int>(
+            std::min(cube_limit / PLATFORM_AIC_CORES_PER_BLOCKDIM, vector_limit / PLATFORM_AIV_CORES_PER_BLOCKDIM)
+        );
+        if (block_dim > max_bd) {
+            LOG_ERROR(
+                "block_dim (%d) exceeds available cores (max_block_dim=%d, cube=%u, vector=%u)", block_dim, max_bd,
+                cube_limit, vector_limit
+            );
+            return -1;
+        }
+    } else if (block_dim > PLATFORM_MAX_BLOCKDIM) {
+        // aclrtGetStreamResLimit unavailable (or reported no cores) — fall back
+        // to the static platform capacity so block_dim stays bounded.
+        LOG_ERROR(
+            "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
+            block_dim, PLATFORM_MAX_BLOCKDIM
+        );
+        return -1;
+    }
+    return 0;
+}
+
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
         return -1;
-    }
-
-    // Validate block_dim
-    if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
-        LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
-        return -1;
-    }
-
-    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
-
-    // Validate even core distribution for initial scheduler threads
-    if (scheduler_thread_num > 0) {
-        if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
-            );
-            return -1;
-        }
-    } else {
-        LOG_INFO_V0(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
-        );
-        // Post-transition: all threads become schedulers
-        if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN(
-                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                "some threads will have different core counts after transition",
-                block_dim, launch_aicpu_num
-            );
-        }
     }
 
     // Ensure device is initialized (lazy initialization)
@@ -328,7 +333,11 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return rc;
     }
 
-    // Calculate execution parameters
+    // Validate block_dim against stream resource limits
+    rc = validate_block_dim(stream_aicore_, block_dim);
+    if (rc != 0) {
+        return rc;
+    }
     block_dim_ = block_dim;
 
     int num_aicore = block_dim * cores_per_blockdim_;

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -536,6 +536,14 @@ private:
     int ensure_device_initialized();
 
     /**
+     * Validate block_dim against the stream's CUBE/VECTOR core limits
+     * (aclrtGetStreamResLimit). When that query is unavailable or reports no
+     * cores, falls back to the static PLATFORM_MAX_BLOCKDIM cap.
+     * Returns 0 if block_dim fits, -1 otherwise (or if block_dim < 1).
+     */
+    int validate_block_dim(rtStream_t stream, int block_dim);
+
+    /**
      * Load AICPU SO and initialize device args
      *
      * Called by run() after prepare_run_context(). Reads aicpu_so_binary_ /

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -292,34 +292,14 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return -1;
     }
 
-    // Validate block_dim
+    // Validate block_dim. Sim has no stream resource query, so the static
+    // platform capacity is the bound (mirrors the onboard fallback in
+    // DeviceRunner::validate_block_dim). The scheduler assigns cores to
+    // threads cluster-aligned round-robin, so block_dim need not be evenly
+    // divisible by the scheduler thread count.
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
         LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;
-    }
-
-    int scheduler_thread_num = runtime.get_orch_built_on_host() ? launch_aicpu_num : launch_aicpu_num - 1;
-
-    // Validate even core distribution for initial scheduler threads
-    if (scheduler_thread_num > 0) {
-        if (block_dim % scheduler_thread_num != 0) {
-            LOG_ERROR(
-                "block_dim (%d) not evenly divisible by scheduler_thread_num (%d)", block_dim, scheduler_thread_num
-            );
-            return -1;
-        }
-    } else {
-        LOG_INFO_V0(
-            "All %d threads are orchestrators, cores will be assigned after orchestration completes", launch_aicpu_num
-        );
-        // Post-transition: all threads become schedulers
-        if (block_dim % launch_aicpu_num != 0) {
-            LOG_WARN(
-                "block_dim (%d) not evenly divisible by aicpu_thread_num (%d), "
-                "some threads will have different core counts after transition",
-                block_dim, launch_aicpu_num
-            );
-        }
     }
 
     // Ensure device is initialized


### PR DESCRIPTION
## Summary

- Add `DeviceRunner::validate_block_dim()` (a2a3 + a5 onboard): query the
  stream's CUBE/VECTOR core limits via `aclrtGetStreamResLimit` and reject a
  `block_dim` that exceeds hardware capacity, with a clear error showing
  `max_block_dim`, `cube`, and `vector` counts. `max_block_dim` is derived
  from `PLATFORM_AIC_CORES_PER_BLOCKDIM` / `PLATFORM_AIV_CORES_PER_BLOCKDIM`
  (not a hardcoded ratio), and a zero core count is treated as "query
  unavailable".
- When `aclrtGetStreamResLimit` is unavailable (older firmware) or reports no
  cores, fall back to the static `PLATFORM_MAX_BLOCKDIM` cap so `block_dim`
  stays bounded — error stays phrased in `block_dim` terms.
- Consolidate the onboard `block_dim` validation (lower bound + capacity
  check) into `validate_block_dim()`, called from `DeviceRunner::run()` once
  the device is initialized; removes the old inline checks.
- Drop the `block_dim % scheduler_thread_num` divisibility check from **both**
  onboard and sim `DeviceRunner::run()`. Both runtimes already tolerate an
  uneven split: `host_build_graph` (`AicpuExecutor::assign_cores_to_threads`)
  and `tensormap_and_ringbuffer` (`SchedulerContext::assign_cores_to_threads`
  / `reassign_cores_for_all_threads`) assign cores to scheduler threads
  cluster-aligned round-robin and size each thread's tracker from its actual
  cluster count, so `block_dim` need not divide evenly. Sim keeps the static
  `PLATFORM_MAX_BLOCKDIM` bound (it has no stream resource query), so onboard
  and sim validation stay consistent.
- Prevents handshake deadlock by failing fast with actionable diagnostics.

## Testing

- [x] Sim runtimes (`a2a3sim` / `a5sim` `libhost_runtime.so`) rebuild cleanly
      with the changes; pre-commit (clang-format, clang-tidy, cpplint) passes.
- [ ] Hardware: confirm an over-capacity `block_dim` is rejected with the new
      `max_block_dim=... cube=... vector=...` diagnostic instead of a
      handshake hang; confirm the `PLATFORM_MAX_BLOCKDIM` fallback path on
      firmware without `aclrtGetStreamResLimit`.
- [ ] Hardware: a non-divisible `block_dim` (e.g. `block_dim=5`,
      `aicpu_thread_num=4`) runs to completion (sanity-check the round-robin
      core split now that the divisibility gate is gone).

## Review notes addressed

- Magic `/2` AIC:AIV ratio → platform constants.
- Lost `PLATFORM_MAX_BLOCKDIM` fallback restored (was only a `LOG_WARN`).
- Zero core count from a "successful" query no longer reports `max_block_dim=0`.
- Divisibility check removed from sim too, so onboard/sim no longer diverge.
- `validate_block_dim` doc comment updated to match the actual contract.

## Notes

- PR-title typo "GetSteamResLimit" fixed.
- `Runtime::get_orch_built_on_host()` is **kept** — this PR only drops its one
  caller in the platform layer (the divisibility check). The flag is still
  load-bearing inside `tensormap_and_ringbuffer` (`aicpu_executor.cpp`,
  `scheduler_cold_path.cpp` `orchestrator_done_`, `runtime_maker.cpp`
  `set_orch_built_on_host`) and `host_build_graph` (`runtime.h` returns
  `true`); removing it is out of scope and would change runtime behavior.