### PR TITLE
Add: a5 AICore SIMT (mscatter) launch support

### DIFF
--- a/docs/simt-launch.md
+++ b/docs/simt-launch.md
@@ -1,0 +1,221 @@
+# a5 AICore SIMT Launch
+
+How the a5 onboard path runs AICore kernels that contain SIMT vector
+intrinsics (e.g. `mscatter`), and the two problems that had to be solved to
+get there. SIMT is currently an a5-only path. For the chip tiers and the
+three-program model this builds on, see
+[a5 hardware.md](../src/a5/docs/hardware.md) and
+[chip-level-arch.md](chip-level-arch.md).
+
+## The setup
+
+On a5 the registered AICore kernel is a thin **SU dispatcher**:
+`KERNEL_ENTRY(aicore_kernel)` in
+[onboard/aicore/kernel.cpp](../src/a5/platform/onboard/aicore/kernel.cpp) is a poll
+loop that calls `aicore_execute`, which jumps into the real per-task kernel
+code. Those per-task kernels — the ones that actually issue `mscatter` and
+other SIMT ops — are compiled separately (one `.cpp` per `func_id`, via
+`kernel_compiler.py`) into `CoreCallable` binaries and uploaded to device as
+children of a `ChipCallable` buffer.
+
+That split is what makes both problems below hard: the launch-time machinery
+(the dispatcher ELF, the host launch call) never sees a SIMT instruction —
+those live in the child binaries that are linked in only at runtime.
+
+## Problem 1 — the compiler won't tag the dispatcher as SIMT
+
+### What the hardware needs
+
+The legacy launch path (`rtRegisterAllKernel` + `rtKernelLaunchWithHandleV2`)
+reads two TLV records out of the kernel ELF's `.ascend.meta.<func>` NOTE
+section at register time:
+
+| TLV type | meaning | consumer |
+| -------- | ------- | -------- |
+| 7 (`COMPILER_ALLOC_UB_SIZE`) | UB (unified buffer) share-mem size | `Kernel::shareMemSize_` |
+| 12 (`AIV_TYPE_FLAG`) | SIMD / SIMT classification | `Kernel::kernelVfType_` |
+
+bisheng emits these **only when it statically sees a SIMT launch inside the
+kernel**. Our dispatcher entry has none (the SIMT ops are in the task `.o`
+files reached through `aicore_execute`), so left alone bisheng tags it
+`NO_VF` / `shareMemSize=0` and the SIMT path won't run.
+
+### The approach we rejected
+
+The first attempt hand-wrote the two TLV records into the section and added
+`-mllvm -cce-dyn-kernel-stack-size=false` to *suppress* bisheng's own
+auto-emission so the hand-written bytes survived runtime parse. It worked but
+was brittle: it couples us to the exact `.ascend.meta` byte layout, so any
+bisheng change to that layout would silently desync the record. It also forced
+us to manually pin `cfg.localMemorySize` to balance the UB budget (see below).
+
+### The approach we took — a compiler-visible VF anchor
+
+Reintroduce vector-unit usage the compiler *can* see, but never execute it, so
+bisheng classifies and emits the record itself. The anchor deliberately uses
+BOTH a SIMT launch and a SIMD op (see below for why). See
+[onboard/aicore/simt_anchor.h](../src/a5/platform/onboard/aicore/simt_anchor.h):
+
+```cpp
+// `static` is load-bearing — see the "no extra global entry" property below.
+static __simt_vf__ LAUNCH_BOUND(1024) __aicore__ void simt_meta_anchor_kernel(__gm__ uint32_t *sink) {
+    sink[threadIdx.x] = threadIdx.x;
+}
+__simd_vf__ __aicore__ void simd_meta_anchor_kernel(__ubuf__ uint32_t *ub) {
+    ub[0] = ub[0] + 1;
+}
+__attribute__((always_inline)) inline __aicore__ void simt_meta_anchor(__gm__ uint32_t *sink) {
+    cce::async_invoke<simt_meta_anchor_kernel>(cce::dim3{1, 1, 1}, sink);
+    simd_meta_anchor_kernel((__ubuf__ uint32_t *)0);
+}
+```
+
+`KERNEL_ENTRY` calls it under an always-false guard (AIV only):
+
+```cpp
+#ifdef __DAV_VEC__
+    if (k_args->force_simt_anchor) {           // always 0 at runtime
+        simt_meta_anchor(reinterpret_cast<__gm__ uint32_t *>(k_args));
+    }
+#endif
+```
+
+These properties make it work and keep it cheap:
+
+- **Built from cce compiler builtins, not pto-isa.** `cce::async_invoke`,
+  `cce::dim3`, `__simt_vf__`, `LAUNCH_BOUND`, `threadIdx` come from bisheng's
+  bundled `__clang_cce_*.h` headers (auto-included for `dav-c310-vec`).
+  `mscatter` itself lowers to exactly these builtins — pto-isa is only a
+  wrapper. So the a5 **platform runtime stays pto-isa-free**; only per-example
+  incore kernels pull pto-isa (via `kernel_compiler.py`).
+- **Survives dead-code elimination.** `force_simt_anchor` is a trailing field
+  in the a5 `KernelArgs` ([kernel_args.h](../src/a5/platform/include/common/kernel_args.h))
+  that the host always leaves 0. Because it is loaded from `__gm__` memory the
+  compiler cannot fold the branch away, so the SIMT launch reaches codegen.
+- **Tags the entry, not a helper.** The final link is `ld -r` (relocatable, not
+  LTO), so cross-TU inlining needs the definition visible at the call site —
+  hence a header with `always_inline`. Inlining lands the `async_invoke` inside
+  `KERNEL_ENTRY`, so the SIMT tag attaches to the entry's `.ascend.meta`
+  section, which is the one runtime reads.
+- **AIV only.** The anchor is `#ifdef __DAV_VEC__`; AIC carries no SIMT and
+  stays `NO_VF` naturally.
+- **Must classify as MIX, not SIMT-only.** A SIMT launch alone makes bisheng
+  emit `AIV_TYPE = SIMT_VF_ONLY (3)`. The shared SU dispatcher routes *both*
+  SIMD and SIMT task `.o` files, and a SIMT-only tag makes runtime reject every
+  SIMD launch through it — the whole a5 ST suite fails `107000` (param-invalid).
+  The `__simd_vf__` companion adds a SIMD VF op so bisheng emits
+  `SIMD_SIMT_MIX_VF (4)` instead. (`__simd_vf__` requires `__ubuf__` pointer
+  args — SIMD runs on UB — so the companion takes a never-dereferenced UB
+  pointer.)
+- **No extra global entry.** Without `static`, `__simt_vf__` (cce_simt_entry)
+  exports a GLOBAL `..._simt_entry` symbol. `rtRegisterAllKernel` registers the
+  whole ELF, so that symbol becomes a *second* launchable kernel beside the real
+  dispatcher entry — and that extra registration also fails the launch path with
+  `107000`. `static` gives the anchor kernel internal linkage; it never needs to
+  be launched (the branch is dead), only to exist at compile time, so the global
+  symbol drops while the meta tag stays. This is the one structural difference
+  from the old hand-written-bytes approach, which added no kernel code at all.
+
+### Why this also removes the manual UB-budget tuning
+
+Register-time check: `shareMemSize_ (TLV7) + cfg.localMemorySize ≤ 224 KB`
+(256 KB UB − 32 KB dcache). With the record auto-emitted, bisheng computes a
+shareMemSize (floor 8 KB) and the runtime auto-allocates AICore local memory
+from what's left. The host launch path therefore sets **nothing** — `cfg` is
+zero-initialized and `cfg.localMemorySize` stays 0, identical to a2a3
+([device_runner_base.cpp](../src/common/platform/onboard/host/device_runner_base.cpp)
+`launch_aicore_kernel`). No `aicore_local_memory_size()` virtual, no
+`PLATFORM_AICORE_LOCAL_MEMORY_SIZE` constant.
+
+### Verified
+
+`readelf` of the linked AIV binary shows bisheng auto-emits
+`.ascend.meta.aicore_kernel_0_mix_aiv` with **TLV7 = 0x2000 (8 KB)** and
+**TLV12 = 4 (`SIMD_SIMT_MIX_VF`)**, and the only GLOBAL kernel entry symbols are
+the two real dispatcher entries (no `..._simt_entry`); the AIC entry has no VF
+type tag. On hardware the full `st-onboard-a5` suite passes — both `simt_basic`
+and the non-SIMT workloads (bgemm, spmd, paged_attention, …) that the earlier
+SIMT-only / extra-global-symbol states broke with `107000`.
+
+## Problem 2 — the 16-byte alignment failure
+
+This is the subtle one, and the one that caused intermittent, confusing
+breakage.
+
+### Where the kernel binary lands on device
+
+A child kernel's binary code address on device is:
+
+```text
+chip_dev + offsetof(ChipCallable, storage_) + child_offset(i) + CoreCallable::binary_data_offset()
+```
+
+(see [chip_callable_layout.h](../src/common/task_interface/chip_callable_layout.h)
+`patch_chip_callable_scratch_for_device`). Of the four terms:
+
+- `chip_dev` — `rtMalloc` result, ≥512 B aligned (asserted ≥ `CALLABLE_ALIGN`).
+- `child_offset(i)` — `callable_align_up` → multiple of `CALLABLE_ALIGN` (64).
+- `binary_data_offset()` — rounds up to 64 → 128.
+
+Three of the four are already multiples of 64, hence 16-aligned. **Only
+`offsetof(ChipCallable, storage_)` decides the binary's final alignment.**
+
+### Why it was misaligned
+
+`ChipCallable`'s header is all `int32`/`uint32`/`char[]` fields
+([callable.h](../src/common/task_interface/callable.h)), so the natural offset
+of `storage_` is **8852 = 4 mod 8**. A SIMT instruction requires its operand /
+code address aligned more strictly than the 4 bytes the all-uint32 header
+yields — SIMT needs ≥8 B (and the next generation needs 16 B), versus SIMD's
+4 B. Binding a `const CoreCallable&` to a 4-mod-8 address is also undefined
+behaviour (the struct has a `uint64`), which UBSan flagged independently.
+
+This is exactly why the SIMT path "used to work, then silently broke": its
+correctness rode on whatever alignment `offsetof(storage_)` happened to have,
+and nothing pinned it.
+
+### How #979 "accidentally" fixed it — and why that wasn't enough
+
+PR #979 (`align Callable.storage_ for 8-byte child structs`) added
+`alignas(alignof(Child))` to `storage_` to fix the UBSan reference-binding
+report. `alignof(CoreCallable)` is 8 (it has a `uint64`), so `offsetof`
+moved **8852 → 8856 (8-aligned)**. That happened to satisfy the 8-byte SIMT
+requirement of the time — so our SIMT change started passing again without us
+touching it. But **8856 = 8 mod 16**: still only 8-byte aligned. The next SIMT
+instruction generation needs 16-byte alignment, which 8856 would again fail.
+
+### The fix — make it explicit and 16-byte
+
+Replace the implicit `alignof(Child)` with a named constant
+([arg_direction.h](../src/common/task_interface/arg_direction.h)):
+
+```cpp
+inline constexpr uint32_t CALLABLE_CHILD_ALIGN = 16;
+...
+alignas(CALLABLE_CHILD_ALIGN) char storage_[];   // callable.h
+```
+
+This moves `offsetof(storage_)` **8856 → 8864 (16-aligned)**, so the child
+kernel binary lands 16-byte aligned. Two `static_assert`s lock the invariant:
+`CALLABLE_CHILD_ALIGN >= alignof(CoreCallable)` (never under-align the child's
+`uint64` reference — keeps #979's fix) and
+`offsetof(ChipCallable, storage_) % CALLABLE_CHILD_ALIGN == 0`.
+
+Cost is +8 bytes per `ChipCallable` (header padding only; children are already
+64-B aligned, so no per-child padding is added), deduped once each — negligible.
+
+### `offsetof(ChipCallable, storage_)` across versions
+
+| state | alignment of `storage_` | `offsetof` | mod 16 | SIMT result |
+| ----- | ----------------------- | ---------- | ------ | ----------- |
+| pre-#979 | none | 8852 | 4 | 4-byte → misaligned, fails (and UB) |
+| #979 | `alignof(CoreCallable)` = 8 | 8856 | 8 | 8-byte → passes by luck; 16-byte SIMT would fail |
+| now | `CALLABLE_CHILD_ALIGN` = 16 | 8864 | 0 | 16-byte → robust |
+
+## What we deliberately did not change
+
+- **Host launch path** — unchanged from main; no manual `localMemorySize`.
+- **No bisheng suppression flag** — `CMakeLists.txt` is back to the default
+  build; bisheng's auto-emission is now what we rely on.
+- **No pto-isa dependency in the platform runtime** — the anchor uses only cce
+  compiler builtins.

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -102,6 +102,12 @@ struct KernelArgs {
     // mirroring the per-device simpler_inner preinstall fix. Trailing field —
     // keeps the CANN-fixed front offsets and AICore-read fields in place.
     uint32_t device_id{0};
+    // Opaque always-false guard read by the AICore SIMT meta anchor (AIV
+    // KERNEL_ENTRY). The host never sets it non-zero; its only purpose is to be
+    // a runtime-valued condition the compiler cannot constant-fold, so the
+    // never-executed SIMT launch in simt_anchor.h survives DCE and bisheng
+    // still classifies the entry as SIMT. Keep it last (trailing field).
+    uint32_t force_simt_anchor{0};
 };
 
 #ifdef __cplusplus

--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -18,6 +18,7 @@
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
 #include "common/pmu_profiling.h"
+#include "simt_anchor.h"
 
 class Runtime;
 
@@ -153,6 +154,17 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ KernelA
         set_aicore_pmu_ring(nullptr);
         set_aicore_pmu_reg_base(0);
     }
+
+#ifdef __DAV_VEC__
+    // SIMT classification anchor (AIV only). Never executes —
+    // `force_simt_anchor` is always 0 — but the compiler cannot prove the
+    // GM-loaded condition false, so the never-taken SIMT launch survives DCE
+    // and bisheng auto-emits this entry's SIMT meta TLVs (UB size + AIV type)
+    // that runtime reads at register time. See simt_anchor.h.
+    if (k_args->force_simt_anchor) {
+        simt_meta_anchor(reinterpret_cast<__gm__ uint32_t *>(k_args));
+    }
+#endif
 
     aicore_execute(k_args->runtime_args, block_idx, core_type);
 }

--- a/src/a5/platform/onboard/aicore/simt_anchor.h
+++ b/src/a5/platform/onboard/aicore/simt_anchor.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file simt_anchor.h
+ * @brief VF-classification anchor for the AICore kernel ELF (onboard / a5)
+ *
+ * bisheng auto-emits the two TLV records runtime reads at register time
+ * (RT_FUNCTION_TYPE_COMPILER_ALLOC_UB_SIZE (7) -> Kernel::shareMemSize_ and
+ * RT_FUNCTION_TYPE_AIV_TYPE_FLAG (12) -> Kernel::kernelVfType_) by statically
+ * classifying which vector functional units a kernel uses. Our KERNEL_ENTRY is
+ * an SU dispatcher whose vector ops live in separately compiled task .o files
+ * invoked through aicore_execute, so left alone bisheng tags it NO_VF.
+ *
+ * This anchor reintroduces (never-executed) VF ops so the classification fires,
+ * replacing the previous hand-written TLV record plus the
+ * `-cce-dyn-kernel-stack-size=false` auto-emit suppression flag. It deliberately
+ * uses BOTH a SIMT launch and a SIMD vector op so bisheng emits
+ * AIV_TYPE = SIMD_SIMT_MIX_VF (4), NOT SIMT_VF_ONLY (3): the shared SU
+ * dispatcher routes both SIMD and SIMT task .o files, and a SIMT-only tag makes
+ * runtime reject every SIMD launch through it (107000 param-invalid across the
+ * whole a5 ST suite — observed in CI). MIX matches the value the old
+ * hand-written record pinned on purpose.
+ *
+ * Letting bisheng own the record removes the silent-breakage risk of the old
+ * approach (a compiler change to the meta-section layout would desync the
+ * hand-written bytes); the UB size is whatever bisheng computes (8 KB floor).
+ *
+ * Built purely from bisheng/cce compiler builtins — cce::async_invoke /
+ * cce::dim3 (`__clang_cce_simt.h`), __simt_vf__ / __simd_vf__ / LAUNCH_BOUND
+ * (`__clang_cce_defines.h`), threadIdx (`__clang_cce_simt_builtin_vars.h`), all
+ * auto-included by ccec for the dav-c310-vec arch. No pto-isa dependency, so
+ * the a5 platform runtime build stays pto-isa-free (only per-example incore
+ * kernels pull pto-isa, via kernel_compiler.py).
+ */
+
+#ifndef PLATFORM_A5_AICORE_SIMT_ANCHOR_H_
+#define PLATFORM_A5_AICORE_SIMT_ANCHOR_H_
+
+#ifdef __DAV_VEC__
+
+#include <cstdint>
+
+// `__simt_vf__` (cce_simt_entry + noinline) marks this as the SIMT VF kernel
+// bisheng's meta-section pass keys on; the threadIdx read keeps it a genuine
+// vector-thread body so the kernel is not folded away.
+//
+// `static` is load-bearing: without it cce_simt_entry exports a GLOBAL
+// `..._simt_entry` symbol, which rtRegisterAllKernel registers as a second
+// launchable kernel alongside the real dispatcher entry — that extra
+// registration fails the whole a5 launch path with 107000 (param-invalid). The
+// anchor branch never executes (force_simt_anchor is always 0), so the kernel
+// only needs to exist at compile time for classification; internal linkage
+// drops the global symbol while keeping the SIMT meta tag.
+static __simt_vf__ LAUNCH_BOUND(1024) __aicore__ void simt_meta_anchor_kernel(__gm__ uint32_t *sink) {
+    sink[threadIdx.x] = threadIdx.x;
+}
+
+// SIMD VF companion: marks the entry as also using the SIMD vector unit so
+// bisheng classifies it SIMD_SIMT_MIX_VF(4) rather than SIMT_VF_ONLY(3). The
+// shared SU dispatcher routes both SIMD and SIMT task .o files, so the entry
+// must advertise MIX or runtime rejects SIMD launches (107000 param-invalid).
+__simd_vf__ __aicore__ void simd_meta_anchor_kernel(__ubuf__ uint32_t *ub) { ub[0] = ub[0] + 1; }
+
+// always_inline so the async_invoke lands inside KERNEL_ENTRY's own body — the
+// final link is `ld -r` (relocatable, not LTO), so cross-TU inlining requires
+// the definition to be visible at the call site. Inlining is what attaches the
+// SIMT tag to the *entry* function's `.ascend.meta` section, which is the one
+// runtime reads at register time.
+__attribute__((always_inline)) inline __aicore__ void simt_meta_anchor(__gm__ uint32_t *sink) {
+    cce::async_invoke<simt_meta_anchor_kernel>(cce::dim3{1, 1, 1}, sink);
+    simd_meta_anchor_kernel((__ubuf__ uint32_t *)0);
+}
+
+#endif  // __DAV_VEC__
+
+#endif  // PLATFORM_A5_AICORE_SIMT_ANCHOR_H_

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -36,6 +36,18 @@ inline constexpr int CORE_MAX_SCALAR_ARGS = 32;
 inline constexpr int CHIP_MAX_SCALAR_ARGS = 128;
 inline constexpr uint32_t CALLABLE_ALIGN = 64;
 
+// Minimum alignment of a child kernel binary's device address within a
+// ChipCallable. The device address is
+//   chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+//            + CoreCallable::binary_data_offset()
+// and child_offset / binary_data_offset are already CALLABLE_ALIGN (64)
+// multiples, so this value only constrains offsetof(storage_). It is driven
+// by the strictest device-side fetch requirement: a5 SIMT vector intrinsics
+// (e.g. mscatter) require a 16-byte-aligned code address. Must stay >=
+// alignof(CoreCallable) (8, from its uint64 resolved_addr_) so aligning
+// storage_ to it never weakens child reference alignment. Powers of two only.
+inline constexpr uint32_t CALLABLE_CHILD_ALIGN = 16;
+
 static inline uint32_t callable_align_up(uint32_t size) { return (size + CALLABLE_ALIGN - 1) & ~(CALLABLE_ALIGN - 1); }
 
 inline const char *arg_direction_name(ArgDirection d) {

--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -110,9 +110,12 @@ struct Callable {
     // Children live in storage_ at CALLABLE_ALIGN-aligned offsets, but the
     // all-uint32 header above can leave offsetof(storage_) at 4-mod-8, which
     // would place an 8-byte-aligned Child (CoreCallable has a uint64) on a
-    // misaligned address — UB on reference binding (caught by UBSan). Align
-    // storage_ to the child's alignment so every child lands aligned.
-    alignas(alignof(Child)) char storage_[];
+    // misaligned address — UB on reference binding (caught by UBSan). It can
+    // also leave it at 8-mod-16, which under-aligns a5 SIMT kernel binaries
+    // (mscatter et al. require a 16-byte-aligned code address). Align storage_
+    // to CALLABLE_CHILD_ALIGN (>= alignof(Child)) so every child — and the
+    // kernel binary inside it — lands at the strictest required alignment.
+    alignas(CALLABLE_CHILD_ALIGN) char storage_[];
 
     ArgDirection sig(int32_t i) const {
         if (i < 0 || i >= sig_count_) throw std::out_of_range("Callable: sig index out of range");
@@ -158,13 +161,19 @@ private:
 using CoreCallable = Callable<void, CORE_MAX_TENSOR_ARGS, 0>;
 using ChipCallable = Callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>;
 
-// storage_ holds CoreCallable children at CALLABLE_ALIGN-aligned offsets; for
-// child() to bind a reference without UB, storage_ itself must be aligned for
-// CoreCallable (which has a uint64 -> alignof 8). The alignas on storage_
-// guarantees this; assert it so a future header tweak can't silently regress.
+// storage_ holds CoreCallable children at CALLABLE_ALIGN-aligned offsets; the
+// child kernel binary's device address is offsetof(storage_) + child_offset +
+// CoreCallable::binary_data_offset(). The latter two are CALLABLE_ALIGN (64)
+// multiples, so storage_ alignment alone decides the binary's alignment.
+// CALLABLE_CHILD_ALIGN (16) must cover both: child() reference binding without
+// UB (needs alignof(CoreCallable) = 8) and a5 SIMT kernel-binary fetch (needs
+// 16). Assert both invariants so a future header tweak can't silently regress.
 static_assert(
-    offsetof(ChipCallable, storage_) % alignof(CoreCallable) == 0,
-    "ChipCallable.storage_ must be aligned for its CoreCallable children"
+    CALLABLE_CHILD_ALIGN >= alignof(CoreCallable), "CALLABLE_CHILD_ALIGN must not under-align CoreCallable children"
+);
+static_assert(
+    offsetof(ChipCallable, storage_) % CALLABLE_CHILD_ALIGN == 0,
+    "ChipCallable.storage_ must be CALLABLE_CHILD_ALIGN-aligned for SIMT kernel binaries"
 );
 
 // ============================================================================

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/aiv/kernel_simt_scatter.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/aiv/kernel_simt_scatter.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+// Minimal SIMT element-scatter kernel (AIV), structurally mirroring
+// pto-isa's runElem2D template (tests/npu/a5/src/st/testcase/mscatter/
+// mscatter_kernel.cpp) so the MSCATTER call sees the same Shape /
+// Stride / Tile / sync surroundings that the upstream ST validates
+// against.
+//
+// Operation: out[idx[r, c]] = src[r, c] for an 8x32 source and 256-slot
+// destination.
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+#include "pipe_sync.h"
+
+using namespace pto;
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr int TILE_ROWS = 8;
+static constexpr int TILE_COLS = 32;
+static constexpr int DST_LEN = TILE_ROWS * TILE_COLS;  // 256
+static constexpr int SRC_TILE_BYTES = TILE_ROWS * TILE_COLS * sizeof(float);
+
+static __aicore__ void simt_scatter_impl(__gm__ float *src, __gm__ int32_t *idx, __gm__ float *out) {
+    // No explicit set_mask_norm / set_vector_mask: pto-isa's mscatter ST does
+    // not call them either. MSCATTER is `__simt_callee__`; bisheng inlines
+    // the SIMT-side mask setup at every call site, so the vec mask state
+    // is owned by MSCATTER itself rather than by the host kernel.
+
+    // Follow pto-isa's runElem2D structure: Shape/Stride descriptors,
+    // static-Valid-extents Tile, single-tile binding, idx-then-src TASSIGN
+    // and TLOAD order, and the MTE2->V sync before MSCATTER. The post-MSCATTER
+    // tail uses the repo's pipe_sync() helper (drains MTE3->S on AIV) rather
+    // than runElem2D's pipe_barrier(PIPE_ALL) + V->MTE3.
+    using SrcShape = pto::Shape<1, 1, 1, TILE_ROWS, TILE_COLS>;
+    using SrcStride = pto::Stride<1, 1, 1, TILE_COLS, 1>;
+    using IdxShape = pto::Shape<1, 1, 1, TILE_ROWS, TILE_COLS>;
+    using IdxStride = pto::Stride<1, 1, 1, TILE_COLS, 1>;
+    using OutShape = pto::Shape<1, 1, 1, 1, DST_LEN>;
+    using OutStride = pto::Stride<1, 1, 1, DST_LEN, 1>;
+
+    GlobalTensor<float, SrcShape, SrcStride> srcGlobal(src);
+    GlobalTensor<int32_t, IdxShape, IdxStride> idxGlobal(idx);
+    GlobalTensor<float, OutShape, OutStride> outGlobal(out);
+
+    using SrcTile = Tile<TileType::Vec, float, TILE_ROWS, TILE_COLS, BLayout::RowMajor, TILE_ROWS, TILE_COLS>;
+    using IdxTile = Tile<TileType::Vec, int32_t, TILE_ROWS, TILE_COLS, BLayout::RowMajor, TILE_ROWS, TILE_COLS>;
+
+    SrcTile srcTile;
+    IdxTile idxTile;
+
+    constexpr int idxBytes = ((TILE_ROWS * TILE_COLS * static_cast<int>(sizeof(int32_t)) + 31) / 32) * 32;
+    TASSIGN(idxTile, 0x0);
+    TASSIGN(srcTile, idxBytes);
+
+    TLOAD(idxTile, idxGlobal);
+    TLOAD(srcTile, srcGlobal);
+
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // Element-scatter on both sim and onboard. The CPU sim backend exposes
+    // only a non-templated MSCATTER whose impl is already per-element, while
+    // the a5 onboard backend defaults the non-templated form to Coalesce::Row
+    // and gates the templated overloads behind PTO_NPU_ARCH_A5, so onboard
+    // must select Coalesce::Elem explicitly. See pto-isa#164.
+#ifdef __CPU_SIM
+    MSCATTER(outGlobal, srcTile, idxTile);
+#else
+    MSCATTER<Coalesce::Elem, ScatterAtomicOp::None, ScatterOOB::Skip>(outGlobal, srcTile, idxTile);
+#endif
+
+    pipe_sync();
+}
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+
+    __gm__ Tensor *idx_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ int32_t *idx = reinterpret_cast<__gm__ int32_t *>(idx_tensor->buffer.addr) + idx_tensor->start_offset;
+
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    simt_scatter_impl(src, idx, out);
+}

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * SIMT basic orchestration: submit a single AIV SIMT scatter task.
+ *
+ * Args layout: [src, indices, out]
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+#define FUNC_SIMT_SCATTER 0
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor src = from_tensor_arg(orch_args.tensor(0));
+    Tensor indices = from_tensor_arg(orch_args.tensor(1));
+    Tensor out = from_tensor_arg(orch_args.tensor(2));
+
+    // PTO2_SCOPE ensures rt_submit_aiv_task flushes through the task
+    // ringbuffer before the entry returns. No set_core_num — let the
+    // runtime use the config's block_dim.
+    PTO2_SCOPE() {
+        Arg args;
+        args.add_input(src);
+        args.add_input(indices);
+        args.add_output(out);
+        rt_submit_aiv_task(FUNC_SIMT_SCATTER, args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/test_simt_basic.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/test_simt_basic.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""SIMT basic element-scatter: minimal AIV scatter kernel that exercises the SIMT launch path.
+
+Config: block_dim=3, aicpu_thread_num=4, sequential identity indices.
+Identity indices keep the golden trivially src-equals-out so a failure
+here points at the SIMT launch path itself (TLV injection, localMemorySize
+budget, sync) rather than at the scatter index semantics.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+TILE_ROWS = 8
+TILE_COLS = 32
+SRC_ELEMS = TILE_ROWS * TILE_COLS  # 256
+DST_LEN = SRC_ELEMS  # 256
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestSimtBasic(SceneTestCase):
+    RTOL = 1e-5
+    ATOL = 1e-5
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/simt_basic_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "SIMT_SCATTER",
+                "source": "kernels/aiv/kernel_simt_scatter.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "Case1",
+            "platforms": ["a5", "a5sim"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        }
+    ]
+
+    def generate_args(self, params):
+        torch.manual_seed(0)
+        src = torch.randn(SRC_ELEMS, dtype=torch.float32)
+        # Identity indices (0..DST_LEN-1) make the golden trivially
+        # `out == src`. Switch to torch.randperm later once the baseline
+        # launch path is confirmed green.
+        indices = torch.arange(DST_LEN, dtype=torch.int32)
+        out = torch.zeros(DST_LEN, dtype=torch.float32)
+        return TaskArgsBuilder(
+            Tensor("src", src),
+            Tensor("indices", indices),
+            Tensor("out", out),
+        )
+
+    def compute_golden(self, args, params):
+        args.out.zero_()
+        args.out[args.indices.to(torch.int64)] = args.src
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
Enables the a5 AICore path to run kernels containing SIMT vector intrinsics (`mscatter` et al.), exercised by a new `simt_basic` ST. Full design write-up in [docs/simt-launch.md](docs/simt-launch.md).

## What this solves

The legacy launch path (`rtRegisterAllKernel` + `rtKernelLaunchWithHandleV2`) needs two things the compiler can't infer for our SU-dispatcher entry, plus a correct child-binary alignment — all without hand-written ELF bytes or pulling pto-isa into the platform runtime.

### 1. VF classification via a compiler-visible anchor

Runtime reads two TLVs from the kernel ELF's `.ascend.meta` section at register time (UB-size 7 → `shareMemSize_`, AIV-type 12 → `kernelVfType_`). bisheng emits them only when it statically sees vector-unit usage; `KERNEL_ENTRY` dispatches into separately compiled task `.o` files, so it sees none. A never-executed VF anchor (`simt_anchor.h`, AIV-only, cce compiler builtins only) makes bisheng classify and emit the record itself. Three properties are load-bearing, each learned from an a5 ST failure:

- **MIX, not SIMT-only.** A SIMT launch alone → `SIMT_VF_ONLY (3)`; the shared dispatcher routes SIMD task `.o` too, so runtime then rejects every SIMD launch (`107000` param-invalid). A `__simd_vf__` companion → `SIMD_SIMT_MIX_VF (4)`.
- **`static` on the `__simt_vf__` kernel.** Without it `cce_simt_entry` exports a GLOBAL `..._simt_entry` symbol that `rtRegisterAllKernel` registers as a second launchable kernel → `107000`. The branch is dead, so internal linkage drops the symbol while keeping the meta tag.
- **DCE-proof guard.** `KernelArgs::force_simt_anchor` (trailing, always 0, but GM-loaded so the branch can't be folded away).

With the record auto-emitted (UB-size floor 8 KB) the runtime auto-allocates AICore local memory — `cfg.localMemorySize` stays 0 (as on a2a3), no manual pinning.

### 2. 16-byte child-kernel alignment

A SIMT kernel binary's device address is `offsetof(ChipCallable, storage_) + child_offset + binary_data_offset`; the latter two are 64B multiples, so only `storage_` alignment matters. #979 reached 8B (`alignof(CoreCallable)`); this raises it to a named `CALLABLE_CHILD_ALIGN` (16) so the binary lands 16B aligned, asserted to never under-align the child `uint64` reference.

## Verified

`readelf` of the linked AIV binary: `TLV7 = 8 KB`, `TLV12 = 4 (MIX_VF)`, no extra GLOBAL `_simt_entry` symbol, AIC entry has no VF tag. On hardware the full `st-onboard-a5` suite passes — `simt_basic` plus the non-SIMT workloads (bgemm, spmd, paged_attention, …) that the SIMT-only / extra-global-symbol states broke with `107000`.