### PR TITLE
Refactor: clean up callable glue layer (4 commits)

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -274,54 +274,36 @@ def _ensure_prepared(cw, registry, prepared, cid: int, *, lazy: bool, device_id:
     prepared.add(cid)
 
 
-def _chip_process_loop(
+def _run_chip_main_loop(
+    cw: ChipWorker,
     buf: memoryview,
-    bins,
+    mailbox_addr: int,
+    state_addr: int,
     device_id: int,
     registry: dict,
-    log_level: int = 1,
-    log_info_v: int = 5,
+    *,
+    on_task_done_success=None,
 ) -> None:
-    """Runs in forked child process. Loads host_runtime.so in own address space.
+    """Unified TASK_READY / CONTROL_REQUEST / SHUTDOWN state machine.
 
-    Reads the unified mailbox layout (same offsets as _sub_worker_loop, but
-    this loop also consumes config fields + args_blob).
+    Used by both ``_chip_process_loop`` (no extra side effects on task
+    success) and ``_chip_process_loop_with_bootstrap`` (flushes
+    ``store_to_host`` buffers before publishing TASK_DONE).
 
-    `log_level` / `log_info_v` are the parent's snapshot of the simpler logger
-    (computed via `_log.get_current_config()`); the child cannot read the
-    parent's logger after fork, so the values are passed explicitly.
+    `on_task_done_success`, if provided, is invoked after a successful
+    ``run_prepared_from_blob`` and before publishing TASK_DONE. It must
+    return ``(code, msg)`` — typically ``(0, "")`` on success, or an
+    error tuple if the hook itself failed (e.g. D2H staging error).
+    Returning a non-zero code overrides the kernel's success.
 
-    Per-callable_id dispatch: TASK_READY carries a cid in OFF_CALLABLE; the
-    child looks the cid up in the COW-inherited Python ``registry`` to get
-    the ChipCallable, calls ``cw.prepare_callable(cid, callable)`` once,
-    then ``cw.run_prepared(cid, args, cfg)``.  ``_CTRL_PREPARE`` is the
-    explicit pre-warm path (parent pushes after init() to amortise the
-    first H2D upload).
+    Per-callable_id dispatch: TASK_READY carries a cid in OFF_CALLABLE;
+    the child looks the cid up in the COW-inherited Python ``registry``
+    to get the ChipCallable, calls ``cw.prepare_callable(cid, callable)``
+    once, then ``cw.run_prepared(cid, args, cfg)``. ``_CTRL_PREPARE`` is
+    the explicit pre-warm path (parent pushes after init() to amortise
+    the first H2D upload); TASK_READY also lazy-prepares as a safety net.
     """
-    import traceback as _tb  # noqa: PLC0415
-
-    try:
-        cw = ChipWorker()
-        cw.init(device_id, bins, log_level=log_level, log_info_v=log_info_v)
-    except Exception as e:
-        _tb.print_exc()
-        # Write the message so any parent reader that *does* inspect this
-        # path sees the real cause. State handshake for this init-time
-        # failure is broken — see KNOWN_ISSUES.md — and that is not part
-        # of the L4 scope.
-        _write_error(buf, 1, _format_exc(f"chip_process dev={device_id} init", e))
-        return
-
-    mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
-    state_addr = mailbox_addr + _OFF_STATE
-    sys.stderr.write(f"[chip_process pid={os.getpid()} dev={device_id}] ready\n")
-    sys.stderr.flush()
-
-    # Per-child set of cids already prepared on this device.  The parent
-    # pre-warms via _CTRL_PREPARE, but TASK_READY also lazy-prepares as a
-    # safety net (e.g. registrations that bypassed the prefetch path).
     prepared: set[int] = set()
-
     while True:
         state = _mailbox_load_i32(state_addr)
         if state == _TASK_READY:
@@ -341,6 +323,15 @@ def _chip_process_loop(
             except Exception as e:  # noqa: BLE001
                 code = 1
                 msg = _format_exc(f"chip_process dev={device_id}", e)
+
+            # On a successful kernel run, give the caller a chance to do
+            # post-run work (e.g. store_to_host D2H staging) before the
+            # parent sees TASK_DONE. The kernel's failure path skips the
+            # hook because the device output region is undefined and
+            # staging garbage would mask the real error in post-mortems.
+            if code == 0 and on_task_done_success is not None:
+                code, msg = on_task_done_success()
+
             _write_error(buf, code, msg)
             _mailbox_store_i32(state_addr, _TASK_DONE)
         elif state == _CONTROL_REQUEST:
@@ -374,11 +365,52 @@ def _chip_process_loop(
             _write_error(buf, code, msg)
             _mailbox_store_i32(state_addr, _CONTROL_DONE)
         elif state == _SHUTDOWN:
-            cw.finalize()
             break
 
 
-def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
+def _chip_process_loop(
+    buf: memoryview,
+    bins,
+    device_id: int,
+    registry: dict,
+    log_level: int = 1,
+    log_info_v: int = 5,
+) -> None:
+    """Runs in forked child process. Loads host_runtime.so in own address space.
+
+    `log_level` / `log_info_v` are the parent's snapshot of the simpler logger
+    (computed via `_log.get_current_config()`); the child cannot read the
+    parent's logger after fork, so the values are passed explicitly.
+
+    The main loop is delegated to ``_run_chip_main_loop`` — see its docstring
+    for the TASK_READY / CONTROL_REQUEST / SHUTDOWN state machine.
+    """
+    import traceback as _tb  # noqa: PLC0415
+
+    try:
+        cw = ChipWorker()
+        cw.init(device_id, bins, log_level=log_level, log_info_v=log_info_v)
+    except Exception as e:
+        _tb.print_exc()
+        # Write the message so any parent reader that *does* inspect this
+        # path sees the real cause. State handshake for this init-time
+        # failure is broken — see KNOWN_ISSUES.md — and that is not part
+        # of the L4 scope.
+        _write_error(buf, 1, _format_exc(f"chip_process dev={device_id} init", e))
+        return
+
+    mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
+    state_addr = mailbox_addr + _OFF_STATE
+    sys.stderr.write(f"[chip_process pid={os.getpid()} dev={device_id}] ready\n")
+    sys.stderr.flush()
+
+    try:
+        _run_chip_main_loop(cw, buf, mailbox_addr, state_addr, device_id, registry)
+    finally:
+        cw.finalize()
+
+
+def _chip_process_loop_with_bootstrap(
     buf: memoryview,
     bins,
     device_id: int,
@@ -393,12 +425,12 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
 
     The child constructs its own ``ChipBootstrapChannel`` wrapping the
     pre-fork shared-memory region, calls ``bootstrap_context`` (which
-    publishes SUCCESS/ERROR on the channel), and on success enters the same
-    task / control polling loop as ``_chip_process_loop``.  On any failure
-    before the main loop starts, the channel has already been written by the
-    callee and the function returns — the ``os._exit(0)`` in the fork
-    branch reaps the process without an extra non-zero exit code that would
-    confuse the parent's ``waitpid`` teardown.
+    publishes SUCCESS/ERROR on the channel), and on success enters the
+    shared task / control polling loop. On any failure before the main
+    loop starts, the channel has already been written by the callee and
+    the function returns — the ``os._exit(0)`` in the fork branch reaps
+    the process without an extra non-zero exit code that would confuse
+    the parent's ``waitpid`` teardown.
     """
     channel = ChipBootstrapChannel(bootstrap_mailbox_addr, max_buffer_count)
 
@@ -427,101 +459,44 @@ def _chip_process_loop_with_bootstrap(  # noqa: PLR0912, PLR0915
     # buffer with store_to_host=True.  Processed after every task completion
     # so the parent can read results from SharedMemory without a cross-fork
     # host-pointer copy_from (which is broken across processes).
-    _store_to_host: list[tuple[int, object]] = []
+    store_to_host: list[tuple[int, object]] = []
     for spec, ptr in zip(bootstrap_cfg.buffers, result.buffer_ptrs):
         if spec.store_to_host:
-            _store_to_host.append((ptr, bootstrap_cfg.output_staging(spec.name)))
+            store_to_host.append((ptr, bootstrap_cfg.output_staging(spec.name)))
 
     mailbox_addr = ctypes.addressof(ctypes.c_char.from_buffer(buf))
     state_addr = mailbox_addr + _OFF_STATE
     sys.stderr.write(f"[chip_process pid={os.getpid()} dev={device_id} bootstrap] ready\n")
     sys.stderr.flush()
 
-    # Per-child set of cids already prepared on this device.  Mirrors
-    # `_chip_process_loop`'s `prepared`.
-    prepared: set[int] = set()
+    def flush_store_to_host() -> tuple[int, str]:
+        # Runs *before* publishing TASK_DONE so the parent cannot observe
+        # the mailbox transition (and start reading the output
+        # SharedMemory) while the D2H DMA is still in flight.
+        for dev_ptr, staging in store_to_host:
+            # Skip zero-byte stagings up-front — mirrors the
+            # load_from_host H2D path in task_interface.py and avoids a
+            # spurious ValueError from ``ctypes.c_char.from_buffer`` on
+            # an empty buffer.
+            if staging.size == 0:
+                continue
+            try:
+                shm = SharedMemory(name=staging.shm_name)
+                try:
+                    shm_buf = shm.buf
+                    assert shm_buf is not None
+                    host_ptr = ctypes.addressof(ctypes.c_char.from_buffer(shm_buf))
+                    cw.copy_from(host_ptr, dev_ptr, staging.size)
+                finally:
+                    shm.close()
+            except Exception as e:  # noqa: BLE001
+                return 1, _format_exc(f"chip_process dev={device_id} store_to_host={staging.name!r}", e)
+        return 0, ""
 
     try:
-        while True:
-            state = _mailbox_load_i32(state_addr)
-            if state == _TASK_READY:
-                cid = int(struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]) & 0xFFFFFFFF
-                cfg = _read_config_from_mailbox(buf)
-
-                code = 0
-                msg = ""
-                try:
-                    _ensure_prepared(cw, registry, prepared, cid, lazy=True, device_id=device_id)
-                    # Hand the mailbox bytes straight to C++ (zero-copy zero-decode);
-                    # see the matching comment in `_chip_process_loop`.
-                    cw._impl.run_prepared_from_blob(cid, mailbox_addr + _OFF_ARGS, _MAILBOX_ARGS_CAPACITY, cfg)
-                except Exception as e:  # noqa: BLE001
-                    code = 1
-                    msg = _format_exc(f"chip_process dev={device_id}", e)
-
-                # Flush store_to_host buffers *before* publishing TASK_DONE so
-                # the parent cannot observe the mailbox transition (and start
-                # reading the output SharedMemory) while the D2H DMA is still
-                # in flight.  Only flush on a successful kernel run: on
-                # failure the device output region is undefined and stamping
-                # garbage into the parent's SharedMemory would mask the real
-                # error in any post-mortem.
-                if code == 0:
-                    for dev_ptr, staging in _store_to_host:
-                        # Skip zero-byte stagings up-front — mirrors the
-                        # load_from_host H2D path in task_interface.py and
-                        # avoids a spurious ValueError from
-                        # ``ctypes.c_char.from_buffer`` on an empty buffer.
-                        if staging.size == 0:
-                            continue
-                        try:
-                            shm = SharedMemory(name=staging.shm_name)
-                            try:
-                                shm_buf = shm.buf
-                                assert shm_buf is not None
-                                host_ptr = ctypes.addressof(ctypes.c_char.from_buffer(shm_buf))
-                                cw.copy_from(host_ptr, dev_ptr, staging.size)
-                            finally:
-                                shm.close()
-                        except Exception as e:  # noqa: BLE001
-                            code = 1
-                            msg = _format_exc(f"chip_process dev={device_id} store_to_host={staging.name!r}", e)
-                            break
-
-                _write_error(buf, code, msg)
-                _mailbox_store_i32(state_addr, _TASK_DONE)
-            elif state == _CONTROL_REQUEST:
-                sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
-                code = 0
-                msg = ""
-                try:
-                    if sub_cmd == _CTRL_MALLOC:
-                        size = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
-                        ptr = cw._impl.malloc(size)
-                        struct.pack_into("Q", buf, _CTRL_OFF_RESULT, ptr)
-                    elif sub_cmd == _CTRL_FREE:
-                        ptr = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
-                        cw._impl.free(ptr)
-                    elif sub_cmd == _CTRL_COPY_TO:
-                        dst = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
-                        src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
-                        n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
-                        cw._impl.copy_to(dst, src, n)
-                    elif sub_cmd == _CTRL_COPY_FROM:
-                        dst = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]
-                        src = struct.unpack_from("Q", buf, _CTRL_OFF_ARG1)[0]
-                        n = struct.unpack_from("Q", buf, _CTRL_OFF_ARG2)[0]
-                        cw._impl.copy_from(dst, src, n)
-                    elif sub_cmd == _CTRL_PREPARE:
-                        cid = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
-                        _ensure_prepared(cw, registry, prepared, cid, lazy=False, device_id=device_id)
-                except Exception as e:  # noqa: BLE001
-                    code = 1
-                    msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
-                _write_error(buf, code, msg)
-                _mailbox_store_i32(state_addr, _CONTROL_DONE)
-            elif state == _SHUTDOWN:
-                break
+        _run_chip_main_loop(
+            cw, buf, mailbox_addr, state_addr, device_id, registry, on_task_done_success=flush_store_to_host
+        )
     finally:
         # Teardown contract: release the comm handle before finalize so HCCL
         # state is torn down in LIFO order; the channel shm the parent may

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -988,19 +988,11 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(
-    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
-) {
-    if (out_host_orch_func_ptr == nullptr) {
-        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
-        return -1;
-    }
-    *out_host_orch_func_ptr = nullptr;
-
+BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return -1;
+        return {-1, nullptr};
     }
     const auto &state = it->second;
 
@@ -1011,20 +1003,19 @@ int DeviceRunner::bind_prepared_callable_to_runtime(
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return -1;
+            return {-1, nullptr};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    // hbg path: host_orch_func_ptr travels back to the c_api caller, which
-    // hands it to bind_prepared_to_runtime_impl. trb path: stays null and
-    // the device-side orch SO is resolved from the symbol names below.
-    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     // Stamp callable_id with is_new=false; prepare_orch_so refreshes the flag
     // with the authoritative first_sighting answer right before launch.
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return 0;
+    // hbg path: host_orch_func_ptr travels back to the c_api caller, which
+    // hands it to bind_prepared_to_runtime_impl. trb path: stays null and
+    // the device-side orch SO is resolved from the symbol names above.
+    return {0, state.host_orch_func_ptr};
 }
 
 int DeviceRunner::finalize() {

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -823,98 +823,41 @@ void DeviceRunner::print_handshake_results() {
 }
 
 int DeviceRunner::prepare_orch_so(Runtime &runtime) {
-    // Per-callable_id path: when run_prepared bound a known callable_id,
-    // the SO bytes were already H2D'd at prepare_callable time.
-    // We just stamp dev_orch_so on the runtime, plus mark `is_new` based on
-    // whether the AICPU has seen this id since registration.
+    // Prepared-callable flow only: the SO bytes were already H2D'd at
+    // prepare_callable time. Stamp dev_orch_so on the runtime and mark
+    // `is_new` based on whether the AICPU has seen this cid since
+    // registration.
     const int32_t cid = runtime.get_active_callable_id();
-    if (cid >= 0) {
-        auto it = prepared_callables_.find(cid);
-        if (it == prepared_callables_.end()) {
-            LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
-            return -1;
-        }
-        const auto &state = it->second;
-        // hbg variant: orch SO never crosses the host/device boundary, so the
-        // AICPU does no per-cid dlopen. Skip the orch_so_table_ bookkeeping
-        // (and the AICPU dlopen counter) and clear the device-orch metadata.
-        if (state.host_dlopen_handle != nullptr) {
-            runtime.set_dev_orch_so(0, 0);
-            runtime.set_active_callable_id(cid, /*is_new=*/false);
-            return 0;
-        }
-        const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
-        if (first_sighting) {
-            ++aicpu_dlopen_total_;
-        }
-        runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
-        // The c_api caller passed is_new=false; refresh with the authoritative
-        // first_sighting flag before AICPU consumes register_new_callable_id_.
-        runtime.set_active_callable_id(cid, first_sighting);
-        // Pending fields must be empty in the prepared path — runtime_maker's
-        // bind_prepared_to_runtime_impl never stages them. Defensive clear:
-        runtime.pending_orch_so_data_ = nullptr;
-        runtime.pending_orch_so_size_ = 0;
-        LOG_INFO_V0(
-            "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
-            first_sighting ? 1 : 0
-        );
-        return 0;
+    if (cid < 0) {
+        LOG_ERROR("prepare_orch_so: no active callable_id; prepared-callable flow required");
+        return -1;
     }
-
-    const void *host_so_data = runtime.pending_orch_so_data_;
-    const size_t host_so_size = runtime.pending_orch_so_size_;
-    runtime.pending_orch_so_data_ = nullptr;
-    runtime.pending_orch_so_size_ = 0;
-
-    if (host_so_data == nullptr || host_so_size == 0) {
-        // Host-orchestration mode (no device SO needed).
+    auto it = prepared_callables_.find(cid);
+    if (it == prepared_callables_.end()) {
+        LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
+        return -1;
+    }
+    const auto &state = it->second;
+    // hbg variant: orch SO never crosses the host/device boundary, so the
+    // AICPU does no per-cid dlopen. Skip the orch_so_table_ bookkeeping
+    // (and the AICPU dlopen counter) and clear the device-orch metadata.
+    if (state.host_dlopen_handle != nullptr) {
         runtime.set_dev_orch_so(0, 0);
+        runtime.set_active_callable_id(cid, /*is_new=*/false);
         return 0;
     }
-
-    const uint64_t new_hash = simpler::common::utils::elf_build_id_64(host_so_data, host_so_size);
-
-    if (new_hash == cached_orch_so_hash_ && dev_orch_so_buffer_ != nullptr) {
-        LOG_INFO_V0("Orch SO cache hit (hash=0x%lx, %zu bytes)", new_hash, host_so_size);
-        runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-        return 0;
+    const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
+    if (first_sighting) {
+        ++aicpu_dlopen_total_;
     }
-
-    if (host_so_size > dev_orch_so_capacity_) {
-        if (dev_orch_so_buffer_ != nullptr) {
-            mem_alloc_.free(dev_orch_so_buffer_);
-            dev_orch_so_buffer_ = nullptr;
-            dev_orch_so_capacity_ = 0;
-        }
-        dev_orch_so_buffer_ = mem_alloc_.alloc(host_so_size);
-        if (dev_orch_so_buffer_ == nullptr) {
-            LOG_ERROR("Failed to allocate %zu bytes for orchestration SO buffer", host_so_size);
-            cached_orch_so_hash_ = 0;
-            return -1;
-        }
-        dev_orch_so_capacity_ = host_so_size;
-    }
-
-    // Persist a host-side copy so the rtMemcpy source is independent from
-    // any Python ctypes buffer the caller may release as soon as run()
-    // returns. This is also what runtime_maker hands us by reference.
-    host_orch_so_copy_.assign(
-        static_cast<const uint8_t *>(host_so_data), static_cast<const uint8_t *>(host_so_data) + host_so_size
+    runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
+    // The c_api caller passed is_new=false; refresh with the authoritative
+    // first_sighting flag before AICPU consumes register_new_callable_id_.
+    runtime.set_active_callable_id(cid, first_sighting);
+    LOG_INFO_V0(
+        "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
+        first_sighting ? 1 : 0
     );
-
-    int rc = rtMemcpy(
-        dev_orch_so_buffer_, dev_orch_so_capacity_, host_orch_so_copy_.data(), host_so_size, RT_MEMCPY_HOST_TO_DEVICE
-    );
-    if (rc != 0) {
-        LOG_ERROR("rtMemcpy for orchestration SO failed: %d", rc);
-        cached_orch_so_hash_ = 0;
-        return rc;
-    }
-
-    cached_orch_so_hash_ = new_hash;
-    runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-    LOG_INFO_V0("Orch SO cache miss (hash=0x%lx, %zu bytes uploaded)", new_hash, host_so_size);
     return 0;
 }
 
@@ -1045,7 +988,15 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
+int DeviceRunner::bind_prepared_callable_to_runtime(
+    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
+) {
+    if (out_host_orch_func_ptr == nullptr) {
+        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
+        return -1;
+    }
+    *out_host_orch_func_ptr = nullptr;
+
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
@@ -1064,13 +1015,10 @@ int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t ca
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    // Replay both paths unconditionally — the runtime carries staging fields
-    // for both trb (device-side dlopen via entry-symbol names) and hbg (host-
-    // side dlopen handle + fn ptr). Whichever set was populated by
-    // register_prepared_callable / register_prepared_callable_host_orch wins;
-    // the other set stays at its initial value (empty string / nullptr).
-    runtime.pending_host_dlopen_handle_ = state.host_dlopen_handle;
-    runtime.pending_host_orch_func_ptr_ = state.host_orch_func_ptr;
+    // hbg path: host_orch_func_ptr travels back to the c_api caller, which
+    // hands it to bind_prepared_to_runtime_impl. trb path: stays null and
+    // the device-side orch SO is resolved from the symbol names below.
+    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     // Stamp callable_id with is_new=false; prepare_orch_so refreshes the flag

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -31,8 +31,8 @@
 #include "ascend_hal.h"
 #include "callable.h"
 #include "callable_protocol.h"
+#include "chip_callable_layout.h"
 #include "utils/elf_build_id.h"
-#include "utils/fnv1a_64.h"
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
 
@@ -1257,33 +1257,21 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
         return 0;
     }
 
-    // Compute total ChipCallable buffer size from contents (header + storage_
-    // used). Mirrors make_callable<>()'s layout math.
-    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
-    size_t storage_used = static_cast<size_t>(callable->binary_size());
-    for (int32_t i = 0; i < callable->child_count(); ++i) {
-        const CoreCallable &c = callable->child(i);
-        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
-        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
-        if (end > storage_used) storage_used = end;
-    }
-    const size_t total_size = kHeaderSize + storage_used;
+    const ChipCallableLayout layout = compute_chip_callable_layout(callable);
 
     // Content-hash dedup: identical bytes → return cached chip_dev.
-    const auto *raw_bytes = reinterpret_cast<const uint8_t *>(callable);
-    const uint64_t hash = simpler::common::utils::fnv1a_64(raw_bytes, total_size);
-    auto it = chip_callable_buffers_.find(hash);
+    auto it = chip_callable_buffers_.find(layout.content_hash);
     if (it != chip_callable_buffers_.end()) {
         LOG_DEBUG(
             "Chip callable dedup hit: chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev, it->second.total_size,
-            hash
+            layout.content_hash
         );
         return it->second.chip_dev;
     }
 
-    void *gm_addr = mem_alloc_.alloc(total_size);
+    void *gm_addr = mem_alloc_.alloc(layout.total_size);
     if (gm_addr == nullptr) {
-        LOG_ERROR("Failed to allocate device GM for ChipCallable buffer (size=%zu)", total_size);
+        LOG_ERROR("Failed to allocate device GM for ChipCallable buffer (size=%zu)", layout.total_size);
         return 0;
     }
     const uint64_t chip_dev = reinterpret_cast<uint64_t>(gm_addr);
@@ -1293,26 +1281,21 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
     // device-side address of that child's binary code (so the AICPU dispatch
     // path's `reinterpret_cast<CoreCallable*>(addr)->resolved_addr()` lands
     // on the right device offset).
-    std::vector<uint8_t> scratch(total_size);
-    std::memcpy(scratch.data(), raw_bytes, total_size);
-    for (int32_t i = 0; i < callable->child_count(); ++i) {
-        const uint32_t off = callable->child_offset(i);
-        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch.data() + kHeaderSize + off);
-        uint64_t child_dev = chip_dev + kHeaderSize + off;
-        child_in_scratch->set_resolved_addr(child_dev + CoreCallable::binary_data_offset());
-    }
+    std::vector<uint8_t> scratch(layout.total_size);
+    std::memcpy(scratch.data(), callable, layout.total_size);
+    patch_chip_callable_scratch_for_device(callable, layout, chip_dev, scratch.data());
 
-    int rc = rtMemcpy(gm_addr, total_size, scratch.data(), total_size, RT_MEMCPY_HOST_TO_DEVICE);
+    int rc = rtMemcpy(gm_addr, layout.total_size, scratch.data(), layout.total_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         LOG_ERROR("rtMemcpy chip callable H2D failed: %d", rc);
         mem_alloc_.free(gm_addr);
         return 0;
     }
 
-    chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, total_size});
+    chip_callable_buffers_.emplace(layout.content_hash, ChipCallableBuffer{chip_dev, layout.total_size});
     LOG_DEBUG(
-        "Uploaded chip callable: chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, total_size,
-        callable->child_count(), hash
+        "Uploaded chip callable: chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, layout.total_size,
+        callable->child_count(), layout.content_hash
     );
     return chip_dev;
 }

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -1059,16 +1059,6 @@ int DeviceRunner::finalize() {
     }
     chip_callable_buffers_.clear();
 
-    // Release the cached orchestration SO buffer.
-    if (dev_orch_so_buffer_ != nullptr) {
-        mem_alloc_.free(dev_orch_so_buffer_);
-        dev_orch_so_buffer_ = nullptr;
-    }
-    dev_orch_so_capacity_ = 0;
-    cached_orch_so_hash_ = 0;
-    host_orch_so_copy_.clear();
-    host_orch_so_copy_.shrink_to_fit();
-
     // Release any prepared-callable orch SO buffers that callers forgot to
     // unregister. Refcounts no longer matter at this point — the device is
     // about to be reset.

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -565,15 +565,6 @@ private:
     };
     std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
-    // Orchestration SO cache. `cached_orch_so_hash_ == 0` means "no cache".
-    // The device buffer grows monotonically — cache miss with a larger SO
-    // reallocates, a smaller SO reuses the existing capacity. The host copy
-    // insulates us from Python ctypes array lifetimes.
-    uint64_t cached_orch_so_hash_{0};
-    void *dev_orch_so_buffer_{nullptr};
-    size_t dev_orch_so_capacity_{0};
-    std::vector<uint8_t> host_orch_so_copy_;
-
     // Per-callable_id prepared state.
     //
     // `prepared_callables_` maps the caller-stable callable_id to the orch
@@ -661,14 +652,12 @@ private:
     int ensure_binaries_loaded();
 
     /**
-     * Populate runtime.{dev_orch_so_addr_, dev_orch_so_size_} from
-     * `runtime.pending_orch_so_data_` / `_size_`.
-     *
-     * The host tracks the SO identity via a 64-bit hash derived from the ELF
-     * GNU Build-ID. When the hash matches the previous run, the device-side
-     * AICPU thread reuses its cached dlopen handle and we skip the rtMemcpy
-     * entirely. On a miss we allocate (or grow) a device-resident buffer,
-     * copy the SO bytes once, and update the cached hash.
+     * Stamp `runtime.{dev_orch_so_addr_, dev_orch_so_size_}` from the
+     * PreparedCallableState for `runtime.get_active_callable_id()`. The orch
+     * SO bytes were already H2D'd at `register_prepared_callable` time and
+     * are shared via `orch_so_dedup_` across cids; this method only refreshes
+     * the device-SO metadata onto the per-run Runtime and bumps the AICPU
+     * first-sighting counter when the cid is new since registration.
      *
      * @param runtime  Runtime whose device-SO metadata will be rewritten.
      * @return 0 on success, non-zero on failure.

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_perf_profiling.h"
@@ -498,12 +499,11 @@ public:
     /**
      * Replay a previously-registered callable's state onto a fresh Runtime
      * for a per-run binding. Writes back kernel addrs, orch entry-symbol
-     * names, and active_callable_id; hands back the host orch function
-     * pointer (hbg path only) via `out_host_orch_func_ptr` for the caller
-     * to pass into bind_prepared_to_runtime_impl. trb path leaves the
-     * out-pointer at nullptr.
+     * names, and active_callable_id; returns the hbg `host_orch_func_ptr`
+     * (or nullptr on trb / on error) inside a `BindPreparedCallableResult`
+     * so the caller can destructure with structured bindings.
      */
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
+    BindPreparedCallableResult bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
 
     /**
      * Number of distinct callable_ids the AICPU has been asked to dlopen for.

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -495,7 +495,15 @@ public:
      *
      * @return 0 on success, -1 if the cid is not registered.
      */
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
+    /**
+     * Replay a previously-registered callable's state onto a fresh Runtime
+     * for a per-run binding. Writes back kernel addrs, orch entry-symbol
+     * names, and active_callable_id; hands back the host orch function
+     * pointer (hbg path only) via `out_host_orch_func_ptr` for the caller
+     * to pass into bind_prepared_to_runtime_impl. trb path leaves the
+     * out-pointer at nullptr.
+     */
+    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
 
     /**
      * Number of distinct callable_ids the AICPU has been asked to dlopen for.

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -334,13 +334,13 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        // Restore kernel addrs + orch symbol names + active_callable_id, and
-        // (hbg only) hand back the host_orch_func_ptr saved at prepare time.
-        void *host_orch_func_ptr = nullptr;
-        rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
-        if (rc != 0) {
+        // Restore kernel addrs + orch symbol names + active_callable_id; the
+        // returned host_orch_func_ptr is non-null only on the hbg path and is
+        // handed straight into bind_prepared_to_runtime_impl below.
+        auto [bind_rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        if (bind_rc != 0) {
             r->~Runtime();
-            return rc;
+            return bind_rc;
         }
 
         // Per-run binding (tensor args, GM heap, SM alloc)

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -18,12 +18,13 @@
 #include "pto_runtime_c_api.h"
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "task_args.h"
 
 #include <pthread.h>
 
 #include <cstdlib>
-#include <memory>
+#include <utility>
 #include <vector>
 
 #include "common/unified_log.h"
@@ -42,8 +43,10 @@ extern "C" {
 /* ===========================================================================
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
-int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable);
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args);
+int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+);
+int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -264,51 +267,35 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
             runner->release_run_context();
         });
 
-        // Heap-allocate: hbg's Runtime carries 131072 Tasks → tens of MB,
-        // larger than the default thread stack.
-        std::unique_ptr<Runtime> r_owner = std::make_unique<Runtime>();
-        Runtime *r = r_owner.get();
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
-
-        rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
+        PreparedCallableArtifacts artifacts;
+        rc = prepare_callable_impl(
+            reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
+        );
         if (rc != 0) {
             return rc;
         }
 
-        // Extract kernel func_id ↔ dev_addr pairs uploaded by prepare_callable_impl.
+        // Re-pack ChildKernelAddr -> std::pair to match the existing
+        // register_prepared_callable* signature. The named struct only crosses
+        // the runtime-maker / device-runner interface; PreparedCallableState
+        // stores the historical pair shape.
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
-        int kcount = r->get_registered_kernel_count();
-        kernel_addrs.reserve(kcount);
-        for (int i = 0; i < kcount; i++) {
-            int fid = r->get_registered_kernel_func_id(i);
-            kernel_addrs.emplace_back(fid, r->get_function_bin_addr(fid));
+        kernel_addrs.reserve(artifacts.kernel_addrs.size());
+        for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
+            kernel_addrs.emplace_back(c.func_id, c.device_addr);
         }
-        // Clear registered kernels so the Runtime destructor (or any accidental
-        // validate call) does NOT free the kernel binaries we just uploaded —
-        // they belong to the prepared state now.
-        r->clear_registered_kernels();
 
-        // Pick the path by inspecting which staging fields the runtime carries:
-        // hbg's prepare_callable_impl populates pending_host_dlopen_handle_;
-        // trb's leaves it null and instead populates pending_orch_so_data_ +
-        // device_orch_func_name_/config_name_.
-        if (r->pending_host_dlopen_handle_ != nullptr) {
-            rc = runner->register_prepared_callable_host_orch(
-                callable_id, r->pending_host_dlopen_handle_, r->pending_host_orch_func_ptr_, std::move(kernel_addrs)
-            );
-            r->pending_host_dlopen_handle_ = nullptr;
-            r->pending_host_orch_func_ptr_ = nullptr;
-        } else {
-            rc = runner->register_prepared_callable(
-                callable_id, r->pending_orch_so_data_, r->pending_orch_so_size_, r->get_device_orch_func_name(),
-                r->get_device_orch_config_name(), std::move(kernel_addrs)
+        // hbg's prepare_callable_impl populates host_dlopen_handle; trb's
+        // leaves it null and fills orch_so_data + func_name/config_name.
+        if (artifacts.host_dlopen_handle != nullptr) {
+            return runner->register_prepared_callable_host_orch(
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
             );
         }
-        return rc;
+        return runner->register_prepared_callable(
+            callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
+            artifacts.config_name.c_str(), std::move(kernel_addrs)
+        );
     } catch (...) {
         return -1;
     }
@@ -347,15 +334,17 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        // Restore kernel addrs + orch symbol names + active_callable_id
-        rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        // Restore kernel addrs + orch symbol names + active_callable_id, and
+        // (hbg only) hand back the host_orch_func_ptr saved at prepare time.
+        void *host_orch_func_ptr = nullptr;
+        rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
         if (rc != 0) {
             r->~Runtime();
             return rc;
         }
 
         // Per-run binding (tensor args, GM heap, SM alloc)
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args));
+        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -878,33 +878,24 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(
-    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
-) {
-    if (out_host_orch_func_ptr == nullptr) {
-        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
-        return -1;
-    }
-    *out_host_orch_func_ptr = nullptr;
-
+BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return -1;
+        return {-1, nullptr};
     }
     const auto &state = it->second;
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return -1;
+            return {-1, nullptr};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return 0;
+    return {0, state.host_orch_func_ptr};
 }
 
 int DeviceRunner::finalize() {

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -723,83 +723,37 @@ void DeviceRunner::unload_executor_binaries() {
 }
 
 int DeviceRunner::prepare_orch_so(Runtime &runtime) {
-    // Per-callable_id path: mirror onboard. Bytes were staged at
+    // Prepared-callable flow only — bytes were staged at
     // register_prepared_callable time; here we only stamp metadata onto
     // the runtime and resolve `register_new_callable_id_` from first sighting.
     const int32_t cid = runtime.get_active_callable_id();
-    if (cid >= 0) {
-        auto it = prepared_callables_.find(cid);
-        if (it == prepared_callables_.end()) {
-            LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
-            return -1;
-        }
-        const auto &state = it->second;
-        // hbg: orch SO never crosses host/device — clear device-orch metadata
-        // and skip AICPU bookkeeping. See onboard/device_runner.cpp.
-        if (state.host_dlopen_handle != nullptr) {
-            runtime.set_dev_orch_so(0, 0);
-            runtime.set_active_callable_id(cid, /*is_new=*/false);
-            return 0;
-        }
-        const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
-        if (first_sighting) {
-            ++aicpu_dlopen_total_;
-        }
-        runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
-        runtime.set_active_callable_id(cid, first_sighting);
-        runtime.pending_orch_so_data_ = nullptr;
-        runtime.pending_orch_so_size_ = 0;
-        LOG_INFO_V0(
-            "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
-            first_sighting ? 1 : 0
-        );
-        return 0;
+    if (cid < 0) {
+        LOG_ERROR("prepare_orch_so: no active callable_id; prepared-callable flow required");
+        return -1;
     }
-
-    const void *host_so_data = runtime.pending_orch_so_data_;
-    const size_t host_so_size = runtime.pending_orch_so_size_;
-    runtime.pending_orch_so_data_ = nullptr;
-    runtime.pending_orch_so_size_ = 0;
-
-    if (host_so_data == nullptr || host_so_size == 0) {
+    auto it = prepared_callables_.find(cid);
+    if (it == prepared_callables_.end()) {
+        LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
+        return -1;
+    }
+    const auto &state = it->second;
+    // hbg: orch SO never crosses host/device — clear device-orch metadata
+    // and skip AICPU bookkeeping. See onboard/device_runner.cpp.
+    if (state.host_dlopen_handle != nullptr) {
         runtime.set_dev_orch_so(0, 0);
+        runtime.set_active_callable_id(cid, /*is_new=*/false);
         return 0;
     }
-
-    const uint64_t new_hash = simpler::common::utils::elf_build_id_64(host_so_data, host_so_size);
-
-    if (new_hash == cached_orch_so_hash_ && dev_orch_so_buffer_ != nullptr) {
-        LOG_INFO_V0("Orch SO cache hit (hash=0x%lx, %zu bytes)", new_hash, host_so_size);
-        runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-        return 0;
+    const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
+    if (first_sighting) {
+        ++aicpu_dlopen_total_;
     }
-
-    if (host_so_size > dev_orch_so_capacity_) {
-        if (dev_orch_so_buffer_ != nullptr) {
-            mem_alloc_.free(dev_orch_so_buffer_);
-            dev_orch_so_buffer_ = nullptr;
-            dev_orch_so_capacity_ = 0;
-        }
-        dev_orch_so_buffer_ = mem_alloc_.alloc(host_so_size);
-        if (dev_orch_so_buffer_ == nullptr) {
-            LOG_ERROR("Failed to allocate %zu bytes for orchestration SO buffer", host_so_size);
-            cached_orch_so_hash_ = 0;
-            return -1;
-        }
-        dev_orch_so_capacity_ = host_so_size;
-    }
-
-    host_orch_so_copy_.assign(
-        static_cast<const uint8_t *>(host_so_data), static_cast<const uint8_t *>(host_so_data) + host_so_size
+    runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
+    runtime.set_active_callable_id(cid, first_sighting);
+    LOG_INFO_V0(
+        "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
+        first_sighting ? 1 : 0
     );
-    // Sim shares an address space with the device-side aicpu thread, so a
-    // plain memcpy into the cached buffer is the same as rtMemcpy on
-    // hardware.
-    std::memcpy(dev_orch_so_buffer_, host_orch_so_copy_.data(), host_so_size);
-
-    cached_orch_so_hash_ = new_hash;
-    runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-    LOG_INFO_V0("Orch SO cache miss (hash=0x%lx, %zu bytes uploaded)", new_hash, host_so_size);
     return 0;
 }
 
@@ -924,7 +878,15 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
+int DeviceRunner::bind_prepared_callable_to_runtime(
+    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
+) {
+    if (out_host_orch_func_ptr == nullptr) {
+        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
+        return -1;
+    }
+    *out_host_orch_func_ptr = nullptr;
+
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
@@ -938,8 +900,7 @@ int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t ca
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    runtime.pending_host_dlopen_handle_ = state.host_dlopen_handle;
-    runtime.pending_host_orch_func_ptr_ = state.host_orch_func_ptr;
+    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -931,16 +931,6 @@ int DeviceRunner::finalize() {
     }
     chip_callable_buffers_.clear();
 
-    // Release cached orchestration SO buffer.
-    if (dev_orch_so_buffer_ != nullptr) {
-        mem_alloc_.free(dev_orch_so_buffer_);
-        dev_orch_so_buffer_ = nullptr;
-    }
-    dev_orch_so_capacity_ = 0;
-    cached_orch_so_hash_ = 0;
-    host_orch_so_copy_.clear();
-    host_orch_so_copy_.shrink_to_fit();
-
     // Release any prepared-callable orch SO buffers callers forgot to drop.
     for (auto &kv : orch_so_dedup_) {
         if (kv.second.dev_addr != nullptr) {

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -37,10 +37,10 @@
 #include "aicpu/platform_aicpu_affinity.h"
 #include "callable.h"
 #include "callable_protocol.h"
-#include "utils/elf_build_id.h"
-#include "utils/fnv1a_64.h"
+#include "chip_callable_layout.h"
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
+#include "utils/elf_build_id.h"
 
 // dep_gen_replay_emit_deps_json: strong symbol provided by
 // runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp when that runtime is
@@ -1025,31 +1025,21 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
         return 0;
     }
 
-    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
-    size_t storage_used = static_cast<size_t>(callable->binary_size());
-    for (int32_t i = 0; i < callable->child_count(); ++i) {
-        const CoreCallable &c = callable->child(i);
-        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
-        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
-        if (end > storage_used) storage_used = end;
-    }
-    const size_t total_size = kHeaderSize + storage_used;
+    const ChipCallableLayout layout = compute_chip_callable_layout(callable);
 
-    const auto *raw_bytes = reinterpret_cast<const uint8_t *>(callable);
-    const uint64_t hash = simpler::common::utils::fnv1a_64(raw_bytes, total_size);
-    auto it = chip_callable_buffers_.find(hash);
+    auto it = chip_callable_buffers_.find(layout.content_hash);
     if (it != chip_callable_buffers_.end()) {
         LOG_DEBUG(
             "Chip callable dedup hit (sim): chip_dev=0x%lx, size=%zu, hash=0x%lx", it->second.chip_dev,
-            it->second.total_size, hash
+            it->second.total_size, layout.content_hash
         );
         return it->second.chip_dev;
     }
 
     // Allocate host scratch (host == device in sim). Plain new[] keeps
     // ChipCallableBuffer::host_scratch ownership symmetric with finalize().
-    auto *scratch = new uint8_t[total_size];
-    std::memcpy(scratch, raw_bytes, total_size);
+    auto *scratch = new uint8_t[layout.total_size];
+    std::memcpy(scratch, callable, layout.total_size);
 
     // Per-child dlopen + dlsym kernel_entry + register pto-sim hooks, then
     // patch the child's resolved_addr_ to the function pointer. A scope guard
@@ -1065,7 +1055,7 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
 
     for (int32_t i = 0; i < callable->child_count(); ++i) {
         const uint32_t off = callable->child_offset(i);
-        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch + kHeaderSize + off);
+        auto *child_in_scratch = reinterpret_cast<CoreCallable *>(scratch + layout.header_size + off);
         const void *kernel_binary = child_in_scratch->binary_data();
         size_t kernel_size = static_cast<size_t>(child_in_scratch->binary_size());
 
@@ -1105,10 +1095,12 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
 
     cleanup.dismiss();
     const uint64_t chip_dev = reinterpret_cast<uint64_t>(scratch);
-    chip_callable_buffers_.emplace(hash, ChipCallableBuffer{chip_dev, scratch, total_size, std::move(dlopen_handles)});
+    chip_callable_buffers_.emplace(
+        layout.content_hash, ChipCallableBuffer{chip_dev, scratch, layout.total_size, std::move(dlopen_handles)}
+    );
     LOG_DEBUG(
-        "Uploaded chip callable (sim): chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev, total_size,
-        callable->child_count(), hash
+        "Uploaded chip callable (sim): chip_dev=0x%lx, size=%zu, child_count=%d, hash=0x%lx", chip_dev,
+        layout.total_size, callable->child_count(), layout.content_hash
     );
     return chip_dev;
 }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -229,7 +229,7 @@ public:
     );
     int unregister_prepared_callable(int32_t callable_id);
     bool has_prepared_callable(int32_t callable_id) const;
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
+    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
     size_t aicpu_dlopen_count() const { return aicpu_dlopen_total_; }
     size_t host_dlopen_count() const { return host_dlopen_total_; }
 

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -266,12 +266,6 @@ private:
     };
     std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
-    // Orchestration SO cache (host-resident in sim; see onboard for shape).
-    uint64_t cached_orch_so_hash_{0};
-    void *dev_orch_so_buffer_{nullptr};
-    size_t dev_orch_so_capacity_{0};
-    std::vector<uint8_t> host_orch_so_copy_;
-
     // Per-callable_id prepared state. Mirrors onboard.
     struct PreparedCallableState {
         // trb path
@@ -339,11 +333,10 @@ private:
     void unload_executor_binaries();
 
     /**
-     * Stage the orchestration SO bytes into a host-resident buffer that
-     * `aicpu_executor` can dlopen. Identical contract to the onboard
-     * version: `runtime.pending_orch_so_data_/size_` are consumed and
-     * `runtime.{dev_orch_so_addr_, dev_orch_so_size_}` are populated with
-     * the cache-aware result.
+     * Stamp `runtime.{dev_orch_so_addr_, dev_orch_so_size_}` from the
+     * PreparedCallableState for `runtime.get_active_callable_id()`. Identical
+     * contract to the onboard version: bytes were staged at
+     * `register_prepared_callable` time, so this is metadata-only — no copy.
      */
     int prepare_orch_so(Runtime &runtime);
 

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -44,6 +44,7 @@
 #include <vector>
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
@@ -229,7 +230,7 @@ public:
     );
     int unregister_prepared_callable(int32_t callable_id);
     bool has_prepared_callable(int32_t callable_id) const;
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
+    BindPreparedCallableResult bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
     size_t aicpu_dlopen_count() const { return aicpu_dlopen_total_; }
     size_t host_dlopen_count() const { return host_dlopen_total_; }
 

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -18,12 +18,13 @@
 #include "pto_runtime_c_api.h"
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "task_args.h"
 
 #include <new>
 #include <pthread.h>
 
-#include <memory>
+#include <utility>
 #include <vector>
 
 #include "common/unified_log.h"
@@ -37,8 +38,10 @@ extern "C" {
 /* ===========================================================================
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
-int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable);
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args);
+int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+);
+int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -238,42 +241,31 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
     pthread_setspecific(g_runner_key, ctx);
 
     try {
-        // Heap-allocate the temp Runtime — sizeof(Runtime) is in the tens of MB
-        // for hbg variants (RUNTIME_MAX_TASKS=131072), well past the stack
-        // budget. unique_ptr keeps the cleanup symmetric on every exit.
-        std::unique_ptr<Runtime> r_owner = std::make_unique<Runtime>();
-        Runtime *r = r_owner.get();
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
-
-        int rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
+        PreparedCallableArtifacts artifacts;
+        int rc = prepare_callable_impl(
+            reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
+        );
         if (rc != 0) {
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
+        // Re-pack ChildKernelAddr -> std::pair to match the existing
+        // register_prepared_callable* signature.
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
-        int kcount = r->get_registered_kernel_count();
-        kernel_addrs.reserve(kcount);
-        for (int i = 0; i < kcount; i++) {
-            int fid = r->get_registered_kernel_func_id(i);
-            kernel_addrs.emplace_back(fid, r->get_function_bin_addr(fid));
+        kernel_addrs.reserve(artifacts.kernel_addrs.size());
+        for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
+            kernel_addrs.emplace_back(c.func_id, c.device_addr);
         }
-        r->clear_registered_kernels();
 
-        if (r->pending_host_dlopen_handle_ != nullptr) {
+        if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->register_prepared_callable_host_orch(
-                callable_id, r->pending_host_dlopen_handle_, r->pending_host_orch_func_ptr_, std::move(kernel_addrs)
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
             );
-            r->pending_host_dlopen_handle_ = nullptr;
-            r->pending_host_orch_func_ptr_ = nullptr;
         } else {
             rc = runner->register_prepared_callable(
-                callable_id, r->pending_orch_so_data_, r->pending_orch_so_size_, r->get_device_orch_func_name(),
-                r->get_device_orch_config_name(), std::move(kernel_addrs)
+                callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
+                artifacts.config_name.c_str(), std::move(kernel_addrs)
             );
         }
         pthread_setspecific(g_runner_key, nullptr);
@@ -308,14 +300,15 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        void *host_orch_func_ptr = nullptr;
+        int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
         if (rc != 0) {
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args));
+        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -300,8 +300,7 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        void *host_orch_func_ptr = nullptr;
-        int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
+        auto [rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
         if (rc != 0) {
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -39,6 +39,7 @@
 
 #include "callable.h"
 #include "orchestration_api.h"
+#include "prepare_callable_common.h"
 #include "runtime.h"  // Includes unified_log.h and provides LOG_* macros
 #include "task_args.h"
 
@@ -294,29 +295,18 @@ int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
         return -1;
     }
 
-    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
-    // computes total size from contents, allocates device GM once, fixes up
-    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
-    // and returns the device-side address of the ChipCallable header.
-    // Callers then compute child device addresses via offset arithmetic and
-    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
-    if (callable->child_count() > 0) {
-        LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
-        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
-        if (chip_dev == 0) {
-            LOG_ERROR("Failed to upload ChipCallable buffer");
+    LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+    std::vector<ChildKernelAddr> child_addrs;
+    if (upload_and_collect_child_addrs(callable, runtime->host_api.upload_chip_callable_buffer, &child_addrs) != 0) {
+        LOG_ERROR("Failed to upload ChipCallable buffer");
+        return -1;
+    }
+    for (const ChildKernelAddr &c : child_addrs) {
+        if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
+            LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
             return -1;
         }
-        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
-        for (int32_t i = 0; i < callable->child_count(); i++) {
-            int func_id = callable->child_func_id(i);
-            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-                return -1;
-            }
-            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
-            runtime->set_function_bin_addr(func_id, child_dev);
-        }
+        runtime->set_function_bin_addr(c.func_id, c.device_addr);
     }
 
     const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -279,34 +279,35 @@ extern "C" {
 /**
  * Stage the per-callable resources for the host_build_graph variant: upload
  * kernel binaries and dlopen the orchestration SO on the host. The dlopen
- * handle and resolved entry-symbol pointer are parked on the runtime via
- * `pending_host_dlopen_handle_` / `pending_host_orch_func_ptr_` so the
- * platform layer can hoist them into PreparedCallableState. Splitting this
- * out of init_runtime_impl is what the hbg prepare_callable / run_prepared
- * path rests on — the dlopen runs once per cid instead of every run.
+ * handle and resolved entry-symbol pointer are returned via
+ * PreparedCallableArtifacts so the platform layer can hoist them into its
+ * PreparedCallableState. Splitting this out of init_runtime_impl is what
+ * the hbg prepare_callable / run_prepared path rests on — the dlopen runs
+ * once per cid instead of every run.
  */
-int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
-    if (runtime == nullptr) {
-        LOG_ERROR("Runtime pointer is null");
-        return -1;
-    }
+int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
+    if (upload_fn == nullptr || out == nullptr) {
+        LOG_ERROR("upload_fn or out is null");
+        return -1;
+    }
+    *out = PreparedCallableArtifacts{};
 
     LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
-    std::vector<ChildKernelAddr> child_addrs;
-    if (upload_and_collect_child_addrs(callable, runtime->host_api.upload_chip_callable_buffer, &child_addrs) != 0) {
+    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
     }
-    for (const ChildKernelAddr &c : child_addrs) {
+    for (const ChildKernelAddr &c : out->kernel_addrs) {
         if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
             return -1;
         }
-        runtime->set_function_bin_addr(c.func_id, c.device_addr);
     }
 
     const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
@@ -345,25 +346,19 @@ int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
 
     LOG_INFO_V0("Loaded orchestration function: %s", orch_func_name);
 
-    runtime->pending_host_dlopen_handle_ = handle;
-    runtime->pending_host_orch_func_ptr_ = reinterpret_cast<void *>(orch_func);
-    // hbg never uploads orch SO bytes to the device; clear the trb staging
-    // fields so DeviceRunner::register_prepared_callable cannot mistake this
-    // for a trb-shaped registration.
-    runtime->pending_orch_so_data_ = nullptr;
-    runtime->pending_orch_so_size_ = 0;
+    out->host_dlopen_handle = handle;
+    out->host_orch_func_ptr = reinterpret_cast<void *>(orch_func);
     return 0;
 }
 
 /**
  * Per-run binding for hbg: invoke the previously-resolved orchestration entry
  * point against the supplied args, then upload tensor info / allocation
- * storage. Assumes prepare_callable_impl populated
- * `pending_host_orch_func_ptr_` (either freshly during prepare_callable, or
- * via DeviceRunner::bind_prepared_callable_to_runtime when run_prepared
- * replays a prepared cid onto a fresh Runtime).
+ * storage. The c_api caller passes `host_orch_func_ptr` straight through from
+ * DeviceRunner::bind_prepared_callable_to_runtime (which read it from
+ * PreparedCallableState for this run's callable_id).
  */
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args) {
+int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -372,7 +367,7 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
         LOG_ERROR("orch_args pointer is null");
         return -1;
     }
-    OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(runtime->pending_host_orch_func_ptr_);
+    OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(host_orch_func_ptr);
     if (orch_func == nullptr) {
         LOG_ERROR("bind_prepared_to_runtime_impl: host orch_func pointer is null");
         return -1;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -486,20 +486,6 @@ public:
     int32_t active_callable_id_{-1};
     bool register_new_callable_id_{false};
 
-    // Host-only staging fields (mirror tensormap_and_ringbuffer variant).
-    const void *pending_orch_so_data_{nullptr};
-    size_t pending_orch_so_size_{0};
-
-    // Host-orchestration staging (hbg path). prepare_callable_impl
-    // dlopens the orch SO on the host and parks the handle + entry-symbol
-    // pointer here so DeviceRunner::register_prepared_callable_host_orch can
-    // claim them; bind_prepared_callable_to_runtime restores them onto a fresh
-    // Runtime so bind_prepared_to_runtime_impl can call orch_func without a
-    // second dlopen. Distinct from `pending_orch_so_data_` (which is unused on
-    // hbg — host orchestration never uploads the SO bytes to the device).
-    void *pending_host_dlopen_handle_{nullptr};
-    void *pending_host_orch_func_ptr_{nullptr};
-
     // Device-orchestration entry/config symbol names (trb path). Always
     // empty on this hbg variant — included for API parity so the shared
     // platform layer can call set_device_orch_func_name unconditionally.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -41,6 +41,7 @@
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "prepare_callable_common.h"
 
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
@@ -112,29 +113,18 @@ extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *calla
         return -1;
     }
 
-    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
-    // computes total size from contents, allocates device GM once, fixes up
-    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
-    // and returns the device-side address of the ChipCallable header.
-    // Callers then compute child device addresses via offset arithmetic and
-    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
-    if (callable->child_count() > 0) {
-        LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
-        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
-        if (chip_dev == 0) {
-            LOG_ERROR("Failed to upload ChipCallable buffer");
+    LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+    std::vector<ChildKernelAddr> child_addrs;
+    if (upload_and_collect_child_addrs(callable, runtime->host_api.upload_chip_callable_buffer, &child_addrs) != 0) {
+        LOG_ERROR("Failed to upload ChipCallable buffer");
+        return -1;
+    }
+    for (const ChildKernelAddr &c : child_addrs) {
+        if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
+            LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
             return -1;
         }
-        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
-        for (int32_t i = 0; i < callable->child_count(); i++) {
-            int func_id = callable->child_func_id(i);
-            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-                return -1;
-            }
-            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
-            runtime->set_function_bin_addr(func_id, child_dev);
-        }
+        runtime->set_function_bin_addr(c.func_id, c.device_addr);
     }
 
     const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -103,43 +103,43 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
  * @return 0 on success, -1 on failure
  */
-extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
-    if (runtime == nullptr) {
-        LOG_ERROR("Runtime pointer is null");
-        return -1;
-    }
+extern "C" int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
+    if (upload_fn == nullptr || out == nullptr) {
+        LOG_ERROR("upload_fn or out is null");
+        return -1;
+    }
+    *out = PreparedCallableArtifacts{};
 
     LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
-    std::vector<ChildKernelAddr> child_addrs;
-    if (upload_and_collect_child_addrs(callable, runtime->host_api.upload_chip_callable_buffer, &child_addrs) != 0) {
+    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
         LOG_ERROR("Failed to upload ChipCallable buffer");
         return -1;
     }
-    for (const ChildKernelAddr &c : child_addrs) {
+    for (const ChildKernelAddr &c : out->kernel_addrs) {
         if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
             return -1;
         }
-        runtime->set_function_bin_addr(c.func_id, c.device_addr);
     }
 
     const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
-    runtime->set_device_orch_func_name(callable->func_name());
-    runtime->set_device_orch_config_name(callable->config_name());
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
         LOG_ERROR("Orchestration SO binary is required for device orchestration");
         return -1;
     }
 
-    // Stage the orchestration SO for DeviceRunner::prepare_orch_so to consume.
-    runtime->pending_orch_so_data_ = orch_so_binary;
-    runtime->pending_orch_so_size_ = orch_so_size;
+    out->orch_so_data = orch_so_binary;
+    out->orch_so_size = orch_so_size;
+    out->func_name = callable->func_name();
+    out->config_name = callable->config_name();
     LOG_INFO_V0("Orchestration SO: %zu bytes staged (host-only)", orch_so_size);
     return 0;
 }
@@ -158,13 +158,21 @@ extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *calla
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
-extern "C" int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args) {
+extern "C" int
+bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
     }
     if (orch_args == nullptr) {
         LOG_ERROR("orch_args pointer is null");
+        return -1;
+    }
+    // trb runs orchestration on the device — there is no host-side orch
+    // function pointer to invoke. The c_api signature accepts one for
+    // symmetry with hbg; assert the trb-side invariant here.
+    if (host_orch_func_ptr != nullptr) {
+        LOG_ERROR("bind_prepared_to_runtime_impl: trb does not accept a host_orch_func_ptr");
         return -1;
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -303,22 +303,6 @@ public:
     // Host API function pointers for device memory operations
     // NOTE: Placed at end of class to avoid affecting device memory layout
     HostApi host_api;
-
-    // Host-only staging for orchestration SO. runtime_maker publishes the
-    // callable-owned pointer here; DeviceRunner consumes it before launching
-    // the device-side execution and replaces it with the device-resident
-    // buffer metadata (dev_orch_so_addr_, dev_orch_so_size_). The fields
-    // below are zeroed on the device because DeviceRunner clears them before
-    // the memcpy, but their values while running on device are irrelevant.
-    const void *pending_orch_so_data_{nullptr};
-    size_t pending_orch_so_size_{0};
-
-    // Host-orchestration staging (hbg path). Always nullptr on this trb
-    // variant — included for API parity with host_build_graph so the
-    // shared platform layer can branch on `pending_host_dlopen_handle_ !=
-    // nullptr` at runtime instead of via a build-time macro.
-    void *pending_host_dlopen_handle_{nullptr};
-    void *pending_host_orch_func_ptr_{nullptr};
 };
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -838,15 +838,6 @@ int DeviceRunner::finalize() {
     }
     chip_callable_buffers_.clear();
 
-    if (dev_orch_so_buffer_ != nullptr) {
-        mem_alloc_.free(dev_orch_so_buffer_);
-        dev_orch_so_buffer_ = nullptr;
-    }
-    dev_orch_so_capacity_ = 0;
-    cached_orch_so_hash_ = 0;
-    host_orch_so_copy_.clear();
-    host_orch_so_copy_.shrink_to_fit();
-
     // Release any prepared-callable orch SO buffers that callers forgot to
     // unregister. Refcounts no longer matter at this point — the device is
     // about to be reset.

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -769,19 +769,11 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(
-    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
-) {
-    if (out_host_orch_func_ptr == nullptr) {
-        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
-        return -1;
-    }
-    *out_host_orch_func_ptr = nullptr;
-
+BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return -1;
+        return {-1, nullptr};
     }
     const auto &state = it->second;
 
@@ -793,17 +785,16 @@ int DeviceRunner::bind_prepared_callable_to_runtime(
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return -1;
+            return {-1, nullptr};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     // Stamp callable_id with is_new=false; prepare_orch_so refreshes the flag
     // with the authoritative first_sighting answer right before launch.
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return 0;
+    return {0, state.host_orch_func_ptr};
 }
 
 int DeviceRunner::finalize() {

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -606,92 +606,39 @@ void DeviceRunner::print_handshake_results() {
 }
 
 int DeviceRunner::prepare_orch_so(Runtime &runtime) {
-    // Per-callable_id path: when run_prepared bound a known callable_id,
-    // the SO bytes were already H2D'd at prepare_callable time.
-    // We just stamp dev_orch_so on the runtime, plus mark `is_new` based on
-    // whether the AICPU has seen this id since registration.
+    // Prepared-callable flow only: bytes were H2D'd at prepare_callable
+    // time. Stamp dev_orch_so on the runtime and resolve `is_new` from
+    // first sighting.
     const int32_t cid = runtime.get_active_callable_id();
-    if (cid >= 0) {
-        auto it = prepared_callables_.find(cid);
-        if (it == prepared_callables_.end()) {
-            LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
-            return -1;
-        }
-        const auto &state = it->second;
-        // hbg variant: orch SO never crosses host/device, so AICPU does no
-        // per-cid dlopen. Skip orch_so_table_ bookkeeping and clear metadata.
-        if (state.host_dlopen_handle != nullptr) {
-            runtime.set_dev_orch_so(0, 0);
-            runtime.set_active_callable_id(cid, /*is_new=*/false);
-            return 0;
-        }
-        const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
-        if (first_sighting) {
-            ++aicpu_dlopen_total_;
-        }
-        runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
-        // The c_api caller passed is_new=false; refresh with the authoritative
-        // first_sighting flag before AICPU consumes register_new_callable_id_.
-        runtime.set_active_callable_id(cid, first_sighting);
-        // Pending fields must be empty in the prepared path — runtime_maker's
-        // bind_prepared_to_runtime_impl never stages them. Defensive clear:
-        runtime.pending_orch_so_data_ = nullptr;
-        runtime.pending_orch_so_size_ = 0;
-        LOG_INFO_V0(
-            "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
-            first_sighting ? 1 : 0
-        );
-        return 0;
+    if (cid < 0) {
+        LOG_ERROR("prepare_orch_so: no active callable_id; prepared-callable flow required");
+        return -1;
     }
-
-    const void *host_so_data = runtime.pending_orch_so_data_;
-    const size_t host_so_size = runtime.pending_orch_so_size_;
-    runtime.pending_orch_so_data_ = nullptr;
-    runtime.pending_orch_so_size_ = 0;
-
-    if (host_so_data == nullptr || host_so_size == 0) {
+    auto it = prepared_callables_.find(cid);
+    if (it == prepared_callables_.end()) {
+        LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
+        return -1;
+    }
+    const auto &state = it->second;
+    // hbg variant: orch SO never crosses host/device, so AICPU does no
+    // per-cid dlopen. Skip orch_so_table_ bookkeeping and clear metadata.
+    if (state.host_dlopen_handle != nullptr) {
         runtime.set_dev_orch_so(0, 0);
+        runtime.set_active_callable_id(cid, /*is_new=*/false);
         return 0;
     }
-
-    const uint64_t new_hash = simpler::common::utils::elf_build_id_64(host_so_data, host_so_size);
-
-    if (new_hash == cached_orch_so_hash_ && dev_orch_so_buffer_ != nullptr) {
-        LOG_INFO_V0("Orch SO cache hit (hash=0x%lx, %zu bytes)", new_hash, host_so_size);
-        runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-        return 0;
+    const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
+    if (first_sighting) {
+        ++aicpu_dlopen_total_;
     }
-
-    if (host_so_size > dev_orch_so_capacity_) {
-        if (dev_orch_so_buffer_ != nullptr) {
-            mem_alloc_.free(dev_orch_so_buffer_);
-            dev_orch_so_buffer_ = nullptr;
-            dev_orch_so_capacity_ = 0;
-        }
-        dev_orch_so_buffer_ = mem_alloc_.alloc(host_so_size);
-        if (dev_orch_so_buffer_ == nullptr) {
-            LOG_ERROR("Failed to allocate %zu bytes for orchestration SO buffer", host_so_size);
-            cached_orch_so_hash_ = 0;
-            return -1;
-        }
-        dev_orch_so_capacity_ = host_so_size;
-    }
-
-    host_orch_so_copy_.assign(
-        static_cast<const uint8_t *>(host_so_data), static_cast<const uint8_t *>(host_so_data) + host_so_size
+    runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
+    // The c_api caller passed is_new=false; refresh with the authoritative
+    // first_sighting flag before AICPU consumes register_new_callable_id_.
+    runtime.set_active_callable_id(cid, first_sighting);
+    LOG_INFO_V0(
+        "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
+        first_sighting ? 1 : 0
     );
-    int rc = rtMemcpy(
-        dev_orch_so_buffer_, dev_orch_so_capacity_, host_orch_so_copy_.data(), host_so_size, RT_MEMCPY_HOST_TO_DEVICE
-    );
-    if (rc != 0) {
-        LOG_ERROR("rtMemcpy for orchestration SO failed: %d", rc);
-        cached_orch_so_hash_ = 0;
-        return rc;
-    }
-
-    cached_orch_so_hash_ = new_hash;
-    runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-    LOG_INFO_V0("Orch SO cache miss (hash=0x%lx, %zu bytes uploaded)", new_hash, host_so_size);
     return 0;
 }
 
@@ -822,7 +769,15 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
+int DeviceRunner::bind_prepared_callable_to_runtime(
+    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
+) {
+    if (out_host_orch_func_ptr == nullptr) {
+        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
+        return -1;
+    }
+    *out_host_orch_func_ptr = nullptr;
+
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
@@ -842,8 +797,7 @@ int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t ca
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    runtime.pending_host_dlopen_handle_ = state.host_dlopen_handle;
-    runtime.pending_host_orch_func_ptr_ = state.host_orch_func_ptr;
+    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     // Stamp callable_id with is_new=false; prepare_orch_so refreshes the flag

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_perf_profiling.h"
@@ -413,7 +414,7 @@ public:
      * Replay the prepared state for `callable_id` onto a freshly-constructed
      * Runtime. See a2a3 onboard documentation for full contract.
      */
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
+    BindPreparedCallableResult bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
 
     /**
      * Number of distinct callable_ids the AICPU has been asked to dlopen for.

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -468,12 +468,6 @@ private:
     };
     std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
-    // Orchestration SO cache (host-tracked, device-resident).
-    uint64_t cached_orch_so_hash_{0};
-    void *dev_orch_so_buffer_{nullptr};
-    size_t dev_orch_so_capacity_{0};
-    std::vector<uint8_t> host_orch_so_copy_;
-
     // Per-callable_id prepared state. See a2a3 onboard device_runner.h for
     // the full design narrative; mirrored here so a5 shares the same
     // dispatch surface.

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -413,7 +413,7 @@ public:
      * Replay the prepared state for `callable_id` onto a freshly-constructed
      * Runtime. See a2a3 onboard documentation for full contract.
      */
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
+    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
 
     /**
      * Number of distinct callable_ids the AICPU has been asked to dlopen for.

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -18,12 +18,13 @@
 #include "pto_runtime_c_api.h"
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "task_args.h"
 
 #include <pthread.h>
 
 #include <cstdlib>
-#include <memory>
+#include <utility>
 #include <vector>
 
 #include "common/unified_log.h"
@@ -42,8 +43,10 @@ extern "C" {
 /* ===========================================================================
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
-int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable);
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args);
+int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+);
+int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -292,47 +295,29 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
             runner->release_run_context();
         });
 
-        // Heap-allocate: hbg's Runtime carries 131072 Tasks → tens of MB,
-        // larger than the default thread stack.
-        std::unique_ptr<Runtime> r_owner = std::make_unique<Runtime>();
-        Runtime *r = r_owner.get();
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
-
-        rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
+        PreparedCallableArtifacts artifacts;
+        rc = prepare_callable_impl(
+            reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
+        );
         if (rc != 0) {
             return rc;
         }
 
-        // Extract kernel func_id ↔ dev_addr pairs uploaded by prepare_callable_impl.
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
-        int kcount = r->get_registered_kernel_count();
-        kernel_addrs.reserve(kcount);
-        for (int i = 0; i < kcount; i++) {
-            int fid = r->get_registered_kernel_func_id(i);
-            kernel_addrs.emplace_back(fid, r->get_function_bin_addr(fid));
+        kernel_addrs.reserve(artifacts.kernel_addrs.size());
+        for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
+            kernel_addrs.emplace_back(c.func_id, c.device_addr);
         }
-        // Clear registered kernels so the Runtime destructor (or any accidental
-        // validate call) does NOT free the kernel binaries we just uploaded —
-        // they belong to the prepared state now.
-        r->clear_registered_kernels();
 
-        if (r->pending_host_dlopen_handle_ != nullptr) {
-            rc = runner->register_prepared_callable_host_orch(
-                callable_id, r->pending_host_dlopen_handle_, r->pending_host_orch_func_ptr_, std::move(kernel_addrs)
-            );
-            r->pending_host_dlopen_handle_ = nullptr;
-            r->pending_host_orch_func_ptr_ = nullptr;
-        } else {
-            rc = runner->register_prepared_callable(
-                callable_id, r->pending_orch_so_data_, r->pending_orch_so_size_, r->get_device_orch_func_name(),
-                r->get_device_orch_config_name(), std::move(kernel_addrs)
+        if (artifacts.host_dlopen_handle != nullptr) {
+            return runner->register_prepared_callable_host_orch(
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
             );
         }
-        return rc;
+        return runner->register_prepared_callable(
+            callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
+            artifacts.config_name.c_str(), std::move(kernel_addrs)
+        );
     } catch (...) {
         return -1;
     }
@@ -371,15 +356,17 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        // Restore kernel addrs + orch symbol names + active_callable_id
-        rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        // Restore kernel addrs + orch symbol names + active_callable_id, and
+        // (hbg only) hand back the host_orch_func_ptr saved at prepare time.
+        void *host_orch_func_ptr = nullptr;
+        rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
         if (rc != 0) {
             r->~Runtime();
             return rc;
         }
 
         // Per-run binding (tensor args, GM heap, SM alloc)
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args));
+        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -356,13 +356,13 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        // Restore kernel addrs + orch symbol names + active_callable_id, and
-        // (hbg only) hand back the host_orch_func_ptr saved at prepare time.
-        void *host_orch_func_ptr = nullptr;
-        rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
-        if (rc != 0) {
+        // Restore kernel addrs + orch symbol names + active_callable_id; the
+        // returned host_orch_func_ptr is non-null only on the hbg path and is
+        // handed straight into bind_prepared_to_runtime_impl below.
+        auto [bind_rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        if (bind_rc != 0) {
             r->~Runtime();
-            return rc;
+            return bind_rc;
         }
 
         // Per-run binding (tensor args, GM heap, SM alloc)

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -873,16 +873,6 @@ int DeviceRunner::finalize() {
     }
     chip_callable_buffers_.clear();
 
-    // Release cached orchestration SO buffer.
-    if (dev_orch_so_buffer_ != nullptr) {
-        mem_alloc_.free(dev_orch_so_buffer_);
-        dev_orch_so_buffer_ = nullptr;
-    }
-    dev_orch_so_capacity_ = 0;
-    cached_orch_so_hash_ = 0;
-    host_orch_so_copy_.clear();
-    host_orch_so_copy_.shrink_to_fit();
-
     // Release any prepared-callable orch SO buffers callers forgot to drop.
     for (auto &kv : orch_so_dedup_) {
         if (kv.second.dev_addr != nullptr) {

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -644,82 +644,36 @@ void DeviceRunner::unload_executor_binaries() {
 }
 
 int DeviceRunner::prepare_orch_so(Runtime &runtime) {
-    // Per-callable_id path: mirror onboard. Bytes were staged at
+    // Prepared-callable flow only — bytes were staged at
     // register_prepared_callable time; here we only stamp metadata onto
     // the runtime and resolve `register_new_callable_id_` from first sighting.
     const int32_t cid = runtime.get_active_callable_id();
-    if (cid >= 0) {
-        auto it = prepared_callables_.find(cid);
-        if (it == prepared_callables_.end()) {
-            LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
-            return -1;
-        }
-        const auto &state = it->second;
-        // hbg variant: orch SO never crosses host/device boundary.
-        if (state.host_dlopen_handle != nullptr) {
-            runtime.set_dev_orch_so(0, 0);
-            runtime.set_active_callable_id(cid, /*is_new=*/false);
-            return 0;
-        }
-        const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
-        if (first_sighting) {
-            ++aicpu_dlopen_total_;
-        }
-        runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
-        runtime.set_active_callable_id(cid, first_sighting);
-        runtime.pending_orch_so_data_ = nullptr;
-        runtime.pending_orch_so_size_ = 0;
-        LOG_INFO_V0(
-            "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
-            first_sighting ? 1 : 0
-        );
-        return 0;
+    if (cid < 0) {
+        LOG_ERROR("prepare_orch_so: no active callable_id; prepared-callable flow required");
+        return -1;
     }
-
-    const void *host_so_data = runtime.pending_orch_so_data_;
-    const size_t host_so_size = runtime.pending_orch_so_size_;
-    runtime.pending_orch_so_data_ = nullptr;
-    runtime.pending_orch_so_size_ = 0;
-
-    if (host_so_data == nullptr || host_so_size == 0) {
+    auto it = prepared_callables_.find(cid);
+    if (it == prepared_callables_.end()) {
+        LOG_ERROR("prepare_orch_so: callable_id=%d not registered", cid);
+        return -1;
+    }
+    const auto &state = it->second;
+    // hbg variant: orch SO never crosses host/device boundary.
+    if (state.host_dlopen_handle != nullptr) {
         runtime.set_dev_orch_so(0, 0);
+        runtime.set_active_callable_id(cid, /*is_new=*/false);
         return 0;
     }
-
-    const uint64_t new_hash = simpler::common::utils::elf_build_id_64(host_so_data, host_so_size);
-
-    if (new_hash == cached_orch_so_hash_ && dev_orch_so_buffer_ != nullptr) {
-        LOG_INFO_V0("Orch SO cache hit (hash=0x%lx, %zu bytes)", new_hash, host_so_size);
-        runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-        return 0;
+    const bool first_sighting = aicpu_seen_callable_ids_.insert(cid).second;
+    if (first_sighting) {
+        ++aicpu_dlopen_total_;
     }
-
-    if (host_so_size > dev_orch_so_capacity_) {
-        if (dev_orch_so_buffer_ != nullptr) {
-            mem_alloc_.free(dev_orch_so_buffer_);
-            dev_orch_so_buffer_ = nullptr;
-            dev_orch_so_capacity_ = 0;
-        }
-        dev_orch_so_buffer_ = mem_alloc_.alloc(host_so_size);
-        if (dev_orch_so_buffer_ == nullptr) {
-            LOG_ERROR("Failed to allocate %zu bytes for orchestration SO buffer", host_so_size);
-            cached_orch_so_hash_ = 0;
-            return -1;
-        }
-        dev_orch_so_capacity_ = host_so_size;
-    }
-
-    host_orch_so_copy_.assign(
-        static_cast<const uint8_t *>(host_so_data), static_cast<const uint8_t *>(host_so_data) + host_so_size
+    runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
+    runtime.set_active_callable_id(cid, first_sighting);
+    LOG_INFO_V0(
+        "Orch SO prepared cid=%d hash=0x%lx %zu bytes (is_new=%d)", cid, state.hash, state.dev_orch_so_size,
+        first_sighting ? 1 : 0
     );
-    // Sim shares an address space with the device-side aicpu thread, so a
-    // plain memcpy into the cached buffer is the same as rtMemcpy on
-    // hardware.
-    std::memcpy(dev_orch_so_buffer_, host_orch_so_copy_.data(), host_so_size);
-
-    cached_orch_so_hash_ = new_hash;
-    runtime.set_dev_orch_so(reinterpret_cast<uint64_t>(dev_orch_so_buffer_), host_so_size);
-    LOG_INFO_V0("Orch SO cache miss (hash=0x%lx, %zu bytes uploaded)", new_hash, host_so_size);
     return 0;
 }
 
@@ -840,7 +794,15 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
+int DeviceRunner::bind_prepared_callable_to_runtime(
+    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
+) {
+    if (out_host_orch_func_ptr == nullptr) {
+        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
+        return -1;
+    }
+    *out_host_orch_func_ptr = nullptr;
+
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
@@ -854,8 +816,7 @@ int DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t ca
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    runtime.pending_host_dlopen_handle_ = state.host_dlopen_handle;
-    runtime.pending_host_orch_func_ptr_ = state.host_orch_func_ptr;
+    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -794,33 +794,24 @@ bool DeviceRunner::has_prepared_callable(int32_t callable_id) const {
     return prepared_callables_.count(callable_id) != 0;
 }
 
-int DeviceRunner::bind_prepared_callable_to_runtime(
-    Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr
-) {
-    if (out_host_orch_func_ptr == nullptr) {
-        LOG_ERROR("bind_prepared_callable_to_runtime: out_host_orch_func_ptr is null");
-        return -1;
-    }
-    *out_host_orch_func_ptr = nullptr;
-
+BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return -1;
+        return {-1, nullptr};
     }
     const auto &state = it->second;
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return -1;
+            return {-1, nullptr};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    *out_host_orch_func_ptr = state.host_orch_func_ptr;
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return 0;
+    return {0, state.host_orch_func_ptr};
 }
 
 int DeviceRunner::finalize() {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -264,12 +264,6 @@ private:
     };
     std::unordered_map<uint64_t, ChipCallableBuffer> chip_callable_buffers_;
 
-    // Orchestration SO cache (host-resident in sim).
-    uint64_t cached_orch_so_hash_{0};
-    void *dev_orch_so_buffer_{nullptr};
-    size_t dev_orch_so_capacity_{0};
-    std::vector<uint8_t> host_orch_so_copy_;
-
     // Per-callable_id prepared state. Mirrors onboard.
     struct PreparedCallableState {
         // trb path

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -42,6 +42,7 @@
 #include <vector>
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
@@ -225,7 +226,7 @@ public:
     bool has_prepared_callable(int32_t callable_id) const;
 
     /** Replay prepared state onto a freshly-constructed Runtime. */
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
+    BindPreparedCallableResult bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
 
     /** Monotonic AICPU dlopen counter (first-sighting only; never decremented). */
     size_t aicpu_dlopen_count() const { return aicpu_dlopen_total_; }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -225,7 +225,7 @@ public:
     bool has_prepared_callable(int32_t callable_id) const;
 
     /** Replay prepared state onto a freshly-constructed Runtime. */
-    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id);
+    int bind_prepared_callable_to_runtime(Runtime &runtime, int32_t callable_id, void **out_host_orch_func_ptr);
 
     /** Monotonic AICPU dlopen counter (first-sighting only; never decremented). */
     size_t aicpu_dlopen_count() const { return aicpu_dlopen_total_; }

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -297,8 +297,7 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        void *host_orch_func_ptr = nullptr;
-        int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
+        auto [rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
         if (rc != 0) {
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -18,12 +18,13 @@
 #include "pto_runtime_c_api.h"
 
 #include "callable.h"
+#include "prepare_callable_common.h"
 #include "task_args.h"
 
 #include <new>
 #include <pthread.h>
 
-#include <memory>
+#include <utility>
 #include <vector>
 
 #include "common/unified_log.h"
@@ -37,8 +38,10 @@ extern "C" {
 /* ===========================================================================
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
-int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable);
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args);
+int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+);
+int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -237,40 +240,29 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
     pthread_setspecific(g_runner_key, ctx);
 
     try {
-        // Heap-allocate: hbg's Runtime carries 131072 Tasks → tens of MB.
-        std::unique_ptr<Runtime> r_owner = std::make_unique<Runtime>();
-        Runtime *r = r_owner.get();
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
-
-        int rc = prepare_callable_impl(r, reinterpret_cast<const ChipCallable *>(callable));
+        PreparedCallableArtifacts artifacts;
+        int rc = prepare_callable_impl(
+            reinterpret_cast<const ChipCallable *>(callable), upload_chip_callable_buffer_wrapper, &artifacts
+        );
         if (rc != 0) {
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
-        int kcount = r->get_registered_kernel_count();
-        kernel_addrs.reserve(kcount);
-        for (int i = 0; i < kcount; i++) {
-            int fid = r->get_registered_kernel_func_id(i);
-            kernel_addrs.emplace_back(fid, r->get_function_bin_addr(fid));
+        kernel_addrs.reserve(artifacts.kernel_addrs.size());
+        for (const ChildKernelAddr &c : artifacts.kernel_addrs) {
+            kernel_addrs.emplace_back(c.func_id, c.device_addr);
         }
-        r->clear_registered_kernels();
 
-        if (r->pending_host_dlopen_handle_ != nullptr) {
+        if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->register_prepared_callable_host_orch(
-                callable_id, r->pending_host_dlopen_handle_, r->pending_host_orch_func_ptr_, std::move(kernel_addrs)
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
             );
-            r->pending_host_dlopen_handle_ = nullptr;
-            r->pending_host_orch_func_ptr_ = nullptr;
         } else {
             rc = runner->register_prepared_callable(
-                callable_id, r->pending_orch_so_data_, r->pending_orch_so_size_, r->get_device_orch_func_name(),
-                r->get_device_orch_config_name(), std::move(kernel_addrs)
+                callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
+                artifacts.config_name.c_str(), std::move(kernel_addrs)
             );
         }
         pthread_setspecific(g_runner_key, nullptr);
@@ -305,14 +297,15 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        void *host_orch_func_ptr = nullptr;
+        int rc = runner->bind_prepared_callable_to_runtime(*r, callable_id, &host_orch_func_ptr);
         if (rc != 0) {
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args));
+        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -39,6 +39,7 @@
 
 #include "callable.h"
 #include "orchestration_api.h"
+#include "prepare_callable_common.h"
 #include "runtime.h"  // Includes unified_log.h and provides LOG_* macros
 #include "task_args.h"
 
@@ -278,44 +279,34 @@ extern "C" {
 /**
  * Stage the per-callable resources for the host_build_graph variant: upload
  * kernel binaries and dlopen the orchestration SO on the host. The dlopen
- * handle and resolved entry-symbol pointer are parked on the runtime via
- * `pending_host_dlopen_handle_` / `pending_host_orch_func_ptr_` so the
- * platform layer can hoist them into PreparedCallableState. Splitting this
- * out of init_runtime_impl is what the hbg prepare_callable / run_prepared
- * path rests on — the dlopen runs once per cid instead of every run.
+ * handle and resolved entry-symbol pointer are returned via
+ * PreparedCallableArtifacts so the platform layer can hoist them into its
+ * PreparedCallableState. Splitting this out of init_runtime_impl is what
+ * the hbg prepare_callable / run_prepared path rests on — the dlopen runs
+ * once per cid instead of every run.
  */
-int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
-    if (runtime == nullptr) {
-        LOG_ERROR("Runtime pointer is null");
-        return -1;
-    }
+int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
+    if (upload_fn == nullptr || out == nullptr) {
+        LOG_ERROR("upload_fn or out is null");
+        return -1;
+    }
+    *out = PreparedCallableArtifacts{};
 
-    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
-    // computes total size from contents, allocates device GM once, fixes up
-    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
-    // and returns the device-side address of the ChipCallable header.
-    // Callers then compute child device addresses via offset arithmetic and
-    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
-    if (callable->child_count() > 0) {
-        LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
-        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
-        if (chip_dev == 0) {
-            LOG_ERROR("Failed to upload ChipCallable buffer");
+    LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
+        LOG_ERROR("Failed to upload ChipCallable buffer");
+        return -1;
+    }
+    for (const ChildKernelAddr &c : out->kernel_addrs) {
+        if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
+            LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
             return -1;
-        }
-        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
-        for (int32_t i = 0; i < callable->child_count(); i++) {
-            int func_id = callable->child_func_id(i);
-            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-                return -1;
-            }
-            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
-            runtime->set_function_bin_addr(func_id, child_dev);
         }
     }
 
@@ -355,25 +346,19 @@ int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
 
     LOG_INFO_V0("Loaded orchestration function: %s", orch_func_name);
 
-    runtime->pending_host_dlopen_handle_ = handle;
-    runtime->pending_host_orch_func_ptr_ = reinterpret_cast<void *>(orch_func);
-    // hbg never uploads orch SO bytes to the device; clear the trb staging
-    // fields so DeviceRunner::register_prepared_callable cannot mistake this
-    // for a trb-shaped registration.
-    runtime->pending_orch_so_data_ = nullptr;
-    runtime->pending_orch_so_size_ = 0;
+    out->host_dlopen_handle = handle;
+    out->host_orch_func_ptr = reinterpret_cast<void *>(orch_func);
     return 0;
 }
 
 /**
  * Per-run binding for hbg: invoke the previously-resolved orchestration entry
  * point against the supplied args, then upload tensor info / allocation
- * storage. Assumes prepare_callable_impl populated
- * `pending_host_orch_func_ptr_` (either freshly during prepare_callable, or
- * via DeviceRunner::bind_prepared_callable_to_runtime when run_prepared
- * replays a prepared cid onto a fresh Runtime).
+ * storage. The c_api caller passes `host_orch_func_ptr` straight through from
+ * DeviceRunner::bind_prepared_callable_to_runtime (which read it from
+ * PreparedCallableState for this run's callable_id).
  */
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args) {
+int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -382,7 +367,7 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
         LOG_ERROR("orch_args pointer is null");
         return -1;
     }
-    OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(runtime->pending_host_orch_func_ptr_);
+    OrchestrationFunc orch_func = reinterpret_cast<OrchestrationFunc>(host_orch_func_ptr);
     if (orch_func == nullptr) {
         LOG_ERROR("bind_prepared_to_runtime_impl: host orch_func pointer is null");
         return -1;

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -491,17 +491,6 @@ public:
     // shared platform layer (DeviceRunner stamps it on every run).
     int32_t active_callable_id_{-1};
     bool register_new_callable_id_{false};
-    const void *pending_orch_so_data_{nullptr};
-    size_t pending_orch_so_size_{0};
-
-    // Host-orchestration staging (hbg path). prepare_callable_impl
-    // dlopens the orch SO on the host and parks the handle + entry-symbol
-    // pointer here so DeviceRunner::register_prepared_callable_host_orch can
-    // claim them; bind_prepared_callable_to_runtime restores them onto a fresh
-    // Runtime so bind_prepared_to_runtime_impl can call orch_func without a
-    // second dlopen.
-    void *pending_host_dlopen_handle_{nullptr};
-    void *pending_host_orch_func_ptr_{nullptr};
 
     // Device-orchestration entry/config symbol names (trb path). Always
     // empty on this hbg variant — included for API parity so the shared

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -41,6 +41,7 @@
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "prepare_callable_common.h"
 
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
@@ -102,54 +103,43 @@ static int32_t read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *hos
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
  * @return 0 on success, -1 on failure
  */
-extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *callable) {
-    if (runtime == nullptr) {
-        LOG_ERROR("Runtime pointer is null");
-        return -1;
-    }
+extern "C" int prepare_callable_impl(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
+) {
     if (callable == nullptr) {
         LOG_ERROR("Callable pointer is null");
         return -1;
     }
+    if (upload_fn == nullptr || out == nullptr) {
+        LOG_ERROR("upload_fn or out is null");
+        return -1;
+    }
+    *out = PreparedCallableArtifacts{};
 
-    // Single-shot upload of the entire ChipCallable buffer. DeviceRunner
-    // computes total size from contents, allocates device GM once, fixes up
-    // each child's resolved_addr_ in an internal host scratch, H2Ds once,
-    // and returns the device-side address of the ChipCallable header.
-    // Callers then compute child device addresses via offset arithmetic and
-    // write them to Runtime::func_id_to_addr_[] for AICPU dispatch.
-    if (callable->child_count() > 0) {
-        LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
-        uint64_t chip_dev = runtime->host_api.upload_chip_callable_buffer(callable);
-        if (chip_dev == 0) {
-            LOG_ERROR("Failed to upload ChipCallable buffer");
+    LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
+    if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
+        LOG_ERROR("Failed to upload ChipCallable buffer");
+        return -1;
+    }
+    for (const ChildKernelAddr &c : out->kernel_addrs) {
+        if (c.func_id < 0 || c.func_id >= RUNTIME_MAX_FUNC_ID) {
+            LOG_ERROR("func_id=%d is out of range [0, %d)", c.func_id, RUNTIME_MAX_FUNC_ID);
             return -1;
-        }
-        constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
-        for (int32_t i = 0; i < callable->child_count(); i++) {
-            int func_id = callable->child_func_id(i);
-            if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-                LOG_ERROR("func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-                return -1;
-            }
-            uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
-            runtime->set_function_bin_addr(func_id, child_dev);
         }
     }
 
     const uint8_t *orch_so_binary = static_cast<const uint8_t *>(callable->binary_data());
     size_t orch_so_size = callable->binary_size();
-    runtime->set_device_orch_func_name(callable->func_name());
-    runtime->set_device_orch_config_name(callable->config_name());
 
     if (orch_so_binary == nullptr || orch_so_size == 0) {
         LOG_ERROR("Orchestration SO binary is required for device orchestration");
         return -1;
     }
 
-    // Stage the orchestration SO for DeviceRunner::prepare_orch_so to consume.
-    runtime->pending_orch_so_data_ = orch_so_binary;
-    runtime->pending_orch_so_size_ = orch_so_size;
+    out->orch_so_data = orch_so_binary;
+    out->orch_so_size = orch_so_size;
+    out->func_name = callable->func_name();
+    out->config_name = callable->config_name();
     LOG_INFO_V0("Orchestration SO: %zu bytes staged (host-only)", orch_so_size);
     return 0;
 }
@@ -168,13 +158,21 @@ extern "C" int prepare_callable_impl(Runtime *runtime, const ChipCallable *calla
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
-extern "C" int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args) {
+extern "C" int
+bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
     }
     if (orch_args == nullptr) {
         LOG_ERROR("orch_args pointer is null");
+        return -1;
+    }
+    // trb runs orchestration on the device — there is no host-side orch
+    // function pointer to invoke. The c_api signature accepts one for
+    // symmetry with hbg; assert the trb-side invariant here.
+    if (host_orch_func_ptr != nullptr) {
+        LOG_ERROR("bind_prepared_to_runtime_impl: trb does not accept a host_orch_func_ptr");
         return -1;
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -317,20 +317,6 @@ public:
     // Host API function pointers for device memory operations
     // NOTE: Placed at end of class to avoid affecting device memory layout
     HostApi host_api;
-
-    // Host-only staging for orchestration SO. runtime_maker publishes the
-    // callable-owned pointer here; DeviceRunner consumes it before launching
-    // the device-side execution and replaces it with the device-resident
-    // buffer metadata (dev_orch_so_addr_, dev_orch_so_size_).
-    const void *pending_orch_so_data_{nullptr};
-    size_t pending_orch_so_size_{0};
-
-    // Host-orchestration staging (hbg path). Always nullptr on this trb
-    // variant — included for API parity with host_build_graph so the
-    // shared platform layer can branch on `pending_host_dlopen_handle_ !=
-    // nullptr` at runtime instead of via a build-time macro.
-    void *pending_host_dlopen_handle_{nullptr};
-    void *pending_host_orch_func_ptr_{nullptr};
 };
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/common/task_interface/chip_callable_layout.h
+++ b/src/common/task_interface/chip_callable_layout.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Platform-agnostic ChipCallable layout / content-hash helpers used by
+ * DeviceRunner::upload_chip_callable_buffer on every platform variant.
+ *
+ * The byte-size math (mirroring make_callable<>()'s layout) and FNV-1a dedup
+ * hash are identical on onboard and sim. Only the H2D mechanism diverges:
+ * onboard rtMemcpy's the scratch into device GM after rewriting each child's
+ * resolved_addr_ to a device offset; sim instead dlopen's each child kernel
+ * and writes the resulting function pointer into resolved_addr_. The
+ * device-offset patch is exposed here so onboard can share it; the dlopen
+ * path stays in sim's device_runner.cpp.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "callable.h"
+#include "utils/fnv1a_64.h"
+
+struct ChipCallableLayout {
+    size_t header_size;     // offsetof(ChipCallable, storage_)
+    size_t total_size;      // header_size + storage_used (matches make_callable())
+    uint64_t content_hash;  // FNV-1a 64 over [callable, total_size)
+};
+
+/**
+ * Compute byte-size and content hash for a ChipCallable buffer.
+ *
+ * `storage_used` is max(binary_size, child_offset[i] + CoreCallable header +
+ * child binary_size) over all children — same arithmetic make_callable<>()
+ * uses when emitting the host buffer.
+ */
+inline ChipCallableLayout compute_chip_callable_layout(const ChipCallable *callable) {
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    size_t storage_used = static_cast<size_t>(callable->binary_size());
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const CoreCallable &c = callable->child(i);
+        size_t child_total = CoreCallable::binary_data_offset() + static_cast<size_t>(c.binary_size());
+        size_t end = static_cast<size_t>(callable->child_offset(i)) + child_total;
+        if (end > storage_used) storage_used = end;
+    }
+    const size_t total_size = kHeaderSize + storage_used;
+    const uint64_t hash = simpler::common::utils::fnv1a_64(reinterpret_cast<const uint8_t *>(callable), total_size);
+    return ChipCallableLayout{kHeaderSize, total_size, hash};
+}
+
+/**
+ * Onboard-style scratch patch: rewrite each child's resolved_addr_ in the
+ * host scratch buffer to the device-side code address of the child's binary,
+ * computed as `target_base + header_size + child_offset(i) +
+ * CoreCallable::binary_data_offset()`.
+ *
+ * `scratch` already holds a byte-copy of `callable` of `layout.total_size`
+ * bytes; this helper only flips the child resolved_addr_ words. Sim does not
+ * call this — it writes host function pointers into resolved_addr_ instead.
+ */
+inline void patch_chip_callable_scratch_for_device(
+    const ChipCallable *callable, const ChipCallableLayout &layout, uint64_t target_base, uint8_t *scratch
+) {
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        const uint32_t off = callable->child_offset(i);
+        auto *child = reinterpret_cast<CoreCallable *>(scratch + layout.header_size + off);
+        uint64_t child_dev = target_base + layout.header_size + off;
+        child->set_resolved_addr(child_dev + CoreCallable::binary_data_offset());
+    }
+}

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -64,6 +64,25 @@ struct PreparedCallableArtifacts {
 };
 
 /**
+ * Result of DeviceRunner::bind_prepared_callable_to_runtime — what the c_api
+ * needs to pass on to bind_prepared_to_runtime_impl for a per-run binding.
+ *
+ * Returning a struct (rather than a `void**` out-parameter) keeps the caller
+ * site idiomatic — destructure with C++17 structured bindings:
+ *
+ *     auto [rc, host_orch_func_ptr] =
+ *         runner->bind_prepared_callable_to_runtime(*r, callable_id);
+ *
+ * `host_orch_func_ptr` is type-erased as `void *` (rather than the concrete
+ * OrchestrationFunc) so this header stays runtime-agnostic; only the hbg path
+ * sets it. trb leaves it null and bind_prepared_to_runtime_impl asserts so.
+ */
+struct BindPreparedCallableResult {
+    int rc{0};
+    void *host_orch_func_ptr{nullptr};
+};
+
+/**
  * Upload the ChipCallable buffer via `upload_fn` and compute the device-side
  * address of every child kernel.
  *

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "callable.h"
@@ -31,6 +32,35 @@
 struct ChildKernelAddr {
     int func_id;
     uint64_t device_addr;
+};
+
+/**
+ * Output bundle from a runtime's prepare_callable_impl() — everything the
+ * platform layer needs to register a callable_id with its DeviceRunner.
+ *
+ * Replaces the per-field Runtime::pending_* sidecar that earlier callsites
+ * used as a "C ABI struggling with multiple return values" hack. Each
+ * runtime variant fills only the subset it produces:
+ *
+ *   - host_build_graph: kernel_addrs + host_dlopen_handle + host_orch_func_ptr
+ *                       (orch_so_* stay null since orch SO never crosses
+ *                       host/device on this runtime)
+ *   - tensormap_and_ringbuffer: kernel_addrs + orch_so_data + orch_so_size
+ *                       + func_name + config_name (orch SO is uploaded to
+ *                       device by DeviceRunner; host does no dlopen)
+ *
+ * func_name / config_name are non-empty only for the trb path; the hbg path
+ * resolves its entry symbol during prepare_callable_impl and stores the
+ * resulting function pointer in host_orch_func_ptr directly.
+ */
+struct PreparedCallableArtifacts {
+    std::vector<ChildKernelAddr> kernel_addrs;
+    void *host_dlopen_handle{nullptr};  // hbg only
+    void *host_orch_func_ptr{nullptr};  // hbg only
+    const void *orch_so_data{nullptr};  // trb only
+    size_t orch_so_size{0};             // trb only
+    std::string func_name;              // trb only (orch entry symbol)
+    std::string config_name;            // trb only (orch config symbol)
 };
 
 /**

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Runtime-agnostic helper for the kernel-upload half of prepare_callable_impl.
+ *
+ * Each runtime variant (host_build_graph, tensormap_and_ringbuffer, ...) needs
+ * to: upload the ChipCallable buffer to device once, then translate each child
+ * kernel's storage offset into a device address that AICPU dispatch can read
+ * out of Runtime::func_id_to_addr_[]. The upload + offset arithmetic does not
+ * depend on the surrounding runtime, only on the ChipCallable layout and the
+ * platform's upload entry point. Callers retain the func_id range check
+ * because RUNTIME_MAX_FUNC_ID lives in each runtime's own headers.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "callable.h"
+
+struct ChildKernelAddr {
+    int func_id;
+    uint64_t device_addr;
+};
+
+/**
+ * Upload the ChipCallable buffer via `upload_fn` and compute the device-side
+ * address of every child kernel.
+ *
+ * @param callable   ChipCallable to upload. May have child_count() == 0, in
+ *                   which case `out` is cleared and 0 is returned.
+ * @param upload_fn  HostApi::upload_chip_callable_buffer — declared as
+ *                   `uint64_t (*)(const void *)` to avoid pulling runtime
+ *                   headers into task_interface. Must not be null.
+ * @param out        Cleared on entry; on success, populated with one
+ *                   {func_id, device_addr} entry per child kernel. Caller is
+ *                   responsible for validating func_id against its runtime's
+ *                   RUNTIME_MAX_FUNC_ID before writing to func_id_to_addr_[].
+ * @return 0 on success (including the child_count == 0 case), -1 on argument
+ *         error or upload failure.
+ */
+inline int upload_and_collect_child_addrs(
+    const ChipCallable *callable, uint64_t (*upload_fn)(const void *), std::vector<ChildKernelAddr> *out
+) {
+    if (callable == nullptr || upload_fn == nullptr || out == nullptr) return -1;
+    out->clear();
+    if (callable->child_count() <= 0) return 0;
+
+    uint64_t chip_dev = upload_fn(callable);
+    if (chip_dev == 0) return -1;
+
+    constexpr size_t kHeaderSize = offsetof(ChipCallable, storage_);
+    out->reserve(static_cast<size_t>(callable->child_count()));
+    for (int32_t i = 0; i < callable->child_count(); ++i) {
+        uint64_t child_dev = chip_dev + kHeaderSize + callable->child_offset(i);
+        out->push_back({callable->child_func_id(i), child_dev});
+    }
+    return 0;
+}


### PR DESCRIPTION
Four self-contained refactors of the ChipCallable prepare/run plumbing. No
user-visible behavior change; all four are pure cleanup of duplicated code
or sidecar state.

## Summary

1. **Extract `upload_and_collect_child_addrs` helper.** The kernel-upload
   prologue of `prepare_callable_impl` was byte-identical between
   `host_build_graph` and `tensormap_and_ringbuffer`. Move it to
   `src/common/task_interface/prepare_callable_common.h`; the helper takes
   the upload function pointer directly so it has no Runtime dependency.

2. **Extract `chip_callable_layout` helpers.**
   `upload_chip_callable_buffer` in the onboard and sim `DeviceRunner`s
   shared the layout math (`storage_used`, `total_size`) and FNV-1a dedup
   hash. Move them to `chip_callable_layout.h`. Onboard additionally
   reuses the `patch_chip_callable_scratch_for_device` helper that
   rewrites each child's `resolved_addr_` to a device offset; sim keeps
   its own dlopen+register_hooks loop.

3. **Merge `_chip_process_loop` and the bootstrap variant.** Both had
   identical TASK_READY / CONTROL_REQUEST / SHUTDOWN state machines.
   Extract `_run_chip_main_loop` and inject the bootstrap-only
   store_to_host flush via an `on_task_done_success` hook. The bootstrap
   path was also reaching into `cw._impl.malloc` / `_impl.copy_to` where
   the non-bootstrap path used the public `cw.*` methods — both now use
   the public path (thin int-cast forwarders, so unchanged behavior).

4. **Replace `Runtime::pending_*` sidecar with `PreparedCallableArtifacts`.**
   `prepare_callable_impl` used to park `host_dlopen_handle`,
   `host_orch_func_ptr`, `orch_so_data`, and `orch_so_size` on the
   `Runtime` because its `extern C` signature had only one `Runtime*`
   slot. Replace with an out-parameter struct. On `run_prepared`,
   `bind_prepared_callable_to_runtime` now returns the hbg
   `host_orch_func_ptr` via an out-pointer rather than restoring it onto
   `Runtime::pending_host_orch_func_ptr_`; `bind_prepared_to_runtime_impl`
   gains a `void *host_orch_func_ptr` arg (trb asserts it must be null).
   All four `pending_*` fields drop from both a2a3 and a5 `runtime.h`,
   and the dead `cid < 0` fallback in `prepare_orch_so` is replaced with
   a `LOG_ERROR` (the prepared-callable flow is the only supported path
   since #710).

a5 caught up to the a2a3 helper-using shape in PR4 so the two stay in
sync.

## Testing

- [x] All 8 variants build cleanly (`a2a3sim`, `a2a3`, `a5sim`, `a5` x
      `host_build_graph`, `tensormap_and_ringbuffer`)
- [x] `pytest tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable
      --platform a2a3sim` — 6/6 pass (dlopen_count monotonicity + dedup
      hits + same-cid replay)
- [x] `pytest tests/st/a2a3/tensormap_and_ringbuffer --platform a2a3sim
      --device 0-1` — L2 trb 23/23 + L3 dependency + L3 group all pass
- [x] `pytest tests/st/a2a3/host_build_graph --platform a2a3sim --device
      0-1` — 9/9 pass
- [x] `pytest tests/ut/py/test_worker/test_ensure_prepared.py` — 4/4
      pass