### PR TITLE
Refactor: Arg dep API — primitive set_dependencies + ArgWithDeps<N> convenience layer

### DIFF
--- a/docs/manual-scope.md
+++ b/docs/manual-scope.md
@@ -5,7 +5,7 @@
 Keep manual scope small and explicit:
 
 - same submit API family as AUTO mode
-- explicit task-to-task deps via `Arg.add_dep(task_id)`
+- explicit task-to-task deps via `Arg.set_dependencies(deps, count)`
 - publish at submit time, same as AUTO mode
 - support allocation-as-task through `alloc_tensors(...).task_id()`
 
@@ -16,7 +16,7 @@ The v0 design keeps these rules:
 1. `PTO2_SCOPE(PTO2ScopeMode::MANUAL)` opts a scope into manual mode.
 2. `MANUAL` nested inside active `MANUAL` is allowed.
 3. `AUTO` nested inside active `MANUAL` is rejected.
-4. Manual deps are attached before submit through `Arg.add_dep(...)`.
+4. Manual deps are attached before submit through `Arg.set_dependencies(...)`.
 5. No post-submit `add_dependency(...)` API exists.
 6. `alloc_tensors(...)` remains output-only and returns a task id.
 7. Scope handling stays close to upstream AUTO mode.
@@ -46,17 +46,26 @@ auto out = rt_submit_task(mixed_kernels, args);
 ```cpp
 Arg args;
 args.add_input(tensor);
-args.add_dep(prev_task_id);
+PTO2TaskId deps[] = {prev_task_id};
+args.set_dependencies(deps, 1);
 ```
 
 Rules:
 
-- `add_dep(...)` must refer to an earlier producer task id
-- if that producer task is already retired when the consumer is submitted, the
-  runtime skips the edge without reporting an error
+- `set_dependencies(...)` may be called at most once per Arg with `count > 0`;
+  build the full dep set on the caller's stack (or any buffer that outlives the
+  submit) and pass `(ptr, count)` in a single call
+- `count == 0` is a valid "set empty" — it clears any previously stored deps,
+  so callers that build the dep set conditionally can pass the result through
+  unguarded even when no branch matched
+- the dependency array is stored by pointer (no copy); it must remain valid
+  until `rt_submit_*_task(...)` returns
+- every entry must refer to an earlier producer task id; if a producer is
+  already retired when the consumer is submitted, the runtime skips the
+  edge without reporting an error
 - explicit deps become ordinary fanins immediately at submit time
-- this applies uniformly in AUTO and MANUAL submits; the task id already carries
-  the ring needed for slot lookup
+- this applies uniformly in AUTO and MANUAL submits; the task id already
+  carries the ring needed for slot lookup
 
 ### Allocation task ids
 
@@ -76,7 +85,7 @@ the producer that later tasks must explicitly depend on.
 Manual scope v0 is:
 
 - AUTO-style submit and publish
-- plus explicit fanins from `Arg.add_dep(...)`
+- plus explicit fanins from `Arg.set_dependencies(...)`
 - plus full TensorMap lookup / insert bypass for tasks submitted inside manual
   scope
 
@@ -114,7 +123,7 @@ The rule is submit-scoped, not tensor-scoped:
 
 For a submitted task:
 
-- explicit `add_dep(...)` edges are always checked first
+- explicit `set_dependencies(...)` edges are always checked first
 - retired explicit-dep producers are skipped as already satisfied
 - if the task is inside manual scope, TensorMap lookup / insert is skipped
 - if the task is outside manual scope, normal AUTO TensorMap behavior is used
@@ -128,33 +137,41 @@ PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
     Arg qk;
     qk.add_input(qi, kj);
     qk.add_output(sij_ci);
-    qk.add_dep(alloc.task_id());
+    PTO2TaskId qk_deps[] = {alloc.task_id()};
+    qk.set_dependencies(qk_deps, 1);
     auto qk_out = rt_submit_aic_task(FUNC_QK, qk);
 
     Arg sf;
     sf.add_input(qk_out.get_ref(0));
     sf.add_output(pij_ci, li_ci, mi_ci);
-    sf.add_dep(qk_out.task_id());
+    PTO2TaskId sf_deps[] = {qk_out.task_id()};
+    sf.set_dependencies(sf_deps, 1);
     auto sf_out = rt_submit_aiv_task(FUNC_SF, sf);
 
     Arg up;
     up.add_input(sf_out.get_ref(1), sf_out.get_ref(2), pv_out.get_ref(0));
     up.add_inout(mi, li, out_view, tmp);
-    up.add_dep(sf_out.task_id());
-    up.add_dep(pv_out.task_id());
+    PTO2TaskId up_deps[] = {sf_out.task_id(), pv_out.task_id()};
+    up.set_dependencies(up_deps, 2);
     auto up_out = rt_submit_aiv_task(FUNC_UP, up);
 }
 ```
 
-Repeated zero-output updater chains must explicitly thread the returned task id:
+Repeated zero-output updater chains must explicitly thread the returned task id.
+When the dep set is conditional, build the array up first and call
+`set_dependencies` once — `count == 0` is a valid "set empty", so no guard is
+needed on the first iteration:
 
 ```cpp
 PTO2TaskId prev_update = PTO2TaskId::invalid();
 for (...) {
     Arg up = ...;
+    PTO2TaskId up_deps[1];
+    uint32_t up_dep_count = 0;
     if (prev_update.is_valid()) {
-        up.add_dep(prev_update);
+        up_deps[up_dep_count++] = prev_update;
     }
+    up.set_dependencies(up_deps, up_dep_count);
     prev_update = rt_submit_aiv_task(FUNC_UP, up).task_id();
 }
 ```
@@ -166,5 +183,5 @@ The a5 port uses the same manual-scope v0 runtime model as a2a3:
 - same `manual_begin_depth` state model
 - same `MANUAL`-inside-`MANUAL` behavior
 - same rejection of `AUTO` inside active `MANUAL`
-- same submit-time explicit dependency model through `Arg.add_dep(...)`
+- same submit-time explicit dependency model through `Arg.set_dependencies(...)`
 - same submit-time TensorMap bypass for tasks submitted inside manual scope

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -200,6 +200,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     PROF_INC(prof_view_count, 1);
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
+                    // --- Primitive dep API (Arg + set_dependencies) ---
+                    // Caller owns the deps buffer; Arg stores (ptr, count).
+                    // Suited for codegen and for cases with a fixed dep set.
                     Arg params_sf;
                     params_sf.add_input(sij_valid);
                     params_sf.add_output(pij_f16_ci);
@@ -232,7 +235,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    Arg params_up;
+                    // --- Convenience dep API (ArgWithDeps + add_dep) ---
+                    // Wrapper owns a stack-sized deps buffer and accepts
+                    // incremental add_dep() calls; the submit overload binds
+                    // them to the underlying Arg via set_dependencies(...).
+                    // Suited for hand-written orch where the dep set is
+                    // assembled conditionally across branches.
+                    ArgWithDeps<> params_up;
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_tmp);
@@ -241,17 +250,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
                     // UP reads SF's mi/li, but SF -> PV -> UP already orders it; only the PV edge is explicit.
-                    PTO2TaskId up_deps[3];
-                    uint32_t up_dep_count = 0;
-                    up_deps[up_dep_count++] = pv_outs.task_id();
+                    params_up.add_dep(pv_outs.task_id());
                     if (prev_update_task.is_valid()) {
-                        up_deps[up_dep_count++] = prev_update_task;
+                        params_up.add_dep(prev_update_task);
                     }
                     // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
                     if (is_last) {
-                        up_deps[up_dep_count++] = alloc_task;
+                        params_up.add_dep(alloc_task);
                     }
-                    params_up.set_dependencies(up_deps, up_dep_count);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -205,7 +205,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_output(pij_f16_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
-                    params_sf.add_dep(qk_outs.task_id());
+                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    params_sf.set_dependencies(sf_deps, 1);
                     params_sf.add_scalar(scale_value);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
@@ -219,7 +220,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
-                    params_pv.add_dep(sf_outs.task_id());
+                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    params_pv.set_dependencies(pv_deps, 1);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
@@ -239,14 +241,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
                     // UP reads SF's mi/li, but SF -> PV -> UP already orders it; only the PV edge is explicit.
-                    params_up.add_dep(pv_outs.task_id());
+                    PTO2TaskId up_deps[3];
+                    uint32_t up_dep_count = 0;
+                    up_deps[up_dep_count++] = pv_outs.task_id();
                     if (prev_update_task.is_valid()) {
-                        params_up.add_dep(prev_update_task);
+                        up_deps[up_dep_count++] = prev_update_task;
                     }
                     // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
                     if (is_last) {
-                        params_up.add_dep(alloc_task);
+                        up_deps[up_dep_count++] = alloc_task;
                     }
+                    params_up.set_dependencies(up_deps, up_dep_count);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -234,7 +234,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_sf.add_output(pij_buf_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
-                    params_sf.add_dep(qk_outs.task_id());
+                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    params_sf.set_dependencies(sf_deps, 1);
                     params_sf.add_scalar(scale_value);
                     params_sf.add_scalar(n_blocks);
                     params_sf.add_scalar(valid_len_last);
@@ -254,7 +255,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_pv.add_input(value_cache);
                     params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
-                    params_pv.add_dep(sf_outs.task_id());
+                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    params_pv.set_dependencies(pv_deps, 1);
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
@@ -277,14 +279,17 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    params_up.add_dep(pv_outs.task_id());
+                    PTO2TaskId up_deps[3];
+                    uint32_t up_dep_count = 0;
+                    up_deps[up_dep_count++] = pv_outs.task_id();
                     if (!is_first) {
-                        params_up.add_dep(pre_task_id);
+                        up_deps[up_dep_count++] = pre_task_id;
                     }
                     // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
                     if (is_last) {
-                        params_up.add_dep(alloc_outs.task_id());
+                        up_deps[up_dep_count++] = alloc_outs.task_id();
                     }
+                    params_up.set_dependencies(up_deps, up_dep_count);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -199,6 +199,9 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     prof_view_count += 1;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
+                    // --- Primitive dep API (Arg + set_dependencies) ---
+                    // Caller owns the deps buffer; Arg stores (ptr, count).
+                    // Suited for codegen and for cases with a fixed dep set.
                     Arg params_sf;
                     params_sf.add_input(sij_valid);
                     params_sf.add_output(pij_f16_ci);
@@ -231,7 +234,13 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    Arg params_up;
+                    // --- Convenience dep API (ArgWithDeps + add_dep) ---
+                    // Wrapper owns a stack-sized deps buffer and accepts
+                    // incremental add_dep() calls; the submit overload binds
+                    // them to the underlying Arg via set_dependencies(...).
+                    // Suited for hand-written orch where the dep set is
+                    // assembled conditionally across branches.
+                    ArgWithDeps<> params_up;
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_tmp);
@@ -239,17 +248,14 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    PTO2TaskId up_deps[3];
-                    uint32_t up_dep_count = 0;
-                    up_deps[up_dep_count++] = pv_outs.task_id();
+                    params_up.add_dep(pv_outs.task_id());
                     if (prev_update_task.is_valid()) {
-                        up_deps[up_dep_count++] = prev_update_task;
+                        params_up.add_dep(prev_update_task);
                     }
                     // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
                     if (is_last) {
-                        up_deps[up_dep_count++] = alloc_task;
+                        params_up.add_dep(alloc_task);
                     }
-                    params_up.set_dependencies(up_deps, up_dep_count);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -205,7 +205,8 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_scalar(scale_value);
-                    params_sf.add_dep(qk_outs.task_id());
+                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    params_sf.set_dependencies(sf_deps, 1);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
                     const Tensor &pij_f16 = sf_outs.get_ref(0);
@@ -218,7 +219,8 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
-                    params_pv.add_dep(sf_outs.task_id());
+                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    params_pv.set_dependencies(pv_deps, 1);
                     CYCLE_COUNT_LAP(prof_param_setup);
                     TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
                     const Tensor &oi_tmp = pv_outs.get_ref(0);
@@ -237,14 +239,17 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    params_up.add_dep(pv_outs.task_id());
+                    PTO2TaskId up_deps[3];
+                    uint32_t up_dep_count = 0;
+                    up_deps[up_dep_count++] = pv_outs.task_id();
                     if (prev_update_task.is_valid()) {
-                        params_up.add_dep(prev_update_task);
+                        up_deps[up_dep_count++] = prev_update_task;
                     }
                     // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
                     if (is_last) {
-                        params_up.add_dep(alloc_task);
+                        up_deps[up_dep_count++] = alloc_task;
                     }
+                    params_up.set_dependencies(up_deps, up_dep_count);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -226,7 +226,8 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_sf.add_output(pij_buf_ci);
                     params_sf.add_output(scalar_ci);
                     params_sf.add_output(scalar_ci);
-                    params_sf.add_dep(qk_outs.task_id());
+                    PTO2TaskId sf_deps[] = {qk_outs.task_id()};
+                    params_sf.set_dependencies(sf_deps, 1);
                     params_sf.add_scalar(scale_value);
                     params_sf.add_scalar(n_blocks);
                     params_sf.add_scalar(valid_len_last);
@@ -245,7 +246,8 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_pv.add_input(value_cache);
                     params_pv.add_input(block_table);
                     params_pv.add_output(tile2d_ci);
-                    params_pv.add_dep(sf_outs.task_id());
+                    PTO2TaskId pv_deps[] = {sf_outs.task_id()};
+                    params_pv.set_dependencies(pv_deps, 1);
                     params_pv.add_scalar(n_blocks);
                     params_pv.add_scalar(b_idx * block_num + bn);
                     CYCLE_COUNT_LAP(prof_param_setup);
@@ -267,14 +269,17 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     params_up.add_inout(li_update);
                     params_up.add_inout(oi);
                     params_up.add_inout(out_view);
-                    params_up.add_dep(pv_outs.task_id());
+                    PTO2TaskId up_deps[3];
+                    uint32_t up_dep_count = 0;
+                    up_deps[up_dep_count++] = pv_outs.task_id();
                     if (prev_update_task.is_valid()) {
-                        params_up.add_dep(prev_update_task);
+                        up_deps[up_dep_count++] = prev_update_task;
                     }
                     // alloc completes inline; this dep only keeps the scratch buffers alive until the last consumer.
                     if (is_last) {
-                        params_up.add_dep(alloc_outs.task_id());
+                        up_deps[up_dep_count++] = alloc_outs.task_id();
                     }
+                    params_up.set_dependencies(up_deps, up_dep_count);
                     params_up.add_scalar(is_first);
                     params_up.add_scalar(is_last);
                     CYCLE_COUNT_LAP(prof_param_setup);

--- a/src/a2a3/platform/include/common/dep_gen.h
+++ b/src/a2a3/platform/include/common/dep_gen.h
@@ -59,8 +59,10 @@
 constexpr int DEP_GEN_TENSOR_SIZE = 128;
 
 /**
- * Max explicit_dep entries per submit. Mirrors runtime PTO2_MAX_EXPLICIT_DEPS;
- * static_asserted in dep_gen_collector_aicpu.cpp against the runtime header.
+ * Max explicit_dep entries captured per submit by dep_gen replay. This is a
+ * diagnostic-side cap only — the runtime's Arg::set_dependencies has no hard
+ * limit on dep count. Submits exceeding this cap are logged and truncated by
+ * dep_gen_aicpu_record_submit(); runtime correctness is unaffected.
  */
 constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 16;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Convenience layer over Arg: bundles a fixed-capacity dependency buffer with
+ * an Arg and exposes an incremental add_dep(...) API on top of the runtime
+ * primitive Arg::set_dependencies(ptr, count).
+ *
+ * Layering:
+ *   - Primitive:   Arg + set_dependencies(ptr, count) in pto_types.h.
+ *                  No cap, caller owns the deps buffer.
+ *   - Convenience: ArgWithDeps<N> in this header. Owns a stack-sized dep
+ *                  buffer of capacity N (default 16); provides add_dep().
+ *                  Submitted via the rt_submit_*_task overloads below, which
+ *                  forward the bundled deps into the underlying Arg.
+ *
+ * This file is auto-included at the bottom of pto_orchestration_api.h so
+ * orchestration sources see ArgWithDeps after a single `#include
+ * "pto_orchestration_api.h"`. The split is purely organizational —
+ * orchestration code should not include this header directly. Code generated
+ * from pypto can ignore the convenience layer entirely and target Arg +
+ * set_dependencies(ptr, count) directly.
+ *
+ * ArgWithDeps uses private inheritance from Arg so that set_dependencies and
+ * the explicit_dep* accessors are NOT reachable on a wrapper instance — users
+ * who pick the convenience layer cannot accidentally mix it with the
+ * primitive layer's dep API on the same object.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <type_traits>
+
+#include "pto_orchestration_api.h"  // Arg, MixedKernels, rt_submit_* primitives
+
+template <size_t MAX_DEP_COUNT = 16>
+class ArgWithDeps : private Arg {
+public:
+    // Tensor / scalar setters — forward to Arg
+    using Arg::add_inout;
+    using Arg::add_input;
+    using Arg::add_no_dep;
+    using Arg::add_output;
+    using Arg::add_scalar;
+    using Arg::add_scalars;
+    using Arg::add_scalars_i32;
+    using Arg::copy_scalars_from;
+
+    // Error / status — forward to Arg
+    using Arg::error_msg;
+    using Arg::has_error;
+    using Arg::launch_spec;
+    using Arg::set_error;
+
+    // NOT exposed: set_dependencies, explicit_dep_count, explicit_dep,
+    // explicit_deps_data — these are the primitive-layer dep API. Users of
+    // the convenience layer reach dependencies only through add_dep() below.
+
+    /**
+     * Append one or more dependencies to the bundled buffer. May be called
+     * multiple times; deps accumulate. Variadic accepts any non-zero number
+     * of PTO2TaskId arguments.
+     *
+     * Overflow (more than MAX_DEP_COUNT total) records an error on the
+     * underlying Arg; the error surfaces at submit time.
+     */
+    template <typename... Ids>
+    void add_dep(Ids... ids) {
+        static_assert(sizeof...(Ids) >= 1, "add_dep: at least one task id is required");
+        static_assert(
+            (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
+        );
+        if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
+            Arg::set_error("ArgWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)");
+            return;
+        }
+        ((deps_[count_++] = ids), ...);
+    }
+
+    /**
+     * Clear the bundled dep buffer and reset the underlying Arg.
+     * Use this to recycle an ArgWithDeps across loop iterations.
+     */
+    void reset() {
+        Arg::reset();
+        count_ = 0;
+    }
+
+    /**
+     * Submit-only hook: bind the bundled deps onto the underlying Arg and
+     * return it as Arg&. Called by the rt_submit_*_task overloads below;
+     * orchestration code does not invoke this directly.
+     *
+     * Idempotent: explicitly clears any prior dep binding before re-setting,
+     * so a wrapper can be re-finalized (e.g. resubmitted) without tripping
+     * the primitive layer's single-shot check.
+     */
+    Arg &finalize_for_submit() {
+        Arg::set_dependencies(nullptr, 0);
+        Arg::set_dependencies(deps_, count_);
+        return *this;
+    }
+
+private:
+    PTO2TaskId deps_[MAX_DEP_COUNT];
+    uint32_t count_ = 0;
+};
+
+// =============================================================================
+// Submit overloads — accept ArgWithDeps<N> transparently
+// =============================================================================
+
+template <size_t N>
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, ArgWithDeps<N> &awd) {
+    return rt_submit_task(mixed_kernels, awd.finalize_for_submit());
+}
+
+template <size_t N>
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+    return rt_submit_aic_task(kernel_id, awd.finalize_for_submit());
+}
+
+template <size_t N>
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+    return rt_submit_aiv_task(kernel_id, awd.finalize_for_submit());
+}

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -24,8 +24,7 @@
  * full PTO2Runtime struct with all internal fields).
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_ORCHESTRATION_PTO_ORCHESTRATION_API_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_ORCHESTRATION_PTO_ORCHESTRATION_API_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -421,4 +420,8 @@ struct PTO2OrchestrationConfig {
 };
 #endif
 
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_ORCHESTRATION_PTO_ORCHESTRATION_API_H_
+// Convenience layer (ArgWithDeps<N> + matching rt_submit_*_task overloads).
+// Pulled in at the bottom so the wrapper sees Arg, MixedKernels, and the
+// rt_submit_*_task primitives defined above. Orchestration sources include
+// only this single header to access both the primitive and convenience APIs.
+#include "pto_arg_with_deps.h"  // NOLINT(build/include_subdir)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -40,10 +40,10 @@
 // Tensor layout. The platform header defines DEP_GEN_TENSOR_SIZE without
 // including runtime/tensor.h, so this check lives at the orch callsite.
 static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot size out of sync with sizeof(Tensor)");
-static_assert(
-    PTO2_MAX_EXPLICIT_DEPS == DEP_GEN_MAX_EXPLICIT_DEPS,
-    "DepGenRecord::explicit_deps array length out of sync with PTO2_MAX_EXPLICIT_DEPS"
-);
+// DEP_GEN_MAX_EXPLICIT_DEPS is a diagnostic-side capture cap only; the runtime
+// imposes no hard cap on explicit dep count. If a submit exceeds this cap,
+// dep_gen_aicpu_record_submit() logs and truncates — runtime correctness is
+// unaffected, only the captured replay record is truncated.
 
 // Weak fallbacks: dep_gen_collector_aicpu.cpp provides the strong symbols in
 // AICPU builds. Host builds (host_build_graph runtime, future dep_gen replay)
@@ -609,7 +609,9 @@ static TaskOutputTensors submit_task_common(
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         PTO2TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
-            orch->report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
+            orch->report_fatal(
+                PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
+            );
             return result;
         }
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -44,7 +44,6 @@
 // pto2_dispatch_payload.h, intrinsic.h comments).
 #define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
 #define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
-#define PTO2_MAX_EXPLICIT_DEPS 16  // Maximum explicit task dependencies per task
 
 typedef enum {
     PTO2_ASYNC_ENGINE_SDMA = 0,
@@ -181,7 +180,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         clear();
         has_error = false;
         error_msg = nullptr;
-        explicit_deps_.reset();
+        explicit_deps_ = nullptr;
+        explicit_dep_count_ = 0;
     }
 
     void set_error(const char *msg) {
@@ -231,24 +231,50 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::NO_DEP, tensor_count_++), ...);
     }
 
-    template <typename... TaskIds>
-    void add_dep(TaskIds... task_ids) {
-        static_assert(sizeof...(TaskIds) >= 1, "add_dep: at least one task id is required");
-        static_assert(
-            (std::is_same_v<std::decay_t<TaskIds>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
-        );
-        if (explicit_deps_.size() + sizeof...(TaskIds) > PTO2_MAX_EXPLICIT_DEPS) {
-            set_error("Too many explicit deps (exceeds explicit dependency capacity=16)");
+    /**
+     * Attach an explicit dependency array. The Arg stores (ptr, count) without
+     * copying — the caller's array must outlive the submit (same lifetime rule
+     * as add_input/add_output, which also store pointers).
+     *
+     * count == 0 is a valid "set empty" — it clears any previously stored deps
+     * and returns. This lets callers that build the dep set conditionally pass
+     * the result through unguarded, including in the no-dep branch:
+     *   PTO2TaskId deps[3];
+     *   uint32_t n = 0;
+     *   if (have_prev) deps[n++] = prev;
+     *   if (is_last)   deps[n++] = alloc;
+     *   args.set_dependencies(deps, n);    // safe even if n == 0
+     *
+     * For count > 0, the call is single-shot: a second non-empty call after
+     * deps are already set will fail with set_error(). Use count == 0 first
+     * if you need to re-set.
+     */
+    void set_dependencies(const PTO2TaskId *deps, uint32_t count) {
+        if (count == 0) {
+            explicit_deps_ = nullptr;
+            explicit_dep_count_ = 0;
             return;
         }
-        (explicit_deps_.add(task_ids), ...);
+        if (deps == nullptr) {
+            set_error("set_dependencies: deps must not be null when count > 0");
+            return;
+        }
+        if (explicit_deps_ != nullptr) {
+            set_error("set_dependencies: may be called at most once per Arg");
+            return;
+        }
+        explicit_deps_ = deps;
+        explicit_dep_count_ = count;
     }
 
-    uint32_t explicit_dep_count() const { return explicit_deps_.size(); }
+    uint32_t explicit_dep_count() const { return explicit_dep_count_; }
 
-    PTO2TaskId explicit_dep(uint32_t index) const { return explicit_deps_.get(index); }
+    PTO2TaskId explicit_dep(uint32_t index) const {
+        always_assert(index < explicit_dep_count_);
+        return explicit_deps_[index];
+    }
 
-    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_.task_ids; }
+    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is
@@ -327,29 +353,9 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     }
 
 private:
-    struct ExplicitDepStorage {
-        PTO2TaskId task_ids[PTO2_MAX_EXPLICIT_DEPS]{};
-        uint32_t count{0};
-
-        void reset() { count = 0; }
-
-        bool add(PTO2TaskId task_id) {
-            if (count >= PTO2_MAX_EXPLICIT_DEPS) {
-                return false;
-            }
-            task_ids[count++] = task_id;
-            return true;
-        }
-
-        uint32_t size() const { return count; }
-
-        PTO2TaskId get(uint32_t index) const {
-            always_assert(index < count);
-            return task_ids[index];
-        }
-    };
-
-    ExplicitDepStorage explicit_deps_;
+    // Caller-owned dependency array; lifetime must extend through submit.
+    const PTO2TaskId *explicit_deps_{nullptr};
+    uint32_t explicit_dep_count_{0};
 
     template <bool is_output, typename... Args>
     bool check_add_tensor_valid(Args &&...) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Convenience layer over Arg: bundles a fixed-capacity dependency buffer with
+ * an Arg and exposes an incremental add_dep(...) API on top of the runtime
+ * primitive Arg::set_dependencies(ptr, count).
+ *
+ * Layering:
+ *   - Primitive:   Arg + set_dependencies(ptr, count) in pto_types.h.
+ *                  No cap, caller owns the deps buffer.
+ *   - Convenience: ArgWithDeps<N> in this header. Owns a stack-sized dep
+ *                  buffer of capacity N (default 16); provides add_dep().
+ *                  Submitted via the rt_submit_*_task overloads below, which
+ *                  forward the bundled deps into the underlying Arg.
+ *
+ * This file is auto-included at the bottom of pto_orchestration_api.h so
+ * orchestration sources see ArgWithDeps after a single `#include
+ * "pto_orchestration_api.h"`. The split is purely organizational —
+ * orchestration code should not include this header directly. Code generated
+ * from pypto can ignore the convenience layer entirely and target Arg +
+ * set_dependencies(ptr, count) directly.
+ *
+ * ArgWithDeps uses private inheritance from Arg so that set_dependencies and
+ * the explicit_dep* accessors are NOT reachable on a wrapper instance — users
+ * who pick the convenience layer cannot accidentally mix it with the
+ * primitive layer's dep API on the same object.
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <type_traits>
+
+#include "pto_orchestration_api.h"  // Arg, MixedKernels, rt_submit_* primitives
+
+template <size_t MAX_DEP_COUNT = 16>
+class ArgWithDeps : private Arg {
+public:
+    // Tensor / scalar setters — forward to Arg
+    using Arg::add_inout;
+    using Arg::add_input;
+    using Arg::add_no_dep;
+    using Arg::add_output;
+    using Arg::add_scalar;
+    using Arg::add_scalars;
+    using Arg::add_scalars_i32;
+    using Arg::copy_scalars_from;
+
+    // Error / status — forward to Arg
+    using Arg::error_msg;
+    using Arg::has_error;
+    using Arg::launch_spec;
+    using Arg::set_error;
+
+    // NOT exposed: set_dependencies, explicit_dep_count, explicit_dep,
+    // explicit_deps_data — these are the primitive-layer dep API. Users of
+    // the convenience layer reach dependencies only through add_dep() below.
+
+    /**
+     * Append one or more dependencies to the bundled buffer. May be called
+     * multiple times; deps accumulate. Variadic accepts any non-zero number
+     * of PTO2TaskId arguments.
+     *
+     * Overflow (more than MAX_DEP_COUNT total) records an error on the
+     * underlying Arg; the error surfaces at submit time.
+     */
+    template <typename... Ids>
+    void add_dep(Ids... ids) {
+        static_assert(sizeof...(Ids) >= 1, "add_dep: at least one task id is required");
+        static_assert(
+            (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
+        );
+        if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
+            Arg::set_error("ArgWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)");
+            return;
+        }
+        ((deps_[count_++] = ids), ...);
+    }
+
+    /**
+     * Clear the bundled dep buffer and reset the underlying Arg.
+     * Use this to recycle an ArgWithDeps across loop iterations.
+     */
+    void reset() {
+        Arg::reset();
+        count_ = 0;
+    }
+
+    /**
+     * Submit-only hook: bind the bundled deps onto the underlying Arg and
+     * return it as Arg&. Called by the rt_submit_*_task overloads below;
+     * orchestration code does not invoke this directly.
+     *
+     * Idempotent: explicitly clears any prior dep binding before re-setting,
+     * so a wrapper can be re-finalized (e.g. resubmitted) without tripping
+     * the primitive layer's single-shot check.
+     */
+    Arg &finalize_for_submit() {
+        Arg::set_dependencies(nullptr, 0);
+        Arg::set_dependencies(deps_, count_);
+        return *this;
+    }
+
+private:
+    PTO2TaskId deps_[MAX_DEP_COUNT];
+    uint32_t count_ = 0;
+};
+
+// =============================================================================
+// Submit overloads — accept ArgWithDeps<N> transparently
+// =============================================================================
+
+template <size_t N>
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, ArgWithDeps<N> &awd) {
+    return rt_submit_task(mixed_kernels, awd.finalize_for_submit());
+}
+
+template <size_t N>
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+    return rt_submit_aic_task(kernel_id, awd.finalize_for_submit());
+}
+
+template <size_t N>
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+    return rt_submit_aiv_task(kernel_id, awd.finalize_for_submit());
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -24,8 +24,7 @@
  * full PTO2Runtime struct with all internal fields).
  */
 
-#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_ORCHESTRATION_PTO_ORCHESTRATION_API_H_
-#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_ORCHESTRATION_PTO_ORCHESTRATION_API_H_
+#pragma once
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -422,4 +421,8 @@ struct PTO2OrchestrationConfig {
 };
 #endif
 
-#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_ORCHESTRATION_PTO_ORCHESTRATION_API_H_
+// Convenience layer (ArgWithDeps<N> + matching rt_submit_*_task overloads).
+// Pulled in at the bottom so the wrapper sees Arg, MixedKernels, and the
+// rt_submit_*_task primitives defined above. Orchestration sources include
+// only this single header to access both the primitive and convenience APIs.
+#include "pto_arg_with_deps.h"  // NOLINT(build/include_subdir)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -555,7 +555,9 @@ static TaskOutputTensors submit_task_common(
     for (uint32_t i = 0; i < args.explicit_dep_count(); i++) {
         PTO2TaskId dep_task_id = args.explicit_dep(i);
         if (!dep_task_id.is_valid()) {
-            orch->report_fatal(PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.add_dep(...) requires a valid task id");
+            orch->report_fatal(
+                PTO2_ERROR_INVALID_ARGS, __FUNCTION__, "Arg.set_dependencies(...) requires valid task ids"
+            );
             return result;
         }
         PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -46,7 +46,6 @@
 // pto2_dispatch_payload.h, intrinsic.h comments).
 #define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
 #define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
-#define PTO2_MAX_EXPLICIT_DEPS 16  // Maximum explicit task dependencies per task
 
 typedef enum {
     PTO2_ASYNC_ENGINE_SDMA = 0,
@@ -179,7 +178,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     void clear() {
         TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
-        explicit_deps_.reset();
+        explicit_deps_ = nullptr;
+        explicit_dep_count_ = 0;
     }
 
     void reset() {
@@ -235,24 +235,50 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::NO_DEP, tensor_count_++), ...);
     }
 
-    template <typename... TaskIds>
-    void add_dep(TaskIds... task_ids) {
-        static_assert(sizeof...(TaskIds) >= 1, "add_dep: at least one task id is required");
-        static_assert(
-            (std::is_same_v<std::decay_t<TaskIds>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
-        );
-        if (explicit_deps_.size() + sizeof...(TaskIds) > PTO2_MAX_EXPLICIT_DEPS) {
-            set_error("Too many explicit deps (exceeds explicit dependency capacity=16)");
+    /**
+     * Attach an explicit dependency array. The Arg stores (ptr, count) without
+     * copying — the caller's array must outlive the submit (same lifetime rule
+     * as add_input/add_output, which also store pointers).
+     *
+     * count == 0 is a valid "set empty" — it clears any previously stored deps
+     * and returns. This lets callers that build the dep set conditionally pass
+     * the result through unguarded, including in the no-dep branch:
+     *   PTO2TaskId deps[3];
+     *   uint32_t n = 0;
+     *   if (have_prev) deps[n++] = prev;
+     *   if (is_last)   deps[n++] = alloc;
+     *   args.set_dependencies(deps, n);    // safe even if n == 0
+     *
+     * For count > 0, the call is single-shot: a second non-empty call after
+     * deps are already set will fail with set_error(). Use count == 0 first
+     * if you need to re-set.
+     */
+    void set_dependencies(const PTO2TaskId *deps, uint32_t count) {
+        if (count == 0) {
+            explicit_deps_ = nullptr;
+            explicit_dep_count_ = 0;
             return;
         }
-        (explicit_deps_.add(task_ids), ...);
+        if (deps == nullptr) {
+            set_error("set_dependencies: deps must not be null when count > 0");
+            return;
+        }
+        if (explicit_deps_ != nullptr) {
+            set_error("set_dependencies: may be called at most once per Arg");
+            return;
+        }
+        explicit_deps_ = deps;
+        explicit_dep_count_ = count;
     }
 
-    uint32_t explicit_dep_count() const { return explicit_deps_.size(); }
+    uint32_t explicit_dep_count() const { return explicit_dep_count_; }
 
-    PTO2TaskId explicit_dep(uint32_t index) const { return explicit_deps_.get(index); }
+    PTO2TaskId explicit_dep(uint32_t index) const {
+        always_assert(index < explicit_dep_count_);
+        return explicit_deps_[index];
+    }
 
-    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_.task_ids; }
+    const PTO2TaskId *explicit_deps_data() const { return explicit_deps_; }
 
     /**
      * Add scalar values. Types are deduced per argument; each value is
@@ -331,29 +357,9 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     }
 
 private:
-    struct ExplicitDepStorage {
-        PTO2TaskId task_ids[PTO2_MAX_EXPLICIT_DEPS]{};
-        uint32_t count{0};
-
-        void reset() { count = 0; }
-
-        bool add(PTO2TaskId task_id) {
-            if (count >= PTO2_MAX_EXPLICIT_DEPS) {
-                return false;
-            }
-            task_ids[count++] = task_id;
-            return true;
-        }
-
-        uint32_t size() const { return count; }
-
-        PTO2TaskId get(uint32_t index) const {
-            always_assert(index < count);
-            return task_ids[index];
-        }
-    };
-
-    ExplicitDepStorage explicit_deps_;
+    // Caller-owned dependency array; lifetime must extend through submit.
+    const PTO2TaskId *explicit_deps_{nullptr};
+    uint32_t explicit_dep_count_{0};
 
     template <bool is_output, typename... Args>
     bool check_add_tensor_valid(Args &&...) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -26,11 +26,11 @@
  *     consumer copies X -> Y
  *     expect Y[0] = 42.0 (no dummy runs a kernel; X must be undisturbed)
  *
- *   case=3: Dummy as many-to-one barrier via explicit add_dep.
+ *   case=3: Dummy as many-to-one barrier via explicit set_dependencies.
  *     producer_A writes X[0] = 42.0
  *     producer_B writes W[0] = 7.0
- *     dummy_T explicit add_dep(A.id, B.id)  // no tensor args, pure barrier
- *     consumer explicit add_dep(dummy.id), copies X -> Y
+ *     dummy_T explicit set_dependencies({A.id, B.id}, 2)  // pure barrier
+ *     consumer explicit set_dependencies({dummy.id}, 1), copies X -> Y
  *     expect Y[0] = 42.0 (consumer waits on dummy which waits on A+B)
  *
  * Args layout: [X, Y, W]
@@ -126,13 +126,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         PTO2TaskId dummy_id;
         {
             Arg args;
-            args.add_dep(a_id, b_id);
+            PTO2TaskId barrier_deps[] = {a_id, b_id};
+            args.set_dependencies(barrier_deps, 2);
             dummy_id = rt_submit_dummy_task(args).task_id();
         }
         // consumer: explicit dep on dummy, reads X
         {
             Arg args;
-            args.add_dep(dummy_id);
+            PTO2TaskId consumer_deps[] = {dummy_id};
+            args.set_dependencies(consumer_deps, 1);
             args.add_input(ext_X);
             args.add_inout(ext_Y);
             rt_submit_aic_task(FUNC_COPY_FIRST, args);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -22,10 +22,11 @@ The orchestration submits one of three scenes, controlled by params["case"]:
     and consumer. Looks after the dummy_ready_queue + dispatch-loop drain
     when several dummies sit on the critical path back-to-back.
 
-  case=3 (explicit add_dep barrier):
+  case=3 (explicit set_dependencies barrier):
     Two independent producers (writing X and W); a dummy_T uses
-    add_dep(A, B) as a many-to-one barrier; the consumer add_deps on dummy
-    and reads X. Verifies dummy_task participates in explicit_dep wiring.
+    set_dependencies({A, B}, 2) as a many-to-one barrier; the consumer
+    set_dependencies({dummy}, 1) and reads X. Verifies dummy_task
+    participates in explicit_dep wiring.
 """
 
 import torch

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -26,11 +26,11 @@
  *     consumer copies X -> Y
  *     expect Y[0] = 42.0 (no dummy runs a kernel; X must be undisturbed)
  *
- *   case=3: Dummy as many-to-one barrier via explicit add_dep.
+ *   case=3: Dummy as many-to-one barrier via explicit set_dependencies.
  *     producer_A writes X[0] = 42.0
  *     producer_B writes W[0] = 7.0
- *     dummy_T explicit add_dep(A.id, B.id)  // no tensor args, pure barrier
- *     consumer explicit add_dep(dummy.id), copies X -> Y
+ *     dummy_T explicit set_dependencies({A.id, B.id}, 2)  // pure barrier
+ *     consumer explicit set_dependencies({dummy.id}, 1), copies X -> Y
  *     expect Y[0] = 42.0 (consumer waits on dummy which waits on A+B)
  *
  * Args layout: [X, Y, W]
@@ -126,13 +126,15 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         PTO2TaskId dummy_id;
         {
             Arg args;
-            args.add_dep(a_id, b_id);
+            PTO2TaskId barrier_deps[] = {a_id, b_id};
+            args.set_dependencies(barrier_deps, 2);
             dummy_id = rt_submit_dummy_task(args).task_id();
         }
         // consumer: explicit dep on dummy, reads X
         {
             Arg args;
-            args.add_dep(dummy_id);
+            PTO2TaskId consumer_deps[] = {dummy_id};
+            args.set_dependencies(consumer_deps, 1);
             args.add_input(ext_X);
             args.add_inout(ext_Y);
             rt_submit_aic_task(FUNC_COPY_FIRST, args);

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -22,10 +22,11 @@ The orchestration submits one of three scenes, controlled by params["case"]:
     and consumer. Looks after the dummy_ready_queue + dispatch-loop drain
     when several dummies sit on the critical path back-to-back.
 
-  case=3 (explicit add_dep barrier):
+  case=3 (explicit set_dependencies barrier):
     Two independent producers (writing X and W); a dummy_T uses
-    add_dep(A, B) as a many-to-one barrier; the consumer add_deps on dummy
-    and reads X. Verifies dummy_task participates in explicit_dep wiring.
+    set_dependencies({A, B}, 2) as a many-to-one barrier; the consumer
+    set_dependencies({dummy}, 1) and reads X. Verifies dummy_task
+    participates in explicit_dep wiring.
 """
 
 import torch


### PR DESCRIPTION
Reworks the explicit-dependency API into two layers and lifts the previous hard cap on dependency count.

## Primitive layer — `Arg::set_dependencies(const PTO2TaskId*, uint32_t)`

- Takes a caller-owned dependency array (`ptr + count`) instead of variadic `PTO2TaskId`s, lifting the hard `PTO2_MAX_EXPLICIT_DEPS = 16` runtime cap
- `Arg` stores `(ptr, count)` without copying, matching `add_input` / `add_output` lifetime semantics — the caller's array must outlive the submit
- `count == 0` explicitly clears any stored deps, so conditionally-built dep arrays can pass through unguarded; `count > 0` is single-shot to preserve the no-accumulation
invariant
- Drops `ExplicitDepStorage` struct, `PTO2_MAX_EXPLICIT_DEPS` macro, and the a2a3 runtime/dep_gen `static_assert` — `DEP_GEN_MAX_EXPLICIT_DEPS = 16` is now a diagnostic-only
truncation cap, unchanged
- Updates `docs/manual-scope.md` (API, rules, examples)

## Convenience layer — `ArgWithDeps<N>` (default N=16)

A thin wrapper on top of the primitive layer that revives the previous `add_dep(...)` ergonomics for hand-written orchestration.

- New header `pto_arg_with_deps.h`, auto-included at the bottom of `pto_orchestration_api.h` so orchestration sources still need only one `#include`
- Private inheritance from `Arg` with selective `using`-declarations exposes the Arg setter surface (`add_input` / `add_output` / `add_inout` / `add_no_dep` / `add_scalar*` /
`has_error` / `error_msg` / `launch_spec`) while keeping `set_dependencies` and the `explicit_dep*` accessors **unreachable on a wrapper instance** — users cannot accidentally
mix the two dep APIs on the same object
- Variadic `add_dep(...)` accumulates into a stack-sized buffer of capacity `N`; overflow reports an error on the underlying Arg ("bump the template arg")
- `reset()` clears both layers; `finalize_for_submit()` is idempotent so a wrapper can be re-submitted without tripping the primitive layer's single-shot check
- New `rt_submit_task` / `rt_submit_aic_task` / `rt_submit_aiv_task` overloads accept `ArgWithDeps<N>&` and call `finalize_for_submit()` transparently — no caller-visible
finalize step
- pypto-generated orchestration can ignore the convenience layer entirely and target the primitive `set_dependencies(ptr, count)` directly

## Example migration

- 4 paged_attention orchestrations (a2a3 / a5 × manual_scope / unroll_manual_scope) migrated to the primitive layer
- `paged_attention_manual_scope` (both a2a3 and a5) further demonstrates **both layers side-by-side**: `params_sf` keeps `Arg + set_dependencies`, `params_up` switches to
`ArgWithDeps + add_dep`, each with a comment marking its intended use case
- `tests/st/{a2a3,a5}/.../dummy_task` (introduced by #754) migrated to `set_dependencies` as part of the refactor

## Verification

- a5sim: paged_attention manual_scope + unroll — PASS
- a2a3 hardware: paged_attention manual_scope (Case1, CaseSmall1), dummy_task (SingleDummyAutoDep, LongDummyChain, DummyExplicitDepBarrier) — PASS