### PR TITLE
Refactor: drop unused READY/RUNNING task states

### DIFF
--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -426,9 +426,9 @@ state machine).
 
 `scope_end` walks the scope's tasks and bumps each one's `fanout_released`
 counter, then returns. A task whose `fanout_released` now meets the
-threshold transitions to CONSUMED inline; others stay COMPLETED / RUNNING /
-PENDING until the scheduler and consumers finish their own releases. This
-mirrors L2's `pto2_scope_end`.
+threshold transitions to CONSUMED inline; others stay COMPLETED or PENDING
+until the scheduler and consumers finish their own releases. This mirrors
+L2's `pto2_scope_end`.
 
 Users who need a synchronous wait for *all* in-flight tasks must call
 `drain()` (or let `Worker::run` finish — its outer `scope_end` is followed
@@ -486,29 +486,29 @@ concurrent hash map can replace it.
 Each `TaskSlotState.state` progresses through:
 
 ```text
-FREE ──► PENDING ──► READY ──► RUNNING ──► COMPLETED ──► CONSUMED ──► FREE
- ↑         │           │          │            │             │
- │       submit       fanin=0   Scheduler    worker        all refs
- │       has fanin    (submit   dispatches   done          released
- │                    or fanout  to WT                     (scope +
- │                    release)                              fanout)
- │                                                          │
- └──────────────────── ring.release(sid) ◄─────────────────┘
+FREE ──► PENDING ──► COMPLETED ──► CONSUMED ──► FREE
+ ↑         │            │             │
+ │       submit      worker(s)     all refs
+ │                   done          released
+ │                                 (scope + fanout)
+ │                                     │
+ └──────── ring.release(sid) ◄─────────┘
 ```
 
 - **FREE**: slot in the ring pool, not allocated
-- **PENDING**: allocated, `fanin_count > 0`, waiting on producers
-- **READY**: pushed to ready_queue (will be dispatched)
-- **RUNNING**: Scheduler has dispatched to a WorkerThread; for group tasks,
-  `sub_complete_count < group_size`
+- **PENDING**: allocated; remains PENDING through "waiting on producers",
+  "queued in ready_queue", and "dispatched to a worker"
 - **COMPLETED**: worker(s) done; may still be referenced by fanout / scope
 - **CONSUMED**: all references released; Scheduler calls `ring.release(sid)`
   and the slot returns to FREE
 
-State transitions are driven by atomic CAS operations:
+There is no separate READY or RUNNING state — readiness is derived from
+`fanin_refcount == fanin_count` and running-vs-idle from the per-core
+`running_slot_state` pointer. State transitions are driven by atomic
+operations:
 
-- Orch: FREE → PENDING/READY at submit time
-- Scheduler: READY → RUNNING → COMPLETED → CONSUMED during dispatch/completion
+- Orch: FREE → PENDING at submit time
+- Scheduler: PENDING → COMPLETED → CONSUMED during completion
 
 ### Fanout-release threshold
 

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -198,7 +198,8 @@ void Scheduler::dispatch_ready() {
                 q->push(slot);   // put back; try again after a completion
                 break;
             }
-            s.state.store(TaskState::RUNNING);
+            // Slot stays in PENDING through dispatch; running-vs-idle is
+            // tracked via the worker's running_slot_state pointer.
             for (int i = 0; i < N; i++) {
                 workers[i]->dispatch({slot, i});
             }
@@ -339,8 +340,8 @@ by completion-handling cost.
 1. **Scheduler is single-threaded**: all three phase handlers run in the
    Scheduler's own thread. Atomics/mutexes on slot state are only needed for
    Orch/WorkerThread ↔ Scheduler coordination.
-2. **Slot transitions are monotonic**: `FREE → PENDING → READY → RUNNING →
-   COMPLETED → CONSUMED` never reverses within one allocation.
+2. **Slot transitions are monotonic**: `FREE → PENDING → COMPLETED →
+   CONSUMED` never reverses within one allocation.
 3. **Dispatch consumes one ready entry**: every `ready_queue.push` is
    matched by exactly one `pick_idle + dispatch`. Group tasks push once,
    dispatch N times via `pick_n_idle`.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -348,19 +348,19 @@ When `PTO2OrchestratorState::submit_task` processes parameters:
 ### 6.2 Task State Machine
 
 ```text
-  [0] PENDING ──fanin satisfied──► [1] READY ──dispatch──► [2] RUNNING
-      ▲                                                         │
-      │                                                         ▼
-  slot recycled ◄── [4] CONSUMED ◄──fanout done── [3] COMPLETED
+  [0] PENDING ──worker(s) done──► [1] COMPLETED ──fanout done──► [2] CONSUMED
+      ▲                                                                │
+      │                                                                ▼
+      └──────────────────── slot recycled ◄───────────────────────────┘
 ```
 
 In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
 
-- **0 (PENDING)**: waiting for dependencies (`fanin_refcount < fanin_count`)
-- **1 (READY)**: all dependencies satisfied, waiting in ready queue
-- **2 (RUNNING)**: currently executing on a worker
-- **3 (COMPLETED)**: hardware execution complete, output may still be in use
-- **4 (CONSUMED)**: output fully consumed, buffers can be released
+- **0 (PENDING)**: slot is allocated and remains PENDING through "waiting on
+  producers", "queued in ready queue", and "dispatched to a worker"; ready vs
+  running is derived from `fanin_refcount` and per-core `running_slot_state`
+- **1 (COMPLETED)**: hardware execution complete, output may still be in use
+- **2 (CONSUMED)**: output fully consumed, buffers can be released
 
 ---
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -144,18 +144,21 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
  * Task state enumeration
  *
  * State transitions:
- *   PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED
+ *   PENDING -> COMPLETED -> CONSUMED
+ *
+ * The slot stays in PENDING from submit through "ready in queue" and "running
+ * on a worker"; readiness and running-vs-idle are derived from fanin_refcount
+ * and per-core running_slot_state respectively, not from task_state itself.
  *
  * Conditions:
- *   PENDING->READY:     fanin_refcount == fanin_count
- *   COMPLETED->CONSUMED: fanout_refcount == fanout_count && state == COMPLETED
+ *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
+ *                         hidden alloc completed inline by the orchestrator
+ *   COMPLETED->CONSUMED:  fanout_refcount == fanout_count && state == COMPLETED
  */
 typedef enum {
-    PTO2_TASK_PENDING = 0,    // Waiting for dependencies (fanin_refcount < fanin_count)
-    PTO2_TASK_READY = 1,      // All dependencies satisfied, waiting in ready queue
-    PTO2_TASK_RUNNING = 2,    // Currently executing on a worker
-    PTO2_TASK_COMPLETED = 3,  // Execution finished, output may still be in use
-    PTO2_TASK_CONSUMED = 4    // Output fully consumed, buffers can be released
+    PTO2_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched
+    PTO2_TASK_COMPLETED = 1,  // Execution finished, output may still be in use
+    PTO2_TASK_CONSUMED = 2    // Output fully consumed, buffers can be released
 } PTO2TaskState;
 
 /**
@@ -323,7 +326,7 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2DepListEntry *fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
-    std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<PTO2TaskState> task_state;  // PENDING/COMPLETED/CONSUMED
 
     // Fanin (accessed together in release_fanin_and_check_ready)
     std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -62,27 +62,6 @@ PTO2SchedProfilingData scheduler_get_profiling(int thread_idx) {
 #endif
 
 // =============================================================================
-// Task State Names
-// =============================================================================
-
-const char *task_state_name(PTO2TaskState state) {
-    switch (state) {
-    case PTO2_TASK_PENDING:
-        return "PENDING";
-    case PTO2_TASK_READY:
-        return "READY";
-    case PTO2_TASK_RUNNING:
-        return "RUNNING";
-    case PTO2_TASK_COMPLETED:
-        return "COMPLETED";
-    case PTO2_TASK_CONSUMED:
-        return "CONSUMED";
-    default:
-        return "UNKNOWN";
-    }
-}
-
-// =============================================================================
 // Ready Queue Implementation
 // =============================================================================
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -14,7 +14,7 @@
  *
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues
- * 2. Tracking task state (PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED)
+ * 2. Tracking task state (PENDING -> COMPLETED -> CONSUMED)
  * 3. Managing fanin/fanout refcounts for dependency resolution
  * 4. Advancing last_task_alive for heap reclamation
  * 5. Two-stage mixed-task completion (subtask done bits → mixed-task complete)
@@ -815,23 +815,17 @@ struct PTO2SchedulerState {
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
-            PTO2TaskState expected = PTO2_TASK_PENDING;
-            if (slot_state.task_state.compare_exchange_strong(
-                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
-                )) {
-                atomic_count += 1;  // CAS(task_state PENDING→READY)
-                // Local-first: try per-CoreType thread-local buffer before global queue.
-                // Dummy slots bypass local_bufs (out-of-range for PTO2_NUM_RESOURCE_SHAPES)
-                // and go straight to dummy_ready_queue; use the profiling-aware push so
-                // atomic_count / push_wait stay consistent with the non-dummy path.
-                PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-                if (shape == PTO2ResourceShape::DUMMY) {
-                    dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
-                } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
-                    ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
-                }
-                return true;
+            // Local-first: try per-CoreType thread-local buffer before global queue.
+            // Dummy slots bypass local_bufs (out-of-range for PTO2_NUM_RESOURCE_SHAPES)
+            // and go straight to dummy_ready_queue; use the profiling-aware push so
+            // atomic_count / push_wait stay consistent with the non-dummy path.
+            PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+            if (shape == PTO2ResourceShape::DUMMY) {
+                dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
+            } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
+                ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
             }
+            return true;
         }
         return false;
     }
@@ -1095,12 +1089,6 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
     unlock();
     return result;
 }
-
-// =============================================================================
-// Debug Utilities (cold path, defined in pto_scheduler.cpp)
-// =============================================================================
-
-const char *task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -143,6 +143,7 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
 //   SUMMARY  — completed / total counts and scan totals               (thread 0 only)
 //   TASK     — one per non-completed task scanned from shared rings   (thread 0 only)
 //              - state=RUNNING: includes running_on=[...] cross-ref
+//              - state=READY:   fanin satisfied but no idle core yet
 //              - state=WAIT:    includes missing_deps=N
 //   CLUSTER  — one per cluster owned by this thread                   (every thread)
 //              - busy slot shows kernel + task_id + cond_reg_state;
@@ -234,12 +235,12 @@ void SchedulerContext::log_stall_diagnostics(
                 int32_t kid_aiv1 = slot_state.task->kernel_id[2];
                 int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
                 if (st >= PTO2_TASK_COMPLETED) continue;
-                // task_state's intermediate values (READY / RUNNING) are not
-                // written on the non-profiling hot path, so we cannot rely on
-                // them — classify by the ground truth instead: a slot is
-                // RUNNING iff some core has it as running_slot_state. A task
-                // occupies at most 3 cores (one cluster), all under the same
-                // owner thread by construction of assign_cores_to_threads.
+                // task_state has no intermediate ready/running value — it
+                // stays PENDING until the worker stores COMPLETED. Classify
+                // by the ground truth instead: a slot is RUNNING iff some
+                // core has it as running_slot_state. A task occupies at most
+                // 3 cores (one cluster), all under the same owner thread by
+                // construction of assign_cores_to_threads.
                 char running_on[192] = {0};
                 int32_t owner = -1;
                 int32_t pos = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -348,19 +348,19 @@ When `PTO2OrchestratorState::submit_task` processes parameters:
 ### 6.2 Task State Machine
 
 ```text
-  [0] PENDING ──fanin satisfied──► [1] READY ──dispatch──► [2] RUNNING
-      ▲                                                         │
-      │                                                         ▼
-  slot recycled ◄── [4] CONSUMED ◄──fanout done── [3] COMPLETED
+  [0] PENDING ──worker(s) done──► [1] COMPLETED ──fanout done──► [2] CONSUMED
+      ▲                                                                │
+      │                                                                ▼
+      └──────────────────── slot recycled ◄───────────────────────────┘
 ```
 
 In the scheduler's `task_state[]` array (`std::atomic<PTO2TaskState>`):
 
-- **0 (PENDING)**: waiting for dependencies (`fanin_refcount < fanin_count`)
-- **1 (READY)**: all dependencies satisfied, waiting in ready queue
-- **2 (RUNNING)**: currently executing on a worker
-- **3 (COMPLETED)**: hardware execution complete, output may still be in use
-- **4 (CONSUMED)**: output fully consumed, buffers can be released
+- **0 (PENDING)**: slot is allocated and remains PENDING through "waiting on
+  producers", "queued in ready queue", and "dispatched to a worker"; ready vs
+  running is derived from `fanin_refcount` and per-core `running_slot_state`
+- **1 (COMPLETED)**: hardware execution complete, output may still be in use
+- **2 (CONSUMED)**: output fully consumed, buffers can be released
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -135,18 +135,21 @@ constexpr uint64_t PTO2_TENSOR_DATA_TIMEOUT_CYCLES = 15 * 1000 * 1000 * 1000ULL;
  * Task state enumeration
  *
  * State transitions:
- *   PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED
+ *   PENDING -> COMPLETED -> CONSUMED
+ *
+ * The slot stays in PENDING from submit through "ready in queue" and "running
+ * on a worker"; readiness and running-vs-idle are derived from fanin_refcount
+ * and per-core running_slot_state respectively, not from task_state itself.
  *
  * Conditions:
- *   PENDING->READY:     fanin_refcount == fanin_count
- *   COMPLETED->CONSUMED: fanout_refcount == fanout_count && state == COMPLETED
+ *   PENDING->COMPLETED:   all subtasks finish (set by scheduler) or task is a
+ *                         hidden alloc completed inline by the orchestrator
+ *   COMPLETED->CONSUMED:  fanout_refcount == fanout_count && state == COMPLETED
  */
 typedef enum {
-    PTO2_TASK_PENDING = 0,    // Waiting for dependencies (fanin_refcount < fanin_count)
-    PTO2_TASK_READY = 1,      // All dependencies satisfied, waiting in ready queue
-    PTO2_TASK_RUNNING = 2,    // Currently executing on a worker
-    PTO2_TASK_COMPLETED = 3,  // Execution finished, output may still be in use
-    PTO2_TASK_CONSUMED = 4    // Output fully consumed, buffers can be released
+    PTO2_TASK_PENDING = 0,    // Submitted; awaiting fanin, queued, or dispatched
+    PTO2_TASK_COMPLETED = 1,  // Execution finished, output may still be in use
+    PTO2_TASK_CONSUMED = 2    // Output fully consumed, buffers can be released
 } PTO2TaskState;
 
 /**
@@ -314,7 +317,7 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2DepListEntry *fanout_head;  // Pointer to first fanout entry (nullptr = empty)
 
     // Task state (completion, consumed check, ready check)
-    std::atomic<PTO2TaskState> task_state;  // PENDING/READY/RUNNING/COMPLETED/CONSUMED
+    std::atomic<PTO2TaskState> task_state;  // PENDING/COMPLETED/CONSUMED
 
     // Fanin (accessed together in release_fanin_and_check_ready)
     std::atomic<int32_t> fanin_refcount;  // Dynamic: counts completed producers

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -62,27 +62,6 @@ PTO2SchedProfilingData scheduler_get_profiling(int thread_idx) {
 #endif
 
 // =============================================================================
-// Task State Names
-// =============================================================================
-
-const char *task_state_name(PTO2TaskState state) {
-    switch (state) {
-    case PTO2_TASK_PENDING:
-        return "PENDING";
-    case PTO2_TASK_READY:
-        return "READY";
-    case PTO2_TASK_RUNNING:
-        return "RUNNING";
-    case PTO2_TASK_COMPLETED:
-        return "COMPLETED";
-    case PTO2_TASK_CONSUMED:
-        return "CONSUMED";
-    default:
-        return "UNKNOWN";
-    }
-}
-
-// =============================================================================
 // Ready Queue Implementation
 // =============================================================================
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -14,7 +14,7 @@
  *
  * The Scheduler is responsible for:
  * 1. Maintaining per-resource-shape ready queues
- * 2. Tracking task state (PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED)
+ * 2. Tracking task state (PENDING -> COMPLETED -> CONSUMED)
  * 3. Managing fanin/fanout refcounts for dependency resolution
  * 4. Advancing last_task_alive for heap reclamation
  * 5. Two-stage mixed-task completion (subtask done bits → mixed-task complete)
@@ -815,23 +815,17 @@ struct PTO2SchedulerState {
         atomic_count += 1;  // fanin_refcount.fetch_add
 
         if (new_refcount == slot_state.fanin_count) {
-            PTO2TaskState expected = PTO2_TASK_PENDING;
-            if (slot_state.task_state.compare_exchange_strong(
-                    expected, PTO2_TASK_READY, std::memory_order_acq_rel, std::memory_order_acquire
-                )) {
-                atomic_count += 1;  // CAS(task_state PENDING→READY)
-                // Local-first: try per-CoreType thread-local buffer before global queue.
-                // Dummy slots bypass local_bufs (out-of-range for PTO2_NUM_RESOURCE_SHAPES)
-                // and go straight to dummy_ready_queue; use the profiling-aware push so
-                // atomic_count / push_wait stay consistent with the non-dummy path.
-                PTO2ResourceShape shape = slot_state.active_mask.to_shape();
-                if (shape == PTO2ResourceShape::DUMMY) {
-                    dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
-                } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
-                    ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
-                }
-                return true;
+            // Local-first: try per-CoreType thread-local buffer before global queue.
+            // Dummy slots bypass local_bufs (out-of-range for PTO2_NUM_RESOURCE_SHAPES)
+            // and go straight to dummy_ready_queue; use the profiling-aware push so
+            // atomic_count / push_wait stay consistent with the non-dummy path.
+            PTO2ResourceShape shape = slot_state.active_mask.to_shape();
+            if (shape == PTO2ResourceShape::DUMMY) {
+                dummy_ready_queue.push(&slot_state, atomic_count, push_wait);
+            } else if (!local_bufs || !local_bufs[static_cast<int32_t>(shape)].try_push(&slot_state)) {
+                ready_queues[static_cast<int32_t>(shape)].push(&slot_state, atomic_count, push_wait);
             }
+            return true;
         }
         return false;
     }
@@ -1086,12 +1080,6 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
     unlock();
     return result;
 }
-
-// =============================================================================
-// Debug Utilities (cold path, defined in pto_scheduler.cpp)
-// =============================================================================
-
-const char *task_state_name(PTO2TaskState state);
 
 // =============================================================================
 // Scheduler Profiling Data

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -143,6 +143,7 @@ SchedulerContext::check_idle_fatal_error(int32_t thread_idx, PTO2SharedMemoryHea
 //   SUMMARY  — completed / total counts and scan totals               (thread 0 only)
 //   TASK     — one per non-completed task scanned from shared rings   (thread 0 only)
 //              - state=RUNNING: includes running_on=[...] cross-ref
+//              - state=READY:   fanin satisfied but no idle core yet
 //              - state=WAIT:    includes missing_deps=N
 //   CLUSTER  — one per cluster owned by this thread                   (every thread)
 //              - busy slot shows kernel + task_id + cond_reg_state;
@@ -234,12 +235,12 @@ void SchedulerContext::log_stall_diagnostics(
                 int32_t kid_aiv1 = slot_state.task->kernel_id[2];
                 int64_t task_id = static_cast<int64_t>(slot_state.task->task_id.raw);
                 if (st >= PTO2_TASK_COMPLETED) continue;
-                // task_state's intermediate values (READY / RUNNING) are not
-                // written on the non-profiling hot path, so we cannot rely on
-                // them — classify by the ground truth instead: a slot is
-                // RUNNING iff some core has it as running_slot_state. A task
-                // occupies at most 3 cores (one cluster), all under the same
-                // owner thread by construction of assign_cores_to_threads.
+                // task_state has no intermediate ready/running value — it
+                // stays PENDING until the worker stores COMPLETED. Classify
+                // by the ground truth instead: a slot is RUNNING iff some
+                // core has it as running_slot_state. A task occupies at most
+                // 3 cores (one cluster), all under the same owner thread by
+                // construction of assign_cores_to_threads.
                 char running_on[192] = {0};
                 int32_t owner = -1;
                 int32_t pos = 0;

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -83,12 +83,12 @@ TEST_F(SchedulerStateTest, ConsumedTransition) {
 
 TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.fanout_refcount.store(1);
 
     sched.check_and_handle_consumed(slot);
-    // CAS fails because state is RUNNING, not COMPLETED
-    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_RUNNING);
+    // CAS fails because state is PENDING, not COMPLETED
+    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_PENDING);
 }
 
 TEST_F(SchedulerStateTest, ConsumedIdempotent) {
@@ -130,7 +130,7 @@ TEST_F(SchedulerStateTest, ReleaseProducerTriggersConsumed) {
 
 TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 1;
     slot.completed_subtasks.store(0);
 
@@ -139,7 +139,7 @@ TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
 
 TEST_F(SchedulerStateTest, SubtaskCompleteMultiBlock) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 6;  // 3 cores * 2 blocks
     slot.completed_subtasks.store(0);
 
@@ -176,7 +176,7 @@ TEST_F(SchedulerStateTest, ScopeEndBatchRelease) {
 
 TEST_F(SchedulerStateTest, GetReadyTasksBatchLocalFirst) {
     alignas(64) PTO2TaskSlotState slot_a, slot_b;
-    init_slot(slot_a, PTO2_TASK_READY, 0, 1);
+    init_slot(slot_a, PTO2_TASK_PENDING, 0, 1);
     init_slot(slot_b, PTO2_TASK_PENDING, 1, 1);
 
     PTO2TaskSlotState *local_buf_storage[4];

--- a/tests/ut/cpp/a2a3/test_task_state.cpp
+++ b/tests/ut/cpp/a2a3/test_task_state.cpp
@@ -19,7 +19,7 @@
  *
  * This file focuses on:
  * - Full lifecycle through src API
- * - Non-profiling ready path behavior (task_state stays PENDING)
+ * - Ready-path behavior (task_state stays PENDING through dispatch)
  * - Double subtask completion (counter-model weakness)
  */
 
@@ -67,7 +67,7 @@ protected:
 };
 
 // =============================================================================
-// Full lifecycle through src API: PENDING -> (fanin) -> READY-equivalent
+// Full lifecycle through src API: PENDING -> (fanin) -> (queued + dispatched)
 // -> (subtask) -> COMPLETED -> (fanout) -> CONSUMED
 // =============================================================================
 TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
@@ -93,23 +93,21 @@ TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
 }
 
 // =============================================================================
-// Non-profiling release_fanin does not CAS task_state to READY.
+// release_fanin does not write task_state.
 //
 // Readiness is determined solely by fanin_refcount reaching fanin_count.
-// task_state stays PENDING after the non-profiling ready path. This is
-// correct by design -- the profiling overload adds the CAS only to count
-// atomic operations.
+// task_state stays PENDING from submit through "queued in ready_queue" and
+// "dispatched to a worker" until the worker stores COMPLETED.
 // =============================================================================
-TEST_F(TaskStateTest, NonProfilingReadyPathStaysPending) {
+TEST_F(TaskStateTest, ReadyPathStaysPending) {
     alignas(64) PTO2TaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
 
     bool ready = sched.release_fanin_and_check_ready(slot);
     ASSERT_TRUE(ready) << "Task should be detected as ready via refcount";
 
-    // task_state remains PENDING -- this is correct by design.
-    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_PENDING)
-        << "Non-profiling path intentionally does not transition task_state to READY";
+    // task_state remains PENDING -- there is no intermediate ready/running state.
+    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_PENDING) << "release_fanin_and_check_ready must not write task_state";
 }
 
 // =============================================================================
@@ -158,7 +156,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
 
     for (int round = 0; round < ROUNDS; round++) {
         alignas(64) PTO2TaskSlotState slot;
-        init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+        init_slot(slot, PTO2_TASK_PENDING, 1, 1);
         slot.total_required_subtasks = 3;
         slot.completed_subtasks.store(0);
         std::atomic<int> done_count{0};
@@ -187,7 +185,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
 // =============================================================================
 TEST_F(TaskStateTest, DoubleSubtaskCompletionCounterWeakness) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 2;
     slot.completed_subtasks.store(0);
 

--- a/tests/ut/cpp/a2a3/test_wiring.cpp
+++ b/tests/ut/cpp/a2a3/test_wiring.cpp
@@ -155,9 +155,9 @@ TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
 
-    // Producers are RUNNING (not yet completed)
+    // Producers are PENDING (not yet completed)
     for (int i = 0; i < 2; i++) {
-        init_slot(producer_slots[i], PTO2_TASK_RUNNING, 1, 2);
+        init_slot(producer_slots[i], PTO2_TASK_PENDING, 1, 2);
     }
 
     init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
@@ -200,7 +200,7 @@ TEST_F(WiringTest, WireTaskMixedProducerStates) {
     PTO2TaskDescriptor desc{};
 
     init_slot(producers[0], PTO2_TASK_COMPLETED, 1, 2);  // early finished
-    init_slot(producers[1], PTO2_TASK_RUNNING, 1, 2);    // still running
+    init_slot(producers[1], PTO2_TASK_PENDING, 1, 2);    // in flight (< COMPLETED)
     init_slot(producers[2], PTO2_TASK_CONSUMED, 1, 2);   // early finished (>= COMPLETED)
 
     init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
@@ -237,8 +237,8 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     memset(&prod_payload, 0, sizeof(prod_payload));
     PTO2TaskDescriptor desc{};
 
-    // Set up producer in RUNNING state with 2 consumers in fanout chain
-    init_slot(producer, PTO2_TASK_RUNNING, 1, 1);
+    // Producer in flight (PENDING, not yet COMPLETED) with 2 consumers in fanout chain
+    init_slot(producer, PTO2_TASK_PENDING, 1, 1);
     producer.payload = &prod_payload;
     producer.task = &desc;
 

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -83,12 +83,12 @@ TEST_F(SchedulerStateTest, ConsumedTransition) {
 
 TEST_F(SchedulerStateTest, ConsumedNotCompletedState) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.fanout_refcount.store(1);
 
     sched.check_and_handle_consumed(slot);
-    // CAS fails because state is RUNNING, not COMPLETED
-    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_RUNNING);
+    // CAS fails because state is PENDING, not COMPLETED
+    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_PENDING);
 }
 
 TEST_F(SchedulerStateTest, ConsumedIdempotent) {
@@ -130,7 +130,7 @@ TEST_F(SchedulerStateTest, ReleaseProducerTriggersConsumed) {
 
 TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 1;
     slot.completed_subtasks.store(0);
 
@@ -139,7 +139,7 @@ TEST_F(SchedulerStateTest, SubtaskCompleteSingle) {
 
 TEST_F(SchedulerStateTest, SubtaskCompleteMultiBlock) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 6;  // 3 cores * 2 blocks
     slot.completed_subtasks.store(0);
 
@@ -176,7 +176,7 @@ TEST_F(SchedulerStateTest, ScopeEndBatchRelease) {
 
 TEST_F(SchedulerStateTest, GetReadyTasksBatchLocalFirst) {
     alignas(64) PTO2TaskSlotState slot_a, slot_b;
-    init_slot(slot_a, PTO2_TASK_READY, 0, 1);
+    init_slot(slot_a, PTO2_TASK_PENDING, 0, 1);
     init_slot(slot_b, PTO2_TASK_PENDING, 1, 1);
 
     PTO2TaskSlotState *local_buf_storage[4];

--- a/tests/ut/cpp/a5/test_task_state.cpp
+++ b/tests/ut/cpp/a5/test_task_state.cpp
@@ -19,7 +19,7 @@
  *
  * This file focuses on:
  * - Full lifecycle through src API
- * - Non-profiling ready path behavior (task_state stays PENDING)
+ * - Ready-path behavior (task_state stays PENDING through dispatch)
  * - Double subtask completion (counter-model weakness)
  */
 
@@ -67,7 +67,7 @@ protected:
 };
 
 // =============================================================================
-// Full lifecycle through src API: PENDING -> (fanin) -> READY-equivalent
+// Full lifecycle through src API: PENDING -> (fanin) -> (queued + dispatched)
 // -> (subtask) -> COMPLETED -> (fanout) -> CONSUMED
 // =============================================================================
 TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
@@ -93,23 +93,21 @@ TEST_F(TaskStateTest, FullLifecycleThroughAPI) {
 }
 
 // =============================================================================
-// Non-profiling release_fanin does not CAS task_state to READY.
+// release_fanin does not write task_state.
 //
 // Readiness is determined solely by fanin_refcount reaching fanin_count.
-// task_state stays PENDING after the non-profiling ready path. This is
-// correct by design -- the profiling overload adds the CAS only to count
-// atomic operations.
+// task_state stays PENDING from submit through "queued in ready_queue" and
+// "dispatched to a worker" until the worker stores COMPLETED.
 // =============================================================================
-TEST_F(TaskStateTest, NonProfilingReadyPathStaysPending) {
+TEST_F(TaskStateTest, ReadyPathStaysPending) {
     alignas(64) PTO2TaskSlotState slot;
     init_slot(slot, PTO2_TASK_PENDING, 1, 1);
 
     bool ready = sched.release_fanin_and_check_ready(slot);
     ASSERT_TRUE(ready) << "Task should be detected as ready via refcount";
 
-    // task_state remains PENDING -- this is correct by design.
-    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_PENDING)
-        << "Non-profiling path intentionally does not transition task_state to READY";
+    // task_state remains PENDING -- there is no intermediate ready/running state.
+    EXPECT_EQ(slot.task_state.load(), PTO2_TASK_PENDING) << "release_fanin_and_check_ready must not write task_state";
 }
 
 // =============================================================================
@@ -158,7 +156,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
 
     for (int round = 0; round < ROUNDS; round++) {
         alignas(64) PTO2TaskSlotState slot;
-        init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+        init_slot(slot, PTO2_TASK_PENDING, 1, 1);
         slot.total_required_subtasks = 3;
         slot.completed_subtasks.store(0);
         std::atomic<int> done_count{0};
@@ -187,7 +185,7 @@ TEST_F(TaskStateTest, ConcurrentSubtaskCompletion) {
 // =============================================================================
 TEST_F(TaskStateTest, DoubleSubtaskCompletionCounterWeakness) {
     alignas(64) PTO2TaskSlotState slot;
-    init_slot(slot, PTO2_TASK_RUNNING, 1, 1);
+    init_slot(slot, PTO2_TASK_PENDING, 1, 1);
     slot.total_required_subtasks = 2;
     slot.completed_subtasks.store(0);
 

--- a/tests/ut/cpp/a5/test_wiring.cpp
+++ b/tests/ut/cpp/a5/test_wiring.cpp
@@ -155,9 +155,9 @@ TEST_F(WiringTest, WireTaskProducersPendingTaskNotReady) {
     memset(&payload, 0, sizeof(payload));
     PTO2TaskDescriptor desc{};
 
-    // Producers are RUNNING (not yet completed)
+    // Producers are PENDING (not yet completed)
     for (int i = 0; i < 2; i++) {
-        init_slot(producer_slots[i], PTO2_TASK_RUNNING, 1, 2);
+        init_slot(producer_slots[i], PTO2_TASK_PENDING, 1, 2);
     }
 
     init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
@@ -200,7 +200,7 @@ TEST_F(WiringTest, WireTaskMixedProducerStates) {
     PTO2TaskDescriptor desc{};
 
     init_slot(producers[0], PTO2_TASK_COMPLETED, 1, 2);  // early finished
-    init_slot(producers[1], PTO2_TASK_RUNNING, 1, 2);    // still running
+    init_slot(producers[1], PTO2_TASK_PENDING, 1, 2);    // in flight (< COMPLETED)
     init_slot(producers[2], PTO2_TASK_CONSUMED, 1, 2);   // early finished (>= COMPLETED)
 
     init_slot(task_slot, PTO2_TASK_PENDING, 0, 1);
@@ -237,8 +237,8 @@ TEST_F(WiringTest, OnMixedTaskCompleteNotifiesConsumers) {
     memset(&prod_payload, 0, sizeof(prod_payload));
     PTO2TaskDescriptor desc{};
 
-    // Set up producer in RUNNING state with 2 consumers in fanout chain
-    init_slot(producer, PTO2_TASK_RUNNING, 1, 1);
+    // Producer in flight (PENDING, not yet COMPLETED) with 2 consumers in fanout chain
+    init_slot(producer, PTO2_TASK_PENDING, 1, 1);
     producer.payload = &prod_payload;
     producer.task = &desc;
 


### PR DESCRIPTION
## Summary

The `PTO2TaskState` enum advertised the chain
`PENDING → READY → RUNNING → COMPLETED → CONSUMED`, but in practice:

- `PTO2_TASK_RUNNING` was never written or read anywhere in `src/`.
- `PTO2_TASK_READY` was written by a single CAS in the profiling-instrumented
  `release_fanin_and_check_ready` and had **no readers**. The `fanin_refcount.fetch_add` already elects a unique winner for the ready-queue push, so the CAS was redundant; the non-profiling overload had already been doing this without writing `task_state`.

The actual transitions performed by the runtime are
`PENDING → COMPLETED → CONSUMED`; ready-vs-running is derived from
`fanin_refcount` / per-core `running_slot_state`, not from `task_state`.

## Changes

- Drop `PTO2_TASK_READY` and `PTO2_TASK_RUNNING`; renumber the enum to
  `PENDING(0) / COMPLETED(1) / CONSUMED(2)`. The `< / >= PTO2_TASK_COMPLETED`
  ordering comparisons in scheduler/orchestrator still hold under the new
  numbering since `CONSUMED` remains the largest value.
- Drop the redundant CAS `PENDING → READY` in the profiling-instrumented
  `release_fanin_and_check_ready` so it matches the non-profiling path.
- Delete the unused `task_state_name()` helper (no callers in repo).
- Update `scheduler_cold_path` stall-dump comment to reflect that `task_state`
  has no intermediate ready/running value.
- Update unit tests to use `PENDING` in place of `READY/RUNNING` fixtures
  (semantically equivalent: anything `< COMPLETED`).
- Sync state-machine docs: `docs/orchestrator.md`, `docs/scheduler.md`, and
  `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md`.

Applied to both `a2a3` and `a5` runtime copies.

## Test plan

- [x] `cmake --build build/ut_cpp --target test_scheduler_state test_task_state test_wiring`
- [x] `ctest -R 'scheduler_state|task_state|wiring'` — 3/3 pass
- [x] `rg 'PTO2_TASK_(READY|RUNNING)|task_state_name'` — zero hits across `src/`, `tests/`, `docs/`