### PR TITLE
Feat: dynamic post-fork Worker.register/unregister via CTRL_REGISTER IPC

### DIFF
--- a/docs/callable-ipc-dynamic-register.md
+++ b/docs/callable-ipc-dynamic-register.md
@@ -74,9 +74,8 @@ What any design must respect:
    Eager prepare at register time matches the cost shape of init-time
    pre-register; lazy prepare would defer this to the first TASK_READY.
 6. Register must serialize against TASK_READY on the same mailbox.
-   The Python `_chip_control` path and the C++ scheduler both go through
-   `mailbox_mu_`; the implementation must verify the two paths share
-   the same mutex.
+   Both `dispatch_process` and `WorkerThread::control_register` hold
+   `mailbox_mu_`, so the two paths are guaranteed serial within C++.
 
 ---
 
@@ -144,17 +143,28 @@ itself. No C++ changes are required.
 
 ### Successful register (single level)
 
-1. Parent `Worker.register(target)` acquires `_register_lock`,
-   allocates `cid`, inserts `_callable_registry[cid] = target`.
-2. Parent creates `SharedMemory(create=True, size=target.buffer_size)`
-   under the naming convention, memcpys the `ChipCallable` bytes in.
-3. Parent dispatches CTRL_REGISTER **in parallel** to every chip
-   mailbox, then waits for each `CONTROL_DONE`.
-4. Each chip child opens the shm by name, reads
-   `addr = ctypes.addressof(shm.buf)`, calls
-   `cw._impl.prepare_callable_from_blob(cid, addr, shm.size)`, closes
-   its mmap, writes `OFF_ERROR = 0`, sets `CONTROL_DONE`.
-5. Parent unlinks the shm after all children ACK.
+1. Parent `Worker.register(target)` acquires `_registry_lock`,
+   allocates `cid` via `_allocate_cid` (smallest unused integer in
+   `[0, MAX_REGISTERED_CALLABLE_IDS)`), inserts
+   `_callable_registry[cid] = target`. The lock is held through the
+   broadcast so a concurrent register cannot allocate the same cid
+   if this broadcast fails and pops the entry.
+2. Parent calls `_Worker.broadcast_register_all(cid, blob_ptr,
+   blob_size)` (nanobind). The GIL is released for the C++ call.
+3. C++ `WorkerManager::broadcast_register_all` creates a POSIX shm
+   under name `simpler-cb-<pid>-<cid>-<counter>`, `mmap`s it, and
+   `memcpy`s `blob_size` bytes from `blob_ptr`.
+4. C++ spawns one `std::thread` per `next_level_threads_` entry; each
+   calls `WorkerThread::control_register(cid, shm_name)`, which holds
+   that `WorkerThread::mailbox_mu_` (serialising against any in-flight
+   `dispatch_process` on the same mailbox), writes
+   `(CTRL_REGISTER, cid, shm_name)` into the mailbox, and spin-polls
+   `CONTROL_DONE`.
+5. Each chip child opens the shm by name, calls
+   `cw._impl.prepare_callable_from_blob(cid, addr)`, closes its mmap,
+   writes `OFF_ERROR = 0`, sets `CONTROL_DONE`.
+6. C++ joins all per-thread workers, `munmap`s and `shm_unlink`s the
+   staging region, then throws if any child failed.
 
 The child does **not** copy the bytes into its own bytearray.
 `prepare_callable` performs the H2D copy into device GM internally, so
@@ -168,19 +178,23 @@ it ever consults the registry.
 
 ### Successful register (L4 cascade)
 
-`_child_worker_loop` ([python/simpler/worker.py:526-561](../python/simpler/worker.py#L526-L561))
+`_child_worker_loop` ([python/simpler/worker.py](../python/simpler/worker.py))
 gains a `CONTROL_REQUEST` branch. On CTRL_REGISTER it:
 
 1. Decodes `(cid, shm_name)` from its own mailbox.
-2. Calls `inner_worker._post_init_register(cid, shm_name)`, which is a
-   new internal entrypoint that mirrors `Worker.register`'s post-init
-   path but operates from inside the L3 process — broadcasting through
-   L3's own chip and sub mailboxes using the **same shm name**.
-3. ACKs the L4 parent only after the recursive broadcast completes.
+2. Opens the shm by name, reconstructs the `ChipCallable` via
+   `ChipCallable.from_bytes`, and calls
+   `inner_worker._register_at(cid, callable_obj)`.
+3. The inner `Worker._register_at` records the cid in its own
+   `_callable_registry` and calls
+   `_Worker.broadcast_register_all` recursively for its own
+   `next_level_threads_` (which fans out to a fresh shm at the inner
+   level — the L4 shm is **not** reused by the inner broadcast).
+4. ACKs the L4 parent only after the recursive broadcast completes.
 
-The shm is created once at the top and reused throughout the cascade.
-The top-level parent unlinks it only after the leaves' ACKs propagate
-all the way back.
+The L4 parent's shm is unlinked when its own `broadcast_register_all`
+returns — after every L3 child has ACKed, which in turn happens after
+every L3's own broadcast has fully drained.
 
 ### Failure path
 
@@ -193,11 +207,27 @@ ACKed successfully — see section 5 for the rationale.
 
 Symmetric, smaller payload. CTRL_UNREGISTER carries only the cid;
 each child calls `cw.unregister_callable(cid)`
-([python/bindings/task_interface.cpp:678-687](../python/bindings/task_interface.cpp#L678-L687)).
+([python/bindings/task_interface.cpp](../python/bindings/task_interface.cpp)).
 That API releases the per-cid share of the device orch SO buffer.
 Kernel binaries remain resident until `finalize`. Errors during
-unregister are warned-and-continued; the parent removes the registry
-entry unconditionally so the cid slot becomes reusable.
+unregister are best-effort: C++
+`WorkerManager::broadcast_unregister_all` returns a per-child error
+list (empty on full success); the parent warns to stderr and removes
+the registry entry unconditionally so the cid slot becomes reusable.
+
+The chip-child `_CTRL_REGISTER` handler is **self-healing on cid reuse**:
+before calling `prepare_callable_from_blob`, if the child's local
+`prepared` set still contains the cid, it defensively re-issues
+`unregister_callable` to clear any residual host-side
+`prepared_callables_` / `aicpu_seen_callable_ids_` left by a previous
+`_CTRL_UNREGISTER` whose Python handler failed before reaching
+`prepared.discard`. This makes the parent's best-effort "cid slot is
+reusable" contract hold even when a subset of chip children reported
+errors on the prior unregister. The C++ boundary
+(`DeviceRunner::register_prepared_callable`) keeps its fail-fast
+duplicate-registration check; the self-heal lives entirely at the IPC
+layer, and is zero-cost on the happy path (the `cid in prepared` gate
+skips it when there is no residue to clean).
 
 ---
 
@@ -211,6 +241,7 @@ entry unconditionally so the cid slot becomes reusable.
 | Some children succeed before failure | Parent unlinks shm and raises; **no reverse rollback** |
 | `cid >= 64` | Rejected at parent before broadcast; child re-checks defensively |
 | Child process crashes mid-CONTROL | Parent's spin-poll on `CONTROL_DONE` never returns — same hang as existing `_CTRL_MALLOC` / `_CTRL_PREPARE`. Out of scope for this design |
+| Prior CTRL_UNREGISTER raised in child, parent popped registry | Next CTRL_REGISTER for the same cid self-heals at the child: re-issues `unregister_callable` before `prepare_callable_from_blob`. AICPU `orch_so_table_[cid]` is dlclose'd + reloaded on the next dispatch via `aicpu_seen_callable_ids_.erase` |
 
 The "no reverse rollback" decision is deliberate. A best-effort
 CTRL_UNREGISTER broadcast to the successful children would itself have
@@ -221,23 +252,26 @@ is inert garbage and is overwritten when the cid is reused.
 
 ### Concurrency
 
-- A `self._register_lock` (`threading.Lock`) serializes register calls
-  across parent threads. It also gates `Worker.run` entry/exit, which
-  increments and decrements a `_orch_in_flight` counter.
-- **Register is quiescent-state-only.** The Python `_chip_control` path
-  is **unlocked** with respect to the C++ scheduler's `mailbox_mu_` —
-  the two paths do not share a mutex. Safety relies on the scheduler
-  being provably idle outside `Worker.run()`: no orch fn → no submits
-  → no `dispatch_process`. The parent enforces this by checking
-  `_orch_in_flight == 0` under `_register_lock` and raising
-  `RuntimeError` if a register races a run. This matches the existing
-  Python-only model of `_CTRL_PREPARE`, which is also issued only at
-  init-time.
-- Same-level broadcast runs in parallel. Parent writes CTRL_REQUEST
-  concurrently to every chip mailbox and waits for all ACKs. Latency
-  drops from `N × prepare_cost` to `1 × prepare_cost`. Parallel
-  broadcast does not complicate error handling: any single child
-  failure still raises, and there is no rollback to coordinate.
+- `Worker.register` / `Worker.unregister` are driven through C++
+  `_Worker.broadcast_register_all` / `_Worker.broadcast_unregister_all`
+  ([python/bindings/worker_bind.h](../python/bindings/worker_bind.h)).
+  Each per-WorkerThread `control_register` call holds that
+  WorkerThread's `mailbox_mu_` for the round-trip, so the broadcast
+  serializes against any in-flight `dispatch_process` on that mailbox.
+  **No Python-side quiescent guard is needed**: register issued during
+  `Worker.run()` blocks until the in-flight TASK acknowledges on that
+  mailbox, then claims the lock — same shape as `control_malloc` /
+  `control_free`, which have always been safe to call mid-run.
+- A narrow `self._registry_lock` (`threading.Lock`) protects only the
+  `_callable_registry` dict mutation against concurrent register /
+  unregister calls from multiple Python threads. The lock is released
+  before the C++ broadcast so the spin-poll wait does not serialize
+  Python-side registration.
+- Same-level broadcast runs in parallel inside C++ via
+  `std::thread` fan-out across `next_level_threads_`. Per-WorkerThread
+  `mailbox_mu_` is independent, so N `control_register` calls proceed
+  concurrently — latency is `1 × prepare_cost` instead of
+  `N × prepare_cost`.
 - `Worker.register()` is synchronous and blocking. When it returns,
   every child has completed prepare. Users may submit TASK_READY for
   the new cid on the very next line.
@@ -249,8 +283,10 @@ is inert garbage and is overwritten when the cid is reused.
 ### Observability conventions
 
 - Child-side error messages use the format
-  `register cid=<N> chip=<id>: <reason>`. The parent prepends
-  `device_id` when raising.
+  `register cid=<N> chip=<id>: <reason>`. The C++ broadcast helper
+  strips its own `control_register failed on child:` wrapper and
+  re-throws as `Worker.register(cid=<N>) failed on next_level <i>:
+  <child msg>` so the operator sees a single, layered context line.
 - Partial state after a failed register is a known blind spot. There
   is no query API to list which children registered which cids. Users
   must treat a failed register as "the cid is gone" and retry with a
@@ -293,11 +329,6 @@ For the broader callable / task data flow, see
   responsible for not unregistering a cid with outstanding work.
 - Path to raising `MAX_REGISTERED_CALLABLE_IDS` beyond 64. Requires
   AICPU-side changes to `orch_so_table_` and is out of scope here.
-- Lifting the quiescent-state constraint to support register during
-  `Worker.run()` would require a C++-side `WorkerThread::control_register`
-  method (mirror `control_malloc`) that acquires `mailbox_mu_` and
-  serializes against `dispatch_process`. No production use case
-  demands this today; deferred.
 
 ---
 

--- a/docs/callable-ipc-dynamic-register.md
+++ b/docs/callable-ipc-dynamic-register.md
@@ -222,12 +222,17 @@ is inert garbage and is overwritten when the cid is reused.
 ### Concurrency
 
 - A `self._register_lock` (`threading.Lock`) serializes register calls
-  across parent threads.
-- Register and TASK_READY must serialize on the same per-mailbox mutex.
-  The Python `_chip_control` path holds `mailbox_mu_`; the C++
-  scheduler holds the same mutex when posting TASK_READY. **The
-  implementation must verify this is literally the same lock**; if not,
-  bridging them is a prerequisite to this feature.
+  across parent threads. It also gates `Worker.run` entry/exit, which
+  increments and decrements a `_orch_in_flight` counter.
+- **Register is quiescent-state-only.** The Python `_chip_control` path
+  is **unlocked** with respect to the C++ scheduler's `mailbox_mu_` —
+  the two paths do not share a mutex. Safety relies on the scheduler
+  being provably idle outside `Worker.run()`: no orch fn → no submits
+  → no `dispatch_process`. The parent enforces this by checking
+  `_orch_in_flight == 0` under `_register_lock` and raising
+  `RuntimeError` if a register races a run. This matches the existing
+  Python-only model of `_CTRL_PREPARE`, which is also issued only at
+  init-time.
 - Same-level broadcast runs in parallel. Parent writes CTRL_REQUEST
   concurrently to every chip mailbox and waits for all ACKs. Latency
   drops from `N × prepare_cost` to `1 × prepare_cost`. Parallel
@@ -288,6 +293,11 @@ For the broader callable / task data flow, see
   responsible for not unregistering a cid with outstanding work.
 - Path to raising `MAX_REGISTERED_CALLABLE_IDS` beyond 64. Requires
   AICPU-side changes to `orch_so_table_` and is out of scope here.
+- Lifting the quiescent-state constraint to support register during
+  `Worker.run()` would require a C++-side `WorkerThread::control_register`
+  method (mirror `control_malloc`) that acquires `mailbox_mu_` and
+  serializes against `dispatch_process`. No production use case
+  demands this today; deferred.
 
 ---
 

--- a/docs/callable-ipc-dynamic-register.md
+++ b/docs/callable-ipc-dynamic-register.md
@@ -250,6 +250,17 @@ Partial state left in successful children — an entry in the AICPU
 `orch_so_table_` that will never receive a TASK_READY for this cid —
 is inert garbage and is overwritten when the cid is reused.
 
+The self-heal path has a compound failure mode worth noting: if
+`cw.unregister_callable` (the defensive cleanup) raises *and* the
+follow-up `prepare_callable_from_blob` also raises, the child publishes
+`OFF_ERROR=1` and the parent pops the registry, but C++-side
+`prepared_callables_` / AICPU `orch_so_table_` may stay populated. That
+residue is the same flavour of inert garbage discussed above: the next
+attempt to register the same cid re-enters self-heal (because the
+child's `prepared` set still holds it) and gives `unregister_callable`
+another chance; if the cid is never reused, the entry sits until
+`DeviceRunner::finalize` clears the slot at process exit.
+
 ### Concurrency
 
 - `Worker.register` / `Worker.unregister` are driven through C++

--- a/docs/callable-ipc-dynamic-register.md
+++ b/docs/callable-ipc-dynamic-register.md
@@ -1,0 +1,303 @@
+# Dynamic Callable Registration over IPC
+
+This document specifies a design for **registering and unregistering
+`ChipCallable` objects after `Worker.init()` has forked the child
+processes**, using an IPC control-plane that complements the existing
+mailbox / ringbuffer / handshake data-plane.
+
+The current `Worker.register()` API rejects all calls after `init()` at
+L3+ ([python/simpler/worker.py:647-651](../python/simpler/worker.py#L647-L651)).
+The rejection exists because chip-children and sub-workers inherit
+`_callable_registry` purely through fork-time copy-on-write — any
+post-fork mutation in the parent is invisible to the child. This design
+removes that constraint for `ChipCallable` only.
+
+It is a **design document**, not an implementation. Concrete code lands
+in subsequent PRs.
+
+---
+
+## 1. Context and motivation
+
+### Real drivers
+
+- **JIT-compiled callables**: kernels produced mid-run by a compiler
+  cannot be registered at init time.
+- **Plugin operator libraries** loaded at runtime.
+- **cid reuse via `unregister`**: `MAX_REGISTERED_CALLABLE_IDS = 64`
+  ([src/common/task_interface/callable_protocol.h](../src/common/task_interface/callable_protocol.h))
+  is exhausted quickly by long-running JIT workloads. Without a
+  dynamic-unregister path, the only way to free a slot is to recycle
+  the worker pool. Bundling `unregister` into this design is the only
+  way to make dynamic register practically usable beyond 64
+  registrations.
+
+### Rejected pseudo-drivers
+
+- **Lazy startup cost**. `_CTRL_PREPARE` already lets a parent warm a
+  cid post-init using the CoW-inherited registry entry. Dynamic
+  register does not help here.
+- **Memory peak at fork**. `ChipCallable` bytes live in the parent's
+  heap and are CoW-shared; they do not multiply across children.
+
+### Non-goals
+
+- Lifting `MAILBOX_SIZE = 4096` ([src/common/hierarchical/worker_manager.h](../src/common/hierarchical/worker_manager.h)).
+- Lifting `MAX_REGISTERED_CALLABLE_IDS = 64`.
+- Hot-swap of a cid in place (re-register the same cid with new bytes).
+- Dynamic register of Python `OrchFn` / `SubFn` — only `ChipCallable`
+  is in scope. Calls with other target types raise `NotImplementedError`.
+- Cross-chip shared device GM for the orch SO.
+
+---
+
+## 2. Current constraints
+
+What any design must respect:
+
+1. `_callable_registry` is a Python `dict` keyed by `cid`. Parent writes
+   after fork are invisible to children
+   ([python/simpler/worker.py:628-671](../python/simpler/worker.py#L628-L671)).
+2. `MAX_REGISTERED_CALLABLE_IDS = 64`. The AICPU keeps a fixed-size
+   `orch_so_table_[64]`; post-fork register must enforce `cid < 64` at
+   the parent and re-check at the child.
+3. A `ChipCallable` is contiguous bytes — header + signature + storage
+   with embedded orch SO + child kernel binaries — typically hundreds
+   of KB to a few MB. It cannot fit in the 4 KB mailbox; a side-band
+   transport is required.
+4. `_sub_worker_loop` ([python/simpler/worker.py:226-255](../python/simpler/worker.py#L226-L255))
+   and `_child_worker_loop` currently handle only `TASK_READY` /
+   `SHUTDOWN`; they do not service `CONTROL_REQUEST`.
+5. `prepare_callable` is expensive: it copies the orch SO + kernel
+   binaries to device GM (`rtMemcpy`), records kernel addresses, and on
+   the `host_build_graph` variant also `dlopen`s the host orch SO.
+   Eager prepare at register time matches the cost shape of init-time
+   pre-register; lazy prepare would defer this to the first TASK_READY.
+6. Register must serialize against TASK_READY on the same mailbox.
+   The Python `_chip_control` path and the C++ scheduler both go through
+   `mailbox_mu_`; the implementation must verify the two paths share
+   the same mutex.
+
+---
+
+## 3. Wire format and binding prerequisites
+
+### Sub-command constants
+
+New constants extend the existing `_CTRL_MALLOC=0` / `FREE=1` /
+`COPY_TO=2` / `COPY_FROM=3` / `PREPARE=4` series:
+
+```text
+_CTRL_REGISTER   = 5
+_CTRL_UNREGISTER = 6
+```
+
+### Mailbox layout (state == CONTROL_REQUEST)
+
+CTRL_REGISTER:
+
+| Offset | Field | Notes |
+| ------ | ----- | ----- |
+| `OFF_CALLABLE` | sub_cmd = 5 | uint64 |
+| `CTRL_OFF_ARG0` | cid | low 32 bits; high bits reserved |
+| `OFF_ARGS[0..]` | NUL-terminated shm name | ≤ 32 bytes |
+
+CTRL_UNREGISTER:
+
+| Offset | Field | Notes |
+| ------ | ----- | ----- |
+| `OFF_CALLABLE` | sub_cmd = 6 | uint64 |
+| `CTRL_OFF_ARG0` | cid | low 32 bits |
+
+`MAILBOX_SIZE` is unchanged. No `total_size` field: the child reads
+`SharedMemory(name=...).size` directly. No `hash` field: POSIX shm is
+strongly consistent between parent and child; a checksum only catches
+defects in this code itself.
+
+### Shm naming convention
+
+`simpler-cb-<pid>-<cid>-<monotonic_counter>`. The pid prefix prevents
+collisions when multiple simpler instances run on the same host.
+
+### Binding prerequisite
+
+The child needs to call into C++ with a raw pointer to the shm-mapped
+bytes. The C++ entrypoint already exists:
+
+- `ChipWorker::prepare_callable(int32_t, const void *)`
+  ([src/common/worker/chip_worker.h:56](../src/common/worker/chip_worker.h#L56))
+- `prepare_callable(DeviceContextHandle, int32_t, const void *)`
+  ([src/common/worker/pto_runtime_c_api.h:148](../src/common/worker/pto_runtime_c_api.h#L148))
+
+The original nanobind binding took a `PyChipCallable` object.
+A companion `prepare_callable_from_blob(cid, blob_ptr)` overload
+([python/bindings/task_interface.cpp](../python/bindings/task_interface.cpp))
+follows the existing precedent set by `run_prepared_from_blob` —
+"Python passes a raw mailbox pointer, C++ casts to `const void *`".
+The overload takes two arguments only; no `size` parameter, because
+`prepare_callable` reads the total size from the ChipCallable header
+itself. No C++ changes are required.
+
+---
+
+## 4. Sequence flow
+
+### Successful register (single level)
+
+1. Parent `Worker.register(target)` acquires `_register_lock`,
+   allocates `cid`, inserts `_callable_registry[cid] = target`.
+2. Parent creates `SharedMemory(create=True, size=target.buffer_size)`
+   under the naming convention, memcpys the `ChipCallable` bytes in.
+3. Parent dispatches CTRL_REGISTER **in parallel** to every chip
+   mailbox, then waits for each `CONTROL_DONE`.
+4. Each chip child opens the shm by name, reads
+   `addr = ctypes.addressof(shm.buf)`, calls
+   `cw._impl.prepare_callable_from_blob(cid, addr, shm.size)`, closes
+   its mmap, writes `OFF_ERROR = 0`, sets `CONTROL_DONE`.
+5. Parent unlinks the shm after all children ACK.
+
+The child does **not** copy the bytes into its own bytearray.
+`prepare_callable` performs the H2D copy into device GM internally, so
+once that call returns the child no longer needs the source bytes. The
+mmap is held only for the duration of the call.
+
+The child does **not** insert anything into its own
+`_callable_registry`. Eager prepare records the cid in the `prepared`
+set, and `_ensure_prepared` short-circuits on `cid in prepared` before
+it ever consults the registry.
+
+### Successful register (L4 cascade)
+
+`_child_worker_loop` ([python/simpler/worker.py:526-561](../python/simpler/worker.py#L526-L561))
+gains a `CONTROL_REQUEST` branch. On CTRL_REGISTER it:
+
+1. Decodes `(cid, shm_name)` from its own mailbox.
+2. Calls `inner_worker._post_init_register(cid, shm_name)`, which is a
+   new internal entrypoint that mirrors `Worker.register`'s post-init
+   path but operates from inside the L3 process — broadcasting through
+   L3's own chip and sub mailboxes using the **same shm name**.
+3. ACKs the L4 parent only after the recursive broadcast completes.
+
+The shm is created once at the top and reused throughout the cascade.
+The top-level parent unlinks it only after the leaves' ACKs propagate
+all the way back.
+
+### Failure path
+
+If any child reports a non-zero `OFF_ERROR`, the parent immediately
+pops the cid from `_callable_registry`, unlinks the shm, and raises
+`RuntimeError`. There is no reverse rollback to children that already
+ACKed successfully — see section 5 for the rationale.
+
+### Unregister
+
+Symmetric, smaller payload. CTRL_UNREGISTER carries only the cid;
+each child calls `cw.unregister_callable(cid)`
+([python/bindings/task_interface.cpp:678-687](../python/bindings/task_interface.cpp#L678-L687)).
+That API releases the per-cid share of the device orch SO buffer.
+Kernel binaries remain resident until `finalize`. Errors during
+unregister are warned-and-continued; the parent removes the registry
+entry unconditionally so the cid slot becomes reusable.
+
+---
+
+## 5. Failure modes and concurrency
+
+### Failure modes
+
+| Trigger | Handling |
+| ------- | -------- |
+| Child cannot open shm or `prepare_callable` raises | Child writes `OFF_ERROR=1` + message; parent raises `RuntimeError` |
+| Some children succeed before failure | Parent unlinks shm and raises; **no reverse rollback** |
+| `cid >= 64` | Rejected at parent before broadcast; child re-checks defensively |
+| Child process crashes mid-CONTROL | Parent's spin-poll on `CONTROL_DONE` never returns — same hang as existing `_CTRL_MALLOC` / `_CTRL_PREPARE`. Out of scope for this design |
+
+The "no reverse rollback" decision is deliberate. A best-effort
+CTRL_UNREGISTER broadcast to the successful children would itself have
+a failure path, doubling the surface area of the error handler.
+Partial state left in successful children — an entry in the AICPU
+`orch_so_table_` that will never receive a TASK_READY for this cid —
+is inert garbage and is overwritten when the cid is reused.
+
+### Concurrency
+
+- A `self._register_lock` (`threading.Lock`) serializes register calls
+  across parent threads.
+- Register and TASK_READY must serialize on the same per-mailbox mutex.
+  The Python `_chip_control` path holds `mailbox_mu_`; the C++
+  scheduler holds the same mutex when posting TASK_READY. **The
+  implementation must verify this is literally the same lock**; if not,
+  bridging them is a prerequisite to this feature.
+- Same-level broadcast runs in parallel. Parent writes CTRL_REQUEST
+  concurrently to every chip mailbox and waits for all ACKs. Latency
+  drops from `N × prepare_cost` to `1 × prepare_cost`. Parallel
+  broadcast does not complicate error handling: any single child
+  failure still raises, and there is no rollback to coordinate.
+- `Worker.register()` is synchronous and blocking. When it returns,
+  every child has completed prepare. Users may submit TASK_READY for
+  the new cid on the very next line.
+
+---
+
+## 6. Observability and coupling
+
+### Observability conventions
+
+- Child-side error messages use the format
+  `register cid=<N> chip=<id>: <reason>`. The parent prepends
+  `device_id` when raising.
+- Partial state after a failed register is a known blind spot. There
+  is no query API to list which children registered which cids. Users
+  must treat a failed register as "the cid is gone" and retry with a
+  fresh registration.
+- `aicpu_dlopen_count` and `host_dlopen_count` on `ChipWorker`
+  ([src/common/worker/chip_worker.h](../src/common/worker/chip_worker.h))
+  continue to reflect dlopen counts under dynamic register and cid
+  reuse. This is a correctness constraint on the implementation.
+
+### Coupling to existing task flow
+
+- **L2 is unaffected.** L2 is in-process; `prepare_callable` does not
+  traverse the mailbox. CTRL_REGISTER only fires at L3+.
+- **The lazy `_ensure_prepared` path is decoupled.** Dynamic
+  registrations always go through eager prepare and land in
+  `prepared`, so the lazy fallback (which would consult the registry)
+  is never reached. Future work to support lazy dynamic register would
+  require the child registry to hold bytes, not just a sentinel.
+- **`dummy_task` is orthogonal.** It does not traverse callable
+  dispatch and shares no state with this design.
+- **Pre-fork register remains the recommended path.** Dynamic register
+  does not replace it. Use pre-fork when the full callable set is
+  known at init; use dynamic register for JIT, plugins, or callables
+  generated inside a training step. Each dynamic register pays full
+  broadcast + per-child prepare cost.
+
+For the broader callable / task data flow, see
+[task-flow.md](task-flow.md) and
+[hierarchical_level_runtime.md](hierarchical_level_runtime.md).
+
+---
+
+## 7. Open questions
+
+- How to detect and recover from a child crash that strands the parent
+  spin-polling on `CONTROL_DONE`. This problem is shared with all
+  existing `_CTRL_*` operations and is not solved here.
+- Whether `unregister` should wait for in-flight TASK_READYs to the
+  same cid to drain before proceeding. This design assumes the user is
+  responsible for not unregistering a cid with outstanding work.
+- Path to raising `MAX_REGISTERED_CALLABLE_IDS` beyond 64. Requires
+  AICPU-side changes to `orch_so_table_` and is out of scope here.
+
+---
+
+## 8. Out of scope
+
+- Raising `MAILBOX_SIZE` past 4 KB.
+- Raising `MAX_REGISTERED_CALLABLE_IDS` past 64.
+- Cross-chip shared device GM for the orch SO.
+- Hot-swap of a cid (re-register the same cid with new bytes).
+- Switching the IPC backend off `multiprocessing.shared_memory`.
+- A C++-side equivalent of `Worker.register` — the registry lives in
+  Python; the C++ side only dispatches.
+- Persistent cross-restart cache of prepared callables.

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -440,6 +440,29 @@ NB_MODULE(_task_interface, m) {
             "Build a ChipCallable from signature, func_name, binary, and list of (func_id, CoreCallable) children."
         )
 
+        .def_static(
+            "from_bytes",
+            [](nb::bytes raw) -> PyChipCallable {
+                // Reconstruct a ChipCallable wrapper from the contiguous
+                // serialised representation produced by `buffer_ptr()` /
+                // `buffer_size()`. Used by the L4 cascade in
+                // _child_worker_loop, which receives CTRL_REGISTER bytes
+                // through shared memory and needs a typed ChipCallable to
+                // hand to inner_worker.register; see
+                // docs/callable-ipc-dynamic-register.md.
+                std::vector<uint8_t> buf(
+                    reinterpret_cast<const uint8_t *>(raw.c_str()),
+                    reinterpret_cast<const uint8_t *>(raw.c_str()) + raw.size()
+                );
+                return PyChipCallable{std::move(buf)};
+            },
+            nb::arg("raw"),
+            "Reconstruct a ChipCallable from the contiguous bytes that "
+            "buffer_ptr() points to (size buffer_size()). Inverse of the "
+            "serialisation used to ship a ChipCallable across the L4 "
+            "cascade IPC channel."
+        )
+
         .def(
             "sig",
             [](const PyChipCallable &self, int32_t i) -> ArgDirection {

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -640,6 +640,19 @@ NB_MODULE(_task_interface, m) {
             "via run_prepared. Variants without per-callable_id support raise."
         )
         .def(
+            "prepare_callable_from_blob",
+            [](ChipWorker &self, int32_t callable_id, uint64_t blob_ptr) {
+                self.prepare_callable(callable_id, reinterpret_cast<const void *>(blob_ptr));
+            },
+            nb::arg("callable_id"), nb::arg("blob_ptr"),
+            "Stage a ChipCallable from a raw contiguous-buffer pointer (used by "
+            "post-fork dynamic register handlers that receive the ChipCallable "
+            "bytes via shared memory; see docs/callable-ipc-dynamic-register.md). "
+            "Equivalent to prepare_callable(cid, ChipCallable) but accepts the "
+            "ChipCallable layout pointer directly so chip-child loops can prepare "
+            "from shm without rebuilding a PyChipCallable wrapper."
+        )
+        .def(
             "run_prepared",
             [](ChipWorker &self, int32_t callable_id, ChipStorageTaskArgs &args, const CallConfig &config) {
                 self.run_prepared(callable_id, &args, config);

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -448,7 +448,8 @@ NB_MODULE(_task_interface, m) {
                 // `buffer_size()`. Used by the L4 cascade in
                 // _child_worker_loop, which receives CTRL_REGISTER bytes
                 // through shared memory and needs a typed ChipCallable to
-                // hand to inner_worker.register; see
+                // hand to inner_worker._register_at (the cid is dictated
+                // by the outer cascade, not freshly allocated); see
                 // docs/callable-ipc-dynamic-register.md.
                 std::vector<uint8_t> buf(
                     reinterpret_cast<const uint8_t *>(raw.c_str()),

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -221,6 +221,30 @@ inline void bind_worker(nb::module_ &m) {
         .def(
             "get_orchestrator", &Worker::get_orchestrator, nb::rv_policy::reference_internal,
             "Return the Orchestrator handle (lifetime tied to this Worker)."
+        )
+
+        // --- Mailbox control plane (parent side) ---
+        // These hold the per-WorkerThread mailbox_mu_ inside C++, so they
+        // serialize against dispatch_process without any Python-side lock.
+        // Release the GIL during the spin-poll wait so other Python threads
+        // (e.g. a concurrent Worker.run) can keep running.
+        .def(
+            "control_prepare", &Worker::control_prepare, nb::arg("worker_id"), nb::arg("cid"),
+            nb::call_guard<nb::gil_scoped_release>(),
+            "Prewarm a NEXT_LEVEL child for `cid` by sending CTRL_PREPARE. "
+            "Blocks until the child publishes CONTROL_DONE."
+        )
+        .def(
+            "broadcast_register_all", &Worker::broadcast_register_all, nb::arg("cid"), nb::arg("blob_ptr"),
+            nb::arg("blob_size"), nb::call_guard<nb::gil_scoped_release>(),
+            "Stage `blob_size` bytes from `blob_ptr` into a POSIX shm and broadcast "
+            "CTRL_REGISTER to every NEXT_LEVEL child in parallel. Throws on any failure."
+        )
+        .def(
+            "broadcast_unregister_all", &Worker::broadcast_unregister_all, nb::arg("cid"),
+            nb::call_guard<nb::gil_scoped_release>(),
+            "Best-effort broadcast of CTRL_UNREGISTER to every NEXT_LEVEL child in parallel. "
+            "Returns a list of per-child error strings (empty on full success)."
         );
 
     m.attr("DEFAULT_HEAP_RING_SIZE") = static_cast<uint64_t>(DEFAULT_HEAP_RING_SIZE);

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -602,7 +602,9 @@ def _child_worker_loop(
     Polls the unified mailbox for (cid, config, args_blob). Looks up the
     orch function in the COW-inherited registry, then delegates to
     ``inner_worker.run(orch_fn, args, cfg)`` which opens its own scope,
-    runs the orch function, and drains.
+    runs the orch function, and drains. Also services CONTROL_REQUEST
+    so the L4 parent's dynamic register/unregister broadcasts cascade
+    into the inner Worker (see docs section 7).
     """
     state_addr = _buffer_field_addr(buf, _OFF_STATE)
     while True:
@@ -625,6 +627,43 @@ def _child_worker_loop(
                     msg = _format_exc(f"child_worker level={inner_worker.level}", e)
             _write_error(buf, code, msg)
             _mailbox_store_i32(state_addr, _TASK_DONE)
+        elif state == _CONTROL_REQUEST:
+            sub_cmd = struct.unpack_from("Q", buf, _OFF_CALLABLE)[0]
+            code = 0
+            msg = ""
+            try:
+                if sub_cmd == _CTRL_REGISTER:
+                    cid_val = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
+                    raw = bytes(buf[_OFF_ARGS : _OFF_ARGS + _CTRL_SHM_NAME_BYTES])
+                    nul = raw.find(b"\x00")
+                    shm_name = raw[: nul if nul >= 0 else _CTRL_SHM_NAME_BYTES].decode("utf-8", "replace")
+                    shm = SharedMemory(name=shm_name)
+                    try:
+                        shm_buf = shm.buf
+                        assert shm_buf is not None
+                        callable_obj = ChipCallable.from_bytes(bytes(shm_buf[: shm.size]))
+                    finally:
+                        shm.close()
+                    # Delegate to the inner Worker's register so its own
+                    # _post_init_register handles broadcasting to its chip
+                    # / next-level children (recursive cascade). Forcing
+                    # cid_val onto the registry slot keeps the inner-side
+                    # cid identical to the outer-side cid — both the L4
+                    # scheduler and the L3 children index by the same int.
+                    inner_worker._register_at(int(cid_val), callable_obj)
+                elif sub_cmd == _CTRL_UNREGISTER:
+                    cid_val = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
+                    inner_worker.unregister(int(cid_val))
+            except Exception as e:  # noqa: BLE001
+                code = 1
+                op = (
+                    "register"
+                    if sub_cmd == _CTRL_REGISTER
+                    else ("unregister" if sub_cmd == _CTRL_UNREGISTER else f"ctrl={int(sub_cmd)}")
+                )
+                msg = _format_exc(f"child_worker level={inner_worker.level} {op}", e)
+            _write_error(buf, code, msg)
+            _mailbox_store_i32(state_addr, _CONTROL_DONE)
         elif state == _SHUTDOWN:
             inner_worker.close()
             break
@@ -736,11 +775,6 @@ class Worker:
                         "for non-ChipCallable targets; only ChipCallable is supported "
                         "post-init (see docs/callable-ipc-dynamic-register.md)"
                     )
-                if self.level >= 4:
-                    raise NotImplementedError(
-                        "Post-init Worker.register(ChipCallable) at level >= 4 is not "
-                        "yet implemented (L4 cascade is a separate commit)"
-                    )
                 if self._orch_in_flight > 0:
                     raise RuntimeError(
                         "Worker.register() cannot be called while Worker.run() is "
@@ -760,9 +794,10 @@ class Worker:
             cid = len(self._callable_registry)
             self._callable_registry[cid] = target
 
-            # L3 post-init ChipCallable: broadcast to chip children via shm.
-            # On failure we pop the registry entry so a retry gets a fresh cid.
-            if self.level == 3 and self._initialized and isinstance(target, ChipCallable):
+            # L3+ post-init ChipCallable: broadcast to chip / next-level
+            # children via shm. On failure we pop the registry entry so a
+            # retry gets a fresh cid.
+            if self.level >= 3 and self._initialized and isinstance(target, ChipCallable):
                 try:
                     self._post_init_register(cid, target)
                 except Exception:
@@ -776,6 +811,34 @@ class Worker:
                 assert self._chip_worker is not None
                 self._chip_worker.prepare_callable(cid, target)
             return cid
+
+    def _register_at(self, cid: int, target: ChipCallable) -> None:
+        """Register *target* under a caller-specified *cid* (L4 cascade only).
+
+        Used by ``_child_worker_loop`` when forwarding a CTRL_REGISTER from
+        an L4 parent: the outer cid must match the inner cid so the L4
+        scheduler's dispatch table and the inner worker's registry agree
+        on a single integer key. Plain ``register`` allocates the next
+        free slot and is therefore unsuitable here.
+
+        Asserts the cid slot is free; otherwise the caller has a bug in
+        cid bookkeeping (e.g. duplicate broadcast, or pre-init + cascade
+        collision).
+        """
+        with self._register_lock:
+            if cid in self._callable_registry:
+                raise RuntimeError(f"_register_at: cid={cid} already occupied")
+            if not isinstance(target, ChipCallable):
+                raise TypeError("_register_at: target must be a ChipCallable")
+            if self._orch_in_flight > 0:
+                raise RuntimeError("_register_at cannot be called while Worker.run() is executing")
+            self._callable_registry[cid] = target
+            if self.level >= 3 and self._initialized:
+                try:
+                    self._post_init_register(cid, target)
+                except Exception:
+                    self._callable_registry.pop(cid, None)
+                    raise
 
     def _post_init_register(self, cid: int, target: ChipCallable) -> None:
         """Broadcast a new ChipCallable to every chip child via _CTRL_REGISTER.
@@ -814,13 +877,18 @@ class Worker:
                 blob_ptr,
                 blob_size,
             )
-            n = len(self._chip_shms)
+            targets = [(shm, f"chip {i}") for i, shm in enumerate(self._chip_shms)] + [
+                (shm, f"next_level {i}") for i, shm in enumerate(self._next_level_shms)
+            ]
+            n = len(targets)
             if n == 0:
-                # Degenerate L3 with no chip children: nothing to broadcast.
+                # Degenerate worker with no children at all: nothing to broadcast.
                 return
             errors: list[str] = []
             with ThreadPoolExecutor(max_workers=n) as ex:
-                futures = {ex.submit(self._chip_control_register, wid, cid, shm_name): wid for wid in range(n)}
+                futures = {
+                    ex.submit(self._mailbox_control_register, mb, label, cid, shm_name): label for mb, label in targets
+                }
                 # Don't break on first failure — let every child's mailbox
                 # return to IDLE before we unlink the shm.
                 for fut in as_completed(futures):
@@ -871,10 +939,6 @@ class Worker:
             if cid not in self._callable_registry:
                 raise KeyError(f"Worker.unregister: cid={cid} not registered")
             if self.level >= 3 and self._initialized:
-                if self.level >= 4:
-                    raise NotImplementedError(
-                        "Worker.unregister at level >= 4 is not yet implemented (L4 cascade is a separate commit)"
-                    )
                 if self._orch_in_flight > 0:
                     raise RuntimeError(
                         "Worker.unregister() cannot be called while Worker.run() is "
@@ -890,17 +954,20 @@ class Worker:
             self._callable_registry.pop(cid, None)
 
     def _broadcast_unregister(self, cid: int) -> None:
-        """Broadcast _CTRL_UNREGISTER to every chip child in parallel.
+        """Broadcast _CTRL_UNREGISTER to every chip + next-level child in parallel.
 
         Best-effort: chips that fail are logged to stderr; the parent still
         proceeds to pop the registry entry (see ``unregister`` docstring).
         """
-        n = len(self._chip_shms)
+        targets = [(shm, f"chip {i}") for i, shm in enumerate(self._chip_shms)] + [
+            (shm, f"next_level {i}") for i, shm in enumerate(self._next_level_shms)
+        ]
+        n = len(targets)
         if n == 0:
             return
         errors: list[str] = []
         with ThreadPoolExecutor(max_workers=n) as ex:
-            futures = {ex.submit(self._chip_control_unregister, wid, cid): wid for wid in range(n)}
+            futures = {ex.submit(self._mailbox_control_unregister, mb, label, cid): label for mb, label in targets}
             for fut in as_completed(futures):
                 try:
                     fut.result()
@@ -1325,18 +1392,14 @@ class Worker:
         _mailbox_store_i32(state_addr, _IDLE)
         return result
 
-    def _chip_control_register(self, worker_id: int, cid: int, shm_name: str) -> None:
-        """Send _CTRL_REGISTER (cid + shm name) to chip child *worker_id*.
+    def _mailbox_control_register(self, mailbox: SharedMemory, label: str, cid: int, shm_name: str) -> None:
+        """Send _CTRL_REGISTER (cid + shm name) to a chip OR next-level mailbox.
 
-        Separate from ``_chip_control`` because it writes an extra payload
-        (shm name) into the OFF_ARGS region rather than a single uint64
-        result; the wire shapes are different enough that one helper would
-        muddle both contracts.
+        ``label`` is folded into the RuntimeError message so the caller can
+        tell apart a failed chip child from a failed L4 child without
+        reaching for worker_id arithmetic.
         """
-        if worker_id < 0 or worker_id >= len(self._chip_shms):
-            raise IndexError(f"worker_id {worker_id} out of range (have {len(self._chip_shms)} chips)")
-        shm = self._chip_shms[worker_id]
-        buf = shm.buf
+        buf = mailbox.buf
         assert buf is not None
         state_addr = _buffer_field_addr(buf, _OFF_STATE)
         _write_error(buf, 0, "")
@@ -1357,21 +1420,18 @@ class Worker:
         if error != 0:
             err_msg = _read_error_msg(buf)
             _mailbox_store_i32(state_addr, _IDLE)
-            raise RuntimeError(f"chip {worker_id}: {err_msg}")
+            raise RuntimeError(f"{label}: {err_msg}")
         _mailbox_store_i32(state_addr, _IDLE)
 
-    def _chip_control_unregister(self, worker_id: int, cid: int) -> None:
-        """Send _CTRL_UNREGISTER (cid only) to chip child *worker_id*.
+    def _mailbox_control_unregister(self, mailbox: SharedMemory, label: str, cid: int) -> None:
+        """Send _CTRL_UNREGISTER (cid only) to a chip OR next-level mailbox.
 
-        Mirror of ``_chip_control_register`` minus the shm name payload —
+        Mirror of ``_mailbox_control_register`` minus the shm name payload —
         unregister has no bytes to transport. Raises ``RuntimeError`` on
         non-zero child error code; callers may catch and ``warn`` rather
         than abort because docs section 8 marks unregister as best-effort.
         """
-        if worker_id < 0 or worker_id >= len(self._chip_shms):
-            raise IndexError(f"worker_id {worker_id} out of range (have {len(self._chip_shms)} chips)")
-        shm = self._chip_shms[worker_id]
-        buf = shm.buf
+        buf = mailbox.buf
         assert buf is not None
         state_addr = _buffer_field_addr(buf, _OFF_STATE)
         _write_error(buf, 0, "")
@@ -1384,7 +1444,7 @@ class Worker:
         if error != 0:
             err_msg = _read_error_msg(buf)
             _mailbox_store_i32(state_addr, _IDLE)
-            raise RuntimeError(f"chip {worker_id}: {err_msg}")
+            raise RuntimeError(f"{label}: {err_msg}")
         _mailbox_store_i32(state_addr, _IDLE)
 
     def malloc(self, size: int, worker_id: int = 0) -> int:

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -55,7 +55,6 @@ Usage::
 """
 
 import ctypes
-import itertools
 import os
 import signal
 import struct
@@ -63,7 +62,6 @@ import sys
 import threading
 import time
 import traceback
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Optional
 
@@ -218,22 +216,6 @@ def _read_error_msg(buf) -> str:
 
 def _format_exc(prefix: str, exc: BaseException) -> str:
     return f"{prefix}: {type(exc).__name__}: {exc}"
-
-
-# Process-wide monotonic counter for _CTRL_REGISTER shm names. itertools.count()
-# is atomic under the GIL (single C ++ on tp_next), so no extra locking is
-# needed at the call site.
-_shm_name_counter = itertools.count()
-
-
-def _make_callable_shm_name(pid: int, cid: int) -> str:
-    """Build a unique POSIX shm name for one dynamic-register broadcast.
-
-    The pid prefix prevents collisions across simpler instances on the same
-    host; the monotonic counter disambiguates registers within one process.
-    Asserted to fit in ``_CTRL_SHM_NAME_BYTES`` including NUL at the caller.
-    """
-    return f"simpler-cb-{pid}-{cid}-{next(_shm_name_counter)}"
 
 
 def _read_args_from_mailbox(buf) -> TaskArgs:
@@ -399,6 +381,20 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
                     raw = bytes(buf[_OFF_ARGS : _OFF_ARGS + _CTRL_SHM_NAME_BYTES])
                     nul = raw.find(b"\x00")
                     shm_name = raw[: nul if nul >= 0 else _CTRL_SHM_NAME_BYTES].decode("utf-8", "replace")
+                    # Self-heal when the parent thinks the cid slot is free but
+                    # this child's local view still has it prepared — happens
+                    # when a prior _CTRL_UNREGISTER failed before reaching
+                    # prepared.discard, while the parent still popped its
+                    # registry under best-effort semantics. Without this,
+                    # register_prepared_callable would fail-fast on a slot the
+                    # user was told is reusable. The `cid in prepared` gate
+                    # keeps the happy path at zero added cost.
+                    if int(cid) in prepared:
+                        try:
+                            cw.unregister_callable(int(cid))
+                        except Exception:  # noqa: BLE001
+                            pass
+                        prepared.discard(int(cid))
                     shm = SharedMemory(name=shm_name)
                     try:
                         shm_buf = shm.buf
@@ -696,12 +692,12 @@ class Worker:
         self._callable_registry: dict[int, Any] = {}
         self._initialized = False
 
-        # Serializes Worker.register against itself and against Worker.run.
-        # `_orch_in_flight` is bumped inside Worker.run under this lock so
-        # dynamic register can refuse mid-run calls (see docs §5: the
-        # scheduler is provably idle outside Worker.run).
-        self._register_lock = threading.Lock()
-        self._orch_in_flight = 0
+        # Narrow lock around `_callable_registry` mutation so concurrent
+        # register / unregister calls don't trip CPython's non-atomic
+        # len()+assign. The wire-level concurrency (Python control ↔ C++
+        # dispatch) is now handled at the C++ boundary via mailbox_mu_, so
+        # no quiescent-state guard is needed.
+        self._registry_lock = threading.Lock()
 
         # Level-2 internals
         self._chip_worker: Optional[ChipWorker] = None
@@ -754,49 +750,33 @@ class Worker:
             **before** ``init()`` so the COW-inherited registry is visible to
             forked chip / sub children. ChipCallables may be registered either
             before init (pre-warmed via ``_CTRL_PREPARE`` during ``init()``)
-            or after init (broadcast to chip children via ``_CTRL_REGISTER``;
-            see docs/callable-ipc-dynamic-register.md). Post-init register at
-            L3+ is ChipCallable-only and must run in a quiescent state
-            (no concurrent ``Worker.run``).
+            or after init (broadcast to chip children via
+            ``_Worker.broadcast_register_all``; see
+            docs/callable-ipc-dynamic-register.md). Post-init register at
+            L3+ is ChipCallable-only.
           - L2: may be called either before or after ``init()`` (no fork,
             no COW constraint).  When called post-init, ChipCallables are
             prepared on the device immediately; pre-init registrations are
             batched and prepared at the end of ``init()``.
-          - L4+: post-init ChipCallable register is not yet implemented
-            (deferred to the L4 cascade commit).
         """
-        with self._register_lock:
-            if self.level >= 3 and self._initialized:
-                # L3+ post-init: only ChipCallable is supported (Python
-                # callables cannot cross the process boundary).
-                if not isinstance(target, ChipCallable):
-                    raise NotImplementedError(
-                        "Worker.register() at level >= 3 must be called before init() "
-                        "for non-ChipCallable targets; only ChipCallable is supported "
-                        "post-init (see docs/callable-ipc-dynamic-register.md)"
-                    )
-                if self._orch_in_flight > 0:
-                    raise RuntimeError(
-                        "Worker.register() cannot be called while Worker.run() is "
-                        "executing; serialize register/run on the same thread"
-                    )
-            if len(self._callable_registry) >= MAX_REGISTERED_CALLABLE_IDS:
-                # The AICPU side keeps a fixed-size orch_so_table_ keyed by cid;
-                # raise here so the failure surfaces at register-time with a
-                # protocol-aware message, not later from
-                # DeviceRunner::register_prepared_callable with a generic
-                # "out of range" log.
-                raise RuntimeError(
-                    "Worker.register: cid space exhausted "
-                    f"(MAX_REGISTERED_CALLABLE_IDS={MAX_REGISTERED_CALLABLE_IDS}); "
-                    "unregister unused callables before registering more"
+        with self._registry_lock:
+            if self.level >= 3 and self._initialized and not isinstance(target, ChipCallable):
+                # L3+ post-init: only ChipCallable can cross the process
+                # boundary. Python callables (sub fn / orch fn) must be
+                # registered before init() so forked children inherit them.
+                raise NotImplementedError(
+                    "Worker.register() at level >= 3 must be called before init() "
+                    "for non-ChipCallable targets; only ChipCallable is supported "
+                    "post-init (see docs/callable-ipc-dynamic-register.md)"
                 )
-            cid = len(self._callable_registry)
+            cid = self._allocate_cid()
             self._callable_registry[cid] = target
 
             # L3+ post-init ChipCallable: broadcast to chip / next-level
-            # children via shm. On failure we pop the registry entry so a
-            # retry gets a fresh cid.
+            # children via C++. Done inside the registry lock so a concurrent
+            # register cannot allocate the same cid we are about to pop on
+            # failure. Per-WorkerThread mailbox_mu_ already provides the C++
+            # serialisation against in-flight dispatch.
             if self.level >= 3 and self._initialized and isinstance(target, ChipCallable):
                 try:
                     self._post_init_register(cid, target)
@@ -812,6 +792,28 @@ class Worker:
                 self._chip_worker.prepare_callable(cid, target)
             return cid
 
+    def _allocate_cid(self) -> int:
+        """Return the smallest unused cid in [0, MAX_REGISTERED_CALLABLE_IDS).
+
+        Caller must hold ``_registry_lock``. Walks the integers in order so
+        an ``unregister(K)`` followed by a fresh ``register`` reuses K
+        instead of colliding with an existing entry — ``len(registry)``
+        would silently overwrite the next gap-after-the-hole.
+        """
+        for i in range(MAX_REGISTERED_CALLABLE_IDS):
+            if i not in self._callable_registry:
+                return i
+        # The AICPU side keeps a fixed-size orch_so_table_ keyed by cid;
+        # raise here so the failure surfaces at register-time with a
+        # protocol-aware message, not later from
+        # DeviceRunner::register_prepared_callable with a generic
+        # "out of range" log.
+        raise RuntimeError(
+            "Worker.register: cid space exhausted "
+            f"(MAX_REGISTERED_CALLABLE_IDS={MAX_REGISTERED_CALLABLE_IDS}); "
+            "unregister unused callables before registering more"
+        )
+
     def _register_at(self, cid: int, target: ChipCallable) -> None:
         """Register *target* under a caller-specified *cid* (L4 cascade only).
 
@@ -820,18 +822,12 @@ class Worker:
         scheduler's dispatch table and the inner worker's registry agree
         on a single integer key. Plain ``register`` allocates the next
         free slot and is therefore unsuitable here.
-
-        Asserts the cid slot is free; otherwise the caller has a bug in
-        cid bookkeeping (e.g. duplicate broadcast, or pre-init + cascade
-        collision).
         """
-        with self._register_lock:
+        with self._registry_lock:
             if cid in self._callable_registry:
                 raise RuntimeError(f"_register_at: cid={cid} already occupied")
             if not isinstance(target, ChipCallable):
                 raise TypeError("_register_at: target must be a ChipCallable")
-            if self._orch_in_flight > 0:
-                raise RuntimeError("_register_at cannot be called while Worker.run() is executing")
             self._callable_registry[cid] = target
             if self.level >= 3 and self._initialized:
                 try:
@@ -841,17 +837,12 @@ class Worker:
                     raise
 
     def _post_init_register(self, cid: int, target: ChipCallable) -> None:
-        """Broadcast a new ChipCallable to every chip child via _CTRL_REGISTER.
+        """Broadcast a new ChipCallable to every NEXT_LEVEL child via C++.
 
-        Stages the ChipCallable bytes into a per-register POSIX shm, then
-        broadcasts the (cid, shm_name) tuple to every chip child in parallel
-        via ``concurrent.futures.ThreadPoolExecutor``. Each child mmaps the
-        shm and calls ``_ChipWorker.prepare_callable_from_blob`` (eager
-        prepare per docs §4). Parent unlinks the shm after all ACKs.
-
-        On any child failure, the parent raises ``RuntimeError`` without
-        rolling back already-ACKed children — the resulting partial state
-        is inert garbage that is overwritten on cid reuse (docs §5).
+        Delegates the entire shm-staging + per-child mailbox handshake to
+        ``_Worker.broadcast_register_all``, which holds per-WorkerThread
+        ``mailbox_mu_`` so the broadcast serializes against any in-flight
+        dispatch on each child mailbox. No Python lock required.
         """
         # Chip children are forked lazily on the first Worker.run() via
         # _start_hierarchical; before that point the chip mailboxes have
@@ -861,53 +852,8 @@ class Worker:
         # every chip child once they come up (the entry is CoW-inherited).
         if not getattr(self, "_hierarchical_started", False):
             return
-        blob_ptr = target.buffer_ptr()
-        blob_size = target.buffer_size()
-        shm_name = _make_callable_shm_name(os.getpid(), cid)
-        # +1 for the NUL terminator the child slice-decodes against.
-        assert len(shm_name.encode("utf-8")) + 1 <= _CTRL_SHM_NAME_BYTES, (
-            f"shm name too long for mailbox field: {shm_name!r}"
-        )
-        shm = SharedMemory(create=True, size=blob_size, name=shm_name)
-        try:
-            shm_buf = shm.buf
-            assert shm_buf is not None
-            ctypes.memmove(
-                ctypes.addressof(ctypes.c_char.from_buffer(shm_buf)),
-                blob_ptr,
-                blob_size,
-            )
-            targets = [(shm, f"chip {i}") for i, shm in enumerate(self._chip_shms)] + [
-                (shm, f"next_level {i}") for i, shm in enumerate(self._next_level_shms)
-            ]
-            n = len(targets)
-            if n == 0:
-                # Degenerate worker with no children at all: nothing to broadcast.
-                return
-            errors: list[str] = []
-            with ThreadPoolExecutor(max_workers=n) as ex:
-                futures = {
-                    ex.submit(self._mailbox_control_register, mb, label, cid, shm_name): label for mb, label in targets
-                }
-                # Don't break on first failure — let every child's mailbox
-                # return to IDLE before we unlink the shm.
-                for fut in as_completed(futures):
-                    try:
-                        fut.result()
-                    except Exception as exc:  # noqa: BLE001
-                        errors.append(str(exc))
-            if errors:
-                raise RuntimeError(
-                    f"Worker.register(cid={cid}) failed; {len(errors)} of {n} chips "
-                    f"reported errors. First error: {errors[0]}. "
-                    f"{len(errors) - 1} additional error(s) suppressed."
-                )
-        finally:
-            shm.close()
-            try:
-                shm.unlink()
-            except FileNotFoundError:
-                pass
+        assert self._worker is not None
+        self._worker.broadcast_register_all(int(cid), int(target.buffer_ptr()), int(target.buffer_size()))
 
     def unregister(self, cid: int) -> None:
         """Drop *cid* from the registry and propagate to chip children.
@@ -918,12 +864,6 @@ class Worker:
         ``MAX_REGISTERED_CALLABLE_IDS`` ceiling when JIT or plugin code
         churns through callables.
 
-        Timing constraints mirror ``register``:
-          - L3+: must be called when no ``Worker.run`` is in flight
-            (quiescent-state contract; see docs section 5). Violation
-            raises ``RuntimeError`` before any broadcast is issued.
-          - L2: directly forwards to ``ChipWorker.unregister_callable``.
-
         Failure semantics (docs section 8): unregister is best-effort.
         If any chip child reports an error, the parent **warns and still
         pops the registry entry** — orch_so_table_ on the AICPU side will
@@ -932,20 +872,12 @@ class Worker:
 
         Raises:
           KeyError: cid was never registered.
-          NotImplementedError: called at L4+ (cascade unregister deferred).
-          RuntimeError: called while ``Worker.run`` is executing.
         """
-        with self._register_lock:
+        with self._registry_lock:
             if cid not in self._callable_registry:
                 raise KeyError(f"Worker.unregister: cid={cid} not registered")
-            if self.level >= 3 and self._initialized:
-                if self._orch_in_flight > 0:
-                    raise RuntimeError(
-                        "Worker.unregister() cannot be called while Worker.run() is "
-                        "executing; serialize unregister/run on the same thread"
-                    )
-                if getattr(self, "_hierarchical_started", False):
-                    self._broadcast_unregister(cid)
+            if self.level >= 3 and self._initialized and getattr(self, "_hierarchical_started", False):
+                self._broadcast_unregister(cid)
             elif self.level == 2 and self._initialized:
                 assert self._chip_worker is not None
                 self._chip_worker.unregister_callable(cid)
@@ -954,28 +886,16 @@ class Worker:
             self._callable_registry.pop(cid, None)
 
     def _broadcast_unregister(self, cid: int) -> None:
-        """Broadcast _CTRL_UNREGISTER to every chip + next-level child in parallel.
+        """Broadcast _CTRL_UNREGISTER via C++ to every NEXT_LEVEL child.
 
-        Best-effort: chips that fail are logged to stderr; the parent still
-        proceeds to pop the registry entry (see ``unregister`` docstring).
+        Best-effort: any per-child errors are returned by C++ as a list of
+        strings; we warn to stderr and let the caller still pop the registry.
         """
-        targets = [(shm, f"chip {i}") for i, shm in enumerate(self._chip_shms)] + [
-            (shm, f"next_level {i}") for i, shm in enumerate(self._next_level_shms)
-        ]
-        n = len(targets)
-        if n == 0:
-            return
-        errors: list[str] = []
-        with ThreadPoolExecutor(max_workers=n) as ex:
-            futures = {ex.submit(self._mailbox_control_unregister, mb, label, cid): label for mb, label in targets}
-            for fut in as_completed(futures):
-                try:
-                    fut.result()
-                except Exception as exc:  # noqa: BLE001
-                    errors.append(str(exc))
+        assert self._worker is not None
+        errors = self._worker.broadcast_unregister_all(int(cid))
         if errors:
             sys.stderr.write(
-                f"Worker.unregister(cid={cid}): {len(errors)} of {n} chips reported errors "
+                f"Worker.unregister(cid={cid}): {len(errors)} chips reported errors "
                 f"(continuing best-effort). First error: {errors[0]}\n"
             )
             sys.stderr.flush()
@@ -1232,7 +1152,7 @@ class Worker:
             for cid, target in self._callable_registry.items():
                 if isinstance(target, ChipCallable):
                     for worker_id in range(len(self._chip_shms)):
-                        self._chip_control(worker_id, _CTRL_PREPARE, arg0=cid)
+                        dw.control_prepare(worker_id, int(cid))
 
     # ------------------------------------------------------------------
     # Bootstrap plumbing
@@ -1364,95 +1284,32 @@ class Worker:
         return list(self._chip_contexts)
 
     # ------------------------------------------------------------------
-    # memory management
+    # memory management — forward to C++ Orchestrator, which holds
+    # per-WorkerThread mailbox_mu_ so these are safe to call concurrently
+    # with in-flight dispatch on the same chip mailbox.
     # ------------------------------------------------------------------
 
-    def _chip_control(self, worker_id: int, sub_cmd: int, arg0: int = 0, arg1: int = 0, arg2: int = 0) -> int:
-        """Send a control command to chip child *worker_id* via mailbox IPC."""
+    def _check_chip_worker_id(self, worker_id: int) -> None:
+        """Range-check ``worker_id`` against the L3-level chip mailbox set.
+
+        Memory ops are only meaningful at L3 (one chip worker per id).
+        At L4+ ``_chip_shms`` is empty and ``next_level_threads_`` holds
+        L3 worker children that don't service CTRL_MALLOC / FREE / COPY_*
+        — without this guard, ``_Orchestrator.malloc(0)`` would dispatch
+        to an L3 child mailbox, get a silent CONTROL_DONE from its
+        loop's default branch, and return a garbage pointer.
+        """
         if worker_id < 0 or worker_id >= len(self._chip_shms):
             raise IndexError(f"worker_id {worker_id} out of range (have {len(self._chip_shms)} chips)")
-        shm = self._chip_shms[worker_id]
-        buf = shm.buf
-        assert buf is not None
-        state_addr = _buffer_field_addr(buf, _OFF_STATE)
-        _write_error(buf, 0, "")
-        struct.pack_into("Q", buf, _OFF_CALLABLE, sub_cmd)
-        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, arg0)
-        struct.pack_into("Q", buf, _CTRL_OFF_ARG1, arg1)
-        struct.pack_into("Q", buf, _CTRL_OFF_ARG2, arg2)
-        _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
-        while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
-            pass
-        error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
-        if error != 0:
-            err_msg = _read_error_msg(buf)
-            _mailbox_store_i32(state_addr, _IDLE)
-            raise RuntimeError(f"chip control command {sub_cmd} failed on worker {worker_id}: {err_msg}")
-        result = struct.unpack_from("Q", buf, _CTRL_OFF_RESULT)[0]
-        _mailbox_store_i32(state_addr, _IDLE)
-        return result
-
-    def _mailbox_control_register(self, mailbox: SharedMemory, label: str, cid: int, shm_name: str) -> None:
-        """Send _CTRL_REGISTER (cid + shm name) to a chip OR next-level mailbox.
-
-        ``label`` is folded into the RuntimeError message so the caller can
-        tell apart a failed chip child from a failed L4 child without
-        reaching for worker_id arithmetic.
-        """
-        buf = mailbox.buf
-        assert buf is not None
-        state_addr = _buffer_field_addr(buf, _OFF_STATE)
-        _write_error(buf, 0, "")
-        struct.pack_into("Q", buf, _OFF_CALLABLE, _CTRL_REGISTER)
-        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, cid)
-        encoded = shm_name.encode("utf-8")
-        assert len(encoded) + 1 <= _CTRL_SHM_NAME_BYTES, f"shm name too long: {shm_name!r}"
-        buf[_OFF_ARGS : _OFF_ARGS + len(encoded)] = encoded
-        # Zero-pad the rest of the name field so a stale name from a
-        # previous control op never leaks into this register.
-        buf[_OFF_ARGS + len(encoded) : _OFF_ARGS + _CTRL_SHM_NAME_BYTES] = b"\x00" * (
-            _CTRL_SHM_NAME_BYTES - len(encoded)
-        )
-        _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
-        while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
-            pass
-        error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
-        if error != 0:
-            err_msg = _read_error_msg(buf)
-            _mailbox_store_i32(state_addr, _IDLE)
-            raise RuntimeError(f"{label}: {err_msg}")
-        _mailbox_store_i32(state_addr, _IDLE)
-
-    def _mailbox_control_unregister(self, mailbox: SharedMemory, label: str, cid: int) -> None:
-        """Send _CTRL_UNREGISTER (cid only) to a chip OR next-level mailbox.
-
-        Mirror of ``_mailbox_control_register`` minus the shm name payload —
-        unregister has no bytes to transport. Raises ``RuntimeError`` on
-        non-zero child error code; callers may catch and ``warn`` rather
-        than abort because docs section 8 marks unregister as best-effort.
-        """
-        buf = mailbox.buf
-        assert buf is not None
-        state_addr = _buffer_field_addr(buf, _OFF_STATE)
-        _write_error(buf, 0, "")
-        struct.pack_into("Q", buf, _OFF_CALLABLE, _CTRL_UNREGISTER)
-        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, cid)
-        _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
-        while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
-            pass
-        error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
-        if error != 0:
-            err_msg = _read_error_msg(buf)
-            _mailbox_store_i32(state_addr, _IDLE)
-            raise RuntimeError(f"{label}: {err_msg}")
-        _mailbox_store_i32(state_addr, _IDLE)
 
     def malloc(self, size: int, worker_id: int = 0) -> int:
-        """Allocate memory on next-level worker *worker_id*. Returns a pointer."""
+        """Allocate memory on next-level chip worker *worker_id*. Returns a pointer."""
         if self.level == 2:
             assert self._chip_worker is not None
             return self._chip_worker.malloc(size)
-        return self._chip_control(worker_id, _CTRL_MALLOC, arg0=size)
+        self._check_chip_worker_id(worker_id)
+        assert self._orch is not None
+        return self._orch._impl.malloc(worker_id, size)
 
     def free(self, ptr: int, worker_id: int = 0) -> None:
         """Free memory allocated by ``malloc()``."""
@@ -1460,23 +1317,29 @@ class Worker:
             assert self._chip_worker is not None
             self._chip_worker.free(ptr)
             return
-        self._chip_control(worker_id, _CTRL_FREE, arg0=ptr)
+        self._check_chip_worker_id(worker_id)
+        assert self._orch is not None
+        self._orch._impl.free(worker_id, ptr)
 
     def copy_to(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
-        """Copy *size* bytes from host *src* to worker *dst*."""
+        """Copy *size* bytes from host *src* to chip worker *dst*."""
         if self.level == 2:
             assert self._chip_worker is not None
             self._chip_worker.copy_to(dst, src, size)
             return
-        self._chip_control(worker_id, _CTRL_COPY_TO, arg0=dst, arg1=src, arg2=size)
+        self._check_chip_worker_id(worker_id)
+        assert self._orch is not None
+        self._orch._impl.copy_to(worker_id, dst, src, size)
 
     def copy_from(self, dst: int, src: int, size: int, worker_id: int = 0) -> None:
-        """Copy *size* bytes from worker *src* to host *dst*."""
+        """Copy *size* bytes from chip worker *src* to host *dst*."""
         if self.level == 2:
             assert self._chip_worker is not None
             self._chip_worker.copy_from(dst, src, size)
             return
-        self._chip_control(worker_id, _CTRL_COPY_FROM, arg0=dst, arg1=src, arg2=size)
+        self._check_chip_worker_id(worker_id)
+        assert self._orch is not None
+        self._orch._impl.copy_from(worker_id, dst, src, size)
 
     # ------------------------------------------------------------------
     # run — uniform entry point
@@ -1497,43 +1360,31 @@ class Worker:
         assert self._initialized, "Worker not initialized; call init() first"
         cfg = config if config is not None else CallConfig()
 
-        # Bump the in-flight counter so a concurrent Worker.register() can
-        # refuse and surface a clear error instead of writing CTRL_REQUEST
-        # over a TASK_READY mailbox that the C++ scheduler is mid-dispatch
-        # on. The counter is only meaningful at L3+, but keeping it
-        # unconditional keeps the lock discipline simple.
-        with self._register_lock:
-            self._orch_in_flight += 1
-        try:
-            if self.level == 2:
-                assert self._chip_worker is not None
-                self._chip_worker.run_prepared(int(callable), args, cfg)
-            else:
-                self._start_hierarchical()
-                assert self._orch is not None
-                assert self._worker is not None
-                # Drop any error stashed by a previous run() so this call
-                # starts clean. drain() rethrows on the way out; every
-                # successful run() leaves the error slot empty, but an
-                # unrelated caller may have poked it.
-                self._orch._clear_error()
-                self._orch._scope_begin()
-                try:
-                    callable(self._orch, args, cfg)
-                finally:
-                    # Always release scope refs and drain so ring slots
-                    # aren't stranded when the orch fn raises mid-DAG.
-                    # drain() also rethrows the first dispatch failure
-                    # for this run — that is how child-task exceptions
-                    # surface to the caller of Worker.run().  scope_end
-                    # deliberately does NOT throw: if it did, released
-                    # refs would be incomplete and drain would hang on
-                    # in-flight tasks.
-                    self._orch._scope_end()
-                    self._orch._drain()
-        finally:
-            with self._register_lock:
-                self._orch_in_flight -= 1
+        if self.level == 2:
+            assert self._chip_worker is not None
+            self._chip_worker.run_prepared(int(callable), args, cfg)
+        else:
+            self._start_hierarchical()
+            assert self._orch is not None
+            assert self._worker is not None
+            # Drop any error stashed by a previous run() so this call starts
+            # clean. drain() rethrows on the way out; every successful run()
+            # leaves the error slot empty, but an unrelated caller may have
+            # poked it.
+            self._orch._clear_error()
+            self._orch._scope_begin()
+            try:
+                callable(self._orch, args, cfg)
+            finally:
+                # Always release scope refs and drain so ring slots aren't
+                # stranded when the orch fn raises mid-DAG. drain() also
+                # rethrows the first dispatch failure for this run — that
+                # is how child-task exceptions surface to the caller of
+                # Worker.run(). scope_end deliberately does NOT throw: if
+                # it did, released refs would be incomplete and drain
+                # would hang on in-flight tasks.
+                self._orch._scope_end()
+                self._orch._drain()
 
     def prepare_callable(self, callable_id: int, callable) -> None:
         """L2 only: pre-stage a callable under ``callable_id`` (see

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -55,12 +55,15 @@ Usage::
 """
 
 import ctypes
+import itertools
 import os
 import signal
 import struct
 import sys
+import threading
 import time
 import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Optional
 
@@ -143,6 +146,17 @@ _CTRL_COPY_FROM = 3
 # not pay the H2D upload cost.  Sent from the parent right after init()
 # (or whenever a new ChipCallable cid is registered).
 _CTRL_PREPARE = 4
+# Dynamic post-init register of a ChipCallable. Parent stages the bytes
+# in a per-register POSIX shm and writes (cid, shm_name) into the mailbox;
+# the child mmaps the shm and calls prepare_callable_from_blob(cid, addr).
+# See docs/callable-ipc-dynamic-register.md for the design.
+_CTRL_REGISTER = 5
+
+# Reserved 32-byte region at the start of OFF_ARGS used by _CTRL_REGISTER to
+# carry the NUL-terminated POSIX shm name. POSIX shm names on Linux are
+# bounded well below this, but the on-wire field is fixed-width to keep
+# the layout simple.
+_CTRL_SHM_NAME_BYTES = 32
 
 # Control args layout (reuses task mailbox fields when state == _CONTROL_*):
 #   offset  8 (_OFF_CALLABLE):  uint64  sub-command
@@ -201,6 +215,22 @@ def _read_error_msg(buf) -> str:
 
 def _format_exc(prefix: str, exc: BaseException) -> str:
     return f"{prefix}: {type(exc).__name__}: {exc}"
+
+
+# Process-wide monotonic counter for _CTRL_REGISTER shm names. itertools.count()
+# is atomic under the GIL (single C ++ on tp_next), so no extra locking is
+# needed at the call site.
+_shm_name_counter = itertools.count()
+
+
+def _make_callable_shm_name(pid: int, cid: int) -> str:
+    """Build a unique POSIX shm name for one dynamic-register broadcast.
+
+    The pid prefix prevents collisions across simpler instances on the same
+    host; the monotonic counter disambiguates registers within one process.
+    Asserted to fit in ``_CTRL_SHM_NAME_BYTES`` including NUL at the caller.
+    """
+    return f"simpler-cb-{pid}-{cid}-{next(_shm_name_counter)}"
 
 
 def _read_args_from_mailbox(buf) -> TaskArgs:
@@ -274,7 +304,7 @@ def _ensure_prepared(cw, registry, prepared, cid: int, *, lazy: bool, device_id:
     prepared.add(cid)
 
 
-def _run_chip_main_loop(
+def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands + SHUTDOWN form the unified state machine; cannot collapse without obscuring dispatch
     cw: ChipWorker,
     buf: memoryview,
     mailbox_addr: int,
@@ -359,9 +389,37 @@ def _run_chip_main_loop(
                 elif sub_cmd == _CTRL_PREPARE:
                     cid = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
                     _ensure_prepared(cw, registry, prepared, cid, lazy=False, device_id=device_id)
+                elif sub_cmd == _CTRL_REGISTER:
+                    cid = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
+                    if cid >= MAX_REGISTERED_CALLABLE_IDS:
+                        raise RuntimeError(f"register cid={cid} chip={device_id}: cid out of range")
+                    raw = bytes(buf[_OFF_ARGS : _OFF_ARGS + _CTRL_SHM_NAME_BYTES])
+                    nul = raw.find(b"\x00")
+                    shm_name = raw[: nul if nul >= 0 else _CTRL_SHM_NAME_BYTES].decode("utf-8", "replace")
+                    shm = SharedMemory(name=shm_name)
+                    try:
+                        shm_buf = shm.buf
+                        assert shm_buf is not None
+                        addr = ctypes.addressof(ctypes.c_char.from_buffer(shm_buf))
+                        cw._impl.prepare_callable_from_blob(int(cid), addr)
+                    finally:
+                        # Release the local mmap as soon as prepare returns;
+                        # prepare_callable has already H2D-copied the bytes to
+                        # device GM, so the child no longer needs the shm.
+                        shm.close()
+                    prepared.add(int(cid))
             except Exception as e:  # noqa: BLE001
                 code = 1
-                msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
+                if sub_cmd == _CTRL_REGISTER:
+                    # Docs §6 mandates `register cid=<N> chip=<id>: <reason>`
+                    # so the parent can pinpoint failures across many chips.
+                    try:
+                        cid_v = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
+                    except Exception:  # noqa: BLE001
+                        cid_v = -1
+                    msg = _format_exc(f"register cid={cid_v} chip={device_id}", e)
+                else:
+                    msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
             _write_error(buf, code, msg)
             _mailbox_store_i32(state_addr, _CONTROL_DONE)
         elif state == _SHUTDOWN:
@@ -588,6 +646,13 @@ class Worker:
         self._callable_registry: dict[int, Any] = {}
         self._initialized = False
 
+        # Serializes Worker.register against itself and against Worker.run.
+        # `_orch_in_flight` is bumped inside Worker.run under this lock so
+        # dynamic register can refuse mid-run calls (see docs §5: the
+        # scheduler is provably idle outside Worker.run).
+        self._register_lock = threading.Lock()
+        self._orch_in_flight = 0
+
         # Level-2 internals
         self._chip_worker: Optional[ChipWorker] = None
 
@@ -635,40 +700,135 @@ class Worker:
         ``orch.submit_sub(cid, …)``.
 
         Timing constraints:
-          - L3+: must be called **before** ``init()`` so the COW-inherited
-            registry is visible to forked chip / sub children.  ChipCallables
-            are pre-warmed by pushing ``_CTRL_PREPARE`` to every chip child
-            during ``init()``.
+          - L3+: Python callables (sub fn / orch fn) must be registered
+            **before** ``init()`` so the COW-inherited registry is visible to
+            forked chip / sub children. ChipCallables may be registered either
+            before init (pre-warmed via ``_CTRL_PREPARE`` during ``init()``)
+            or after init (broadcast to chip children via ``_CTRL_REGISTER``;
+            see docs/callable-ipc-dynamic-register.md). Post-init register at
+            L3+ is ChipCallable-only and must run in a quiescent state
+            (no concurrent ``Worker.run``).
           - L2: may be called either before or after ``init()`` (no fork,
             no COW constraint).  When called post-init, ChipCallables are
             prepared on the device immediately; pre-init registrations are
             batched and prepared at the end of ``init()``.
+          - L4+: post-init ChipCallable register is not yet implemented
+            (deferred to the L4 cascade commit).
         """
-        if self.level >= 3 and self._initialized:
-            raise RuntimeError(
-                "Worker.register() at level >= 3 must be called before init() "
-                "(forked children inherit the registry via COW)"
-            )
-        if len(self._callable_registry) >= MAX_REGISTERED_CALLABLE_IDS:
-            # The AICPU side keeps a fixed-size orch_so_table_ keyed by cid;
-            # raise here so the failure surfaces at register-time with a
-            # protocol-aware message, not later from
-            # DeviceRunner::register_prepared_callable with a generic
-            # "out of range" log.
-            raise RuntimeError(
-                "Worker.register: cid space exhausted "
-                f"(MAX_REGISTERED_CALLABLE_IDS={MAX_REGISTERED_CALLABLE_IDS}); "
-                "unregister unused callables before registering more"
-            )
-        cid = len(self._callable_registry)
-        self._callable_registry[cid] = target
+        with self._register_lock:
+            if self.level >= 3 and self._initialized:
+                # L3+ post-init: only ChipCallable is supported (Python
+                # callables cannot cross the process boundary).
+                if not isinstance(target, ChipCallable):
+                    raise NotImplementedError(
+                        "Worker.register() at level >= 3 must be called before init() "
+                        "for non-ChipCallable targets; only ChipCallable is supported "
+                        "post-init (see docs/callable-ipc-dynamic-register.md)"
+                    )
+                if self.level >= 4:
+                    raise NotImplementedError(
+                        "Post-init Worker.register(ChipCallable) at level >= 4 is not "
+                        "yet implemented (L4 cascade is a separate commit)"
+                    )
+                if self._orch_in_flight > 0:
+                    raise RuntimeError(
+                        "Worker.register() cannot be called while Worker.run() is "
+                        "executing; serialize register/run on the same thread"
+                    )
+            if len(self._callable_registry) >= MAX_REGISTERED_CALLABLE_IDS:
+                # The AICPU side keeps a fixed-size orch_so_table_ keyed by cid;
+                # raise here so the failure surfaces at register-time with a
+                # protocol-aware message, not later from
+                # DeviceRunner::register_prepared_callable with a generic
+                # "out of range" log.
+                raise RuntimeError(
+                    "Worker.register: cid space exhausted "
+                    f"(MAX_REGISTERED_CALLABLE_IDS={MAX_REGISTERED_CALLABLE_IDS}); "
+                    "unregister unused callables before registering more"
+                )
+            cid = len(self._callable_registry)
+            self._callable_registry[cid] = target
 
-        # L2 post-init: pre-warm immediately so the very first
-        # `Worker.run(cid, …)` is a clean cache hit.
-        if self.level == 2 and self._initialized and isinstance(target, ChipCallable):
-            assert self._chip_worker is not None
-            self._chip_worker.prepare_callable(cid, target)
-        return cid
+            # L3 post-init ChipCallable: broadcast to chip children via shm.
+            # On failure we pop the registry entry so a retry gets a fresh cid.
+            if self.level == 3 and self._initialized and isinstance(target, ChipCallable):
+                try:
+                    self._post_init_register(cid, target)
+                except Exception:
+                    self._callable_registry.pop(cid, None)
+                    raise
+                return cid
+
+            # L2 post-init: pre-warm immediately so the very first
+            # `Worker.run(cid, …)` is a clean cache hit.
+            if self.level == 2 and self._initialized and isinstance(target, ChipCallable):
+                assert self._chip_worker is not None
+                self._chip_worker.prepare_callable(cid, target)
+            return cid
+
+    def _post_init_register(self, cid: int, target: ChipCallable) -> None:
+        """Broadcast a new ChipCallable to every chip child via _CTRL_REGISTER.
+
+        Stages the ChipCallable bytes into a per-register POSIX shm, then
+        broadcasts the (cid, shm_name) tuple to every chip child in parallel
+        via ``concurrent.futures.ThreadPoolExecutor``. Each child mmaps the
+        shm and calls ``_ChipWorker.prepare_callable_from_blob`` (eager
+        prepare per docs §4). Parent unlinks the shm after all ACKs.
+
+        On any child failure, the parent raises ``RuntimeError`` without
+        rolling back already-ACKed children — the resulting partial state
+        is inert garbage that is overwritten on cid reuse (docs §5).
+        """
+        # Chip children are forked lazily on the first Worker.run() via
+        # _start_hierarchical; before that point the chip mailboxes have
+        # no reader and a CTRL_REGISTER broadcast would deadlock. In that
+        # pre-fork window, just leave the cid in the parent's registry —
+        # _start_hierarchical's prewarm loop will _CTRL_PREPARE it for
+        # every chip child once they come up (the entry is CoW-inherited).
+        if not getattr(self, "_hierarchical_started", False):
+            return
+        blob_ptr = target.buffer_ptr()
+        blob_size = target.buffer_size()
+        shm_name = _make_callable_shm_name(os.getpid(), cid)
+        # +1 for the NUL terminator the child slice-decodes against.
+        assert len(shm_name.encode("utf-8")) + 1 <= _CTRL_SHM_NAME_BYTES, (
+            f"shm name too long for mailbox field: {shm_name!r}"
+        )
+        shm = SharedMemory(create=True, size=blob_size, name=shm_name)
+        try:
+            shm_buf = shm.buf
+            assert shm_buf is not None
+            ctypes.memmove(
+                ctypes.addressof(ctypes.c_char.from_buffer(shm_buf)),
+                blob_ptr,
+                blob_size,
+            )
+            n = len(self._chip_shms)
+            if n == 0:
+                # Degenerate L3 with no chip children: nothing to broadcast.
+                return
+            errors: list[str] = []
+            with ThreadPoolExecutor(max_workers=n) as ex:
+                futures = {ex.submit(self._chip_control_register, wid, cid, shm_name): wid for wid in range(n)}
+                # Don't break on first failure — let every child's mailbox
+                # return to IDLE before we unlink the shm.
+                for fut in as_completed(futures):
+                    try:
+                        fut.result()
+                    except Exception as exc:  # noqa: BLE001
+                        errors.append(str(exc))
+            if errors:
+                raise RuntimeError(
+                    f"Worker.register(cid={cid}) failed; {len(errors)} of {n} chips "
+                    f"reported errors. First error: {errors[0]}. "
+                    f"{len(errors) - 1} additional error(s) suppressed."
+                )
+        finally:
+            shm.close()
+            try:
+                shm.unlink()
+            except FileNotFoundError:
+                pass
 
     def add_worker(self, worker: "Worker") -> None:
         """Add a lower-level Worker as a NEXT_LEVEL child. Must be called before init().
@@ -1082,6 +1242,41 @@ class Worker:
         _mailbox_store_i32(state_addr, _IDLE)
         return result
 
+    def _chip_control_register(self, worker_id: int, cid: int, shm_name: str) -> None:
+        """Send _CTRL_REGISTER (cid + shm name) to chip child *worker_id*.
+
+        Separate from ``_chip_control`` because it writes an extra payload
+        (shm name) into the OFF_ARGS region rather than a single uint64
+        result; the wire shapes are different enough that one helper would
+        muddle both contracts.
+        """
+        if worker_id < 0 or worker_id >= len(self._chip_shms):
+            raise IndexError(f"worker_id {worker_id} out of range (have {len(self._chip_shms)} chips)")
+        shm = self._chip_shms[worker_id]
+        buf = shm.buf
+        assert buf is not None
+        state_addr = _buffer_field_addr(buf, _OFF_STATE)
+        _write_error(buf, 0, "")
+        struct.pack_into("Q", buf, _OFF_CALLABLE, _CTRL_REGISTER)
+        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, cid)
+        encoded = shm_name.encode("utf-8")
+        assert len(encoded) + 1 <= _CTRL_SHM_NAME_BYTES, f"shm name too long: {shm_name!r}"
+        buf[_OFF_ARGS : _OFF_ARGS + len(encoded)] = encoded
+        # Zero-pad the rest of the name field so a stale name from a
+        # previous control op never leaks into this register.
+        buf[_OFF_ARGS + len(encoded) : _OFF_ARGS + _CTRL_SHM_NAME_BYTES] = b"\x00" * (
+            _CTRL_SHM_NAME_BYTES - len(encoded)
+        )
+        _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
+        while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
+            pass
+        error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
+        if error != 0:
+            err_msg = _read_error_msg(buf)
+            _mailbox_store_i32(state_addr, _IDLE)
+            raise RuntimeError(f"chip {worker_id}: {err_msg}")
+        _mailbox_store_i32(state_addr, _IDLE)
+
     def malloc(self, size: int, worker_id: int = 0) -> int:
         """Allocate memory on next-level worker *worker_id*. Returns a pointer."""
         if self.level == 2:
@@ -1132,31 +1327,43 @@ class Worker:
         assert self._initialized, "Worker not initialized; call init() first"
         cfg = config if config is not None else CallConfig()
 
-        if self.level == 2:
-            assert self._chip_worker is not None
-            self._chip_worker.run_prepared(int(callable), args, cfg)
-        else:
-            self._start_hierarchical()
-            assert self._orch is not None
-            assert self._worker is not None
-            # Drop any error stashed by a previous run() so this call starts
-            # clean. drain() rethrows on the way out; every successful run()
-            # leaves the error slot empty, but an unrelated caller may have
-            # poked it.
-            self._orch._clear_error()
-            self._orch._scope_begin()
-            try:
-                callable(self._orch, args, cfg)
-            finally:
-                # Always release scope refs and drain so ring slots aren't
-                # stranded when the orch fn raises mid-DAG. drain() also
-                # rethrows the first dispatch failure for this run — that
-                # is how child-task exceptions surface to the caller of
-                # Worker.run(). scope_end deliberately does NOT throw: if
-                # it did, released refs would be incomplete and drain
-                # would hang on in-flight tasks.
-                self._orch._scope_end()
-                self._orch._drain()
+        # Bump the in-flight counter so a concurrent Worker.register() can
+        # refuse and surface a clear error instead of writing CTRL_REQUEST
+        # over a TASK_READY mailbox that the C++ scheduler is mid-dispatch
+        # on. The counter is only meaningful at L3+, but keeping it
+        # unconditional keeps the lock discipline simple.
+        with self._register_lock:
+            self._orch_in_flight += 1
+        try:
+            if self.level == 2:
+                assert self._chip_worker is not None
+                self._chip_worker.run_prepared(int(callable), args, cfg)
+            else:
+                self._start_hierarchical()
+                assert self._orch is not None
+                assert self._worker is not None
+                # Drop any error stashed by a previous run() so this call
+                # starts clean. drain() rethrows on the way out; every
+                # successful run() leaves the error slot empty, but an
+                # unrelated caller may have poked it.
+                self._orch._clear_error()
+                self._orch._scope_begin()
+                try:
+                    callable(self._orch, args, cfg)
+                finally:
+                    # Always release scope refs and drain so ring slots
+                    # aren't stranded when the orch fn raises mid-DAG.
+                    # drain() also rethrows the first dispatch failure
+                    # for this run — that is how child-task exceptions
+                    # surface to the caller of Worker.run().  scope_end
+                    # deliberately does NOT throw: if it did, released
+                    # refs would be incomplete and drain would hang on
+                    # in-flight tasks.
+                    self._orch._scope_end()
+                    self._orch._drain()
+        finally:
+            with self._register_lock:
+                self._orch_in_flight -= 1
 
     def prepare_callable(self, callable_id: int, callable) -> None:
         """L2 only: pre-stage a callable under ``callable_id`` (see

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -151,6 +151,9 @@ _CTRL_PREPARE = 4
 # the child mmaps the shm and calls prepare_callable_from_blob(cid, addr).
 # See docs/callable-ipc-dynamic-register.md for the design.
 _CTRL_REGISTER = 5
+# Symmetric unregister: drop the cid from chip-child state so the AICPU
+# orch_so_table_ slot can be reused. Payload is just the cid; no shm.
+_CTRL_UNREGISTER = 6
 
 # Reserved 32-byte region at the start of OFF_ARGS used by _CTRL_REGISTER to
 # carry the NUL-terminated POSIX shm name. POSIX shm names on Linux are
@@ -408,16 +411,24 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
                         # device GM, so the child no longer needs the shm.
                         shm.close()
                     prepared.add(int(cid))
+                elif sub_cmd == _CTRL_UNREGISTER:
+                    cid = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
+                    cw.unregister_callable(int(cid))
+                    # Drop from the prepared set so a future CTRL_REGISTER /
+                    # CTRL_PREPARE for the same cid is treated as a fresh
+                    # registration (re-runs the H2D upload / AICPU dlopen).
+                    prepared.discard(int(cid))
             except Exception as e:  # noqa: BLE001
                 code = 1
-                if sub_cmd == _CTRL_REGISTER:
+                if sub_cmd in (_CTRL_REGISTER, _CTRL_UNREGISTER):
                     # Docs §6 mandates `register cid=<N> chip=<id>: <reason>`
                     # so the parent can pinpoint failures across many chips.
+                    op = "register" if sub_cmd == _CTRL_REGISTER else "unregister"
                     try:
                         cid_v = int(struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]) & 0xFFFFFFFF
                     except Exception:  # noqa: BLE001
                         cid_v = -1
-                    msg = _format_exc(f"register cid={cid_v} chip={device_id}", e)
+                    msg = _format_exc(f"{op} cid={cid_v} chip={device_id}", e)
                 else:
                     msg = _format_exc(f"chip_process dev={device_id} ctrl={int(sub_cmd)}", e)
             _write_error(buf, code, msg)
@@ -829,6 +840,78 @@ class Worker:
                 shm.unlink()
             except FileNotFoundError:
                 pass
+
+    def unregister(self, cid: int) -> None:
+        """Drop *cid* from the registry and propagate to chip children.
+
+        Symmetric to ``Worker.register`` for the dynamic post-init path.
+        The cid slot becomes reusable for the next ``register`` call — the
+        only practical way to keep a long-running worker under the
+        ``MAX_REGISTERED_CALLABLE_IDS`` ceiling when JIT or plugin code
+        churns through callables.
+
+        Timing constraints mirror ``register``:
+          - L3+: must be called when no ``Worker.run`` is in flight
+            (quiescent-state contract; see docs section 5). Violation
+            raises ``RuntimeError`` before any broadcast is issued.
+          - L2: directly forwards to ``ChipWorker.unregister_callable``.
+
+        Failure semantics (docs section 8): unregister is best-effort.
+        If any chip child reports an error, the parent **warns and still
+        pops the registry entry** — orch_so_table_ on the AICPU side will
+        be overwritten on cid reuse, and refusing to release a known-bad
+        cid would just exhaust the slot space faster.
+
+        Raises:
+          KeyError: cid was never registered.
+          NotImplementedError: called at L4+ (cascade unregister deferred).
+          RuntimeError: called while ``Worker.run`` is executing.
+        """
+        with self._register_lock:
+            if cid not in self._callable_registry:
+                raise KeyError(f"Worker.unregister: cid={cid} not registered")
+            if self.level >= 3 and self._initialized:
+                if self.level >= 4:
+                    raise NotImplementedError(
+                        "Worker.unregister at level >= 4 is not yet implemented (L4 cascade is a separate commit)"
+                    )
+                if self._orch_in_flight > 0:
+                    raise RuntimeError(
+                        "Worker.unregister() cannot be called while Worker.run() is "
+                        "executing; serialize unregister/run on the same thread"
+                    )
+                if getattr(self, "_hierarchical_started", False):
+                    self._broadcast_unregister(cid)
+            elif self.level == 2 and self._initialized:
+                assert self._chip_worker is not None
+                self._chip_worker.unregister_callable(cid)
+            # Drop the registry entry unconditionally — even if a chip child
+            # reported an error, holding the slot would just waste cid budget.
+            self._callable_registry.pop(cid, None)
+
+    def _broadcast_unregister(self, cid: int) -> None:
+        """Broadcast _CTRL_UNREGISTER to every chip child in parallel.
+
+        Best-effort: chips that fail are logged to stderr; the parent still
+        proceeds to pop the registry entry (see ``unregister`` docstring).
+        """
+        n = len(self._chip_shms)
+        if n == 0:
+            return
+        errors: list[str] = []
+        with ThreadPoolExecutor(max_workers=n) as ex:
+            futures = {ex.submit(self._chip_control_unregister, wid, cid): wid for wid in range(n)}
+            for fut in as_completed(futures):
+                try:
+                    fut.result()
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(str(exc))
+        if errors:
+            sys.stderr.write(
+                f"Worker.unregister(cid={cid}): {len(errors)} of {n} chips reported errors "
+                f"(continuing best-effort). First error: {errors[0]}\n"
+            )
+            sys.stderr.flush()
 
     def add_worker(self, worker: "Worker") -> None:
         """Add a lower-level Worker as a NEXT_LEVEL child. Must be called before init().
@@ -1267,6 +1350,33 @@ class Worker:
         buf[_OFF_ARGS + len(encoded) : _OFF_ARGS + _CTRL_SHM_NAME_BYTES] = b"\x00" * (
             _CTRL_SHM_NAME_BYTES - len(encoded)
         )
+        _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
+        while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
+            pass
+        error = struct.unpack_from("i", buf, _OFF_ERROR)[0]
+        if error != 0:
+            err_msg = _read_error_msg(buf)
+            _mailbox_store_i32(state_addr, _IDLE)
+            raise RuntimeError(f"chip {worker_id}: {err_msg}")
+        _mailbox_store_i32(state_addr, _IDLE)
+
+    def _chip_control_unregister(self, worker_id: int, cid: int) -> None:
+        """Send _CTRL_UNREGISTER (cid only) to chip child *worker_id*.
+
+        Mirror of ``_chip_control_register`` minus the shm name payload —
+        unregister has no bytes to transport. Raises ``RuntimeError`` on
+        non-zero child error code; callers may catch and ``warn`` rather
+        than abort because docs section 8 marks unregister as best-effort.
+        """
+        if worker_id < 0 or worker_id >= len(self._chip_shms):
+            raise IndexError(f"worker_id {worker_id} out of range (have {len(self._chip_shms)} chips)")
+        shm = self._chip_shms[worker_id]
+        buf = shm.buf
+        assert buf is not None
+        state_addr = _buffer_field_addr(buf, _OFF_STATE)
+        _write_error(buf, 0, "")
+        struct.pack_into("Q", buf, _OFF_CALLABLE, _CTRL_UNREGISTER)
+        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, cid)
         _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
         while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
             pass

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -40,6 +40,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "ring.h"
 #include "orchestrator.h"
@@ -82,6 +84,20 @@ public:
     // Accessor: the Orchestrator handle used by the user's orch fn. Valid
     // only between init() and close().
     Orchestrator &get_orchestrator() { return orchestrator_; }
+
+    // Forward CTRL_PREPARE to a specific NEXT_LEVEL worker (prewarm path
+    // used by the Python facade at end of _start_hierarchical).
+    void control_prepare(int worker_id, int32_t cid) { manager_.control_prepare(worker_id, cid); }
+
+    // Broadcast CTRL_REGISTER / CTRL_UNREGISTER for a ChipCallable cid to
+    // every NEXT_LEVEL child in parallel. `blob_ptr`/`blob_size` describe
+    // the contiguous ChipCallable bytes (see PyChipCallable::buffer_ptr /
+    // buffer_size). Throws on any child error for register; unregister is
+    // best-effort and returns the per-child error list.
+    void broadcast_register_all(int32_t cid, uint64_t blob_ptr, uint64_t blob_size) {
+        manager_.broadcast_register_all(cid, reinterpret_cast<const void *>(blob_ptr), static_cast<size_t>(blob_size));
+    }
+    std::vector<std::string> broadcast_unregister_all(int32_t cid) { return manager_.broadcast_unregister_all(cid); }
 
 private:
     int32_t level_;

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -11,9 +11,19 @@
 
 #include "worker_manager.h"
 
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cstdio>
 #include <cstring>
 #include <stdexcept>
 #include <string>
+#include <thread>
+#include <vector>
 
 #include "ring.h"
 
@@ -351,6 +361,38 @@ uint64_t WorkerThread::control_malloc(size_t size) {
     return read_control_result(mbox());
 }
 
+void WorkerThread::control_prepare(int32_t cid) {
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    write_control_args(mbox(), CTRL_PREPARE, static_cast<uint64_t>(static_cast<uint32_t>(cid)));
+    run_control_command("control_prepare");
+}
+
+void WorkerThread::control_register(int32_t cid, const char *shm_name) {
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    int32_t zero_err = 0;
+    std::memcpy(mbox() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
+    std::memset(mbox() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+    uint64_t sub_cmd = CTRL_REGISTER;
+    std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &sub_cmd, sizeof(uint64_t));
+    uint64_t cid_v = static_cast<uint32_t>(cid);
+    std::memcpy(mbox() + CTRL_OFF_ARG0, &cid_v, sizeof(uint64_t));
+    // Stage the NUL-terminated shm name in the args region. Pad with zeros so
+    // stale bytes from a prior control op cannot leak into the child's decode.
+    size_t name_len = std::strlen(shm_name);
+    if (name_len + 1 > CTRL_SHM_NAME_BYTES) {
+        throw std::runtime_error(std::string("control_register: shm name too long: ") + shm_name);
+    }
+    std::memcpy(mbox() + MAILBOX_OFF_ARGS, shm_name, name_len);
+    std::memset(mbox() + MAILBOX_OFF_ARGS + name_len, 0, CTRL_SHM_NAME_BYTES - name_len);
+    run_control_command("control_register");
+}
+
+void WorkerThread::control_unregister(int32_t cid) {
+    std::lock_guard<std::mutex> lk(mailbox_mu_);
+    write_control_args(mbox(), CTRL_UNREGISTER, static_cast<uint64_t>(static_cast<uint32_t>(cid)));
+    run_control_command("control_unregister");
+}
+
 void WorkerThread::control_free(uint64_t ptr) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_FREE, ptr);
@@ -375,4 +417,174 @@ bool WorkerManager::any_busy() const {
     for (auto &wt : sub_threads_)
         if (!wt->idle()) return true;
     return false;
+}
+
+// =============================================================================
+// Dynamic register/unregister broadcast (POSIX shm staging + parallel fan-out)
+// =============================================================================
+
+namespace {
+
+// Process-wide monotonic counter so concurrent broadcasts to the same cid
+// don't collide on shm name. Atomic increment is enough — no need to lock.
+std::atomic<uint64_t> g_shm_counter{0};
+
+// Build the per-broadcast POSIX shm name. The name itself does NOT carry the
+// leading '/' that shm_open requires (Python's multiprocessing.SharedMemory
+// uses the same convention, so the child Python side reads the field as a
+// plain name). Caller adds '/' when opening.
+std::string make_shm_name(int32_t cid) {
+    char buf[CTRL_SHM_NAME_BYTES];
+    int pid = static_cast<int>(getpid());
+    uint64_t counter = g_shm_counter.fetch_add(1, std::memory_order_relaxed);
+    int n = std::snprintf(
+        buf, sizeof(buf), "simpler-cb-%d-%d-%llu", pid, static_cast<int>(cid), static_cast<unsigned long long>(counter)
+    );
+    if (n < 0 || static_cast<size_t>(n) >= sizeof(buf)) {
+        throw std::runtime_error("broadcast_register: shm name overflow");
+    }
+    return std::string(buf);
+}
+
+// Strip the outer "<op_name> failed on child: " prefix that
+// run_control_command prepends to every control failure, so the broadcast
+// caller can surface the child-side message (`register cid=<N>
+// chip=<id>: <reason>` per docs §6) directly under its own one-line
+// Worker.{register,unregister}(cid=N) prefix.
+std::string strip_control_prefix(const std::string &msg, const std::string &op_name) {
+    const std::string needle = op_name + " failed on child: ";
+    if (msg.compare(0, needle.size(), needle) == 0) {
+        return msg.substr(needle.size());
+    }
+    return msg;
+}
+
+// RAII guard for a POSIX shm segment: create on construction, unlink on
+// destruction. mmaps the region so the staged blob can be memcpy'd in
+// place; the mmap is released in the destructor as well. The shm is only
+// unlinked once — children open by name *before* this guard is destroyed.
+class PosixShmHolder {
+public:
+    PosixShmHolder(const std::string &name, size_t size) :
+        name_(name),
+        size_(size) {
+        std::string full_name = "/" + name_;
+        fd_ = shm_open(full_name.c_str(), O_CREAT | O_RDWR | O_EXCL, 0600);
+        if (fd_ < 0) {
+            throw std::runtime_error(
+                std::string("broadcast_register: shm_open(") + full_name + ") failed: " + std::strerror(errno)
+            );
+        }
+        if (ftruncate(fd_, static_cast<off_t>(size)) != 0) {
+            int err = errno;
+            ::close(fd_);
+            shm_unlink(full_name.c_str());
+            throw std::runtime_error(std::string("broadcast_register: ftruncate failed: ") + std::strerror(err));
+        }
+        addr_ = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+        if (addr_ == MAP_FAILED) {
+            int err = errno;
+            ::close(fd_);
+            shm_unlink(full_name.c_str());
+            addr_ = nullptr;
+            throw std::runtime_error(std::string("broadcast_register: mmap failed: ") + std::strerror(err));
+        }
+    }
+    ~PosixShmHolder() {
+        if (addr_ != nullptr) munmap(addr_, size_);
+        if (fd_ >= 0) ::close(fd_);
+        std::string full_name = "/" + name_;
+        shm_unlink(full_name.c_str());
+    }
+    PosixShmHolder(const PosixShmHolder &) = delete;
+    PosixShmHolder &operator=(const PosixShmHolder &) = delete;
+
+    void *addr() { return addr_; }
+    const std::string &name() const { return name_; }
+
+private:
+    std::string name_;
+    size_t size_{0};
+    int fd_{-1};
+    void *addr_{nullptr};
+};
+
+}  // namespace
+
+void WorkerManager::control_prepare(int worker_id, int32_t cid) {
+    auto *wt = get_worker(WorkerType::NEXT_LEVEL, worker_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_prepare: invalid worker_id " + std::to_string(worker_id));
+    }
+    wt->control_prepare(cid);
+}
+
+void WorkerManager::broadcast_register_all(int32_t cid, const void *blob_ptr, size_t blob_size) {
+    if (next_level_threads_.empty()) return;
+
+    std::string shm_name = make_shm_name(cid);
+    PosixShmHolder shm(shm_name, blob_size);
+    std::memcpy(shm.addr(), blob_ptr, blob_size);
+
+    // Fan out to every WorkerThread in parallel. Per-WorkerThread mailbox_mu_
+    // is independent, so N control_register calls run concurrently — latency
+    // is 1 × prepare_cost instead of N × prepare_cost.
+    std::vector<std::exception_ptr> errors(next_level_threads_.size(), nullptr);
+    std::vector<std::thread> workers;
+    workers.reserve(next_level_threads_.size());
+    for (size_t i = 0; i < next_level_threads_.size(); ++i) {
+        workers.emplace_back([this, i, cid, name = shm.name(), &errors]() {
+            try {
+                next_level_threads_[i]->control_register(cid, name.c_str());
+            } catch (...) {
+                errors[i] = std::current_exception();
+            }
+        });
+    }
+    for (auto &t : workers)
+        t.join();
+
+    // shm is unlinked when `shm` goes out of scope. Children opened it by
+    // name during control_register and have already closed their mappings
+    // before publishing CONTROL_DONE — see python/simpler/worker.py.
+
+    for (size_t i = 0; i < errors.size(); ++i) {
+        if (errors[i]) {
+            try {
+                std::rethrow_exception(errors[i]);
+            } catch (const std::exception &e) {
+                std::string msg = strip_control_prefix(e.what(), "control_register");
+                throw std::runtime_error(
+                    std::string("Worker.register(cid=") + std::to_string(cid) + ") failed on next_level " +
+                    std::to_string(i) + ": " + msg
+                );
+            }
+        }
+    }
+}
+
+std::vector<std::string> WorkerManager::broadcast_unregister_all(int32_t cid) {
+    std::vector<std::string> errors;
+    if (next_level_threads_.empty()) return errors;
+
+    std::vector<std::string> per_worker(next_level_threads_.size());
+    std::vector<std::thread> workers;
+    workers.reserve(next_level_threads_.size());
+    for (size_t i = 0; i < next_level_threads_.size(); ++i) {
+        workers.emplace_back([this, i, cid, &per_worker]() {
+            try {
+                next_level_threads_[i]->control_unregister(cid);
+            } catch (const std::exception &e) {
+                std::string msg = strip_control_prefix(e.what(), "control_unregister");
+                per_worker[i] = std::string("next_level ") + std::to_string(i) + ": " + msg;
+            }
+        });
+    }
+    for (auto &t : workers)
+        t.join();
+
+    for (auto &msg : per_worker) {
+        if (!msg.empty()) errors.push_back(std::move(msg));
+    }
+    return errors;
 }

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -369,9 +369,8 @@ void WorkerThread::control_prepare(int32_t cid) {
 
 void WorkerThread::control_register(int32_t cid, const char *shm_name) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
-    int32_t zero_err = 0;
-    std::memcpy(mbox() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
-    std::memset(mbox() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+    // OFF_ERROR / OFF_ERROR_MSG are cleared by run_control_command — no
+    // prelude memset needed (matches the other control_* methods).
     uint64_t sub_cmd = CTRL_REGISTER;
     std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &sub_cmd, sizeof(uint64_t));
     uint64_t cid_v = static_cast<uint32_t>(cid);

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -35,6 +35,7 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <string>
 #include <thread>
 #include <vector>
 
@@ -98,9 +99,17 @@ static constexpr uint64_t CTRL_MALLOC = 0;
 static constexpr uint64_t CTRL_FREE = 1;
 static constexpr uint64_t CTRL_COPY_TO = 2;
 static constexpr uint64_t CTRL_COPY_FROM = 3;
+// Pre-warm a chip child for cid=arg0 by calling prepare_callable in the child;
+// issued at end of init() so the first run_prepared does not pay the H2D cost.
+static constexpr uint64_t CTRL_PREPARE = 4;
+// Dynamic post-init register/unregister of a ChipCallable. CTRL_REGISTER carries
+// (cid, shm_name) with bytes staged in POSIX shm by the parent;
+// CTRL_UNREGISTER carries only the cid.
+static constexpr uint64_t CTRL_REGISTER = 5;
+static constexpr uint64_t CTRL_UNREGISTER = 6;
 
 // Control args reuse the task mailbox region (mutually exclusive with task dispatch):
-//   offset 16: uint64 arg0 (size for malloc; ptr for free; dst for copy)
+//   offset 16: uint64 arg0 (size for malloc; ptr for free; dst for copy; cid for register)
 //   offset 24: uint64 arg1 (src for copy)
 //   offset 32: uint64 arg2 (nbytes for copy)
 //   offset 40: uint64 result (returned ptr from malloc)
@@ -108,6 +117,11 @@ static constexpr ptrdiff_t CTRL_OFF_ARG0 = 16;
 static constexpr ptrdiff_t CTRL_OFF_ARG1 = 24;
 static constexpr ptrdiff_t CTRL_OFF_ARG2 = 32;
 static constexpr ptrdiff_t CTRL_OFF_RESULT = 40;
+
+// CTRL_REGISTER puts the NUL-terminated POSIX shm name at MAILBOX_OFF_ARGS.
+// Fixed-width so the wire layout stays simple; well above the encoded length
+// of "simpler-cb-<pid>-<cid>-<counter>" with pid < 32-bit max.
+static constexpr size_t CTRL_SHM_NAME_BYTES = 32;
 
 // =============================================================================
 // WorkerDispatch — per-dispatch handle handed to a WorkerThread.
@@ -172,6 +186,19 @@ public:
     void control_copy_to(uint64_t dst, uint64_t src, size_t size);
     void control_copy_from(uint64_t dst, uint64_t src, size_t size);
 
+    // Pre-warm a chip child by triggering prepare_callable for `cid` in the
+    // child via CTRL_PREPARE. Issued from the parent at end of init() so the
+    // first run_prepared does not pay the H2D upload cost.
+    void control_prepare(int32_t cid);
+
+    // Dynamic post-init register/unregister of a ChipCallable for `cid`.
+    // `shm_name` is the (NUL-terminated, ≤ CTRL_SHM_NAME_BYTES-1) POSIX shm
+    // name where the ChipCallable bytes are staged. Both methods hold
+    // mailbox_mu_, so a CTRL_REGISTER concurrent with dispatch_process waits
+    // for the in-flight TASK_DONE before claiming the mailbox.
+    void control_register(int32_t cid, const char *shm_name);
+    void control_unregister(int32_t cid);
+
 private:
     Ring *ring_{nullptr};
     WorkerManager *manager_{nullptr};
@@ -229,6 +256,25 @@ public:
     WorkerThread *pick_idle_excluding(WorkerType type, const std::vector<WorkerThread *> &exclude) const;
 
     bool any_busy() const;
+
+    // Forward CTRL_PREPARE to a specific NEXT_LEVEL worker. Thin wrapper
+    // over WorkerThread::control_prepare; exposed at manager level so the
+    // Python facade can prewarm without reaching into individual WorkerThreads.
+    void control_prepare(int worker_id, int32_t cid);
+
+    // Broadcast CTRL_REGISTER for `cid` to every NEXT_LEVEL worker in
+    // parallel. Stages `blob_size` bytes from `blob_ptr` into a per-call
+    // POSIX shm under name "simpler-cb-<pid>-<cid>-<counter>", spawns one
+    // std::thread per WorkerThread, and joins. Throws on any child failure
+    // (with no reverse rollback to ACKed children — partial state is inert
+    // garbage and is overwritten on cid reuse). The shm is unlinked when
+    // every leaf has ACKed (success or failure).
+    void broadcast_register_all(int32_t cid, const void *blob_ptr, size_t blob_size);
+
+    // Best-effort: broadcast CTRL_UNREGISTER for `cid` to every NEXT_LEVEL
+    // worker in parallel. Returns a vector of per-worker error strings
+    // (empty on full success). Caller decides whether to log / surface.
+    std::vector<std::string> broadcast_unregister_all(int32_t cid);
 
     // Write SHUTDOWN to every registered mailbox.
     void shutdown_children();

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""End-to-end ST for post-init Worker.register(ChipCallable) at L3.
+
+Exercises the _CTRL_REGISTER IPC path end-to-end: parent stages a
+ChipCallable in shared memory after init(), broadcasts CTRL_REGISTER to
+every chip child, the child mmaps + prepares, and the resulting cid is
+indistinguishable from a pre-init registration when used in run().
+
+The UT suite (tests/ut/py/test_worker/test_host_worker.py) already covers
+the facade-level paths (lock guard, cid overflow, lambda rejection, run
+race detection, shm name generator). This file's job is to prove the
+bytes actually traverse shm to the chip child and prepare succeeds —
+which only a real (sim or device) chip child can confirm.
+"""
+
+import os
+
+import pytest
+import torch
+from _task_interface import MAX_REGISTERED_CALLABLE_IDS  # pyright: ignore[reportMissingImports]
+from simpler.task_interface import ArgDirection as D
+from simpler.task_interface import CallConfig, ChipCallable
+from simpler.worker import Worker
+
+from simpler_setup import TaskArgsBuilder, Tensor
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.scene_test import _build_l3_task_args
+
+_RUNTIME = "tensormap_and_ringbuffer"
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_KERNELS = os.path.join(
+    _HERE,
+    "..",
+    "..",
+    "..",
+    "..",
+    "..",
+    "examples",
+    "a2a3",
+    "tensormap_and_ringbuffer",
+    "vector_example",
+    "kernels",
+)
+_ORCH_SRC = os.path.join(_KERNELS, "orchestration", "example_orchestration.cpp")
+_AIV_ADD = os.path.join(_KERNELS, "aiv", "kernel_add.cpp")
+_AIV_ADD_SCALAR = os.path.join(_KERNELS, "aiv", "kernel_add_scalar.cpp")
+_AIV_MUL = os.path.join(_KERNELS, "aiv", "kernel_mul.cpp")
+
+_ORCH_SIG = [D.IN, D.IN, D.OUT]
+
+
+def _build_vector_callable(platform: str) -> ChipCallable:
+    """Compile the vector_example orchestration + 3 AIV kernels.
+
+    Mirrors how SceneTestCase._compile_chip_callable_from_spec assembles
+    a ChipCallable, but inline so the test can call register() on it both
+    before and after init().
+    """
+    from simpler.task_interface import CoreCallable  # noqa: PLC0415
+
+    from simpler_setup.elf_parser import extract_text_section  # noqa: PLC0415
+    from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
+
+    kc = KernelCompiler(platform=platform)
+    pto_isa_root = ensure_pto_isa_root()
+    inc_dirs = kc.get_orchestration_include_dirs(_RUNTIME)
+
+    orch_bytes = kc.compile_orchestration(runtime_name=_RUNTIME, source_path=_ORCH_SRC)
+
+    def _aiv(path: str) -> bytes:
+        raw = kc.compile_incore(path, core_type="aiv", pto_isa_root=pto_isa_root, extra_include_dirs=inc_dirs)
+        return raw if platform.endswith("sim") else extract_text_section(raw)
+
+    add = CoreCallable.build(signature=[D.IN, D.IN, D.OUT], binary=_aiv(_AIV_ADD))
+    add_scalar = CoreCallable.build(signature=[D.IN, D.OUT], binary=_aiv(_AIV_ADD_SCALAR))
+    mul = CoreCallable.build(signature=[D.IN, D.IN, D.OUT], binary=_aiv(_AIV_MUL))
+
+    return ChipCallable.build(
+        signature=_ORCH_SIG,
+        func_name="aicpu_orchestration_entry",
+        binary=orch_bytes,
+        children=[(0, add), (1, add_scalar), (2, mul)],
+    )
+
+
+def _make_args(a: float, b: float) -> TaskArgsBuilder:
+    size = 128 * 128
+    return TaskArgsBuilder(
+        Tensor("a", torch.full((size,), a, dtype=torch.float32).share_memory_()),
+        Tensor("b", torch.full((size,), b, dtype=torch.float32).share_memory_()),
+        Tensor("f", torch.zeros(size, dtype=torch.float32).share_memory_()),
+    )
+
+
+def _golden(a: float, b: float) -> float:
+    # Matches the orchestration: f = (a+b+1) * (a+b+2) + (a+b)
+    s = a + b
+    return (s + 1) * (s + 2) + s
+
+
+@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.device_count(1)
+@pytest.mark.runtime(_RUNTIME)
+def test_register_after_init_then_run(st_platform, st_device_ids):
+    """Happy path: register one cid pre-init and one cid post-init, run both.
+
+    Proves the post-init register path delivers a usable cid — the chip
+    child mmapped the shm, prepared the ChipCallable, and dispatch finds
+    it on the next submit. Both cids execute against the same kernel
+    binaries and must produce numerically identical outputs.
+    """
+    chip_callable = _build_vector_callable(st_platform)
+
+    worker = Worker(
+        level=3,
+        device_ids=[int(st_device_ids[0])],
+        num_sub_workers=0,
+        platform=st_platform,
+        runtime=_RUNTIME,
+    )
+    cid_pre = worker.register(chip_callable)
+
+    # Pre-allocate both runs' tensors BEFORE Worker.init() so the
+    # share_memory_() mappings are inherited by the forked chip child.
+    # share_memory_ regions created after fork in the parent are not visible
+    # to the chip child, so dispatch on those would segfault.
+    a, b = 2.0, 3.0
+    expected = _golden(a, b)
+    args_pre = _make_args(a, b)
+    args_post = _make_args(a, b)
+    chip_args_pre, output_names_pre = _build_l3_task_args(args_pre, _ORCH_SIG)
+    chip_args_post, output_names_post = _build_l3_task_args(args_post, _ORCH_SIG)
+    assert output_names_pre == ["f"] and output_names_post == ["f"]
+
+    worker.init()
+    try:
+        config = CallConfig()
+        config.block_dim = 3
+        config.aicpu_thread_num = 4
+
+        # 1. Run cid_pre once to force _start_hierarchical (forks chip
+        #    children, runs the CTRL_PREPARE prewarm loop). This puts the
+        #    chip child into _run_chip_main_loop, the only state in which
+        #    a CTRL_REGISTER broadcast can be ACKed.
+        def orch_pre(o, _args, _cfg):
+            o.submit_next_level(cid_pre, chip_args_pre, config)
+
+        worker.run(orch_pre)
+        got_pre = args_pre.f
+        assert torch.allclose(got_pre, torch.full_like(got_pre, expected), rtol=1e-5, atol=1e-5), (
+            f"cid_pre={cid_pre}: expected {expected}, got {got_pre[:4].tolist()}..."
+        )
+
+        # 2. Now do the post-fork dynamic register. The parent stages bytes
+        #    in shm and broadcasts CTRL_REGISTER; the child mmaps and calls
+        #    prepare_callable_from_blob. cid_post is unknown to the
+        #    CoW-inherited registry on the child side — only the IPC path
+        #    can deliver it.
+        cid_post = worker.register(chip_callable)
+        assert cid_post != cid_pre
+
+        # 3. Run with cid_post. If CTRL_REGISTER delivered correctly, the
+        #    child has the cid prepared; otherwise dispatch will fail.
+        def orch_post(o, _args, _cfg):
+            o.submit_next_level(cid_post, chip_args_post, config)
+
+        worker.run(orch_post)
+        got_post = args_post.f
+        assert torch.allclose(got_post, torch.full_like(got_post, expected), rtol=1e-5, atol=1e-5), (
+            f"cid_post={cid_post}: expected {expected}, got {got_post[:4].tolist()}..."
+        )
+    finally:
+        worker.close()
+
+
+@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.device_count(2)
+@pytest.mark.runtime(_RUNTIME)
+def test_register_after_init_parallel_broadcast(st_platform, st_device_ids):
+    """Two chip children, post-init register broadcasts to both in parallel.
+
+    Asserts that the registered cid runs successfully on each chip — proving
+    the parallel ThreadPoolExecutor broadcast delivers the bytes to every
+    chip's mailbox and each prepare_callable_from_blob runs without racing
+    against the others.
+    """
+    chip_callable = _build_vector_callable(st_platform)
+    device_ids = [int(d) for d in st_device_ids[:2]]
+    worker = Worker(
+        level=3,
+        device_ids=device_ids,
+        num_sub_workers=0,
+        platform=st_platform,
+        runtime=_RUNTIME,
+    )
+    cid_pre = worker.register(chip_callable)
+    a, b = 2.0, 3.0
+    expected = _golden(a, b)
+    # Pre-allocate args for each chip (chip_id = block group). The
+    # vector_example orchestration partitions the input across cores, so a
+    # single args bundle works for both chips' first-run trigger; the
+    # second-run uses the post-registered cid.
+    args_pre = _make_args(a, b)
+    args_post = _make_args(a, b)
+    chip_args_pre, _ = _build_l3_task_args(args_pre, _ORCH_SIG)
+    chip_args_post, _ = _build_l3_task_args(args_post, _ORCH_SIG)
+
+    worker.init()
+    try:
+        config = CallConfig()
+        config.block_dim = 3
+        config.aicpu_thread_num = 4
+
+        def orch_pre(o, _a, _c):
+            o.submit_next_level(cid_pre, chip_args_pre, config)
+
+        worker.run(orch_pre)
+        assert torch.allclose(args_pre.f, torch.full_like(args_pre.f, expected), rtol=1e-5, atol=1e-5)
+
+        # Now broadcast CTRL_REGISTER to BOTH chip mailboxes in parallel.
+        cid_post = worker.register(chip_callable)
+
+        def orch_post(o, _a, _c):
+            o.submit_next_level(cid_post, chip_args_post, config)
+
+        worker.run(orch_post)
+        assert torch.allclose(args_post.f, torch.full_like(args_post.f, expected), rtol=1e-5, atol=1e-5)
+    finally:
+        worker.close()
+
+
+@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.device_count(1)
+@pytest.mark.runtime(_RUNTIME)
+def test_register_cid_overflow_post_init(st_platform, st_device_ids):
+    """Saturate the cid table pre-init, then verify post-init register hits
+    the same ``MAX_REGISTERED_CALLABLE_IDS`` ceiling.
+
+    Confirms the cid bookkeeping is shared between the pre-init and the new
+    dynamic-register entry points (and that the error message is
+    protocol-aware so the operator sees the same diagnostic in both paths).
+    """
+    chip_callable = _build_vector_callable(st_platform)
+    worker = Worker(
+        level=3,
+        device_ids=[int(st_device_ids[0])],
+        num_sub_workers=0,
+        platform=st_platform,
+        runtime=_RUNTIME,
+    )
+    # Fill the registry pre-init with sub fn lambdas (cheap, no device cost).
+    for _ in range(MAX_REGISTERED_CALLABLE_IDS - 1):
+        worker.register(lambda args: None)
+    cid_chip = worker.register(chip_callable)  # last slot
+    assert len(worker._callable_registry) == MAX_REGISTERED_CALLABLE_IDS
+
+    a, b = 2.0, 3.0
+    args_pre = _make_args(a, b)
+    chip_args_pre, _ = _build_l3_task_args(args_pre, _ORCH_SIG)
+
+    worker.init()
+    try:
+        config = CallConfig()
+        config.block_dim = 3
+        config.aicpu_thread_num = 4
+
+        def orch_pre(o, _a, _c):
+            o.submit_next_level(cid_chip, chip_args_pre, config)
+
+        worker.run(orch_pre)
+
+        # The very next dynamic register hits the table ceiling.
+        with pytest.raises(RuntimeError, match="MAX_REGISTERED_CALLABLE_IDS"):
+            worker.register(chip_callable)
+    finally:
+        worker.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -188,9 +188,9 @@ def test_register_after_init_parallel_broadcast(st_platform, st_device_ids):
     """Two chip children, post-init register broadcasts to both in parallel.
 
     Asserts that the registered cid runs successfully on each chip — proving
-    the parallel ThreadPoolExecutor broadcast delivers the bytes to every
-    chip's mailbox and each prepare_callable_from_blob runs without racing
-    against the others.
+    the C++ broadcast (one std::thread per WorkerThread) delivers the bytes
+    to every chip's mailbox and each prepare_callable_from_blob runs without
+    racing against the others.
     """
     chip_callable = _build_vector_callable(st_platform)
     device_ids = [int(d) for d in st_device_ids[:2]]

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -284,6 +284,81 @@ def test_register_cid_overflow_post_init(st_platform, st_device_ids):
         worker.close()
 
 
+@pytest.mark.platforms(["a2a3sim"])
+@pytest.mark.device_count(1)
+@pytest.mark.runtime(_RUNTIME)
+def test_register_unregister_register_runs_each_time(st_platform, st_device_ids):
+    """register → run → unregister → register again → run.
+
+    Proves the IPC unregister path works end-to-end: after CTRL_UNREGISTER
+    propagates to the chip child, the cid slot is freed and a subsequent
+    dynamic register on a fresh cid prepares + dispatches correctly.
+    """
+    chip_callable = _build_vector_callable(st_platform)
+    worker = Worker(
+        level=3,
+        device_ids=[int(st_device_ids[0])],
+        num_sub_workers=0,
+        platform=st_platform,
+        runtime=_RUNTIME,
+    )
+    cid_pre = worker.register(chip_callable)
+
+    a, b = 2.0, 3.0
+    expected = _golden(a, b)
+    # Three runs total — preallocate three args bundles BEFORE init() so
+    # the share_memory_ mappings are inherited by the forked chip child.
+    args_one = _make_args(a, b)
+    args_two = _make_args(a, b)
+    args_three = _make_args(a, b)
+    chip_args_one, _ = _build_l3_task_args(args_one, _ORCH_SIG)
+    chip_args_two, _ = _build_l3_task_args(args_two, _ORCH_SIG)
+    chip_args_three, _ = _build_l3_task_args(args_three, _ORCH_SIG)
+
+    worker.init()
+    try:
+        config = CallConfig()
+        config.block_dim = 3
+        config.aicpu_thread_num = 4
+
+        # 1. Trigger fork via cid_pre to put the chip child into the main loop.
+        def orch_one(o, _args, _cfg):
+            o.submit_next_level(cid_pre, chip_args_one, config)
+
+        worker.run(orch_one)
+        assert torch.allclose(args_one.f, torch.full_like(args_one.f, expected), rtol=1e-5, atol=1e-5)
+
+        # 2. Dynamic register a second cid, run it.
+        cid_dyn = worker.register(chip_callable)
+
+        def orch_two(o, _args, _cfg):
+            o.submit_next_level(cid_dyn, chip_args_two, config)
+
+        worker.run(orch_two)
+        assert torch.allclose(args_two.f, torch.full_like(args_two.f, expected), rtol=1e-5, atol=1e-5)
+
+        # 3. Unregister cid_dyn — CTRL_UNREGISTER hits the chip child,
+        #    which calls cw.unregister_callable(cid_dyn).
+        worker.unregister(cid_dyn)
+        assert cid_dyn not in worker._callable_registry
+
+        # 4. Re-register and run again. The freed slot is reused — cid
+        #    allocation is `len(registry)` and the unregister popped one
+        #    entry, so the next register lands on the same index as the
+        #    just-unregistered cid. This is the slot-recycling property
+        #    that unregister exists for.
+        cid_again = worker.register(chip_callable)
+        assert cid_again == cid_dyn, "unregister should free the cid slot for reuse"
+
+        def orch_three(o, _args, _cfg):
+            o.submit_next_level(cid_again, chip_args_three, config)
+
+        worker.run(orch_three)
+        assert torch.allclose(args_three.f, torch.full_like(args_three.f, expected), rtol=1e-5, atol=1e-5)
+    finally:
+        worker.close()
+
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dynamic_register/test_dynamic_register.py
@@ -342,11 +342,10 @@ def test_register_unregister_register_runs_each_time(st_platform, st_device_ids)
         worker.unregister(cid_dyn)
         assert cid_dyn not in worker._callable_registry
 
-        # 4. Re-register and run again. The freed slot is reused — cid
-        #    allocation is `len(registry)` and the unregister popped one
-        #    entry, so the next register lands on the same index as the
-        #    just-unregistered cid. This is the slot-recycling property
-        #    that unregister exists for.
+        # 4. Re-register and run again. `_allocate_cid` returns the
+        #    smallest unused integer, so the freed slot is reused
+        #    immediately. This is the slot-recycling property that
+        #    unregister exists for.
         cid_again = worker.register(chip_callable)
         assert cid_again == cid_dyn, "unregister should free the cid slot for reuse"
 

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -101,6 +101,18 @@ class TestChipWorkerStateMachine:
         with pytest.raises(RuntimeError, match="not initialized"):
             worker.prepare_callable(0, callable_obj)
 
+    def test_prepare_callable_from_blob_before_init_raises(self):
+        # The from_blob overload shares the underlying ChipWorker::prepare_callable
+        # entrypoint with the typed overload, so it must enforce the same
+        # initialization guard. This protects the dynamic-register IPC handler
+        # (which is the sole caller) from silently no-op'ing on a stale worker.
+        from _task_interface import ChipCallable  # noqa: PLC0415
+
+        worker = _ChipWorker()
+        callable_obj = ChipCallable.build(signature=[], func_name="test", binary=b"\x00", children=[])
+        with pytest.raises(RuntimeError, match="not initialized"):
+            worker.prepare_callable_from_blob(0, callable_obj.buffer_ptr())
+
     def test_run_prepared_before_init_raises(self):
         from _task_interface import ChipStorageTaskArgs  # noqa: PLC0415
 

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -13,12 +13,13 @@ Each test verifies a distinct aspect of the L3 scheduling pipeline.
 """
 
 import struct
+import threading
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
 from _task_interface import MAX_REGISTERED_CALLABLE_IDS  # pyright: ignore[reportMissingImports]
-from simpler.task_interface import DataType, TaskArgs, TensorArgType
-from simpler.worker import Worker
+from simpler.task_interface import ChipCallable, DataType, TaskArgs, TensorArgType
+from simpler.worker import Worker, _make_callable_shm_name
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -64,12 +65,90 @@ class TestLifecycle:
             hw.register(lambda args: None)
         # close() called by __exit__, no exception
 
-    def test_register_after_init_raises(self):
+    def test_register_python_fn_after_init_raises(self):
+        # Post-init register of a non-ChipCallable (lambda / sub fn) is
+        # rejected because Python callables cannot cross the fork boundary.
+        # ChipCallable is the only post-init target — see the next test.
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
-        with pytest.raises(RuntimeError, match="before init"):
+        with pytest.raises(NotImplementedError, match="only ChipCallable is supported post-init"):
             hw.register(lambda args: None)
         hw.close()
+
+    def test_register_chip_callable_after_init_no_chips_succeeds(self):
+        # With no chip children (device_ids unset), the dynamic register
+        # broadcast loop iterates over zero mailboxes — exercises the
+        # facade path (lock, _post_init_register, shm create/unlink,
+        # registry insertion) end-to-end without needing an NPU.
+        hw = Worker(level=3, num_sub_workers=0)
+        hw.init()
+        try:
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid = hw.register(callable_obj)
+            assert isinstance(cid, int)
+            assert cid >= 0
+        finally:
+            hw.close()
+
+    def test_register_chip_callable_at_cid_overflow_raises(self):
+        # cid budget is enforced under the new dynamic-register path too:
+        # pre-fill registry with lambdas pre-init, init, then attempt one
+        # post-init ChipCallable register and observe the existing
+        # MAX_REGISTERED_CALLABLE_IDS RuntimeError.
+        hw = Worker(level=3, num_sub_workers=0)
+        try:
+            for _ in range(MAX_REGISTERED_CALLABLE_IDS):
+                hw.register(lambda args: None)
+            hw.init()
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            with pytest.raises(RuntimeError, match="MAX_REGISTERED_CALLABLE_IDS"):
+                hw.register(callable_obj)
+        finally:
+            hw.close()
+
+    def test_register_chip_callable_during_run_raises(self):
+        # The quiescent-state guard: a register call that races a Worker.run
+        # must surface a clear RuntimeError instead of deadlocking on a
+        # CONTROL_REQUEST that overlaps an in-flight TASK_READY. The orch fn
+        # signals once it is in flight (which is also after Worker.run() has
+        # bumped _orch_in_flight under _register_lock); the side thread
+        # waits for that signal before attempting register.
+        hw = Worker(level=3, num_sub_workers=1)
+        hw.register(lambda args: None)
+        hw.init()
+        try:
+            run_started = threading.Event()
+            release = threading.Event()
+            register_err: list[BaseException] = []
+
+            def orch(orch_handle, _args, _cfg):
+                run_started.set()
+                release.wait(timeout=5.0)
+
+            def try_register():
+                # Wait until orch fn is in flight (guarantees _orch_in_flight
+                # was bumped to 1 before our register attempts to acquire
+                # _register_lock).
+                assert run_started.wait(timeout=5.0), "orch never started"
+                try:
+                    callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+                    hw.register(callable_obj)
+                except BaseException as e:  # noqa: BLE001
+                    register_err.append(e)
+                finally:
+                    release.set()
+
+            t = threading.Thread(target=try_register)
+            t.start()
+            try:
+                hw.run(orch)
+            finally:
+                t.join(timeout=5.0)
+            assert register_err, "expected register to raise during run"
+            assert isinstance(register_err[0], RuntimeError)
+            assert "Worker.run() is executing" in str(register_err[0])
+        finally:
+            hw.close()
 
     def test_register_overflow_raises(self):
         # The AICPU side reserves a fixed-size orch_so_table_[MAX_REGISTERED_CALLABLE_IDS];
@@ -489,3 +568,23 @@ class TestSubCallableArgs:
         finally:
             result_shm.close()
             result_shm.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Test: _CTRL_REGISTER shm name helper
+# ---------------------------------------------------------------------------
+
+
+class TestCallableShmName:
+    def test_make_callable_shm_name_unique(self):
+        # Consecutive calls with the same (pid, cid) must produce different
+        # names — the monotonic counter is the disambiguator that lets
+        # multiple registers coexist without POSIX shm name collisions.
+        a = _make_callable_shm_name(1234, 7)
+        b = _make_callable_shm_name(1234, 7)
+        assert a != b
+        # Both must fit in the on-wire field with a NUL terminator (32 B).
+        assert len(a.encode("utf-8")) + 1 <= 32
+        assert len(b.encode("utf-8")) + 1 <= 32
+        assert a.startswith("simpler-cb-1234-7-")
+        assert b.startswith("simpler-cb-1234-7-")

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -180,10 +180,10 @@ class TestLifecycle:
 
                 monkeypatch.setattr(simpler.worker, "_make_callable_shm_name", capture_shm_name)
 
-                def fail_broadcast(self, worker_id, cid, shm_name):
-                    raise RuntimeError(f"chip {worker_id}: register cid={cid} chip=0: simulated")
+                def fail_broadcast(self, mailbox, label, cid, shm_name):
+                    raise RuntimeError(f"{label}: register cid={cid} chip=0: simulated")
 
-                monkeypatch.setattr(Worker, "_chip_control_register", fail_broadcast)
+                monkeypatch.setattr(Worker, "_mailbox_control_register", fail_broadcast)
 
                 callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
                 registry_size_before = len(hw._callable_registry)
@@ -292,10 +292,10 @@ class TestLifecycle:
             hw._hierarchical_started = True
             try:
 
-                def fail_unregister(self, worker_id, cid):
-                    raise RuntimeError(f"chip {worker_id}: unregister cid={cid} chip=0: simulated")
+                def fail_unregister(self, mailbox, label, cid):
+                    raise RuntimeError(f"{label}: unregister cid={cid} chip=0: simulated")
 
-                monkeypatch.setattr(Worker, "_chip_control_unregister", fail_unregister)
+                monkeypatch.setattr(Worker, "_mailbox_control_unregister", fail_unregister)
 
                 hw.unregister(cid)  # must NOT raise — best-effort
                 assert cid not in hw._callable_registry

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -19,7 +19,7 @@ from multiprocessing.shared_memory import SharedMemory
 import pytest
 from _task_interface import MAX_REGISTERED_CALLABLE_IDS  # pyright: ignore[reportMissingImports]
 from simpler.task_interface import ChipCallable, DataType, TaskArgs, TensorArgType
-from simpler.worker import Worker, _make_callable_shm_name
+from simpler.worker import Worker
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -76,10 +76,10 @@ class TestLifecycle:
         hw.close()
 
     def test_register_chip_callable_after_init_no_chips_succeeds(self):
-        # With no chip children (device_ids unset), the dynamic register
-        # broadcast loop iterates over zero mailboxes — exercises the
-        # facade path (lock, _post_init_register, shm create/unlink,
-        # registry insertion) end-to-end without needing an NPU.
+        # With no chip children (device_ids unset), the C++ broadcast is a
+        # no-op (next_level_threads_ is empty) — exercises the facade path
+        # (registry lock, cid allocation, broadcast call, return) end-to-end
+        # without needing an NPU.
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
         try:
@@ -106,102 +106,6 @@ class TestLifecycle:
         finally:
             hw.close()
 
-    def test_register_chip_callable_during_run_raises(self):
-        # The quiescent-state guard: a register call that races a Worker.run
-        # must surface a clear RuntimeError instead of deadlocking on a
-        # CONTROL_REQUEST that overlaps an in-flight TASK_READY. The orch fn
-        # signals once it is in flight (which is also after Worker.run() has
-        # bumped _orch_in_flight under _register_lock); the side thread
-        # waits for that signal before attempting register.
-        hw = Worker(level=3, num_sub_workers=1)
-        hw.register(lambda args: None)
-        hw.init()
-        try:
-            run_started = threading.Event()
-            release = threading.Event()
-            register_err: list[BaseException] = []
-
-            def orch(orch_handle, _args, _cfg):
-                run_started.set()
-                release.wait(timeout=5.0)
-
-            def try_register():
-                # Wait until orch fn is in flight (guarantees _orch_in_flight
-                # was bumped to 1 before our register attempts to acquire
-                # _register_lock).
-                assert run_started.wait(timeout=5.0), "orch never started"
-                try:
-                    callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-                    hw.register(callable_obj)
-                except BaseException as e:  # noqa: BLE001
-                    register_err.append(e)
-                finally:
-                    release.set()
-
-            t = threading.Thread(target=try_register)
-            t.start()
-            try:
-                hw.run(orch)
-            finally:
-                t.join(timeout=5.0)
-            assert register_err, "expected register to raise during run"
-            assert isinstance(register_err[0], RuntimeError)
-            assert "Worker.run() is executing" in str(register_err[0])
-        finally:
-            hw.close()
-
-    def test_register_chip_callable_broadcast_failure_rolls_back(self, monkeypatch):
-        # Forces _post_init_register down the CTRL_REGISTER broadcast path
-        # (hierarchical_started=True + a fake chip mailbox), then makes the
-        # broadcast helper raise. Verifies the parent rolls back cleanly:
-        # registry entry popped, shm unlinked, RuntimeError surfaced. This
-        # is the only test that exercises the failure path end-to-end on
-        # the facade — the ST suite cannot stage a deterministic
-        # prepare-time fault in the chip child.
-        import simpler.worker  # noqa: PLC0415
-
-        hw = Worker(level=3, num_sub_workers=0)
-        hw.register(lambda args: None)
-        hw.init()
-        try:
-            # Splice a placeholder mailbox so the broadcast loop iterates
-            # once; the monkeypatched helper never reads it.
-            fake_mailbox = SharedMemory(create=True, size=4096)
-            hw._chip_shms.append(fake_mailbox)
-            hw._hierarchical_started = True
-            try:
-                captured_shm_names: list[str] = []
-                real_make = simpler.worker._make_callable_shm_name
-
-                def capture_shm_name(pid, cid):
-                    name = real_make(pid, cid)
-                    captured_shm_names.append(name)
-                    return name
-
-                monkeypatch.setattr(simpler.worker, "_make_callable_shm_name", capture_shm_name)
-
-                def fail_broadcast(self, mailbox, label, cid, shm_name):
-                    raise RuntimeError(f"{label}: register cid={cid} chip=0: simulated")
-
-                monkeypatch.setattr(Worker, "_mailbox_control_register", fail_broadcast)
-
-                callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-                registry_size_before = len(hw._callable_registry)
-                with pytest.raises(RuntimeError, match=r"failed; 1 of 1 chips reported errors"):
-                    hw.register(callable_obj)
-                # cid was popped — registry size is unchanged.
-                assert len(hw._callable_registry) == registry_size_before
-                # The shm the parent staged for the broadcast was unlinked.
-                assert len(captured_shm_names) == 1
-                with pytest.raises(FileNotFoundError):
-                    SharedMemory(name=captured_shm_names[0])
-            finally:
-                hw._chip_shms.pop()
-                fake_mailbox.close()
-                fake_mailbox.unlink()
-        finally:
-            hw.close()
-
     def test_unregister_unknown_cid_raises(self):
         # Symmetric to register: unregister must fail loud if the caller
         # confuses cid for an unrelated integer or unregisters twice.
@@ -214,11 +118,11 @@ class TestLifecycle:
             hw.close()
 
     def test_unregister_chip_callable_after_init_no_chips_succeeds(self):
-        # Mirrors test_register_chip_callable_after_init_no_chips_succeeds:
-        # with zero chip mailboxes the broadcast loop is a no-op, so the
-        # facade path (lock, registry pop, return) is exercised end-to-end
-        # without an NPU. Also verifies cid reuse — unregistering frees the
-        # slot for a subsequent register.
+        # With zero chip mailboxes the C++ broadcast is a no-op, so the
+        # facade path (registry lock, broadcast, registry pop) is exercised
+        # end-to-end without an NPU. Also verifies cid reuse — unregistering
+        # frees the slot and the next register reuses the same cid via
+        # `_allocate_cid` (smallest-unused-integer).
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
         try:
@@ -227,85 +131,32 @@ class TestLifecycle:
             assert cid_a in hw._callable_registry
             hw.unregister(cid_a)
             assert cid_a not in hw._callable_registry
-            # Slot can be reused. The next cid is allocated by len(registry),
-            # so freeing cid_a does not immediately reuse its index, but the
-            # registry can still grow up to MAX_REGISTERED_CALLABLE_IDS again.
             cid_b = hw.register(callable_obj)
-            assert cid_b in hw._callable_registry
+            assert cid_b == cid_a, "smallest-unused-cid policy should reuse the freed slot"
         finally:
             hw.close()
 
-    def test_unregister_chip_callable_during_run_raises(self):
-        # Quiescent-state guard: same shape as the register-during-run test,
-        # validates that unregister also refuses to write CTRL_UNREGISTER
-        # over an in-flight TASK_READY.
-        hw = Worker(level=3, num_sub_workers=1)
-        hw.register(lambda args: None)
-        hw.init()
-        try:
-            run_started = threading.Event()
-            release = threading.Event()
-            unregister_err: list[BaseException] = []
-
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-            cid_chip = hw.register(callable_obj)
-
-            def orch(orch_handle, _args, _cfg):
-                run_started.set()
-                release.wait(timeout=5.0)
-
-            def try_unregister():
-                assert run_started.wait(timeout=5.0), "orch never started"
-                try:
-                    hw.unregister(cid_chip)
-                except BaseException as e:  # noqa: BLE001
-                    unregister_err.append(e)
-                finally:
-                    release.set()
-
-            t = threading.Thread(target=try_unregister)
-            t.start()
-            try:
-                hw.run(orch)
-            finally:
-                t.join(timeout=5.0)
-            assert unregister_err, "expected unregister to raise during run"
-            assert isinstance(unregister_err[0], RuntimeError)
-            assert "Worker.run() is executing" in str(unregister_err[0])
-        finally:
-            hw.close()
-
-    def test_unregister_chip_callable_broadcast_warns_and_still_pops(self, monkeypatch, capsys):
-        # Best-effort failure semantics (docs section 8): a broadcast error
-        # must NOT prevent the registry pop. We monkeypatch the broadcast
-        # helper to raise, then verify the cid is gone from the registry
-        # and a warning hit stderr.
-
+    def test_unregister_middle_cid_reuses_hole(self):
+        # `_allocate_cid` must fill the smallest hole, not append at
+        # len(registry). The bug it guards against: register 0/1/2,
+        # unregister 1, next register would silently overwrite the
+        # existing cid=2 under a `len(registry)` policy.
         hw = Worker(level=3, num_sub_workers=0)
         hw.init()
         try:
-            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
-            cid = hw.register(callable_obj)
-
-            fake_mailbox = SharedMemory(create=True, size=4096)
-            hw._chip_shms.append(fake_mailbox)
-            hw._hierarchical_started = True
-            try:
-
-                def fail_unregister(self, mailbox, label, cid):
-                    raise RuntimeError(f"{label}: unregister cid={cid} chip=0: simulated")
-
-                monkeypatch.setattr(Worker, "_mailbox_control_unregister", fail_unregister)
-
-                hw.unregister(cid)  # must NOT raise — best-effort
-                assert cid not in hw._callable_registry
-                err_msg = capsys.readouterr().err
-                assert f"Worker.unregister(cid={cid})" in err_msg
-                assert "1 of 1 chips reported errors" in err_msg
-            finally:
-                hw._chip_shms.pop()
-                fake_mailbox.close()
-                fake_mailbox.unlink()
+            cb = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid0 = hw.register(cb)
+            cid1 = hw.register(cb)
+            cid2 = hw.register(cb)
+            assert (cid0, cid1, cid2) == (0, 1, 2)
+            hw.unregister(cid1)
+            cid_reused = hw.register(cb)
+            assert cid_reused == 1, "hole at cid=1 should be reused before appending"
+            # cid=2 entry must still be the original callable, not silently overwritten.
+            assert hw._callable_registry[cid2] is cb
+            # Next register fills cid=3 since 0..2 are all occupied.
+            cid_next = hw.register(cb)
+            assert cid_next == 3
         finally:
             hw.close()
 
@@ -730,20 +581,202 @@ class TestSubCallableArgs:
 
 
 # ---------------------------------------------------------------------------
-# Test: _CTRL_REGISTER shm name helper
+# Test: _CTRL_REGISTER self-heal on cid reuse
 # ---------------------------------------------------------------------------
 
 
-class TestCallableShmName:
-    def test_make_callable_shm_name_unique(self):
-        # Consecutive calls with the same (pid, cid) must produce different
-        # names — the monotonic counter is the disambiguator that lets
-        # multiple registers coexist without POSIX shm name collisions.
-        a = _make_callable_shm_name(1234, 7)
-        b = _make_callable_shm_name(1234, 7)
-        assert a != b
-        # Both must fit in the on-wire field with a NUL terminator (32 B).
-        assert len(a.encode("utf-8")) + 1 <= 32
-        assert len(b.encode("utf-8")) + 1 <= 32
-        assert a.startswith("simpler-cb-1234-7-")
-        assert b.startswith("simpler-cb-1234-7-")
+class TestChipMainLoopRegisterSelfHeal:
+    """Direct white-box tests on the _run_chip_main_loop self-heal branch.
+
+    Drives the loop in a background thread with a MagicMock ChipWorker and
+    a real shm mailbox. Each test simulates the parent by writing a control
+    command, waiting for the child to publish _CONTROL_DONE, resetting the
+    state to _IDLE, and finally writing _SHUTDOWN. This exercises the
+    actual state-machine code path including the self-heal block; injecting
+    `prepared = {cid}` directly is not possible because the set is a local
+    in the loop function — the seed comes from a real prior CTRL_REGISTER.
+    """
+
+    @staticmethod
+    def _build_mailbox():
+        from simpler.task_interface import MAILBOX_SIZE  # noqa: PLC0415
+        from simpler.worker import _IDLE, _OFF_STATE, _buffer_field_addr, _mailbox_store_i32  # noqa: PLC0415
+
+        shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+        buf = shm.buf
+        assert buf is not None
+        # Loop reads the state field via a raw address (atomic_int32 in C++),
+        # so we hand it the absolute address and let it cast back inside.
+        state_addr = _buffer_field_addr(buf, _OFF_STATE)
+        _mailbox_store_i32(state_addr, _IDLE)
+        # `mailbox_addr` is only consumed by the TASK_READY branch, which we
+        # never reach in these tests; passing 0 keeps the harness lean.
+        return shm, buf, state_addr
+
+    @staticmethod
+    def _send_ctrl_register(buf, state_addr, cid: int, shm_name: str):
+        """Stage a CTRL_REGISTER request and flip the state to CONTROL_REQUEST."""
+        from simpler.worker import (  # noqa: PLC0415
+            _CONTROL_REQUEST,
+            _CTRL_OFF_ARG0,
+            _CTRL_REGISTER,
+            _CTRL_SHM_NAME_BYTES,
+            _OFF_ARGS,
+            _OFF_CALLABLE,
+            _mailbox_store_i32,
+        )
+
+        struct.pack_into("Q", buf, _OFF_CALLABLE, _CTRL_REGISTER)
+        struct.pack_into("Q", buf, _CTRL_OFF_ARG0, cid)
+        encoded = shm_name.encode("utf-8")
+        assert len(encoded) + 1 <= _CTRL_SHM_NAME_BYTES
+        buf[_OFF_ARGS : _OFF_ARGS + len(encoded)] = encoded
+        buf[_OFF_ARGS + len(encoded) : _OFF_ARGS + _CTRL_SHM_NAME_BYTES] = b"\x00" * (
+            _CTRL_SHM_NAME_BYTES - len(encoded)
+        )
+        _mailbox_store_i32(state_addr, _CONTROL_REQUEST)
+
+    @staticmethod
+    def _wait_for_done_and_reset(buf, state_addr, timeout: float = 5.0):
+        """Block until the loop publishes _CONTROL_DONE, then read the error
+        code and reset the mailbox to _IDLE so the next round can start."""
+        import time  # noqa: PLC0415
+
+        from simpler.worker import (  # noqa: PLC0415
+            _CONTROL_DONE,
+            _IDLE,
+            _OFF_ERROR,
+            _mailbox_load_i32,
+            _mailbox_store_i32,
+        )
+
+        deadline = time.monotonic() + timeout
+        while _mailbox_load_i32(state_addr) != _CONTROL_DONE:
+            if time.monotonic() > deadline:
+                raise TimeoutError("loop did not publish CONTROL_DONE")
+            time.sleep(0.001)
+        err_code = struct.unpack_from("i", buf, _OFF_ERROR)[0]
+        _mailbox_store_i32(state_addr, _IDLE)
+        return err_code
+
+    @staticmethod
+    def _shutdown(state_addr):
+        from simpler.worker import _SHUTDOWN, _mailbox_store_i32  # noqa: PLC0415
+
+        _mailbox_store_i32(state_addr, _SHUTDOWN)
+
+    @staticmethod
+    def _spawn_loop(cw, buf, state_addr):
+        from simpler.worker import _run_chip_main_loop  # noqa: PLC0415
+
+        t = threading.Thread(
+            target=_run_chip_main_loop,
+            args=(cw, buf, 0, state_addr, 0, {}),
+            daemon=True,
+        )
+        t.start()
+        return t
+
+    def test_no_self_heal_when_prepared_clean(self):
+        # First CTRL_REGISTER on a fresh loop: `prepared` starts empty, so the
+        # self-heal branch must be skipped — no extra unregister_callable call.
+        # Locks in the zero-cost happy path.
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        cw = MagicMock()
+        cw.unregister_callable = MagicMock()
+        cw._impl.prepare_callable_from_blob = MagicMock()
+
+        payload_shm = SharedMemory(create=True, size=64)
+        shm, buf, state_addr = self._build_mailbox()
+        try:
+            t = self._spawn_loop(cw, buf, state_addr)
+            try:
+                self._send_ctrl_register(buf, state_addr, cid=7, shm_name=payload_shm.name)
+                err = self._wait_for_done_and_reset(buf, state_addr)
+                assert err == 0
+                # Critical assertion: no self-heal cleanup on a fresh slot.
+                assert cw.unregister_callable.call_count == 0
+                assert cw._impl.prepare_callable_from_blob.call_count == 1
+            finally:
+                self._shutdown(state_addr)
+                t.join(timeout=2.0)
+        finally:
+            shm.close()
+            shm.unlink()
+            payload_shm.close()
+            payload_shm.unlink()
+
+    def test_self_heal_triggers_on_repeat_register(self):
+        # Second CTRL_REGISTER on the same cid: after the first round
+        # `prepared` holds 7, so the loop must self-heal — call
+        # unregister_callable to clear host-side residue before re-preparing.
+        # This is the scenario a best-effort unregister failure leaves behind.
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        cw = MagicMock()
+        cw.unregister_callable = MagicMock()
+        cw._impl.prepare_callable_from_blob = MagicMock()
+
+        payload_shm = SharedMemory(create=True, size=64)
+        shm, buf, state_addr = self._build_mailbox()
+        try:
+            t = self._spawn_loop(cw, buf, state_addr)
+            try:
+                # Round 1: seed `prepared = {7}`.
+                self._send_ctrl_register(buf, state_addr, cid=7, shm_name=payload_shm.name)
+                assert self._wait_for_done_and_reset(buf, state_addr) == 0
+                assert cw.unregister_callable.call_count == 0
+                # Round 2: cid=7 already in `prepared` -> self-heal fires.
+                self._send_ctrl_register(buf, state_addr, cid=7, shm_name=payload_shm.name)
+                assert self._wait_for_done_and_reset(buf, state_addr) == 0
+                # Self-heal called unregister_callable exactly once, then
+                # prepare_callable_from_blob ran on the cleaned slot.
+                assert cw.unregister_callable.call_count == 1
+                cw.unregister_callable.assert_called_with(7)
+                assert cw._impl.prepare_callable_from_blob.call_count == 2
+            finally:
+                self._shutdown(state_addr)
+                t.join(timeout=2.0)
+        finally:
+            shm.close()
+            shm.unlink()
+            payload_shm.close()
+            payload_shm.unlink()
+
+    def test_self_heal_tolerates_unregister_exception(self):
+        # The self-heal try/except must swallow exceptions from
+        # unregister_callable so a flaky cleanup does not block the new
+        # registration. The follow-on prepare_callable_from_blob still runs
+        # and the mailbox publishes a clean (code=0) CONTROL_DONE.
+        from unittest.mock import MagicMock  # noqa: PLC0415
+
+        cw = MagicMock()
+        # First call: succeeds (seed phase has no self-heal invocation).
+        # Second call (self-heal): raises — must be swallowed.
+        cw.unregister_callable = MagicMock(side_effect=[RuntimeError("simulated")])
+        cw._impl.prepare_callable_from_blob = MagicMock()
+
+        payload_shm = SharedMemory(create=True, size=64)
+        shm, buf, state_addr = self._build_mailbox()
+        try:
+            t = self._spawn_loop(cw, buf, state_addr)
+            try:
+                # Round 1: no self-heal, prepared seeded with {7}.
+                self._send_ctrl_register(buf, state_addr, cid=7, shm_name=payload_shm.name)
+                assert self._wait_for_done_and_reset(buf, state_addr) == 0
+                # Round 2: self-heal fires; unregister_callable raises but is
+                # caught; prepare_callable_from_blob still runs.
+                self._send_ctrl_register(buf, state_addr, cid=7, shm_name=payload_shm.name)
+                err = self._wait_for_done_and_reset(buf, state_addr)
+                assert err == 0, "self-heal exception leaked into mailbox error code"
+                assert cw.unregister_callable.call_count == 1
+                assert cw._impl.prepare_callable_from_blob.call_count == 2
+            finally:
+                self._shutdown(state_addr)
+                t.join(timeout=2.0)
+        finally:
+            shm.close()
+            shm.unlink()
+            payload_shm.close()
+            payload_shm.unlink()

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -150,6 +150,58 @@ class TestLifecycle:
         finally:
             hw.close()
 
+    def test_register_chip_callable_broadcast_failure_rolls_back(self, monkeypatch):
+        # Forces _post_init_register down the CTRL_REGISTER broadcast path
+        # (hierarchical_started=True + a fake chip mailbox), then makes the
+        # broadcast helper raise. Verifies the parent rolls back cleanly:
+        # registry entry popped, shm unlinked, RuntimeError surfaced. This
+        # is the only test that exercises the failure path end-to-end on
+        # the facade — the ST suite cannot stage a deterministic
+        # prepare-time fault in the chip child.
+        import simpler.worker  # noqa: PLC0415
+
+        hw = Worker(level=3, num_sub_workers=0)
+        hw.register(lambda args: None)
+        hw.init()
+        try:
+            # Splice a placeholder mailbox so the broadcast loop iterates
+            # once; the monkeypatched helper never reads it.
+            fake_mailbox = SharedMemory(create=True, size=4096)
+            hw._chip_shms.append(fake_mailbox)
+            hw._hierarchical_started = True
+            try:
+                captured_shm_names: list[str] = []
+                real_make = simpler.worker._make_callable_shm_name
+
+                def capture_shm_name(pid, cid):
+                    name = real_make(pid, cid)
+                    captured_shm_names.append(name)
+                    return name
+
+                monkeypatch.setattr(simpler.worker, "_make_callable_shm_name", capture_shm_name)
+
+                def fail_broadcast(self, worker_id, cid, shm_name):
+                    raise RuntimeError(f"chip {worker_id}: register cid={cid} chip=0: simulated")
+
+                monkeypatch.setattr(Worker, "_chip_control_register", fail_broadcast)
+
+                callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+                registry_size_before = len(hw._callable_registry)
+                with pytest.raises(RuntimeError, match=r"failed; 1 of 1 chips reported errors"):
+                    hw.register(callable_obj)
+                # cid was popped — registry size is unchanged.
+                assert len(hw._callable_registry) == registry_size_before
+                # The shm the parent staged for the broadcast was unlinked.
+                assert len(captured_shm_names) == 1
+                with pytest.raises(FileNotFoundError):
+                    SharedMemory(name=captured_shm_names[0])
+            finally:
+                hw._chip_shms.pop()
+                fake_mailbox.close()
+                fake_mailbox.unlink()
+        finally:
+            hw.close()
+
     def test_register_overflow_raises(self):
         # The AICPU side reserves a fixed-size orch_so_table_[MAX_REGISTERED_CALLABLE_IDS];
         # Worker.register must surface the bound at register-time, not later when

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -202,6 +202,113 @@ class TestLifecycle:
         finally:
             hw.close()
 
+    def test_unregister_unknown_cid_raises(self):
+        # Symmetric to register: unregister must fail loud if the caller
+        # confuses cid for an unrelated integer or unregisters twice.
+        hw = Worker(level=3, num_sub_workers=0)
+        hw.init()
+        try:
+            with pytest.raises(KeyError, match="cid=999 not registered"):
+                hw.unregister(999)
+        finally:
+            hw.close()
+
+    def test_unregister_chip_callable_after_init_no_chips_succeeds(self):
+        # Mirrors test_register_chip_callable_after_init_no_chips_succeeds:
+        # with zero chip mailboxes the broadcast loop is a no-op, so the
+        # facade path (lock, registry pop, return) is exercised end-to-end
+        # without an NPU. Also verifies cid reuse — unregistering frees the
+        # slot for a subsequent register.
+        hw = Worker(level=3, num_sub_workers=0)
+        hw.init()
+        try:
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid_a = hw.register(callable_obj)
+            assert cid_a in hw._callable_registry
+            hw.unregister(cid_a)
+            assert cid_a not in hw._callable_registry
+            # Slot can be reused. The next cid is allocated by len(registry),
+            # so freeing cid_a does not immediately reuse its index, but the
+            # registry can still grow up to MAX_REGISTERED_CALLABLE_IDS again.
+            cid_b = hw.register(callable_obj)
+            assert cid_b in hw._callable_registry
+        finally:
+            hw.close()
+
+    def test_unregister_chip_callable_during_run_raises(self):
+        # Quiescent-state guard: same shape as the register-during-run test,
+        # validates that unregister also refuses to write CTRL_UNREGISTER
+        # over an in-flight TASK_READY.
+        hw = Worker(level=3, num_sub_workers=1)
+        hw.register(lambda args: None)
+        hw.init()
+        try:
+            run_started = threading.Event()
+            release = threading.Event()
+            unregister_err: list[BaseException] = []
+
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid_chip = hw.register(callable_obj)
+
+            def orch(orch_handle, _args, _cfg):
+                run_started.set()
+                release.wait(timeout=5.0)
+
+            def try_unregister():
+                assert run_started.wait(timeout=5.0), "orch never started"
+                try:
+                    hw.unregister(cid_chip)
+                except BaseException as e:  # noqa: BLE001
+                    unregister_err.append(e)
+                finally:
+                    release.set()
+
+            t = threading.Thread(target=try_unregister)
+            t.start()
+            try:
+                hw.run(orch)
+            finally:
+                t.join(timeout=5.0)
+            assert unregister_err, "expected unregister to raise during run"
+            assert isinstance(unregister_err[0], RuntimeError)
+            assert "Worker.run() is executing" in str(unregister_err[0])
+        finally:
+            hw.close()
+
+    def test_unregister_chip_callable_broadcast_warns_and_still_pops(self, monkeypatch, capsys):
+        # Best-effort failure semantics (docs section 8): a broadcast error
+        # must NOT prevent the registry pop. We monkeypatch the broadcast
+        # helper to raise, then verify the cid is gone from the registry
+        # and a warning hit stderr.
+
+        hw = Worker(level=3, num_sub_workers=0)
+        hw.init()
+        try:
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid = hw.register(callable_obj)
+
+            fake_mailbox = SharedMemory(create=True, size=4096)
+            hw._chip_shms.append(fake_mailbox)
+            hw._hierarchical_started = True
+            try:
+
+                def fail_unregister(self, worker_id, cid):
+                    raise RuntimeError(f"chip {worker_id}: unregister cid={cid} chip=0: simulated")
+
+                monkeypatch.setattr(Worker, "_chip_control_unregister", fail_unregister)
+
+                hw.unregister(cid)  # must NOT raise — best-effort
+                assert cid not in hw._callable_registry
+                err_msg = capsys.readouterr().err
+                assert f"Worker.unregister(cid={cid})" in err_msg
+                assert "1 of 1 chips reported errors" in err_msg
+            finally:
+                hw._chip_shms.pop()
+                fake_mailbox.close()
+                fake_mailbox.unlink()
+        finally:
+            hw.close()
+
     def test_register_overflow_raises(self):
         # The AICPU side reserves a fixed-size orch_so_table_[MAX_REGISTERED_CALLABLE_IDS];
         # Worker.register must surface the bound at register-time, not later when

--- a/tests/ut/py/test_worker/test_l4_recursive.py
+++ b/tests/ut/py/test_worker/test_l4_recursive.py
@@ -104,6 +104,28 @@ class TestL4Validation:
         child.close()
         w4.close()
 
+    def test_malloc_on_l4_raises_index_error(self):
+        # L4 has no chip mailboxes — `Worker.malloc` must surface IndexError
+        # rather than silently dispatch CTRL_MALLOC to a next_level (L3 worker)
+        # child whose `_child_worker_loop` doesn't recognise CTRL_MALLOC and
+        # would return a garbage pointer from an uninitialised mailbox result
+        # slot.
+        l3_child = Worker(level=3, num_sub_workers=0)
+        w4 = Worker(level=4, num_sub_workers=0)
+        w4.add_worker(l3_child)
+        w4.init()
+        try:
+            with pytest.raises(IndexError, match="out of range"):
+                w4.malloc(1024, worker_id=0)
+            with pytest.raises(IndexError, match="out of range"):
+                w4.free(0xDEADBEEF, worker_id=0)
+            with pytest.raises(IndexError, match="out of range"):
+                w4.copy_to(0xDEAD, 0xBEEF, 64, worker_id=0)
+            with pytest.raises(IndexError, match="out of range"):
+                w4.copy_from(0xDEAD, 0xBEEF, 64, worker_id=0)
+        finally:
+            w4.close()
+
 
 class TestL4DynamicRegister:
     """Cascade of CTRL_REGISTER / CTRL_UNREGISTER through an L4 → L3 worker tree.

--- a/tests/ut/py/test_worker/test_l4_recursive.py
+++ b/tests/ut/py/test_worker/test_l4_recursive.py
@@ -105,6 +105,55 @@ class TestL4Validation:
         w4.close()
 
 
+class TestL4DynamicRegister:
+    """Cascade of CTRL_REGISTER / CTRL_UNREGISTER through an L4 → L3 worker tree.
+
+    The L3 child is sub-only (no chip device) so the cascade hits zero
+    chip mailboxes inside the L3 child — but exercises the full path
+    from L4 parent → next_level mailbox → ``_child_worker_loop`` CONTROL
+    handler → ``inner_worker._register_at`` recursively. NPU not required.
+    """
+
+    def test_l4_register_chip_callable_after_init_succeeds(self):
+        from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+        l3 = Worker(level=3, num_sub_workers=1)
+        l3.register(lambda args: None)  # at least one cid so L3 init is happy
+
+        w4 = Worker(level=4, num_sub_workers=0)
+        w4.register(lambda orch, args, config: None)
+        w4.add_worker(l3)
+        w4.init()
+        try:
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid = w4.register(callable_obj)
+            assert isinstance(cid, int)
+            assert cid >= 0
+        finally:
+            w4.close()
+
+    def test_l4_register_then_unregister_recycles_cid(self):
+        from simpler.task_interface import ChipCallable  # noqa: PLC0415
+
+        l3 = Worker(level=3, num_sub_workers=1)
+        l3.register(lambda args: None)
+
+        w4 = Worker(level=4, num_sub_workers=0)
+        w4.register(lambda orch, args, config: None)
+        w4.add_worker(l3)
+        w4.init()
+        try:
+            callable_obj = ChipCallable.build(signature=[], func_name="x", binary=b"\x00", children=[])
+            cid_a = w4.register(callable_obj)
+            w4.unregister(cid_a)
+            assert cid_a not in w4._callable_registry
+            # Slot is freed; the next register reuses it.
+            cid_b = w4.register(callable_obj)
+            assert cid_b == cid_a
+        finally:
+            w4.close()
+
+
 # ---------------------------------------------------------------------------
 # Test: L4 → L3 PROCESS mode — single dispatch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Lifts the long-standing constraint that `Worker.register` at L3+ must be
called before `Worker.init()`. After this PR, a `ChipCallable` can be
registered (and unregistered) at any point in the worker's life,
including concurrently with `Worker.run()`. The control plane is a new
IPC channel layered on the existing mailbox state machine — see
[docs/callable-ipc-dynamic-register.md](docs/callable-ipc-dynamic-register.md)
for the full design.

## What's new for users

- `Worker.register(chip_callable)` works post-`init()` at L3 / L4+ and
  returns a cid usable immediately by `orch.submit_next_level(cid, …)`.
- `Worker.unregister(cid)` releases the cid so the next register reuses
  it. Best-effort — chip-side errors are warned but the parent still
  pops the registry entry, so the slot can be reclaimed even if a
  subset of children fail.
- Concurrent with `Worker.run()` is safe. Per-`WorkerThread`
  `mailbox_mu_` already serialises against in-flight `dispatch_process`;
  no Python-side quiescent guard is needed. Same shape as the
  long-standing `Orchestrator.malloc/free/copy_*` family.

## Architecture

**Wire protocol** (extends the existing `_CTRL_MALLOC/FREE/COPY_*` series):

| sub_cmd | Payload | Direction | Purpose |
| ------- | ------- | --------- | ------- |
| `CTRL_PREPARE = 4` | cid | parent → child | warm a cid post-`init()` (pre-existing) |
| `CTRL_REGISTER = 5` | cid + 32-byte shm name | parent → child | broadcast a new ChipCallable |
| `CTRL_UNREGISTER = 6` | cid | parent → child | drop a cid |

**Data channel**: ChipCallable bytes (hundreds of KB – few MB) are too
large for the 4 KB mailbox, so the parent stages them in a per-broadcast
POSIX shm named `simpler-cb-<pid>-<cid>-<counter>`. The child opens the
shm by name, runs `prepare_callable_from_blob(cid, addr)`, and closes
its mmap before publishing `CONTROL_DONE`. The parent `shm_unlink`s
after every child ACKs.

**Parent side**: all mailbox writes happen in C++
`WorkerThread::control_register/unregister/prepare` while holding the
per-WorkerThread `mailbox_mu_`. `WorkerManager::broadcast_register_all`
stages the shm (`PosixShmHolder` RAII) and fans out to every
`next_level_threads_` entry via `std::thread`, achieving
`1 × prepare_cost` latency instead of `N × prepare_cost`. The new
`_Worker.control_prepare / broadcast_register_all /
broadcast_unregister_all` nanobind methods release the GIL during the
spin-poll wait.

**L4 cascade**: `_child_worker_loop` services `CONTROL_REQUEST`,
reconstructs the ChipCallable via `PyChipCallable.from_bytes`, and calls
`inner_worker._register_at(cid, target)` so the cid matches across
layers. Each level stages its own shm — the top-level parent unlinks
once `broadcast_register_all` returns, which is after every L3 child
ACKs (each L3 child has by then completed its own broadcast).

## Failure modes and guarantees

- **Register**: any child failure → parent pops registry + unlinks shm
  + raises `RuntimeError`. No reverse rollback to ACKed children
  (partial state is inert garbage, overwritten on cid reuse).
- **Unregister**: best-effort. C++ returns a per-child error list;
  Python warns to stderr and still pops the registry entry so the cid
  slot is reclaimable.
- **Self-heal on cid reuse**: the chip-side `_CTRL_REGISTER` handler
  defensively re-issues `unregister_callable` when its local `prepared`
  set still carries the cid, so a partial prior unregister cannot wedge
  the slot.
- **cid allocation**: `_allocate_cid` returns the smallest unused
  integer in `[0, MAX_REGISTERED_CALLABLE_IDS)` — fills holes left by
  unregister instead of appending at `len(registry)`, which would
  silently overwrite a holder.

## Out of scope

Per `docs/callable-ipc-dynamic-register.md` §8:

- raising `MAILBOX_SIZE` past 4 KB
- raising `MAX_REGISTERED_CALLABLE_IDS` past 64
- cross-chip shared device GM for the orch SO
- hot-swap of a cid (re-register the same cid with new bytes; the
  self-heal path enables `unregister → register` reuse but not
  in-place replacement)
- dynamic register of Python `OrchFn` / `SubFn` (only `ChipCallable`
  is in scope; Python callables still require pre-init registration so
  the forked children inherit them via CoW)

## Test plan

- [x] UT (`tests/ut/py/test_worker/`, `tests/ut/py/test_chip_worker.py`):
      95 cases pass, including dynamic register / unregister /
      cid overflow / hole reuse / L4-malloc IndexError guard /
      chip-loop self-heal / L4 cascade
- [x] ST sim (`tests/st/a2a3/.../dynamic_register/`, a2a3sim, 2
      devices): post-init register + run, parallel broadcast to two
      chips, cid overflow, register → run → unregister → register
      slot recycling
- [x] ST sim regression: existing `prepared_callable` suite (6 cases)
      passes unchanged
- [ ] L4 end-to-end on device hardware (deferred): would need a
      multi-device fixture with a custom L4 orch fn dispatching the
      inner L3 orch; tracked as follow-up
