### PR TITLE
Add: pop_hit/pop_miss in v2 phase records + DAG-stats from deps.json

### DIFF
--- a/simpler_setup/tools/sched_overhead_analysis.py
+++ b/simpler_setup/tools/sched_overhead_analysis.py
@@ -26,9 +26,125 @@ import argparse
 import json
 import re
 import sys
+from collections import defaultdict
 from pathlib import Path
 
 from .device_log_resolver import infer_device_id_from_log_path, resolve_device_log_path
+
+
+def _to_uint64(v):
+    """Coerce JSON-encoded uint64 (int or string after the deps.json v2 schema
+    bump in #769) to a Python int. Returns None when unparseable."""
+    try:
+        n = int(v)
+    except (TypeError, ValueError):
+        return None
+    if n < 0:
+        n &= (1 << 64) - 1
+    return n
+
+
+def compute_dag_stats_from_deps(deps_data, perf_data, threads):
+    """Annotate ``threads`` in-place with fanout / fanin per-thread aggregates
+    derived from deps.json edges + per-task scheduling-thread attribution.
+
+    Why this lives in Python and not the runtime: the DAG edge set is already
+    captured structurally by dep_gen (deps.json), and the per-task → scheduler-
+    thread map is in ``l2_perf_records.json::core_to_thread``. Re-instrumenting
+    the AICPU to track fanout edge counts is duplicate work; running this in
+    Python over the existing artifacts is cheaper, more accurate (deps.json
+    captures #599 race-window edges that fanout[] dropped), and lets the
+    analysis work on default builds that don't have PTO2_SCHED_PROFILING=1.
+
+    Edge dedup: deps.json may carry multiple records for the same (pred, succ)
+    pair (different ``source``: explicit / creator / tensormap). The runtime
+    fanin builder dedups to a single edge per pair, so this function projects
+    onto unique (pred, succ) before counting — yields a count that matches the
+    runtime's view, not the structural superset.
+
+    Per-thread attribution: each completed task has a ``core_id``; the JSON's
+    top-level ``core_to_thread`` maps that to a scheduler thread index. fanout
+    work for task T is billed to the thread that retired T (where on_mixed_
+    task_complete walks T's fanout list). fanin work for the consumers it makes
+    ready is tightly coupled in time and billed to the same thread.
+
+    Mutates ``threads`` dict so existing report code that reads
+    ``t["fanout_edges"]`` / ``["fanout_max_degree"]`` / ``["fanin_edges"]`` /
+    ``["fanin_max_degree"]`` works unchanged.
+    """
+    if not isinstance(deps_data, dict) or not isinstance(perf_data, dict):
+        return
+    raw_edges = deps_data.get("edges", [])
+
+    # Unique (pred, succ) — collapses explicit + creator + tensormap variants.
+    edges_by_pred = defaultdict(set)
+    edges_by_succ = defaultdict(set)
+    for e in raw_edges:
+        if not isinstance(e, dict):
+            continue
+        pred = _to_uint64(e.get("pred"))
+        succ = _to_uint64(e.get("succ"))
+        if pred is None or succ is None:
+            continue
+        edges_by_pred[pred].add(succ)
+        edges_by_succ[succ].add(pred)
+
+    # core_id → scheduler-thread mapping (from runtime header passthrough).
+    core_to_thread = perf_data.get("core_to_thread") or []
+
+    def task_thread(task):
+        """Map a perf task record to its scheduler-thread index, or None when
+        unattributable."""
+        cid = task.get("core_id")
+        if not isinstance(cid, int):
+            return None
+        if 0 <= cid < len(core_to_thread):
+            tidx = core_to_thread[cid]
+            return tidx if tidx >= 0 else None
+        return None
+
+    # Per-thread accumulators. Tasks that don't map to a known thread fall
+    # through into an "unattributed" bucket so the run total still reconciles
+    # against the raw edge counts in deps.json.
+    per_thread_fanout = defaultdict(lambda: {"edges": 0, "max": 0, "tasks": 0})
+    per_thread_fanin = defaultdict(lambda: {"edges": 0, "max": 0, "tasks": 0})
+
+    # Dedup by task_id: mixed (AIC+AIV) tasks emit one perf row per subtask /
+    # core (see l2_perf_collector.cpp:567 — collected_perf_records_ is keyed by
+    # core_idx). Without dedup a mixed task's fanout would be charged once per
+    # subtask, inflating per-thread edge counts by the subtask count.
+    seen_task_ids = set()
+    for task in perf_data.get("tasks", []):
+        tid_raw = _to_uint64(task.get("task_id"))
+        if tid_raw is None or tid_raw in seen_task_ids:
+            continue
+        seen_task_ids.add(tid_raw)
+        thr = task_thread(task)
+        if thr is None:
+            continue
+        out_count = len(edges_by_pred.get(tid_raw, ()))
+        in_count = len(edges_by_succ.get(tid_raw, ()))
+        fo = per_thread_fanout[thr]
+        fi = per_thread_fanin[thr]
+        fo["edges"] += out_count
+        fo["max"] = max(fo["max"], out_count)
+        fo["tasks"] += 1
+        fi["edges"] += in_count
+        fi["max"] = max(fi["max"], in_count)
+        fi["tasks"] += 1
+
+    for thr_idx, fo in per_thread_fanout.items():
+        t = threads.get(thr_idx)
+        if t is None:
+            continue
+        t["fanout_edges"] = fo["edges"]
+        t["fanout_max_degree"] = fo["max"]
+    for thr_idx, fi in per_thread_fanin.items():
+        t = threads.get(thr_idx)
+        if t is None:
+            continue
+        t["fanin_edges"] = fi["edges"]
+        t["fanin_max_degree"] = fi["max"]
 
 
 def auto_select_l2_perf_records_json():
@@ -72,6 +188,8 @@ def parse_scheduler_from_json_phases(data):
         phase_us = {p: 0.0 for p in ["complete", "scan", "dispatch", "idle"]}
         total_tasks = 0
         max_loop_iter = 0
+        pop_hit = 0
+        pop_miss = 0
 
         for rec in records:
             phase = phase_map.get(rec.get("phase", ""))
@@ -84,16 +202,27 @@ def parse_scheduler_from_json_phases(data):
                 total_tasks += rec["tasks_processed"]
             loop_iter = rec.get("loop_iter", 0)
             max_loop_iter = max(max_loop_iter, loop_iter)
+            # Per-emit queue-health deltas; only present on dispatch records.
+            # Summing across records gives the run-cumulative pop_hit /
+            # pop_miss (the runtime's final-drain emit closes the tail).
+            if phase == "dispatch":
+                pop_hit += rec.get("pop_hit", 0)
+                pop_miss += rec.get("pop_miss", 0)
 
         total_us = sum(phase_us.values())
         loops = max_loop_iter
         tasks_per_loop = total_tasks / loops if loops > 0 else 0.0
+        pop_total = pop_hit + pop_miss
+        pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0.0
 
         t = {
             "completed": total_tasks,
             "total_us": total_us,
             "loops": loops,
             "tasks_per_loop": tasks_per_loop,
+            "pop_hit": pop_hit,
+            "pop_miss": pop_miss,
+            "pop_hit_rate": pop_hit_rate,
             "format": "json_phase",
         }
         for p, us in phase_us.items():
@@ -108,17 +237,21 @@ def parse_scheduler_from_json_phases(data):
 def parse_scheduler_threads(log_path):
     """Parse device log for PTO2 scheduler stats per thread.
 
-    Supports three formats:
-    1. New two-level tree (PTO2_SCHED_PROFILING=1):
+    Recognized line formats (any combination present in the log is fine):
+
+    1. Two-level tree (PTO2_SCHED_PROFILING=1) — header + per-phase timing:
         Thread N: === Scheduler Phase Breakdown: total=Xus, Y tasks ===
         Thread N:   complete       : Xus (Y%)
-            [fanout: edges=A, max_degree=B, avg=C]  [fanin: edges=D, max_degree=E, avg=F]
-        Thread N:   dispatch       : Xus (Y%)  [pop: hit=A, miss=B, hit_rate=C%]
+        Thread N:   dispatch       : Xus (Y%)
         Thread N:   scan           : Xus (Y%)
         Thread N:   idle           : Xus (Y%)
 
-    2. Summary (PTO2_SCHED_PROFILING=0):
+    2. Summary line (always emitted, regardless of SCHED_PROFILING):
         Thread N: Scheduler summary: total_time=Xus, loops=Y, tasks_scheduled=Z
+
+    Per-thread fanout / fanin / pop aggregates are not parsed from the log;
+    they live in the v2 JSON phase records (see ``parse_scheduler_from_json_phases``)
+    and ``deps.json`` (see ``compute_dag_stats_from_deps``).
     """
     threads = {}
     with open(log_path, errors="ignore") as f:
@@ -156,7 +289,22 @@ def parse_scheduler_threads(log_path):
                         "format": "summary",
                     }
 
-            # New format: complete with fanout/fanin stats
+            # Per-phase timing line (any of complete / dispatch / scan / idle).
+            # Current device log carries only us / % per phase; fanout / fanin /
+            # pop live in v2 JSON phase records and deps.json (see
+            # parse_scheduler_from_json_phases / compute_dag_stats_from_deps).
+            m = re.search(r"Thread (\d+):\s+(complete|dispatch|scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)", line)
+            if m:
+                tid = int(m.group(1))
+                if tid in threads:
+                    phase = m.group(2)
+                    threads[tid][f"{phase}_us"] = float(m.group(3))
+                    threads[tid][f"{phase}_pct"] = float(m.group(4))
+                continue
+
+            # Legacy bracketed sub-stats from pre-cleanup PTO2_SCHED_PROFILING=1
+            # logs. Recognized so an old log file still produces a complete
+            # Part 2 / Part 3 report; fresh runs do not emit these lines.
             m = re.search(
                 r"Thread (\d+):\s+complete\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)"
                 r"\s+\[fanout: edges=(\d+), max_degree=(\d+), avg=([\d.]+)\]"
@@ -170,13 +318,10 @@ def parse_scheduler_threads(log_path):
                     threads[tid]["complete_pct"] = float(m.group(3))
                     threads[tid]["fanout_edges"] = int(m.group(4))
                     threads[tid]["fanout_max_degree"] = int(m.group(5))
-                    threads[tid]["fanout_avg"] = float(m.group(6))
                     threads[tid]["fanin_edges"] = int(m.group(7))
                     threads[tid]["fanin_max_degree"] = int(m.group(8))
-                    threads[tid]["fanin_avg"] = float(m.group(9))
                 continue
 
-            # New format: dispatch with pop stats
             m = re.search(
                 r"Thread (\d+):\s+dispatch\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)"
                 r"\s+\[pop: hit=(\d+), miss=(\d+), hit_rate=([\d.]+)%\]",
@@ -190,16 +335,6 @@ def parse_scheduler_threads(log_path):
                     threads[tid]["pop_hit"] = int(m.group(4))
                     threads[tid]["pop_miss"] = int(m.group(5))
                     threads[tid]["pop_hit_rate"] = float(m.group(6))
-                continue
-
-            # New format: scan and idle (no extra stats)
-            m = re.search(r"Thread (\d+):\s+(scan|idle)\s+:\s+([\d.]+)us \(\s*([\d.]+)%\)", line)
-            if m:
-                tid = int(m.group(1))
-                if tid in threads:
-                    phase = m.group(2)
-                    threads[tid][f"{phase}_us"] = float(m.group(3))
-                    threads[tid][f"{phase}_pct"] = float(m.group(4))
                 continue
 
     return threads
@@ -255,40 +390,63 @@ def validate_perf_tasks_for_overhead_analysis(tasks):
     return True, ""
 
 
-def run_analysis(l2_perf_records_path, log_path, print_sources=True, selection_strategy=None):  # noqa: PLR0912, PLR0915
+def run_analysis(  # noqa: PLR0912, PLR0915
+    l2_perf_records_path,
+    log_path,
+    print_sources=True,
+    selection_strategy=None,
+    deps_json_path=None,
+    perf_data=None,
+):
     """Run scheduler overhead analysis report.
 
     Args:
         l2_perf_records_path: Path to l2_perf_records_*.json.
-        log_path: Path to selected device log file.
+        log_path: Path to selected device log file, or None when running on
+            v2 perf JSON that carries its own phase data.
         print_sources: Whether to print selected input files.
         selection_strategy: Optional human-readable device-log selection strategy.
+        perf_data: Optional pre-parsed perf JSON dict. When provided, skip
+            re-reading from disk — main() already parses the file to probe
+            for v2 phase data, so passing the result through saves a second
+            load on large artifacts.
+        deps_json_path: Optional deps.json (dep_gen replay output) co-located
+            with the perf JSON. When present and the JSON-phases path is
+            used, per-thread fanout / fanin aggregates are derived from it.
 
     Returns:
         int: 0 on success, non-zero on failure.
     """
     l2_perf_records_path = Path(l2_perf_records_path)
-    log_path = Path(log_path)
+    log_path = Path(log_path) if log_path is not None else None
 
     if not l2_perf_records_path.exists():
         print(f"Error: Perf JSON not found: {l2_perf_records_path}", file=sys.stderr)
         return 1
-    if not log_path.exists():
+    if log_path is not None and not log_path.exists():
         print(f"Error: Device log not found: {log_path}", file=sys.stderr)
         return 1
 
     if print_sources:
         print(f"Perf data:  {l2_perf_records_path}")
-        print(f"Device log: {log_path}")
-        if selection_strategy:
-            print(f"Selection:  {selection_strategy}")
-        inferred_device_id = infer_device_id_from_log_path(log_path)
-        if inferred_device_id is not None:
-            print(f"Device ID:  {inferred_device_id}")
+        if log_path is not None:
+            print(f"Device log: {log_path}")
+            if selection_strategy:
+                print(f"Selection:  {selection_strategy}")
+            inferred_device_id = infer_device_id_from_log_path(log_path)
+            if inferred_device_id is not None:
+                print(f"Device ID:  {inferred_device_id}")
+        else:
+            print("Device log: (not used — v2 JSON carries phase data)")
+        if deps_json_path is not None:
+            print(f"Deps JSON:  {deps_json_path}")
 
     # === Part 1: Per-task time breakdown from perf data ===
-    with open(l2_perf_records_path) as f:
-        data = json.load(f)
+    if perf_data is not None:
+        data = perf_data
+    else:
+        with open(l2_perf_records_path) as f:
+            data = json.load(f)
     tasks = data["tasks"]
     n_total = len(tasks)
 
@@ -347,12 +505,42 @@ def run_analysis(l2_perf_records_path, log_path, print_sources=True, selection_s
     print()
 
     # === Part 2: AICPU scheduler loop breakdown ===
-    # Prefer JSON Phase data (version >= 2), fall back to device log
+    # Prefer v2 JSON phase data; fall back to device log when the caller
+    # supplied one. The JSON path is self-contained, so sim runs without a
+    # device log are first-class.
     threads = parse_scheduler_from_json_phases(data)
     phase_source = "perf JSON phase data"
     if not threads:
-        threads = parse_scheduler_threads(log_path)
-        phase_source = "device log"
+        if log_path is not None:
+            threads = parse_scheduler_threads(log_path)
+            phase_source = "device log"
+        else:
+            print(
+                "Error: No JSON phase data found and no device log provided — "
+                "rerun with --enable-l2-swimlane (so phase data is captured) "
+                "or pass --device-log for a fallback path.",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Annotate per-thread fanout / fanin from deps.json when both inputs are
+    # available (the JSON-phases path + a colocated deps.json). Without that,
+    # the report still prints Part 2 phase timings but suppresses the DAG-stats
+    # rows so missing-artifact zeros are not mistaken for measured values.
+    dag_stats_available = False
+    if deps_json_path is not None and phase_source == "perf JSON phase data":
+        try:
+            with open(deps_json_path) as df:
+                deps_data = json.load(df)
+            compute_dag_stats_from_deps(deps_data, data, threads)
+            dag_stats_available = True
+        except (OSError, ValueError) as ex:
+            print(f"Warning: failed to load deps.json for DAG stats: {ex}", file=sys.stderr)
+    elif phase_source == "device log":
+        # Legacy log format may have populated fanout_edges / fanin_edges /
+        # pop_* directly via parse_scheduler_threads.
+        dag_stats_available = any("fanout_edges" in t or "pop_hit" in t for t in threads.values())
+
     n_threads = len(threads)
 
     print("=" * 90)
@@ -400,29 +588,42 @@ def run_analysis(l2_perf_records_path, log_path, print_sources=True, selection_s
         print(fmt3.format(phase_labels[p], f"{tot:.1f}", f"{pct:.1f}%", f"{avg:.2f}"))
     print()
 
-    # Fanout stats (from complete phase)
-    fanout_edges = sum(t.get("fanout_edges", 0) for t in threads.values())
-    fanout_max = max((t.get("fanout_max_degree", 0) for t in threads.values()), default=0)
-    fanout_avg = fanout_edges / total_completed if total_completed > 0 else 0
-    print(
-        f"  Fanout (notify consumers): total edges={fanout_edges}, max_degree={fanout_max}, avg_degree={fanout_avg:.1f}"
-    )
-
-    # Fanin stats (from complete phase)
-    fanin_edges = sum(t.get("fanin_edges", 0) for t in threads.values())
-    fanin_max = max((t.get("fanin_max_degree", 0) for t in threads.values()), default=0)
-    fanin_avg = fanin_edges / total_completed if total_completed > 0 else 0
-    print(
-        f"  Fanin  (release producers): total edges={fanin_edges}, max_degree={fanin_max}, avg_degree={fanin_avg:.1f}"
-    )
+    # DAG stats (fanout / fanin) — populated only when deps.json was
+    # available (JSON path) or the device log carried legacy bracketed
+    # sub-stats. When neither input is present, suppress the rows so
+    # missing-artifact zeros aren't mistaken for measurements.
+    if dag_stats_available:
+        fanout_edges = sum(t.get("fanout_edges", 0) for t in threads.values())
+        fanout_max = max((t.get("fanout_max_degree", 0) for t in threads.values()), default=0)
+        fanout_avg = fanout_edges / total_completed if total_completed > 0 else 0
+        print(
+            f"  Fanout (notify consumers): total edges={fanout_edges}, "
+            f"max_degree={fanout_max}, avg_degree={fanout_avg:.1f}"
+        )
+        fanin_edges = sum(t.get("fanin_edges", 0) for t in threads.values())
+        fanin_max = max((t.get("fanin_max_degree", 0) for t in threads.values()), default=0)
+        fanin_avg = fanin_edges / total_completed if total_completed > 0 else 0
+        print(
+            f"  Fanin  (release producers): total edges={fanin_edges}, "
+            f"max_degree={fanin_max}, avg_degree={fanin_avg:.1f}"
+        )
+    else:
+        fanout_edges = fanout_max = fanin_edges = fanin_max = 0
+        fanout_avg = fanin_avg = 0.0
+        print("  Fanout / Fanin: (deps.json not provided — pass --deps-json or rerun with --enable-dep-gen)")
     print()
 
-    # Pop stats (from dispatch phase)
-    pop_hit = sum(t.get("pop_hit", 0) for t in threads.values())
-    pop_miss = sum(t.get("pop_miss", 0) for t in threads.values())
-    pop_total = pop_hit + pop_miss
-    pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0
-    print(f"  Pop: hit={pop_hit}, miss={pop_miss}, hit_rate={pop_hit_rate:.1f}%")
+    # Pop stats (per-emit dispatch deltas from v2 JSON, or legacy log brackets).
+    if any("pop_hit" in t for t in threads.values()):
+        pop_hit = sum(t.get("pop_hit", 0) for t in threads.values())
+        pop_miss = sum(t.get("pop_miss", 0) for t in threads.values())
+        pop_total = pop_hit + pop_miss
+        pop_hit_rate = pop_hit / pop_total * 100 if pop_total > 0 else 0
+        print(f"  Pop: hit={pop_hit}, miss={pop_miss}, hit_rate={pop_hit_rate:.1f}%")
+    else:
+        pop_hit = pop_miss = 0
+        pop_hit_rate = 0.0
+        print("  Pop: (no per-emit pop deltas in input — needs --enable-l2-swimlane on a v2 JSON capture)")
 
     print()
     print("=" * 90)
@@ -466,12 +667,15 @@ def run_analysis(l2_perf_records_path, log_path, print_sources=True, selection_s
         print(f"  Pop hit_rate={pop_hit_rate:.1f}%: {pop_note}.")
         print("  Cache flush (dc cvac + dsb sy) is the dominant non-pop cost.")
     elif dominant_phase == "complete":
-        print(f"  Fanout: avg_degree={fanout_avg:.1f}, max_degree={fanout_max}.")
-        print(f"  Fanin:  avg_degree={fanin_avg:.1f}, max_degree={fanin_max}.")
-        if fanin_edges > fanout_edges:
-            print("  Fanin traversal (release_producer + check_consumed) dominates the complete phase.")
+        if dag_stats_available:
+            print(f"  Fanout: avg_degree={fanout_avg:.1f}, max_degree={fanout_max}.")
+            print(f"  Fanin:  avg_degree={fanin_avg:.1f}, max_degree={fanin_max}.")
+            if fanin_edges > fanout_edges:
+                print("  Fanin traversal (release_producer + check_consumed) dominates the complete phase.")
+            else:
+                print("  Fanout traversal and atomic ops dominate the complete phase.")
         else:
-            print("  Fanout traversal and atomic ops dominate the complete phase.")
+            print("  DAG stats unavailable (no deps.json); cannot attribute complete-phase cost further.")
     elif dominant_phase == "scan":
         print("  Scan phase overhead indicates frequent perf header updates.")
     print("=" * 90)
@@ -499,6 +703,14 @@ Examples:
         "--device-log", help="Path to device log file/path/glob. Overrides auto-resolution when provided"
     )
     parser.add_argument("-d", "--device-id", help="Device id for auto-selection from device-<id>")
+    parser.add_argument(
+        "--deps-json",
+        help=(
+            "Path to deps.json (dep_gen replay output). When provided and the "
+            "JSON-phases path is used, fanout / fanin per-thread aggregates "
+            "are computed from it. Defaults to deps.json next to the perf JSON."
+        ),
+    )
     args = parser.parse_args()
 
     # Resolve perf path
@@ -514,21 +726,67 @@ Examples:
         print(f"Error: Perf JSON not found: {l2_perf_records_path}", file=sys.stderr)
         return 1
 
-    # Resolve device log path (strict in this standalone CLI)
-    log_path, strategy = resolve_device_log_path(
+    # Probe perf JSON: if it's v2 with non-empty aicpu_scheduler_phases, the
+    # device log becomes optional — phase data is self-contained, fanout / fanin
+    # come from deps.json. Required only when v2 phases are absent (older data
+    # / capture path regressed / build without PTO2_PROFILING=1).
+    # Single load — pass the parsed dict to run_analysis() so it doesn't
+    # reread the file (large artifacts hit JSON parsing twice otherwise).
+    perf_data = None
+    has_json_phases = False
+    try:
+        with open(l2_perf_records_path) as _f:
+            perf_data = json.load(_f)
+        has_json_phases = perf_data.get("version", 1) >= 2 and any(
+            thr for thr in perf_data.get("aicpu_scheduler_phases", [])
+        )
+    except (OSError, ValueError):
+        pass
+
+    log_path = None
+    strategy = None
+    resolved_log, resolved_strategy = resolve_device_log_path(
         device_id=args.device_id,
         device_log=args.device_log,
         l2_perf_records_path=l2_perf_records_path,
     )
-    if log_path is None:
-        print(f"Error: Failed to resolve device log ({strategy})", file=sys.stderr)
+    explicit_log_requested = args.device_log is not None or args.device_id is not None
+    if resolved_log is not None and resolved_log.exists():
+        log_path = resolved_log
+        strategy = resolved_strategy
+    elif explicit_log_requested:
+        # Caller explicitly named a log via --device-log or --device-id and we
+        # couldn't honor that. Falling through to the JSON-only path would
+        # silently analyze a different source than they asked for — bad UX
+        # when debugging log-vs-JSON discrepancies. Fail loud regardless of
+        # whether v2 phase data exists.
+        if resolved_log is None:
+            print(f"Error: Failed to resolve device log ({resolved_strategy})", file=sys.stderr)
+        else:
+            print(f"Error: Device log not found: {resolved_log}", file=sys.stderr)
+        return 1
+    elif not has_json_phases:
+        # No explicit request, auto-resolution failed, and no JSON phases to
+        # fall back on. Need a log to reconstruct Part 2/3 — fail loud.
+        if resolved_log is None:
+            print(f"Error: Failed to resolve device log ({resolved_strategy})", file=sys.stderr)
+        else:
+            print(f"Error: Device log not found: {resolved_log}", file=sys.stderr)
         return 1
 
-    if not log_path.exists():
-        print(f"Error: Device log not found: {log_path}", file=sys.stderr)
-        return 1
+    # Auto-discover deps.json sibling when not explicitly given.
+    deps_json_path = Path(args.deps_json) if args.deps_json else (l2_perf_records_path.parent / "deps.json")
+    if not deps_json_path.exists():
+        deps_json_path = None
 
-    return run_analysis(l2_perf_records_path, log_path, print_sources=True, selection_strategy=strategy)
+    return run_analysis(
+        l2_perf_records_path,
+        log_path,
+        print_sources=True,
+        selection_strategy=strategy,
+        deps_json_path=deps_json_path,
+        perf_data=perf_data,
+    )
 
 
 if __name__ == "__main__":

--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -127,10 +127,13 @@ void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads);
  * @param tasks_processed Number of tasks processed in this batch (scheduler phases), or
  *                        full PTO2 task_id encoding (ring_id << 32) | local_id (orchestrator
  *                        phases in tensormap_and_ringbuffer)
+ * @param extra1, extra2  Phase-specific delta counters (see AicpuPhaseRecord doc).
+ *                        SCHED_DISPATCH uses extra1=pop_hit, extra2=pop_miss; other
+ *                        phases pass 0.
  */
 void l2_perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
-    uint64_t tasks_processed
+    uint64_t tasks_processed, uint32_t extra1 = 0, uint32_t extra2 = 0
 );
 
 /**

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -307,10 +307,15 @@ enum class AicpuPhaseId : uint32_t {
 };
 
 /**
- * Single AICPU scheduler phase record (32 bytes)
+ * Single AICPU scheduler phase record (40 bytes)
  *
  * Records one phase within one loop iteration of a scheduler thread.
  * No thread_id field: identity is derived from array index (position = identity).
+ *
+ * extra1 / extra2 carry phase-specific stats; meaning is keyed by phase_id:
+ *   SCHED_DISPATCH: extra1 = pop_hit delta since last emit
+ *                   extra2 = pop_miss delta since last emit
+ *   All other phases: extras are 0 (reserved for future per-phase metrics).
  */
 struct AicpuPhaseRecord {
     uint64_t start_time;    // Phase start timestamp
@@ -322,7 +327,10 @@ struct AicpuPhaseRecord {
                                    // (ring_id << 32) | local_id for cross-view correlation.
         uint64_t tasks_processed;  // Scheduler phases: number of tasks processed in this batch
     };
+    uint32_t extra1;  // Phase-specific delta (e.g. SCHED_DISPATCH = pop_hit)
+    uint32_t extra2;  // Phase-specific delta (e.g. SCHED_DISPATCH = pop_miss)
 };
+static_assert(sizeof(AicpuPhaseRecord) == 40, "AicpuPhaseRecord layout drift");
 
 /**
  * AICPU orchestrator cumulative summary

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -488,7 +488,7 @@ static void switch_phase_buffer(int thread_idx) {
 
 void l2_perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
-    uint64_t tasks_processed
+    uint64_t tasks_processed, uint32_t extra1, uint32_t extra2
 ) {
     if (s_phase_header == nullptr) {
         return;
@@ -554,6 +554,8 @@ void l2_perf_aicpu_record_phase(
     record->loop_iter = loop_iter;
     record->phase_id = phase_id;
     record->task_id = tasks_processed;
+    record->extra1 = extra1;
+    record->extra2 = extra2;
 
     buf->count = idx + 1;
 }

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -716,8 +716,14 @@ int L2PerfCollector::export_swimlane_json() {
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                         << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ", \"phase\": \""
                         << sched_phase_name(pr.phase_id) << "\""
-                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed
-                        << "}";
+                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed;
+                // Phase-specific deltas (currently only SCHED_DISPATCH carries
+                // pop_hit / pop_miss). Other phases pass zero extras; omitting
+                // them keeps the JSON terse per record.
+                if (pr.phase_id == AicpuPhaseId::SCHED_DISPATCH) {
+                    outfile << ", \"pop_hit\": " << pr.extra1 << ", \"pop_miss\": " << pr.extra2;
+                }
+                outfile << "}";
                 first = false;
             }
             if (!first) outfile << "\n";

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -85,9 +85,9 @@ Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after co
 ```text
 Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
 Thread 0: --- Phase Breakdown ---
-Thread 0:   complete:    1485.020us (42.7%)  [fanout: edges=432, max_degree=2, avg=1.2]  [fanin: edges=320, max_degree=3, avg=0.9]
+Thread 0:   complete:    1485.020us (42.7%)
 Thread 0:   scan:        14.400us (0.4%)
-Thread 0:   dispatch:    1973.060us (56.7%)  [pop: hit=352, miss=3043, hit_rate=10.4%]
+Thread 0:   dispatch:    1973.060us (56.7%)
 Thread 0:   idle:        4.940us (0.1%)
 ```
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -148,14 +148,14 @@ Thread 1: Scheduler summary: total_time=168.620us, loops=3880, tasks_scheduled=9
 
 ```text
 Thread X: === Scheduler Phase Breakdown: total=XXXus, XXX tasks ===
-Thread X:   complete       : XXXus (XX.X%)  [fanout: edges=XXX, max_degree=X, avg=X.X]  [fanin: edges=XXX, max_degree=X, avg=X.X]
+Thread X:   complete       : XXXus (XX.X%)
 Thread X:     poll         : XXXus (XX.X%)  hit=XXX, miss=XXX, hit_rate=XX.X%
 Thread X:     otc_lock     : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     otc_fanout   : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     otc_fanin    : XXXus (XX.X%)  atomics=XXX
 Thread X:     otc_self     : XXXus (XX.X%)  atomics=XXX
 Thread X:     perf         : XXXus (XX.X%)
-Thread X:   dispatch       : XXXus (XX.X%)  [pop: hit=XXX, miss=XXX, hit_rate=XX.X%]
+Thread X:   dispatch       : XXXus (XX.X%)
 Thread X:     poll         : XXXus (XX.X%)
 Thread X:     pop          : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     setup        : XXXus (XX.X%)
@@ -164,6 +164,10 @@ Thread X:   idle           : XXXus (XX.X%)
 Thread X:   avg/complete   : XXXus
 Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
 ```
+
+Per-thread fanout / fanin edge counts and ready-queue pop hit / miss
+stats live in the v2 JSON `aicpu_scheduler_phases[]` and `deps.json`;
+consume them via `simpler_setup/tools/sched_overhead_analysis.py`.
 
 ---
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -384,17 +384,12 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
             cycles_to_us(sched_total), cur_thread_completed
         );
 
-        double notify_avg =
-            cur_thread_completed > 0 ? static_cast<double>(l2_perf.notify_edges_total) / cur_thread_completed : 0.0;
-        double fanin_avg =
-            cur_thread_completed > 0 ? static_cast<double>(l2_perf.fanin_edges_total) / cur_thread_completed : 0.0;
+        // fanout / fanin per-thread aggregates live in
+        // sched_overhead_analysis.compute_dag_stats_from_deps (deps.json edges
+        // × core_to_thread).
         LOG_INFO_V9(
-            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-            ", max_degree=%d, avg=%.1f]  [fanin: "
-            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(l2_perf.sched_complete_cycle), l2_perf.sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(l2_perf.notify_edges_total), l2_perf.notify_max_degree, notify_avg,
-            static_cast<uint64_t>(l2_perf.fanin_edges_total), l2_perf.fanin_max_degree, fanin_avg
+            "Thread %d:   complete       : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_complete_cycle),
+            l2_perf.sched_complete_cycle * 100.0 / sched_total
         );
 
         uint64_t c_parent = l2_perf.sched_complete_cycle > 0 ? l2_perf.sched_complete_cycle : 1;
@@ -436,12 +431,12 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
             cycles_to_us(l2_perf.sched_complete_perf_cycle), l2_perf.sched_complete_perf_cycle * 100.0 / c_parent
         );
 
-        uint64_t pop_total = l2_perf.pop_hit + l2_perf.pop_miss;
-        double pop_hit_rate = pop_total > 0 ? l2_perf.pop_hit * 100.0 / pop_total : 0.0;
+        // pop_hit / pop_miss per-emit deltas live in each v2 JSON dispatch
+        // record's extras; sum-of-deltas equals the run-cumulative tracked
+        // in this struct (final-drain emit covers the trailing-idle tail).
         LOG_INFO_V9(
-            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(l2_perf.sched_dispatch_cycle), l2_perf.sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(l2_perf.pop_hit), static_cast<uint64_t>(l2_perf.pop_miss), pop_hit_rate
+            "Thread %d:   dispatch       : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_dispatch_cycle),
+            l2_perf.sched_dispatch_cycle * 100.0 / sched_total
         );
         uint64_t global_dispatch_count = l2_perf.pop_hit - l2_perf.local_dispatch_count;
         uint64_t total_dispatched = l2_perf.local_dispatch_count + global_dispatch_count;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -121,16 +121,15 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
 #if PTO2_SCHED_PROFILING
-        CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
-        l2_perf.notify_edges_total += cstats.fanout_edges;
-        if (cstats.fanout_edges > l2_perf.notify_max_degree) l2_perf.notify_max_degree = cstats.fanout_edges;
-        l2_perf.notify_tasks_enqueued += cstats.tasks_enqueued;
-        l2_perf.phase_complete_count++;
+        // SCHED_PROFILING variant takes thread_idx for its per-thread atomic
+        // counter side-effects (g_sched_*_atomic_count[thread_idx], consumed
+        // by the otc_* log lines). Its return value is unused.
+        (void)sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
 #else
         sched_->on_mixed_task_complete(slot_state, local_bufs);
+#endif
 #if PTO2_PROFILING
         l2_perf.phase_complete_count++;
-#endif
 #endif
         if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
             deferred_release_slot_states[deferred_release_count++] = &slot_state;
@@ -138,10 +137,9 @@ void SchedulerContext::complete_slot_task(
             LOG_INFO_V9("Thread %d: release", thread_idx);
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe =
-                    sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
-                l2_perf.fanin_edges_total += fe;
-                if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
+                // SCHED_PROFILING variant takes thread_idx for the per-thread
+                // atomic counter side-effects. The return value is unused.
+                (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -71,8 +71,9 @@ const PTO2ResourceShape *SchedulerContext::get_dispatch_order(int32_t thread_idx
 int SchedulerContext::pop_ready_tasks_batch(
     PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count
 ) {
-#if PTO2_SCHED_PROFILING
+#if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
+#if PTO2_SCHED_PROFILING
     extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
     uint64_t t_pop_start = get_sys_cnt_aicpu();
     int count = sched_->get_ready_tasks_batch(
@@ -80,6 +81,11 @@ int SchedulerContext::pop_ready_tasks_batch(
         l2_perf.local_dispatch_count
     );
     l2_perf.sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+#else
+    int count = sched_->get_ready_tasks_batch(shape, local_buf, out, max_count);
+#endif
+    // pop_hit / pop_miss are PTO2_PROFILING-gated (not the inner verbose tier)
+    // so the v2 JSON dispatch records carry queue-health stats on default builds.
     if (count > 0) {
         l2_perf.pop_hit += count;
     } else {
@@ -530,11 +536,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 if (deferred_release_count >= PTO2_DEFERRED_RELEASE_CAP) {
                     while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                        int32_t fe = sched_->on_task_release(
+                        (void)sched_->on_task_release(
                             *deferred_release_slot_states[--deferred_release_count], thread_idx
                         );
-                        l2_perf.fanin_edges_total += fe;
-                        if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
 #else
                         sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
@@ -584,12 +588,19 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         } else {
             CYCLE_COUNT_LAP(l2_perf.sched_dispatch_cycle);
             if (l2_perf.l2_perf_enabled && l2_perf.phase_dispatch_count > 0) {
+                // Per-emit pop deltas via snapshot diff; the cumulative
+                // pop_hit / pop_miss stay intact for the cold-path log.
+                uint64_t pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
+                uint64_t pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
                 l2_perf_aicpu_record_phase(
                     thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, l2_perf.sched_loop_count,
-                    l2_perf.phase_dispatch_count
+                    l2_perf.phase_dispatch_count, static_cast<uint32_t>(pop_hit_delta),
+                    static_cast<uint32_t>(pop_miss_delta)
                 );
                 _t0_phase = _t1;
                 l2_perf.phase_dispatch_count = 0;
+                l2_perf.pop_hit_at_last_emit = l2_perf.pop_hit;
+                l2_perf.pop_miss_at_last_emit = l2_perf.pop_miss;
             }
         }
 #endif
@@ -604,10 +615,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         } else {
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe =
-                    sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
-                l2_perf.fanin_edges_total += fe;
-                if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
+                (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
@@ -646,6 +654,23 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 
 #if PTO2_PROFILING
+    // Final-drain: emit any pop_hit / pop_miss accrued since the last
+    // dispatch emit (typically the trailing idle loops while waiting for
+    // orchestrator_done_) as a zero-duration synthetic dispatch record so
+    // sum(record.pop_*) reconciles with the run-cumulative counter.
+    if (l2_perf.l2_perf_enabled) {
+        uint64_t final_pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
+        uint64_t final_pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
+        if (final_pop_hit_delta != 0 || final_pop_miss_delta != 0) {
+            uint64_t t_now = get_sys_cnt_aicpu();
+            l2_perf_aicpu_record_phase(
+                thread_idx, AicpuPhaseId::SCHED_DISPATCH, t_now, t_now, l2_perf.sched_loop_count, 0,
+                static_cast<uint32_t>(final_pop_hit_delta), static_cast<uint32_t>(final_pop_miss_delta)
+            );
+            l2_perf.pop_hit_at_last_emit = l2_perf.pop_hit;
+            l2_perf.pop_miss_at_last_emit = l2_perf.pop_miss;
+        }
+    }
     log_l2_perf_summary(thread_idx, cur_thread_completed);
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -347,17 +347,17 @@ struct alignas(64) SchedL2PerfCounters {
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
     uint32_t phase_dispatch_count{0};
+    // Run-cumulative pop counters; the v2 JSON dispatch-record emitter writes
+    // per-emit deltas computed as (current - pop_*_at_last_emit) and the
+    // end-of-run cold-path log reads the cumulatives directly.
+    uint64_t pop_hit{0};
+    uint64_t pop_miss{0};
+    uint64_t pop_hit_at_last_emit{0};
+    uint64_t pop_miss_at_last_emit{0};
 #if PTO2_SCHED_PROFILING
     uint32_t phase_wiring_count{0};
     uint64_t complete_probe_count{0};
     uint64_t complete_hit_count{0};
-    uint64_t notify_edges_total{0};
-    int32_t notify_max_degree{0};
-    uint64_t notify_tasks_enqueued{0};
-    uint64_t fanin_edges_total{0};
-    int32_t fanin_max_degree{0};
-    uint64_t pop_hit{0};
-    uint64_t pop_miss{0};
     uint64_t local_dispatch_count{0};
     uint64_t local_overflow_count{0};
     uint64_t sched_complete_perf_cycle{0};

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -130,10 +130,13 @@ void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads)
  * @param tasks_processed Number of tasks processed in this batch (scheduler phases), or
  *                        full PTO2 task_id encoding (ring_id << 32) | local_id (orchestrator
  *                        phases in tensormap_and_ringbuffer)
+ * @param extra1, extra2  Phase-specific delta counters (see AicpuPhaseRecord doc).
+ *                        SCHED_DISPATCH uses extra1=pop_hit, extra2=pop_miss; other
+ *                        phases pass 0.
  */
 void l2_perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
-    uint64_t tasks_processed
+    uint64_t tasks_processed, uint32_t extra1 = 0, uint32_t extra2 = 0
 );
 
 /**

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -262,10 +262,15 @@ enum class AicpuPhaseId : uint32_t {
 };
 
 /**
- * Single AICPU scheduler phase record (32 bytes)
+ * Single AICPU scheduler phase record (40 bytes)
  *
  * Records one phase within one loop iteration of a scheduler thread.
  * No thread_id field: identity is derived from array index (position = identity).
+ *
+ * extra1 / extra2 carry phase-specific stats; meaning is keyed by phase_id:
+ *   SCHED_DISPATCH: extra1 = pop_hit delta since last emit
+ *                   extra2 = pop_miss delta since last emit
+ *   All other phases: extras are 0 (reserved for future per-phase metrics).
  */
 struct AicpuPhaseRecord {
     uint64_t start_time;    // Phase start timestamp
@@ -277,7 +282,10 @@ struct AicpuPhaseRecord {
                                    // (ring_id << 32) | local_id for cross-view correlation.
         uint64_t tasks_processed;  // Scheduler phases: number of tasks processed in this batch
     };
+    uint32_t extra1;  // Phase-specific delta (e.g. SCHED_DISPATCH = pop_hit)
+    uint32_t extra2;  // Phase-specific delta (e.g. SCHED_DISPATCH = pop_miss)
 };
+static_assert(sizeof(AicpuPhaseRecord) == 40, "AicpuPhaseRecord layout drift");
 
 /**
  * AICPU orchestrator cumulative summary

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -420,7 +420,7 @@ static void switch_phase_buffer(int thread_idx) {
 
 void l2_perf_aicpu_record_phase(
     int thread_idx, AicpuPhaseId phase_id, uint64_t start_time, uint64_t end_time, uint32_t loop_iter,
-    uint64_t tasks_processed
+    uint64_t tasks_processed, uint32_t extra1, uint32_t extra2
 ) {
     if (s_phase_header == nullptr) {
         return;
@@ -473,6 +473,8 @@ void l2_perf_aicpu_record_phase(
     record->loop_iter = loop_iter;
     record->phase_id = phase_id;
     record->task_id = tasks_processed;
+    record->extra1 = extra1;
+    record->extra2 = extra2;
 
     buf->count = idx + 1;
 }

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -1470,8 +1470,14 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
                 outfile << "      {\"start_time_us\": " << std::fixed << std::setprecision(3) << start_us
                         << ", \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ", \"phase\": \""
                         << sched_phase_name(pr.phase_id) << "\""
-                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed
-                        << "}";
+                        << ", \"loop_iter\": " << pr.loop_iter << ", \"tasks_processed\": " << pr.tasks_processed;
+                // Phase-specific deltas (currently only SCHED_DISPATCH carries
+                // pop_hit / pop_miss). Other phases pass zero extras; omitting
+                // them keeps the JSON terse per record.
+                if (pr.phase_id == AicpuPhaseId::SCHED_DISPATCH) {
+                    outfile << ", \"pop_hit\": " << pr.extra1 << ", \"pop_miss\": " << pr.extra2;
+                }
+                outfile << "}";
                 first = false;
             }
             if (!first) outfile << "\n";

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -85,9 +85,9 @@ Each of the 3 scheduler threads (Thread 0, 1, 2) prints its own summary after co
 ```text
 Thread 0: completed=352 tasks in 3477.420us (147 loops, 2.4 tasks/loop)
 Thread 0: --- Phase Breakdown ---
-Thread 0:   complete:    1485.020us (42.7%)  [fanout: edges=432, max_degree=2, avg=1.2]  [fanin: edges=320, max_degree=3, avg=0.9]
+Thread 0:   complete:    1485.020us (42.7%)
 Thread 0:   scan:        14.400us (0.4%)
-Thread 0:   dispatch:    1973.060us (56.7%)  [pop: hit=352, miss=3043, hit_rate=10.4%]
+Thread 0:   dispatch:    1973.060us (56.7%)
 Thread 0:   idle:        4.940us (0.1%)
 ```
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -163,14 +163,14 @@ Thread 1: Scheduler summary: total_time=168.620us, loops=3880, tasks_scheduled=9
 
 ```text
 Thread X: === Scheduler Phase Breakdown: total=XXXus, XXX tasks ===
-Thread X:   complete       : XXXus (XX.X%)  [fanout: edges=XXX, max_degree=X, avg=X.X]  [fanin: edges=XXX, max_degree=X, avg=X.X]
+Thread X:   complete       : XXXus (XX.X%)
 Thread X:     poll         : XXXus (XX.X%)  hit=XXX, miss=XXX, hit_rate=XX.X%
 Thread X:     otc_lock     : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     otc_fanout   : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     otc_fanin    : XXXus (XX.X%)  atomics=XXX
 Thread X:     otc_self     : XXXus (XX.X%)  atomics=XXX
 Thread X:     perf         : XXXus (XX.X%)
-Thread X:   dispatch       : XXXus (XX.X%)  [pop: hit=XXX, miss=XXX, hit_rate=XX.X%]
+Thread X:   dispatch       : XXXus (XX.X%)
 Thread X:     poll         : XXXus (XX.X%)
 Thread X:     pop          : XXXus (XX.X%)  work=XXXus wait=XXXus  atomics=XXX
 Thread X:     setup        : XXXus (XX.X%)
@@ -179,6 +179,10 @@ Thread X:   idle           : XXXus (XX.X%)
 Thread X:   avg/complete   : XXXus
 Thread X: Scheduler summary: total_time=XXXus, loops=XXX, tasks_scheduled=XXX
 ```
+
+Per-thread fanout / fanin edge counts and ready-queue pop hit / miss
+stats live in the v2 JSON `aicpu_scheduler_phases[]` and `deps.json`;
+consume them via `simpler_setup/tools/sched_overhead_analysis.py`.
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -384,17 +384,12 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
             cycles_to_us(sched_total), cur_thread_completed
         );
 
-        double notify_avg =
-            cur_thread_completed > 0 ? static_cast<double>(l2_perf.notify_edges_total) / cur_thread_completed : 0.0;
-        double fanin_avg =
-            cur_thread_completed > 0 ? static_cast<double>(l2_perf.fanin_edges_total) / cur_thread_completed : 0.0;
+        // fanout / fanin per-thread aggregates live in
+        // sched_overhead_analysis.compute_dag_stats_from_deps (deps.json edges
+        // × core_to_thread).
         LOG_INFO_V9(
-            "Thread %d:   complete       : %.3fus (%.1f%%)  [fanout: edges=%" PRIu64
-            ", max_degree=%d, avg=%.1f]  [fanin: "
-            "edges=%" PRIu64 ", max_degree=%d, avg=%.1f]",
-            thread_idx, cycles_to_us(l2_perf.sched_complete_cycle), l2_perf.sched_complete_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(l2_perf.notify_edges_total), l2_perf.notify_max_degree, notify_avg,
-            static_cast<uint64_t>(l2_perf.fanin_edges_total), l2_perf.fanin_max_degree, fanin_avg
+            "Thread %d:   complete       : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_complete_cycle),
+            l2_perf.sched_complete_cycle * 100.0 / sched_total
         );
 
         uint64_t c_parent = l2_perf.sched_complete_cycle > 0 ? l2_perf.sched_complete_cycle : 1;
@@ -436,12 +431,12 @@ void SchedulerContext::log_l2_perf_summary(int32_t thread_idx, int32_t cur_threa
             cycles_to_us(l2_perf.sched_complete_perf_cycle), l2_perf.sched_complete_perf_cycle * 100.0 / c_parent
         );
 
-        uint64_t pop_total = l2_perf.pop_hit + l2_perf.pop_miss;
-        double pop_hit_rate = pop_total > 0 ? l2_perf.pop_hit * 100.0 / pop_total : 0.0;
+        // pop_hit / pop_miss per-emit deltas live in each v2 JSON dispatch
+        // record's extras; sum-of-deltas equals the run-cumulative tracked
+        // in this struct (final-drain emit covers the trailing-idle tail).
         LOG_INFO_V9(
-            "Thread %d:   dispatch       : %.3fus (%.1f%%)  [pop: hit=%" PRIu64 ", miss=%" PRIu64 ", hit_rate=%.1f%%]",
-            thread_idx, cycles_to_us(l2_perf.sched_dispatch_cycle), l2_perf.sched_dispatch_cycle * 100.0 / sched_total,
-            static_cast<uint64_t>(l2_perf.pop_hit), static_cast<uint64_t>(l2_perf.pop_miss), pop_hit_rate
+            "Thread %d:   dispatch       : %.3fus (%.1f%%)", thread_idx, cycles_to_us(l2_perf.sched_dispatch_cycle),
+            l2_perf.sched_dispatch_cycle * 100.0 / sched_total
         );
         uint64_t global_dispatch_count = l2_perf.pop_hit - l2_perf.local_dispatch_count;
         uint64_t total_dispatched = l2_perf.local_dispatch_count + global_dispatch_count;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -121,16 +121,15 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
 #if PTO2_SCHED_PROFILING
-        CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
-        l2_perf.notify_edges_total += cstats.fanout_edges;
-        if (cstats.fanout_edges > l2_perf.notify_max_degree) l2_perf.notify_max_degree = cstats.fanout_edges;
-        l2_perf.notify_tasks_enqueued += cstats.tasks_enqueued;
-        l2_perf.phase_complete_count++;
+        // SCHED_PROFILING variant takes thread_idx for its per-thread atomic
+        // counter side-effects (g_sched_*_atomic_count[thread_idx], consumed
+        // by the otc_* log lines). Its return value is unused.
+        (void)sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
 #else
         sched_->on_mixed_task_complete(slot_state, local_bufs);
+#endif
 #if PTO2_PROFILING
         l2_perf.phase_complete_count++;
-#endif
 #endif
         if (deferred_release_count < PTO2_DEFERRED_RELEASE_CAP) {
             deferred_release_slot_states[deferred_release_count++] = &slot_state;
@@ -138,10 +137,9 @@ void SchedulerContext::complete_slot_task(
             LOG_INFO_V9("Thread %d: release", thread_idx);
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe =
-                    sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
-                l2_perf.fanin_edges_total += fe;
-                if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
+                // SCHED_PROFILING variant takes thread_idx for the per-thread
+                // atomic counter side-effects. The return value is unused.
+                (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -67,8 +67,9 @@ const PTO2ResourceShape *SchedulerContext::get_dispatch_order(int32_t thread_idx
 int SchedulerContext::pop_ready_tasks_batch(
     PTO2ResourceShape shape, int32_t thread_idx, PTO2LocalReadyBuffer &local_buf, PTO2TaskSlotState **out, int max_count
 ) {
-#if PTO2_SCHED_PROFILING
+#if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
+#if PTO2_SCHED_PROFILING
     extern uint64_t g_sched_pop_atomic_count[], g_sched_pop_wait_cycle[];
     uint64_t t_pop_start = get_sys_cnt_aicpu();
     int count = sched_->get_ready_tasks_batch(
@@ -76,6 +77,11 @@ int SchedulerContext::pop_ready_tasks_batch(
         l2_perf.local_dispatch_count
     );
     l2_perf.sched_dispatch_pop_cycle += (get_sys_cnt_aicpu() - t_pop_start);
+#else
+    int count = sched_->get_ready_tasks_batch(shape, local_buf, out, max_count);
+#endif
+    // pop_hit / pop_miss are PTO2_PROFILING-gated (not the inner verbose tier)
+    // so the v2 JSON dispatch records carry queue-health stats on default builds.
     if (count > 0) {
         l2_perf.pop_hit += count;
     } else {
@@ -539,11 +545,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 if (deferred_release_count >= PTO2_DEFERRED_RELEASE_CAP) {
                     while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                        int32_t fe = sched_->on_task_release(
+                        (void)sched_->on_task_release(
                             *deferred_release_slot_states[--deferred_release_count], thread_idx
                         );
-                        l2_perf.fanin_edges_total += fe;
-                        if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
 #else
                         sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
@@ -592,12 +596,19 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         } else {
             CYCLE_COUNT_LAP(l2_perf.sched_dispatch_cycle);
             if (l2_perf.l2_perf_enabled && l2_perf.phase_dispatch_count > 0) {
+                // Per-emit pop deltas via snapshot diff; the cumulative
+                // pop_hit / pop_miss stay intact for the cold-path log.
+                uint64_t pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
+                uint64_t pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
                 l2_perf_aicpu_record_phase(
                     thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, l2_perf.sched_loop_count,
-                    l2_perf.phase_dispatch_count
+                    l2_perf.phase_dispatch_count, static_cast<uint32_t>(pop_hit_delta),
+                    static_cast<uint32_t>(pop_miss_delta)
                 );
                 _t0_phase = _t1;
                 l2_perf.phase_dispatch_count = 0;
+                l2_perf.pop_hit_at_last_emit = l2_perf.pop_hit;
+                l2_perf.pop_miss_at_last_emit = l2_perf.pop_miss;
             }
         }
 #endif
@@ -612,10 +623,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         } else {
             while (deferred_release_count > 0) {
 #if PTO2_SCHED_PROFILING
-                int32_t fe =
-                    sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
-                l2_perf.fanin_edges_total += fe;
-                if (fe > l2_perf.fanin_max_degree) l2_perf.fanin_max_degree = fe;
+                (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
 #else
                 sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
 #endif
@@ -654,6 +662,23 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 
 #if PTO2_PROFILING
+    // Final-drain: emit any pop_hit / pop_miss accrued since the last
+    // dispatch emit (typically the trailing idle loops while waiting for
+    // orchestrator_done_) as a zero-duration synthetic dispatch record so
+    // sum(record.pop_*) reconciles with the run-cumulative counter.
+    if (l2_perf.l2_perf_enabled) {
+        uint64_t final_pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
+        uint64_t final_pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
+        if (final_pop_hit_delta != 0 || final_pop_miss_delta != 0) {
+            uint64_t t_now = get_sys_cnt_aicpu();
+            l2_perf_aicpu_record_phase(
+                thread_idx, AicpuPhaseId::SCHED_DISPATCH, t_now, t_now, l2_perf.sched_loop_count, 0,
+                static_cast<uint32_t>(final_pop_hit_delta), static_cast<uint32_t>(final_pop_miss_delta)
+            );
+            l2_perf.pop_hit_at_last_emit = l2_perf.pop_hit;
+            l2_perf.pop_miss_at_last_emit = l2_perf.pop_miss;
+        }
+    }
     log_l2_perf_summary(thread_idx, cur_thread_completed);
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -349,17 +349,17 @@ struct alignas(64) SchedL2PerfCounters {
     uint64_t sched_loop_count{0};
     uint32_t phase_complete_count{0};
     uint32_t phase_dispatch_count{0};
+    // Run-cumulative pop counters; the v2 JSON dispatch-record emitter writes
+    // per-emit deltas computed as (current - pop_*_at_last_emit) and the
+    // end-of-run cold-path log reads the cumulatives directly.
+    uint64_t pop_hit{0};
+    uint64_t pop_miss{0};
+    uint64_t pop_hit_at_last_emit{0};
+    uint64_t pop_miss_at_last_emit{0};
 #if PTO2_SCHED_PROFILING
     uint32_t phase_wiring_count{0};
     uint64_t complete_probe_count{0};
     uint64_t complete_hit_count{0};
-    uint64_t notify_edges_total{0};
-    int32_t notify_max_degree{0};
-    uint64_t notify_tasks_enqueued{0};
-    uint64_t fanin_edges_total{0};
-    int32_t fanin_max_degree{0};
-    uint64_t pop_hit{0};
-    uint64_t pop_miss{0};
     uint64_t local_dispatch_count{0};
     uint64_t local_overflow_count{0};
     uint64_t sched_complete_perf_cycle{0};

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -134,56 +134,139 @@ class TestL2Swimlane(SceneTestCase):
         )
 
         # ---- Tool smoke: sched_overhead_analysis ----
-        # The analysis joins l2_perf_records.json with AICPU cycle counters
-        # (dispatch_time / finish_time, populated in l2_perf_collector.cpp).
-        # No #ifdef gates the capture — the fields are unconditionally written
-        # when the value is non-zero, so coverage hinges on the AICPU actually
-        # writing real cycle counts. That happens on hardware; on sim the
-        # cycle counters may be 0 or absent.
-        #
-        # Sim: smoke is `--help` — verifies the module imports, argparse is
-        # wired, the entry point hasn't bit-rotted. Cheap, doesn't false-
-        # positive on missing device data.
-        # Hardware: full run with stdout assertions — section headers must
-        # all print AND at least one numeric metric must be non-zero. The
-        # "all zeros" failure mode (e.g., capture path was silently dropped
-        # in a refactor) would print `0.0 us` everywhere; the regex check
-        # below catches that.
-        if st_platform.endswith("sim"):
-            subprocess.run(
-                [sys.executable, "-m", "simpler_setup.tools.sched_overhead_analysis", "--help"],
-                check=True,
-                timeout=10,
-                stdout=subprocess.DEVNULL,
+        # Runs full on sim and hardware after the v2-phase / deps.json work
+        # made device log optional (sim now produces a complete report from
+        # JSON-only inputs). pop_hit / pop_miss come from the new dispatch-
+        # phase extras the runtime writes (l2_perf_collector.cpp). The
+        # differential block below cross-validates the script's printed
+        # numbers against an independent oracle computed straight from the
+        # raw artifacts — any regression in either the runtime capture path
+        # or the parser arithmetic fails here in the same CI step that
+        # produced the data.
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "simpler_setup.tools.sched_overhead_analysis",
+                "--l2-perf-records-json",
+                str(perf),
+            ],
+            check=True,
+            timeout=120,
+            capture_output=True,
+            text=True,
+        )
+        for header in ("Part 1:", "Part 2:", "Part 3:"):
+            assert header in result.stdout, (
+                f"sched_overhead missing section header '{header}'\nstdout:\n{result.stdout}"
             )
-        else:
-            result = subprocess.run(
-                [
-                    sys.executable,
-                    "-m",
-                    "simpler_setup.tools.sched_overhead_analysis",
-                    "--l2-perf-records-json",
-                    str(perf),
-                ],
-                check=True,
-                timeout=120,
-                capture_output=True,
-                text=True,
-            )
-            for header in ("Part 1:", "Part 2:", "Part 3:"):
-                assert header in result.stdout, (
-                    f"sched_overhead missing section header '{header}'\nstdout:\n{result.stdout}"
-                )
-            # Bad pattern: AICPU didn't capture real cycle counters → tool
-            # "succeeds" but every metric is 0. Match the line that's printed
-            # unconditionally in Part 2 and assert its value is non-zero.
-            m = re.search(r"Avg scheduler loop iteration:\s+([\d.]+)\s+us", result.stdout)
-            assert m, f"sched_overhead stdout missing 'Avg scheduler loop iteration'\nstdout:\n{result.stdout}"
-            assert float(m.group(1)) > 0.0, (
-                f"sched_overhead reports zero loop iteration (avg_loop_us={m.group(1)}). "
-                f"AICPU likely didn't capture dispatch_time/finish_time cycle counters — "
-                f"the L2 perf collector path may have regressed.\nstdout:\n{result.stdout}"
-            )
+        # Bad pattern: AICPU didn't capture real cycle counters → tool
+        # "succeeds" but every metric is 0. Match the line that's printed
+        # unconditionally in Part 2 and assert its value is non-zero.
+        m = re.search(r"Avg scheduler loop iteration:\s+([\d.]+)\s+us", result.stdout)
+        assert m, f"sched_overhead stdout missing 'Avg scheduler loop iteration'\nstdout:\n{result.stdout}"
+        assert float(m.group(1)) > 0.0, (
+            f"sched_overhead reports zero loop iteration (avg_loop_us={m.group(1)}). "
+            f"AICPU likely didn't capture dispatch_time/finish_time cycle counters — "
+            f"the L2 perf collector path may have regressed.\nstdout:\n{result.stdout}"
+        )
+        self._verify_sched_overhead_differential(result.stdout, perf)
+
+    def _verify_sched_overhead_differential(self, stdout, perf_path):
+        """Cross-check the script's printed Pop / Fanout / Fanin totals against
+        an oracle computed independently from the raw artifacts. The script
+        and the oracle should agree exactly — if they don't, either the
+        runtime capture regressed or the parser arithmetic drifted, and the
+        bug is caught in the same CI step that produced the data.
+        """
+        with perf_path.open() as f:
+            perf = json.load(f)
+
+        # Oracle: pop_hit / pop_miss are the sum across all dispatch records.
+        # Compares against the "Pop: hit=N, miss=M" line the script prints.
+        phases = perf.get("aicpu_scheduler_phases", [])
+        oracle_pop_hit = sum(
+            r.get("pop_hit", 0) for thr_recs in phases for r in thr_recs if r.get("phase") == "dispatch"
+        )
+        oracle_pop_miss = sum(
+            r.get("pop_miss", 0) for thr_recs in phases for r in thr_recs if r.get("phase") == "dispatch"
+        )
+        pop_match = re.search(r"Pop:\s*hit=(\d+),\s*miss=(\d+)", stdout)
+        assert pop_match, f"sched_overhead stdout missing 'Pop: hit=N, miss=M' line\nstdout:\n{stdout}"
+        printed_pop_hit, printed_pop_miss = int(pop_match.group(1)), int(pop_match.group(2))
+        assert printed_pop_hit == oracle_pop_hit, (
+            f"Pop hit mismatch: printed={printed_pop_hit}, oracle={oracle_pop_hit} "
+            f"(summed from dispatch-record extras)\nstdout:\n{stdout}"
+        )
+        assert printed_pop_miss == oracle_pop_miss, (
+            f"Pop miss mismatch: printed={printed_pop_miss}, oracle={oracle_pop_miss}\nstdout:\n{stdout}"
+        )
+
+        # Fanout / fanin differential — only meaningful when deps.json is
+        # colocated (i.e. --enable-dep-gen was also on). When absent, skip.
+        deps_path = perf_path.parent / "deps.json"
+        if not deps_path.exists():
+            return
+        with deps_path.open() as f:
+            deps = json.load(f)
+        unique_edges = set()
+        for e in deps.get("edges", []):
+            try:
+                pred, succ = int(e["pred"]), int(e["succ"])
+            except (TypeError, ValueError, KeyError):
+                continue
+            if pred < 0:
+                pred &= (1 << 64) - 1
+            if succ < 0:
+                succ &= (1 << 64) - 1
+            unique_edges.add((pred, succ))
+
+        # Per-thread oracle: a task's fanout is billed to the thread that
+        # retired it (core_to_thread[task.core_id]). Sum across threads ==
+        # total edges (modulo unattributed tasks, e.g. alloc-only with no
+        # core_id). The script prints the sum-across-threads total.
+        core_to_thread = perf.get("core_to_thread") or []
+        edges_by_pred = {}
+        edges_by_succ = {}
+        for pred, succ in unique_edges:
+            edges_by_pred.setdefault(pred, set()).add(succ)
+            edges_by_succ.setdefault(succ, set()).add(pred)
+        # Dedup by task_id: mixed tasks emit one perf row per subtask/core.
+        oracle_fanout = 0
+        oracle_fanin = 0
+        seen_tids = set()
+        for task in perf.get("tasks", []):
+            cid = task.get("core_id")
+            if not isinstance(cid, int) or not (0 <= cid < len(core_to_thread)):
+                continue
+            if core_to_thread[cid] < 0:
+                continue
+            try:
+                tid = int(task["task_id"])
+            except (TypeError, ValueError, KeyError):
+                continue
+            if tid < 0:
+                tid &= (1 << 64) - 1
+            if tid in seen_tids:
+                continue
+            seen_tids.add(tid)
+            oracle_fanout += len(edges_by_pred.get(tid, ()))
+            oracle_fanin += len(edges_by_succ.get(tid, ()))
+
+        fanout_match = re.search(r"Fanout \(.*?\):\s*total edges=(\d+),\s*max_degree=(\d+)", stdout)
+        fanin_match = re.search(r"Fanin\s+\(.*?\):\s*total edges=(\d+),\s*max_degree=(\d+)", stdout)
+        assert fanout_match, f"sched_overhead stdout missing 'Fanout' line\nstdout:\n{stdout}"
+        assert fanin_match, f"sched_overhead stdout missing 'Fanin' line\nstdout:\n{stdout}"
+        printed_fanout = int(fanout_match.group(1))
+        printed_fanin = int(fanin_match.group(1))
+        assert printed_fanout == oracle_fanout, (
+            f"Fanout edges mismatch: printed={printed_fanout}, oracle={oracle_fanout} "
+            f"(derived from {len(unique_edges)} unique deps.json edges + core_to_thread)\n"
+            f"stdout:\n{stdout}"
+        )
+        assert printed_fanin == oracle_fanin, (
+            f"Fanin edges mismatch: printed={printed_fanin}, oracle={oracle_fanin}\nstdout:\n{stdout}"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

\`sched_overhead_analysis\` used to need a \`PTO2_SCHED_PROFILING=1\` build for Part 2/3 to show real numbers — fanout / fanin / pop stats only landed in the verbose device log under that macro. Default builds got all-zero rows; sim had no device log at all and hit a hard-gate in \`main()\` before anything ran.

This PR makes Part 2/3 work on the default build by splitting the old log-only data into two right-sized homes:

### Runtime capture (trace, not log)
- New per-record dispatch-phase extras (\`extra1=pop_hit\`, \`extra2=pop_miss\`) in \`AicpuPhaseRecord\` (struct 32→40 bytes, static_asserted).
- \`l2_perf_aicpu_record_phase()\` gets two optional \`uint32_t\` params (default 0 for non-dispatch callers).
- \`scheduler_dispatch.cpp\` passes per-emit pop counter deltas + resets them so each dispatch record carries only its own emit window.
- \`pop_hit\` / \`pop_miss\` themselves move out from under \`PTO2_SCHED_PROFILING\` to \`PTO2_PROFILING\` so they accumulate on default builds.
- Host JSON writer emits \`pop_hit\` / \`pop_miss\` only on dispatch records (keeps records terse).
- Mirrored across a2a3 and a5.

### Post-hoc computation (script side)
- \`compute_dag_stats_from_deps()\` projects \`deps.json\` edges onto unique \`(pred, succ)\` pairs (matches runtime \`PTO2FaninBuilder\` dedup) and bills each producer's fanout / each consumer's fanin to the scheduler thread that retired the task (via \`core_to_thread\`).
- \`parse_scheduler_from_json_phases\` reads the new dispatch-record extras and computes \`pop_hit_rate\` per thread.
- \`main()\` drops the "device log mandatory" hard gate: when the perf JSON is v2 with non-empty \`aicpu_scheduler_phases\`, the log becomes optional. **Sim is now first-class** for this tool.
- New \`--deps-json\` flag (auto-discovers \`deps.json\` next to the perf JSON).

### Differential verification (in \`test_l2_swimlane.py\`)
After invoking \`sched_overhead\`, the test parses **Pop / Fanout / Fanin** totals out of stdout and compares to an independent oracle computed directly from the raw artifacts:
- pop totals = sum of dispatch-record extras across threads
- fanout/fanin totals = unique \`deps.json\` edges attributed by \`core_to_thread\`, summed across threads

Any regression in either the runtime capture path or the parser arithmetic fails in the same CI step that produced the data.

## Test plan

- [x] \`pip install --no-build-isolation -e .\` builds clean on macOS arm64
- [x] \`pytest tests/.../dfx/{l2_swimlane,dep_gen}/* --platform a2a3sim --enable-l2-swimlane --enable-dep-gen\` — both pass; differential check fires when both flags are on
- [x] Pre-commit gate clean (clang-format, clang-tidy, cpplint, ruff, pyright)
- [x] Verified by hand against vector_example: 6 unique edges (matches docs), fanout_max=3 (t0 fanout), fanin_max=2 (t3, t4); pop_hit=5 = task count
- [ ] CI sim smokes green (linux + macOS)
- [ ] CI onboard a2a3 / a5 smokes green