### PR TITLE
Refactor: drop vestigial orch_built_on_host flag

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -233,9 +233,6 @@ public:
      */
     Runtime();
 
-    // Orchestration is always built on the host for this runtime
-    bool get_orch_built_on_host() const { return true; }
-
     // =========================================================================
     // Task Management
     // =========================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -212,9 +212,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         uint64_t orch_cycle_start = 0;
         int32_t pto2_submitted_tasks = -1;
 #endif
-        if (runtime->get_orch_built_on_host()) {
-            LOG_INFO_V0("Thread %d: Host orchestration mode, no-op", thread_idx);
-        } else {
+        // Orchestrator thread: load + run the device orchestration SO. The braces
+        // scope the per-callable dlopen / SO-table locals to this block.
+        {
             // Per-callable_id dispatch: the orch SO state lives in
             // `orch_so_table_[callable_id]` keyed by registration order;
             // reload is governed by `register_new_callable_id_`.
@@ -658,11 +658,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
     if (!sched_ctx_.is_completed() && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
-        // Device orchestration: wait for primary orchestrator to initialize SM header
-        if (!runtime->get_orch_built_on_host()) {
-            while (!runtime_init_ready_.load(std::memory_order_acquire)) {
-                SPIN_WAIT_HINT();
-            }
+        // Device orchestration: wait for the primary orchestrator to initialize the SM header
+        while (!runtime_init_ready_.load(std::memory_order_acquire)) {
+            SPIN_WAIT_HINT();
         }
         if (rt == nullptr) {
             LOG_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
@@ -695,7 +693,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
         // alive for the next run's cache-hit reuse (see run() reload_so branch).
-        if (!runtime->get_orch_built_on_host() && rt != nullptr) {
+        if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
             const int32_t callable_id = runtime->get_active_callable_id();
             framework_bind_runtime(nullptr);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -292,7 +292,6 @@ extern "C" int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorage
     runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
 
     // Set up device orchestration state
-    runtime->set_orch_built_on_host(false);
     runtime->set_orch_args(device_args);
 
     LOG_INFO_V0("Device orchestration ready: %d tensors + %d scalars", tensor_count, scalar_count);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -179,8 +179,6 @@ private:
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
 
-    // Device orchestration: when false, orchestration runs on device (thread 3)
-    bool orch_built_on_host_;
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
     void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
     void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
@@ -238,11 +236,9 @@ public:
     // Device orchestration (for AICPU thread 3)
     // =========================================================================
 
-    bool get_orch_built_on_host() const;
     void *get_gm_sm_ptr() const;
     void *get_gm_heap_ptr() const;
     const ChipStorageTaskArgs &get_orch_args() const;
-    void set_orch_built_on_host(bool v);
     void set_gm_sm_ptr(void *p);
     void set_gm_heap(void *p);
     void set_slot_states_ptr(void *p);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -840,8 +840,8 @@ int32_t SchedulerContext::init(
     }
     completed_tasks_.store(0, std::memory_order_release);
 
-    // Host orchestration: graph already built; device orch: orchestrator sets it.
-    orchestrator_done_ = runtime->get_orch_built_on_host();
+    // Device orchestration: the orchestrator thread flips this when the graph is built.
+    orchestrator_done_ = false;
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -43,7 +43,6 @@ Runtime::Runtime() {
     tensor_pair_count = 0;
 
     // Initialize device orchestration state
-    orch_built_on_host_ = true;
     gm_sm_ptr_ = nullptr;
     gm_heap_ptr_ = nullptr;
     slot_states_ptr_ = nullptr;
@@ -92,11 +91,9 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // Device orchestration
 // =============================================================================
 
-bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
 void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
 void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
 const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
-void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
 void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
 void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
 void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -247,9 +247,6 @@ public:
      */
     Runtime();
 
-    // Orchestration is always built on the host for this runtime
-    bool get_orch_built_on_host() const { return true; }
-
     // =========================================================================
     // Task Management
     // =========================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -211,9 +211,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         uint64_t orch_cycle_start = 0;
         int32_t submitted_tasks = -1;
 #endif
-        if (runtime->get_orch_built_on_host()) {
-            LOG_INFO_V0("Thread %d: Host orchestration mode, no-op", thread_idx);
-        } else {
+        // Orchestrator thread: load + run the device orchestration SO. The braces
+        // scope the per-callable dlopen / SO-table locals to this block.
+        {
             // Per-callable_id dispatch: the orch SO state lives in
             // `orch_so_table_[callable_id]` keyed by registration order;
             // reload is governed by `register_new_callable_id_`.
@@ -647,11 +647,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Scheduler thread (orchestrator threads skip dispatch when orch_to_sched_ is false)
     if (!sched_ctx_.is_completed() && (thread_idx < sched_thread_num_ || orch_to_sched_)) {
-        // Device orchestration: wait for primary orchestrator to initialize SM header
-        if (!runtime->get_orch_built_on_host()) {
-            while (!runtime_init_ready_.load(std::memory_order_acquire)) {
-                SPIN_WAIT_HINT();
-            }
+        // Device orchestration: wait for the primary orchestrator to initialize the SM header
+        while (!runtime_init_ready_.load(std::memory_order_acquire)) {
+            SPIN_WAIT_HINT();
         }
         if (rt == nullptr) {
             LOG_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
@@ -684,7 +682,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
         // alive for the next run's cache-hit reuse (see run() reload_so branch).
-        if (!runtime->get_orch_built_on_host() && rt != nullptr) {
+        if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
             const int32_t callable_id = runtime->get_active_callable_id();
             framework_bind_runtime(nullptr);

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -292,7 +292,6 @@ extern "C" int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorage
     runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
 
     // Set up device orchestration state
-    runtime->set_orch_built_on_host(false);
     runtime->set_orch_args(device_args);
 
     LOG_INFO_V0("Device orchestration ready: %d tensors + %d scalars", tensor_count, scalar_count);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -193,8 +193,6 @@ private:
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
 
-    // Device orchestration: when false, orchestration runs on device (thread 3)
-    bool orch_built_on_host_;
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
     void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
     void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
@@ -252,11 +250,9 @@ public:
     // Device orchestration (for AICPU thread 3)
     // =========================================================================
 
-    bool get_orch_built_on_host() const;
     void *get_gm_sm_ptr() const;
     void *get_gm_heap_ptr() const;
     const ChipStorageTaskArgs &get_orch_args() const;
-    void set_orch_built_on_host(bool v);
     void set_gm_sm_ptr(void *p);
     void set_gm_heap(void *p);
     void set_slot_states_ptr(void *p);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -832,8 +832,8 @@ int32_t SchedulerContext::init(
     }
     completed_tasks_.store(0, std::memory_order_release);
 
-    // Host orchestration: graph already built; device orch: orchestrator sets it.
-    orchestrator_done_ = runtime->get_orch_built_on_host();
+    // Device orchestration: the orchestrator thread flips this when the graph is built.
+    orchestrator_done_ = false;
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -45,7 +45,6 @@ Runtime::Runtime() {
     tensor_pair_count = 0;
 
     // Initialize device orchestration state
-    orch_built_on_host_ = true;
     gm_sm_ptr_ = nullptr;
     gm_heap_ptr_ = nullptr;
     slot_states_ptr_ = nullptr;
@@ -94,11 +93,9 @@ void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 // Device orchestration
 // =============================================================================
 
-bool Runtime::get_orch_built_on_host() const { return orch_built_on_host_; }
 void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
 void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
 const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
-void Runtime::set_orch_built_on_host(bool v) { orch_built_on_host_ = v; }
 void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
 void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
 void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }


### PR DESCRIPTION
## Summary

`Runtime::orch_built_on_host_` used to distinguish the host-built-graph runtime
from the (since removed, #701) `aicpu_build_graph` one. With only
`host_build_graph` and `tensormap_and_ringbuffer` left it is a per-runtime
constant, and after #760 removed the last platform-layer caller it is also
unreferenced outside the runtime internals. This drops it:

- **`host_build_graph`** (a2a3 + a5): `get_orch_built_on_host()` was hard-coded
  to `true` and has no callers — deleted.
- **`tensormap_and_ringbuffer`** (a2a3 + a5): `bind_prepared_to_runtime_impl`
  unconditionally sets the flag to `false` before the runtime struct reaches
  any reader (the ctor's `= true` was always overwritten first), so every
  `get_orch_built_on_host()` site already took the device-orchestration path.
  Inlined that:
  - drop the `orch_built_on_host_` field + getter + setter (`runtime.h`,
    `runtime/shared/runtime.cpp`) and the `set_orch_built_on_host(false)` call
    in `host/runtime_maker.cpp`;
  - `aicpu/aicpu_executor.cpp`: the `if (get_orch_built_on_host()) { /* host
    orchestration, no-op */ } else { ... }` becomes a plain scope (kept as a
    block so the per-callable dlopen / SO-table locals stay scoped); the
    SM-header spin-wait and the `rt`-destroy guard lose their always-true
    `!get_orch_built_on_host()` prefix;
  - `runtime/scheduler/scheduler_cold_path.cpp`: `orchestrator_done_` init
    becomes a literal `false`.

**No behavior change** — every removed branch was statically unreachable.

## Testing

- [x] a2a3 + a5 **sim** `libhost_runtime.so` (both runtimes) rebuild cleanly;
      pre-commit (clang-format, clang-tidy, cpplint) passes.
- [ ] Hardware: a2a3 + a5 `tensormap_and_ringbuffer` ST (e.g. an AICPU-orch
      example) still runs to completion — the touched code is the AICPU
      executor's orchestrator/scheduler path.