### PR TITLE
Refactor(a5): align profiling stack with a2a3 (host CRTP + stable ring)

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -202,24 +202,32 @@ What the swimlane shows:
 
 `kernel_args.l2_perf_data_base` is the single device-side handle
 host publishes for the run. The shared region carries a fixed
-header plus per-core / per-thread state:
+`L2PerfDataHeader` plus per-core / per-thread state (same struct
+shape on both architectures):
 
 ```text
-L2PerfDataHeader / L2PerfSetupHeader            (host init, device R/W)
-├── num_cores
-└── (a2a3) per-thread ready queues
-    (a5)  per-core / per-thread buffer pointers
+L2PerfDataHeader                                (host init, device R/W)
+├── queues  [MAX_AICPU_THREADS][READYQUEUE_SIZE]
+├── queue_heads / queue_tails (per-thread)
+└── num_cores
 
 L2PerfBufferState[num_cores]                    (per-core perf state)
-├── free_queue (a2a3 only)
-├── current_buf_ptr (a2a3) / fixed buffer (a5)
+├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
+├── current_buf_ptr           (AICPU active L2PerfBuffer*)
+├── aicore_ring_ptr           (stable L2PerfAicoreRing*, host writes once)
 ├── total_record_count
-└── dropped_record_count
+├── dropped_record_count
+└── mismatch_record_count     (ring slot / task_id invariant violations)
+
+[L2PerfAicoreRing[num_cores]]                   (stable AICore staging)
+└── L2PerfRecord dual_issue_slots[PLATFORM_L2_AICORE_RING_SIZE]
 
 [AicpuPhaseHeader + PhaseBufferState[num_threads]]  (optional)
 ├── magic / num_sched_threads
 ├── orch_summary  (cumulative orchestrator cycles)
-└── per-thread phase buffers
+└── per-thread phase buffers (PhaseBufferState aliases L2PerfBufferState;
+                              `aicore_ring_ptr` / `mismatch_record_count`
+                              unused for PHASE)
 ```
 
 The records themselves are identical across architectures:
@@ -235,9 +243,11 @@ both architectures' output unchanged.
 **Producer/consumer protocol on AICore.** AICore writes per-task
 timing into a stable per-core `L2PerfAicoreRing` at
 `dual_issue_slots[reg_task_id % PLATFORM_L2_AICORE_RING_SIZE]`.
-The ring address is published once via
-`Handshake::l2_perf_aicore_ring_addr` and never reassigned, so AICore
-is fully decoupled from any AICPU-side records-buffer rotation. AICPU,
+The ring address is published once via a per-core table on
+`KernelArgs` (a2a3: `aicore_ring_addr`; a5:
+`aicore_l2_perf_ring_addrs`), forwarded by `KERNEL_ENTRY` into
+platform-owned AICore state, and never reassigned — so AICore is
+fully decoupled from any AICPU-side records-buffer rotation. AICPU,
 on observing FIN, validates the slot's register token, copies the slot
 record into the current `L2PerfBuffer::records[count]`, fills
 `func_id` / `core_type` / `dispatch_time` / `finish_time` / `fanout`,
@@ -340,50 +350,93 @@ PMU and TensorDump — see
 [profiling-framework.md](../profiling-framework.md) for the
 framework reference.
 
-### 5.3 a5 — bulk rtMemcpy after stream sync
+### 5.3 a5 — same framework, host-shadow transport
 
-`L2PerfCollector` allocates one `L2PerfBuffer` per core and one
-`PhaseBuffer` per AICPU thread on device, plus a single
-`L2PerfSetupHeader` that stores all buffer pointers and the
-`AicpuPhaseHeader`. AICore writes timing into per-task WIP slots
-and AICPU completes records + writes phase data directly into
-device memory; when a buffer fills up, records are silently
-dropped (AICPU-side early return) and accounted in
-`PmuBufferState`-style counters. Collection is a single bulk
-pass after `rtStreamSynchronize`: copy `L2PerfSetupHeader` back,
-then for each per-core / per-thread buffer copy the 64-byte
-header, read `count`, and copy `count*sizeof(record)` bytes.
+a5's `L2PerfCollector` derives from
+`ProfilerBase<L2PerfCollector, L2PerfModule>` and shares the
+mgmt + poll thread structure with a2a3. The single behavioral
+deviation from §5.2 is the **transport channel**: a5 has no
+`halHostRegister`, so each device buffer is paired with a
+host-shadow `malloc()` and the mgmt loop synchronizes the two via
+`profiling_copy.h` (`rtMemcpy` onboard, plain `memcpy` in sim).
+
+The AICore-side write target is a per-core, **stable**
+`L2PerfAicoreRing` (`dual_issue_slots[PLATFORM_L2_AICORE_RING_SIZE]`)
+allocated once by the host and addressed via
+`L2PerfBufferState::aicore_ring_ptr` (AICPU side) and
+`KernelArgs::aicore_l2_perf_ring_addrs[block_idx]` forwarded into
+`set_aicore_l2_perf_ring()` by `KERNEL_ENTRY` (AICore side). The ring
+address never changes during a run, so AICore's write address is
+decoupled from the AICPU's rotating `L2PerfBuffer`. Buffer rotation is
+internal to `l2_perf_aicpu_complete_record` when `records[count]` hits
+`PLATFORM_PROF_BUFFER_SIZE`. The runtime `Handshake` carries no
+profiling fields.
+
+The framework's `MemoryOps` therefore carries five callbacks on
+a5 (`alloc` / `reg` / `free_` / `copy_to_device` /
+`copy_from_device`); the mgmt loop mirrors the entire shm region
+(`L2PerfDataHeader` + per-core `L2PerfBufferState` + per-thread
+`PhaseBufferState`) device → host at the top of every tick, then
+pushes back only the fields host actually modified (advanced
+`queue_heads[q]`, refilled `free_queue.tail` and
+`buffer_ptrs[slot]`) via `BufferPoolManager::write_range_to_device`.
+The bulk `mirror_shm_to_device` is deliberately **not** called from
+the mgmt loop: it would race with AICPU writes to device-only
+fields (`current_buf_ptr`, `total/dropped/mismatch` counters,
+`queue_tails`, `free_queue.head`, `AicpuPhaseHeader::magic`,
+`orch_summary`, `core_to_thread[]`) and roll them back to whatever
+the host shadow held at the start of the tick. Per-buffer
+payloads (`L2PerfBuffer` / `PhaseBuffer`) are pulled on demand
+inside `ProfilerAlgorithms::process_entry` after a popped
+ready-entry resolves to its host shadow. `BufferPoolManager`'s
+`release_owned_buffers` frees the device pointer via the
+collector's `release_fn` and the paired shadow via `std::free()`.
 
 ```text
         HOST                                         DEVICE
 ┌──────────────────────────┐               ┌──────────────────────────┐
 │ L2PerfCollector          │               │ AICPU + AICore           │
+│   : ProfilerBase<...>    │               │                          │
 │                          │               │                          │
-│ initialize()             │  alloc +      │ AICore on task end:      │
-│   rtMalloc setup region  │──copy────────>│   write timing into      │
-│   one L2PerfBuffer per   │               │   wip[task_id & 1]       │
-│     core                 │               │                          │
-│   one PhaseBuffer per    │               │ AICPU on FIN:            │
-│     scheduler thread     │               │   commit wip slot →      │
-│                          │               │     records[count],      │
-│ ── kernel execution ──   │               │   fill func_id /         │
-│                          │               │   dispatch / finish /    │
-│                          │               │   fanout                 │
+│ initialize()             │  alloc + reg  │ AICore on task end:      │
+│   rtMalloc shm           │──+ shadow────>│   write timing into      │
+│   per-core L2PerfBuffer  │   memset 0    │   per-core ring slot     │
+│   per-core AicoreRing    │   + push 0s   │   dual_issue_slots[      │
+│   per-thread PhaseBuffer │               │     task_id & 1]         │
+│   register_mapping(s)    │               │                          │
+│   set_memory_context     │               │ AICPU on FIN:            │
+│                          │               │   read ring slot →       │
+│                          │               │   commit into records[]  │
+│ start(thread_factory)    │               │                          │
+│   mgmt_thread starts     │               │ AICPU per-thread flush   │
+│   poll_thread starts     │               │   on exit: enqueue       │
+│                          │               │   current_buf_ptr →      │
+│ mgmt every 10us tick:    │               │   ready_queue            │
+│   copy_from_device(shm)  │<──memcpy─────<│                          │
+│   for each ready entry:  │               │                          │
+│     copy buf from device │<──memcpy─────<│                          │
+│     resolve host ptr     │               │                          │
+│     push to L2 ready_q   │               │                          │
+│   advance queue_heads,   │               │                          │
+│     refill free_queues   │               │                          │
+│   write_range_to_device  │──memcpy──────>│                          │
+│     for each modified    │               │                          │
+│     field                │               │                          │
 │                          │               │                          │
-│                          │               │ AICPU scheduler thread:  │
-│                          │               │   per-loop-iter:         │
-│                          │               │     write AicpuPhase-    │
-│                          │               │     Record               │
+│ poll thread:             │               │                          │
+│   wait_pop_ready          │               │                          │
+│   on_buffer_collected →  │               │                          │
+│     copy_perf/phase      │               │                          │
+│   notify_copy_done       │               │                          │
 │                          │               │                          │
 │ rtStreamSynchronize      │               │                          │
-│ collect_all()            │  batch        │                          │
-│   memcpy setup region    │<──memcpy─────<│                          │
-│   per core/thread:       │               │                          │
-│     copy buffer hdr →    │               │                          │
-│     read count           │               │                          │
-│     copy count*record    │               │                          │
+│ stop()                   │               │                          │
+│   join mgmt + poll       │               │                          │
+│ read_phase_header_meta   │               │                          │
+│ reconcile_counters       │               │                          │
+│   sanity-check leftovers │               │                          │
+│   + 3-bucket cross-check │               │                          │
 │ export_swimlane_json()   │               │                          │
-│   → l2_perf_records.json │               │                          │
 │ finalize(free)           │               │                          │
 └──────────────────────────┘               └──────────────────────────┘
 ```
@@ -391,22 +444,37 @@ header, read `count`, and copy `count*sizeof(record)` bytes.
 **Lifecycle** (`device_runner.cpp`):
 
 ```text
-initialize()
-  l2_perf_collector_.initialize(num_aicore, ...)
+init_l2_perf()
+  l2_perf_collector_.initialize(num_aicore, ..., output_prefix_)
   kernel_args_.args.l2_perf_data_base = l2_perf_collector_.get_l2_perf_setup_device_ptr()
+  kernel_args_.args.aicore_l2_perf_ring_addrs =
+      l2_perf_collector_.get_aicore_ring_addrs_device_ptr()
+l2_perf_collector_.start(thread_factory)   ← mgmt + poll threads
 launch AICPU / AICore
 rtStreamSynchronize
-collect_all()                      ← rtMemcpy setup region back, then per-core
-                                     and per-thread buffers (header → records)
-export_swimlane_json(output_prefix)
-finalize()
+l2_perf_collector_.stop()                  ← join mgmt + poll, drain final batch
+l2_perf_collector_.read_phase_header_metadata()
+l2_perf_collector_.reconcile_counters()    ← sanity-check + 3-bucket cross-check
+l2_perf_collector_.export_swimlane_json()
+l2_perf_collector_.finalize()
 ```
 
 [`L2PerfCollector`](../src/a5/platform/include/host/l2_perf_collector.h)
-on a5 is self-contained — `initialize` / `collect_all` /
-`export_swimlane_json` / `finalize`. There are no helper threads
-to coordinate, so the a5 collector does not derive from
-`ProfilerBase`.
+on a5 inherits the same CRTP base
+([`profiling_common::ProfilerBase`](../src/a5/platform/include/host/profiling_common/profiler_base.h))
+as a2a3 and parameterizes
+[`BufferPoolManager`](../src/a5/platform/include/host/profiling_common/buffer_pool_manager.h)
+with `L2PerfModule` (`kBufferKinds = 2`). The only a5-specific
+glue is the 5-callback `MemoryOps` and the per-tick shm mirror.
+
+a5's per-thread AICPU flush hooks (`l2_perf_aicpu_flush_buffers` /
+`l2_perf_aicpu_flush_phase_buffers`) are the only data path on the
+records side — host never reads from `current_buf_ptr` to recover
+records. `reconcile_counters` is purely passive: it logs an error if
+any `current_buf_ptr` is non-zero with a non-empty buffer (a
+device-flush bug), then runs the three-bucket cross-check
+`collected + dropped + mismatch == device_total` per pool (PERF +
+PHASE), same shape as a2a3.
 
 ### 5.4 a2a3 vs a5 at a glance
 
@@ -415,12 +483,14 @@ to coordinate, so the a5 collector does not derive from
 | Record shape | identical (`L2PerfRecord` / `AicpuPhaseRecord` / `AicpuOrchSummary`) | |
 | AICore WIP-slot protocol | identical | |
 | AICPU commit on FIN | identical | |
-| Host transport | `halHostRegister` shared memory | `rtMemcpy` after `rtStreamSynchronize` |
-| Buffer model | rotating pool (free + ready queues) per kind | one `L2PerfBuffer` per core + one `PhaseBuffer` per thread |
-| Ready queue | per-AICPU-thread, multiplexes PERF + PHASE via `is_phase` | none (all buffers pre-allocated) |
-| Host threads | mgmt + poll, streams during execution | drain after sync |
-| Host-class shape | `ProfilerBase` subclass (mgmt + poll thread + `BufferPoolManager<L2PerfModule>`, `kBufferKinds = 2`) | self-contained `initialize`/`collect_all`/`finalize` |
-| Lifecycle | `initialize` → `start` → `stop` → `read_phase_header_metadata` → `reconcile_counters` → `export_swimlane_json` → `finalize` | `initialize` → `collect_all` → `export_swimlane_json` → `finalize` |
+| Buffer model | rotating pool (free + ready queues) per kind | identical |
+| Ready queue | per-AICPU-thread, multiplexes PERF + PHASE via `is_phase` | identical |
+| Host threads | mgmt + poll, streams during execution | identical |
+| Host-class shape | `ProfilerBase<L2PerfCollector, L2PerfModule>` (`kBufferKinds = 2`) | identical |
+| Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
+| `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
+| `reconcile_counters` | passive cross-check (collected + dropped + mismatch == device_total) | identical |
+| Lifecycle | `initialize` → `start` → `stop` → `read_phase_header_metadata` → `reconcile_counters` → `export_swimlane_json` → `finalize` | identical |
 
 ## 6. Overhead
 
@@ -437,9 +507,10 @@ When enabled, the dominant per-task overhead is:
 
 Per scheduler-loop iteration, AICPU also writes a 32-byte
 `AicpuPhaseRecord` per phase (4 phases × 32 B = 128 B per
-iteration). Streaming (a2a3) drains both kinds of buffers
-concurrently with execution; bulk drain (a5) defers the host-side
-cost to after `rtStreamSynchronize`.
+iteration). Both architectures drain buffers concurrently with
+execution via the mgmt + poll thread pair; a5 additionally pays
+per-tick `rtMemcpy`/`memcpy` round-trips to keep the host shadow in
+sync, which overlap with device execution.
 
 `--rounds > 1` collects only on the first round so the steady-state
 benchmark is not perturbed.

--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -180,9 +180,10 @@ Three layers cooperate; the split is the same across architectures:
   shared region.
 - **AICPU** programs the PMU event group at init, starts/stops the
   counters via `PMU_CTRL_0/1`, observes per-task FIN, and commits one
-  `PmuRecord` per task. Stamps `PmuBufferState::owning_thread_id` with
-  the AICPU scheduler thread that drives the core (per-buffer, stable
-  for a run).
+  `PmuRecord` per task. The owning AICPU scheduler thread index is
+  carried out of band on the ready-queue entry (its per-thread queue
+  index in `PmuDataHeader::queues[thread][...]`) and threaded through
+  to the CSV row as `thread_id`.
 - **AICore** brackets the counting window around the kernel body via
   `CTRL` SPR bit 0.
 
@@ -193,9 +194,8 @@ end-to-end; §5.4 is a side-by-side comparison.
 ### 5.1 Common interfaces
 
 `kernel_args.pmu_data_base` is the single device-side handle host
-publishes for the run. Its target struct shape differs per
-architecture (a2a3 uses `PmuDataHeader`; a5 uses `PmuSetupHeader`),
-but in both cases it carries:
+publishes for the run. Its target struct is `PmuDataHeader` on both
+architectures; in both cases it carries:
 
 - `num_cores` — number of AICore instances in use
 - `event_type` — `PmuEventType` value the host wrote at init time
@@ -203,10 +203,14 @@ but in both cases it carries:
 AICPU reads it on init to find per-core state. On every task FIN it
 commits a `PmuRecord` and increments `PmuBufferState::total_record_count`.
 On the drop path it increments `PmuBufferState::dropped_record_count`
-instead. Host uses these two counters at finalize for the cross-check:
+instead. a5 also tracks `PmuBufferState::mismatch_record_count` for
+records lost to ring-slot `task_id` mismatch (a hard invariant
+violation, distinct from capacity drops). Host uses these counters at
+finalize for the cross-check:
 
 ```text
-collected_on_host + dropped == total
+collected_on_host + dropped + mismatch == total   (a5, 3 buckets)
+collected_on_host + dropped == total              (a2a3, 2 buckets)
 ```
 
 ### 5.2 a2a3 — shared-memory streaming (DAV_2201, 8 counters)
@@ -300,48 +304,78 @@ buffer pooling, and `Module` trait pattern are shared with TensorDump
 and L2Perf — see [profiling-framework.md](../profiling-framework.md) for
 the framework reference.
 
-### 5.3 a5 — streaming with host shadow buffers (DAV_3510, 10 counters)
+### 5.3 a5 — same framework, host-shadow transport (DAV_3510, 10 counters)
 
 AICore reads the 10 PMU counters via the `ld_dev` MMIO load intrinsic
 into a per-core dual-issue staging slot indexed by `reg_task_id & 1`.
 AICPU, on observing FIN, validates the slot's recorded `task_id`
 against the register token, copies the record into
 `PmuBuffer::records[count]`, fills `func_id` / `core_type`, and
-advances `count`. When a buffer is full, AICPU switches to a new
+advances `count`. When a buffer fills up, AICPU switches to a new
 buffer via the SPSC free queue / ready queue protocol (identical to
 a2a3). At shutdown, AICPU flushes any partially-filled buffers via
-`pmu_aicpu_flush_buffers()`. The host runs a dedicated collector
-thread that polls ready queues via `rtMemcpy`, writes records to CSV,
-and recycles buffers back into SPSC free queues.
+`pmu_aicpu_flush_buffers()`.
+
+a5's `PmuCollector` derives from
+`ProfilerBase<PmuCollector, PmuModule>` and shares the mgmt + poll
+thread structure with a2a3. The single behavioral deviation from
+§5.2 is the **transport channel**: a5 has no `halHostRegister`, so
+each device buffer is paired with a host-shadow `malloc()` and the
+mgmt loop synchronizes the two via `profiling_copy.h` (`rtMemcpy`
+onboard, `memcpy` in sim). `MemoryOps` therefore carries five
+callbacks (`alloc` / `reg` / `free_` / `copy_to_device` /
+`copy_from_device`); the mgmt loop mirrors the entire shm region
+(`PmuDataHeader` + per-core `PmuBufferState`) device → host at the
+top of every tick, then pushes back only the fields host modified
+(advanced `queue_heads[q]`, refilled `free_queue.tail` and
+`buffer_ptrs[slot]`) via `BufferPoolManager::write_range_to_device`.
+The bulk `mirror_shm_to_device` is **not** called from the mgmt
+loop: it would race with AICPU writes to device-only fields
+(`current_buf_ptr`, `total/dropped` counters, `queue_tails`,
+`free_queue.head`) and roll them back. Each popped `PmuBuffer` is
+still pulled on demand inside
+`ProfilerAlgorithms::process_entry`.
 
 ```text
         HOST                                         DEVICE
 ┌──────────────────────────┐               ┌──────────────────────────┐
 │ PmuCollector             │               │ AICore                   │
+│   : ProfilerBase<...>    │               │                          │
 │                          │               │                          │
-│ init()                   │  alloc +      │ per-task end:            │
-│   rtMalloc data region   │──copy────────>│   ld_dev 10 PMU_CNTs +   │
-│   pre-fill free queues   │               │     PMU_CNT_TOTAL        │
-│   build PmuDataHeader    │               │   write into             │
-│                          │               │   dual_issue_slots[      │
-│ start(tf)                │               │     reg_task_id & 1]     │
-│   ┌────────────────────┐ │               │                          │
-│   │ collector thread   │ │               │ AICPU thread             │
-│   │ poll_and_collect() │ │               │ on FIN:                  │
-│   │  poll ready queues │ │  rtMemcpy     │   match slot's task_id   │
-│   │  via copy hooks    │<┼──(shadow)────<│     vs reg_task_id       │
-│   │  write CSV         │ │               │   copy into              │
-│   │  recycle → free_q  │─┼──copy hook──>│     records[count]       │
-│   └────────────────────┘ │               │   fill func_id/core_type │
-│                          │               │   ++count                │
-│                          │               │   if buffer full:        │
-│                          │  SPSC ready   │     push ready entry,    │
-│                          │<──queues─────<│     pop next from free_q │
+│ init()                   │  alloc + reg  │ per-task end:            │
+│   rtMalloc data region   │──+ shadow────>│   ld_dev 10 PMU_CNTs +   │
+│   per-core PmuBuffers    │   memset 0    │     PMU_CNT_TOTAL        │
+│   register_mapping(s)    │   + push 0s   │   write into             │
+│   build PmuDataHeader    │               │   dual_issue_slots[      │
+│                          │               │     reg_task_id & 1]     │
+│ start(thread_factory)    │               │                          │
+│   mgmt_thread starts     │               │ AICPU thread             │
+│   poll_thread starts     │               │ on FIN:                  │
+│                          │               │   match slot's task_id   │
+│ mgmt every 10us tick:    │               │     vs reg_task_id       │
+│   copy_from_device(shm)  │<──memcpy─────<│   copy into              │
+│   for each ready entry:  │               │     records[count]       │
+│     copy buf from device │<──memcpy─────<│   fill func_id/core_type │
+│     resolve host ptr     │               │   ++count                │
+│     push to L2 ready_q   │               │   if buffer full:        │
+│   advance queue_heads,   │               │     push ready entry,    │
+│     refill free_queues   │               │     pop next from free_q │
+│   write_range_to_device  │──memcpy──────>│                          │
+│     for each modified    │               │ pmu_aicpu_flush():       │
+│     field                │               │   push remaining full    │
+│                          │               │   buffers to ready_q     │
+│ poll thread:             │               │                          │
+│   wait_pop_ready         │               │                          │
+│   on_buffer_collected →  │               │                          │
+│     write_buffer_to_csv  │               │                          │
+│   notify_copy_done       │               │                          │
 │                          │               │                          │
-│ rtStreamSynchronize      │               │ pmu_aicpu_flush():       │
-│ drain_remaining_buffers()│               │   push remaining full    │
-│   final sync + drain     │               │   buffers to ready_q     │
+│ rtStreamSynchronize      │               │                          │
+│ stop()                   │               │                          │
+│   join mgmt + poll       │               │                          │
 │ reconcile_counters()     │               │                          │
+│   sanity-check leftovers │               │                          │
+│   + cross-check          │               │                          │
 │ finalize(free)           │               │                          │
 └──────────────────────────┘               └──────────────────────────┘
 ```
@@ -357,47 +391,59 @@ Device memory layout:
 
 [PmuBufferState[num_cores]]             (per-core state)
 ├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
-├── current_buf_ptr          (AICPU active buffer)
+├── current_buf_ptr            (AICPU active buffer)
+├── aicore_ring_ptr            (stable PmuAicoreRing*, host writes once)
 ├── current_buf_seq
-├── dropped_record_count
 ├── total_record_count
-└── owning_thread_id
+├── dropped_record_count
+└── mismatch_record_count      (ring slot / task_id invariant violations)
+
+PmuAicoreRing[num_cores]                (stable AICore staging, never rotated)
+└── PmuRecord dual_issue_slots[PLATFORM_PMU_AICORE_RING_SIZE]
 
 PmuBuffer pool (rotated)                (BUFFERS_PER_CORE per core)
-├── count                 (header, 64 B)
-├── dual_issue_slots[2]   (AICore staging, indexed task_id & 1)
-└── records[RECORDS_PER_BUFFER]
+└── PmuRecord records[RECORDS_PER_BUFFER] + count
 ```
 
 `halHostRegister` is not supported on DAV_3510, so the a5 collector
-maintains separate host shadow buffers and synchronizes via `rtMemcpy`
-(onboard) or `memcpy` (sim). The platform copy hooks
-`pmu_platform_copy_to/from_device` abstract this difference.
+maintains a paired host-shadow `malloc()` per device buffer and
+synchronizes via `rtMemcpy` (onboard) / `memcpy` (sim). The framework
+copy hooks `profiling_copy_to_device` / `profiling_copy_from_device`
+(in [`profiling_copy.h`](../../src/a5/platform/include/host/profiling_copy.h))
+abstract this difference.
 
-Each `Handshake` carries `pmu_buffer_addr` and `pmu_reg_base` so each
-AICore worker locates its `PmuBuffer` and the PMU MMIO register block.
+Each AICore worker resolves its PMU MMIO base at kernel entry from
+`KernelArgs::regs[get_physical_core_id()]` (the per-physical-core
+register-base table the host already fills for AICPU) and reads its
+`PmuAicoreRing` from `KernelArgs::aicore_pmu_ring_addrs[block_idx]`
+(filled by the host in `PmuCollector::init`). Both addresses are
+forwarded by `KERNEL_ENTRY` into platform-owned per-core slots
+([`aicore_profiling_state.h`](../src/a5/platform/include/aicore/aicore_profiling_state.h));
+the runtime `Handshake` carries no profiling fields. Because the
+resolved reg base is valid from Phase 1 onward (no AICPU-side init
+dependency), `aicore_execute` caches it once after Phase 3 alongside
+the rings rather than re-reading per record.
 
 **Lifecycle** (`device_runner.cpp`):
 
 ```text
-init()
+init_pmu()
   pmu_collector_.init(num_aicore, num_threads, csv_path, event_type, ...)
-  kernel_args_.args.pmu_data_base = pmu_collector_.get_pmu_shm_device_ptr()
-                                      → AICPU programs PMU event group,
-                                        publishes (pmu_buffer_addr,
-                                        pmu_reg_base) into Handshakes
-start(tf)                       ← spawn collector thread
-                                  (poll_and_collect: drain AICPU ready
-                                  queues via copy hooks, write CSV,
-                                  recycle buffers into free queues)
+  kernel_args_.args.pmu_data_base             = pmu_collector_.get_pmu_shm_device_ptr()
+  kernel_args_.args.aicore_pmu_ring_addrs = pmu_collector_.get_aicore_ring_addrs_device_ptr()
+                                      → AICPU pmu_aicpu_init() resolves
+                                        per-core PMU MMIO bases from
+                                        regs[physical_core_ids[i]] and
+                                        caches state->aicore_ring_ptr.
+                                        AICore separately resolves its
+                                        own base at kernel entry from
+                                        regs[get_physical_core_id()].
+pmu_collector_.start(thread_factory)   ← mgmt + poll threads
 launch AICPU / AICore
 rtStreamSynchronize
-stop()                          ← signal_execution_complete, join thread
-drain_remaining_buffers()       ← final sync: drain remaining ready
-                                  queue entries + scan current_buf_ptr
-                                  for partially-filled buffers
-reconcile_counters()            ← assert collected + dropped == total
-finalize(free)
+pmu_collector_.stop()                  ← join mgmt + poll, drain final batch
+pmu_collector_.reconcile_counters()    ← collected + dropped + mismatch == device_total
+pmu_collector_.finalize(free)
 ```
 
 **Slot match key vs logical `task_id`.** `pmu_aicpu_complete_record`
@@ -414,12 +460,20 @@ adjacent dispatches from colliding (the runtime's `dispatch_seq++`
 guarantees neighboring register tokens differ by 1 → different slots).
 
 [`PmuCollector`](../src/a5/platform/include/host/pmu_collector.h) on
-a5 uses the same streaming lifecycle as a2a3 — `init` / `start` /
-`stop` / `drain_remaining_buffers` / `reconcile_counters` / `finalize`.
-The collector thread runs `poll_and_collect()` concurrently with kernel
-execution. The only architectural difference from a2a3 is the memory
-transport: host shadow buffers + `rtMemcpy` copy hooks instead of
-`halHostRegister` shared memory.
+a5 inherits the same CRTP base
+([`profiling_common::ProfilerBase`](../src/a5/platform/include/host/profiling_common/profiler_base.h))
+as a2a3 and parameterizes
+[`BufferPoolManager`](../src/a5/platform/include/host/profiling_common/buffer_pool_manager.h)
+with `PmuModule`. The only a5-specific glue is the 5-callback
+`MemoryOps` and the per-tick shm mirror.
+
+a5's per-thread AICPU flush (`pmu_aicpu_flush_buffers`) is the only
+data path on the records side — host never reads from
+`current_buf_ptr` to recover records. `reconcile_counters` is purely
+passive: it logs an error if any `current_buf_ptr` is non-zero with
+a non-empty buffer (a device-flush bug), then runs the three-bucket
+cross-check `collected + dropped + mismatch == device_total` against
+device-side counters.
 
 ### 5.4 a2a3 vs a5 at a glance
 
@@ -428,11 +482,13 @@ transport: host shadow buffers + `rtMemcpy` copy hooks instead of
 | HW counter slots | 8 (DAV_2201) | 10 (DAV_3510) |
 | Counter readout | AICPU MMIO `read_reg` | AICore MMIO `ld_dev` |
 | Per-core staging | direct write into `records[count]` | dual-issue slots, AICPU commits on FIN |
-| Host transport | `halHostRegister` shared memory | host shadow buffers + `rtMemcpy` copy hooks |
-| Buffer model | rotating pool (free + ready queues) | rotating pool (free + ready queues, same SPSC protocol) |
-| Host threads | mgmt + poll, streams during execution | collector thread, streams during execution |
-| Host-class shape | `ProfilerBase` subclass (mgmt + poll thread + `BufferPoolManager<PmuModule>`) | streaming `init`/`start`/`stop`/`drain`/`finalize` |
-| Lifecycle | `init` → `start` → `stop` → `reconcile_counters` → `finalize` | `init` → `start` → `stop` → `drain_remaining_buffers` → `reconcile_counters` → `finalize` |
+| Buffer model | rotating pool (free + ready queues, SPSC protocol) | identical |
+| Host threads | mgmt + poll, streams during execution | identical |
+| Host-class shape | `ProfilerBase<PmuCollector, PmuModule>` | identical |
+| Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
+| `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
+| `reconcile_counters` | passive cross-check (collected + dropped == device_total) | passive cross-check with mismatch bucket (collected + dropped + mismatch == device_total); leftover non-empty `current_buf_ptr` logged as a device flush bug |
+| Lifecycle | `init` → `start` → `stop` → `reconcile_counters` → `finalize` | identical |
 
 ## 6. Overhead
 

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -218,24 +218,23 @@ Both architectures share the same device-side layout, published via
 `kernel_args.dump_data_base`:
 
 ```text
-DumpSetupHeader                                 (host init, AICPU reads)
+DumpDataHeader                                  (host init, AICPU reads)
+├── queues  [MAX_AICPU_THREADS][READYQUEUE_SIZE]
+├── queue_heads / queue_tails (per-thread)
 ├── num_dump_threads
 ├── records_per_buffer
-├── magic = 0x44554D50 ("DUMP")
-├── dump_buffer_ptrs  [MAX_AICPU_THREADS]  ──> DumpBuffer    (per-thread)
-├── arena_header_ptrs [MAX_AICPU_THREADS]  ──> DumpArenaHeader
-├── arena_data_ptrs   [MAX_AICPU_THREADS]  ──> arena bytes
-└── arena_sizes       [MAX_AICPU_THREADS]
+└── magic = 0x44554D50 ("DUMP")
 
-DumpBuffer (per-thread, 64 B header + records[])
-  ├── count          (AICPU writes)
-  ├── capacity       (host sets)
-  ├── dropped_count  (AICPU increments when full)
-  └── TensorDumpRecord records[capacity]      ← 128 B each
+DumpBufferState[num_dump_threads]               (per-thread)
+├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
+├── current_buf_ptr            (AICPU active DumpMetaBuffer*)
+├── current_buf_seq
+├── arena_base / arena_size    (per-thread arena pointers)
+├── arena_write_offset         (AICPU monotonic cursor)
+└── dropped_record_count
 
-DumpArenaHeader (per-thread)
-  ├── write_offset   (AICPU monotonic cursor)
-  └── arena_size     (host sets)
+DumpMetaBuffer pool (rotated)                   (BUFFERS_PER_THREAD per thread)
+└── TensorDumpRecord records[RECORDS_PER_BUFFER] + count   ← 128 B each
 
 arena_data (per-thread, circular byte buffer)
   default = BUFFERS_PER_THREAD × RECORDS_PER_BUFFER × AVG_TENSOR_BYTES
@@ -247,10 +246,10 @@ These structs are binary-identical between a2a3 and a5
 `KernelArgs`, not `Runtime` — AICPU reads it from
 `k_args->dump_data_base` in `kernel.cpp` and passes it to
 `set_platform_dump_base()`. Dump enablement is propagated
-separately via the per-worker handshake field
-`enable_profiling_flag` (`bit0 = PROFILING_FLAG_DUMP_TENSOR`), so
-device-side code does not infer "dump enabled" from
-`dump_data_base != 0`.
+separately via the umbrella bitmask `KernelArgs::enable_profiling_flag`
+(`bit0 = PROFILING_FLAG_DUMP_TENSOR`); the AICPU kernel entry calls
+`set_dump_tensor_enabled()` with the decoded bit, so device-side
+code does not infer "dump enabled" from `dump_data_base != 0`.
 
 Each record is fixed at 128 B (two cache lines) — see
 `TensorDumpRecord` in
@@ -337,7 +336,7 @@ poll thread that drains the L2 hand-off queue into
 │ TensorDumpCollector      │               │ AICPU thread             │
 │                          │               │                          │
 │ initialize()             │  alloc +      │ dump_tensor_init()       │
-│   rtMalloc + halRegister │──register────>│   read DumpSetupHeader   │
+│   rtMalloc + halRegister │──register────>│   read DumpDataHeader    │
 │   build DumpDataHeader   │              │   cache per-thread ptrs  │
 │                          │               │                          │
 │ start()                  │               │ per-task run loop:       │
@@ -400,75 +399,126 @@ trait pattern are shared with PMU and L2Perf — see
 [profiling-framework.md](../profiling-framework.md) for the
 framework reference.
 
-### 5.5 a5 — bulk rtMemcpy after stream sync
+### 5.5 a5 — same framework, host-shadow transport
 
-`TensorDumpCollector` allocates the per-thread `DumpBuffer`s and
-arenas on device once, publishes the setup header, and lets the
-device write to them through the run. Collection is a single bulk
-pass driven from the host after `rtStreamSynchronize`: per-thread,
-copy the `DumpBuffer` header to learn the record count, then copy
-`count` records plus the corresponding arena slice in one shot.
+a5's `TensorDumpCollector` derives from
+`ProfilerBase<TensorDumpCollector, DumpModule>` and shares the
+mgmt + poll thread structure with a2a3. The single behavioral
+deviation from §5.4 is the **transport channel**: a5 has no
+`halHostRegister`, so each device buffer is paired with a
+host-shadow `malloc()` and the mgmt loop synchronizes the two via
+`profiling_copy.h` (`rtMemcpy` onboard, `memcpy` in sim).
+`MemoryOps` therefore carries five callbacks (`alloc` / `reg` /
+`free_` / `copy_to_device` / `copy_from_device`); the mgmt loop
+mirrors the entire shm region (`DumpDataHeader` + per-thread
+`DumpBufferState`) device → host at the top of every tick, then
+pushes back only the fields host modified (advanced
+`queue_heads[q]`, refilled `free_queue.tail` and
+`buffer_ptrs[slot]`) via `BufferPoolManager::write_range_to_device`.
+The bulk `mirror_shm_to_device` is **not** called from the mgmt
+loop: it would race with AICPU writes to device-only fields
+(`current_buf_ptr`, `total/dropped` counters, `queue_tails`,
+`free_queue.head`) and roll them back. Each popped
+`DumpMetaBuffer` is still pulled on demand inside
+`ProfilerAlgorithms::process_entry`. The per-thread arena lives
+outside the shm region, so `on_buffer_collected` issues an
+additional `copy_from_device` for the arena bytes referenced by
+the buffer's records.
 
 ```text
         HOST                                         DEVICE
 ┌──────────────────────────┐               ┌──────────────────────────┐
 │ TensorDumpCollector      │               │ AICPU thread             │
+│   : ProfilerBase<...>    │               │                          │
 │                          │               │                          │
-│ initialize()             │  alloc +      │ dump_tensor_init()       │
-│   rtMalloc / malloc      │──copy────────>│   read DumpSetupHeader   │
-│   build DumpSetupHeader  │               │   cache per-thread ptrs  │
-│   copy to device         │               │                          │
-│                          │               │ per-task run loop:       │
-│                          │               │   BEFORE_DISPATCH        │
+│ initialize()             │  alloc + reg  │ dump_tensor_init()       │
+│   rtMalloc shm           │──+ shadow────>│   read DumpDataHeader    │
+│   per-thread arenas      │   memset 0    │   cache per-thread ptrs  │
+│   per-thread             │   + push 0s   │                          │
+│   DumpMetaBuffers        │               │ per-task run loop:       │
+│   register_mapping(s)    │               │   BEFORE_DISPATCH        │
 │                          │               │     dump_tensor_record() │
-│ ── kernel execution ──   │               │   dispatch kernel        │
-│                          │               │   wait FIN               │
-│ rtStreamSynchronize      │               │   AFTER_COMPLETION       │
+│ start(thread_factory)    │               │   dispatch kernel        │
+│   mgmt_thread starts     │               │   wait FIN               │
+│   poll_thread starts     │               │   AFTER_COMPLETION       │
 │                          │               │     dump_tensor_record() │
-│ collect_all()            │  batch        │                          │
-│   2-step per thread:     │<──memcpy─────<│ dump_tensor_flush()      │
-│   1. copy DumpBuffer hdr │               │   log per-thread stats   │
-│      read count          │               └──────────────────────────┘
-│   2. copy records+arena  │
-│                          │
-│ export_dump_files()      │
-│   → <output_prefix>/     │
-│     tensor_dump/         │
-│       tensor_dump.json   │
-│       tensor_dump.bin    │
-└──────────────────────────┘
+│ mgmt every 10us tick:    │               │   if buffer full:        │
+│   copy_from_device(shm)  │<──memcpy─────<│     push ready entry,    │
+│   for each ready entry:  │               │     pop next from free_q │
+│     copy buf from device │<──memcpy─────<│                          │
+│     resolve host ptr     │               │ dump_tensor_flush():     │
+│     push to L2 ready_q   │               │   push remaining buffers │
+│   advance queue_heads,   │               │   to ready_q             │
+│     refill free_queues   │               │                          │
+│   write_range_to_device  │──memcpy──────>│                          │
+│     for each modified    │               │                          │
+│     field                │               │                          │
+│                          │               │                          │
+│ poll thread:             │               │                          │
+│   wait_pop_ready          │               │                          │
+│   on_buffer_collected →  │               │                          │
+│     copy arena slice     │<──memcpy─────<│                          │
+│     extract DumpedTensors│               │                          │
+│     queue to writer thrd │               │                          │
+│   notify_copy_done       │               │                          │
+│                          │               │                          │
+│ rtStreamSynchronize      │               │                          │
+│ stop()                   │               │                          │
+│   join mgmt + poll       │               │                          │
+│ reconcile_counters()     │               │                          │
+│   sanity-check leftovers │               │                          │
+│   + dropped accounting   │               │                          │
+│ export_dump_files()      │               │                          │
+│   → <output_prefix>/     │               │                          │
+│     tensor_dump/...      │               │                          │
+└──────────────────────────┘               └──────────────────────────┘
 ```
 
 **Lifecycle** (`device_runner.cpp`):
 
 ```text
 init_tensor_dump()
-  dump_collector_.initialize(...)
-  kernel_args_.args.dump_data_base = dump_collector_.get_dump_setup_device_ptr()
+  dump_collector_.initialize(num_dump_threads, ..., output_prefix_)
+  kernel_args_.args.dump_data_base = dump_collector_.get_dump_shm_device_ptr()
+dump_collector_.start(thread_factory)   ← mgmt + poll threads
 launch AICPU / AICore
-rtStreamSynchronize                ← wait for kernel completion
-collect_all()                      ← batch memcpy all buffers back
-export_dump_files()
+rtStreamSynchronize
+dump_collector_.stop()                  ← join mgmt + poll, drain final batch
+dump_collector_.reconcile_counters()    ← sanity-check + dropped accounting
+dump_collector_.export_dump_files()
+dump_collector_.finalize()
 ```
 
 [`TensorDumpCollector`](../src/a5/platform/include/host/tensor_dump_collector.h)
-on a5 is self-contained — `initialize` / `collect_all` /
-`export_dump_files` / `finalize`. `collect_all()` is the
-synchronous batch drain after stream sync; there are no helper
-threads to coordinate, so the a5 collector does not derive from
-`ProfilerBase`.
+on a5 inherits the same CRTP base
+([`profiling_common::ProfilerBase`](../src/a5/platform/include/host/profiling_common/profiler_base.h))
+as a2a3 and parameterizes
+[`BufferPoolManager`](../src/a5/platform/include/host/profiling_common/buffer_pool_manager.h)
+with `DumpModule`. The only a5-specific glue is the 5-callback
+`MemoryOps`, the per-tick shm mirror, and the on-demand arena copy
+inside `on_buffer_collected`.
+
+a5's per-thread AICPU flush (`dump_tensor_flush`) is the only data
+path on the records side — host never reads from `current_buf_ptr`
+to recover records. `reconcile_counters` is purely passive: it logs
+an error if any `current_buf_ptr` is non-zero with a non-empty buffer
+(a device-flush bug), then accumulates each thread's
+`dropped_record_count` for the final anomaly report.
 
 ### 5.6 a2a3 vs a5 at a glance
 
 | Aspect | a2a3 | a5 |
 | ------ | ---- | -- |
-| Device-side layout | identical (same `DumpSetupHeader` / `DumpBuffer` / `DumpArenaHeader`, `static_assert`-checked) | |
+| Device-side layout | identical (same `DumpDataHeader` / `DumpMetaBuffer` / arena shape, `static_assert`-checked) | |
 | AICPU recording logic | identical | |
-| Host transport | `halHostRegister` shared memory | `rtMemcpy` after `rtStreamSynchronize` |
-| Buffer model | rotating pool (free + ready queues per thread) | one `DumpBuffer` + arena per thread |
-| Host threads | mgmt + poll, streams during execution | drain after sync |
-| Host-class shape | `ProfilerBase` subclass (mgmt + poll thread + `BufferPoolManager<DumpModule>`) | self-contained `initialize`/`collect_all`/`finalize` |
-| Lifecycle | `initialize` → `start` → `stop` → `reconcile_counters` → `export_dump_files` → `finalize` | `initialize` → `collect_all` → `export_dump_files` → `finalize` |
+| Buffer model | rotating pool (free + ready queues per thread) | identical |
+| Host threads | mgmt + poll, streams during execution | identical |
+| Host-class shape | `ProfilerBase<TensorDumpCollector, DumpModule>` | identical |
+| Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
+| `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
+| Arena access | direct via SVM | `copy_from_device` inside `on_buffer_collected` |
+| `reconcile_counters` | passive sanity check + dropped accounting | identical |
+| Lifecycle | `initialize` → `start` → `stop` → `reconcile_counters` → `export_dump_files` → `finalize` | identical |
 
 ## 6. Overhead
 

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -1,13 +1,19 @@
 # Profiling Framework
 
-Shared host-side infrastructure under
-[`src/a2a3/platform/include/host/profiling_common/`](../src/a2a3/platform/include/host/profiling_common/)
-that the PMU, L2Perf, and TensorDump collectors are built on. This page is
-the framework reference; the per-collector pages
+Shared host-side infrastructure that the PMU, L2Perf, and TensorDump
+collectors are built on. Each architecture maintains its own copy of the
+framework headers under `src/<arch>/platform/include/host/profiling_common/`
+([a2a3](../src/a2a3/platform/include/host/profiling_common/),
+[a5](../src/a5/platform/include/host/profiling_common/)) — the two copies
+are kept byte-for-byte structurally aligned so reviewers can diff them, but
+each arch is free to evolve independently. This page describes the shape;
+§8 covers the a5-specific deviations driven by transport differences.
+
+The per-collector pages
 ([pmu-profiling.md](dfx/pmu-profiling.md),
 [l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md),
 [tensor-dump.md](dfx/tensor-dump.md))
-describe the data they collect and how they enable it on-device.
+describe the data each subsystem collects and how it enables it on-device.
 
 ## 1. Why a shared framework
 
@@ -295,3 +301,96 @@ Existing collectors are the canonical examples:
   — two kinds (perf records + phase markers), per-core / per-thread
   instances; the canonical multi-kind example. See
   [l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md).
+
+## 8. a5 specifics — host-shadow transport
+
+a5's framework headers (under
+[`src/a5/platform/include/host/profiling_common/`](../src/a5/platform/include/host/profiling_common/))
+mirror a2a3's class shapes — same `ProfilerBase<Derived, Module>` /
+`BufferPoolManager<Module>` / `ProfilerAlgorithms<Module>` decomposition,
+same Module concept contract, same start/stop lifecycle. The only
+behavioral deviation is the **transport channel**: a5 has no
+`halHostRegister`, so device↔host synchronization goes through
+`profiling_copy.h` (`rtMemcpy` onboard, `memcpy` in sim) against a
+host-shadow `malloc()` paired with each device buffer. Three mechanical
+changes capture that:
+
+1. **`MemoryOps` carries 5 callbacks instead of 3.** In addition to
+   `alloc` / `reg` / `free_`, a5 adds `copy_to_device` and
+   `copy_from_device`. `reg` allocates the paired host shadow (instead of
+   mapping a HAL view onto the device pointer); a default
+   `default_host_shadow_register` (`malloc + memset 0 + copy_to_device`)
+   is installed when the collector passes `nullptr` for `register_cb`.
+2. **The mgmt loop mirrors the shm region into the host shadow per tick,
+   then writes back only the fields it modified.** At the top of every
+   tick the loop calls `manager_.mirror_shm_from_device()` to pull the
+   `DataHeader` (with its `queue_tails`) and all `BufferState`s into the
+   host shadow. As host advances `queue_heads[q]` or refills a
+   `free_queue.tail` / `buffer_ptrs[slot]`, those individual fields are
+   pushed back to device with `manager_.write_range_to_device(&field,
+   sizeof(field))`. The bulk `mirror_shm_to_device` is deliberately
+   **not** called from the mgmt loop — it would race with AICPU writes
+   to device-only fields (`current_buf_ptr`, `total/dropped/mismatch`
+   counters, `queue_tails`, `free_queue.head`,
+   `AicpuPhaseHeader::magic`, `orch_summary`, `core_to_thread[]`),
+   rolling them back to whatever the host shadow had at the start of
+   the tick. Per-buffer payloads (`L2PerfBuffer` / `PmuBuffer` /
+   `DumpMetaBuffer`) are still pulled on demand inside
+   `ProfilerAlgorithms::process_entry` after resolving the host pointer
+   for a popped ready entry. The bulk `mirror_shm_to_device` is kept
+   for init/teardown where AICPU is not yet running or has exited.
+3. **`release_owned_buffers` frees the paired host shadow.** When the
+   framework recycles a device buffer at finalize time, it also frees the
+   `malloc()`'d shadow tracked in `dev_to_host_`. `clear_mappings()` does
+   the same for any remaining mappings (per-state buffers and the shm
+   region itself).
+
+Each collector's `reconcile_counters` is purely passive — same shape as
+a2a3. It pulls the post-`stop()` `BufferState`s, logs an error if any
+`current_buf_ptr` still references a non-empty buffer (a device flush
+bug, since AICPU is the only writer that can clear it), and runs the
+three-bucket cross-check
+`collected_on_host + dropped + mismatch == device_total` against
+device-side counters per pool. Host never reads from `current_buf_ptr`
+to recover records — recovering would mask AICPU flush bugs.
+
+### 8.1 Profiling state lives on `KernelArgs`, not `Handshake`
+
+a5 carries the same "profiling out of the runtime synchronization protocol"
+design as a2a3 (PR #714) plus the AICore-side rings of PR #709. The runtime
+`Handshake` struct contains **no profiling fields** — enablement bits and
+per-core ring/reg addresses travel through `KernelArgs`:
+
+| `KernelArgs` field | Producer | Consumer |
+| ------------------ | -------- | -------- |
+| `enable_profiling_flag` (bitmask) | host (DeviceRunner) | AICPU `kernel.cpp` → `set_l2_swimlane_enabled` / `set_pmu_enabled` / `set_dump_tensor_enabled`; AICore `KERNEL_ENTRY` → `set_aicore_profiling_flag` |
+| `aicore_l2_perf_ring_addrs` (table) | host (`L2PerfCollector::initialize`) | AICore `KERNEL_ENTRY` indexes `table[block_idx]` → `set_aicore_l2_perf_ring` |
+| `aicore_pmu_ring_addrs` (table) | host (`PmuCollector::init`) | AICore `KERNEL_ENTRY` → `set_aicore_pmu_ring` |
+| `regs` (per-physical-core register-base table) | host (already required for AICPU MMIO) | AICore `KERNEL_ENTRY` resolves `regs[get_physical_core_id()]` → `set_aicore_pmu_reg_base`; AICore `aicore_execute` caches the value at Phase-3 |
+
+AICore's per-core profiling slots live in
+[`aicore/aicore_profiling_state.h`](../src/a5/platform/include/aicore/aicore_profiling_state.h)
+— `[[block_local]]` static on onboard, `pthread_key_t` TLS in sim. The
+runtime `aicore_execute(runtime, block_idx, core_type)` signature is
+unchanged; adding a new profiling field touches `KernelArgs` and this
+state surface, never the runtime protocol.
+
+### 8.2 Stable AICore staging ring (decouples AICore write from AICPU buffer rotation)
+
+L2Perf and PMU on a5 both use the "AICore writes, AICPU commits" model.
+The AICore-side write target is a per-core
+[`L2PerfAicoreRing`](../src/a5/platform/include/common/l2_perf_profiling.h) /
+[`PmuAicoreRing`](../src/a5/platform/include/common/pmu_profiling.h) of
+`PLATFORM_{L2,PMU}_AICORE_RING_SIZE` (= 2, dual-issue) slots, allocated
+once by the host and addressed by
+`BufferState::aicore_ring_ptr` (AICPU-visible) and the per-core
+`aicore_*_ring_addrs[block_idx]` (AICore-visible). The address is
+never reassigned, so AICore's write target is stable across AICPU's
+rotating `L2PerfBuffer` / `PmuBuffer` flips — flipping is now
+fully internal to `*_complete_record` and never crosses into Handshake.
+
+Everything else — Module concept contract, alloc policy
+(1-in/1-out + proactive replenish), `kIdleTimeoutSec` / `kSubsystemName`
+contract, mgmt-then-poll start/stop ordering, buffer-pool sizing
+constants — matches a2a3 exactly. New collectors should be reviewed
+against both arches when added.

--- a/src/a5/platform/include/aicore/aicore_profiling_state.h
+++ b/src/a5/platform/include/aicore/aicore_profiling_state.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * @file aicore_profiling_state.h
+ * @brief AICore-side per-core profiling state set/get interface.
+ *
+ * Mirrors the AICPU-side `set_l2_swimlane_enabled` / `set_pmu_enabled` /
+ * etc. setters: the platform owns a per-core slot for profiling state,
+ * populated once by the AICore kernel entry from `KernelArgs`, and read by
+ * `aicore_execute` via getters. Runtime never touches the underlying
+ * storage, so adding profiling fields does not change `aicore_execute`'s
+ * signature or the runtime's `Handshake` struct.
+ *
+ * Storage backend:
+ *   - onboard: `[[block_local]]` static variables in aicore/kernel.cpp
+ *   - sim:     pthread TLS in aicore/kernel.cpp
+ *
+ * Lifecycle:
+ *   1. Host fills `KernelArgs::enable_profiling_flag`, the two per-core
+ *      ring address arrays (`aicore_l2_perf_ring_addrs`,
+ *      `aicore_pmu_ring_addrs`), and `regs` (the per-physical-core
+ *      register-base array — already required for AICPU).
+ *   2. AICore kernel entry indexes the ring arrays by `block_idx` and
+ *      resolves its own PMU MMIO base from `regs[physical_core_id]`,
+ *      then calls the matching setters before invoking `aicore_execute`.
+ *   3. `aicore_execute` and downstream profiling helpers read via getters.
+ *
+ * a5 specifics: PMU on a5 is AICore-side (AICore reads MMIO + writes the
+ * staging slot), so a5 carries an extra `pmu_ring` + `pmu_reg_base` pair
+ * that a2a3 does not have.
+ */
+
+#ifndef PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
+#define PLATFORM_AICORE_AICORE_PROFILING_STATE_H_
+
+#include <cstdint>
+
+#include "aicore/aicore.h"
+#include "common/l2_perf_profiling.h"
+#include "common/pmu_profiling.h"
+
+/**
+ * Profiling enable bitmask (umbrella over dump_tensor / l2_swimlane / pmu).
+ * Same layout as `KernelArgs::enable_profiling_flag`. AICore reads via
+ * `GET_PROFILING_FLAG(get_aicore_profiling_flag(), PROFILING_FLAG_*)`.
+ */
+__aicore__ void set_aicore_profiling_flag(uint32_t flag);
+__aicore__ uint32_t get_aicore_profiling_flag();
+
+/**
+ * Per-core L2Perf staging ring. Set once at kernel entry from
+ * `((__gm__ uint64_t*)k_args->aicore_l2_perf_ring_addrs)[block_idx]`;
+ * nullptr when the L2 swimlane bit is off or the address table is null.
+ */
+__aicore__ void set_aicore_l2_perf_ring(__gm__ L2PerfAicoreRing *ring);
+__aicore__ __gm__ L2PerfAicoreRing *get_aicore_l2_perf_ring();
+
+/**
+ * Per-core PMU staging ring (a5-only — AICore writes the snapshot).
+ */
+__aicore__ void set_aicore_pmu_ring(__gm__ PmuAicoreRing *ring);
+__aicore__ __gm__ PmuAicoreRing *get_aicore_pmu_ring();
+
+/**
+ * Per-core PMU MMIO base (a5-only). AICore at kernel entry resolves this
+ * once from `((__gm__ uint64_t*)k_args->regs)[get_physical_core_id()]`
+ * and stashes the value via the setter; the getter just returns the
+ * stored value. `regs` is filled by the host before kernel launch, so the
+ * resolved base is valid from Phase 1 onward without depending on any
+ * AICPU-side init ordering.
+ */
+__aicore__ void set_aicore_pmu_reg_base(uint64_t reg_base);
+__aicore__ uint64_t get_aicore_pmu_reg_base();
+
+#endif  // PLATFORM_AICORE_AICORE_PROFILING_STATE_H_

--- a/src/a5/platform/include/aicore/l2_perf_collector_aicore.h
+++ b/src/a5/platform/include/aicore/l2_perf_collector_aicore.h
@@ -19,8 +19,9 @@
 #ifndef PLATFORM_AICORE_L2_PERF_COLLECTOR_AICORE_H_
 #define PLATFORM_AICORE_L2_PERF_COLLECTOR_AICORE_H_
 
-#include "common/l2_perf_profiling.h"
 #include "aicore/aicore.h"
+#include "common/l2_perf_profiling.h"
+#include "common/platform_config.h"
 
 // Include platform-specific timestamp implementation
 // Build system selects the correct inner_kernel.h based on platform:
@@ -34,25 +35,35 @@
 /**
  * Record task execution performance data
  *
- * Writes timing metrics to the WIP staging slot (wip[task_id & 1]).
- * Buffer management and final commit are handled by AICPU.
+ * Writes timing metrics to the per-core L2PerfAicoreRing slot
+ * (`dual_issue_slots[task_id % PLATFORM_L2_AICORE_RING_SIZE]`). The
+ * ring is allocated once by the host and never reassigned, so AICore writes
+ * to a stable address regardless of AICPU buffer rotations. AICPU reads the
+ * slot in `l2_perf_aicpu_complete_record` and commits the record into the
+ * rotating L2PerfBuffer.
  *
  * AICore writes L2PerfRecord.task_id as the register dispatch token (low 32 bits, zero-extended).
  * For tensormap_and_ringbuffer, AICPU overwrites with the full (ring_id << 32) | local_id
  * encoding after handshake match.
  *
- * @param l2_perf_buf Performance buffer pointer
- * @param task_id Register dispatch id (DATA_MAIN_BASE), stored in task_id low 32 bits
- * @param start_time Start timestamp
- * @param end_time End timestamp
+ * @param ring        Per-core L2PerfAicoreRing pointer (from get_aicore_l2_perf_ring())
+ * @param task_id     Register dispatch id (DATA_MAIN_BASE), stored in task_id low 32 bits
+ * @param start_time  Start timestamp
+ * @param end_time    End timestamp
  */
 __aicore__ __attribute__((always_inline)) static inline void
-l2_perf_aicore_record_task(__gm__ L2PerfBuffer *l2_perf_buf, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
-    // Write to WIP staging slot — parity alternates with dual-slot dispatch
-    __gm__ L2PerfRecord *record = &l2_perf_buf->wip[task_id & 1u];
+l2_perf_aicore_record_task(__gm__ L2PerfAicoreRing *ring, uint32_t task_id, uint64_t start_time, uint64_t end_time) {
+    // Modulo-indexed slot. PLATFORM_L2_AICORE_RING_SIZE is conventionally a
+    // power of two so the compiler reduces this to a mask, but using `%`
+    // keeps the index correct if the ring size is ever retuned to a
+    // non-power-of-two value (matches the a2a3 convention).
+    __gm__ L2PerfRecord *record = &ring->dual_issue_slots[task_id % PLATFORM_L2_AICORE_RING_SIZE];
 
     record->start_time = start_time;
     record->end_time = end_time;
+
+    // Publish task_id last so AICPU can validate the slot is ready.
+    OUT_OF_ORDER_STORE_BARRIER();
     record->task_id = static_cast<uint64_t>(task_id);
 
     // Flush cache to make data visible to AICPU

--- a/src/a5/platform/include/aicore/pmu_collector_aicore.h
+++ b/src/a5/platform/include/aicore/pmu_collector_aicore.h
@@ -17,15 +17,16 @@
  *     and restores them at finalize.
  *   - AICore gates counting around each kernel execution via CTRL SPR bit 0
  *     (pmu_aicore_begin / pmu_aicore_end), reads the 10 PMU counters +
- *     PMU_CNT_TOTAL via MMIO using the handshake-supplied reg_base, and
- *     writes the snapshot into PmuBuffer::dual_issue_slots[task_id & 1].
+ *     PMU_CNT_TOTAL via MMIO using the per-core reg_base obtained from
+ *     `get_aicore_pmu_reg_base()`, and writes the snapshot into
+ *     PmuAicoreRing::dual_issue_slots[task_id % RING_SIZE].
  *   - AICPU, on COND FIN, validates the slot and copies it into
  *     PmuBuffer::records[count] while filling func_id / core_type
  *     (pmu_aicpu_complete_record).
  *
- * The two dual_issue_slots exist because AICore's dual-issue dispatch
- * can have up to two tasks in flight per core — the parity task_id & 1
- * keeps N and N+1 from colliding.
+ * PLATFORM_PMU_AICORE_RING_SIZE dual-issue slots exist because AICore's
+ * dual-issue dispatch can have up to two tasks in flight per core — the
+ * parity task_id % RING_SIZE keeps N and N+1 from colliding.
  */
 
 #ifndef PLATFORM_AICORE_PMU_COLLECTOR_AICORE_H_
@@ -53,25 +54,25 @@ __aicore__ __attribute__((always_inline)) static inline void pmu_aicore_end() {
 }
 
 /**
- * Record PMU counters for one completed task into the dual-issue slot
- * (AICore-side producer half of the PMU record path).
+ * Record PMU counters for one completed task into the per-core staging-ring
+ * dual-issue slot (AICore-side producer half of the PMU record path).
  *
  * Must be called after pmu_aicore_end() has frozen the counters.
  * AICPU picks up the slot and commits it via pmu_aicpu_complete_record.
  *
  * Leaves func_id and core_type untouched — those are AICPU-owned fields.
  *
- * @param buf       Per-core PmuBuffer (from Handshake.pmu_buffer_addr)
- * @param reg_base  Per-core PMU MMIO base (from Handshake.pmu_reg_base)
+ * @param ring      Per-core PmuAicoreRing (from get_aicore_pmu_ring())
+ * @param reg_base  Per-core PMU MMIO base (from get_aicore_pmu_reg_base())
  * @param task_id   Register dispatch token (DATA_MAIN_BASE value for this task)
  */
 __aicore__ __attribute__((always_inline)) static inline void
-pmu_aicore_record_task(__gm__ PmuBuffer *buf, uint64_t reg_base, uint32_t task_id) {
-    if (buf == nullptr || reg_base == 0) {
+pmu_aicore_record_task(__gm__ PmuAicoreRing *ring, uint64_t reg_base, uint32_t task_id) {
+    if (ring == nullptr || reg_base == 0) {
         return;
     }
 
-    __gm__ PmuRecord *slot = &buf->dual_issue_slots[task_id & 1u];
+    __gm__ PmuRecord *slot = &ring->dual_issue_slots[task_id % PLATFORM_PMU_AICORE_RING_SIZE];
 
     // Read the 10 event counters + 64-bit cycle counter via the AICore MMIO
     // load intrinsic ld_dev(base, offset) — the only legal way for AICore to

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -19,8 +19,8 @@
 #ifndef PLATFORM_AICPU_L2_PERF_COLLECTOR_AICPU_H_
 #define PLATFORM_AICPU_L2_PERF_COLLECTOR_AICPU_H_
 
+#include "common/core_type.h"
 #include "common/l2_perf_profiling.h"
-#include "runtime.h"
 
 // Include platform-specific timestamp implementation
 // Build system selects the correct inner_aicpu.h based on platform:
@@ -30,9 +30,9 @@
 // ============= Public Interface =============
 
 /**
- * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
- * entry (onboard) before `l2_perf_aicpu_init_profiling()` so AICPU code can
- * read perf state without reaching into the generic `Runtime` struct.
+ * L2 perf platform setters — called by the host (sim) or the AICPU kernel
+ * entry (onboard) before `l2_perf_aicpu_init()` so AICPU code can read perf
+ * state without reaching into the generic `Runtime` struct.
  */
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
 extern "C" uint64_t get_platform_l2_perf_base();
@@ -40,23 +40,29 @@ extern "C" void set_l2_swimlane_enabled(bool enable);
 extern "C" bool is_l2_swimlane_enabled();
 
 /**
- * Initialize performance profiling
+ * Initialize performance profiling for `worker_count` cores.
  *
- * Sets up double buffers for each core and initializes tracking state.
- * Reads the perf device-base pointer published via `set_platform_l2_perf_base()`.
+ * Caches per-core BufferState (including stable AICore staging-ring
+ * pointers `state.aicore_ring_ptr`) and pops the initial L2PerfBuffer from
+ * each free_queue. Reads the perf device-base pointer published via
+ * `set_platform_l2_perf_base()`. Does **not** write any Handshake field —
+ * profiling state lives in `KernelArgs` + AICore platform-owned slots.
  *
- * @param runtime Runtime instance pointer (used for worker_count / task_count only)
+ * @param worker_count Number of active AICore workers
  */
-void l2_perf_aicpu_init_profiling(Runtime *runtime);
+void l2_perf_aicpu_init(int worker_count);
 
 /**
  * Complete a L2PerfRecord with AICPU-side metadata after AICore task completion
  *
- * Reads l2_perf_buf->count, validates task_id match against the latest record,
- * and fills all AICPU-side fields. Callers must pre-extract fanout into a
- * plain uint64_t array (platform layer cannot depend on runtime linked-list types).
+ * Reads from the per-core L2PerfAicoreRing dual-issue slot
+ * (`s_perf_aicore_rings[core_id]->dual_issue_slots[reg_task_id & ...]`),
+ * validates task_id match, and commits the record into
+ * `state->current_buf_ptr->records[count++]`. Callers must pre-extract
+ * fanout into a plain uint64_t array (platform layer cannot depend on
+ * runtime linked-list types).
  *
- * @param l2_perf_buf           L2PerfBuffer pointer (from handshake l2_perf_records_addr)
+ * @param core_id               Core ID owning the destination buffer (resolved via s_perf_buffer_states)
  * @param expected_reg_task_id  Register dispatch token (low 32 bits) to validate
  * @param task_id               Task identifier to write (PTO2 encoding or plain id)
  * @param func_id               Kernel function identifier
@@ -65,24 +71,15 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime);
  * @param finish_time           AICPU timestamp when task completion was observed
  * @param fanout                Pre-extracted successor task ID array (nullptr if none)
  * @param fanout_count          Number of entries in fanout array (0 if none)
+ *
+ * Routes the destination via state->current_buf_ptr (not Handshake), so that
+ * flush()-clearing current_buf_ptr deterministically halts subsequent commits
+ * (they take the dropped path). Same shape as a2a3.
  */
 int l2_perf_aicpu_complete_record(
-    L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
+    int core_id, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
     uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
 );
-
-/**
- * Switch performance buffer when current buffer is full
- *
- * Enqueues the full buffer to ReadyQueue, pops a new buffer from FreeQueue,
- * and updates the handshake l2_perf_records_addr. If FreeQueue is empty,
- * overwrites the current buffer (lossy fallback).
- *
- * @param runtime Runtime instance pointer
- * @param core_id Core ID
- * @param thread_idx Thread index
- */
-void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
 
 /**
  * Flush remaining performance data
@@ -96,25 +93,15 @@ void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx);
 void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num);
 
 /**
- * Update total task count in performance header
- *
- * Allows dynamic update of total_tasks as orchestrator makes progress.
- * Used by tensormap_and_ringbuffer runtime where task count grows incrementally.
- *
- * @param total_tasks Current total task count
- */
-void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks);
-
-/**
  * Initialize AICPU phase profiling
  *
  * Sets up AicpuPhaseHeader and clears per-thread phase record buffers.
- * Must be called once from thread 0 after l2_perf_aicpu_init_profiling().
+ * Must be called once from thread 0 after l2_perf_aicpu_init().
  *
- * @param runtime Runtime instance pointer
+ * @param worker_count Number of AICore workers (used to locate phase region)
  * @param num_sched_threads Number of scheduler threads
  */
-void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads);
+void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads);
 
 /**
  * Record a single scheduler phase

--- a/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/pmu_collector_aicpu.h
@@ -17,8 +17,9 @@
  *   pmu_aicpu_init()              — resolve per-core PMU MMIO bases + buffer
  *                                   pointers, program events, start counters,
  *                                   pop initial PmuBuffers from free_queues,
- *                                   publish (pmu_buffer_addr, pmu_reg_base)
- *                                   to each Handshake.
+ *                                   and cache the per-core stable
+ *                                   PmuAicoreRing pointer.
+ *                                   Profiling state never goes through Handshake.
  *   [task loop]
  *     pmu_aicpu_complete_record()     — copy the dual-issue slot AICore wrote
  *                                   into PmuBuffer::records[count], filling
@@ -37,7 +38,6 @@
 
 #include "common/core_type.h"
 #include "common/pmu_profiling.h"
-#include "runtime.h"  // Handshake
 
 extern "C" void set_platform_pmu_base(uint64_t pmu_data_base);
 extern "C" uint64_t get_platform_pmu_base();
@@ -49,32 +49,33 @@ extern "C" bool is_pmu_enabled();
  *
  * For each logical core i in [0, num_cores):
  *   - Resolve the PMU MMIO base from physical_core_ids[i] via the platform's
- *     PMU reg-addr table.
+ *     register-base table (`get_platform_regs()`).
  *   - Program event selectors (PMU_CNT0_IDX..CNT9_IDX).
  *   - Start counters (set PMU_CTRL_0 and PMU_CTRL_1).
  *   - Pop an initial PmuBuffer from the per-core free_queue.
- *   - Publish (pmu_buffer_addr, pmu_reg_base) into handshakes[i] so the
- *     matching AICore can read PMU MMIO and write the dual-issue slot.
+ *   - Cache the per-core stable PmuAicoreRing pointer (host-published into
+ *     PmuBufferState::aicore_ring_ptr at SHM init time) so the PMU
+ *     complete-path can read AICore-written slots without touching SHM.
+ *
+ * AICore resolves its own MMIO base independently at kernel entry from the
+ * same `regs` table via `regs[get_physical_core_id()]`, so this init does
+ * **not** need to publish a separate per-core table for AICore.
  *
  * On sim (or when a core has no PMU reg addr), the core is skipped for MMIO
- * programming. The handshake fields still carry whatever reg_base the
- * platform reg table returns (0 on sim for missing entries), so AICore
- * no-ops the read if reg_base is 0.
+ * programming. AICore no-ops the read if its resolved reg_base is 0.
  *
- * Must be called after the host has published pmu_data_base (via
- * set_platform_pmu_base) and after every active core has reported its
- * physical_core_id via handshake. Must be called BEFORE the caller
- * sets aicpu_regs_ready=1 on each handshake.
+ * Profiling state lives outside Handshake — this function does **not**
+ * touch any Handshake field.
  *
- * @param handshakes         Handshake array (one per core)
- * @param physical_core_ids  Array of hardware physical core ids
- * @param num_cores          Number of active cores
+ * @param physical_core_ids   Array of hardware physical core ids (length num_cores)
+ * @param num_cores           Number of active AICore workers
  */
-void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, int num_cores);
+void pmu_aicpu_init(const uint32_t *physical_core_ids, int num_cores);
 
 /**
- * Commit one PmuRecord from the dual-issue staging slot.
- * Switches buffer via SPSC free_queue/ready_queue when full.
+ * Commit one PmuRecord from the per-core stable AICore staging-ring slot.
+ * Switches the rotating PmuBuffer via SPSC free_queue/ready_queue when full;
+ * the AICore staging ring address is never reassigned.
  *
  * @param core_id     Logical core index
  * @param thread_idx  AICPU thread index (selects ready_queue)

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -65,15 +65,22 @@ extern "C" {
  *       - AICore: receives Runtime* pointer with workers at offset 0
  */
 struct KernelArgs {
-    uint64_t unused[5] = {0};          // Alignment padding (required by CANN runtime offset)
-    DeviceArgs *device_args{nullptr};  // Device arguments (AICPU reads, contains SO info)
-    Runtime *runtime_args{nullptr};    // Task runtime in device memory
-    uint64_t regs{0};                  // Per-core register base address array (platform-specific)
-    uint64_t dump_data_base{0};        // Dump shared memory base address; use explicit flags to detect enablement
-    uint64_t l2_perf_data_base{0};     // L2 perf shared memory base address; use explicit flags to detect enablement
-    uint64_t pmu_data_base{0};         // PMU buffer base address (device memory); 0 = PMU disabled
-    uint32_t log_level{1};             // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
-    uint32_t log_info_v{5};            // INFO verbosity threshold (0..9); default V5
+    uint64_t unused[5] = {0};                               // Alignment padding (required by CANN runtime offset)
+    DeviceArgs *device_args{nullptr};                       // Device arguments (AICPU reads, contains SO info)
+    __may_used_by_aicore__ Runtime *runtime_args{nullptr};  // Task runtime in device memory
+    uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
+    uint64_t dump_data_base{0};     // Dump shared memory base address; use explicit flags to detect enablement
+    uint64_t l2_perf_data_base{0};  // L2 perf shared memory base address; use explicit flags to detect enablement
+    uint64_t pmu_data_base{0};      // PMU buffer base address (device memory); 0 = PMU disabled
+    // Profiling per-core address arrays (moved out of Handshake). Each *_addrs
+    // field is a device pointer to uint64_t[num_aicore]. AICore KERNEL_ENTRY
+    // indexes by block_idx and forwards into per-core platform state.
+    uint64_t aicore_l2_perf_ring_addrs{0};  // L2PerfAicoreRing* per core; 0 when L2 swimlane is off
+    uint64_t aicore_pmu_ring_addrs{0};      // PmuAicoreRing* per core; 0 when PMU is off
+    uint32_t log_level{1};                  // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
+    uint32_t log_info_v{5};                 // INFO verbosity threshold (0..9); default V5
+    uint32_t enable_profiling_flag{0};      // Profiling umbrella bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
+    uint32_t _pad{0};                       // Alignment padding
 };
 
 #ifdef __cplusplus

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -98,20 +98,41 @@ struct L2PerfRecord {
 static_assert(sizeof(L2PerfRecord) % 64 == 0, "L2PerfRecord must be 64-byte aligned for optimal cache performance");
 
 // =============================================================================
-// L2PerfBuffer - Fixed-Size Record Buffer with WIP Staging Slots
+// L2PerfAicoreRing - Stable AICore→AICPU Staging Ring (per core, never rotated)
+// =============================================================================
+
+/**
+ * Per-core staging ring written exclusively by AICore.
+ *
+ * AICore stores each task's timing in `dual_issue_slots[reg_task_id %
+ * PLATFORM_L2_AICORE_RING_SIZE]` and never touches any other L2Perf
+ * memory. The ring is allocated once by the host, addressed through
+ * `L2PerfBufferState[block_idx].aicore_ring_ptr` (also published into the
+ * `KernelArgs::aicore_l2_perf_ring_addrs` the AICore kernel entry
+ * forwards into `set_aicore_l2_perf_ring()`), and lives for the entire run
+ * — its address is never reassigned, decoupling AICore writes from the
+ * AICPU's records-buffer rotation.
+ */
+struct L2PerfAicoreRing {
+    L2PerfRecord dual_issue_slots[PLATFORM_L2_AICORE_RING_SIZE];
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// L2PerfBuffer - Fixed-Size Record Buffer (AICPU-only)
 // =============================================================================
 
 /**
  * Fixed-size performance record buffer
  *
  * Capacity: PLATFORM_PROF_BUFFER_SIZE (defined in platform_config.h)
- * Allocated dynamically by Host, pushed into per-core free_queue.
+ * Allocated dynamically by Host, pushed into per-core free_queue, rotated
+ * by AICPU when full.
  *
- * WIP protocol: AICore writes timing to wip[reg_task_id & 1], AICPU copies
- * it into records[count] at completion. Dual-slot parity ensures no overlap.
+ * Owned and written exclusively by AICPU: AICore never touches this memory.
+ * AICPU reads timing from L2PerfAicoreRing::dual_issue_slots, fills in the
+ * AICPU-side fields, then commits into records[count++].
  */
 struct L2PerfBuffer {
-    L2PerfRecord wip[2];                              // AICore WIP staging slots (index = reg_task_id & 1)
     L2PerfRecord records[PLATFORM_PROF_BUFFER_SIZE];  // Committed records (AICPU writes)
     volatile uint32_t count;                          // Current committed record count
 } __attribute__((aligned(64)));
@@ -154,23 +175,39 @@ static_assert(sizeof(L2PerfFreeQueue) == 128, "L2PerfFreeQueue must be 128 bytes
  * Contains:
  * - free_queue: SPSC queue of available buffer addresses
  * - current_buf_ptr: Currently active buffer being written (0 = no active buffer)
+ * - aicore_ring_ptr: Stable per-core L2PerfAicoreRing address (L2PerfRecord
+ *   profiling only; unused by Phase profiling). Set by host at init, read by
+ *   AICPU in `l2_perf_aicpu_complete_record` to read the AICore-published
+ *   timing slots. Never reassigned during the run.
  * - current_buf_seq: Monotonic sequence number for ordering
+ * - total_record_count / dropped_record_count / mismatch_record_count:
+ *   per-core/-thread tallies AICPU keeps so the host can cross-check
+ *   `collected + dropped + mismatch == device_total` at end-of-run.
+ *   `mismatch_record_count` accounts for ring slot/task_id invariant
+ *   violations (a hard error class, distinct from capacity drops).
  *
  * Used in two contexts:
- * - Per-core L2PerfRecord profiling (current_buf_ptr → L2PerfBuffer)
- * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer)
+ * - Per-core L2PerfRecord profiling (current_buf_ptr → L2PerfBuffer,
+ *   aicore_ring_ptr → L2PerfAicoreRing)
+ * - Per-thread Phase profiling (current_buf_ptr → PhaseBuffer,
+ *   aicore_ring_ptr / mismatch_record_count unused)
  *
  * Writers:
  * - free_queue.tail: Host writes (pushes new buffers)
  * - free_queue.head: Device writes (pops buffers)
  * - current_buf_ptr: Device writes (after pop), Host reads (for flush/collect)
  * - current_buf_seq: Device writes (monotonic counter)
+ * - aicore_ring_ptr: Host writes once at init, AICPU reads
  */
 struct L2PerfBufferState {
-    L2PerfFreeQueue free_queue;         // SPSC queue of free buffer addresses
-    volatile uint64_t current_buf_ptr;  // Current active buffer (0 = none)
-    volatile uint32_t current_buf_seq;  // Sequence number for ordering
-    uint32_t pad[13];                   // Pad to 192 bytes (aligned to cache line)
+    L2PerfFreeQueue free_queue;               // SPSC queue of free buffer addresses
+    volatile uint64_t current_buf_ptr;        // Current active buffer (0 = none)
+    volatile uint64_t aicore_ring_ptr;        // Stable AICore staging ring (L2Perf only; 0 for Phase)
+    volatile uint32_t current_buf_seq;        // Sequence number for ordering
+    volatile uint32_t total_record_count;     // Records the AICPU attempted to write to this state
+    volatile uint32_t dropped_record_count;   // Records dropped (queue full / overwrite / no buffer)
+    volatile uint32_t mismatch_record_count;  // Records lost to ring/task_id invariant violation (hard errors)
+    uint32_t pad[8];                          // Pad to 192 bytes (aligned to cache line)
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(L2PerfBufferState) == 192, "L2PerfBufferState must be 192 bytes for cache alignment");
@@ -228,8 +265,7 @@ struct L2PerfDataHeader {
     volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
 
     // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;             // Actual number of cores launched
-    volatile uint32_t total_tasks;  // Total tasks (AICPU writes after orchestration)
+    uint32_t num_cores;  // Actual number of cores launched
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -221,6 +221,31 @@ constexpr int PLATFORM_DUMP_TIMEOUT_SECONDS = 30;
 constexpr int PLATFORM_PMU_RECORDS_PER_BUFFER = 512;
 
 /**
+ * Per-core L2Perf staging ring depth (AICore-side WIP slots).
+ *
+ * Must be ≥ the maximum number of in-flight tasks per core (today's
+ * dual-issue dispatch keeps this at 2). The ring lives outside the
+ * rotating L2PerfBuffer so AICore's write address never changes mid-run.
+ *
+ * Indexing uses `task_id % PLATFORM_L2_AICORE_RING_SIZE` (see
+ * `l2_perf_aicore_record_task`), so non-power-of-two values are correct
+ * but compile to an integer divide on the AICore hot path. Prefer a power
+ * of two so the compiler reduces the modulo to a mask.
+ */
+constexpr int PLATFORM_L2_AICORE_RING_SIZE = 2;
+
+/**
+ * Per-core PMU staging ring depth (AICore-side dual-issue slots).
+ *
+ * Same constraints as PLATFORM_L2_AICORE_RING_SIZE: ≥ in-flight task
+ * depth on a single core, and ideally a power of two so the
+ * `task_id % RING_SIZE` slot index compiles to a mask. Decoupled from
+ * the rotating PmuBuffer so the AICore write address is stable across
+ * buffer flips.
+ */
+constexpr int PLATFORM_PMU_AICORE_RING_SIZE = 2;
+
+/**
  * SPSC free-queue slot count per core (Host pushes, AICPU pops).
  */
 constexpr int PLATFORM_PMU_SLOT_COUNT = 4;

--- a/src/a5/platform/include/common/pmu_profiling.h
+++ b/src/a5/platform/include/common/pmu_profiling.h
@@ -153,40 +153,39 @@ struct PmuRecord {
 } __attribute__((aligned(64)));
 
 // =============================================================================
+// PmuAicoreRing - Stable AICore→AICPU Staging Ring (per core, never rotated)
+// =============================================================================
+
+/**
+ * Per-core PMU staging ring written exclusively by AICore.
+ *
+ * AICore reads PMU MMIO itself (via ld_dev) and stores each task's snapshot
+ * in `dual_issue_slots[reg_task_id % PLATFORM_PMU_AICORE_RING_SIZE]`.
+ * The ring is allocated once by the host and addressed through
+ * `PmuBufferState[block_idx].aicore_ring_ptr` (also published into the
+ * `KernelArgs::aicore_pmu_ring_addrs` the AICore kernel entry forwards
+ * into `set_aicore_pmu_ring()`); its address is never reassigned, so AICore
+ * writes are decoupled from AICPU's PmuBuffer rotation.
+ */
+struct PmuAicoreRing {
+    PmuRecord dual_issue_slots[PLATFORM_PMU_AICORE_RING_SIZE];
+} __attribute__((aligned(64)));
+
+// =============================================================================
 // PMU Streaming Buffer Structures (mirrors a2a3 pmu_profiling.h)
 // =============================================================================
 
 /**
  * Fixed-capacity PMU record buffer.
- * Allocated by Host, pushed into per-core free_queue.
- *
- * a5-specific: dual_issue_slots[2] exist because AICore reads PMU MMIO
- * itself (via ld_dev) and writes the snapshot here. AICPU validates and
- * commits into records[] on COND FIN. Parity task_id & 1 picks the slot
- * so adjacent dual-issue dispatches never collide.
+ * Allocated by Host, pushed into per-core free_queue, rotated by AICPU when
+ * full. Owned and written exclusively by AICPU: AICore never touches this
+ * memory. AICPU reads the snapshot from PmuAicoreRing::dual_issue_slots and
+ * commits into records[count++] on COND FIN.
  */
 struct PmuBuffer {
-    // Header (first 64 bytes) — host copies this alone first to learn count.
-    volatile uint32_t count;  // Number of valid records
-    uint32_t pad[15];         // Pad count to 64 bytes; isolates count's cache line from
-                              // dual_issue_slots (AICore writer) to avoid false sharing.
-
-    // Dual-issue staging slots — AICore writes a PmuRecord here after
-    // each task, then AICPU copies it into records[count] and fills
-    // func_id / core_type on FIN. Index = task_id & 1.
-    PmuRecord dual_issue_slots[2];
-
-    // Records (flexible-size, up to PLATFORM_PMU_RECORDS_PER_BUFFER)
     PmuRecord records[PLATFORM_PMU_RECORDS_PER_BUFFER];
+    volatile uint32_t count;
 } __attribute__((aligned(64)));
-
-static_assert(
-    offsetof(PmuBuffer, dual_issue_slots) == 64, "PmuBuffer header must be exactly 64 bytes before dual_issue_slots"
-);
-static_assert(
-    offsetof(PmuBuffer, records) == 64 + 2 * sizeof(PmuRecord),
-    "PmuBuffer records must follow header + 2 dual_issue_slots"
-);
 
 /**
  * SPSC lock-free queue for free PmuBuffer management.
@@ -211,26 +210,32 @@ static_assert(sizeof(PmuFreeQueue) == 128, "PmuFreeQueue must be 128 bytes");
  * Per-core PMU buffer state.
  *
  * Writers:
- *   free_queue.tail:        Host writes (pushes new/recycled buffers)
- *   free_queue.head:        Device writes (pops buffers)
- *   current_buf_ptr:        Device writes (after pop), Host reads (for collect/drain)
- *   current_buf_seq:        Device writes (monotonic counter)
- *   dropped_record_count:   Device writes (tasks whose PmuRecord was never handed
- *                           to the host, e.g. free_queue empty, ready_queue full,
- *                           no active buffer)
- *   total_record_count:     Device writes — monotonic count of every task the
- *                           AICPU attempted to record (success + dropped)
+ *   free_queue.tail:           Host writes (pushes new/recycled buffers)
+ *   free_queue.head:           Device writes (pops buffers)
+ *   current_buf_ptr:           Device writes (after pop), Host reads (for collect/drain)
+ *   aicore_ring_ptr:           Host writes once at init, AICPU reads
+ *   current_buf_seq:           Device writes (monotonic counter)
+ *   total_record_count:        Device writes — monotonic count of every task the
+ *                              AICPU attempted to record (collected + dropped + mismatch)
+ *   dropped_record_count:      Device writes (tasks whose PmuRecord was never handed
+ *                              to the host: free_queue empty, ready_queue full,
+ *                              no active buffer)
+ *   mismatch_record_count:     Device writes — slots where AICore had not yet
+ *                              published the expected reg_task_id (hard invariant
+ *                              violation, distinct from capacity drops)
  *
- * Host reads dropped / total at finalize time to cross-check:
- *   collected_on_host + sum(dropped) == sum(total)
+ * Host reads dropped / mismatch / total at finalize time to cross-check:
+ *   collected_on_host + sum(dropped) + sum(mismatch) == sum(total)
  */
 struct PmuBufferState {
-    PmuFreeQueue free_queue;                 // SPSC queue of free PmuBuffer addresses
-    volatile uint64_t current_buf_ptr;       // Current active PmuBuffer (0 = none)
-    volatile uint32_t current_buf_seq;       // Sequence number for ordering
-    volatile uint32_t dropped_record_count;  // Tasks whose record was dropped on device
-    volatile uint32_t total_record_count;    // Total tasks the AICPU attempted to record
-    uint32_t pad[11];                        // Pad to 192 bytes
+    PmuFreeQueue free_queue;                  // SPSC queue of free PmuBuffer addresses
+    volatile uint64_t current_buf_ptr;        // Current active PmuBuffer (0 = none)
+    volatile uint64_t aicore_ring_ptr;        // Stable AICore staging ring (PmuAicoreRing*)
+    volatile uint32_t current_buf_seq;        // Sequence number for ordering
+    volatile uint32_t total_record_count;     // Total tasks the AICPU attempted to record
+    volatile uint32_t dropped_record_count;   // Tasks whose record was dropped on device
+    volatile uint32_t mismatch_record_count;  // Tasks lost to ring/task_id invariant violation
+    uint32_t pad[8];                          // Pad to 192 bytes
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(PmuBufferState) == 192, "PmuBufferState must be 192 bytes");

--- a/src/a5/platform/include/host/l2_perf_collector.h
+++ b/src/a5/platform/include/host/l2_perf_collector.h
@@ -11,396 +11,341 @@
 
 /**
  * @file l2_perf_collector.h
- * @brief Platform-agnostic performance data collector with dynamic memory management
+ * @brief Platform-agnostic performance data collector with dynamic memory management.
  *
  * Architecture:
- * - ProfMemoryManager: Dedicated thread that polls ReadyQueue, allocates new
- *   device buffers, and replaces full buffers in slot arrays.
- * - L2PerfCollector: Main thread collects data from ProfMemoryManager's
- *   internal queue, copies records to host vectors, and exports results.
+ * - BufferPoolManager<L2PerfModule>: shared mgmt-thread infrastructure that
+ *   polls the AICPU ready queue, replenishes per-core / per-thread free
+ *   queues, and hands full buffers off to the collector thread.
+ * - L2PerfCollector: copies records from the manager's ready queue into
+ *   host vectors and exports the swimlane visualization.
  *
- * Design Pattern: Dependency Injection via Callbacks for memory operations.
- *
- * A5 specifics:
- * - A5 does not support halHostRegister (no SVM/shared memory).
- * - Both onboard and sim use the same host-shadow collector flow.
- * - Platform-specific copy hooks handle the actual Host↔Device transfer
- *   (`rtMemcpy` on onboard, `memcpy` in sim).
+ * a5 specifics: device↔host transfers go through profiling_copy.h. The
+ * framework's mgmt loop mirrors the shm region per tick; per-buffer
+ * payloads (L2PerfBuffer / PhaseBuffer) are pulled on demand inside
+ * ProfilerAlgorithms.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_L2_PERF_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_L2_PERF_COLLECTOR_H_
 
 #include <atomic>
-#include <condition_variable>
+#include <cstdint>
 #include <functional>
-#include <mutex>
-#include <queue>
+#include <optional>
 #include <string>
 #include <thread>
-#include <unordered_map>
 #include <vector>
 
 #include "common/l2_perf_profiling.h"
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
-#include "host/profiling_copy.h"
-#include "runtime.h"
+#include "common/unified_log.h"
+#include "host/profiling_common/profiler_base.h"
+
+// ---------------------------------------------------------------------------
+// L2 Perf profiling Module (drives BufferPoolManager<L2PerfModule>)
+// ---------------------------------------------------------------------------
 
 /**
- * Memory allocation callback for performance profiling
- *
- * @param size Memory size in bytes
- * @return Allocated device memory pointer, or nullptr on failure
+ * L2 Perf has two distinct buffer kinds going through one ready queue per
+ * AICPU thread:
+ *   - kind 0: per-core L2PerfBuffer (task records)
+ *   - kind 1: per-thread PhaseBuffer (scheduler/orchestrator phase records)
+ * The ReadyQueueEntry::is_phase flag picks between them.
  */
-using L2PerfAllocCallback = void *(*)(size_t size);
 
 /**
- * Memory registration callback (for Host-Device shared memory)
- *
- * Kept for interface parity with a2a3. A5 does not support host register,
- * so callers pass nullptr and the collector ignores it.
+ * Buffer kind discriminator carried in ReadyBufferInfo and used to index
+ * the per-kind recycled pool inside BufferPoolManager.
  */
-using L2PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
+enum class ProfBufferType { PERF_RECORD = 0, PHASE = 1 };
 
 /**
- * Memory unregister callback
- *
- * Kept for interface parity with a2a3. A5 does not support host register,
- * so callers pass nullptr and the collector ignores it.
- */
-using L2PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Memory free callback
- *
- * @param dev_ptr Device memory pointer
- * @return 0 on success, error code on failure
- */
-using L2PerfFreeCallback = int (*)(void *dev_ptr);
-
-/**
- * Thread factory callback for creating threads with device binding
- *
- * Creates a std::thread that runs the given function with proper device
- * context setup/teardown (e.g., rtSetDevice/rtDeviceReset on onboard).
- *
- * @param fn Function to execute in the new thread
- * @return The newly created thread
- */
-using ThreadFactory = std::function<std::thread(std::function<void()>)>;
-
-// =============================================================================
-// ProfMemoryManager - Dynamic Buffer Memory Management Thread
-// =============================================================================
-
-/**
- * Buffer type identifier for ReadyBufferInfo
- */
-enum class ProfBufferType { PERF_RECORD, PHASE };
-
-/**
- * Information about a ready (full) buffer, passed from mgmt thread to main thread
+ * Information about a ready (full) buffer, passed from mgmt thread to
+ * collector thread.
  */
 struct ReadyBufferInfo {
     ProfBufferType type;
     uint32_t index;         // core_index (PERF_RECORD) or thread_idx (PHASE)
-    uint32_t slot_idx;      // Reserved (unused in free queue design)
+    uint32_t slot_idx;      // Reserved (unused in free-queue design)
     void *dev_buffer_ptr;   // Device address of the full buffer
-    void *host_buffer_ptr;  // Host-side buffer (sim: same as dev; onboard: host copy)
+    void *host_buffer_ptr;  // Host shadow (filled by ProfilerAlgorithms)
     uint32_t buffer_seq;    // Sequence number for ordering
 };
 
-/**
- * Notification that a buffer has been copied and can be freed
- */
-struct CopyDoneInfo {
-    void *dev_buffer_ptr;  // Device buffer to free
-    ProfBufferType type;   // Buffer type (for recycling)
+struct L2PerfModule {
+    using DataHeader = L2PerfDataHeader;
+    using ReadyEntry = ReadyQueueEntry;
+    using ReadyBufferInfo = ::ReadyBufferInfo;
+    using FreeQueue = L2PerfFreeQueue;  // PhaseBufferState aliases L2PerfBufferState
+
+    static constexpr int kBufferKinds = 2;  // 0=PERF_RECORD, 1=PHASE
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_PROF_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_PROF_SLOT_COUNT;
+    static constexpr const char *kSubsystemName = "L2PerfModule";
+
+    /**
+     * batch_size for proactive_replenish's alloc fallback. Sized so that a
+     * fully empty recycled pool refills to the configured per-instance
+     * ceiling in one tick.
+     */
+    static constexpr int batch_size(int kind) {
+        constexpr int kPerfBatch = PLATFORM_PROF_BUFFERS_PER_CORE - PLATFORM_PROF_SLOT_COUNT;
+        constexpr int kPhaseBatch = PLATFORM_PROF_BUFFERS_PER_THREAD - PLATFORM_PROF_SLOT_COUNT;
+        const int b = (kind == 0) ? kPerfBatch : kPhaseBatch;
+        return b < 1 ? 1 : b;
+    }
+
+    static int kind_of(const ReadyBufferInfo &info) { return static_cast<int>(info.type); }
+
+    static DataHeader *header_from_shm(void *shm) { return get_l2_perf_header(shm); }
+
+    /**
+     * Branch on `is_phase` to pick the per-core perf state vs. the
+     * per-thread phase state. Returns nullopt for out-of-range indices
+     * (which would otherwise corrupt unrelated BufferStates downstream).
+     */
+    static std::optional<profiling_common::EntrySite<L2PerfModule>>
+    resolve_entry(void *shm, DataHeader *header, int /*q*/, const ReadyEntry &entry) {
+        const bool is_phase = (entry.is_phase != 0);
+        const int num_cores = static_cast<int>(header->num_cores);
+
+        if (is_phase) {
+            if (entry.core_index >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
+                LOG_ERROR("L2PerfModule: invalid phase entry: thread=%u", entry.core_index);
+                return std::nullopt;
+            }
+        } else {
+            if (entry.core_index >= static_cast<uint32_t>(num_cores)) {
+                LOG_ERROR("L2PerfModule: invalid perf entry: core=%u", entry.core_index);
+                return std::nullopt;
+            }
+        }
+
+        L2PerfBufferState *state = is_phase ?
+                                       get_phase_buffer_state(shm, num_cores, static_cast<int>(entry.core_index)) :
+                                       get_perf_buffer_state(shm, static_cast<int>(entry.core_index));
+
+        profiling_common::EntrySite<L2PerfModule> site;
+        site.kind = is_phase ? 1 : 0;
+        site.free_queue = &state->free_queue;
+        site.buffer_size = is_phase ? sizeof(PhaseBuffer) : sizeof(L2PerfBuffer);
+        site.info.type = is_phase ? ProfBufferType::PHASE : ProfBufferType::PERF_RECORD;
+        site.info.index = entry.core_index;
+        site.info.slot_idx = 0;
+        site.info.dev_buffer_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
+        site.info.host_buffer_ptr = nullptr;  // filled by ProfilerAlgorithms
+        site.info.buffer_seq = entry.buffer_seq;
+        return site;
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void *shm, DataHeader *header, Cb &&cb) {
+        const int num_cores = static_cast<int>(header->num_cores);
+
+        // Per-core perf states (kind 0)
+        for (int i = 0; i < num_cores; i++) {
+            L2PerfBufferState *state = get_perf_buffer_state(shm, i);
+            cb(/*kind=*/0, &state->free_queue, sizeof(L2PerfBuffer));
+        }
+
+        // Per-thread phase states (kind 1) — gated on AicpuPhaseHeader being
+        // initialized (runtimes that don't emit phase records leave it zero).
+        AicpuPhaseHeader *ph = get_phase_header(shm, num_cores);
+        const int num_phase_threads = (ph->magic == AICPU_PHASE_MAGIC) ? static_cast<int>(ph->num_sched_threads) : 0;
+        for (int t = 0; t < num_phase_threads; t++) {
+            PhaseBufferState *state = get_phase_buffer_state(shm, num_cores, t);
+            cb(/*kind=*/1, &state->free_queue, sizeof(PhaseBuffer));
+        }
+    }
 };
 
 /**
- * Dynamic profiling buffer memory manager
+ * Memory allocation callback for performance profiling.
  *
- * Runs a dedicated thread that:
- * 1. Polls ReadyQueue in shared memory for full buffer entries
- * 2. Allocates new device buffers via callback
- * 3. Writes new buffer addresses into slots (for device to pick up)
- * 4. Pushes old (full) buffer info to internal queue for main thread to copy
- * 5. Frees device buffers after main thread confirms copy is done
- *
- * A5 specifics:
- * - The collector always maintains host shadow copies of shared state/buffers.
- * - Device-visible updates and reads always go through the platform copy hooks.
+ * @param size       Memory size in bytes
+ * @param user_data  Opaque allocator context
+ * @return Allocated device memory pointer, or nullptr on failure
  */
-class ProfMemoryManager {
-public:
-    ProfMemoryManager() = default;
-    ~ProfMemoryManager();
+using L2PerfAllocCallback = void *(*)(size_t size, void *user_data);
 
-    // Disable copy
-    ProfMemoryManager(const ProfMemoryManager &) = delete;
-    ProfMemoryManager &operator=(const ProfMemoryManager &) = delete;
+/**
+ * Memory registration callback (host-visible mapping). nullptr on a5 — the
+ * framework allocates a paired host shadow via malloc + memset 0 +
+ * copy_to_device. Stateless: HAL state is global, so no user_data is
+ * threaded through.
+ */
+using L2PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
 
-    // Allow L2PerfCollector to register initial buffer mappings
-    friend class L2PerfCollector;
+/**
+ * Memory unregister callback. May be nullptr. Stateless (see register_cb).
+ */
+using L2PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
 
-    /**
-     * Start the memory management thread
-     *
-     * @param shared_mem_host Host-side shared memory base address (shadow buffer)
-     * @param num_cores Number of AICore instances (L2PerfBufferState count)
-     * @param num_phase_threads Number of phase profiling threads (PhaseBufferState count)
-     * @param alloc_cb Device memory allocation callback
-     * @param register_cb Host-device mapping callback (nullptr for A5)
-     * @param free_cb Device memory free callback
-     * @param device_id Device ID for interface parity (unused on A5)
-     * @param thread_factory Thread factory for creating device-bound threads (empty to use std::thread)
-     */
-    void start(
-        void *shared_mem_host, int num_cores, int num_phase_threads, L2PerfAllocCallback alloc_cb,
-        L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, int device_id,
-        const ThreadFactory &thread_factory = {}
-    );
-
-    /**
-     * Stop the memory management thread
-     * Blocks until the thread exits.
-     */
-    void stop();
-
-    /**
-     * Try to pop a ready buffer info (non-blocking)
-     *
-     * @param[out] info Ready buffer info
-     * @return true if an item was available, false otherwise
-     */
-    bool try_pop_ready(ReadyBufferInfo &info);
-
-    /**
-     * Wait for a ready buffer info with timeout
-     *
-     * @param[out] info Ready buffer info
-     * @param timeout Maximum wait time
-     * @return true if an item was available, false on timeout
-     */
-    bool wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout);
-
-    /**
-     * Notify that a buffer has been copied and can be freed
-     *
-     * @param info Copy done notification
-     */
-    void notify_copy_done(const CopyDoneInfo &info);
-
-    /**
-     * Check if the manager thread is running
-     */
-    bool is_running() const { return running_.load(); }
-
-private:
-    std::thread mgmt_thread_;
-    std::atomic<bool> running_{false};
-
-    // Shared memory references
-    void *shared_mem_host_{nullptr};  // Host-side shadow buffer
-    void *shared_mem_dev_{nullptr};   // Device-side base address
-    int num_cores_{0};
-    int num_phase_threads_{0};
-
-    // Callbacks
-    L2PerfAllocCallback alloc_cb_{nullptr};
-    L2PerfRegisterCallback register_cb_{nullptr};
-    L2PerfFreeCallback free_cb_{nullptr};
-    int device_id_{-1};
-
-    // Management thread → main thread (ready buffers)
-    std::mutex ready_mutex_;
-    std::condition_variable ready_cv_;
-    std::queue<ReadyBufferInfo> ready_queue_;
-
-    // Main thread → management thread (buffers to free)
-    std::mutex done_mutex_;
-    std::queue<CopyDoneInfo> done_queue_;
-
-    // Device-to-host pointer mapping (populated during alloc_and_register)
-    std::unordered_map<void *, void *> dev_to_host_;
-
-    // Recycled buffer pools (avoids alloc/free churn in mgmt_loop)
-    std::vector<void *> recycled_perf_buffers_;
-    std::vector<void *> recycled_phase_buffers_;
-
-    // Management thread main loop
-    void mgmt_loop();
-
-    // Allocate a new device buffer and paired host shadow
-    void *alloc_and_register(size_t size, void **host_ptr_out);
-
-    // Free a previously allocated buffer and its host shadow
-    void free_buffer(void *dev_ptr);
-
-    // Resolve device pointer to host pointer
-    void *resolve_host_ptr(void *dev_ptr);
-
-    // Register an external dev→host mapping (for initial buffers)
-    void register_mapping(void *dev_ptr, void *host_ptr);
-
-    // Process one ReadyQueue entry
-    void process_ready_entry(L2PerfDataHeader *header, int thread_idx, const ReadyQueueEntry &entry);
-};
+/**
+ * Memory free callback.
+ */
+using L2PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
 
 // =============================================================================
-// L2PerfCollector - Main Collector
+// L2PerfCollector
 // =============================================================================
 
 /**
- * Performance data collector
+ * Performance data collector.
  *
- * Manages performance profiling lifecycle:
- * 1. Initialize shared memory (Header + SlotArrays) and allocate initial buffers
- * 2. Start ProfMemoryManager thread
- * 3. Collect records from ProfMemoryManager's queue (main thread)
- * 4. Export swimlane visualization
+ * Lifecycle:
+ *   1. initialize()                — allocate shared memory, pre-fill
+ *                                    free_queues, hand the memory context
+ *                                    to the base via set_memory_context().
+ *   2. start(tf)                   — inherited from ProfilerBase: assembles
+ *                                    a MemoryOps from the stashed callbacks
+ *                                    and launches the mgmt + poll threads.
+ *   3. ... device execution ...
+ *   4. stop()                      — joins both threads in the correct
+ *                                    order (mgmt first so its final-drain
+ *                                    entries have a consumer).
+ *   5. read_phase_header_metadata() — single-shot read of orch_summary +
+ *                                    core→thread mapping from the
+ *                                    AicpuPhaseHeader.
+ *   6. reconcile_counters()        — leftover-active sanity check (a5 lacks
+ *                                    total/dropped/mismatch counters until
+ *                                    the staging-ring redesign lands).
+ *   7. export_swimlane_json() / finalize().
  *
- * Platform-agnostic: Memory management delegated to callbacks
+ * Host never reads from device-side `current_buf_ptr` to recover records:
+ * device flush is the only data path. Any non-zero `current_buf_ptr` after
+ * stop() with non-empty count is logged as a bug.
  */
-class L2PerfCollector {
+class L2PerfCollector : public profiling_common::ProfilerBase<L2PerfCollector, L2PerfModule> {
 public:
     L2PerfCollector() = default;
     ~L2PerfCollector();
 
-    // Disable copy and move
     L2PerfCollector(const L2PerfCollector &) = delete;
     L2PerfCollector &operator=(const L2PerfCollector &) = delete;
 
+    // ProfilerBase contract
+    static constexpr int kIdleTimeoutSec = PLATFORM_PROF_TIMEOUT_SECONDS;
+    static constexpr const char *kSubsystemName = "L2Perf";
+
     /**
-     * Initialize performance profiling
+     * Initialize performance profiling.
      *
-     * Allocates shared memory for slot arrays, allocates initial buffers,
-     * and writes buffer addresses into slots.
+     * Allocates the shared-memory region (header + per-core / per-thread
+     * BufferStates), pre-allocates initial L2PerfBuffers and PhaseBuffers,
+     * and seeds the per-pool free_queues + the framework's recycled pools.
      *
-     * @param num_aicore Number of AICore instances
-     * @param device_id Device ID
-     * @param alloc_cb Memory allocation callback
-     * @param register_cb Memory registration callback (ignored on A5)
-     * @param free_cb Memory free callback
+     * @param num_aicore     Number of AICore instances
+     * @param device_id      Device ID (forwarded to register_cb)
+     * @param alloc_cb       Device memory allocation callback
+     * @param register_cb    Memory registration callback (nullptr on a5 ⇒
+     *                       host-shadow allocation via malloc)
+     * @param free_cb        Device memory free callback
+     * @param user_data      Opaque pointer forwarded to callbacks
+     * @param output_prefix  Per-task directory; l2_perf_records.json lands
+     *                       here. Required (non-empty); CallConfig::validate()
+     *                       enforces this upstream.
      * @return 0 on success, error code on failure
      */
     int initialize(
         int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
-        L2PerfFreeCallback free_cb
+        L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
     );
 
     /**
-     * Start the memory management thread
-     *
-     * Must be called after initialize() and before device execution starts.
-     *
-     * @param thread_factory Thread factory for creating device-bound threads (empty to use std::thread)
+     * Per-buffer callback invoked by ProfilerBase's poll loop. Dispatches
+     * on info.type to copy either an L2PerfBuffer (PERF_RECORD) into the
+     * per-core record vector or a PhaseBuffer (PHASE) into the per-thread
+     * phase-record vector.
      */
-    void start_memory_manager(const ThreadFactory &thread_factory = {});
+    void on_buffer_collected(const ReadyBufferInfo &info);
 
     /**
-     * Poll and collect performance data from the memory manager's queue
+     * Export collected records as a Chrome Trace Event JSON (swimlane view).
+     * Writes <output_prefix>/l2_perf_records.json — directory captured at
+     * initialize() time.
      *
-     * Runs on the main thread (or a dedicated collector thread in sim mode).
-     * Pulls ready buffers from ProfMemoryManager, copies records to host vectors,
-     * and notifies the manager to free old device buffers.
-     *
-     * @param expected_tasks Expected total number of tasks (0 = auto-detect)
-     */
-    void poll_and_collect(int expected_tasks = 0);
-
-    /**
-     * Export performance data to Chrome Trace Event Format
-     *
-     * @param output_path Output directory path
      * @return 0 on success, error code on failure
      */
-    int export_swimlane_json(const std::string &output_path);
+    int export_swimlane_json();
 
     /**
-     * Stop the memory management thread and clean up remaining data
+     * Free all device memory and unregister mappings. Idempotent on a
+     * collector that was never initialized.
      *
-     * Must be called after device execution completes.
-     */
-    void stop_memory_manager();
-
-    /**
-     * Cleanup all resources
-     *
-     * @param unregister_cb Memory unregister callback (nullptr on A5)
-     * @param free_cb Memory free callback
+     * @param unregister_cb  Memory unregister callback (nullptr on a5)
+     * @param free_cb        Memory free callback
+     * @param user_data      Opaque pointer forwarded to callbacks
      * @return 0 on success, error code on failure
      */
-    int finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb);
+    int finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data);
 
     /**
-     * Check if collector is initialized
+     * @return true if initialize() succeeded and finalize() has not run.
      */
-    bool is_initialized() const { return perf_shared_mem_host_ != nullptr; }
+    bool is_initialized() const { return shm_host_ != nullptr; }
 
     /**
-     * Get the device pointer to the L2PerfDataHeader.
-     * Used to set kernel_args.l2_perf_data_base after initialize() succeeds.
+     * Device pointer to the L2PerfDataHeader. Set kernel_args.l2_perf_data_base
+     * to this after initialize() succeeds so the AICPU side can find the
+     * shared memory.
      */
     void *get_l2_perf_setup_device_ptr() const { return perf_shared_mem_dev_; }
 
     /**
-     * Drain remaining buffers from the memory manager's ready queue
-     *
-     * After poll_and_collect() exits (all PERF records collected) and
-     * the memory manager is stopped, Phase buffers may still be in the
-     * ready queue. This method drains them into the collected vectors.
-     *
-     * Must be called after stop_memory_manager() and before collect_phase_data().
+     * Device pointer to the per-core L2PerfAicoreRing-address table
+     * (uint64_t[num_aicore]). Wire this into
+     * `KernelArgs::aicore_l2_perf_ring_addrs` so the AICore kernel
+     * entry forwards each core's ring pointer into platform state.
      */
-    void drain_remaining_buffers();
+    void *get_aicore_ring_addrs_device_ptr() const { return aicore_ring_addrs_dev_; }
 
     /**
-     * Collect AICPU phase profiling data from shared memory
+     * Read AICPU phase metadata that lives in AicpuPhaseHeader (not on the
+     * buffer pipeline): the orchestrator summary and core→thread mapping.
+     * Single-shot — must be called after stop() so orch_summary has settled.
+     * The shm region was last mirrored to host shadow at the end of mgmt's
+     * final-drain pass.
+     */
+    void read_phase_header_metadata();
+
+    /**
+     * Sanity-check per-core / per-thread `current_buf_ptr` for any
+     * un-flushed leftovers (device flush should always succeed-or-bump-
+     * dropped, so a non-empty leftover indicates an AICPU flush bug).
      *
-     * Reads scheduler phase records and orchestrator summary from the
-     * phase profiling region. Must be called after AICPU threads have joined.
+     * NOTE: a5's L2PerfBufferState does not yet carry total/dropped/mismatch
+     * counters (they land with the AICore staging-ring redesign in a later
+     * task). The full `collected + dropped + mismatch == device_total`
+     * cross-check is therefore deferred. Must be called after stop().
      */
-    void collect_phase_data();
+    void reconcile_counters();
 
     /**
-     * Scan L2PerfBufferState::current_buf_ptr for all cores to recover
-     * partial records not delivered through the pipeline.
-     *
-     * Must be called after device execution completes and after
-     * stop_memory_manager(). Follows the same pattern as collect_phase_data()
-     * for PhaseBufferStates.
-     */
-    void scan_remaining_perf_buffers();
-
-    /**
-     * Signal that device execution is complete (streams synchronized).
-     * poll_and_collect() will drain remaining pipeline data and exit.
-     */
-    void signal_execution_complete();
-
-    /**
-     * Get collected records (for testing)
+     * @return Per-core L2PerfRecord vectors (indexed by core_index). For tests.
      */
     const std::vector<std::vector<L2PerfRecord>> &get_records() const { return collected_perf_records_; }
 
 private:
-    // Shared memory pointers
-    void *perf_shared_mem_dev_{nullptr};   // Device memory pointer (slot arrays)
-    void *perf_shared_mem_host_{nullptr};  // Host-side shadow buffer
-    int device_id_{-1};
+    // Shared memory pointers. shm_host_ / device_id_ live on ProfilerBase
+    // (set via set_memory_context in initialize()).
+    void *perf_shared_mem_dev_{nullptr};
 
-    // Configuration
+    // Per-core stable AICore staging rings — allocated once, never rotated.
+    // The host owns the device-side L2PerfAicoreRing buffers and the address
+    // table; AICPU reads `state.aicore_ring_ptr` (set at init), and AICore
+    // reads from `KernelArgs::aicore_l2_perf_ring_addrs[block_idx]`.
+    std::vector<void *> aicore_rings_dev_;
+    void *aicore_ring_addrs_dev_{nullptr};
+    void *aicore_ring_addrs_host_{nullptr};
+
     int num_aicore_{0};
 
-    // Callbacks (stored for memory manager and finalize)
-    L2PerfAllocCallback alloc_cb_{nullptr};
-    L2PerfRegisterCallback register_cb_{nullptr};
-    L2PerfFreeCallback free_cb_{nullptr};
-
-    // Memory manager
-    ProfMemoryManager memory_manager_;
+    // Per-task output directory captured at initialize() time. Consumed by
+    // export_swimlane_json() to build <prefix>/l2_perf_records.json.
+    std::string output_prefix_;
 
     // Collected data (per-core vectors, indexed by core_index)
     std::vector<std::vector<L2PerfRecord>> collected_perf_records_;
@@ -413,11 +358,19 @@ private:
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)
     std::vector<int8_t> core_to_thread_;
 
-    // Signal from device_runner that execution is complete
-    std::atomic<bool> execution_complete_{false};
+    // Running totals used at reconcile time. The full cross-check awaits
+    // task-02 staging-ring counters; for now we just log the collected
+    // total alongside the leftover-active sanity result.
+    uint64_t total_perf_collected_{0};
+    uint64_t total_phase_collected_{0};
 
-    // Allocate a single buffer (L2PerfBuffer or PhaseBuffer) and its host shadow
+    // Allocate a single buffer (shm region / L2PerfBuffer / PhaseBuffer) and
+    // its paired host shadow.
     void *alloc_single_buffer(size_t size, void **host_ptr_out);
+
+    // Per-buffer-kind handlers used by on_buffer_collected.
+    void copy_perf_buffer(const ReadyBufferInfo &info);
+    void copy_phase_buffer(const ReadyBufferInfo &info);
 };
 
 #endif  // SRC_A5_PLATFORM_INCLUDE_HOST_L2_PERF_COLLECTOR_H_

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -13,29 +13,43 @@
  * @file pmu_collector.h
  * @brief Host-side PMU buffer allocation, streaming collection, and CSV export.
  *
- * Lifecycle mirrors a2a3 PmuCollector:
- *   init()                    — Allocate PmuDataHeader + PmuBufferState shared memory,
- *                               pre-allocate PmuBuffers and push into free_queues.
- *   [start collector thread]
- *   poll_and_collect()        — Poll ready_queues, recycle buffers, write CSV.
- *   signal_execution_complete() — Notify collector that device is done.
- *   [join collector thread]
- *   drain_remaining_buffers() — Scan any buffers still held by AICPU after execution.
- *   finalize()                — Free all device memory.
+ * Architecture:
+ * - BufferPoolManager<PmuModule>: shared mgmt-thread infrastructure that
+ *   polls per-thread PmuReadyQueues, drains the done_queue, and replenishes
+ *   the per-core free_queues from a unified recycled pool.
+ * - PmuCollector: collector thread pops full PmuBuffers from the manager
+ *   and appends them to the CSV file.
  *
- * Memory model (a5-specific):
- *   a5 has no halHostRegister, so host↔device SPSC fields are accessed
- *   through host shadow buffers + rtMemcpy (onboard) or memcpy (sim).
- *   Each device buffer has a paired host shadow in buf_pool_.
- *   The shared memory region (PmuDataHeader + PmuBufferState[]) also has
- *   separate device and host copies synchronized via copy hooks.
+ * a5 specifics: device↔host transfers go through profiling_copy.h. The
+ * framework's mgmt loop mirrors the shm region per tick; per-buffer
+ * payloads (PmuBuffer) are pulled on demand inside ProfilerAlgorithms.
+ *
+ * Lifecycle:
+ *   init()                       — Allocate header + per-core states +
+ *                                  PmuBuffers (pre-fills free_queues; rest
+ *                                  go into the recycled pool). Calls
+ *                                  set_memory_context() on the base so
+ *                                  start(tf) can launch threads.
+ *   start(tf)                    — Inherited from ProfilerBase: assembles
+ *                                  MemoryOps from the stashed callbacks
+ *                                  and launches the mgmt + poll threads.
+ *   [device execution]
+ *   stop()                       — Stop mgmt → join mgmt → signal poll →
+ *                                  drain L2 → join poll, in that order. On
+ *                                  return both thread exits and queue
+ *                                  drains are complete.
+ *   reconcile_counters()         — Sanity-check PmuBufferState::current_buf_ptr
+ *                                  (any non-zero pointer with records is a
+ *                                  device-flush bug, logged as ERROR) and
+ *                                  run the device-side cross-check
+ *                                  collected + dropped == total.
+ *   finalize()                   — Free all device memory and unregister.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_PMU_COLLECTOR_H_
 
 #include <atomic>
-#include <cerrno>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -43,36 +57,123 @@
 #include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <mutex>
+#include <optional>
 #include <string>
-#include <unordered_set>
+#include <thread>
 #include <vector>
 
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/pmu_profiling.h"
 #include "common/unified_log.h"
-#include "host/profiling_copy.h"
+#include "host/profiling_common/profiler_base.h"
 
 // ---------------------------------------------------------------------------
-// Memory operation callbacks (injected by DeviceRunner, same as a2a3)
+// PMU profiling Module (drives BufferPoolManager<PmuModule>)
 // ---------------------------------------------------------------------------
 
 /**
- * Allocate device memory. Returns nullptr on failure.
+ * One buffer kind (PmuBuffer); per-core buffer states. The collector
+ * pre-allocates PLATFORM_PMU_BUFFERS_PER_CORE buffers per core at init time
+ * to absorb steady-state load. process_entry refills the originating
+ * core's free_queue with exactly one buffer (recycled → drain done →
+ * alloc), and proactive_replenish tops up to SLOT_COUNT with a batch alloc
+ * when the recycled pool drains.
+ */
+
+/**
+ * Internal hand-off struct delivered from the mgmt thread to the
+ * collector. thread_index is the logical AICPU thread queue the entry was
+ * popped from, passed through by ProfilerBase's mgmt loop.
+ */
+struct PmuReadyBufferInfo {
+    uint32_t core_index;
+    uint32_t thread_index;
+    void *dev_buffer_ptr;
+    void *host_buffer_ptr;
+    uint32_t buffer_seq;
+};
+
+struct PmuModule {
+    using DataHeader = PmuDataHeader;
+    using ReadyEntry = PmuReadyQueueEntry;
+    using ReadyBufferInfo = ::PmuReadyBufferInfo;
+    using FreeQueue = PmuFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_PMU_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_PMU_SLOT_COUNT;
+    static constexpr const char *kSubsystemName = "PmuModule";
+
+    /**
+     * Buffers grown by proactive_replenish are batch-allocated up to the
+     * configured per-core ceiling minus the slot count, so a double-empty
+     * (recycled + done both dry) recovers in one tick.
+     */
+    static constexpr int batch_size(int /*kind*/) {
+        constexpr int kBatch = PLATFORM_PMU_BUFFERS_PER_CORE - PLATFORM_PMU_SLOT_COUNT;
+        return kBatch < 1 ? 1 : kBatch;
+    }
+
+    static DataHeader *header_from_shm(void *shm) { return get_pmu_header(shm); }
+
+    /**
+     * `count` is intentionally NOT reset here — AICPU is the sole writer
+     * and resets it itself when popping from free_queue.
+     */
+    static std::optional<profiling_common::EntrySite<PmuModule>>
+    resolve_entry(void *shm, DataHeader * /*header*/, int q, const ReadyEntry &entry) {
+        PmuBufferState *state = get_pmu_buffer_state(shm, static_cast<int>(entry.core_index));
+        profiling_common::EntrySite<PmuModule> site;
+        site.kind = 0;
+        site.free_queue = &state->free_queue;
+        site.buffer_size = sizeof(PmuBuffer);
+        site.info.core_index = entry.core_index;
+        site.info.thread_index = static_cast<uint32_t>(q);
+        site.info.dev_buffer_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
+        site.info.host_buffer_ptr = nullptr;  // filled by ProfilerAlgorithms
+        site.info.buffer_seq = entry.buffer_seq;
+        return site;
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void *shm, DataHeader *header, Cb &&cb) {
+        const int num_cores = static_cast<int>(header->num_cores);
+        for (int c = 0; c < num_cores; c++) {
+            PmuBufferState *state = get_pmu_buffer_state(shm, c);
+            cb(/*kind=*/0, &state->free_queue, sizeof(PmuBuffer));
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Memory operation callbacks (injected by DeviceRunner)
+// ---------------------------------------------------------------------------
+
+/**
+ * Allocate device memory.
+ *
+ * @param size       Bytes to allocate
+ * @param user_data  Opaque allocator context
+ * @return Device pointer, or nullptr on failure
  */
 using PmuAllocCallback = void *(*)(size_t size, void *user_data);
 
 /**
- * Register device memory for host-visible access.
- * Unused on a5 (no halHostRegister); kept for interface parity with a2a3.
+ * Register device memory for host-visible access. nullptr on a5 — the
+ * framework allocates a paired host shadow via malloc + memset 0 +
+ * copy_to_device. Stateless: HAL state is global, so no user_data is
+ * threaded through.
  */
-using PmuRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void *user_data, void **host_ptr);
+using PmuRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
 
 /**
- * Unregister previously registered host-visible device memory.
- * Unused on a5; kept for interface parity with a2a3.
+ * Unregister a previously registered host-visible mapping. May be nullptr.
+ * Stateless (see register_cb).
  */
-using PmuUnregisterCallback = int (*)(void *dev_ptr, int device_id, void *user_data);
+using PmuUnregisterCallback = int (*)(void *dev_ptr, int device_id);
 
 /**
  * Free device memory.
@@ -83,7 +184,7 @@ using PmuFreeCallback = int (*)(void *dev_ptr, void *user_data);
 // PmuCollector
 // ---------------------------------------------------------------------------
 
-class PmuCollector {
+class PmuCollector : public profiling_common::ProfilerBase<PmuCollector, PmuModule> {
 public:
     PmuCollector() = default;
     ~PmuCollector();
@@ -91,95 +192,113 @@ public:
     PmuCollector(const PmuCollector &) = delete;
     PmuCollector &operator=(const PmuCollector &) = delete;
 
+    // ProfilerBase contract
+    static constexpr int kIdleTimeoutSec = PLATFORM_PMU_TIMEOUT_SECONDS;
+    static constexpr const char *kSubsystemName = "PMU";
+
     /**
-     * Allocate PMU shared memory and pre-populate free_queues.
+     * Allocate PMU shared memory and pre-populate per-core free_queues.
      *
-     * @param num_cores               Number of AICore instances in use
-     * @param num_threads             Number of AICPU scheduling threads
-     * @param kernel_args_pmu_data_base  Out: device address of PmuDataHeader
-     * @param csv_path                Output CSV file path
-     * @param event_type              PmuEventType value (written to CSV rows)
+     * Allocates the PmuDataHeader + per-core PmuBufferState array, plus
+     * `num_cores * PLATFORM_PMU_BUFFERS_PER_CORE` PmuBuffers. The first
+     * PLATFORM_PMU_SLOT_COUNT buffers per core are pushed directly into
+     * that core's free_queue; the surplus go into the BufferPoolManager's
+     * shared recycled pool.
+     *
+     * @param num_cores                         Number of AICore instances in use
+     * @param num_threads                       Number of AICPU scheduling threads
+     * @param csv_path                          Output CSV path
+     * @param event_type                        PmuEventType selector (written
+     *                                          to PmuDataHeader::event_type
+     *                                          so AICPU can configure HW
+     *                                          counters)
      * @param alloc_cb / register_cb / free_cb  Memory operation callbacks
-     * @param user_data               Opaque pointer forwarded to callbacks
-     * @param device_id               Device ID (for interface parity)
+     *                                          (register_cb nullptr on a5)
+     * @param user_data                         Opaque pointer forwarded to callbacks
+     * @param device_id                         Device ID (for register_cb)
      * @return 0 on success, non-zero on failure
      */
     int init(
-        int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
-        PmuEventType event_type, PmuAllocCallback alloc_cb, PmuFreeCallback free_cb, void *user_data, int device_id
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, PmuAllocCallback alloc_cb,
+        PmuRegisterCallback register_cb, PmuFreeCallback free_cb, void *user_data, int device_id
     );
 
     /**
-     * Main body of the collector thread.
-     * Polls all per-thread ready_queues via rtMemcpy, appends records to CSV,
-     * recycles buffers back into free_queues.
+     * Device pointer to the PmuDataHeader. Set kernel_args.pmu_data_base
+     * to this after init() succeeds so the AICPU side can find the shared
+     * memory.
      */
-    void poll_and_collect();
+    void *get_pmu_shm_device_ptr() const { return shm_dev_; }
 
     /**
-     * Signal that device execution has finished.
-     * The collector thread will drain remaining entries then exit.
+     * Device pointer to the per-core PmuAicoreRing-address table
+     * (uint64_t[num_cores]). Wire into
+     * `KernelArgs::aicore_pmu_ring_addrs`. Filled by the host at init.
      */
-    void signal_execution_complete();
+    void *get_aicore_ring_addrs_device_ptr() const { return aicore_ring_addrs_dev_; }
 
     /**
-     * After the collector thread exits, scan PmuBufferState.current_buf_ptr for
-     * any remaining non-empty buffers that AICPU flushed but the collector
-     * thread may not have consumed yet.
+     * Per-buffer callback invoked by ProfilerBase's poll loop. Flushes
+     * records to CSV.
      */
-    void drain_remaining_buffers();
+    void on_buffer_collected(const PmuReadyBufferInfo &info);
 
     /**
-     * Free all device/shared memory and unregister mapped regions.
+     * After stop(), perform purely-passive accounting:
+     *   - LOG_ERROR any non-zero PmuBufferState::current_buf_ptr with
+     *     records (device flush should always succeed-or-bump-dropped, so
+     *     a non-empty leftover indicates an AICPU flush bug — host does
+     *     NOT recover, to avoid masking the bug).
+     *   - Run the device-side cross-check:
+     *       collected + dropped == device_total.
+     * Must be called after stop(), so the AICPU-side flush has settled.
+     */
+    void reconcile_counters();
+
+    /**
+     * Free all device memory and unregister mappings. Idempotent.
      */
     void finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data);
 
+    /**
+     * @return true if init() succeeded and finalize() has not run.
+     */
     bool is_initialized() const { return initialized_; }
 
 private:
     bool initialized_ = false;
     int num_cores_ = 0;
     int num_threads_ = 0;
-    int device_id_ = -1;
-    PmuEventType event_type_ = PmuEventType::PIPE_UTILIZATION;
+    PmuEventType event_type_{PmuEventType::PIPE_UTILIZATION};
 
-    // Shared memory region (PmuDataHeader + PmuBufferState[])
-    void *shm_dev_ = nullptr;   // Device address
-    void *shm_host_ = nullptr;  // Host shadow
-    size_t shm_size_ = 0;
+    // Shared memory region (PmuDataHeader + PmuBufferState[]). shm_host_ /
+    // device_id_ live on ProfilerBase (set via set_memory_context in init()).
+    void *shm_dev_ = nullptr;
 
-    // Pre-allocated PmuBuffers (one pool per core × BUFFERS_PER_CORE)
-    struct BufEntry {
-        void *dev_ptr = nullptr;
-        void *host_ptr = nullptr;
-    };
-    std::vector<BufEntry> buf_pool_;
+    // Per-core stable PmuAicoreRings + the per-core ring-address table that
+    // travels through KernelArgs into AICore platform state.
+    std::vector<void *> aicore_rings_dev_;
+    void *aicore_ring_addrs_dev_ = nullptr;
+    void *aicore_ring_addrs_host_ = nullptr;
 
-    PmuAllocCallback alloc_cb_ = nullptr;
-    PmuFreeCallback free_cb_ = nullptr;
-    void *user_data_ = nullptr;
-
+    // CSV output. File is opened lazily on the first record write so that
+    // a hung device run that produces no records does not leave a
+    // header-only CSV on disk.
     std::string csv_path_;
     std::string csv_header_;
     std::ofstream csv_file_;
     std::mutex csv_mutex_;
 
-    std::atomic<bool> execution_complete_{false};
+    // Running total of records written to CSV. Used at reconcile time to
+    // verify collected + dropped == device_total.
     uint64_t total_collected_ = 0;
 
-    std::unordered_set<uint64_t> drained_bufs_;
+    PmuDataHeader *pmu_header() const { return get_pmu_header(shm_host_); }
+    PmuBufferState *pmu_state(int core_id) const { return get_pmu_buffer_state(shm_host_, core_id); }
 
-    // Internal helpers
-    PmuDataHeader *pmu_header_host() const { return get_pmu_header(shm_host_); }
-    PmuBufferState *pmu_state_host(int core_id) const { return get_pmu_buffer_state(shm_host_, core_id); }
-    PmuDataHeader *pmu_header_dev() const { return get_pmu_header(shm_dev_); }
-    PmuBufferState *pmu_state_dev(int core_id) const { return get_pmu_buffer_state(shm_dev_, core_id); }
-
+    void *alloc_single_buffer(size_t size, void **host_ptr_out);
     void write_buffer_to_csv(int core_id, int thread_idx, const void *buf_host_ptr);
-    void push_to_free_queue(int core_id, uint64_t buf_dev_addr);
     void ensure_csv_open_unlocked();
-
-    void *resolve_host_ptr(uint64_t dev_addr);
 };
 
 // ---------------------------------------------------------------------------
@@ -211,14 +330,17 @@ inline PmuEventType resolve_pmu_event_type(int requested_event_type) {
     return resolved;
 }
 
+/**
+ * Build the CSV path under the caller-provided per-task directory.
+ * Filename is fixed (no timestamp) — the directory is the per-task
+ * uniqueness boundary.
+ */
 inline std::string make_pmu_csv_path(const std::string &output_dir) {
     std::error_code ec;
     std::filesystem::create_directories(output_dir, ec);
     if (ec) {
         LOG_WARN("Failed to create PMU output directory %s: %s", output_dir.c_str(), ec.message().c_str());
     }
-    // Filename is fixed (no timestamp) — the caller-provided directory is the
-    // per-task uniqueness boundary.
     return output_dir + "/pmu.csv";
 }
 

--- a/src/a5/platform/include/host/profiling_common/buffer_pool_manager.h
+++ b/src/a5/platform/include/host/profiling_common/buffer_pool_manager.h
@@ -1,0 +1,557 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file buffer_pool_manager.h
+ * @brief Generic buffer-pool data structure shared by L2Perf, TensorDump,
+ *        and PMU collectors. Owns:
+ *
+ *   - ready_queue (mgmt → collector) with mutex/cv,
+ *   - done_queue (collector → mgmt) with mutex,
+ *   - per-kind recycled-buffer pools,
+ *   - dev↔host pointer mapping table,
+ *   - alloc_and_register / free_buffer / resolve_host_ptr helpers.
+ *
+ * Owns no threads. ProfilerBase drives the mgmt loop and forwards memory
+ * context here once via set_memory_context(). The Module concept contract
+ * lives at the top of profiler_base.h.
+ *
+ * Defines the shared types used by the framework: ThreadFactory (for thread
+ * creation with optional device-context binding), MemoryOps (type-erased
+ * alloc/reg/free/copy callbacks), and DoneInfo (per-buffer ownership info
+ * passed through done_queue).
+ *
+ * a5 vs a2a3 differences (intentional)
+ * ------------------------------------
+ *
+ * a5 has no `halHostRegister`, so device↔host transfers go through
+ * rtMemcpy (onboard) or memcpy (sim) against a paired host shadow. Two
+ * mechanical changes capture that:
+ *
+ *   1. MemoryOps carries `copy_to_device` and `copy_from_device` in
+ *      addition to the {alloc, reg, free_} of a2a3. The mgmt loop calls
+ *      `mirror_shm_from_device` once per tick to refresh the host shadow,
+ *      then writes back only the fields it actually modifies via
+ *      `write_range_to_device(field_ptr, sizeof(field))`. The bulk
+ *      `mirror_shm_to_device` is kept for init/teardown but is NOT used by
+ *      the mgmt loop — bulk write-back races with AICPU writes to
+ *      device-only fields (current_buf_ptr, total/dropped/mismatch
+ *      counters, queue_tails, free_queue.head, AicpuPhaseHeader::magic).
+ *   2. `reg` allocates a paired host shadow (instead of mapping a HAL view
+ *      onto the device pointer); `release_owned_buffers` therefore frees
+ *      both the device pointer (via `release_fn`) and the host shadow
+ *      (`free()` on the value stashed in `dev_to_host_`).
+ *
+ * Buffer-content mirroring (the per-tick shm copy moves header +
+ * BufferStates only — not the bulk records) is done on demand inside
+ * ProfilerAlgorithms::process_entry, which calls
+ * `manager_.copy_buffer_from_device(host_buf, dev_buf, buffer_size)` after
+ * resolving the host pointer.
+ */
+
+#ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PROFILING_COMMON_BUFFER_POOL_MANAGER_H_
+#define SRC_A5_PLATFORM_INCLUDE_HOST_PROFILING_COMMON_BUFFER_POOL_MANAGER_H_
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdlib>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "common/unified_log.h"
+
+namespace profiling_common {
+
+/**
+ * Thread factory for spawning the mgmt thread with optional device-context
+ * binding. Pass `create_thread()` from device_runner to get a sim/onboard
+ * device-bound worker; pass {} (default) to fall back to a bare std::thread.
+ */
+using ThreadFactory = std::function<std::thread(std::function<void()>)>;
+
+/**
+ * Type-erased memory-op callbacks used by BufferPoolManager.
+ *
+ * - alloc:            allocate `size` bytes of device memory; return nullptr
+ *                     on failure.
+ * - reg:              "register" dev_ptr for host visibility. On a5 this
+ *                     allocates a paired host shadow (malloc + memset 0 +
+ *                     copy_to_device of the zeros) and writes its address to
+ *                     *host_ptr_out. ProfilerBase::start always installs a
+ *                     non-null reg wrapper — collectors do not need to
+ *                     branch.
+ * - free_:            free a previously allocated device pointer.
+ * - copy_to_device:   memcpy host → device. Used at init/teardown for the
+ *                     bulk shm push, and used by the mgmt loop via
+ *                     `write_range_to_device` to push narrow host-modified
+ *                     fields back (advanced `queue_heads[q]`, refilled
+ *                     `free_queue.tail` + `buffer_ptrs[slot]`) without
+ *                     clobbering AICPU-owned fields.
+ * - copy_from_device: memcpy device → host, used at the top of every mgmt
+ *                     tick to mirror device-side `queue_tails` /
+ *                     BufferState updates into the host shadow.
+ */
+struct MemoryOps {
+    std::function<void *(size_t)> alloc;
+    std::function<int(void *dev_ptr, size_t size, int device_id, void **host_ptr_out)> reg;
+    std::function<int(void *dev_ptr)> free_;
+    std::function<int(void *dev_dst, const void *host_src, size_t size)> copy_to_device;
+    std::function<int(void *host_dst, const void *dev_src, size_t size)> copy_from_device;
+};
+
+/**
+ * Per-buffer ownership info threaded through the done_queue so that the mgmt
+ * thread, when it recycles a finished buffer, knows which per-kind pool it
+ * came from.
+ */
+struct DoneInfo {
+    void *dev_ptr;
+    int kind;  // [0, Module::kBufferKinds)
+};
+
+template <typename Module>
+class BufferPoolManager {
+    // Static checks for the Module concept. Required type aliases trigger
+    // clear "no type named X in Module" errors at instantiation if missing;
+    // the explicit static_asserts cover constants and surface invariants.
+    using _DataHeaderRequired = typename Module::DataHeader;
+    using _ReadyEntryRequired = typename Module::ReadyEntry;
+    using _ReadyBufferInfoRequired = typename Module::ReadyBufferInfo;
+    static_assert(Module::kBufferKinds > 0, "Module::kBufferKinds must be > 0");
+
+public:
+    using ReadyBufferInfo = typename Module::ReadyBufferInfo;
+
+    BufferPoolManager() :
+        recycled_(Module::kBufferKinds) {}
+    ~BufferPoolManager() = default;
+
+    BufferPoolManager(const BufferPoolManager &) = delete;
+    BufferPoolManager &operator=(const BufferPoolManager &) = delete;
+
+    /**
+     * Configure the buffer pool's memory context. Called by ProfilerBase::start()
+     * before any allocator-touching method (alloc_and_register / free_buffer /
+     * resolve_host_ptr / drain_done_into_recycled triggered by the mgmt loop)
+     * is invoked. Must NOT be called concurrently with the mgmt thread.
+     *
+     * @param ops              Memory-op callbacks (alloc/reg/free/copy_*).
+     * @param shared_mem_dev   Device base of the subsystem's shared memory.
+     * @param shared_mem_host  Host shadow of the same region.
+     * @param shm_size         Total bytes of the shared-memory region (used
+     *                         by the mgmt loop's per-tick mirror).
+     * @param device_id        Forwarded to ops.reg.
+     */
+    void
+    set_memory_context(MemoryOps ops, void *shared_mem_dev, void *shared_mem_host, size_t shm_size, int device_id) {
+        ops_ = std::move(ops);
+        shared_mem_dev_ = shared_mem_dev;
+        shared_mem_host_ = shared_mem_host;
+        shm_size_ = shm_size;
+        device_id_ = device_id;
+    }
+
+    /**
+     * Release every device buffer the framework currently owns: recycled
+     * pools, done_queue, and ready_queue. Buffers still in the per-pool
+     * free_queue or held as current_buf_ptr are NOT touched — those belong
+     * to the collector and must be released by it (the AICPU may still be
+     * referencing them via shared memory until execution ends).
+     *
+     * For each unique device pointer freed, the paired host shadow recorded
+     * in `dev_to_host_` is also `free()`d before the mapping is erased. On
+     * a5 every shadow comes from `malloc()` (either via ops_.reg or via
+     * collector-side `alloc_single_buffer`), so the unconditional free is
+     * correct.
+     *
+     * `release_fn(dev_ptr)` is invoked once per unique pointer; the
+     * collector is expected to call its free_cb on the device pointer.
+     *
+     * Only safe to call after ProfilerBase::stop() has joined the mgmt thread.
+     */
+    template <typename ReleaseFn>
+    void release_owned_buffers(const ReleaseFn &release_fn) {
+        std::unordered_map<void *, bool> seen;
+        auto release_once = [&](void *p) {
+            if (p == nullptr) return;
+            if (seen.emplace(p, true).second) {
+                auto it = dev_to_host_.find(p);
+                void *host_ptr = (it != dev_to_host_.end()) ? it->second : nullptr;
+                release_fn(p);
+                // a5: free the paired host shadow (malloc'd by ops_.reg or by
+                // alloc_single_buffer). Skip the self-free corner case where
+                // dev_ptr and host_ptr happen to alias.
+                if (host_ptr != nullptr && host_ptr != p) {
+                    std::free(host_ptr);
+                }
+                if (it != dev_to_host_.end()) {
+                    dev_to_host_.erase(it);
+                }
+            }
+        };
+
+        for (auto &pool : recycled_) {
+            for (void *p : pool)
+                release_once(p);
+            pool.clear();
+        }
+        {
+            std::scoped_lock<std::mutex> lock(done_mutex_);
+            while (!done_queue_.empty()) {
+                release_once(done_queue_.front().dev_ptr);
+                done_queue_.pop();
+            }
+        }
+        {
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
+            while (!ready_queue_.empty()) {
+                release_once(ready_queue_.front().dev_buffer_ptr);
+                ready_queue_.pop();
+            }
+        }
+    }
+
+    /**
+     * Drop the dev↔host mapping table — call after the collector has freed
+     * its share of buffers (free_queue + current_buf_ptr) and there are no
+     * further resolve_host_ptr() lookups expected. Frees host shadows that
+     * are still mapped (collectors may have invoked free_cb on the dev
+     * pointer without going through release_owned_buffers).
+     */
+    void clear_mappings() {
+        for (auto &kv : dev_to_host_) {
+            if (kv.second != nullptr && kv.second != kv.first) {
+                std::free(kv.second);
+            }
+        }
+        dev_to_host_.clear();
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-tick mirror of the shared-memory region
+    // -------------------------------------------------------------------------
+
+    /**
+     * Pull the entire device-side shared-memory region into the host shadow.
+     * Called at the top of every mgmt tick so that subsequent reads of
+     * `queue_tails`, `BufferState::current_buf_ptr`, etc. see fresh values.
+     */
+    int mirror_shm_from_device() {
+        if (shared_mem_host_ == nullptr || shared_mem_dev_ == nullptr || shm_size_ == 0) {
+            return 0;
+        }
+        if (!ops_.copy_from_device) return 0;
+        return ops_.copy_from_device(shared_mem_host_, shared_mem_dev_, shm_size_);
+    }
+
+    /**
+     * Push the host-side modifications (advanced `queue_heads`, refilled
+     * free_queues) back to the device. Called at the bottom of every mgmt
+     * tick.
+     *
+     * NOTE: deprecated for a5 — bulk write_back races with AICPU writes to
+     * device-owned fields (BufferState::current_buf_ptr, total/dropped/mismatch
+     * counters, queue_tails, free_queue.head, AicpuPhaseHeader::magic, ...).
+     * The bulk write rolls those updates back to whatever was in the host
+     * shadow at mirror_from_device time. Keep the method around so callers
+     * outside the mgmt loop (init/teardown) still have a way to push the
+     * whole region, but the mgmt loop now uses `write_field_to_device` /
+     * `write_range_to_device` for the few fields host actually modifies.
+     */
+    int mirror_shm_to_device() {
+        if (shared_mem_host_ == nullptr || shared_mem_dev_ == nullptr || shm_size_ == 0) {
+            return 0;
+        }
+        if (!ops_.copy_to_device) return 0;
+        return ops_.copy_to_device(shared_mem_dev_, shared_mem_host_, shm_size_);
+    }
+
+    /**
+     * Push a single field/range from host shadow to its mirrored device
+     * location. `host_field_ptr` must lie inside the host shm shadow
+     * (`[shared_mem_host_, shared_mem_host_ + shm_size_)`). Used by the
+     * mgmt loop to avoid bulk writing the entire shm region, which would
+     * clobber device-only counters and current_buf_ptr values written by
+     * AICPU between the from/to mirror calls.
+     *
+     * Accepts `const volatile void*` so callers can pass the address of
+     * volatile fields (queue_heads[], free_queue.tail, free_queue.buffer_ptrs[])
+     * without an explicit cast at the call site.
+     *
+     * Returns the underlying ops result, or -1 on bounds violation.
+     */
+    int write_range_to_device(const volatile void *host_field_ptr, size_t size) {
+        if (shared_mem_host_ == nullptr || shared_mem_dev_ == nullptr || shm_size_ == 0) {
+            return 0;
+        }
+        if (!ops_.copy_to_device) return 0;
+        const auto *host_base = static_cast<const char *>(shared_mem_host_);
+        const auto *host_field = const_cast<const char *>(static_cast<const volatile char *>(host_field_ptr));
+        if (host_field < host_base || host_field + size > host_base + shm_size_) {
+            LOG_ERROR(
+                "BufferPoolManager::write_range_to_device: field [%p, %p) outside shm [%p, %p)",
+                static_cast<const void *>(host_field), static_cast<const void *>(host_field + size),
+                static_cast<const void *>(host_base), static_cast<const void *>(host_base + shm_size_)
+            );
+            return -1;
+        }
+        size_t offset = static_cast<size_t>(host_field - host_base);
+        void *dev_field = static_cast<char *>(shared_mem_dev_) + offset;
+        return ops_.copy_to_device(dev_field, host_field, size);
+    }
+
+    /**
+     * Re-pull a single field/range from device into the host shadow.
+     * Symmetric counterpart of `write_range_to_device`. Used to refresh
+     * a specific field after the per-tick `mirror_shm_from_device` to
+     * defeat a torn-read race: the bulk mirror is not atomic w.r.t.
+     * concurrent AICPU writes, so a producer-published entry (e.g. a
+     * `queues[t][tail]` slot) may be observed half-written if it was
+     * mirrored before AICPU finished writing it. Re-reading the entry
+     * after observing `head < tail` gives the latest device-side bytes.
+     *
+     * Accepts `volatile void*` so callers can pass the address of volatile
+     * fields without an explicit cast.
+     *
+     * Returns the underlying ops result, or -1 on bounds violation.
+     */
+    int read_range_from_device(volatile void *host_field_ptr, size_t size) {
+        if (shared_mem_host_ == nullptr || shared_mem_dev_ == nullptr || shm_size_ == 0) {
+            return 0;
+        }
+        if (!ops_.copy_from_device) return 0;
+        const auto *host_base = static_cast<const char *>(shared_mem_host_);
+        const auto *host_field = const_cast<const char *>(static_cast<volatile char *>(host_field_ptr));
+        if (host_field < host_base || host_field + size > host_base + shm_size_) {
+            LOG_ERROR(
+                "BufferPoolManager::read_range_from_device: field [%p, %p) outside shm [%p, %p)",
+                static_cast<const void *>(host_field), static_cast<const void *>(host_field + size),
+                static_cast<const void *>(host_base), static_cast<const void *>(host_base + shm_size_)
+            );
+            return -1;
+        }
+        size_t offset = static_cast<size_t>(host_field - host_base);
+        const void *dev_field = static_cast<const char *>(shared_mem_dev_) + offset;
+        return ops_.copy_from_device(const_cast<void *>(static_cast<const void *>(host_field)), dev_field, size);
+    }
+
+    /**
+     * Pull a single buffer's contents (e.g. an L2PerfBuffer / PmuBuffer /
+     * DumpMetaBuffer) from device to its host shadow. Called by
+     * ProfilerAlgorithms::process_entry after resolving the host pointer
+     * for a popped ready entry, before delivering it to the collector.
+     */
+    int copy_buffer_from_device(void *host_dst, void *dev_src, size_t size) {
+        if (!ops_.copy_from_device) return 0;
+        return ops_.copy_from_device(host_dst, dev_src, size);
+    }
+
+    /**
+     * Push a single buffer's contents from host shadow to device. Currently
+     * unused by the mgmt loop (AICPU resets buffer state itself when it
+     * pops from free_queue), but exposed for collector-side use cases.
+     */
+    int copy_buffer_to_device(void *dev_dst, const void *host_src, size_t size) {
+        if (!ops_.copy_to_device) return 0;
+        return ops_.copy_to_device(dev_dst, host_src, size);
+    }
+
+    // -------------------------------------------------------------------------
+    // ready_queue: mgmt thread pushes, collector thread pops
+    // -------------------------------------------------------------------------
+
+    void push_to_ready(const ReadyBufferInfo &info) {
+        {
+            std::scoped_lock<std::mutex> lock(ready_mutex_);
+            ready_queue_.push(info);
+        }
+        ready_cv_.notify_one();
+    }
+
+    bool try_pop_ready(ReadyBufferInfo &out) {
+        std::scoped_lock<std::mutex> lock(ready_mutex_);
+        if (ready_queue_.empty()) return false;
+        out = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+
+    bool wait_pop_ready(ReadyBufferInfo &out, std::chrono::milliseconds timeout) {
+        std::unique_lock<std::mutex> lock(ready_mutex_);
+        if (!ready_cv_.wait_for(lock, timeout, [this] {
+                return !ready_queue_.empty();
+            })) {
+            return false;
+        }
+        out = ready_queue_.front();
+        ready_queue_.pop();
+        return true;
+    }
+
+    // -------------------------------------------------------------------------
+    // done_queue: collector thread reports buffers it has finished copying;
+    // mgmt thread folds them back into the recycled pool of the right kind.
+    // -------------------------------------------------------------------------
+
+    void notify_copy_done(void *dev_ptr, int kind) {
+        std::scoped_lock<std::mutex> lock(done_mutex_);
+        done_queue_.push(DoneInfo{dev_ptr, kind});
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers used from Module::process_entry / proactive_replenish
+    // -------------------------------------------------------------------------
+
+    /**
+     * Allocate a new device buffer and pair it with a host shadow via
+     * ops_.reg. Tracks the resulting dev→host mapping so resolve_host_ptr()
+     * can find it on subsequent ready-queue pops.
+     *
+     * @param size              Byte size to allocate.
+     * @param[out] host_ptr_out Host shadow pointer.
+     * @return                  Device pointer, or nullptr on failure.
+     */
+    void *alloc_and_register(size_t size, void **host_ptr_out) {
+        void *dev_ptr = ops_.alloc(size);
+        if (dev_ptr == nullptr) {
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        void *host_ptr = nullptr;
+        int rc = ops_.reg(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("BufferPoolManager: register failed: %d", rc);
+            // Best-effort dev free; no shadow was registered yet.
+            if (ops_.free_) {
+                ops_.free_(dev_ptr);
+            }
+            *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        *host_ptr_out = host_ptr;
+        dev_to_host_[dev_ptr] = host_ptr;
+        return dev_ptr;
+    }
+
+    /**
+     * Free a device pointer + paired host shadow tracked in dev_to_host_.
+     * Currently unused by the mgmt loop (recycle path keeps buffers alive)
+     * but kept for symmetry with a2a3.
+     */
+    void free_buffer(void *dev_ptr) {
+        if (dev_ptr == nullptr) return;
+        auto it = dev_to_host_.find(dev_ptr);
+        void *host_ptr = (it != dev_to_host_.end()) ? it->second : nullptr;
+        if (it != dev_to_host_.end()) {
+            dev_to_host_.erase(it);
+        }
+        if (ops_.free_) {
+            ops_.free_(dev_ptr);
+        }
+        if (host_ptr != nullptr && host_ptr != dev_ptr) {
+            std::free(host_ptr);
+        }
+    }
+
+    /**
+     * Resolve a device pointer to the host-mapped pointer recorded at
+     * alloc_and_register / register_mapping time.
+     */
+    void *resolve_host_ptr(void *dev_ptr) {
+        auto it = dev_to_host_.find(dev_ptr);
+        if (it != dev_to_host_.end()) return it->second;
+        LOG_ERROR("BufferPoolManager: no host mapping for dev_ptr=%p", dev_ptr);
+        return nullptr;
+    }
+
+    /**
+     * Register an externally-allocated mapping. Used by the Collector during
+     * initialize() when it pre-allocates buffers and wants the mgmt thread
+     * to be able to resolve them later.
+     */
+    void register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
+
+    /**
+     * Pull from the recycled pool of the given kind, or return nullptr if
+     * empty. Caller is responsible for resolving host_ptr (via
+     * resolve_host_ptr) before handing the buffer back to AICPU.
+     */
+    void *pop_recycled(int kind) {
+        auto &pool = recycled_[kind];
+        if (pool.empty()) return nullptr;
+        void *p = pool.back();
+        pool.pop_back();
+        return p;
+    }
+
+    void push_recycled(int kind, void *dev_ptr) { recycled_[kind].push_back(dev_ptr); }
+
+    bool recycled_empty() const {
+        for (const auto &pool : recycled_) {
+            if (!pool.empty()) return false;
+        }
+        return true;
+    }
+
+    /**
+     * Drain everything currently in done_queue back into the per-kind
+     * recycled pool. May be called from Module::process_entry when its
+     * primary recycled pool ran out, to harvest buffers the collector freed
+     * in the meantime.
+     */
+    void drain_done_into_recycled() {
+        std::scoped_lock<std::mutex> lock(done_mutex_);
+        while (!done_queue_.empty()) {
+            const DoneInfo &info = done_queue_.front();
+            recycled_[info.kind].push_back(info.dev_ptr);
+            done_queue_.pop();
+        }
+    }
+
+    void *shared_mem_dev() const { return shared_mem_dev_; }
+    void *shared_mem_host() const { return shared_mem_host_; }
+    int device_id() const { return device_id_; }
+
+private:
+    // Subsystem inputs (set by ProfilerBase::start via set_memory_context).
+    void *shared_mem_dev_{nullptr};
+    void *shared_mem_host_{nullptr};
+    size_t shm_size_{0};
+    int device_id_{-1};
+    MemoryOps ops_;
+
+    // mgmt → collector
+    std::mutex ready_mutex_;
+    std::condition_variable ready_cv_;
+    std::queue<ReadyBufferInfo> ready_queue_;
+
+    // collector → mgmt
+    std::mutex done_mutex_;
+    std::queue<DoneInfo> done_queue_;
+
+    // dev → host mapping (single source of truth for resolve_host_ptr)
+    std::unordered_map<void *, void *> dev_to_host_;
+
+    // Per-kind recycled buffer pools (vector indexed by Module's BufferKind id)
+    std::vector<std::vector<void *>> recycled_;
+};
+
+}  // namespace profiling_common
+
+#endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PROFILING_COMMON_BUFFER_POOL_MANAGER_H_

--- a/src/a5/platform/include/host/profiling_common/profiler_base.h
+++ b/src/a5/platform/include/host/profiling_common/profiler_base.h
@@ -1,0 +1,674 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file profiler_base.h
+ * @brief CRTP scaffolding shared by L2Perf / Dump / PMU collectors.
+ *
+ * Owns the BufferPoolManager<Module>, the mgmt thread (which polls AICPU
+ * ready queues and recycles buffers), and the collector poll thread.
+ *
+ * Module concept contract
+ * -----------------------
+ *
+ * Each profiling subsystem provides a `Module` struct (e.g., L2PerfModule,
+ * DumpModule, PmuModule) that supplies the data-layout traits the unified
+ * mgmt-loop algorithms (ProfilerAlgorithms<Module>) need. Required members:
+ *
+ *   // Types
+ *   using DataHeader      = ...;   // Shared-memory header (e.g. L2PerfDataHeader).
+ *   using ReadyEntry      = ...;   // Per-AICPU-thread ready-queue entry.
+ *   using ReadyBufferInfo = ...;   // Hand-off struct to the collector thread
+ *                                  // (carries dev/host ptrs, optional kind
+ *                                  // discriminator, and the seq).
+ *   using FreeQueue       = ...;   // Per-instance SPSC queue of free buffer
+ *                                  // pointers; must expose `head`, `tail`,
+ *                                  // `buffer_ptrs[kSlotCount]`.
+ *
+ *   // Constants
+ *   static constexpr int      kBufferKinds;    // L2Perf=2 (perf+phase), Dump=1, PMU=1.
+ *   static constexpr uint32_t kReadyQueueSize; // Per-thread ready-queue depth.
+ *   static constexpr uint32_t kSlotCount;      // FreeQueue::buffer_ptrs[] length.
+ *   static constexpr const char* kSubsystemName; // "PMU" / "L2Perf" / "Dump".
+ *
+ *   // Header pointer cast (host_ptr → DataHeader*)
+ *   static DataHeader* header_from_shm(void* shared_mem_host);
+ *
+ *   // Per-kind alloc batch size for proactive_replenish's batch-alloc fallback.
+ *   static int batch_size(int kind);
+ *
+ *   // Required only when kBufferKinds > 1: discriminate which recycled bin
+ *   // a finished buffer belongs to. Single-kind modules omit this method;
+ *   // ProfilerBase::consume passes 0 unconditionally for them.
+ *   static int kind_of(const ReadyBufferInfo& info);
+ *
+ *   // Resolve a popped ReadyEntry into the originating BufferState's
+ *   // free_queue + the partially-filled ReadyBufferInfo. Algorithm fills in
+ *   // host_buffer_ptr after a resolve_host_ptr lookup. Return std::nullopt
+ *   // to drop the entry (e.g. invalid index).
+ *   static std::optional<EntrySite<Module>> resolve_entry(
+ *       void* shm_host, DataHeader*, int q, const ReadyEntry&);
+ *
+ *   // Enumerate every (kind, instance) free_queue and its buffer size for
+ *   // proactive_replenish to top up. Callback signature:
+ *   //   (int kind, FreeQueue* fq, size_t buffer_size).
+ *   template <typename Cb>
+ *   static void for_each_instance(void* shm_host, DataHeader*, Cb&&);
+ *
+ * Alloc policy
+ * ------------
+ *
+ *   process_entry          replenishes the originating free_queue with EXACTLY
+ *                          one buffer per call, matching the 1-in / 1-out
+ *                          ratio against the entry the AICPU just produced.
+ *                          Single allocation when both recycled and done are
+ *                          dry; bounds the per-tick latency.
+ *   proactive_replenish    fills to kSlotCount across all instances of every
+ *                          kind. When recycled drains it batch-allocates
+ *                          `batch_size(kind)` buffers at once to amortize the
+ *                          allocator cost — recovery from a double-empty
+ *                          condition takes one tick instead of N.
+ *
+ * The above two algorithms live in ProfilerAlgorithms<Module>; Module only
+ * supplies the data-access traits above. Implementors must NOT zero `count`
+ * (or any other AICPU-owned field) on the host side — AICPU is the sole
+ * writer to those fields and resets them itself on flush/drop/pop.
+ *
+ * Lifecycle (the only correct teardown order):
+ *   1. Derived::init() — on the success path, calls set_memory_context() to
+ *      stash the alloc/reg/free callbacks, user_data, shm_dev/host pointers,
+ *      shm_size and device_id on the base. If init aborts before that,
+ *      start(tf) becomes a no-op (shm_host_ stays nullptr).
+ *   2. start(tf) — atomically: (a) assembles a MemoryOps from the stashed
+ *      callbacks, (b) hands it to the manager via set_memory_context,
+ *      (c) launches the mgmt thread, (d) launches the poll thread. Mgmt is
+ *      started before poll because mgmt is the only writer to L2 (the
+ *      ready_queue) and poll is its sole consumer.
+ *   3. ... device execution ...
+ *   4. stop() — atomically:
+ *        a) flips mgmt_running_, joins the mgmt thread; the mgmt thread's
+ *           final-drain pass pushes the last L1→L2 entries before exiting.
+ *        b) execution_complete_ is set; the poll loop sees it on its next
+ *           idle tick, drains L2 (which now contains mgmt's final-drain
+ *           output), and exits.
+ *        c) collector thread joined.
+ *      Caller is then guaranteed L1 and L2 are both empty and all collected
+ *      data has been delivered to Derived::on_buffer_collected.
+ *
+ * a5 vs a2a3 (intentional differences)
+ * ------------------------------------
+ *
+ *   - MemoryOps adds copy_to_device / copy_from_device (a5 has no SVM, so
+ *     every device read/write goes through rtMemcpy or memcpy).
+ *   - mgmt_loop pulls the device-side shared-memory region into the host
+ *     shadow at the top of every tick (`mirror_shm_from_device`) and
+ *     pushes the few host-modified fields (`queue_heads[q]` after pop,
+ *     `free_queue.tail` + `buffer_ptrs[]` after refill) back as narrow
+ *     `write_range_to_device` writes. The bulk `mirror_shm_to_device` is
+ *     intentionally NOT called from mgmt_loop: it raced with AICPU writes
+ *     to device-only fields (current_buf_ptr, total/dropped/mismatch
+ *     counters, queue_tails, free_queue.head, AicpuPhaseHeader::magic) and
+ *     rolled them back to the host-shadow values mirrored in at the top of
+ *     the tick. Buffer contents are mirrored on demand inside
+ *     ProfilerAlgorithms.
+ *   - reg always allocates a paired host shadow; the framework never falls
+ *     back to identity-mapping (which would be wrong on a5). Collectors
+ *     pass nullptr-safe callbacks via Derived::init.
+ *
+ * Required Derived contract
+ * -------------------------
+ *
+ *   void on_buffer_collected(const ReadyBufferInfo& info);
+ *       Copy records out of `info.host_buffer_ptr` and update any
+ *       per-collector state. The base class then calls
+ *       `manager_.notify_copy_done(...)` so the buffer is recycled —
+ *       Derived must NOT do that itself.
+ *
+ *   static constexpr int          kIdleTimeoutSec;
+ *       Bound on how long the loop sits with no buffers AND no
+ *       `execution_complete_` signal before logging an error and exiting
+ *       (use the subsystem's PLATFORM_*_TIMEOUT_SECONDS).
+ *
+ *   static constexpr const char*  kSubsystemName;
+ *       Used in the idle-timeout log line (e.g. "L2Perf", "PMU", "TensorDump").
+ */
+
+#ifndef SRC_A5_PLATFORM_INCLUDE_HOST_PROFILING_COMMON_PROFILER_BASE_H_
+#define SRC_A5_PLATFORM_INCLUDE_HOST_PROFILING_COMMON_PROFILER_BASE_H_
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <thread>
+#include <utility>
+
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+#include "host/profiling_common/buffer_pool_manager.h"
+#include "host/profiling_copy.h"
+
+namespace profiling_common {
+
+// Common subsystem callback signatures. All three collectors (PMU / TensorDump
+// / L2Perf) used to declare their own typedefs with identical shapes; these
+// are the canonical types stashed in ProfilerBase via set_memory_context().
+using ProfAllocCallback = void *(*)(size_t size, void *user_data);
+using ProfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr_out);
+using ProfFreeCallback = int (*)(void *dev_ptr, void *user_data);
+
+/**
+ * Default a5 host-shadow register: malloc a paired shadow, zero it, and push
+ * the zeros to device (so the device buffer starts in a known state). Used
+ * when Derived::init does not provide its own register_cb. Collectors that
+ * need a specialized register path (e.g. extra metadata initialization) can
+ * pass a custom register_cb at init time.
+ */
+inline int default_host_shadow_register(void *dev_ptr, size_t size, int /*device_id*/, void **host_ptr_out) {
+    if (host_ptr_out == nullptr) return -1;
+    void *host_ptr = std::malloc(size);
+    if (host_ptr == nullptr) {
+        *host_ptr_out = nullptr;
+        return -1;
+    }
+    std::memset(host_ptr, 0, size);
+    int rc = profiling_copy_to_device(dev_ptr, host_ptr, size);
+    if (rc != 0) {
+        std::free(host_ptr);
+        *host_ptr_out = nullptr;
+        return rc;
+    }
+    *host_ptr_out = host_ptr;
+    return 0;
+}
+
+// Result of Module::resolve_entry. Carries everything the unified
+// process_entry algorithm needs to (a) refill the originating pool's free
+// queue and (b) hand the ready buffer off to the collector.
+//
+//   kind        — recycled-pool index in [0, Module::kBufferKinds).
+//   free_queue  — the originating pool's SPSC queue to refill with one buffer.
+//   buffer_size — bytes to allocate if the recycled+done fallbacks are dry.
+//   info        — partially-filled ReadyBufferInfo (dev_buffer_ptr, buffer_seq,
+//                 and any module-specific index fields are set; algorithm fills
+//                 host_buffer_ptr after a resolve_host_ptr lookup).
+template <typename Module>
+struct EntrySite {
+    int kind;
+    typename Module::FreeQueue *free_queue;
+    size_t buffer_size;
+    typename Module::ReadyBufferInfo info;
+};
+
+// Unified mgmt-loop algorithms parameterized on Module's data-access traits.
+// Module supplies the layout (constants + types + resolve_entry +
+// for_each_instance); ProfilerAlgorithms supplies the control flow that used
+// to be hand-rolled per subsystem.
+template <typename Module>
+struct ProfilerAlgorithms {
+    using DataHeader = typename Module::DataHeader;
+    using ReadyEntry = typename Module::ReadyEntry;
+    using ReadyBufferInfo = typename Module::ReadyBufferInfo;
+    using FreeQueue = typename Module::FreeQueue;
+
+    // Pop one entry from the per-thread ready queue, advancing the head with
+    // the appropriate memory barriers. Returns false if the queue is empty
+    // (or the device wrote an out-of-range head/tail, which is treated as
+    // empty and reported).
+    //
+    // a5: the head advance is written back to device immediately via
+    // `mgr.write_range_to_device(&header->queue_heads[q], ...)` so AICPU sees
+    // the consumer-side update without us bulk-mirroring the whole shm region
+    // (which would clobber AICPU-owned fields elsewhere in the shm).
+    //
+    // Torn-read defense: the per-tick `mirror_shm_from_device` is a single
+    // bulk rtMemcpy that is not atomic w.r.t. concurrent AICPU writes. AICPU
+    // publishes a ready entry by first writing `queues[q][tail].{buffer_ptr,
+    // core_index, buffer_seq}` and then bumping `queue_tails[q]`. If the
+    // bulk mirror happens to scan the entry slot first and the tail counter
+    // last, host can observe `head < tail` while the entry it's about to
+    // read is still pre-publish (e.g. `buffer_ptr == 0`). We refresh the
+    // entry with `read_range_from_device` and skip the pop if the refreshed
+    // entry still looks empty — try again next tick.
+    template <typename Mgr>
+    static bool try_pop_aicpu_entry(Mgr &mgr, DataHeader *header, int q, ReadyEntry &out) {
+        uint32_t head = header->queue_heads[q];
+        uint32_t tail = header->queue_tails[q];
+        if (head >= Module::kReadyQueueSize || tail >= Module::kReadyQueueSize) {
+            LOG_ERROR(
+                "%s: invalid queue indices for thread %d: head=%u tail=%u (max=%u)", Module::kSubsystemName, q, head,
+                tail, Module::kReadyQueueSize
+            );
+            return false;
+        }
+        if (head == tail) return false;
+        // Order the tail-vs-empty check before the entry read so the
+        // entry load cannot be speculated past it on aarch64.
+        rmb();
+
+        // Re-pull this single entry from device to defeat the torn-read
+        // race described above. If the entry's `buffer_ptr` is still 0 the
+        // producer hasn't finished publishing — treat the queue as empty
+        // for this tick.
+        mgr.read_range_from_device(&header->queues[q][head], sizeof(header->queues[q][head]));
+        rmb();
+        out = header->queues[q][head];
+        if (out.buffer_ptr == 0) {
+            return false;
+        }
+        head = (head + 1) % Module::kReadyQueueSize;
+        header->queue_heads[q] = head;
+        wmb();
+        // Push the new head value back to device. The bulk mirror_shm_to_device
+        // is intentionally not used here — see buffer_pool_manager.h.
+        mgr.write_range_to_device(&header->queue_heads[q], sizeof(header->queue_heads[q]));
+        return true;
+    }
+
+    // Refill the originating pool's free_queue with exactly one buffer
+    // (recycled → drain done → alloc), then push the popped buffer's
+    // ReadyBufferInfo to the collector LAST. Skips the push if host_ptr
+    // resolution fails — handing a null pointer to on_buffer_collected
+    // would crash the collector thread.
+    //
+    // a5 specifics: after resolving the popped buffer's host shadow, copy
+    // the buffer contents from device to host before delivery. The host
+    // shadow seen by the collector then matches what the device wrote.
+    template <typename Mgr>
+    static void process_entry(Mgr &mgr, DataHeader *header, int q, const ReadyEntry &entry) {
+        auto site_opt = Module::resolve_entry(mgr.shared_mem_host(), header, q, entry);
+        if (!site_opt.has_value()) return;
+        auto &site = *site_opt;
+
+        void *new_dev = obtain_buffer(mgr, site.kind, site.buffer_size);
+        if (new_dev != nullptr) {
+            push_to_free_queue(mgr, *site.free_queue, new_dev);
+        }
+
+        site.info.host_buffer_ptr = mgr.resolve_host_ptr(site.info.dev_buffer_ptr);
+        if (site.info.host_buffer_ptr == nullptr) {
+            // resolve_host_ptr already logged. Drop rather than deliver null.
+            return;
+        }
+        // a5: pull buffer contents from device into the host shadow before
+        // the collector reads `count` and `records[]`.
+        mgr.copy_buffer_from_device(site.info.host_buffer_ptr, site.info.dev_buffer_ptr, site.buffer_size);
+
+        mgr.push_to_ready(site.info);
+    }
+
+    // Drain done_queue into recycled, then top up every (kind, instance)
+    // free_queue to kSlotCount. When the recycled pool of a given kind drains
+    // mid-fill, batch-allocate `batch_size(kind)` buffers and continue.
+    template <typename Mgr>
+    static void proactive_replenish(Mgr &mgr, DataHeader *header) {
+        mgr.drain_done_into_recycled();
+        Module::for_each_instance(mgr.shared_mem_host(), header, [&](int kind, FreeQueue *fq, size_t buf_size) {
+            top_up_free_queue(mgr, kind, *fq, buf_size);
+        });
+    }
+
+private:
+    // Three-level fallback used by process_entry's 1-in/1-out replenish.
+    template <typename Mgr>
+    static void *obtain_buffer(Mgr &mgr, int kind, size_t buf_size) {
+        void *p = mgr.pop_recycled(kind);
+        if (p != nullptr) return p;
+        mgr.drain_done_into_recycled();
+        p = mgr.pop_recycled(kind);
+        if (p != nullptr) return p;
+
+        void *host_ptr = nullptr;
+        p = mgr.alloc_and_register(buf_size, &host_ptr);
+        if (p == nullptr) {
+            LOG_WARN(
+                "%s: alloc failed for %zu bytes (kind=%d) — increase BUFFERS_PER_* to reduce drops",
+                Module::kSubsystemName, buf_size, kind
+            );
+        }
+        return p;
+    }
+
+    // Append one buffer pointer to a per-instance free_queue. Caller owns
+    // the "queue is not full" guarantee (process_entry: 1-in/1-out;
+    // top_up_free_queue: explicit fq_used < kSlotCount).
+    //
+    // a5: write the new slot and the advanced tail back to device via
+    // `write_range_to_device` so AICPU sees the refill without us bulk
+    // mirroring (which would clobber AICPU-owned fields). The slot is
+    // written before the tail so AICPU never observes a tail update without
+    // the corresponding pointer.
+    template <typename Mgr>
+    static void push_to_free_queue(Mgr &mgr, FreeQueue &fq, void *dev_ptr) {
+        uint32_t fq_tail = fq.tail;
+        uint32_t slot_idx = fq_tail % Module::kSlotCount;
+        fq.buffer_ptrs[slot_idx] = reinterpret_cast<uint64_t>(dev_ptr);
+        wmb();
+        mgr.write_range_to_device(&fq.buffer_ptrs[slot_idx], sizeof(fq.buffer_ptrs[slot_idx]));
+        fq.tail = fq_tail + 1;
+        wmb();
+        mgr.write_range_to_device(&fq.tail, sizeof(fq.tail));
+    }
+
+    // Fill one (kind, instance) free_queue to kSlotCount, batch-allocating
+    // when the recycled pool of this kind drains mid-fill.
+    template <typename Mgr>
+    static void top_up_free_queue(Mgr &mgr, int kind, FreeQueue &fq, size_t buf_size) {
+        rmb();
+        uint32_t fq_head = fq.head;
+        uint32_t fq_tail = fq.tail;
+        uint32_t fq_used = fq_tail - fq_head;
+
+        while (fq_used < Module::kSlotCount) {
+            void *new_dev = mgr.pop_recycled(kind);
+            if (new_dev == nullptr) {
+                const int batch = Module::batch_size(kind);
+                for (int i = 0; i < batch; i++) {
+                    void *host_ptr = nullptr;
+                    void *dev = mgr.alloc_and_register(buf_size, &host_ptr);
+                    if (dev == nullptr) break;
+                    mgr.push_recycled(kind, dev);
+                }
+                new_dev = mgr.pop_recycled(kind);
+            }
+            if (new_dev == nullptr) return;
+
+            uint32_t slot_idx = fq_tail % Module::kSlotCount;
+            fq.buffer_ptrs[slot_idx] = reinterpret_cast<uint64_t>(new_dev);
+            wmb();
+            mgr.write_range_to_device(&fq.buffer_ptrs[slot_idx], sizeof(fq.buffer_ptrs[slot_idx]));
+            fq_tail++;
+            fq.tail = fq_tail;
+            wmb();
+            mgr.write_range_to_device(&fq.tail, sizeof(fq.tail));
+            fq_used++;
+        }
+    }
+};
+
+template <typename Derived, typename Module>
+class ProfilerBase {
+public:
+    using Manager = BufferPoolManager<Module>;
+    using DataHeader = typename Module::DataHeader;
+    using ReadyEntry = typename Module::ReadyEntry;
+    using ReadyBufferInfo = typename Module::ReadyBufferInfo;
+
+    ProfilerBase(const ProfilerBase &) = delete;
+    ProfilerBase &operator=(const ProfilerBase &) = delete;
+
+private:
+    friend Derived;
+    ProfilerBase() = default;
+    ~ProfilerBase() = default;
+
+public:
+    /**
+     * Stash the memory context produced by Derived::init(). Must be called
+     * on the init() success path; if init aborts before this, start(tf) is
+     * a no-op.
+     *
+     * register_cb may be nullptr — start(tf) installs the default a5
+     * host-shadow register in that case (malloc + memset 0 + copy_to_device).
+     */
+    void set_memory_context(
+        ProfAllocCallback alloc_cb, ProfRegisterCallback register_cb, ProfFreeCallback free_cb, void *user_data,
+        void *shm_dev, void *shm_host, size_t shm_size, int device_id
+    ) {
+        alloc_cb_ = alloc_cb;
+        register_cb_ = register_cb;
+        free_cb_ = free_cb;
+        user_data_ = user_data;
+        shm_dev_ = shm_dev;
+        shm_host_ = shm_host;
+        shm_size_ = shm_size;
+        device_id_ = device_id;
+    }
+
+    /**
+     * Drop the stashed memory context. Called by Derived::finalize() so
+     * that a subsequent start(tf) on a finalized collector becomes a no-op.
+     */
+    void clear_memory_context() {
+        alloc_cb_ = nullptr;
+        register_cb_ = nullptr;
+        free_cb_ = nullptr;
+        user_data_ = nullptr;
+        shm_dev_ = nullptr;
+        shm_host_ = nullptr;
+        shm_size_ = 0;
+        device_id_ = -1;
+    }
+
+    /**
+     * Assemble a MemoryOps from the callbacks stashed by set_memory_context()
+     * and launch the mgmt + poll threads. If shm_host_ is nullptr (Derived's
+     * init() aborted before set_memory_context, or finalize() has cleared
+     * the context) this is a no-op.
+     *
+     * Order matters: mgmt is started before poll because mgmt is the only
+     * writer to L2 (the ready_queue) and poll is its sole consumer. The
+     * register slot defaults to default_host_shadow_register when Derived
+     * passed nullptr, so BufferPoolManager always has a valid reg path.
+     */
+    void start(const ThreadFactory &thread_factory) {
+        if (shm_host_ == nullptr) return;
+
+        MemoryOps ops;
+        ops.alloc = [cb = alloc_cb_, ud = user_data_](size_t size) {
+            return cb(size, ud);
+        };
+        ops.free_ = [cb = free_cb_, ud = user_data_](void *dev_ptr) {
+            return cb(dev_ptr, ud);
+        };
+        if (register_cb_ != nullptr) {
+            ops.reg = register_cb_;
+        } else {
+            ops.reg = &default_host_shadow_register;
+        }
+        ops.copy_to_device = [](void *dev_dst, const void *host_src, size_t size) {
+            return profiling_copy_to_device(dev_dst, host_src, size);
+        };
+        ops.copy_from_device = [](void *host_dst, const void *dev_src, size_t size) {
+            return profiling_copy_from_device(host_dst, dev_src, size);
+        };
+        manager_.set_memory_context(std::move(ops), shm_dev_, shm_host_, shm_size_, device_id_);
+
+        mgmt_running_.store(true, std::memory_order_release);
+        if (thread_factory) {
+            mgmt_thread_ = thread_factory([this]() {
+                mgmt_loop();
+            });
+        } else {
+            mgmt_thread_ = std::thread(&ProfilerBase::mgmt_loop, this);
+        }
+
+        execution_complete_.store(false, std::memory_order_release);
+        if (thread_factory) {
+            collector_thread_ = thread_factory([this]() {
+                poll_and_collect_loop();
+            });
+        } else {
+            collector_thread_ = std::thread(&ProfilerBase::poll_and_collect_loop, this);
+        }
+    }
+
+    /**
+     * Stop the mgmt thread, drain whatever it pushes during its final pass,
+     * and join the collector. Idempotent. Caller is guaranteed on return
+     * that mgmt's L1 ringbuffer and the host-side L2 ready_queue are both
+     * empty and Derived::on_buffer_collected has been called for every
+     * entry that was in either queue. Framework-owned buffers are NOT freed
+     * here — Derived's finalize() must do that.
+     *
+     * Order matters: stop+join mgmt first so its final-drain pass is fully
+     * landed in L2 BEFORE we tell poll to exit. Otherwise mgmt's last batch
+     * has no consumer.
+     */
+    void stop() {
+        mgmt_running_.store(false, std::memory_order_release);
+        if (mgmt_thread_.joinable()) {
+            mgmt_thread_.join();
+        }
+        execution_complete_.store(true, std::memory_order_release);
+        if (collector_thread_.joinable()) {
+            collector_thread_.join();
+        }
+    }
+
+    Manager &manager() { return manager_; }
+    const Manager &manager() const { return manager_; }
+
+protected:
+    Manager manager_;
+    std::atomic<bool> execution_complete_{false};
+    std::thread collector_thread_;
+
+    // Memory context stashed by Derived::init() via set_memory_context().
+    // Derived may read these from finalize() / alloc helpers via the
+    // inherited names. ProfilerBase owns the lifetime: Derived must call
+    // clear_memory_context() in finalize() to drop them.
+    ProfAllocCallback alloc_cb_{nullptr};
+    ProfRegisterCallback register_cb_{nullptr};
+    ProfFreeCallback free_cb_{nullptr};
+    void *user_data_{nullptr};
+    void *shm_dev_{nullptr};
+    void *shm_host_{nullptr};
+    size_t shm_size_{0};
+    int device_id_{-1};
+
+private:
+    /**
+     * mgmt thread main loop. Each tick:
+     *   0) Mirror the device-side shared-memory region (DataHeader + all
+     *      BufferStates) into the host shadow so subsequent reads see the
+     *      latest queue_tails / current_buf_ptr / per-state counters.
+     *   1) Drain done_queue into recycled pools.
+     *   2) Iterate AICPU per-thread ready queues (PLATFORM_MAX_AICPU_THREADS
+     *      upper bound; empty queues are O(1) head==tail checks) and call
+     *      Module::process_entry per entry. process_entry pulls each
+     *      popped buffer's contents from device on demand.
+     *      try_pop_aicpu_entry / push_to_free_queue write the few host-modified
+     *      fields (queue_heads[q], free_queue.tail/buffer_ptrs[]) back to
+     *      device immediately via `write_range_to_device`.
+     *   3) Call Module::proactive_replenish to top up any depleted free
+     *      queues.
+     *   4) Sleep 10 us if no work was done.
+     *
+     * The bulk `mirror_shm_to_device` deliberately is NOT called: it races
+     * with AICPU writes to device-only fields (current_buf_ptr, total/dropped/
+     * mismatch counters, queue_tails, free_queue.head, AicpuPhaseHeader::magic,
+     * orch_summary, core_to_thread[]) and rolls them back to whatever was
+     * mirrored in at the start of the tick. Each host-side modification is
+     * written back as a narrow field write inside Alg.
+     *
+     * On exit (mgmt_running_ → false) it does one final drain pass without
+     * sleeping to flush any straggler entries the device pushed before
+     * stopping.
+     */
+    void mgmt_loop() {
+        DataHeader *header = Module::header_from_shm(manager_.shared_mem_host());
+        using Alg = ProfilerAlgorithms<Module>;
+
+        while (mgmt_running_.load(std::memory_order_acquire)) {
+            manager_.mirror_shm_from_device();
+
+            manager_.drain_done_into_recycled();
+
+            bool found_any = false;
+            for (int q = 0; q < PLATFORM_MAX_AICPU_THREADS; q++) {
+                ReadyEntry entry;
+                while (Alg::try_pop_aicpu_entry(manager_, header, q, entry)) {
+                    Alg::process_entry(manager_, header, q, entry);
+                    found_any = true;
+                }
+            }
+
+            Alg::proactive_replenish(manager_, header);
+
+            if (!found_any) {
+                std::this_thread::sleep_for(std::chrono::microseconds(10));
+            }
+        }
+
+        // Final drain after mgmt_running_ flipped: don't sleep, don't
+        // replenish. try_pop_aicpu_entry still pushes the advanced
+        // queue_heads back to device per-pop.
+        manager_.mirror_shm_from_device();
+        for (int q = 0; q < PLATFORM_MAX_AICPU_THREADS; q++) {
+            ReadyEntry entry;
+            while (Alg::try_pop_aicpu_entry(manager_, header, q, entry)) {
+                Alg::process_entry(manager_, header, q, entry);
+            }
+        }
+    }
+
+    /**
+     * Main collector loop. Blocks on the manager's ready_queue with a 100 ms
+     * cv-wait tick. On each hit it dispatches the buffer to Derived via
+     * on_buffer_collected() and recycles the buffer. Exits in two cases:
+     *
+     *   1. execution_complete_ was set (by stop()) and the ready_queue is
+     *      empty, after a final non-blocking drain pass.
+     *   2. No buffer arrived for `Derived::kIdleTimeoutSec` consecutive
+     *      seconds AND execution_complete_ has not been signalled — this
+     *      is a hang detector that logs an error and bails out.
+     */
+    void poll_and_collect_loop() {
+        const auto wait_tick = std::chrono::milliseconds(100);
+        const auto idle_timeout = std::chrono::seconds(Derived::kIdleTimeoutSec);
+        std::optional<std::chrono::steady_clock::time_point> idle_start;
+
+        while (true) {
+            ReadyBufferInfo info;
+            if (manager_.wait_pop_ready(info, wait_tick)) {
+                consume(info);
+                idle_start.reset();
+                continue;
+            }
+            if (execution_complete_.load(std::memory_order_acquire)) {
+                while (manager_.try_pop_ready(info)) {
+                    consume(info);
+                }
+                break;
+            }
+            if (!idle_start.has_value()) {
+                idle_start = std::chrono::steady_clock::now();
+            }
+            if (std::chrono::steady_clock::now() - idle_start.value() >= idle_timeout) {
+                LOG_ERROR(
+                    "%s collector idle timeout after %d seconds — giving up", Derived::kSubsystemName,
+                    Derived::kIdleTimeoutSec
+                );
+                break;
+            }
+        }
+    }
+
+    void consume(const ReadyBufferInfo &info) {
+        static_cast<Derived *>(this)->on_buffer_collected(info);
+        if constexpr (Module::kBufferKinds > 1) {
+            manager_.notify_copy_done(info.dev_buffer_ptr, Module::kind_of(info));
+        } else {
+            manager_.notify_copy_done(info.dev_buffer_ptr, 0);
+        }
+    }
+
+    std::thread mgmt_thread_;
+    std::atomic<bool> mgmt_running_{false};
+};
+
+}  // namespace profiling_common
+
+#endif  // SRC_A5_PLATFORM_INCLUDE_HOST_PROFILING_COMMON_PROFILER_BASE_H_

--- a/src/a5/platform/include/host/tensor_dump_collector.h
+++ b/src/a5/platform/include/host/tensor_dump_collector.h
@@ -11,91 +11,63 @@
 
 /**
  * @file tensor_dump_collector.h
- * @brief Host-side tensor dump collector with independent shared memory
+ * @brief Host-side tensor dump collector with independent shared memory.
  *
- * Fully decoupled from profiling: uses its own shared memory region,
- * ready queues, and memory manager thread.
+ * Architecture:
+ * - BufferPoolManager<DumpModule>: shared mgmt-thread infrastructure that
+ *   polls per-thread DumpReadyQueues, replenishes free_queues, and hands
+ *   full DumpMetaBuffers off to the collector thread.
+ * - TensorDumpCollector: copies tensor metadata + arena bytes into host
+ *   vectors and writes the result to disk (.bin + JSON).
  *
- * Mirrors L2PerfCollector architecture:
- * - DumpMemoryManager: Background thread that polls dump ready queues,
- *   recycles metadata buffers, and hands off full buffers to the main thread.
- * - TensorDumpCollector: Main thread copies tensor data from arenas,
- *   manages lifecycle, and exports dump files.
- *
- * A5 specifics: memory access uses host-shadow copies + explicit memcpy
- * instead of halHostRegister/SVM. Data structures and interaction logic
- * are identical to A2A3.
+ * a5 specifics: device↔host transfers use rtMemcpy / memcpy via
+ * profiling_copy.h. The framework's mgmt loop mirrors the shm region per
+ * tick; per-buffer payloads (metadata buffers) are pulled on demand inside
+ * ProfilerAlgorithms. The collector additionally pulls arena bytes inside
+ * on_buffer_collected, since arenas live outside the shm region and only
+ * the part needed for the buffer's records is worth copying.
  */
 
 #ifndef SRC_A5_PLATFORM_INCLUDE_HOST_TENSOR_DUMP_COLLECTOR_H_
 #define SRC_A5_PLATFORM_INCLUDE_HOST_TENSOR_DUMP_COLLECTOR_H_
 
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <string>
 #include <thread>
-#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include "common/memory_barrier.h"
 #include "common/platform_config.h"
 #include "common/tensor_dump.h"
+#include "common/unified_log.h"
 #include "data_type.h"
+#include "host/profiling_common/profiler_base.h"
 #include "host/profiling_copy.h"
 
+// ---------------------------------------------------------------------------
+// Tensor Dump profiling Module (drives BufferPoolManager<DumpModule>)
+// ---------------------------------------------------------------------------
+
 /**
- * Device memory allocation callback.
- *
- * @param size Memory size in bytes
- * @return Allocated device memory pointer, or nullptr on failure
+ * One buffer kind (DumpMetaBuffer); one ready_queue per AICPU thread.
+ * Per-thread arena buffers are owned by the collector itself, not the
+ * framework. process_entry refills the originating thread's free_queue
+ * with exactly one buffer; proactive_replenish tops up to SLOT_COUNT and
+ * batch-allocates when the recycled pool drains.
  */
-using DumpAllocCallback = void *(*)(size_t size);
 
 /**
- * Memory registration callback (for Host-Device shared memory).
- *
- * Kept for interface parity with A2A3. A5 does not support host register,
- * so callers pass nullptr and the collector ignores it.
- */
-using DumpRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Memory unregister callback.
- *
- * Kept for interface parity with A2A3. A5 does not support host register,
- * so callers pass nullptr and the collector ignores it.
- */
-using DumpUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Memory free callback.
- *
- * @param dev_ptr Device memory pointer
- * @return 0 on success, error code on failure
- */
-using DumpFreeCallback = int (*)(void *dev_ptr);
-
-/**
- * Callback for binding the memory-manager thread to a device context.
- *
- * Called once at the start of the management thread. On A5 onboard this
- * wraps rtSetDevice; in simulation mode callers pass nullptr.
- *
- * @param device_id Device ID
- * @return 0 on success, error code on failure
- */
-using DumpSetDeviceCallback = int (*)(int device_id);
-
-// =============================================================================
-// DumpMemoryManager - Background Thread
-// =============================================================================
-
-/**
- * Information about a ready (full) dump metadata buffer
+ * Information about a ready (full) dump metadata buffer.
  */
 struct DumpReadyBufferInfo {
     uint32_t thread_index;
@@ -104,70 +76,87 @@ struct DumpReadyBufferInfo {
     uint32_t buffer_seq;
 };
 
-/**
- * Dump buffer memory manager thread.
- *
- * Polls per-thread ready queues in DumpDataHeader, hands off full
- * DumpMetaBuffers to the main thread, and recycles them back into
- * the SPSC free_queue.
- */
-class DumpMemoryManager {
-public:
-    DumpMemoryManager() = default;
-    ~DumpMemoryManager();
+struct DumpModule {
+    using DataHeader = DumpDataHeader;
+    using ReadyEntry = DumpReadyQueueEntry;
+    using ReadyBufferInfo = ::DumpReadyBufferInfo;
+    using FreeQueue = DumpFreeQueue;
 
-    DumpMemoryManager(const DumpMemoryManager &) = delete;
-    DumpMemoryManager &operator=(const DumpMemoryManager &) = delete;
+    static constexpr int kBufferKinds = 1;
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_DUMP_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_DUMP_SLOT_COUNT;
+    static constexpr const char *kSubsystemName = "DumpModule";
 
-    friend class TensorDumpCollector;
+    /**
+     * Tensor-dump bursts can be very large; the batch is sized so a fully
+     * empty recycled pool refills to the configured per-thread ceiling in
+     * one tick.
+     */
+    static constexpr int batch_size(int /*kind*/) {
+        constexpr int kBatch = PLATFORM_DUMP_BUFFERS_PER_THREAD - PLATFORM_DUMP_SLOT_COUNT;
+        return kBatch < 1 ? 1 : kBatch;
+    }
 
-    void start(
-        void *shared_mem_host, void *shared_mem_dev, int num_dump_threads, DumpAllocCallback alloc_cb,
-        DumpRegisterCallback register_cb, DumpFreeCallback free_cb, int device_id,
-        DumpSetDeviceCallback set_device_cb = nullptr
-    );
+    static DataHeader *header_from_shm(void *shm) { return get_dump_header(shm); }
 
-    void stop();
+    static std::optional<profiling_common::EntrySite<DumpModule>>
+    resolve_entry(void *shm, DataHeader * /*header*/, int /*q*/, const ReadyEntry &entry) {
+        DumpBufferState *state = get_dump_buffer_state(shm, static_cast<int>(entry.thread_index));
+        profiling_common::EntrySite<DumpModule> site;
+        site.kind = 0;
+        site.free_queue = &state->free_queue;
+        site.buffer_size = sizeof(DumpMetaBuffer);
+        site.info.thread_index = entry.thread_index;
+        site.info.dev_buffer_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
+        site.info.host_buffer_ptr = nullptr;  // filled by ProfilerAlgorithms
+        site.info.buffer_seq = entry.buffer_seq;
+        return site;
+    }
 
-    bool try_pop_ready(DumpReadyBufferInfo &info);
-    bool wait_pop_ready(DumpReadyBufferInfo &info, std::chrono::milliseconds timeout);
-    void notify_copy_done(void *dev_buffer_ptr);
-
-    bool is_running() const { return running_.load(); }
-
-private:
-    std::thread mgmt_thread_;
-    std::atomic<bool> running_{false};
-
-    void *shared_mem_host_{nullptr};
-    void *shared_mem_dev_{nullptr};
-    int num_dump_threads_{0};
-
-    DumpAllocCallback alloc_cb_{nullptr};
-    DumpRegisterCallback register_cb_{nullptr};
-    DumpFreeCallback free_cb_{nullptr};
-    DumpSetDeviceCallback set_device_cb_{nullptr};
-    int device_id_{-1};
-    std::mutex ready_mutex_;
-    std::condition_variable ready_cv_;
-    std::queue<DumpReadyBufferInfo> ready_queue_;
-
-    std::mutex done_mutex_;
-    std::queue<void *> done_queue_;  // Device pointers to recycle
-
-    std::unordered_map<void *, void *> dev_to_host_;
-    std::vector<void *> recycled_dump_buffers_;
-
-    void mgmt_loop();
-    void *alloc_and_register(size_t size, void **host_ptr_out);
-    void free_buffer(void *dev_ptr);
-    void *resolve_host_ptr(void *dev_ptr);
-    void register_mapping(void *dev_ptr, void *host_ptr);
-    void process_dump_entry(DumpDataHeader *header, int thread_idx, const DumpReadyQueueEntry &entry);
+    template <typename Cb>
+    static void for_each_instance(void *shm, DataHeader *header, Cb &&cb) {
+        const int n_threads = static_cast<int>(header->num_dump_threads);
+        for (int t = 0; t < n_threads; t++) {
+            DumpBufferState *state = get_dump_buffer_state(shm, t);
+            cb(/*kind=*/0, &state->free_queue, sizeof(DumpMetaBuffer));
+        }
+    }
 };
 
+// ---------------------------------------------------------------------------
+// Memory operation callbacks (injected by DeviceRunner)
+// ---------------------------------------------------------------------------
+
+/**
+ * Allocate device memory.
+ *
+ * @param size       Bytes to allocate
+ * @param user_data  Opaque allocator context
+ * @return Device pointer, or nullptr on failure
+ */
+using DumpAllocCallback = void *(*)(size_t size, void *user_data);
+
+/**
+ * Register device memory for host-visible access. nullptr on a5 — the
+ * framework allocates a paired host shadow via malloc + memset 0 +
+ * copy_to_device. Kept in the public surface for interface parity with
+ * a2a3 so future host-mapped backends can plug in here.
+ */
+using DumpRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
+
+/**
+ * Unregister a previously registered host-visible mapping. nullptr on a5;
+ * kept for interface parity with a2a3.
+ */
+using DumpUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+
+/**
+ * Free device memory.
+ */
+using DumpFreeCallback = int (*)(void *dev_ptr, void *user_data);
+
 // =============================================================================
-// TensorDumpCollector - Main Collector
+// TensorDumpCollector
 // =============================================================================
 
 /**
@@ -188,12 +177,12 @@ struct DumpedTensor {
     bool is_contiguous;
     bool truncated;
     bool overwritten;
-    uint64_t payload_size;  // original payload size (bytes may be cleared after writing)
-    uint64_t bin_offset;    // byte offset into tensors.bin
+    uint64_t payload_size;
+    uint64_t bin_offset;
     std::vector<uint8_t> bytes;
 };
 
-class TensorDumpCollector {
+class TensorDumpCollector : public profiling_common::ProfilerBase<TensorDumpCollector, DumpModule> {
 public:
     TensorDumpCollector() = default;
     ~TensorDumpCollector();
@@ -201,82 +190,122 @@ public:
     TensorDumpCollector(const TensorDumpCollector &) = delete;
     TensorDumpCollector &operator=(const TensorDumpCollector &) = delete;
 
+    // ProfilerBase contract
+    static constexpr int kIdleTimeoutSec = PLATFORM_DUMP_TIMEOUT_SECONDS;
+    static constexpr const char *kSubsystemName = "TensorDump";
+
     /**
      * Initialize tensor dump shared memory.
      *
-     * Allocates DumpDataHeader + DumpBufferState array, per-thread arenas,
-     * and initial DumpMetaBuffers.
+     * Allocates the DumpDataHeader + per-thread DumpBufferState array, the
+     * per-thread arenas (single contiguous payload region per thread), and
+     * the initial DumpMetaBuffers. The first PLATFORM_DUMP_SLOT_COUNT meta
+     * buffers are pushed into each thread's free_queue; the rest go into
+     * the BufferPoolManager's recycled pool.
      *
+     * `output_prefix` is the per-task directory under which `tensor_dump/`
+     * lands. Required (non-empty); CallConfig::validate() enforces this
+     * upstream. Stored on the collector so the lazily-started writer thread
+     * (kicked off inside on_buffer_collected) can derive its run_dir
+     * without threading the prefix through the buffer-pool callback path.
+     *
+     * @param num_dump_threads  Number of AICPU scheduling threads
+     * @param device_id         Device ID
+     * @param alloc_cb          Memory allocation callback
+     * @param register_cb       Host-visibility callback (nullptr on a5)
+     * @param free_cb           Memory free callback
+     * @param user_data         Opaque pointer forwarded to callbacks
+     * @param output_prefix     Per-task directory; tensor_dump/ subdir lands here
      * @return 0 on success, error code on failure
      */
     int initialize(
         int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
-        DumpFreeCallback free_cb, DumpSetDeviceCallback set_device_cb = nullptr
+        DumpFreeCallback free_cb, void *user_data, const std::string &output_prefix
     );
 
-    void start_memory_manager();
-
     /**
-     * Streams payloads to `<output_path>/tensor_dump/<base>.bin` while the device
-     * runs. Caller-provided directory is the per-task uniqueness boundary.
+     * Per-buffer callback invoked by ProfilerBase's poll loop. Pulls the
+     * relevant portion of the originating thread's arena from device, copies
+     * tensor metadata + arena bytes into host-side DumpedTensor records, and
+     * queues payloads to the writer thread. The writer thread is started
+     * lazily on the first invocation per run.
      */
-    void poll_and_collect(const std::string &output_path);
+    void on_buffer_collected(const DumpReadyBufferInfo &info);
 
     /**
-     * Write JSON manifest. Bin file is already written by poll_and_collect's
-     * writer thread, so no parameter is needed (uses run_dir_).
+     * Write collected dumps to <output_prefix>/tensor_dump/{*.bin, *.json}.
+     * Sorts tensors by (task_id, subtask_id, func_id, stage, arg_index, role).
      */
     int export_dump_files();
-    void stop_memory_manager();
-    void drain_remaining_buffers();
-    void scan_remaining_dump_buffers();
-    void signal_execution_complete();
 
-    int finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb);
+    /**
+     * After stop(), perform purely-passive accounting:
+     *   - LOG_ERROR any non-zero DumpBufferState::current_buf_ptr with
+     *     records (device flush should always succeed-or-bump-dropped, so
+     *     a non-empty leftover indicates an AICPU flush bug — host does
+     *     NOT recover, to avoid masking the bug).
+     *   - Accumulate device-side dropped_record_count into
+     *     total_dropped_record_count_ for the final anomaly report.
+     * Must be called after stop().
+     */
+    void reconcile_counters();
 
-    bool is_initialized() const { return dump_shared_mem_host_ != nullptr; }
+    /**
+     * Free all device memory and unregister mappings (per-thread arenas,
+     * DumpMetaBuffers held by the framework or still in per-pool free
+     * queues). Idempotent on a collector that was never initialized.
+     */
+    int finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb, void *user_data);
 
+    /**
+     * @return true if initialize() succeeded and finalize() has not run.
+     */
+    bool is_initialized() const { return shm_host_ != nullptr; }
+
+    /**
+     * Device pointer to the DumpDataHeader. Set kernel_args.dump_data_base
+     * to this after initialize() succeeds so the AICPU side can find the
+     * shared memory.
+     */
     void *get_dump_shm_device_ptr() const { return dump_shared_mem_dev_; }
 
 private:
     void *dump_shared_mem_dev_{nullptr};
-    void *dump_shared_mem_host_{nullptr};
-    int device_id_{-1};
     int num_dump_threads_{0};
 
-    DumpAllocCallback alloc_cb_{nullptr};
-    DumpRegisterCallback register_cb_{nullptr};
-    DumpFreeCallback free_cb_{nullptr};
-    DumpSetDeviceCallback set_device_cb_{nullptr};
+    // Per-task output directory captured at initialize() time. The writer
+    // thread builds run_dir_ = output_prefix_ / "tensor_dump" lazily on the
+    // first on_buffer_collected.
+    std::string output_prefix_;
 
-    // Per-thread arena pointers
+    // Per-thread arena pointers (device + host shadow)
     struct ArenaInfo {
         void *dev_ptr{nullptr};
         void *host_ptr{nullptr};
         uint64_t size{0};
-        uint64_t high_water{0};  // For overwrite detection
+        uint64_t high_water{0};
     };
     std::vector<ArenaInfo> arenas_;
 
-    DumpMemoryManager memory_manager_;
-
-    // Collected dump tensors
+    // Collected dump tensors (metadata only; payloads live in tensors.bin)
     std::vector<DumpedTensor> collected_;
     std::mutex collected_mutex_;
-
-    // Execution complete signal
-    std::atomic<bool> execution_complete_{false};
 
     // Stats
     uint32_t total_dropped_record_count_{0};
     uint32_t total_truncated_count_{0};
     uint32_t total_overwrite_count_{0};
 
+    // Run-scoped state for the writer thread (lazily started on first
+    // on_buffer_collected and joined by export_dump_files).
+    std::chrono::steady_clock::time_point run_start_time_;
+    std::chrono::steady_clock::time_point last_progress_time_;
+    uint64_t buffers_collected_{0};
+    bool writer_started_{false};
+
     void *alloc_single_buffer(size_t size, void **host_ptr_out);
     void process_dump_buffer(const DumpReadyBufferInfo &info);
-
-    // Track processed buffer pointers to prevent double-processing
-    std::unordered_set<void *> processed_buffers_;
+    void start_writer_thread_once();
 
     // Writer thread: streams tensor payloads to a single tensors.bin
     std::thread writer_thread_;
@@ -288,7 +317,7 @@ private:
     // Output directory and single binary file
     std::filesystem::path run_dir_;
     std::ofstream bin_file_;
-    uint64_t next_bin_offset_{0};  // only accessed by collect thread
+    uint64_t next_bin_offset_{0};
 
     // Writer stats
     std::atomic<uint64_t> bytes_written_{0};

--- a/src/a5/platform/onboard/aicore/kernel.cpp
+++ b/src/a5/platform/onboard/aicore/kernel.cpp
@@ -12,7 +12,12 @@
  * Minimal AICore Kernel
  */
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "common/core_type.h"
+#include "common/kernel_args.h"
+#include "common/l2_perf_profiling.h"
+#include "common/platform_config.h"
+#include "common/pmu_profiling.h"
 
 class Runtime;
 
@@ -31,6 +36,35 @@ class Runtime;
 [[block_local]] int block_idx;
 [[block_local]] CoreType core_type;
 
+// Per-core profiling state. Populated once by KERNEL_ENTRY from KernelArgs;
+// read by aicore_execute and profiling helpers via the getters below. This
+// mirrors the AICPU-side set_l2_swimlane_enabled / set_pmu_enabled pattern,
+// keeping profiling fields out of runtime's Handshake and out of
+// aicore_execute's signature.
+//
+// The setters/getters are marked `weak` because kernel.cpp is compiled twice
+// (AIC + AIV) and linked into a single AICore binary; weak linkage lets the
+// linker dedup the otherwise-duplicate symbol definitions across the two
+// compilation units.
+[[block_local]] static uint32_t s_aicore_profiling_flag;
+[[block_local]] static __gm__ L2PerfAicoreRing *s_aicore_l2_perf_ring;
+[[block_local]] static __gm__ PmuAicoreRing *s_aicore_pmu_ring;
+[[block_local]] static uint64_t s_aicore_pmu_reg_base;
+
+__attribute__((weak)) __aicore__ void set_aicore_profiling_flag(uint32_t flag) { s_aicore_profiling_flag = flag; }
+__attribute__((weak)) __aicore__ uint32_t get_aicore_profiling_flag() { return s_aicore_profiling_flag; }
+
+__attribute__((weak)) __aicore__ void set_aicore_l2_perf_ring(__gm__ L2PerfAicoreRing *ring) {
+    s_aicore_l2_perf_ring = ring;
+}
+__attribute__((weak)) __aicore__ __gm__ L2PerfAicoreRing *get_aicore_l2_perf_ring() { return s_aicore_l2_perf_ring; }
+
+__attribute__((weak)) __aicore__ void set_aicore_pmu_ring(__gm__ PmuAicoreRing *ring) { s_aicore_pmu_ring = ring; }
+__attribute__((weak)) __aicore__ __gm__ PmuAicoreRing *get_aicore_pmu_ring() { return s_aicore_pmu_ring; }
+
+__attribute__((weak)) __aicore__ void set_aicore_pmu_reg_base(uint64_t reg_base) { s_aicore_pmu_reg_base = reg_base; }
+__attribute__((weak)) __aicore__ uint64_t get_aicore_pmu_reg_base() { return s_aicore_pmu_reg_base; }
+
 extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
 /**
@@ -45,10 +79,15 @@ extern __aicore__ void aicore_execute(__gm__ Runtime *runtime, int block_idx, Co
  *    - Use DCCI to ensure cache coherency with AICPU
  *
  * Each core (AIC or AIV) gets its own handshake buffer indexed by block_idx.
+ * Profiling state flows from KernelArgs into platform-owned per-core slots
+ * via set_aicore_profiling_flag() / set_aicore_l2_perf_ring() /
+ * set_aicore_pmu_ring() / set_aicore_pmu_reg_base(); the runtime's
+ * Handshake stays profiling-free and aicore_execute keeps its original
+ * signature.
  *
- * @param runtime Address of Runtime structure in device memory
+ * @param k_args Address of KernelArgs structure (contains runtime_args + profiling tables)
  */
-extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime *runtime) {
+extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ KernelArgs *k_args) {
     // Calculate block_idx for this core
 #ifdef __DAV_VEC__
     block_idx = get_block_idx() * get_subblockdim() + get_subblockid() + get_block_num();
@@ -58,5 +97,40 @@ extern "C" __global__ __aicore__ void KERNEL_ENTRY(aicore_kernel)(__gm__ Runtime
     core_type = CoreType::AIC;
 #endif
 
-    aicore_execute(runtime, block_idx, core_type);
+    // Publish per-core profiling state into platform-owned slots before the
+    // executor runs. AICore reads via get_aicore_*() — never touches Handshake
+    // for profiling. The PMU MMIO base is resolved here from
+    // `regs[physical_core_id]`; both fields are filled by the host before
+    // kernel launch, so the resolved base is valid from Phase 1 onward and
+    // does not depend on any AICPU init ordering.
+    set_aicore_profiling_flag(k_args->enable_profiling_flag);
+    if (GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE)) {
+        __gm__ uint64_t *ring_table = reinterpret_cast<__gm__ uint64_t *>(k_args->aicore_l2_perf_ring_addrs);
+        if (ring_table != nullptr) {
+            set_aicore_l2_perf_ring(reinterpret_cast<__gm__ L2PerfAicoreRing *>(ring_table[block_idx]));
+        } else {
+            set_aicore_l2_perf_ring(nullptr);
+        }
+    } else {
+        set_aicore_l2_perf_ring(nullptr);
+    }
+    if (GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_PMU)) {
+        __gm__ uint64_t *pmu_ring_table = reinterpret_cast<__gm__ uint64_t *>(k_args->aicore_pmu_ring_addrs);
+        if (pmu_ring_table != nullptr) {
+            set_aicore_pmu_ring(reinterpret_cast<__gm__ PmuAicoreRing *>(pmu_ring_table[block_idx]));
+        } else {
+            set_aicore_pmu_ring(nullptr);
+        }
+        __gm__ uint64_t *regs_array = reinterpret_cast<__gm__ uint64_t *>(k_args->regs);
+        if (regs_array != nullptr) {
+            set_aicore_pmu_reg_base(regs_array[get_physical_core_id()]);
+        } else {
+            set_aicore_pmu_reg_base(0);
+        }
+    } else {
+        set_aicore_pmu_ring(nullptr);
+        set_aicore_pmu_reg_base(0);
+    }
+
+    aicore_execute(k_args->runtime_args, block_idx, core_type);
 }

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -88,16 +88,17 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_log_level(static_cast<int>(k_args->log_level));
     set_log_info_v(static_cast<int>(k_args->log_info_v));
 
-    // Store platform regs before calling aicpu_execute
-    // Dump enable is an execution control flag propagated via handshake.
-    // The dump base address is only the backing storage location.
+    // Store platform regs before calling aicpu_execute. Profiling enable
+    // bits live on KernelArgs::enable_profiling_flag now (no longer
+    // mirrored into Handshake), so decode the umbrella bitmask once and
+    // hand it to the existing platform-state setters.
     set_platform_regs(k_args->regs);
     set_platform_dump_base(k_args->dump_data_base);
-    set_dump_tensor_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_dump_tensor_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_perf_base(k_args->l2_perf_data_base);
-    set_l2_swimlane_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
+    set_l2_swimlane_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
-    set_pmu_enabled(GET_PROFILING_FLAG(runtime->workers[0].enable_profiling_flag, PROFILING_FLAG_PMU));
+    set_pmu_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
     if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -104,6 +104,35 @@ int KernelArgsHelper::finalize_runtime_args() {
     return 0;
 }
 
+int KernelArgsHelper::init_device_kernel_args(MemoryAllocator &allocator) {
+    allocator_ = &allocator;
+    if (device_k_args_ == nullptr) {
+        void *dev_ptr = allocator_->alloc(sizeof(KernelArgs));
+        if (dev_ptr == nullptr) {
+            LOG_ERROR("Alloc for device KernelArgs failed");
+            return -1;
+        }
+        device_k_args_ = reinterpret_cast<KernelArgs *>(dev_ptr);
+    }
+    int rc = rtMemcpy(device_k_args_, sizeof(KernelArgs), &args, sizeof(KernelArgs), RT_MEMCPY_HOST_TO_DEVICE);
+    if (rc != 0) {
+        LOG_ERROR("rtMemcpy for KernelArgs failed: %d", rc);
+        allocator_->free(device_k_args_);
+        device_k_args_ = nullptr;
+        return rc;
+    }
+    return 0;
+}
+
+int KernelArgsHelper::finalize_device_kernel_args() {
+    if (device_k_args_ != nullptr && allocator_ != nullptr) {
+        int rc = allocator_->free(device_k_args_);
+        device_k_args_ = nullptr;
+        return rc;
+    }
+    return 0;
+}
+
 // =============================================================================
 // AicpuSoInfo Implementation
 // =============================================================================
@@ -148,6 +177,17 @@ int AicpuSoInfo::finalize() {
 // =============================================================================
 // DeviceRunner Implementation
 // =============================================================================
+
+// rtMalloc / rtFree wrappers shared by all three profiling subsystems.
+// `user_data` is unused on a5 onboard but kept in the signature to match
+// the framework's canonical alloc/free callback shape.
+static void *prof_alloc_cb(size_t size, void * /*user_data*/) {
+    void *ptr = nullptr;
+    int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
+    return (rc == 0) ? ptr : nullptr;
+}
+
+static int prof_free_cb(void *dev_ptr, void * /*user_data*/) { return rtFree(dev_ptr); }
 
 DeviceRunner::~DeviceRunner() { finalize(); }
 
@@ -378,9 +418,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         runtime.workers[i].task = 0;
         // Set core type: first 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-        runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
-        runtime.workers[i].l2_perf_records_addr = static_cast<uint64_t>(0);
     }
+    // Profiling enablement lives on KernelArgs (no longer mirrored into Handshake).
+    kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
 
     // Set function_bin_addr for all tasks: Runtime::func_id_to_addr_[] stores
     // a CoreCallable device address; the binary code address is one
@@ -405,36 +445,29 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     });
 
     auto runtime_args_cleanup = RAIIScopeGuard([this]() {
+        kernel_args_.finalize_device_kernel_args();
         kernel_args_.finalize_runtime_args();
     });
 
-    // Initialize performance profiling if enabled
+    // Initialize per-subsystem shared memory.
     if (enable_l2_swimlane_) {
-        rc = init_l2_perf_collection(num_aicore, device_id_);
+        rc = init_l2_perf(num_aicore, device_id_);
         if (rc != 0) {
-            LOG_ERROR("init_l2_perf_collection failed: %d", rc);
+            LOG_ERROR("init_l2_perf failed: %d", rc);
             return rc;
         }
-        // Start memory management thread (needs device context)
-        l2_perf_collector_.start_memory_manager([this](std::function<void()> fn) {
-            return create_thread(std::move(fn));
-        });
     }
 
-    // Initialize tensor dump if enabled
     if (enable_dump_tensor_) {
-        rc = init_tensor_dump(runtime, num_aicore, device_id_);
+        rc = init_tensor_dump(runtime, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
         }
-        dump_collector_.start_memory_manager();
     }
 
     if (enable_pmu_) {
-        rc = init_pmu_buffers(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_
-        );
+        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.args.pmu_data_base = 0;
@@ -442,13 +475,19 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
+    // Cleanup guard for early returns: stops all started collectors so
+    // their mgmt + poll threads exit cleanly. stop() is idempotent and a
+    // no-op on collectors that never started.
+    auto perf_cleanup = RAIIScopeGuard([this]() {
+        finalize_collectors();
+    });
+
     LOG_INFO_V0("=== Initialize runtime args ===");
     rc = prepare_orch_so(runtime);
     if (rc != 0) {
         LOG_ERROR("prepare_orch_so failed: %d", rc);
         return rc;
     }
-    // Initialize runtime args
     rc = kernel_args_.init_runtime_args(runtime, mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("init_runtime_args failed: %d", rc);
@@ -462,8 +501,23 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     kernel_args_.args.log_level = static_cast<uint32_t>(HostLogger::get_instance().level());
     kernel_args_.args.log_info_v = static_cast<uint32_t>(HostLogger::get_instance().info_v());
 
+    // Start collector mgmt + poll threads now, just before kernels launch.
+    // Starting earlier wastes CPU on empty queues and risks tripping
+    // ProfilerBase's poll-loop idle-timeout if device-side init is slow.
+    auto thread_factory = [this](std::function<void()> fn) {
+        return create_thread(std::move(fn));
+    };
+    if (enable_l2_swimlane_) {
+        l2_perf_collector_.start(thread_factory);
+    }
+    if (enable_dump_tensor_) {
+        dump_collector_.start(thread_factory);
+    }
+    if (enable_pmu_) {
+        pmu_collector_.start(thread_factory);
+    }
+
     LOG_INFO_V0("=== launch_aicpu_kernel DynTileFwkKernelServerInit ===");
-    // Launch AICPU init kernel
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (init) failed: %d", rc);
@@ -471,7 +525,6 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     LOG_INFO_V0("=== launch_aicpu_kernel DynTileFwkKernelServer ===");
-    // Launch AICPU main kernel (over-launch for affinity gate)
     rc = launch_aicpu_kernel(
         stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
     );
@@ -481,103 +534,52 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     LOG_INFO_V0("=== launch_aicore_kernel ===");
-    // Launch AICore kernel
-    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.args.runtime_args);
+    rc = kernel_args_.init_device_kernel_args(mem_alloc_);
+    if (rc != 0) {
+        LOG_ERROR("init_device_kernel_args failed: %d", rc);
+        return rc;
+    }
+    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
         return rc;
     }
 
-    // Launch collector threads before synchronization.
-    // The enclosing scope ensures guards signal + join on any early return.
-    {
-        std::thread collector_thread;
-        if (enable_l2_swimlane_) {
-            collector_thread = create_thread([this]() {
-                poll_and_collect_performance_data(0);  // auto-detect task count
-            });
-        }
-        auto perf_thread_guard = RAIIScopeGuard([&]() {
-            if (collector_thread.joinable()) {
-                collector_thread.join();
-            }
-        });
-        auto perf_signal_guard = RAIIScopeGuard([this]() {
-            if (enable_l2_swimlane_) {
-                l2_perf_collector_.signal_execution_complete();
-            }
-        });
-
-        std::thread dump_collector_thread;
-        if (enable_dump_tensor_) {
-            dump_collector_thread = create_thread([this]() {
-                dump_collector_.poll_and_collect(output_prefix_);
-            });
-        }
-        auto dump_thread_guard = RAIIScopeGuard([&]() {
-            if (dump_collector_thread.joinable()) {
-                dump_collector_thread.join();
-            }
-        });
-        auto dump_signal_guard = RAIIScopeGuard([this]() {
-            if (enable_dump_tensor_) {
-                dump_collector_.signal_execution_complete();
-            }
-        });
-
-        std::thread pmu_collector_thread;
-        if (enable_pmu_ && pmu_collector_.is_initialized()) {
-            pmu_collector_thread = create_thread([this]() {
-                pmu_collector_.poll_and_collect();
-            });
-        }
-        auto pmu_thread_guard = RAIIScopeGuard([&]() {
-            if (pmu_collector_thread.joinable()) {
-                pmu_collector_thread.join();
-            }
-        });
-        auto pmu_signal_guard = RAIIScopeGuard([&]() {
-            if (enable_pmu_ && pmu_collector_.is_initialized()) {
-                pmu_collector_.signal_execution_complete();
-            }
-        });
-
-        LOG_INFO_V0("=== rtStreamSynchronize stream_aicpu_ ===");
-        rc = rtStreamSynchronize(stream_aicpu_);
-        if (rc != 0) {
-            LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
-            return rc;
-        }
-
-        LOG_INFO_V0("=== rtStreamSynchronize stream_aicore_ ===");
-        rc = rtStreamSynchronize(stream_aicore_);
-        if (rc != 0) {
-            LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
-            return rc;
-        }
+    LOG_INFO_V0("=== rtStreamSynchronize stream_aicpu_ ===");
+    rc = rtStreamSynchronize(stream_aicpu_);
+    if (rc != 0) {
+        LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
+        return rc;
     }
 
-    // After streams are synchronized and guards have signal+joined all threads,
-    // stop memory managers, drain remaining buffers, and export.
-    // All three collectors write under `output_prefix_`, the per-task directory
-    // the user must set on CallConfig (CallConfig::validate() enforces non-empty).
+    LOG_INFO_V0("=== rtStreamSynchronize stream_aicore_ ===");
+    rc = rtStreamSynchronize(stream_aicore_);
+    if (rc != 0) {
+        LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
+        return rc;
+    }
+
+    // Tear down collectors. stop() joins mgmt then collector in the only
+    // safe order (mgmt's final-drain pass into L2 has poll as its
+    // consumer). Diagnostic exports use the per-task `output_prefix_`
+    // directory the user set on CallConfig (validate() enforces non-empty
+    // upstream).
     if (enable_l2_swimlane_) {
-        l2_perf_collector_.stop_memory_manager();
-        l2_perf_collector_.drain_remaining_buffers();
-        l2_perf_collector_.scan_remaining_perf_buffers();
-        l2_perf_collector_.collect_phase_data();
-        l2_perf_collector_.export_swimlane_json(output_prefix_);
+        l2_perf_collector_.stop();
+        l2_perf_collector_.read_phase_header_metadata();
+        l2_perf_collector_.reconcile_counters();
+        l2_perf_collector_.export_swimlane_json();
     }
 
     if (enable_dump_tensor_) {
-        dump_collector_.stop_memory_manager();
-        dump_collector_.drain_remaining_buffers();
-        dump_collector_.scan_remaining_dump_buffers();
+        dump_collector_.stop();
+        dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
-    if (enable_pmu_ && pmu_collector_.is_initialized()) {
-        pmu_collector_.drain_remaining_buffers();
+    if (enable_pmu_) {
+        pmu_collector_.stop();
+        pmu_collector_.reconcile_counters();
     }
 
     // Print handshake results (reads from device memory, must be before free)
@@ -810,7 +812,8 @@ int DeviceRunner::finalize() {
 
     release_run_context();
 
-    // Cleanup kernel args (deviceArgs)
+    // Cleanup kernel args (deviceArgs); device-side KernelArgs + runtime args
+    // are released by runtime_args_cleanup RAII so they also unwind on errors.
     kernel_args_.finalize_device_args();
 
     // Cleanup AICPU SO
@@ -852,28 +855,16 @@ int DeviceRunner::finalize() {
     aicpu_seen_callable_ids_.clear();
     aicpu_dlopen_total_ = 0;
 
-    // Cleanup performance profiling (frees L2PerfSetupHeader + all per-core/per-thread buffers)
+    // Cleanup all profiling subsystems (free shm + per-buffer dev/host
+    // shadows). All three collectors share the same alloc/free shape.
     if (l2_perf_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr) -> int {
-            return rtFree(dev_ptr);
-        };
-        l2_perf_collector_.finalize(nullptr, free_cb);
+        l2_perf_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
-
-    // Cleanup tensor dump
     if (dump_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr) -> int {
-            return rtFree(dev_ptr);
-        };
-        dump_collector_.finalize(nullptr, free_cb);
+        dump_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
-
-    // Cleanup PMU profiling
     if (pmu_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr, void * /*user_data*/) -> int {
-            return rtFree(dev_ptr);
-        };
-        pmu_collector_.finalize(nullptr, free_cb, nullptr);
+        pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
@@ -918,7 +909,7 @@ int DeviceRunner::launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, con
     );
 }
 
-int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
+int DeviceRunner::launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args) {
     if (aicore_kernel_binary_.empty()) {
         LOG_ERROR("AICore kernel binary is empty");
         return -1;
@@ -941,10 +932,10 @@ int DeviceRunner::launch_aicore_kernel(rtStream_t stream, Runtime *runtime) {
     }
 
     struct Args {
-        Runtime *runtime;
+        KernelArgs *k_args;
     };
-    // Pass device address of Runtime to AICore
-    Args args = {runtime};
+    // Pass device address of KernelArgs to AICore (KERNEL_ENTRY signature).
+    Args args = {k_args};
     rtArgsEx_t rt_args;
     std::memset(&rt_args, 0, sizeof(rt_args));
     rt_args.args = &args;
@@ -1028,49 +1019,39 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
     return chip_dev;
 }
 
-int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
-    // Device memory allocation via rtMalloc directly
-    auto alloc_cb = [](size_t size) -> void * {
-        void *ptr = nullptr;
-        int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
-        return (rc == 0) ? ptr : nullptr;
-    };
+void DeviceRunner::finalize_collectors() {
+    if (l2_perf_collector_.is_initialized()) {
+        l2_perf_collector_.stop();
+    }
+    if (dump_collector_.is_initialized()) {
+        dump_collector_.stop();
+    }
+    if (pmu_collector_.is_initialized()) {
+        pmu_collector_.stop();
+    }
+}
 
-    auto free_cb = [](void *dev_ptr) -> int {
-        return rtFree(dev_ptr);
-    };
-
-    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, nullptr, free_cb);
+int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
+    int rc = l2_perf_collector_.initialize(
+        num_aicore, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
+        output_prefix_
+    );
     if (rc == 0) {
         kernel_args_.args.l2_perf_data_base =
             reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+        kernel_args_.args.aicore_l2_perf_ring_addrs =
+            reinterpret_cast<uint64_t>(l2_perf_collector_.get_aicore_ring_addrs_device_ptr());
     }
     return rc;
 }
 
-void DeviceRunner::poll_and_collect_performance_data(int expected_tasks) {
-    l2_perf_collector_.poll_and_collect(expected_tasks);
-}
-
-int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {
-    (void)num_aicore;
+int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.sche_cpu_num;
 
-    auto alloc_cb = [](size_t size) -> void * {
-        void *ptr = nullptr;
-        int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
-        return (rc == 0) ? ptr : nullptr;
-    };
-
-    auto free_cb = [](void *dev_ptr) -> int {
-        return rtFree(dev_ptr);
-    };
-
-    auto set_device_cb = [](int dev_id) -> int {
-        return rtSetDevice(dev_id);
-    };
-
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb, set_device_cb);
+    int rc = dump_collector_.initialize(
+        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
+        output_prefix_
+    );
     if (rc != 0) {
         return rc;
     }
@@ -1079,22 +1060,17 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
     return 0;
 }
 
-int DeviceRunner::init_pmu_buffers(
+int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
 ) {
-    auto alloc_cb = [](size_t size, void * /*user_data*/) -> void * {
-        void *ptr = nullptr;
-        int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
-        return (rc == 0) ? ptr : nullptr;
-    };
-
-    auto free_cb = [](void *dev_ptr, void * /*user_data*/) -> int {
-        return rtFree(dev_ptr);
-    };
-
     int rc = pmu_collector_.init(
-        num_cores, num_threads, &kernel_args_.args.pmu_data_base, csv_path, event_type, alloc_cb, free_cb, nullptr,
-        device_id
+        num_cores, num_threads, csv_path, event_type, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb,
+        /*user_data=*/nullptr, device_id
     );
+    if (rc == 0) {
+        kernel_args_.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
+        kernel_args_.args.aicore_pmu_ring_addrs =
+            reinterpret_cast<uint64_t>(pmu_collector_.get_aicore_ring_addrs_device_ptr());
+    }
     return rc;
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -78,6 +78,7 @@ struct DeviceArgs {
 struct KernelArgsHelper {
     KernelArgs args;
     MemoryAllocator *allocator_{nullptr};
+    KernelArgs *device_k_args_{nullptr};  // Device pointer (populated by init_device_kernel_args)
 
     /**
      * Initialize device arguments by allocating device memory and copying data
@@ -110,6 +111,20 @@ struct KernelArgsHelper {
      * @return 0 on success, error code on failure
      */
     int finalize_runtime_args();
+
+    /**
+     * Allocate device memory for the host-resident KernelArgs and copy the
+     * struct over. AICore's KERNEL_ENTRY expects a KernelArgs* (not a
+     * Runtime*) so it can read the profiling enablement bits + ring address
+     * tables and forward them into AICore platform state. Call this after
+     * every kernel_args.args.* field is populated for the run.
+     */
+    int init_device_kernel_args(MemoryAllocator &allocator);
+
+    /**
+     * Free device memory allocated for the device-resident KernelArgs copy.
+     */
+    int finalize_device_kernel_args();
 
     /**
      * Implicit conversion operators for seamless use with runtime APIs
@@ -273,17 +288,6 @@ public:
     void print_handshake_results();
 
     /**
-     * Poll and collect performance data from the memory manager's queue
-     *
-     * Runs on a dedicated collector thread. Pulls ready buffers from
-     * ProfMemoryManager, copies records to host vectors, and notifies
-     * the manager to free old device buffers.
-     *
-     * @param expected_tasks Expected total number of tasks
-     */
-    void poll_and_collect_performance_data(int expected_tasks);
-
-    /**
      * Cleanup all resources
      *
      * Frees all device memory, destroys streams, and resets state.
@@ -311,13 +315,15 @@ public:
      * Launch an AICore kernel
      *
      * Internal method used by run(). Can be called directly for custom
-     * workflows.
+     * workflows. Receives the device-resident KernelArgs pointer, which the
+     * AICore KERNEL_ENTRY uses to forward profiling state into platform
+     * slots before calling aicore_execute(runtime_args, ...).
      *
      * @param stream  AICore stream
-     * @param runtime   Pointer to device runtime
+     * @param k_args  Device pointer to the populated KernelArgs
      * @return 0 on success, error code on failure
      */
-    int launch_aicore_kernel(rtStream_t stream, Runtime *runtime);
+    int launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args);
 
     /**
      * Upload an entire ChipCallable buffer to device memory in one shot.
@@ -556,7 +562,7 @@ private:
      * @param device_id Device ID
      * @return 0 on success, error code on failure
      */
-    int init_l2_perf_collection(int num_aicore, int device_id);
+    int init_l2_perf(int num_aicore, int device_id);
 
     /**
      * Initialize tensor dump device buffers.
@@ -566,7 +572,7 @@ private:
      * @param device_id Device ID for allocations
      * @return 0 on success, error code on failure
      */
-    int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
+    int init_tensor_dump(Runtime &runtime, int device_id);
 
     /**
      * Initialize PMU profiling device buffers.
@@ -585,9 +591,13 @@ private:
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                  // diagnostic artifact root directory
 
-    int init_pmu_buffers(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
-    );
+    int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+
+    // Per-run collector teardown: stops mgmt + poll threads on every collector
+    // whose init succeeded, in the only safe order (stop() joins mgmt before
+    // poll). Idempotent — collectors that never initialized are skipped.
+    // Does not release device memory; full release happens in finalize().
+    void finalize_collectors();
 };
 
 #endif  // RUNTIME_DEVICERUNNER_H

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -21,8 +21,11 @@
 
 #include "inner_kernel.h"
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "common/core_type.h"
+#include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
+#include "common/pmu_profiling.h"
 #include "runtime.h"
 
 // Per-thread simulated register state — use pthread TLS instead of C++
@@ -30,17 +33,60 @@
 // with RTLD_LOCAL on aarch64.
 static pthread_key_t g_reg_base_key;
 static pthread_key_t g_core_id_key;
+static pthread_key_t g_block_idx_key;
+static pthread_key_t g_aicore_profiling_flag_key;
+static pthread_key_t g_aicore_l2_perf_ring_key;
+static pthread_key_t g_aicore_pmu_ring_key;
+static pthread_key_t g_pmu_reg_base_key;
 static pthread_once_t g_tls_once = PTHREAD_ONCE_INIT;
 
 static void create_tls_keys() {
     pthread_key_create(&g_reg_base_key, nullptr);
     pthread_key_create(&g_core_id_key, nullptr);
+    pthread_key_create(&g_block_idx_key, nullptr);
+    pthread_key_create(&g_aicore_profiling_flag_key, nullptr);
+    pthread_key_create(&g_aicore_l2_perf_ring_key, nullptr);
+    pthread_key_create(&g_aicore_pmu_ring_key, nullptr);
+    pthread_key_create(&g_pmu_reg_base_key, nullptr);
 }
 
 volatile uint8_t *sim_get_reg_base() { return static_cast<volatile uint8_t *>(pthread_getspecific(g_reg_base_key)); }
 
 uint32_t sim_get_physical_core_id() {
     return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_core_id_key)));
+}
+
+// Per-core profiling state setters/getters. Same contract as the onboard
+// [[block_local]] backing in src/a5/platform/onboard/aicore/kernel.cpp —
+// AICore never reaches into the runtime's Handshake for profiling, runtime's
+// aicore_execute keeps its original signature, and adding profiling fields
+// only touches KernelArgs + this state surface.
+__aicore__ void set_aicore_profiling_flag(uint32_t flag) {
+    pthread_setspecific(g_aicore_profiling_flag_key, reinterpret_cast<void *>(static_cast<uintptr_t>(flag)));
+}
+__aicore__ uint32_t get_aicore_profiling_flag() {
+    return static_cast<uint32_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_aicore_profiling_flag_key)));
+}
+
+__aicore__ void set_aicore_l2_perf_ring(__gm__ L2PerfAicoreRing *ring) {
+    pthread_setspecific(g_aicore_l2_perf_ring_key, reinterpret_cast<void *>(ring));
+}
+__aicore__ __gm__ L2PerfAicoreRing *get_aicore_l2_perf_ring() {
+    return reinterpret_cast<__gm__ L2PerfAicoreRing *>(pthread_getspecific(g_aicore_l2_perf_ring_key));
+}
+
+__aicore__ void set_aicore_pmu_ring(__gm__ PmuAicoreRing *ring) {
+    pthread_setspecific(g_aicore_pmu_ring_key, reinterpret_cast<void *>(ring));
+}
+__aicore__ __gm__ PmuAicoreRing *get_aicore_pmu_ring() {
+    return reinterpret_cast<__gm__ PmuAicoreRing *>(pthread_getspecific(g_aicore_pmu_ring_key));
+}
+
+__aicore__ void set_aicore_pmu_reg_base(uint64_t reg_base) {
+    pthread_setspecific(g_pmu_reg_base_key, reinterpret_cast<void *>(static_cast<uintptr_t>(reg_base)));
+}
+__aicore__ uint64_t get_aicore_pmu_reg_base() {
+    return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(pthread_getspecific(g_pmu_reg_base_key)));
 }
 
 // Core identity setter function pointers — set by DeviceRunner after dlopen.
@@ -59,22 +105,44 @@ extern "C" void set_sim_core_identity_helpers(void *set_subblock_id, void *set_c
 // Declare the original function (defined in aicore_executor.cpp with weak linkage)
 void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type);
 
-// Wrapper with extern "C" for dlsym lookup
-// NOTE: physical_core_id stays in wrapper signature (DeviceRunner passes it for register indexing)
+// Wrapper with extern "C" for dlsym lookup. Mirrors the onboard kernel.cpp
+// KERNEL_ENTRY: receives launch arguments straight from the host, populates
+// the per-thread profiling slots via set_aicore_*(), then invokes the runtime
+// executor with its original signature.
 extern "C" void aicore_execute_wrapper(
-    __gm__ Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+    __gm__ Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs,
+    uint32_t enable_profiling_flag, uint64_t aicore_l2_perf_ring_addrs, uint64_t aicore_pmu_ring_addrs
 ) {
     pthread_once(&g_tls_once, create_tls_keys);
 
     // Set up simulated register base for this thread.
     // regs points to an array of uint64_t base addresses (one per core).
     // physical_core_id indexes into it to get this core's register block.
+    uint64_t this_core_reg_base = 0;
     if (regs != 0) {
         uint64_t *regs_array = reinterpret_cast<uint64_t *>(regs);
-        pthread_setspecific(g_reg_base_key, reinterpret_cast<void *>(regs_array[physical_core_id]));
+        this_core_reg_base = regs_array[physical_core_id];
+        pthread_setspecific(g_reg_base_key, reinterpret_cast<void *>(this_core_reg_base));
     }
 
     pthread_setspecific(g_core_id_key, reinterpret_cast<void *>(static_cast<uintptr_t>(physical_core_id)));
+    pthread_setspecific(g_block_idx_key, reinterpret_cast<void *>(static_cast<uintptr_t>(block_idx)));
+
+    // Publish per-core profiling state before the executor runs.
+    set_aicore_profiling_flag(enable_profiling_flag);
+    if ((enable_profiling_flag & PROFILING_FLAG_L2_SWIMLANE) && aicore_l2_perf_ring_addrs != 0) {
+        uint64_t *ring_table = reinterpret_cast<uint64_t *>(aicore_l2_perf_ring_addrs);
+        set_aicore_l2_perf_ring(reinterpret_cast<__gm__ L2PerfAicoreRing *>(ring_table[block_idx]));
+    } else {
+        set_aicore_l2_perf_ring(nullptr);
+    }
+    if ((enable_profiling_flag & PROFILING_FLAG_PMU) && aicore_pmu_ring_addrs != 0) {
+        uint64_t *pmu_ring_table = reinterpret_cast<uint64_t *>(aicore_pmu_ring_addrs);
+        set_aicore_pmu_ring(reinterpret_cast<__gm__ PmuAicoreRing *>(pmu_ring_table[block_idx]));
+    } else {
+        set_aicore_pmu_ring(nullptr);
+    }
+    set_aicore_pmu_reg_base(this_core_reg_base);
 
     // Set core identity for pto-isa TPUSH/TPOP simulation.
     // Core layout in sim DeviceRunner:

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -45,7 +45,8 @@
 // Function pointer types for dynamically loaded executors
 typedef int (*aicpu_execute_func_t)(Runtime *runtime);
 typedef void (*aicore_execute_func_t)(
-    Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs
+    Runtime *runtime, int block_idx, CoreType core_type, uint32_t physical_core_id, uint64_t regs,
+    uint32_t enable_profiling_flag, uint64_t aicore_l2_perf_ring_addrs, uint64_t aicore_pmu_ring_addrs
 );
 typedef void (*set_platform_regs_func_t)(uint64_t regs);
 
@@ -97,6 +98,16 @@ bool create_temp_so_file(const std::string &path_template, const uint8_t *data, 
 // =============================================================================
 // DeviceRunner Implementation
 // =============================================================================
+
+// malloc / free wrappers shared by all three profiling subsystems.
+// `user_data` is unused in sim but kept in the signature to match the
+// framework's canonical alloc/free callback shape.
+static void *prof_alloc_cb(size_t size, void * /*user_data*/) { return std::malloc(size); }
+
+static int prof_free_cb(void *dev_ptr, void * /*user_data*/) {
+    std::free(dev_ptr);
+    return 0;
+}
 
 DeviceRunner::~DeviceRunner() { finalize(); }
 
@@ -241,9 +252,8 @@ int DeviceRunner::ensure_binaries_loaded() {
             return -1;
         }
 
-        aicore_execute_func_ = reinterpret_cast<void (*)(Runtime *, int, CoreType, uint32_t, uint64_t)>(
-            dlsym(aicore_so_handle_, "aicore_execute_wrapper")
-        );
+        aicore_execute_func_ =
+            reinterpret_cast<aicore_execute_func_t>(dlsym(aicore_so_handle_, "aicore_execute_wrapper"));
         if (aicore_execute_func_ == nullptr) {
             LOG_ERROR("dlsym failed for aicore_execute_wrapper: %s", dlerror());
             return -1;
@@ -343,8 +353,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         runtime.workers[i].task = 0;
         // First 1/3 are AIC, remaining 2/3 are AIV
         runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
-        runtime.workers[i].enable_profiling_flag = enable_profiling_flag;
     }
+    // Profiling state lives on KernelArgs now (no longer mirrored into Handshake).
+    kernel_args_.enable_profiling_flag = enable_profiling_flag;
 
     // Set function_bin_addr for each task: Runtime::func_id_to_addr_[] stores
     // a CoreCallable host address (chip buffer + offset); dereference
@@ -369,33 +380,26 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // Store runtime pointer for print_handshake_results
     last_runtime_ = &runtime;
 
-    // Initialize performance profiling if enabled
+    // Initialize per-subsystem shared memory.
     if (enable_l2_swimlane_) {
-        rc = init_l2_perf_collection(num_aicore, device_id_);
+        rc = init_l2_perf(num_aicore, device_id_);
         if (rc != 0) {
-            LOG_ERROR("init_l2_perf_collection failed: %d", rc);
+            LOG_ERROR("init_l2_perf failed: %d", rc);
             return rc;
         }
-        // Start memory management thread
-        l2_perf_collector_.start_memory_manager([this](std::function<void()> fn) {
-            return create_thread(std::move(fn));
-        });
     }
 
     if (enable_dump_tensor_) {
         // Initialize tensor dump (independent from profiling)
-        rc = init_tensor_dump(runtime, num_aicore, device_id_);
+        rc = init_tensor_dump(runtime, device_id_);
         if (rc != 0) {
             LOG_ERROR("init_tensor_dump failed: %d", rc);
             return rc;
         }
-        dump_collector_.start_memory_manager();
     }
 
     if (enable_pmu_) {
-        rc = init_pmu_buffers(
-            num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_
-        );
+        rc = init_pmu(num_aicore, launch_aicpu_num, make_pmu_csv_path(output_prefix_), pmu_event_type_, device_id_);
         if (rc != 0) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.pmu_data_base = 0;
@@ -403,11 +407,11 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
+    // Cleanup guard for early returns: stops all started collectors so
+    // their mgmt + poll threads exit cleanly. stop() is idempotent and a
+    // no-op on collectors that never started.
     auto perf_cleanup = RAIIScopeGuard([this]() {
-        bool was_initialized = l2_perf_collector_.is_initialized();
-        if (was_initialized) {
-            l2_perf_collector_.stop_memory_manager();
-        }
+        finalize_collectors();
     });
 
     // Allocate simulated register blocks for all AICore cores
@@ -467,6 +471,23 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // (RTLD_GLOBAL singleton) and the AICPU sim SO reads it directly via the
     // same global lookup.
 
+    // Start collector mgmt + poll threads now, just before kernels launch.
+    // Starting earlier wastes CPU on empty queues and risks tripping
+    // ProfilerBase's poll-loop idle-timeout if the AICPU SO is slow to come
+    // up.
+    auto thread_factory = [this](std::function<void()> fn) {
+        return create_thread(std::move(fn));
+    };
+    if (enable_l2_swimlane_) {
+        l2_perf_collector_.start(thread_factory);
+    }
+    if (enable_dump_tensor_) {
+        dump_collector_.start(thread_factory);
+    }
+    if (enable_pmu_) {
+        pmu_collector_.start(thread_factory);
+    }
+
     // Launch AICPU threads (over-launch for affinity gate)
     constexpr int over_launch = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
     LOG_INFO_V0("Launching %d AICPU threads (logical=%d)", over_launch, launch_aicpu_num);
@@ -493,61 +514,19 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         CoreType core_type = runtime.workers[i].core_type;
         uint32_t physical_core_id = static_cast<uint32_t>(i);
         aicore_threads.push_back(create_thread([this, &runtime, i, core_type, physical_core_id]() {
-            aicore_execute_func_(&runtime, i, core_type, physical_core_id, kernel_args_.regs);
+            aicore_execute_func_(
+                &runtime, i, core_type, physical_core_id, kernel_args_.regs, kernel_args_.enable_profiling_flag,
+                kernel_args_.aicore_l2_perf_ring_addrs, kernel_args_.aicore_pmu_ring_addrs
+            );
         }));
     }
 
-    // Poll and collect performance data during execution (if enabled)
-    std::thread collector_thread;
-    if (enable_l2_swimlane_) {
-        collector_thread = create_thread([this, &runtime]() {
-            l2_perf_collector_.poll_and_collect(runtime.get_task_count());
-        });
-    }
-
-    std::thread dump_collector_thread;
-    if (enable_dump_tensor_) {
-        dump_collector_thread = std::thread([this]() {
-            dump_collector_.poll_and_collect(output_prefix_);
-        });
-    }
-
-    std::thread pmu_collector_thread;
-    if (enable_pmu_) {
-        pmu_collector_thread = std::thread([this]() {
-            pmu_collector_.poll_and_collect();
-        });
-    }
-
-    // Wait for all AICPU and AICore threads to complete
     LOG_INFO_V0("Waiting for threads to complete");
     for (auto &t : aicpu_threads) {
         t.join();
     }
     for (auto &t : aicore_threads) {
         t.join();
-    }
-
-    // Signal all collectors that device execution is complete
-    if (enable_l2_swimlane_) {
-        l2_perf_collector_.signal_execution_complete();
-    }
-    if (enable_dump_tensor_) {
-        dump_collector_.signal_execution_complete();
-    }
-    if (enable_pmu_) {
-        pmu_collector_.signal_execution_complete();
-    }
-
-    // Wait for all collector threads
-    if (collector_thread.joinable()) {
-        collector_thread.join();
-    }
-    if (dump_collector_thread.joinable()) {
-        dump_collector_thread.join();
-    }
-    if (pmu_collector_thread.joinable()) {
-        pmu_collector_thread.join();
     }
 
     LOG_INFO_V0("All threads completed");
@@ -558,25 +537,27 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return runtime_rc;
     }
 
-    // Diagnostic exports use the per-task `output_prefix_` directory the user
-    // set on CallConfig (CallConfig::validate() enforces non-empty upstream).
+    // Tear down collectors. stop() joins mgmt then collector in the only
+    // safe order (mgmt's final-drain pass into L2 has poll as its
+    // consumer). Diagnostic exports use the per-task `output_prefix_`
+    // directory the user set on CallConfig (validate() enforces non-empty
+    // upstream).
     if (enable_l2_swimlane_) {
-        l2_perf_collector_.stop_memory_manager();
-        l2_perf_collector_.drain_remaining_buffers();
-        l2_perf_collector_.scan_remaining_perf_buffers();
-        l2_perf_collector_.collect_phase_data();
-        l2_perf_collector_.export_swimlane_json(output_prefix_);
+        l2_perf_collector_.stop();
+        l2_perf_collector_.read_phase_header_metadata();
+        l2_perf_collector_.reconcile_counters();
+        l2_perf_collector_.export_swimlane_json();
     }
 
     if (enable_dump_tensor_) {
-        dump_collector_.stop_memory_manager();
-        dump_collector_.drain_remaining_buffers();
-        dump_collector_.scan_remaining_dump_buffers();
+        dump_collector_.stop();
+        dump_collector_.reconcile_counters();
         dump_collector_.export_dump_files();
     }
 
-    if (enable_pmu_ && pmu_collector_.is_initialized()) {
-        pmu_collector_.drain_remaining_buffers();
+    if (enable_pmu_) {
+        pmu_collector_.stop();
+        pmu_collector_.reconcile_counters();
     }
 
     // Print handshake results at end of run
@@ -820,34 +801,15 @@ int DeviceRunner::finalize() {
         return 0;
     }
 
-    // Cleanup performance profiling
+    // Cleanup all profiling subsystems.
     if (l2_perf_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr) -> int {
-            free(dev_ptr);
-            return 0;
-        };
-
-        l2_perf_collector_.finalize(nullptr, free_cb);
+        l2_perf_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
-
-    // Cleanup tensor dump
     if (dump_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr) -> int {
-            free(dev_ptr);
-            return 0;
-        };
-
-        dump_collector_.finalize(nullptr, free_cb);
+        dump_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
-
     if (pmu_collector_.is_initialized()) {
-        auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-            (void)user_data;
-            free(dev_ptr);
-            return 0;
-        };
-
-        pmu_collector_.finalize(nullptr, free_cb, nullptr);
+        pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
 
     // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
@@ -999,41 +961,38 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
 // Performance Profiling Implementation
 // =============================================================================
 
-int DeviceRunner::init_l2_perf_collection(int num_aicore, int device_id) {
-    // Define allocation callback (a5sim: use malloc)
-    auto alloc_cb = [](size_t size) -> void * {
-        return malloc(size);
-    };
+void DeviceRunner::finalize_collectors() {
+    if (l2_perf_collector_.is_initialized()) {
+        l2_perf_collector_.stop();
+    }
+    if (dump_collector_.is_initialized()) {
+        dump_collector_.stop();
+    }
+    if (pmu_collector_.is_initialized()) {
+        pmu_collector_.stop();
+    }
+}
 
-    // Define free callback (a5sim: use free)
-    auto free_cb = [](void *dev_ptr) -> int {
-        free(dev_ptr);
-        return 0;
-    };
-
-    // Simulation: no registration needed (pass nullptr)
-    int rc = l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, nullptr, free_cb);
+int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
+    int rc = l2_perf_collector_.initialize(
+        num_aicore, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
+        output_prefix_
+    );
     if (rc == 0) {
         kernel_args_.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
+        kernel_args_.aicore_l2_perf_ring_addrs =
+            reinterpret_cast<uint64_t>(l2_perf_collector_.get_aicore_ring_addrs_device_ptr());
     }
     return rc;
 }
 
-int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_id) {
-    (void)num_aicore;
+int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.sche_cpu_num;
 
-    auto alloc_cb = [](size_t size) -> void * {
-        return malloc(size);
-    };
-
-    auto free_cb = [](void *dev_ptr) -> int {
-        free(dev_ptr);
-        return 0;
-    };
-
-    // Simulation: no registration needed (dev == host)
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb);
+    int rc = dump_collector_.initialize(
+        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
+        output_prefix_
+    );
     if (rc != 0) {
         return rc;
     }
@@ -1042,23 +1001,17 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int num_aicore, int device_
     return 0;
 }
 
-int DeviceRunner::init_pmu_buffers(
+int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
 ) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        (void)user_data;
-        return malloc(size);
-    };
-
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        (void)user_data;
-        free(dev_ptr);
-        return 0;
-    };
-
-    // Simulation: no halHostRegister needed (dev == host)
     int rc = pmu_collector_.init(
-        num_cores, num_threads, &kernel_args_.pmu_data_base, csv_path, event_type, alloc_cb, free_cb, nullptr, -1
+        num_cores, num_threads, csv_path, event_type, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb,
+        /*user_data=*/nullptr, /*device_id=*/-1
     );
+    if (rc == 0) {
+        kernel_args_.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());
+        kernel_args_.aicore_pmu_ring_addrs =
+            reinterpret_cast<uint64_t>(pmu_collector_.get_aicore_ring_addrs_device_ptr());
+    }
     return rc;
 }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -297,7 +297,7 @@ private:
     bool aicpu_so_loaded_{false};  // true after AICPU SO is dlopen'd; load-once across runs.
     void *aicore_so_handle_{nullptr};
     int (*aicpu_execute_func_)(Runtime *){nullptr};
-    void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t){nullptr};
+    void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t, uint32_t, uint64_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
@@ -339,19 +339,18 @@ private:
      * @param device_id Device ID (ignored in simulation)
      * @return 0 on success, error code on failure
      */
-    int init_l2_perf_collection(int num_aicore, int device_id);
+    int init_l2_perf(int num_aicore, int device_id);
 
     /**
      * Initialize tensor dump for simulation.
      */
-    int init_tensor_dump(Runtime &runtime, int num_aicore, int device_id);
+    int init_tensor_dump(Runtime &runtime, int device_id);
 
     /**
      * Initialize PMU profiling buffers for simulation.
      *
      * Allocates PmuDataHeader + per-core PmuBuffer on host memory, publishes
-     * the header pointer into kernel_args.pmu_data_base. pmu_reg_addrs
-     * stays 0 on sim (no hardware PMU model).
+     * the header pointer into kernel_args.pmu_data_base.
      * Signature matches a2a3 for cross-platform consistency.
      */
     // Enablement for the three diagnostics sub-features. Written by the c_api
@@ -364,9 +363,11 @@ private:
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                  // diagnostic artifact root directory
 
-    int init_pmu_buffers(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
-    );
+    int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
+
+    // Per-run collector teardown: stops mgmt + poll threads on every collector
+    // whose init succeeded. Idempotent. Mirrors the onboard helper.
+    void finalize_collectors();
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -16,6 +16,12 @@
  * Uses per-core L2PerfBufferState with SPSC free queues for O(1) buffer switching.
  * Host memory manager dynamically allocates replacement buffers and pushes
  * them into the free_queue. Device pops from free_queue when switching.
+ *
+ * AICore writes timing into a per-core stable L2PerfAicoreRing
+ * (state.aicore_ring_ptr); AICPU reads the slot in complete_record and
+ * commits into records[]. The ring address is set once by the host at init
+ * and never reassigned, so AICore's write address is decoupled from the
+ * AICPU rotating L2PerfBuffer.
  */
 
 #include "aicpu/l2_perf_collector_aicpu.h"
@@ -34,6 +40,13 @@ static L2PerfDataHeader *s_l2_perf_header = nullptr;
 
 // Per-core L2PerfBufferState cache
 static L2PerfBufferState *s_perf_buffer_states[PLATFORM_MAX_CORES] = {};
+
+// Per-core stable AICore staging ring pointer cache. Populated by
+// l2_perf_aicpu_init() from state->aicore_ring_ptr (host-published at SHM
+// init time); read by complete_record. Never reassigned during the run, so
+// no synchronization is needed for concurrent readers. AICPU sees these
+// addresses as plain pointers (no __gm__ on AICPU).
+static L2PerfAicoreRing *s_perf_aicore_rings[PLATFORM_MAX_CORES] = {};
 
 // Per-thread PhaseBufferState cache
 static PhaseBufferState *s_phase_buffer_states[PLATFORM_MAX_AICPU_THREADS] = {};
@@ -87,7 +100,7 @@ static int enqueue_ready_buffer(
     return 0;
 }
 
-void l2_perf_aicpu_init_profiling(Runtime *runtime) {
+void l2_perf_aicpu_init(int worker_count) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize profiling");
@@ -96,17 +109,16 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
 
     s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
-    int32_t task_count = runtime->get_task_count();
-    s_l2_perf_header->total_tasks = static_cast<uint32_t>(task_count);
+    LOG_INFO_V0("Initializing performance profiling for %d cores (memcpy-based)", worker_count);
 
-    LOG_INFO_V0("Initializing performance profiling for %d cores (memcpy-based)", runtime->worker_count);
-
-    // Pop first buffer from free_queue for each core
-    for (int i = 0; i < runtime->worker_count; i++) {
-        Handshake *h = &runtime->workers[i];
+    // Pop first buffer from free_queue for each core, and cache the stable
+    // AICore staging ring pointer so complete_record can read it without
+    // touching SHM.
+    for (int i = 0; i < worker_count; i++) {
         L2PerfBufferState *state = get_perf_buffer_state(l2_perf_base, i);
 
         s_perf_buffer_states[i] = state;
+        s_perf_aicore_rings[i] = reinterpret_cast<L2PerfAicoreRing *>(state->aicore_ring_ptr);
 
         // Pop first buffer from free_queue
         rmb();
@@ -123,40 +135,161 @@ void l2_perf_aicpu_init_profiling(Runtime *runtime) {
 
             L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(buf_ptr);
             buf->count = 0;
-            h->l2_perf_records_addr = buf_ptr;
 
             LOG_DEBUG("Core %d: popped initial buffer (addr=0x%lx)", i, buf_ptr);
         } else {
             LOG_ERROR("Core %d: free_queue is empty during init!", i);
             state->current_buf_ptr = 0;
-            h->l2_perf_records_addr = 0;
         }
     }
 
     wmb();
 
-    LOG_INFO_V0("Performance profiling initialized for %d cores", runtime->worker_count);
+    LOG_INFO_V0("Performance profiling initialized for %d cores", worker_count);
+}
+
+/**
+ * Switch performance buffer when the current buffer is full.
+ *
+ * Internal-only: complete_record calls this when records[count] is at
+ * capacity. Enqueues the full buffer to the per-thread ready_queue and
+ * pops a fresh one from the free_queue. Failure paths bump
+ * dropped_record_count so reconcile sees a consistent device state.
+ *
+ * The AICore staging ring (state->aicore_ring_ptr / s_perf_aicore_rings[])
+ * is **never** touched here: AICore's write address is the same for the
+ * entire run.
+ */
+static void switch_buffer(int core_id, int thread_idx) {
+    L2PerfBufferState *state = s_perf_buffer_states[core_id];
+    if (state == nullptr) {
+        return;
+    }
+
+    L2PerfBuffer *full_buf = reinterpret_cast<L2PerfBuffer *>(state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    LOG_INFO_V0("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = state->free_queue.head;
+    uint32_t tail = state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep AICore alive
+        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
+        state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Enqueue full buffer to ReadyQueue
+    uint32_t seq = state->current_buf_seq;
+    int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
+    if (rc != 0) {
+        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
+        state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
+    rmb();
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = new_buf_ptr;
+    state->current_buf_seq = seq + 1;
+    wmb();
+
+    L2PerfBuffer *new_buf = reinterpret_cast<L2PerfBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+    wmb();
+
+    LOG_INFO_V0("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
 int l2_perf_aicpu_complete_record(
-    L2PerfBuffer *l2_perf_buf, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
+    int core_id, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
     uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
 ) {
-    rmb();
-    uint32_t count = l2_perf_buf->count;
-    if (count >= PLATFORM_PROF_BUFFER_SIZE) return -1;
+    if (core_id < 0 || core_id >= PLATFORM_MAX_CORES) return -1;
 
-    // Read from WIP staging slot (AICore writes here, parity = reg_task_id & 1)
-    L2PerfRecord *wip = &l2_perf_buf->wip[expected_reg_task_id & 1u];
-    // One PoC cache line: matches AICore l2_perf_aicore_record_task() dcci(..., SINGLE_CACHE_LINE, ...)
-    // and aicpu/cache_ops.cpp step size; wip timing fields live in the first line.
-    cache_invalidate_range(wip, 64);
-    if (static_cast<uint32_t>(wip->task_id) != expected_reg_task_id) return -1;
+    L2PerfBufferState *state = s_perf_buffer_states[core_id];
+    if (state == nullptr) return -1;
+
+    // Account every commit attempt before any drop path so reconcile equation
+    // (collected + dropped + mismatch == total) holds.
+    state->total_record_count += 1;
+
+    // Read AICore-published timing from the per-core stable staging ring.
+    L2PerfAicoreRing *ring = s_perf_aicore_rings[core_id];
+    if (ring == nullptr) {
+        state->dropped_record_count += 1;
+        wmb();
+        return -1;
+    }
+    L2PerfRecord *slot = &ring->dual_issue_slots[expected_reg_task_id % PLATFORM_L2_AICORE_RING_SIZE];
+    cache_invalidate_range(slot, 64);
+    if (static_cast<uint32_t>(slot->task_id) != expected_reg_task_id) {
+        // AICore hasn't published this slot yet — count separately from
+        // capacity drops (mismatch is a hard invariant violation).
+        state->mismatch_record_count += 1;
+        wmb();
+        return -1;
+    }
+
+    rmb();
+    uint64_t cur_ptr = state->current_buf_ptr;
+    if (cur_ptr == 0) {
+        // Buffer was flushed/cleared — late FIN after flush. Count as dropped
+        // so the buffer doesn't get re-populated post-stop().
+        state->dropped_record_count += 1;
+        wmb();
+        return -1;
+    }
+
+    L2PerfBuffer *l2_perf_buf = reinterpret_cast<L2PerfBuffer *>(cur_ptr);
+    uint32_t count = l2_perf_buf->count;
+    if (count >= PLATFORM_PROF_BUFFER_SIZE) {
+        // Flip to a fresh buffer when full. Caller doesn't need a thread_idx
+        // routed to switch_buffer, so derive it from the AicpuPhaseHeader's
+        // core→thread map (filled at init by the runtime). Until phase
+        // metadata is populated, fall back to thread 0 — the per-thread
+        // ready_queue is only used for collector throughput, so a temporary
+        // single-thread serialization is harmless.
+        int thread_idx = 0;
+        if (s_phase_header != nullptr && core_id >= 0 && core_id < PLATFORM_MAX_CORES) {
+            int8_t mapped = s_phase_header->core_to_thread[core_id];
+            if (mapped >= 0 && mapped < PLATFORM_MAX_AICPU_THREADS) {
+                thread_idx = static_cast<int>(static_cast<unsigned char>(mapped));
+            }
+        }
+        switch_buffer(core_id, thread_idx);
+        rmb();
+        cur_ptr = state->current_buf_ptr;
+        if (cur_ptr == 0) {
+            state->dropped_record_count += 1;
+            wmb();
+            return -1;
+        }
+        l2_perf_buf = reinterpret_cast<L2PerfBuffer *>(cur_ptr);
+        count = l2_perf_buf->count;
+        if (count >= PLATFORM_PROF_BUFFER_SIZE) {
+            state->dropped_record_count += 1;
+            wmb();
+            return -1;
+        }
+    }
 
     // Copy AICore timing to committed record slot
     L2PerfRecord *record = &l2_perf_buf->records[count];
-    record->start_time = wip->start_time;
-    record->end_time = wip->end_time;
+    record->start_time = slot->start_time;
+    record->end_time = slot->end_time;
 
     // Fill AICPU-owned fields
     record->task_id = task_id;
@@ -178,67 +311,6 @@ int l2_perf_aicpu_complete_record(
     l2_perf_buf->count = count + 1;
     wmb();
     return 0;
-}
-
-void l2_perf_aicpu_switch_buffer(Runtime *runtime, int core_id, int thread_idx) {
-    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
-    if (l2_perf_base == nullptr) {
-        return;
-    }
-
-    L2PerfBufferState *state = s_perf_buffer_states[core_id];
-    if (state == nullptr) {
-        return;
-    }
-
-    L2PerfBuffer *full_buf = reinterpret_cast<L2PerfBuffer *>(state->current_buf_ptr);
-    if (full_buf == nullptr) {
-        return;
-    }
-
-    LOG_INFO_V0("Thread %d: Core %d buffer is full (count=%u)", thread_idx, core_id, full_buf->count);
-
-    // Check free_queue before committing the full buffer
-    rmb();
-    uint32_t head = state->free_queue.head;
-    uint32_t tail = state->free_queue.tail;
-
-    if (head == tail) {
-        // No replacement buffer available — overwrite current buffer to keep AICore alive
-        LOG_WARN("Thread %d: Core %d no free buffer, overwriting current buffer (data lost)", thread_idx, core_id);
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    // Enqueue full buffer to ReadyQueue
-    uint32_t seq = state->current_buf_seq;
-    int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, core_id, state->current_buf_ptr, seq, 0);
-    if (rc != 0) {
-        LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
-        // Revert: discard data and keep writing
-        full_buf->count = 0;
-        wmb();
-        return;
-    }
-
-    // Pop next buffer from free_queue
-    uint64_t new_buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-    rmb();
-    state->free_queue.head = head + 1;
-    state->current_buf_ptr = new_buf_ptr;
-    state->current_buf_seq = seq + 1;
-    wmb();
-
-    L2PerfBuffer *new_buf = reinterpret_cast<L2PerfBuffer *>(new_buf_ptr);
-    new_buf->count = 0;
-
-    // Update handshake for AICore
-    Handshake *h = &runtime->workers[core_id];
-    h->l2_perf_records_addr = new_buf_ptr;
-    wmb();
-
-    LOG_INFO_V0("Thread %d: Core %d switched to new buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
 
 void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int core_num) {
@@ -277,7 +349,17 @@ void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, in
             state->current_buf_ptr = 0;
             wmb();
         } else {
-            LOG_ERROR("Thread %d: Core %d failed to enqueue buffer (queue full), data lost!", thread_idx, core_id);
+            // ready_queue full at end-of-run: account the loss and clear the
+            // buffer so host reconcile sees a clean state (current_buf_ptr=0)
+            // and dropped == flush failures rather than silent leftover.
+            LOG_ERROR(
+                "Thread %d: Core %d failed to enqueue buffer (queue full), %u records lost!", thread_idx, core_id,
+                buf->count
+            );
+            state->dropped_record_count += buf->count;
+            buf->count = 0;
+            state->current_buf_ptr = 0;
+            wmb();
         }
     }
 
@@ -286,25 +368,14 @@ void l2_perf_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, in
     LOG_INFO_V0("Thread %d: Performance buffer flush complete, %d buffers flushed", thread_idx, flushed_count);
 }
 
-void l2_perf_aicpu_update_total_tasks(uint32_t total_tasks) {
-    void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
-    if (l2_perf_base == nullptr) {
-        return;
-    }
-
-    L2PerfDataHeader *header = get_l2_perf_header(l2_perf_base);
-    header->total_tasks = total_tasks;
-    wmb();
-}
-
-void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads) {
+void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads) {
     void *l2_perf_base = reinterpret_cast<void *>(g_platform_l2_perf_base);
     if (l2_perf_base == nullptr) {
         LOG_ERROR("l2_perf_data_base is NULL, cannot initialize phase profiling");
         return;
     }
 
-    s_phase_header = get_phase_header(l2_perf_base, runtime->worker_count);
+    s_phase_header = get_phase_header(l2_perf_base, worker_count);
     s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
     s_phase_header->magic = AICPU_PHASE_MAGIC;
@@ -322,7 +393,7 @@ void l2_perf_aicpu_init_phase_profiling(Runtime *runtime, int num_sched_threads)
         total_threads = PLATFORM_MAX_AICPU_THREADS;
     }
     for (int t = 0; t < total_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(l2_perf_base, runtime->worker_count, t);
+        PhaseBufferState *state = get_phase_buffer_state(l2_perf_base, worker_count, t);
 
         s_phase_buffer_states[t] = state;
 
@@ -386,6 +457,10 @@ static void switch_phase_buffer(int thread_idx) {
     int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, thread_idx, state->current_buf_ptr, seq, 1);
     if (rc != 0) {
         LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), discarding data", thread_idx);
+        // Treat the entire un-enqueued buffer as dropped to keep the
+        // reconcile equation balanced. record_phase already counted these
+        // records in total_record_count when they were committed.
+        state->dropped_record_count += full_buf->count;
         full_buf->count = 0;
         wmb();
         return;
@@ -426,13 +501,18 @@ void l2_perf_aicpu_record_phase(
         return;
     }
 
+    PhaseBufferState *state = s_phase_buffer_states[thread_idx];
+    if (state == nullptr) return;
+
+    // Account every commit attempt before any drop path so reconcile
+    // (collected + dropped + mismatch == total) holds. PHASE has no
+    // ring/AICore staging path so mismatch stays 0 here.
+    state->total_record_count += 1;
+
     PhaseBuffer *buf = s_current_phase_buf[thread_idx];
 
     // Try to recover from nullptr (no buffer was available on previous switch)
     if (buf == nullptr) {
-        PhaseBufferState *state = s_phase_buffer_states[thread_idx];
-        if (state == nullptr) return;
-
         rmb();
         uint32_t head = state->free_queue.head;
         uint32_t tail = state->free_queue.tail;
@@ -451,7 +531,11 @@ void l2_perf_aicpu_record_phase(
 
             LOG_INFO_V0("Thread %d: recovered phase buffer", thread_idx);
         }
-        if (buf == nullptr) return;  // Still no buffer available
+        if (buf == nullptr) {
+            state->dropped_record_count += 1;
+            wmb();
+            return;  // Still no buffer available
+        }
     }
 
     uint32_t idx = buf->count;
@@ -460,9 +544,15 @@ void l2_perf_aicpu_record_phase(
         // Buffer full, switch to next buffer
         switch_phase_buffer(thread_idx);
         buf = s_current_phase_buf[thread_idx];
-        if (buf == nullptr) return;  // No buffer available
+        if (buf == nullptr) {
+            state->dropped_record_count += 1;
+            wmb();
+            return;  // No buffer available
+        }
         idx = buf->count;
         if (idx >= PLATFORM_PHASE_RECORDS_PER_THREAD) {
+            state->dropped_record_count += 1;
+            wmb();
             return;  // Switch failed; drop this record
         }
     }
@@ -475,6 +565,7 @@ void l2_perf_aicpu_record_phase(
     record->task_id = tasks_processed;
 
     buf->count = idx + 1;
+    wmb();
 }
 
 void l2_perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
@@ -529,13 +620,13 @@ void l2_perf_aicpu_flush_phase_buffers(int thread_idx) {
     int rc = enqueue_ready_buffer(s_l2_perf_header, thread_idx, thread_idx, buf_ptr, seq, 1);
     if (rc == 0) {
         LOG_INFO_V0("Thread %d: flushed phase buffer with %u records", thread_idx, buf->count);
-        state->current_buf_ptr = 0;
-        s_current_phase_buf[thread_idx] = nullptr;
-        wmb();
     } else {
-        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), data lost!", thread_idx);
+        LOG_ERROR("Thread %d: failed to enqueue phase buffer (queue full), %u records lost!", thread_idx, buf->count);
+        state->dropped_record_count += buf->count;
+        buf->count = 0;
     }
-
+    state->current_buf_ptr = 0;
+    s_current_phase_buf[thread_idx] = nullptr;
     wmb();
 }
 

--- a/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/pmu_collector_aicpu.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file pmu_collector_aicpu.cpp
- * @brief AICPU-side PMU init/finalize + record commit from AICore slot (a5)
+ * @brief AICPU-side PMU init/finalize + record commit from AICore staging-ring slot (a5)
  *
  * Buffer switching mirrors a2a3 pmu_collector_aicpu.cpp:
  *   - SPSC free_queue: Host pushes free PmuBuffers, AICPU pops when switching.
@@ -19,8 +19,12 @@
  *   - On free_queue empty or ready_queue full: overwrite current buffer (data lost,
  *     same policy as a2a3 — avoids blocking the AICPU dispatch loop).
  *
- * a5-specific: AICore writes PMU counters into dual_issue_slots[] via ld_dev;
- * AICPU validates the slot and commits into records[] on COND FIN.
+ * a5-specific: AICore reads PMU MMIO itself (via ld_dev) and writes the
+ * snapshot into a per-core stable PmuAicoreRing
+ * (state.aicore_ring_ptr); AICPU validates the slot and commits into
+ * records[] on COND FIN. The ring address is set once by the host and
+ * never reassigned, so the AICore writer is decoupled from the AICPU
+ * PmuBuffer rotation.
  */
 
 #include "aicpu/pmu_collector_aicpu.h"
@@ -43,6 +47,12 @@ static uint32_t g_pmu_saved_ctrl1[PLATFORM_MAX_CORES];
 // Per-core cached PmuBufferState pointer and PMU header pointer.
 static PmuBufferState *s_pmu_buffer_states[PLATFORM_MAX_CORES];
 static PmuDataHeader *s_pmu_header = nullptr;
+
+// Per-core cached PmuAicoreRing pointer (the stable AICore staging ring).
+// Populated by pmu_aicpu_init() from state->aicore_ring_ptr (host-published
+// at SHM init); read by complete_record. Never reassigned during the run.
+// AICPU treats these as plain pointers (no __gm__ on AICPU).
+static PmuAicoreRing *s_pmu_aicore_rings[PLATFORM_MAX_CORES];
 
 // Per-core resolved PMU MMIO base address, keyed by logical core_id.
 // Populated by pmu_aicpu_init(); 0 means "no PMU for this core" (sim).
@@ -114,7 +124,8 @@ static int enqueue_pmu_ready_buffer(int thread_idx, uint32_t core_index, uint64_
 }
 
 // ---------------------------------------------------------------------------
-// Internal: switch the current buffer for one core
+// Internal: switch the current buffer for one core (called from
+// complete_record when records[count] hits PLATFORM_PMU_RECORDS_PER_BUFFER)
 // ---------------------------------------------------------------------------
 
 static void pmu_switch_buffer(int core_id, int thread_idx) {
@@ -165,6 +176,7 @@ static void pmu_switch_buffer(int core_id, int thread_idx) {
 
     PmuBuffer *new_buf = reinterpret_cast<PmuBuffer *>(new_buf_ptr);
     new_buf->count = 0;
+    wmb();
 
     LOG_INFO_V0("Thread %d: Core %d switched to new PMU buffer (addr=0x%lx)", thread_idx, core_id, new_buf_ptr);
 }
@@ -173,14 +185,14 @@ static void pmu_switch_buffer(int core_id, int thread_idx) {
 // High-level interface
 // ---------------------------------------------------------------------------
 
-void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, int num_cores) {
+void pmu_aicpu_init(const uint32_t *physical_core_ids, int num_cores) {
     void *pmu_base = reinterpret_cast<void *>(get_platform_pmu_base());
     if (pmu_base == nullptr) {
         LOG_ERROR("pmu_aicpu_init: pmu_data_base is NULL");
         return;
     }
-    if (handshakes == nullptr) {
-        LOG_ERROR("pmu_aicpu_init: handshakes is NULL");
+    if (physical_core_ids == nullptr) {
+        LOG_ERROR("pmu_aicpu_init: physical_core_ids is NULL");
         return;
     }
     s_pmu_header = reinterpret_cast<PmuDataHeader *>(pmu_base);
@@ -189,16 +201,21 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
 
     // Resolve per-core PMU MMIO base from physical_core_ids. 0 means "no PMU
     // for this core" (sim or misconfigured) — subsequent record/stop become no-ops.
+    // AICore resolves the same value independently at kernel entry from
+    // `regs[get_physical_core_id()]`, so no separate AICore-visible table is
+    // populated here.
     uint64_t *regs_array = reinterpret_cast<uint64_t *>(get_platform_regs());
     for (int i = 0; i < num_cores; i++) {
         if (i >= PLATFORM_MAX_CORES) {
             LOG_ERROR("pmu_aicpu_init: num_cores %d exceeds PLATFORM_MAX_CORES %d", num_cores, PLATFORM_MAX_CORES);
             break;
         }
-        s_pmu_reg_addrs[i] = regs_array ? regs_array[physical_core_ids[i]] : 0;
+        uint64_t reg_addr = regs_array ? regs_array[physical_core_ids[i]] : 0;
+        s_pmu_reg_addrs[i] = reg_addr;
         g_pmu_saved_ctrl0[i] = 0;
         g_pmu_saved_ctrl1[i] = 0;
     }
+    wmb();
 
     // Program event selectors and start PMU counters
     const PmuEventConfig *evt = pmu_resolve_event_config_a5(static_cast<PmuEventType>(pmu_event_type));
@@ -215,10 +232,12 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
         pmu_start(reg_addr, g_pmu_saved_ctrl0[i], g_pmu_saved_ctrl1[i]);
     }
 
-    // Pop initial PmuBuffer from each core's free_queue
+    // Pop initial PmuBuffer from each core's free_queue and cache the stable
+    // AICore staging ring pointer.
     for (int i = 0; i < num_cores; i++) {
         PmuBufferState *state = get_pmu_buffer_state(pmu_base, i);
         s_pmu_buffer_states[i] = state;
+        s_pmu_aicore_rings[i] = reinterpret_cast<PmuAicoreRing *>(state->aicore_ring_ptr);
 
         rmb();
         uint32_t head = state->free_queue.head;
@@ -242,13 +261,6 @@ void pmu_aicpu_init(Handshake *handshakes, const uint32_t *physical_core_ids, in
         }
     }
 
-    // Publish per-core (pmu_buffer_addr, pmu_reg_base) into the matching Handshake
-    for (int i = 0; i < num_cores; i++) {
-        PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(s_pmu_buffer_states[i]->current_buf_ptr);
-        handshakes[i].pmu_buffer_addr = reinterpret_cast<uint64_t>(buf);
-        handshakes[i].pmu_reg_base = s_pmu_reg_addrs[i];
-    }
-
     LOG_INFO_V0("PMU initialized: %d cores, event_type=%u", num_cores, pmu_event_type);
 }
 
@@ -265,8 +277,26 @@ void pmu_aicpu_complete_record(
     }
 
     // Account the task *before* any drop path so total reflects every task the
-    // AICPU tried to record. total == collected + dropped invariant on host.
+    // AICPU tried to record. collected + dropped + mismatch == total invariant on host.
     state->total_record_count += 1;
+
+    // Read AICore-published PmuRecord from the stable per-core staging ring.
+    PmuAicoreRing *ring = s_pmu_aicore_rings[core_id];
+    if (ring == nullptr) {
+        state->dropped_record_count += 1;
+        wmb();
+        return;
+    }
+    PmuRecord *slot = &ring->dual_issue_slots[reg_task_id % PLATFORM_PMU_AICORE_RING_SIZE];
+    cache_invalidate_range(slot, sizeof(PmuRecord));
+
+    if (static_cast<uint32_t>(slot->task_id) != reg_task_id) {
+        // AICore hasn't published this slot yet — hard invariant violation,
+        // separate from capacity drops.
+        state->mismatch_record_count += 1;
+        wmb();
+        return;
+    }
 
     rmb();
     uint64_t cur_ptr = state->current_buf_ptr;
@@ -277,7 +307,7 @@ void pmu_aicpu_complete_record(
     }
     PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(cur_ptr);
 
-    // Switch buffer if full
+    // Switch buffer if full (internal — ring address is unchanged)
     if (buf->count >= static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
         pmu_switch_buffer(core_id, thread_idx);
         rmb();
@@ -292,15 +322,6 @@ void pmu_aicpu_complete_record(
 
     uint32_t idx = buf->count;
 
-    // Fetch AICore's writes into the dual-issue slot
-    PmuRecord *slot = &buf->dual_issue_slots[reg_task_id & 1u];
-    cache_invalidate_range(slot, sizeof(PmuRecord));
-
-    if (static_cast<uint32_t>(slot->task_id) != reg_task_id) {
-        // AICore hasn't published this slot yet — bail out defensively
-        return;
-    }
-
     PmuRecord *rec = &buf->records[idx];
     rec->task_id = task_id;
     rec->func_id = func_id;
@@ -310,6 +331,7 @@ void pmu_aicpu_complete_record(
         rec->pmu_counters[i] = slot->pmu_counters[i];
     }
     buf->count = idx + 1;
+
     wmb();
 }
 
@@ -358,11 +380,16 @@ void pmu_aicpu_flush_buffers(int thread_idx, const int *cur_thread_cores, int co
             state->current_buf_ptr = 0;
             wmb();
         } else {
+            // ready_queue full at end-of-run: account the loss and clear the
+            // buffer so host reconcile sees a clean state (current_buf_ptr=0)
+            // and dropped == flush failures rather than silent leftover.
             LOG_ERROR(
-                "Thread %d: Core %d failed to flush PMU buffer (ready_queue full), data lost!", thread_idx, core_id
+                "Thread %d: Core %d failed to flush PMU buffer (ready_queue full), %u records lost!", thread_idx,
+                core_id, buf->count
             );
             state->dropped_record_count += buf->count;
             buf->count = 0;
+            state->current_buf_ptr = 0;
             wmb();
         }
     }

--- a/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
@@ -460,24 +460,30 @@ void dump_tensor_flush(int thread_idx) {
     }
 
     DumpMetaBuffer *buf = s_current_dump_buf[thread_idx];
-    if (buf != nullptr && buf->count > 0) {
+    DumpBufferState *state = s_dump_states[thread_idx];
+    if (buf != nullptr && buf->count > 0 && state != nullptr) {
         uint64_t buf_addr = reinterpret_cast<uint64_t>(buf);
-        uint32_t seq = s_dump_states[thread_idx]->current_buf_seq;
-        if (enqueue_dump_ready_buffer(thread_idx, buf_addr, seq) != 0) {
-            account_dropped_records(s_dump_states[thread_idx], buf->count);
-            buf->count = 0;
+        uint32_t seq = state->current_buf_seq;
+        if (enqueue_dump_ready_buffer(thread_idx, buf_addr, seq) == 0) {
+            s_current_dump_buf[thread_idx] = nullptr;
+            state->current_buf_ptr = 0;
             wmb();
-            if (!s_logged_ready_queue_full[thread_idx]) {
-                s_logged_ready_queue_full[thread_idx] = true;
-                LOG_WARN(
-                    "Tensor dump ready queue is full on thread %d, so the current metadata buffer will be "
-                    "overwritten. Increase PLATFORM_DUMP_READYQUEUE_SIZE.",
-                    thread_idx
-                );
-            }
+        } else {
+            // ready_queue full at end-of-run: account the loss and clear the
+            // buffer so host reconcile sees a clean state (current_buf_ptr=0)
+            // and dropped == flush failures rather than silent leftover.
+            // Bounded to one per thread per run (unlike the hot-path
+            // dump_tensor_record site), so no spam guard is needed here.
+            LOG_ERROR(
+                "Thread %d: failed to flush tensor-dump buffer (ready_queue full), %u records lost!", thread_idx,
+                buf->count
+            );
+            account_dropped_records(state, buf->count);
+            buf->count = 0;
+            s_current_dump_buf[thread_idx] = nullptr;
+            state->current_buf_ptr = 0;
+            wmb();
         }
-        s_current_dump_buf[thread_idx] = nullptr;
-        s_dump_states[thread_idx]->current_buf_ptr = 0;
     }
 
     s_buffers_flushed[thread_idx]++;

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -11,14 +11,17 @@
 
 /**
  * @file l2_perf_collector.cpp
- * @brief Platform-agnostic performance data collector implementation
+ * @brief Performance data collector implementation. The mgmt-thread +
+ *        buffer-pool machinery lives in profiling_common::BufferPoolManager
+ *        parameterized by L2PerfModule (host/l2_perf_collector.h); the
+ *        poll loop lives in profiling_common::ProfilerBase. This file
+ *        owns the per-buffer on_buffer_collected callback and the export
+ *        logic.
  *
- * Implements ProfMemoryManager (dynamic buffer management thread) and
- * L2PerfCollector (data collection and export).
- *
- * A5 specifics:
- * - The collector always uses host shadow buffers and platform copy hooks.
- * - Onboard hooks call rtMemcpy; sim hooks call memcpy.
+ * a5 specifics: device↔host transfers go through profiling_copy.h. The
+ * framework's mgmt loop mirrors the shm region per tick; per-buffer
+ * payloads (L2PerfBuffer / PhaseBuffer) are pulled on demand inside
+ * ProfilerAlgorithms.
  */
 
 #include "host/l2_perf_collector.h"
@@ -32,577 +35,12 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
-#include <optional>
 #include <string>
 #include <vector>
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
-
-// =============================================================================
-// ProfMemoryManager Implementation
-// =============================================================================
-
-ProfMemoryManager::~ProfMemoryManager() {
-    if (running_.load()) {
-        stop();
-    }
-}
-
-void ProfMemoryManager::start(
-    void *shared_mem_host, int num_cores, int num_phase_threads, L2PerfAllocCallback alloc_cb,
-    L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, int device_id, const ThreadFactory &thread_factory
-) {
-    shared_mem_host_ = shared_mem_host;
-    num_cores_ = num_cores;
-    num_phase_threads_ = num_phase_threads;
-    alloc_cb_ = alloc_cb;
-    register_cb_ = register_cb;
-    free_cb_ = free_cb;
-    device_id_ = device_id;
-
-    running_.store(true);
-    if (thread_factory) {
-        mgmt_thread_ = thread_factory([this]() {
-            mgmt_loop();
-        });
-    } else {
-        mgmt_thread_ = std::thread(&ProfMemoryManager::mgmt_loop, this);
-    }
-
-    LOG_INFO_V0("ProfMemoryManager started: %d cores, %d phase threads", num_cores, num_phase_threads);
-}
-
-void ProfMemoryManager::stop() {
-    running_.store(false);
-    if (mgmt_thread_.joinable()) {
-        mgmt_thread_.join();
-    }
-
-    // Drain remaining done_queue and free buffers
-    {
-        std::scoped_lock<std::mutex> lock(done_mutex_);
-        while (!done_queue_.empty()) {
-            CopyDoneInfo info = done_queue_.front();
-            done_queue_.pop();
-            free_buffer(info.dev_buffer_ptr);
-        }
-    }
-
-    // Free recycled buffers
-    for (void *ptr : recycled_perf_buffers_) {
-        free_buffer(ptr);
-    }
-    recycled_perf_buffers_.clear();
-    for (void *ptr : recycled_phase_buffers_) {
-        free_buffer(ptr);
-    }
-    recycled_phase_buffers_.clear();
-
-    LOG_INFO_V0("ProfMemoryManager stopped");
-}
-
-bool ProfMemoryManager::try_pop_ready(ReadyBufferInfo &info) {
-    std::scoped_lock<std::mutex> lock(ready_mutex_);
-    if (ready_queue_.empty()) {
-        return false;
-    }
-    info = ready_queue_.front();
-    ready_queue_.pop();
-    return true;
-}
-
-bool ProfMemoryManager::wait_pop_ready(ReadyBufferInfo &info, std::chrono::milliseconds timeout) {
-    std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this] {
-            return !ready_queue_.empty();
-        })) {
-        info = ready_queue_.front();
-        ready_queue_.pop();
-        return true;
-    }
-    return false;
-}
-
-void ProfMemoryManager::notify_copy_done(const CopyDoneInfo &info) {
-    std::scoped_lock<std::mutex> lock(done_mutex_);
-    done_queue_.push(info);
-}
-
-void *ProfMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size);
-    if (dev_ptr == nullptr) {
-        const char *hint = (size == sizeof(L2PerfBuffer)) ?
-                               "increase PLATFORM_PROF_BUFFERS_PER_CORE to reduce profiling data loss" :
-                               "increase PLATFORM_PROF_BUFFERS_PER_THREAD to reduce profiling data loss";
-        LOG_WARN("ProfMemoryManager: alloc failed for %zu bytes, %s", size, hint);
-        *host_ptr_out = nullptr;
-        return nullptr;
-    }
-
-    if (register_cb_ != nullptr) {
-        void *host_ptr = nullptr;
-        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
-        if (rc != 0 || host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: register failed: %d", rc);
-            free_buffer(dev_ptr);
-            *host_ptr_out = nullptr;
-            return nullptr;
-        }
-        *host_ptr_out = host_ptr;
-    } else {
-        void *host_ptr = malloc(size);
-        if (host_ptr == nullptr) {
-            LOG_ERROR("ProfMemoryManager: host shadow alloc failed for %zu bytes", size);
-            free_buffer(dev_ptr);
-            *host_ptr_out = nullptr;
-            return nullptr;
-        }
-        memset(host_ptr, 0, size);
-        profiling_copy_to_device(dev_ptr, host_ptr, size);
-        *host_ptr_out = host_ptr;
-    }
-
-    dev_to_host_[dev_ptr] = *host_ptr_out;
-    return dev_ptr;
-}
-
-void ProfMemoryManager::free_buffer(void *dev_ptr) {
-    if (dev_ptr == nullptr) return;
-
-    if (free_cb_ != nullptr) {
-        auto it = dev_to_host_.find(dev_ptr);
-        if (it != dev_to_host_.end()) {
-            // In non-SVM mode, free the host shadow if it differs from dev_ptr
-            if (register_cb_ == nullptr && it->second != nullptr && it->second != dev_ptr) {
-                free(it->second);
-            }
-            dev_to_host_.erase(it);
-        }
-        free_cb_(dev_ptr);
-    }
-}
-
-void *ProfMemoryManager::resolve_host_ptr(void *dev_ptr) {
-    auto it = dev_to_host_.find(dev_ptr);
-    if (it != dev_to_host_.end()) {
-        return it->second;
-    }
-    LOG_ERROR("ProfMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
-    return nullptr;
-}
-
-void ProfMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
-
-void ProfMemoryManager::process_ready_entry(
-    L2PerfDataHeader * /*header*/, int /*thread_idx*/, const ReadyQueueEntry &entry
-) {
-    bool is_phase = (entry.is_phase != 0);
-    uint64_t old_dev_ptr = entry.buffer_ptr;
-    uint32_t seq = entry.buffer_seq;
-
-    void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
-    if (old_host_ptr != nullptr) {
-        size_t buf_size = is_phase ? sizeof(PhaseBuffer) : sizeof(L2PerfBuffer);
-        profiling_copy_from_device(old_host_ptr, reinterpret_cast<void *>(old_dev_ptr), buf_size);
-    }
-
-    if (is_phase) {
-        uint32_t tidx = entry.core_index;
-        if (tidx >= static_cast<uint32_t>(PLATFORM_MAX_AICPU_THREADS)) {
-            LOG_ERROR("ProfMemoryManager: invalid phase entry: thread=%u", tidx);
-            return;
-        }
-
-        PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, tidx);
-
-        PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, tidx);
-        profiling_copy_from_device(state, dev_state, sizeof(PhaseBufferState));
-
-        // Replenish free_queue
-        rmb();
-        uint32_t head_val = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-        uint32_t available = tail - head_val;
-
-        int to_push = PLATFORM_PROF_SLOT_COUNT;
-        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void *host_ptr = nullptr;
-            void *new_dev_ptr = nullptr;
-
-            if (!recycled_phase_buffers_.empty()) {
-                new_dev_ptr = recycled_phase_buffers_.back();
-                recycled_phase_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                std::scoped_lock<std::mutex> lock(done_mutex_);
-                while (!done_queue_.empty()) {
-                    CopyDoneInfo dinfo = done_queue_.front();
-                    done_queue_.pop();
-                    if (dinfo.type == ProfBufferType::PERF_RECORD)
-                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
-                }
-            }
-            if (new_dev_ptr == nullptr && !recycled_phase_buffers_.empty()) {
-                new_dev_ptr = recycled_phase_buffers_.back();
-                recycled_phase_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                new_dev_ptr = alloc_and_register(sizeof(PhaseBuffer), &host_ptr);
-            }
-            if (new_dev_ptr == nullptr) break;
-
-            reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
-            uint32_t zero = 0;
-            profiling_copy_to_device(
-                reinterpret_cast<char *>(new_dev_ptr) + offsetof(PhaseBuffer, count), &zero, sizeof(uint32_t)
-            );
-
-            uint32_t cur_tail = tail + p;
-            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
-                reinterpret_cast<uint64_t>(new_dev_ptr);
-            wmb();
-            state->free_queue.tail = cur_tail + 1;
-            wmb();
-
-            // In memcpy mode, write the slot and tail back to device
-            PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, tidx);
-            uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev_ptr);
-            profiling_copy_to_device(
-                &dev_state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT], &slot_val, sizeof(uint64_t)
-            );
-            uint32_t new_tail = cur_tail + 1;
-            profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-        }
-
-        // Resolve host pointer of old buffer
-        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
-        if (old_host_ptr == nullptr) {
-            LOG_ERROR(
-                "ProfMemoryManager: cannot resolve host ptr for phase buffer dev=%p",
-                reinterpret_cast<void *>(old_dev_ptr)
-            );
-            return;
-        }
-
-        // Push old buffer to ready queue for main thread to copy
-        ReadyBufferInfo info;
-        info.type = ProfBufferType::PHASE;
-        info.index = tidx;
-        info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
-        info.host_buffer_ptr = old_host_ptr;
-        info.buffer_seq = seq;
-
-        {
-            std::scoped_lock<std::mutex> lock(ready_mutex_);
-            ready_queue_.push(info);
-        }
-        ready_cv_.notify_one();
-
-    } else {
-        uint32_t core_index = entry.core_index;
-        if (core_index >= static_cast<uint32_t>(num_cores_)) {
-            LOG_ERROR("ProfMemoryManager: invalid perf entry: core=%u", core_index);
-            return;
-        }
-
-        L2PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, core_index);
-
-        L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, core_index);
-        profiling_copy_from_device(state, dev_state, sizeof(L2PerfBufferState));
-
-        // Replenish free_queue
-        rmb();
-        uint32_t head_val = state->free_queue.head;
-        uint32_t tail = state->free_queue.tail;
-        uint32_t available = tail - head_val;
-
-        int to_push = PLATFORM_PROF_SLOT_COUNT;
-        for (int p = 0; p < to_push && available + p < static_cast<uint32_t>(PLATFORM_PROF_SLOT_COUNT); p++) {
-            void *host_ptr = nullptr;
-            void *new_dev_ptr = nullptr;
-
-            if (!recycled_perf_buffers_.empty()) {
-                new_dev_ptr = recycled_perf_buffers_.back();
-                recycled_perf_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                std::scoped_lock<std::mutex> lock(done_mutex_);
-                while (!done_queue_.empty()) {
-                    CopyDoneInfo dinfo = done_queue_.front();
-                    done_queue_.pop();
-                    if (dinfo.type == ProfBufferType::PERF_RECORD)
-                        recycled_perf_buffers_.push_back(dinfo.dev_buffer_ptr);
-                    else recycled_phase_buffers_.push_back(dinfo.dev_buffer_ptr);
-                }
-            }
-            if (new_dev_ptr == nullptr && !recycled_perf_buffers_.empty()) {
-                new_dev_ptr = recycled_perf_buffers_.back();
-                recycled_perf_buffers_.pop_back();
-                host_ptr = resolve_host_ptr(new_dev_ptr);
-            }
-            if (new_dev_ptr == nullptr) {
-                new_dev_ptr = alloc_and_register(sizeof(L2PerfBuffer), &host_ptr);
-            }
-            if (new_dev_ptr == nullptr) break;
-
-            reinterpret_cast<L2PerfBuffer *>(host_ptr)->count = 0;
-            uint32_t zero = 0;
-            profiling_copy_to_device(
-                reinterpret_cast<char *>(new_dev_ptr) + offsetof(L2PerfBuffer, count), &zero, sizeof(uint32_t)
-            );
-
-            uint32_t cur_tail = tail + p;
-            state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT] =
-                reinterpret_cast<uint64_t>(new_dev_ptr);
-            wmb();
-            state->free_queue.tail = cur_tail + 1;
-            wmb();
-
-            // In memcpy mode, write the slot and tail back to device
-            L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, core_index);
-            uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev_ptr);
-            profiling_copy_to_device(
-                &dev_state->free_queue.buffer_ptrs[cur_tail % PLATFORM_PROF_SLOT_COUNT], &slot_val, sizeof(uint64_t)
-            );
-            uint32_t new_tail = cur_tail + 1;
-            profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-        }
-
-        void *old_host_ptr = resolve_host_ptr(reinterpret_cast<void *>(old_dev_ptr));
-        if (old_host_ptr == nullptr) {
-            LOG_ERROR(
-                "ProfMemoryManager: cannot resolve host ptr for perf buffer dev=%p",
-                reinterpret_cast<void *>(old_dev_ptr)
-            );
-            return;
-        }
-
-        ReadyBufferInfo info;
-        info.type = ProfBufferType::PERF_RECORD;
-        info.index = core_index;
-        info.slot_idx = 0;  // Not used in free queue design
-        info.dev_buffer_ptr = reinterpret_cast<void *>(old_dev_ptr);
-        info.host_buffer_ptr = old_host_ptr;
-        info.buffer_seq = seq;
-
-        {
-            std::scoped_lock<std::mutex> lock(ready_mutex_);
-            ready_queue_.push(info);
-        }
-        ready_cv_.notify_one();
-    }
-}
-
-void ProfMemoryManager::mgmt_loop() {
-    L2PerfDataHeader *header = get_l2_perf_header(shared_mem_host_);
-
-    while (running_.load()) {
-        // 1. Recycle done queue: move completed buffers to recycled pools for reuse
-        {
-            std::scoped_lock<std::mutex> lock(done_mutex_);
-            while (!done_queue_.empty()) {
-                CopyDoneInfo info = done_queue_.front();
-                done_queue_.pop();
-                if (info.type == ProfBufferType::PERF_RECORD) {
-                    recycled_perf_buffers_.push_back(info.dev_buffer_ptr);
-                } else {
-                    recycled_phase_buffers_.push_back(info.dev_buffer_ptr);
-                }
-            }
-        }
-
-        // 2. Poll ReadyQueues from all AICPU threads
-        L2PerfDataHeader *dev_header = get_l2_perf_header(shared_mem_dev_);
-        profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
-
-        bool found_any = false;
-        for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-            rmb();
-            uint32_t head = header->queue_heads[t];
-            uint32_t tail = header->queue_tails[t];
-
-            // Validate indices to prevent OOB access from corrupted shared memory
-            if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                LOG_ERROR(
-                    "mgmt_loop: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
-                    PLATFORM_PROF_READYQUEUE_SIZE
-                );
-                continue;
-            }
-
-            while (head != tail) {
-                ReadyQueueEntry entry;
-                profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(ReadyQueueEntry));
-
-                process_ready_entry(header, t, entry);
-
-                head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-                header->queue_heads[t] = head;
-                wmb();
-
-                // In memcpy mode, write updated head back to device
-                profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
-
-                found_any = true;
-
-                // Re-read tail in case more entries arrived
-                profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
-                rmb();
-                tail = header->queue_tails[t];
-                if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                    LOG_ERROR("mgmt_loop: invalid tail for thread %d: %u", t, tail);
-                    break;
-                }
-            }
-        }
-
-        // 3. Proactive replenishment: push buffers to cores/threads whose free_queue
-        //    is completely empty (avail == 0). Try recycled pool first, alloc as fallback.
-        if (!recycled_perf_buffers_.empty() || !recycled_phase_buffers_.empty()) {
-            for (int i = 0; i < num_cores_ && !recycled_perf_buffers_.empty(); i++) {
-                L2PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
-                L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
-                profiling_copy_from_device(state, dev_state, sizeof(L2PerfBufferState));
-                rmb();
-                uint32_t avail = state->free_queue.tail - state->free_queue.head;
-                if (avail == 0) {
-                    void *dev_ptr = recycled_perf_buffers_.back();
-                    recycled_perf_buffers_.pop_back();
-                    void *host_ptr = resolve_host_ptr(dev_ptr);
-                    if (host_ptr != nullptr) {
-                        reinterpret_cast<L2PerfBuffer *>(host_ptr)->count = 0;
-                        uint32_t zero = 0;
-                        profiling_copy_to_device(
-                            reinterpret_cast<char *>(dev_ptr) + offsetof(L2PerfBuffer, count), &zero, sizeof(uint32_t)
-                        );
-                        uint32_t t_val = state->free_queue.tail;
-                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
-                            reinterpret_cast<uint64_t>(dev_ptr);
-                        wmb();
-                        state->free_queue.tail = t_val + 1;
-                        wmb();
-                        L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
-                        uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
-                        profiling_copy_to_device(
-                            &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
-                            sizeof(uint64_t)
-                        );
-                        uint32_t new_tail = t_val + 1;
-                        profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-                    }
-                }
-            }
-            for (int t = 0; t < num_phase_threads_ && !recycled_phase_buffers_.empty(); t++) {
-                PhaseBufferState *state = get_phase_buffer_state(shared_mem_host_, num_cores_, t);
-                PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, t);
-                profiling_copy_from_device(state, dev_state, sizeof(PhaseBufferState));
-                rmb();
-                uint32_t avail = state->free_queue.tail - state->free_queue.head;
-                if (avail == 0) {
-                    void *dev_ptr = recycled_phase_buffers_.back();
-                    recycled_phase_buffers_.pop_back();
-                    void *host_ptr = resolve_host_ptr(dev_ptr);
-                    if (host_ptr != nullptr) {
-                        reinterpret_cast<PhaseBuffer *>(host_ptr)->count = 0;
-                        uint32_t zero = 0;
-                        profiling_copy_to_device(
-                            reinterpret_cast<char *>(dev_ptr) + offsetof(PhaseBuffer, count), &zero, sizeof(uint32_t)
-                        );
-                        uint32_t t_val = state->free_queue.tail;
-                        state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
-                            reinterpret_cast<uint64_t>(dev_ptr);
-                        wmb();
-                        state->free_queue.tail = t_val + 1;
-                        wmb();
-                        PhaseBufferState *dev_state = get_phase_buffer_state(shared_mem_dev_, num_cores_, t);
-                        uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
-                        profiling_copy_to_device(
-                            &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
-                            sizeof(uint64_t)
-                        );
-                        uint32_t new_tail = t_val + 1;
-                        profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-                    }
-                }
-            }
-        }
-        // Alloc fallback: if recycled pools are both empty, scan for depleted cores and alloc.
-        // This only triggers when ALL pre-allocated buffers are in-flight (extreme workloads).
-        if (recycled_perf_buffers_.empty() && recycled_phase_buffers_.empty()) {
-            for (int i = 0; i < num_cores_; i++) {
-                L2PerfBufferState *state = get_perf_buffer_state(shared_mem_host_, i);
-                L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
-                profiling_copy_from_device(state, dev_state, sizeof(L2PerfBufferState));
-                rmb();
-                if (state->free_queue.tail - state->free_queue.head == 0) {
-                    void *host_ptr = nullptr;
-                    void *dev_ptr = alloc_and_register(sizeof(L2PerfBuffer), &host_ptr);
-                    if (dev_ptr == nullptr) break;  // HBM exhausted, stop trying
-                    reinterpret_cast<L2PerfBuffer *>(host_ptr)->count = 0;
-                    uint32_t zero = 0;
-                    profiling_copy_to_device(
-                        reinterpret_cast<char *>(dev_ptr) + offsetof(L2PerfBuffer, count), &zero, sizeof(uint32_t)
-                    );
-                    uint32_t t_val = state->free_queue.tail;
-                    state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT] =
-                        reinterpret_cast<uint64_t>(dev_ptr);
-                    wmb();
-                    state->free_queue.tail = t_val + 1;
-                    wmb();
-                    L2PerfBufferState *dev_state = get_perf_buffer_state(shared_mem_dev_, i);
-                    uint64_t slot_val = reinterpret_cast<uint64_t>(dev_ptr);
-                    profiling_copy_to_device(
-                        &dev_state->free_queue.buffer_ptrs[t_val % PLATFORM_PROF_SLOT_COUNT], &slot_val,
-                        sizeof(uint64_t)
-                    );
-                    uint32_t new_tail = t_val + 1;
-                    profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-                    break;  // One alloc per iteration to limit rtMalloc frequency
-                }
-            }
-        }
-
-        // 4. If nothing found, yield briefly to avoid busy-spinning
-        if (!found_any) {
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        }
-    }
-
-    // Final drain: process any remaining entries
-    L2PerfDataHeader *dev_header = get_l2_perf_header(shared_mem_dev_);
-    profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
-    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        rmb();
-        uint32_t head = header->queue_heads[t];
-        uint32_t tail = header->queue_tails[t];
-        if (head >= PLATFORM_PROF_READYQUEUE_SIZE || tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-            LOG_ERROR("mgmt_loop drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
-            continue;
-        }
-        while (head != tail) {
-            ReadyQueueEntry entry;
-            profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(ReadyQueueEntry));
-            process_ready_entry(header, t, entry);
-            head = (head + 1) % PLATFORM_PROF_READYQUEUE_SIZE;
-            header->queue_heads[t] = head;
-            wmb();
-            profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
-            profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
-            rmb();
-            tail = header->queue_tails[t];
-            if (tail >= PLATFORM_PROF_READYQUEUE_SIZE) {
-                LOG_ERROR("mgmt_loop drain: invalid tail for thread %d: %u", t, tail);
-                break;
-            }
-        }
-    }
-}
+#include "host/profiling_copy.h"
 
 // =============================================================================
 // L2PerfCollector Implementation
@@ -618,37 +56,53 @@ static bool is_scheduler_phase(AicpuPhaseId id) {
 }
 
 L2PerfCollector::~L2PerfCollector() {
-    if (perf_shared_mem_host_ != nullptr) {
+    stop();
+    if (shm_host_ != nullptr) {
         LOG_WARN("L2PerfCollector destroyed without finalize()");
     }
 }
 
 void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size);
+    void *dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
-        *host_ptr_out = nullptr;
+        if (host_ptr_out) *host_ptr_out = nullptr;
         return nullptr;
     }
 
-    void *host_ptr = malloc(size);
-    if (host_ptr == nullptr) {
-        LOG_ERROR("Host shadow alloc failed for %zu bytes", size);
-        *host_ptr_out = nullptr;
-        return nullptr;
+    void *host_ptr = nullptr;
+    if (register_cb_ != nullptr) {
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("Buffer registration failed: %d", rc);
+            free_cb_(dev_ptr, user_data_);
+            if (host_ptr_out) *host_ptr_out = nullptr;
+            return nullptr;
+        }
+    } else {
+        // a5 default: malloc + zero + push zeros to device.
+        host_ptr = std::malloc(size);
+        if (host_ptr == nullptr) {
+            LOG_ERROR("Host shadow alloc failed for %zu bytes", size);
+            free_cb_(dev_ptr, user_data_);
+            if (host_ptr_out) *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        std::memset(host_ptr, 0, size);
+        profiling_copy_to_device(dev_ptr, host_ptr, size);
     }
-    *host_ptr_out = host_ptr;
 
-    // Register mapping so ProfMemoryManager can resolve dev→host
-    memory_manager_.register_mapping(dev_ptr, *host_ptr_out);
+    if (host_ptr_out) *host_ptr_out = host_ptr;
+    // Track dev→host so the framework can resolve_host_ptr() at recycle time.
+    manager_.register_mapping(dev_ptr, host_ptr);
     return dev_ptr;
 }
 
 int L2PerfCollector::initialize(
     int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
-    L2PerfFreeCallback free_cb
+    L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
 ) {
-    if (perf_shared_mem_host_ != nullptr) {
+    if (shm_host_ != nullptr) {
         LOG_ERROR("L2PerfCollector already initialized");
         return -1;
     }
@@ -660,65 +114,86 @@ int L2PerfCollector::initialize(
         return -1;
     }
 
-    device_id_ = device_id;
     num_aicore_ = num_aicore;
-    alloc_cb_ = alloc_cb;
-    register_cb_ = register_cb;
-    free_cb_ = free_cb;
+    output_prefix_ = output_prefix;
+    total_perf_collected_ = 0;
+    total_phase_collected_ = 0;
+
+    // Stash the memory context on the base up-front so alloc_single_buffer
+    // (which reads alloc_cb_/register_cb_/free_cb_/user_data_/device_id_)
+    // sees consistent values during init. shm_host_ stays nullptr until the
+    // shm allocation succeeds — that nullptr guard makes a post-failure
+    // start(tf) a no-op.
+    set_memory_context(
+        alloc_cb, register_cb, free_cb, user_data, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+    );
 
     // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     size_t total_size = calc_perf_data_size_with_phases(num_aicore, num_phase_threads);
 
     LOG_DEBUG("Shared memory allocation plan:");
-    LOG_DEBUG("  Number of cores:      %d", num_aicore);
-    LOG_DEBUG("  Header size:          %zu bytes", sizeof(L2PerfDataHeader));
+    LOG_DEBUG("  Number of cores:        %d", num_aicore);
+    LOG_DEBUG("  Header size:            %zu bytes", sizeof(L2PerfDataHeader));
     LOG_DEBUG("  L2PerfBufferState size: %zu bytes each", sizeof(L2PerfBufferState));
-    LOG_DEBUG("  PhaseBufferState size:%zu bytes each", sizeof(PhaseBufferState));
-    LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
+    LOG_DEBUG("  PhaseBufferState size:  %zu bytes each", sizeof(PhaseBufferState));
+    LOG_DEBUG("  Total shared memory:    %zu bytes (%zu KB)", total_size, total_size / 1024);
 
-    // Step 2: Allocate shared memory for slot arrays
-    void *perf_dev_ptr = alloc_cb(total_size);
+    // Step 2: Allocate shared memory + paired host shadow
+    void *perf_host_ptr = nullptr;
+    void *perf_dev_ptr = alloc_single_buffer(total_size, &perf_host_ptr);
     if (perf_dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
     }
-    LOG_DEBUG("Allocated shared memory: %p", perf_dev_ptr);
+    LOG_DEBUG("Allocated shared memory: dev=%p host=%p", perf_dev_ptr, perf_host_ptr);
 
-    // Step 3: Allocate host-side shadow for the shared memory region
-    void *perf_host_ptr = malloc(total_size);
-    if (perf_host_ptr == nullptr) {
-        LOG_ERROR("Host shadow alloc failed for shared memory (%zu bytes)", total_size);
-        return -1;
-    }
-    LOG_DEBUG("Allocated host shadow: %p", perf_host_ptr);
-
-    // Step 4: Initialize header
+    // Step 3: Initialize header on host shadow
+    std::memset(perf_host_ptr, 0, total_size);
     L2PerfDataHeader *header = get_l2_perf_header(perf_host_ptr);
-
     for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        memset(header->queues[t], 0, sizeof(header->queues[t]));
         header->queue_heads[t] = 0;
         header->queue_tails[t] = 0;
     }
-
     header->num_cores = num_aicore;
-    header->total_tasks = 0;
 
     LOG_DEBUG("Initialized L2PerfDataHeader:");
     LOG_DEBUG("  num_cores:        %d", header->num_cores);
     LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
     LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
 
-    // Step 5: Initialize L2PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
+    // Step 4: Allocate per-core stable L2PerfAicoreRings + the address-table
+    // buffer. Rings are allocated once and never rotated; AICore writes into
+    // them at task time, AICPU reads at FIN time. The address-table mirrors
+    // each ring's device pointer so the AICore-side `KernelArgs` machinery
+    // can index by `block_idx` without needing to walk SHM.
+    aicore_rings_dev_.assign(num_aicore, nullptr);
+    void *table_host_ptr = nullptr;
+    size_t table_size = static_cast<size_t>(num_aicore) * sizeof(uint64_t);
+    void *table_dev_ptr = alloc_single_buffer(table_size, &table_host_ptr);
+    if (table_dev_ptr == nullptr) {
+        LOG_ERROR("Failed to allocate L2Perf aicore ring address table (%zu bytes)", table_size);
+        return -1;
+    }
+    std::memset(table_host_ptr, 0, table_size);
+    aicore_ring_addrs_dev_ = table_dev_ptr;
+    aicore_ring_addrs_host_ = table_host_ptr;
+
+    // Step 4b: Initialize L2PerfBufferStates — 1 buffer/core in free_queue, rest to recycled pool.
     for (int i = 0; i < num_aicore; i++) {
         L2PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
-        memset(state, 0, sizeof(L2PerfBufferState));
+        std::memset(state, 0, sizeof(L2PerfBufferState));
 
-        state->free_queue.head = 0;
-        state->free_queue.tail = 0;
-        state->current_buf_ptr = 0;
-        state->current_buf_seq = 0;
+        // Allocate the per-core staging ring (no host shadow needed: AICore
+        // writes, AICPU reads — host never touches the ring directly).
+        void *ring_dev = alloc_cb(sizeof(L2PerfAicoreRing), user_data);
+        if (ring_dev == nullptr) {
+            LOG_ERROR("Failed to allocate L2PerfAicoreRing for core %d", i);
+            return -1;
+        }
+        aicore_rings_dev_[i] = ring_dev;
+        state->aicore_ring_ptr = reinterpret_cast<uint64_t>(ring_dev);
+        reinterpret_cast<uint64_t *>(table_host_ptr)[i] = reinterpret_cast<uint64_t>(ring_dev);
 
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_CORE; s++) {
             void *host_buf_ptr = nullptr;
@@ -727,34 +202,27 @@ int L2PerfCollector::initialize(
                 LOG_ERROR("Failed to allocate L2PerfBuffer for core %d, buffer %d", i, s);
                 return -1;
             }
-            L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(host_buf_ptr);
-            memset(buf, 0, sizeof(L2PerfBuffer));
-            buf->count = 0;
 
             if (s == 0) {
                 state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
             } else {
-                memory_manager_.recycled_perf_buffers_.push_back(dev_buf_ptr);
+                manager_.push_recycled(static_cast<int>(ProfBufferType::PERF_RECORD), dev_buf_ptr);
             }
         }
-        wmb();
         state->free_queue.tail = 1;
-        wmb();
     }
     LOG_DEBUG(
         "Initialized %d L2PerfBufferStates: 1 buffer/core, %d in recycled pool", num_aicore,
         num_aicore * (PLATFORM_PROF_BUFFERS_PER_CORE - 1)
     );
 
-    // Step 6: Initialize PhaseBufferStates — 1 buffer per thread in free_queue, rest to recycled pool
+    // Push the populated address table to device.
+    profiling_copy_to_device(table_dev_ptr, table_host_ptr, table_size);
+
+    // Step 5: Initialize PhaseBufferStates — 1 buffer/thread in free_queue, rest to recycled pool.
     for (int t = 0; t < num_phase_threads; t++) {
         PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
-        memset(state, 0, sizeof(PhaseBufferState));
-
-        state->free_queue.head = 0;
-        state->free_queue.tail = 0;
-        state->current_buf_ptr = 0;
-        state->current_buf_seq = 0;
+        std::memset(state, 0, sizeof(PhaseBufferState));
 
         for (int s = 0; s < PLATFORM_PROF_BUFFERS_PER_THREAD; s++) {
             void *host_buf_ptr = nullptr;
@@ -763,421 +231,235 @@ int L2PerfCollector::initialize(
                 LOG_ERROR("Failed to allocate PhaseBuffer for thread %d, buffer %d", t, s);
                 return -1;
             }
-            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(host_buf_ptr);
-            memset(buf, 0, sizeof(PhaseBuffer));
-            buf->count = 0;
 
             if (s == 0) {
                 state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(dev_buf_ptr);
             } else {
-                memory_manager_.recycled_phase_buffers_.push_back(dev_buf_ptr);
+                manager_.push_recycled(static_cast<int>(ProfBufferType::PHASE), dev_buf_ptr);
             }
         }
-        wmb();
         state->free_queue.tail = 1;
-        wmb();
     }
     LOG_DEBUG(
         "Initialized %d PhaseBufferStates: 1 buffer/thread, %d in recycled pool", num_phase_threads,
         num_phase_threads * (PLATFORM_PROF_BUFFERS_PER_THREAD - 1)
     );
 
-    int rc = profiling_copy_to_device(perf_dev_ptr, perf_host_ptr, total_size);
-    if (rc != 0) {
-        LOG_ERROR("Failed to copy shared memory to device: %d", rc);
-        return rc;
-    }
-    for (int i = 0; i < num_aicore; i++) {
-        L2PerfBufferState *state = get_perf_buffer_state(perf_host_ptr, i);
-        void *dev_buf = reinterpret_cast<void *>(state->free_queue.buffer_ptrs[0]);
-        void *host_buf = memory_manager_.resolve_host_ptr(dev_buf);
-        if (host_buf != nullptr) {
-            profiling_copy_to_device(dev_buf, host_buf, sizeof(L2PerfBuffer));
-        }
-    }
-    for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_host_ptr, num_aicore, t);
-        void *dev_buf = reinterpret_cast<void *>(state->free_queue.buffer_ptrs[0]);
-        void *host_buf = memory_manager_.resolve_host_ptr(dev_buf);
-        if (host_buf != nullptr) {
-            profiling_copy_to_device(dev_buf, host_buf, sizeof(PhaseBuffer));
-        }
-    }
+    // Step 6: Push the initialized shm region (header + BufferStates +
+    // free_queue contents) to device.
+    profiling_copy_to_device(perf_dev_ptr, perf_host_ptr, total_size);
 
-    wmb();
-
-    // Step 7: Stash device pointer for the caller to publish via
-    // kernel_args.l2_perf_data_base (read back via get_l2_perf_setup_device_ptr()).
-    LOG_DEBUG("L2 perf device base = 0x%lx", reinterpret_cast<uint64_t>(perf_dev_ptr));
-
+    // Step 7: Publish shm pointers on the base now that the region is ready.
     perf_shared_mem_dev_ = perf_dev_ptr;
-    perf_shared_mem_host_ = perf_host_ptr;
+    set_memory_context(alloc_cb, register_cb, free_cb, user_data, perf_dev_ptr, perf_host_ptr, total_size, device_id);
 
+    collected_perf_records_.assign(num_aicore_, {});
+    collected_phase_records_.assign(PLATFORM_MAX_AICPU_THREADS, {});
+
+    LOG_DEBUG("L2 perf device base = 0x%lx", reinterpret_cast<uint64_t>(perf_dev_ptr));
     LOG_INFO_V0("Performance profiling initialized (dynamic buffer mode)");
     return 0;
 }
 
-void L2PerfCollector::start_memory_manager(const ThreadFactory &thread_factory) {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
+// ---------------------------------------------------------------------------
+// ProfilerBase callbacks
+// ---------------------------------------------------------------------------
 
-    memory_manager_.shared_mem_dev_ = perf_shared_mem_dev_;
-    memory_manager_.start(
-        perf_shared_mem_host_, num_aicore_, PLATFORM_MAX_AICPU_THREADS, alloc_cb_, register_cb_, free_cb_, device_id_,
-        thread_factory
-    );
-}
-
-void L2PerfCollector::stop_memory_manager() {
-    if (memory_manager_.is_running()) {
-        memory_manager_.stop();
-    }
-}
-
-void L2PerfCollector::signal_execution_complete() { execution_complete_.store(true); }
-
-void L2PerfCollector::poll_and_collect(int expected_tasks) {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
-
-    execution_complete_.store(false);
-
-    LOG_INFO_V0("Collecting performance data");
-
-    L2PerfDataHeader *header = get_l2_perf_header(perf_shared_mem_host_);
-
-    const auto timeout_duration = std::chrono::seconds(PLATFORM_PROF_TIMEOUT_SECONDS);
-    std::optional<std::chrono::steady_clock::time_point> idle_start;
-
-    // Initialize collection storage before the waiting loop so buffers
-    // can be processed immediately, preventing device memory leaks.
-    int total_records_collected = 0;
-    int buffers_processed = 0;
-
-    collected_perf_records_.clear();
-    collected_perf_records_.resize(num_aicore_);
-    collected_phase_records_.clear();
-    collected_phase_records_.resize(PLATFORM_MAX_AICPU_THREADS);
-
-    // Helper lambda: read total_tasks from device (memcpy mode) or host shadow
-    auto read_total_tasks = [&]() -> uint32_t {
-        L2PerfDataHeader *dev_header = get_l2_perf_header(perf_shared_mem_dev_);
-        uint32_t val = 0;
-        profiling_copy_from_device(&val, &dev_header->total_tasks, sizeof(uint32_t));
-        header->total_tasks = val;
-        rmb();
-        return header->total_tasks;
-    };
-
-    if (expected_tasks <= 0) {
-        LOG_INFO_V0("Waiting for AICPU to write total_tasks in L2PerfDataHeader...");
-        idle_start = std::chrono::steady_clock::now();
-
-        while (true) {
-            uint32_t raw_total_tasks = read_total_tasks();
-
-            if (raw_total_tasks > 0) {
-                expected_tasks = static_cast<int>(raw_total_tasks);
-                LOG_INFO_V0("AICPU reported task count: %d", expected_tasks);
-                break;
-            }
-
-            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
-            if (elapsed >= timeout_duration) {
-                LOG_ERROR(
-                    "Timeout waiting for AICPU task count after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
-                );
-                return;
-            }
-
-            // Process ready buffers while waiting to free device memory
-            ReadyBufferInfo info;
-            if (memory_manager_.try_pop_ready(info)) {
-                if (info.type == ProfBufferType::PERF_RECORD) {
-                    L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
-                    rmb();
-                    uint32_t count = buf->count;
-                    if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                        count = PLATFORM_PROF_BUFFER_SIZE;
-                    }
-                    uint32_t core_index = info.index;
-                    if (core_index < static_cast<uint32_t>(num_aicore_)) {
-                        for (uint32_t i = 0; i < count; i++) {
-                            collected_perf_records_[core_index].push_back(buf->records[i]);
-                        }
-                        total_records_collected += count;
-                    }
-                } else {
-                    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
-                    rmb();
-                    uint32_t count = buf->count;
-                    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                    }
-                    uint32_t tidx = info.index;
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_phase_records_[tidx].push_back(buf->records[i]);
-                    }
-                }
-                memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
-                idle_start = std::chrono::steady_clock::now();
-                buffers_processed++;
-            }
-        }
-    }
-
-    LOG_DEBUG("Initial expected tasks: %d", expected_tasks);
-
-    idle_start.reset();
-    int last_logged_expected = -1;
-
-    while (total_records_collected < expected_tasks) {
-        // Check for updated expected_tasks
-        int current_expected = static_cast<int>(read_total_tasks());
-        if (current_expected > expected_tasks) {
-            expected_tasks = current_expected;
-            if (last_logged_expected < 0) {
-                LOG_INFO_V0("Updated expected_tasks to %d (orchestrator progress)", expected_tasks);
-                last_logged_expected = expected_tasks;
-            }
-        }
-
-        ReadyBufferInfo info;
-        if (memory_manager_.wait_pop_ready(info, std::chrono::milliseconds(100))) {
-            idle_start.reset();
-
-            if (info.type == ProfBufferType::PERF_RECORD) {
-                L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
-                rmb();
-                uint32_t count = buf->count;
-                if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                    count = PLATFORM_PROF_BUFFER_SIZE;
-                }
-
-                uint32_t core_index = info.index;
-                if (core_index < static_cast<uint32_t>(num_aicore_)) {
-                    for (uint32_t i = 0; i < count; i++) {
-                        collected_perf_records_[core_index].push_back(buf->records[i]);
-                    }
-                    total_records_collected += count;
-                }
-
-                LOG_DEBUG(
-                    "Collected %u perf records from core %u (total: %d/%d)", count, core_index, total_records_collected,
-                    expected_tasks
-                );
-
-            } else {
-                PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
-                rmb();
-                uint32_t count = buf->count;
-                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                }
-
-                uint32_t tidx = info.index;
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[tidx].push_back(buf->records[i]);
-                }
-
-                LOG_DEBUG("Collected %u phase records from thread %u", count, tidx);
-            }
-
-            // Notify memory manager to recycle old buffer
-            memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
-            buffers_processed++;
-
-        } else {
-            // Timeout on wait — check for execution complete signal or overall timeout
-            if (execution_complete_.load()) {
-                // Device is done. Final non-blocking drain and exit.
-                ReadyBufferInfo drain_info;
-                while (memory_manager_.try_pop_ready(drain_info)) {
-                    if (drain_info.type == ProfBufferType::PERF_RECORD) {
-                        L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(drain_info.host_buffer_ptr);
-                        rmb();
-                        uint32_t count = buf->count;
-                        if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                            count = PLATFORM_PROF_BUFFER_SIZE;
-                        }
-                        uint32_t ci = drain_info.index;
-                        if (ci < static_cast<uint32_t>(num_aicore_)) {
-                            for (uint32_t i = 0; i < count; i++) {
-                                collected_perf_records_[ci].push_back(buf->records[i]);
-                            }
-                            total_records_collected += count;
-                        }
-                    } else {
-                        PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(drain_info.host_buffer_ptr);
-                        rmb();
-                        uint32_t count = buf->count;
-                        if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                            count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                        }
-                        uint32_t tidx = drain_info.index;
-                        for (uint32_t i = 0; i < count; i++) {
-                            collected_phase_records_[tidx].push_back(buf->records[i]);
-                        }
-                    }
-                    memory_manager_.notify_copy_done({drain_info.dev_buffer_ptr, drain_info.type});
-                    buffers_processed++;
-                }
-                LOG_INFO_V0(
-                    "Execution complete signal received, exiting with %d/%d records", total_records_collected,
-                    expected_tasks
-                );
-                break;
-            }
-            if (!idle_start.has_value()) {
-                idle_start = std::chrono::steady_clock::now();
-            }
-            auto elapsed = std::chrono::steady_clock::now() - idle_start.value();
-            if (elapsed >= timeout_duration) {
-                LOG_ERROR(
-                    "Performance data collection idle timeout after %ld seconds",
-                    std::chrono::duration_cast<std::chrono::seconds>(elapsed).count()
-                );
-                LOG_ERROR("Collected %d / %d records before timeout", total_records_collected, expected_tasks);
-                break;
-            }
-        }
-    }
-
-    LOG_INFO_V0("Total buffers processed: %d", buffers_processed);
-    LOG_INFO_V0("Total records collected: %d", total_records_collected);
-
-    if (total_records_collected < expected_tasks) {
-        LOG_WARN("Incomplete collection (%d / %d records)", total_records_collected, expected_tasks);
-    }
-
-    LOG_INFO_V0("Performance data collection complete");
-}
-
-void L2PerfCollector::drain_remaining_buffers() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
-
-    int drained_perf = 0;
-    int drained_phase = 0;
-
-    ReadyBufferInfo info;
-    while (memory_manager_.try_pop_ready(info)) {
-        if (info.type == ProfBufferType::PERF_RECORD) {
-            L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
-            rmb();
-            uint32_t count = buf->count;
-            if (count > PLATFORM_PROF_BUFFER_SIZE) {
-                count = PLATFORM_PROF_BUFFER_SIZE;
-            }
-            uint32_t core_index = info.index;
-            if (core_index < static_cast<uint32_t>(num_aicore_)) {
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_perf_records_[core_index].push_back(buf->records[i]);
-                }
-                drained_perf += count;
-            }
-        } else {
-            PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
-            rmb();
-            uint32_t count = buf->count;
-            if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-            }
-            uint32_t tidx = info.index;
-            for (uint32_t i = 0; i < count; i++) {
-                collected_phase_records_[tidx].push_back(buf->records[i]);
-            }
-            drained_phase += count;
-        }
-
-        memory_manager_.notify_copy_done({info.dev_buffer_ptr, info.type});
-    }
-
-    if (drained_perf > 0 || drained_phase > 0) {
-        LOG_INFO_V0("Drained remaining buffers: %d perf records, %d phase records", drained_perf, drained_phase);
-    }
-
-    if (drained_phase > 0) {
-        has_phase_data_ = true;
-    }
-}
-
-void L2PerfCollector::scan_remaining_perf_buffers() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
-    }
-
-    for (int i = 0; i < num_aicore_; i++) {
-        L2PerfBufferState *host_state = get_perf_buffer_state(perf_shared_mem_host_, i);
-        L2PerfBufferState *dev_state = get_perf_buffer_state(perf_shared_mem_dev_, i);
-        profiling_copy_from_device(host_state, dev_state, sizeof(L2PerfBufferState));
-    }
+void L2PerfCollector::copy_perf_buffer(const ReadyBufferInfo &info) {
+    L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(info.host_buffer_ptr);
     rmb();
-
-    int total_recovered = 0;
-
-    for (int core_index = 0; core_index < num_aicore_; core_index++) {
-        L2PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, core_index);
-
-        rmb();
-        uint64_t buf_ptr = state->current_buf_ptr;
-        if (buf_ptr == 0) {
-            continue;
-        }
-
-        void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
-        if (host_ptr == nullptr) {
-            LOG_ERROR(
-                "scan_remaining_perf_buffers: no host mapping for dev_ptr=%p (core %d)",
-                reinterpret_cast<void *>(buf_ptr), core_index
-            );
-            continue;
-        }
-
-        profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(L2PerfBuffer));
-
-        L2PerfBuffer *buf = reinterpret_cast<L2PerfBuffer *>(host_ptr);
-        uint32_t count = buf->count;
-        if (count == 0) {
-            continue;
-        }
-        if (count > PLATFORM_PROF_BUFFER_SIZE) {
-            count = PLATFORM_PROF_BUFFER_SIZE;
-        }
-
+    uint32_t count = buf->count;
+    if (count > PLATFORM_PROF_BUFFER_SIZE) {
+        count = PLATFORM_PROF_BUFFER_SIZE;
+    }
+    uint32_t core_index = info.index;
+    if (core_index < static_cast<uint32_t>(num_aicore_)) {
         for (uint32_t i = 0; i < count; i++) {
             collected_perf_records_[core_index].push_back(buf->records[i]);
         }
-        total_recovered += count;
-    }
-
-    if (total_recovered > 0) {
-        LOG_INFO_V0("scan_remaining_perf_buffers: recovered %d records from active buffers", total_recovered);
+        total_perf_collected_ += count;
     }
 }
 
-void L2PerfCollector::collect_phase_data() {
-    if (perf_shared_mem_host_ == nullptr) {
-        return;
+void L2PerfCollector::copy_phase_buffer(const ReadyBufferInfo &info) {
+    PhaseBuffer *buf = reinterpret_cast<PhaseBuffer *>(info.host_buffer_ptr);
+    rmb();
+    uint32_t count = buf->count;
+    if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
+        count = PLATFORM_PHASE_RECORDS_PER_THREAD;
     }
+    uint32_t tidx = info.index;
+    if (tidx < collected_phase_records_.size()) {
+        for (uint32_t i = 0; i < count; i++) {
+            collected_phase_records_[tidx].push_back(buf->records[i]);
+        }
+        total_phase_collected_ += count;
+        if (count > 0) {
+            has_phase_data_ = true;
+        }
+    }
+}
 
-    AicpuPhaseHeader *host_ph = get_phase_header(perf_shared_mem_host_, num_aicore_);
-    AicpuPhaseHeader *dev_ph = get_phase_header(perf_shared_mem_dev_, num_aicore_);
-    profiling_copy_from_device(host_ph, dev_ph, sizeof(AicpuPhaseHeader));
-    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        PhaseBufferState *host_state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
-        PhaseBufferState *dev_state = get_phase_buffer_state(perf_shared_mem_dev_, num_aicore_, t);
-        profiling_copy_from_device(host_state, dev_state, sizeof(PhaseBufferState));
+void L2PerfCollector::on_buffer_collected(const ReadyBufferInfo &info) {
+    if (info.type == ProfBufferType::PERF_RECORD) {
+        copy_perf_buffer(info);
+    } else {
+        copy_phase_buffer(info);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// reconcile_counters / read_phase_header_metadata
+// ---------------------------------------------------------------------------
+//
+// Host never recovers records from device-side current_buf_ptr. Device flush
+// is the only data path: a flush failure must bump dropped_record_count and
+// clear current_buf_ptr on the device side. Host's job here is purely
+// accounting + sanity check.
+//
+// L2PerfBufferState now tracks total / dropped / mismatch counters — same
+// three-bucket accounting as PMU and a2a3. The cross-check equation
+// (collected + dropped + mismatch == device_total) is enforced per pool
+// (PERF + PHASE). Empty PHASE pools (runtime emits no phase records) are
+// skipped via the `optional` flag.
+
+void L2PerfCollector::reconcile_counters() {
+    if (shm_host_ == nullptr) return;
+
+    // Pull the latest BufferStates (current_buf_ptr) before the per-unit
+    // sanity loop so leftovers reflect post-stop() device state.
+    if (manager_.shared_mem_dev() != nullptr && shm_size_ > 0) {
+        profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
     }
     rmb();
 
-    AicpuPhaseHeader *phase_header = get_phase_header(perf_shared_mem_host_, num_aicore_);
+    // After stop(), AICPU's per-thread flush hooks
+    // (l2_perf_aicpu_flush_buffers / l2_perf_aicpu_flush_phase_buffers)
+    // should have either enqueued the active buffer (success →
+    // current_buf_ptr=0) or cleared it on enqueue failure. A non-zero
+    // pointer with non-zero count means records AICPU neither delivered
+    // nor cleared — a device-side flush bug. Empty buffers (count=0,
+    // never written) are fine; AICPU's flush legitimately skips them.
+    int leftover_active = 0;
+    for (int i = 0; i < num_aicore_; i++) {
+        L2PerfBufferState *state = get_perf_buffer_state(shm_host_, i);
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) continue;
+        void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+        if (host_ptr == nullptr) continue;
+        profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(L2PerfBuffer));
+        uint32_t count = reinterpret_cast<L2PerfBuffer *>(host_ptr)->count;
+        if (count == 0) continue;
+        LOG_ERROR(
+            "L2Perf reconcile: core %d has un-flushed PERF buffer (current_buf_ptr=0x%lx, count=%u) "
+            "after stop() — device flush failed",
+            i, static_cast<unsigned long>(buf_ptr), count
+        );
+        leftover_active++;
+    }
 
-    // Validate magic
+    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
+        PhaseBufferState *state = get_phase_buffer_state(shm_host_, num_aicore_, t);
+        uint64_t buf_ptr = state->current_buf_ptr;
+        if (buf_ptr == 0) continue;
+        void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
+        if (host_ptr == nullptr) continue;
+        profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(PhaseBuffer));
+        uint32_t count = reinterpret_cast<PhaseBuffer *>(host_ptr)->count;
+        if (count == 0) continue;
+        LOG_ERROR(
+            "L2Perf reconcile: thread %d has un-flushed PHASE buffer (current_buf_ptr=0x%lx, count=%u) "
+            "after stop() — device flush failed",
+            t, static_cast<unsigned long>(buf_ptr), count
+        );
+        leftover_active++;
+    }
+
+    if (leftover_active > 0) {
+        LOG_ERROR("L2Perf reconcile: %d unit(s) had un-cleared current_buf_ptr — see prior errors", leftover_active);
+    }
+
+    // Cross-check device-side totals against host CSV.  PERF and PHASE
+    // each have their own pool of buffer states with the same accounting
+    // shape: total_record_count = collected + dropped + mismatch.
+    auto reconcile_one = [&](const char *kind, const char *unit_name, int unit_count, auto get_state,
+                             uint64_t collected, bool optional) {
+        uint64_t total_device = 0;
+        uint64_t dropped_device = 0;
+        uint64_t mismatch_device = 0;
+        for (int i = 0; i < unit_count; i++) {
+            L2PerfBufferState *state = get_state(i);
+            total_device += state->total_record_count;
+            dropped_device += state->dropped_record_count;
+            mismatch_device += state->mismatch_record_count;
+        }
+
+        if (optional && total_device == 0 && collected == 0 && dropped_device == 0 && mismatch_device == 0) {
+            return;
+        }
+
+        if (dropped_device > 0) {
+            LOG_WARN(
+                "L2Perf reconcile: %lu %s records dropped on device side (buffer full / "
+                "ready_queue full / late FIN after flush).",
+                static_cast<unsigned long>(dropped_device), kind
+            );
+        }
+        if (mismatch_device > 0) {
+            LOG_ERROR(
+                "L2Perf reconcile: %lu %s records lost to AICore staging-slot task_id mismatch — "
+                "completion-before-dispatch invariant violated",
+                static_cast<unsigned long>(mismatch_device), kind
+            );
+        }
+        uint64_t accounted = collected + dropped_device + mismatch_device;
+        if (accounted != total_device) {
+            LOG_WARN(
+                "L2Perf reconcile: %s count mismatch (collected=%lu + dropped=%lu + mismatch=%lu != "
+                "device_total=%lu, silent_loss=%ld)",
+                kind, static_cast<unsigned long>(collected), static_cast<unsigned long>(dropped_device),
+                static_cast<unsigned long>(mismatch_device), static_cast<unsigned long>(total_device),
+                static_cast<long>(total_device) - static_cast<long>(accounted)
+            );
+        } else {
+            LOG_INFO_V0(
+                "L2Perf reconcile: %s counts match (collected=%lu, dropped=%lu, mismatch=%lu, device_total=%lu)", kind,
+                static_cast<unsigned long>(collected), static_cast<unsigned long>(dropped_device),
+                static_cast<unsigned long>(mismatch_device), static_cast<unsigned long>(total_device)
+            );
+        }
+        (void)unit_name;
+    };
+
+    reconcile_one(
+        "PERF", "core", num_aicore_,
+        [this](int i) {
+            return get_perf_buffer_state(shm_host_, i);
+        },
+        total_perf_collected_, /*optional=*/false
+    );
+    reconcile_one(
+        "PHASE", "thread", PLATFORM_MAX_AICPU_THREADS,
+        [this](int i) {
+            return get_phase_buffer_state(shm_host_, num_aicore_, i);
+        },
+        total_phase_collected_, /*optional=*/true
+    );
+}
+
+void L2PerfCollector::read_phase_header_metadata() {
+    if (shm_host_ == nullptr) return;
+
+    // Pull the AicpuPhaseHeader portion from device (the mgmt loop's final
+    // mirror covered it, but stop() may have raced with a final orch_summary
+    // write — re-mirror to be safe).
+    if (manager_.shared_mem_dev() != nullptr && shm_size_ > 0) {
+        profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
+    }
+    rmb();
+
+    AicpuPhaseHeader *phase_header = get_phase_header(shm_host_, num_aicore_);
+
     if (phase_header->magic != AICPU_PHASE_MAGIC) {
         LOG_INFO_V0(
             "No phase profiling data found (magic mismatch: 0x%x vs 0x%x)", phase_header->magic, AICPU_PHASE_MAGIC
@@ -1192,46 +474,9 @@ void L2PerfCollector::collect_phase_data() {
         );
         return;
     }
-    LOG_INFO_V0("Collecting remaining phase data: %d scheduler threads", num_sched_threads);
+    LOG_INFO_V0("Collecting phase metadata: %d scheduler threads", num_sched_threads);
 
-    int total_slots = PLATFORM_MAX_AICPU_THREADS;
-
-    // Scan remaining PhaseBufferStates for active buffers with partial data.
-    // READY buffers were already enqueued to the ReadyQueue and collected via
-    // poll_and_collect() or drain_remaining_buffers(). Only current_buf_ptr
-    // contains partial data that was never enqueued (the active buffer when execution ended).
-    int total_phase_records = 0;
-    for (int t = 0; t < total_slots; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
-
-        rmb();
-        uint64_t buf_ptr = state->current_buf_ptr;
-        if (buf_ptr != 0) {
-            void *host_ptr = memory_manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_ptr));
-            if (host_ptr == nullptr) {
-                LOG_ERROR(
-                    "collect_phase_data: no host mapping for dev_ptr=%p (thread %d)", reinterpret_cast<void *>(buf_ptr),
-                    t
-                );
-                continue;
-            }
-            profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_ptr), sizeof(PhaseBuffer));
-            PhaseBuffer *pbuf = reinterpret_cast<PhaseBuffer *>(host_ptr);
-            if (pbuf->count > 0) {
-                uint32_t count = pbuf->count;
-                if (count > static_cast<uint32_t>(PLATFORM_PHASE_RECORDS_PER_THREAD)) {
-                    count = PLATFORM_PHASE_RECORDS_PER_THREAD;
-                }
-
-                for (uint32_t i = 0; i < count; i++) {
-                    collected_phase_records_[t].push_back(pbuf->records[i]);
-                }
-                total_phase_records += count;
-            }
-        }
-    }
-
-    // Log per-thread totals
+    // Per-thread breakdown of records already collected via the buffer pipeline.
     for (size_t t = 0; t < collected_phase_records_.size(); t++) {
         if (!collected_phase_records_[t].empty()) {
             size_t sched_count = 0, orch_count = 0;
@@ -1246,10 +491,8 @@ void L2PerfCollector::collect_phase_data() {
         }
     }
 
-    // Read orchestrator summary
     collected_orch_summary_ = phase_header->orch_summary;
     bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
-
     if (orch_valid) {
         LOG_INFO_V0(
             "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
@@ -1259,7 +502,6 @@ void L2PerfCollector::collect_phase_data() {
         LOG_INFO_V0("  Orchestrator: no summary data");
     }
 
-    // Check if drain_remaining_buffers() already accumulated some Phase records
     bool has_accumulated = has_phase_data_;
     if (!has_accumulated) {
         for (const auto &v : collected_phase_records_) {
@@ -1269,23 +511,22 @@ void L2PerfCollector::collect_phase_data() {
             }
         }
     }
-    has_phase_data_ = (total_phase_records > 0 || orch_valid || has_accumulated);
+    has_phase_data_ = (orch_valid || has_accumulated);
 
-    // Read core-to-thread mapping
     int num_cores = static_cast<int>(phase_header->num_cores);
     if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
         core_to_thread_.assign(phase_header->core_to_thread, phase_header->core_to_thread + num_cores);
         LOG_INFO_V0("  Core-to-thread mapping: %d cores", num_cores);
     }
 
-    LOG_INFO_V0(
-        "Phase data collection complete: %d remaining records, orch_summary=%s", total_phase_records,
-        orch_valid ? "yes" : "no"
-    );
+    LOG_INFO_V0("Phase metadata collection complete: orch_summary=%s", orch_valid ? "yes" : "no");
 }
 
-int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
-    // Step 1: Validate collected data
+// ---------------------------------------------------------------------------
+// export_swimlane_json
+// ---------------------------------------------------------------------------
+
+int L2PerfCollector::export_swimlane_json() {
     bool has_any_records = false;
     for (const auto &core_records : collected_perf_records_) {
         if (!core_records.empty()) {
@@ -1298,16 +539,13 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         return -1;
     }
 
-    // Step 2: Create output directory (recursively — parent `outputs/` may not
-    // yet exist on a clean checkout / standalone run).
     std::error_code ec;
-    std::filesystem::create_directories(output_path, ec);
+    std::filesystem::create_directories(output_prefix_, ec);
     if (ec) {
-        LOG_ERROR("Error: Failed to create output directory %s: %s", output_path.c_str(), ec.message().c_str());
+        LOG_ERROR("Error: Failed to create output directory %s: %s", output_prefix_.c_str(), ec.message().c_str());
         return -1;
     }
 
-    // Step 3: Flatten per-core vectors into tagged records with core_id derived from index
     struct TaggedRecord {
         const L2PerfRecord *record;
         uint32_t core_id;
@@ -1324,12 +562,10 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         }
     }
 
-    // Sort by canonical task_id (64-bit PTO2 raw)
     std::sort(tagged_records.begin(), tagged_records.end(), [](const TaggedRecord &a, const TaggedRecord &b) {
         return a.record->task_id < b.record->task_id;
     });
 
-    // Step 4: Calculate base time (minimum timestamp across all records)
     uint64_t base_time_cycles = UINT64_MAX;
     for (const auto &tagged : tagged_records) {
         if (tagged.record->start_time < base_time_cycles) {
@@ -1340,7 +576,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         }
     }
 
-    // Include phase record timestamps in base_time calculation
     if (has_phase_data_) {
         for (const auto &thread_records : collected_phase_records_) {
             for (const auto &pr : thread_records) {
@@ -1355,18 +590,14 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         }
     }
 
-    // Step 5: Compose output path. Filename is fixed (no timestamp) — the
-    // caller-provided directory is the per-task uniqueness boundary.
-    std::string filepath = output_path + "/l2_perf_records.json";
+    std::string filepath = output_prefix_ + "/l2_perf_records.json";
 
-    // Step 6: Open JSON file for writing
     std::ofstream outfile(filepath);
     if (!outfile.is_open()) {
         LOG_ERROR("Error: Failed to open file: %s", filepath.c_str());
         return -1;
     }
 
-    // Step 7: Write JSON data
     int version = has_phase_data_ ? 2 : 1;
     outfile << "{\n";
     outfile << "  \"version\": " << version << ",\n";
@@ -1376,7 +607,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         const auto &tagged = tagged_records[i];
         const auto &record = *tagged.record;
 
-        // Convert times to microseconds
         double start_us = cycles_to_us(record.start_time - base_time_cycles);
         double end_us = cycles_to_us(record.end_time - base_time_cycles);
         double duration_us = end_us - start_us;
@@ -1415,7 +645,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
     }
     outfile << "  ]";
 
-    // Step 8: Write phase profiling data (version 2)
     if (has_phase_data_) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
@@ -1457,7 +686,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
             }
         };
 
-        // AICPU scheduler phases (filtered from unified collected_phase_records_)
         outfile << ",\n  \"aicpu_scheduler_phases\": [\n";
         for (size_t t = 0; t < collected_phase_records_.size(); t++) {
             outfile << "    [\n";
@@ -1481,7 +709,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         }
         outfile << "  ]";
 
-        // AICPU orchestrator summary
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC) {
             double orch_start_us = cycles_to_us(collected_orch_summary_.start_time - base_time_cycles);
             double orch_end_us = cycles_to_us(collected_orch_summary_.end_time - base_time_cycles);
@@ -1511,7 +738,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
             outfile << "  }";
         }
 
-        // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
         bool has_orch_phases = false;
         for (const auto &v : collected_phase_records_) {
             for (const auto &r : v) {
@@ -1556,7 +782,6 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
         outfile << "]";
     }
 
-    // Step 9: Close file
     outfile << "\n}\n";
     outfile.close();
 
@@ -1568,104 +793,117 @@ int L2PerfCollector::export_swimlane_json(const std::string &output_path) {
     return 0;
 }
 
-int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb) {
-    if (perf_shared_mem_host_ == nullptr) {
-        return 0;
-    }
+// ---------------------------------------------------------------------------
+// finalize
+// ---------------------------------------------------------------------------
 
-    stop_memory_manager();
+int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data) {
+    if (shm_host_ == nullptr) return 0;
+
+    // Stop mgmt + collector threads if the caller didn't already (idempotent).
+    stop();
 
     LOG_DEBUG("Cleaning up performance profiling resources");
 
-    for (int i = 0; i < num_aicore_; i++) {
-        L2PerfBufferState *host_state = get_perf_buffer_state(perf_shared_mem_host_, i);
-        L2PerfBufferState *dev_state = get_perf_buffer_state(perf_shared_mem_dev_, i);
-        profiling_copy_from_device(host_state, dev_state, sizeof(L2PerfBufferState));
-    }
-    for (int t = 0; t < PLATFORM_MAX_AICPU_THREADS; t++) {
-        PhaseBufferState *host_state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
-        PhaseBufferState *dev_state = get_phase_buffer_state(perf_shared_mem_dev_, num_aicore_, t);
-        profiling_copy_from_device(host_state, dev_state, sizeof(PhaseBufferState));
-    }
-
-    // Free buffers in free_queues and current_buf_ptr
-    for (int i = 0; i < num_aicore_; i++) {
-        L2PerfBufferState *state = get_perf_buffer_state(perf_shared_mem_host_, i);
-
-        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            memory_manager_.free_buffer(reinterpret_cast<void *>(state->current_buf_ptr));
+    auto release_dev = [&](void *p) {
+        if (p == nullptr) return;
+        if (unregister_cb != nullptr) {
+            unregister_cb(p, device_id_);
         }
+        if (free_cb != nullptr) {
+            free_cb(p, user_data);
+        }
+    };
+
+    // Free buffers still parked in per-core / per-thread free_queues and as
+    // current_buf_ptr — these are owned by the AICPU side, not the
+    // framework. Only release the device pointer here; the paired host
+    // shadow stays in dev_to_host_ and is freed by clear_mappings() below
+    // (single source of truth for shadow lifetime, no double-free risk).
+    for (int i = 0; i < num_aicore_; i++) {
+        L2PerfBufferState *state = get_perf_buffer_state(shm_host_, i);
+
+        release_dev(reinterpret_cast<void *>(state->current_buf_ptr));
+        state->current_buf_ptr = 0;
 
         rmb();
         uint32_t head = state->free_queue.head;
         uint32_t tail = state->free_queue.tail;
-        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
-        while (head != tail && max_iters-- > 0) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            if (buf_ptr != 0 && free_cb != nullptr) {
-                memory_manager_.free_buffer(reinterpret_cast<void *>(buf_ptr));
-            }
-            head++;
+        uint32_t queued = tail - head;
+        if (queued > PLATFORM_PROF_SLOT_COUNT) {
+            queued = PLATFORM_PROF_SLOT_COUNT;
         }
-        if (head != tail) {
-            LOG_WARN("finalize: perf free_queue not fully drained for core %d (head=%u tail=%u)", i, head, tail);
+        for (uint32_t k = 0; k < queued; k++) {
+            uint32_t slot = (head + k) % PLATFORM_PROF_SLOT_COUNT;
+            release_dev(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+            state->free_queue.buffer_ptrs[slot] = 0;
         }
+        state->free_queue.head = tail;
     }
 
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
     for (int t = 0; t < num_phase_threads; t++) {
-        PhaseBufferState *state = get_phase_buffer_state(perf_shared_mem_host_, num_aicore_, t);
+        PhaseBufferState *state = get_phase_buffer_state(shm_host_, num_aicore_, t);
 
-        if (state->current_buf_ptr != 0 && free_cb != nullptr) {
-            memory_manager_.free_buffer(reinterpret_cast<void *>(state->current_buf_ptr));
-        }
+        release_dev(reinterpret_cast<void *>(state->current_buf_ptr));
+        state->current_buf_ptr = 0;
 
         rmb();
         uint32_t head = state->free_queue.head;
         uint32_t tail = state->free_queue.tail;
-        uint32_t max_iters = PLATFORM_PROF_SLOT_COUNT;
-        while (head != tail && max_iters-- > 0) {
-            uint64_t buf_ptr = state->free_queue.buffer_ptrs[head % PLATFORM_PROF_SLOT_COUNT];
-            if (buf_ptr != 0 && free_cb != nullptr) {
-                memory_manager_.free_buffer(reinterpret_cast<void *>(buf_ptr));
-            }
-            head++;
+        uint32_t queued = tail - head;
+        if (queued > PLATFORM_PROF_SLOT_COUNT) {
+            queued = PLATFORM_PROF_SLOT_COUNT;
         }
-        if (head != tail) {
-            LOG_WARN("finalize: phase free_queue not fully drained for thread %d (head=%u tail=%u)", t, head, tail);
+        for (uint32_t k = 0; k < queued; k++) {
+            uint32_t slot = (head + k) % PLATFORM_PROF_SLOT_COUNT;
+            release_dev(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+            state->free_queue.buffer_ptrs[slot] = 0;
+        }
+        state->free_queue.head = tail;
+    }
+
+    // Release framework-owned buffers (recycled pools, ready_queue,
+    // done_queue). release_owned_buffers frees both dev + host shadow and
+    // erases mappings for them.
+    manager_.release_owned_buffers([&](void *p) {
+        release_dev(p);
+    });
+
+    // Free per-core L2PerfAicoreRings (no host shadow paired). The rings
+    // were allocated directly via alloc_cb (not alloc_single_buffer), so no
+    // entry exists in dev_to_host_ for them.
+    for (auto *ring_dev : aicore_rings_dev_) {
+        if (ring_dev != nullptr) {
+            release_dev(ring_dev);
         }
     }
+    aicore_rings_dev_.clear();
 
-    // Unregister host mapping if SVM was used
-    if (unregister_cb != nullptr && register_cb_ != nullptr) {
-        int rc = unregister_cb(perf_shared_mem_dev_, device_id_);
-        if (rc != 0) {
-            LOG_ERROR("halHostUnregister failed: %d", rc);
-            return rc;
-        }
-        LOG_DEBUG("Host mapping unregistered");
+    // Free address table (device + host shadow via clear_mappings below).
+    if (aicore_ring_addrs_dev_ != nullptr) {
+        release_dev(aicore_ring_addrs_dev_);
+        aicore_ring_addrs_dev_ = nullptr;
+    }
+    aicore_ring_addrs_host_ = nullptr;
+
+    // Free shared memory region (device only — shadow stays in
+    // dev_to_host_ until clear_mappings).
+    if (perf_shared_mem_dev_ != nullptr) {
+        release_dev(perf_shared_mem_dev_);
+        perf_shared_mem_dev_ = nullptr;
     }
 
-    // Free host shadow of shared memory (only in non-SVM mode)
-    if (register_cb_ == nullptr && perf_shared_mem_host_ != nullptr && perf_shared_mem_host_ != perf_shared_mem_dev_) {
-        free(perf_shared_mem_host_);
-    }
+    // Free remaining host shadows: per-state buffers + the shm region.
+    manager_.clear_mappings();
 
-    if (free_cb != nullptr && perf_shared_mem_dev_ != nullptr) {
-        free_cb(perf_shared_mem_dev_);
-        LOG_DEBUG("Shared memory freed");
-    }
-
-    perf_shared_mem_dev_ = nullptr;
-    perf_shared_mem_host_ = nullptr;
     collected_perf_records_.clear();
     collected_phase_records_.clear();
     core_to_thread_.clear();
     has_phase_data_ = false;
-    device_id_ = -1;
-    alloc_cb_ = nullptr;
-    register_cb_ = nullptr;
-    free_cb_ = nullptr;
+    total_perf_collected_ = 0;
+    total_phase_collected_ = 0;
+    clear_memory_context();
 
     LOG_DEBUG("Performance profiling cleanup complete");
     return 0;

--- a/src/a5/platform/src/host/pmu_collector.cpp
+++ b/src/a5/platform/src/host/pmu_collector.cpp
@@ -9,133 +9,178 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
+/**
+ * @file pmu_collector.cpp
+ * @brief Host-side PMU collector. The mgmt-thread + buffer-pool machinery
+ *        lives in profiling_common::BufferPoolManager parameterized by
+ *        PmuModule (host/pmu_collector.h); this file owns the per-buffer
+ *        on_buffer_collected callback (CSV output) and the device-side
+ *        cross-check. The poll loop itself lives in
+ *        profiling_common::ProfilerBase.
+ *
+ * a5 specifics: device↔host transfers go through profiling_copy.h. Each
+ * PmuBuffer's contents are pulled from device on demand inside
+ * ProfilerAlgorithms::process_entry, so on_buffer_collected can read
+ * `count` and `records[]` directly off the host shadow.
+ */
+
 #include "host/pmu_collector.h"
 
 #include <cassert>
+#include <cstdlib>
 #include <cstring>
 #include <iomanip>
 #include <ios>
-#include <thread>
 
+#include "common/memory_barrier.h"
 #include "common/unified_log.h"
+#include "host/profiling_copy.h"
 
-// ---------------------------------------------------------------------------
-// Destructor
-// ---------------------------------------------------------------------------
+PmuCollector::~PmuCollector() { stop(); }
 
-PmuCollector::~PmuCollector() = default;
+void *PmuCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
+    void *dev_ptr = alloc_cb_(size, user_data_);
+    if (dev_ptr == nullptr) {
+        if (host_ptr_out) *host_ptr_out = nullptr;
+        return nullptr;
+    }
+
+    void *host_ptr = nullptr;
+    if (register_cb_ != nullptr) {
+        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
+        if (rc != 0 || host_ptr == nullptr) {
+            LOG_ERROR("PmuCollector: register failed: %d", rc);
+            free_cb_(dev_ptr, user_data_);
+            if (host_ptr_out) *host_ptr_out = nullptr;
+            return nullptr;
+        }
+    } else {
+        host_ptr = std::malloc(size);
+        if (host_ptr == nullptr) {
+            LOG_ERROR("PmuCollector: host shadow alloc failed for %zu bytes", size);
+            free_cb_(dev_ptr, user_data_);
+            if (host_ptr_out) *host_ptr_out = nullptr;
+            return nullptr;
+        }
+        std::memset(host_ptr, 0, size);
+        profiling_copy_to_device(dev_ptr, host_ptr, size);
+    }
+
+    if (host_ptr_out) *host_ptr_out = host_ptr;
+    manager_.register_mapping(dev_ptr, host_ptr);
+    return dev_ptr;
+}
 
 // ---------------------------------------------------------------------------
 // init
 // ---------------------------------------------------------------------------
 
 int PmuCollector::init(
-    int num_cores, int num_threads, uint64_t *kernel_args_pmu_data_base, const std::string &csv_path,
-    PmuEventType event_type, PmuAllocCallback alloc_cb, PmuFreeCallback free_cb, void *user_data, int device_id
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, PmuAllocCallback alloc_cb,
+    PmuRegisterCallback register_cb, PmuFreeCallback free_cb, void *user_data, int device_id
 ) {
-    if (num_cores <= 0 || num_threads <= 0 || kernel_args_pmu_data_base == nullptr || alloc_cb == nullptr ||
-        free_cb == nullptr) {
+    if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
+        return -1;
+    }
+    if (initialized_) {
+        LOG_ERROR("PmuCollector already initialized");
         return -1;
     }
 
     num_cores_ = num_cores;
     num_threads_ = num_threads;
-    device_id_ = device_id;
     event_type_ = event_type;
-    alloc_cb_ = alloc_cb;
-    free_cb_ = free_cb;
-    user_data_ = user_data;
     csv_path_ = csv_path;
 
-    // Reset per-run accumulators. The collector instance is reused across
-    // tests within the same process; without this, a small test running
-    // after a large one inherits the previous run's collected/drained state
-    // and the cross-check at drain time spuriously reports a mismatch.
     total_collected_ = 0;
-    drained_bufs_.clear();
-    execution_complete_.store(false, std::memory_order_release);
     if (csv_file_.is_open()) {
         csv_file_.close();
     }
 
+    // Stash callbacks on the base up-front so alloc_single_buffer sees
+    // consistent values during init. shm_host_ stays nullptr until the shm
+    // allocation succeeds — start(tf) gates on shm_host_.
+    set_memory_context(
+        alloc_cb, register_cb, free_cb, user_data, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+    );
+
     // ---- Allocate shared header + buffer-state region ----
-    shm_size_ = calc_pmu_data_size(num_cores);
-    shm_dev_ = alloc_cb(shm_size_, user_data);
-    if (shm_dev_ == nullptr) {
-        LOG_ERROR("PmuCollector: failed to allocate PMU shared memory (%zu bytes)", shm_size_);
+    size_t shm_size = calc_pmu_data_size(num_cores);
+    void *shm_host_local = nullptr;
+    void *shm_dev_local = alloc_single_buffer(shm_size, &shm_host_local);
+    if (shm_dev_local == nullptr) {
+        LOG_ERROR("PmuCollector: failed to allocate PMU shared memory (%zu bytes)", shm_size);
         return -1;
     }
 
-    // Allocate host shadow
-    shm_host_ = std::malloc(shm_size_);
-    if (shm_host_ == nullptr) {
-        LOG_ERROR("PmuCollector: failed to allocate host shadow (%zu bytes)", shm_size_);
-        free_cb(shm_dev_, user_data);
-        shm_dev_ = nullptr;
+    std::memset(shm_host_local, 0, shm_size);
+    PmuDataHeader *hdr = get_pmu_header(shm_host_local);
+    hdr->event_type = static_cast<uint32_t>(event_type);
+    hdr->num_cores = static_cast<uint32_t>(num_cores);
+
+    // ---- Allocate the per-core ring-address table for AICore. The ring
+    // table is filled fully by the host. AICore resolves its own PMU MMIO
+    // base at kernel entry from `KernelArgs::regs[get_physical_core_id()]`,
+    // so no separate PMU reg-address table is needed.
+    aicore_rings_dev_.assign(num_cores, nullptr);
+    size_t table_size = static_cast<size_t>(num_cores) * sizeof(uint64_t);
+    aicore_ring_addrs_dev_ = alloc_single_buffer(table_size, &aicore_ring_addrs_host_);
+    if (aicore_ring_addrs_dev_ == nullptr) {
+        LOG_ERROR("PmuCollector: failed to allocate aicore ring address table (%zu bytes)", table_size);
         return -1;
     }
-    std::memset(shm_host_, 0, shm_size_);
+    std::memset(aicore_ring_addrs_host_, 0, table_size);
 
-    // Write event_type into header so AICPU can read it from SHM
-    get_pmu_header(shm_host_)->event_type = static_cast<uint32_t>(event_type);
-
-    // Publish device address to KernelArgs
-    *kernel_args_pmu_data_base = reinterpret_cast<uint64_t>(shm_dev_);
-
-    // ---- Allocate per-core PmuBuffers and populate free_queues ----
+    // ---- Allocate per-core PmuBuffers; populate free_queues + recycled pool ----
     const size_t buf_size = sizeof(PmuBuffer);
-    int total_bufs = num_cores * PLATFORM_PMU_BUFFERS_PER_CORE;
-    buf_pool_.resize(total_bufs);
 
     for (int c = 0; c < num_cores; c++) {
-        PmuBufferState *state = pmu_state_host(c);
+        PmuBufferState *state = get_pmu_buffer_state(shm_host_local, c);
+
+        // Allocate the per-core stable PmuAicoreRing (no host shadow needed).
+        void *ring_dev = alloc_cb(sizeof(PmuAicoreRing), user_data);
+        if (ring_dev == nullptr) {
+            LOG_ERROR("PmuCollector: failed to allocate PmuAicoreRing for core %d", c);
+            return -1;
+        }
+        aicore_rings_dev_[c] = ring_dev;
+        state->aicore_ring_ptr = reinterpret_cast<uint64_t>(ring_dev);
+        reinterpret_cast<uint64_t *>(aicore_ring_addrs_host_)[c] = reinterpret_cast<uint64_t>(ring_dev);
 
         for (int b = 0; b < PLATFORM_PMU_BUFFERS_PER_CORE; b++) {
-            int idx = c * PLATFORM_PMU_BUFFERS_PER_CORE + b;
-            void *dev_ptr = alloc_cb(buf_size, user_data);
+            void *host_ptr = nullptr;
+            void *dev_ptr = alloc_single_buffer(buf_size, &host_ptr);
             if (dev_ptr == nullptr) {
                 LOG_ERROR("PmuCollector: failed to allocate PmuBuffer c=%d b=%d", c, b);
                 return -1;
             }
 
-            void *host_ptr = std::malloc(buf_size);
-            if (host_ptr == nullptr) {
-                LOG_ERROR("PmuCollector: failed to allocate host shadow for PmuBuffer c=%d b=%d", c, b);
-                free_cb(dev_ptr, user_data);
-                return -1;
+            if (b < PLATFORM_PMU_SLOT_COUNT) {
+                uint32_t tail = state->free_queue.tail;
+                assert(tail - state->free_queue.head < PLATFORM_PMU_SLOT_COUNT && "free_queue overflow on init");
+                state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
+                state->free_queue.tail = tail + 1;
+            } else {
+                manager_.push_recycled(0, dev_ptr);
             }
-            std::memset(host_ptr, 0, buf_size);
-
-            // Zero the device buffer
-            profiling_copy_to_device(dev_ptr, host_ptr, buf_size);
-
-            buf_pool_[idx] = {dev_ptr, host_ptr};
-
-            // Push into free_queue (host is producer, device is consumer)
-            uint32_t tail = state->free_queue.tail;
-            assert(tail - state->free_queue.head < PLATFORM_PMU_SLOT_COUNT && "free_queue overflow on init");
-            state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
-            __sync_synchronize();
-            state->free_queue.tail = tail + 1;
-            __sync_synchronize();
         }
     }
 
-    // Copy the entire host shadow (header + buffer states + free_queue contents) to device
-    profiling_copy_to_device(shm_dev_, shm_host_, shm_size_);
+    // Push the populated ring address table to device.
+    profiling_copy_to_device(aicore_ring_addrs_dev_, aicore_ring_addrs_host_, table_size);
+
+    // Push the entire initialized shm region (header + BufferStates +
+    // free_queue contents) to device.
+    profiling_copy_to_device(shm_dev_local, shm_host_local, shm_size);
 
     // ---- Build CSV header string (file is opened lazily on first record) ----
-    // Deferring the open avoids leaving a header-only CSV on disk when the
-    // device hangs before producing any PMU records.
     {
         std::string header = "thread_id,core_id,task_id,func_id,core_type,pmu_total_cycles";
         const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type);
         if (evt == nullptr) {
             evt = &PMU_EVENTS_A5_PIPE_UTIL;
         }
-        // Emit only counters with a non-empty name (= valid counters for this event).
-        // Trailing slots in the event table are padded with empty names and skipped.
         for (int i = 0; i < PMU_COUNTER_COUNT_A5; i++) {
             const char *name = evt->counter_names[i];
             if (name == nullptr || name[0] == '\0') {
@@ -149,27 +194,26 @@ int PmuCollector::init(
     }
 
     initialized_ = true;
+    shm_dev_ = shm_dev_local;
+
+    // Re-set_memory_context now that the shm region is ready. start(tf)
+    // gates on shm_host_ being non-null, so this is the moment the
+    // collector becomes startable.
+    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_dev_local, shm_host_local, shm_size, device_id);
+
     LOG_INFO_V0(
         "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
-        num_threads, static_cast<unsigned long>(*kernel_args_pmu_data_base), csv_path_.c_str()
+        num_threads, reinterpret_cast<unsigned long>(shm_dev_), csv_path_.c_str()
     );
     return 0;
 }
 
 // ---------------------------------------------------------------------------
-// Collector lifecycle
-// ---------------------------------------------------------------------------
-
-void PmuCollector::signal_execution_complete() { execution_complete_.store(true, std::memory_order_release); }
-
-// ---------------------------------------------------------------------------
-// write_buffer_to_csv
+// CSV writing
 // ---------------------------------------------------------------------------
 
 void PmuCollector::ensure_csv_open_unlocked() {
-    if (csv_file_.is_open()) {
-        return;
-    }
+    if (csv_file_.is_open()) return;
     csv_file_.open(csv_path_, std::ios::out | std::ios::trunc);
     if (!csv_file_.is_open()) {
         LOG_ERROR("PmuCollector: failed to open CSV file: %s", csv_path_.c_str());
@@ -184,16 +228,13 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
     if (n > static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER)) {
         n = static_cast<uint32_t>(PLATFORM_PMU_RECORDS_PER_BUFFER);
     }
-    if (n == 0) {
-        return;
-    }
+    if (n == 0) return;
 
     std::lock_guard<std::mutex> lock(csv_mutex_);
     ensure_csv_open_unlocked();
-    if (!csv_file_.is_open()) {
-        return;
-    }
+    if (!csv_file_.is_open()) return;
     total_collected_ += n;
+
     const PmuEventConfig *evt = pmu_resolve_event_config_a5(event_type_);
     if (evt == nullptr) {
         evt = &PMU_EVENTS_A5_PIPE_UTIL;
@@ -201,12 +242,9 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
     for (uint32_t i = 0; i < n; i++) {
         const PmuRecord &r = buf->records[i];
         csv_file_ << thread_idx << ',' << core_id << ',';
-        // task_id is printed as hex so the PTO2 (ring_id<<32)|local_id encoding is
-        // readable at a glance.
         csv_file_ << "0x" << std::hex << std::setw(16) << std::setfill('0') << r.task_id << std::dec
                   << std::setfill(' ');
         csv_file_ << ',' << r.func_id << ',' << static_cast<int>(r.core_type) << ',' << r.pmu_total_cycles;
-        // Only emit columns for counters with a non-empty name, matching the header.
         for (int k = 0; k < PMU_COUNTER_COUNT_A5; k++) {
             const char *name = evt->counter_names[k];
             if (name == nullptr || name[0] == '\0') {
@@ -220,267 +258,207 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
 }
 
 // ---------------------------------------------------------------------------
-// resolve_host_ptr: device address -> host shadow
+// ProfilerBase callback
 // ---------------------------------------------------------------------------
 
-void *PmuCollector::resolve_host_ptr(uint64_t dev_addr) {
-    for (auto &e : buf_pool_) {
-        if (reinterpret_cast<uint64_t>(e.dev_ptr) == dev_addr) {
-            return e.host_ptr;
-        }
-    }
-    return nullptr;
+void PmuCollector::on_buffer_collected(const PmuReadyBufferInfo &info) {
+    write_buffer_to_csv(static_cast<int>(info.core_index), static_cast<int>(info.thread_index), info.host_buffer_ptr);
 }
 
 // ---------------------------------------------------------------------------
-// push_to_free_queue: recycle a buffer back to a core's free_queue
+// reconcile_counters: passive sanity-check + device-side cross-check
 // ---------------------------------------------------------------------------
+//
+// Host never recovers records from device-side current_buf_ptr. Device
+// flush (pmu_aicpu_flush_buffers) is the only data path: a flush failure
+// must bump dropped_record_count and clear current_buf_ptr on the device
+// side. Host's job here is purely accounting + sanity assertion —
+// recovering would mask AICPU flush bugs.
 
-void PmuCollector::push_to_free_queue(int core_id, uint64_t buf_dev_addr) {
-    // Sync host shadow of this core's buffer state from device
-    profiling_copy_from_device(pmu_state_host(core_id), pmu_state_dev(core_id), sizeof(PmuBufferState));
+void PmuCollector::reconcile_counters() {
+    if (shm_host_ == nullptr) return;
 
-    PmuBufferState *state = pmu_state_host(core_id);
-
-    // Zero the count on the host shadow buffer
-    void *buf_host = resolve_host_ptr(buf_dev_addr);
-    if (buf_host != nullptr) {
-        PmuBuffer *buf = reinterpret_cast<PmuBuffer *>(buf_host);
-        buf->count = 0;
-        // Zero count on device too
-        uint32_t zero = 0;
-        uintptr_t dev_count_addr = static_cast<uintptr_t>(buf_dev_addr) + offsetof(PmuBuffer, count);
-        profiling_copy_to_device(reinterpret_cast<void *>(dev_count_addr), &zero, sizeof(uint32_t));
+    // Pull the latest BufferStates (current_buf_ptr, total/dropped/mismatch
+    // counters) before the per-core sanity loop so the cross-check sees
+    // post-stop() device state.
+    if (manager_.shared_mem_dev() != nullptr && shm_size_ > 0) {
+        profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
     }
+    rmb();
 
-    // Write the buffer address into the free_queue slot on host shadow
-    uint32_t tail = state->free_queue.tail;
-    state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT] = buf_dev_addr;
-    __sync_synchronize();
-    state->free_queue.tail = tail + 1;
-    __sync_synchronize();
-
-    // Copy updated free_queue slot and tail back to device
-    PmuBufferState *dev_state = pmu_state_dev(core_id);
-    uint64_t slot_val = buf_dev_addr;
-    profiling_copy_to_device(
-        &dev_state->free_queue.buffer_ptrs[tail % PLATFORM_PMU_SLOT_COUNT], &slot_val, sizeof(uint64_t)
-    );
-    uint32_t new_tail = tail + 1;
-    profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-}
-
-// ---------------------------------------------------------------------------
-// poll_and_collect: collector thread body
-// ---------------------------------------------------------------------------
-
-void PmuCollector::poll_and_collect() {
-    if (shm_host_ == nullptr) {
-        return;
-    }
-
-    PmuDataHeader *hdr = pmu_header_host();
-    PmuDataHeader *dev_hdr = pmu_header_dev();
-    constexpr int kIdleTimeoutMs = PLATFORM_PMU_TIMEOUT_SECONDS * 1000;
-    constexpr int kPollIntervalUs = 100;
-    int idle_ms = 0;
-
-    while (true) {
-        bool found_any = false;
-
-        // Read queue_tails from device
-        profiling_copy_from_device(hdr->queue_tails, dev_hdr->queue_tails, sizeof(hdr->queue_tails));
-
-        for (int t = 0; t < num_threads_; t++) {
-            __sync_synchronize();
-            uint32_t head = hdr->queue_heads[t];
-            uint32_t tail = hdr->queue_tails[t];
-
-            while (head != tail) {
-                // Read the ready queue entry from device
-                PmuReadyQueueEntry entry;
-                profiling_copy_from_device(
-                    &entry, &dev_hdr->queues[t][head % PLATFORM_PMU_READYQUEUE_SIZE], sizeof(PmuReadyQueueEntry)
-                );
-
-                uint32_t core_id = entry.core_index;
-                uint64_t buf_dev = entry.buffer_ptr;
-
-                // Copy buffer from device to host shadow
-                void *buf_host = resolve_host_ptr(buf_dev);
-                if (buf_host != nullptr) {
-                    profiling_copy_from_device(buf_host, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
-                    drained_bufs_.insert(buf_dev);
-                    write_buffer_to_csv(static_cast<int>(core_id), t, buf_host);
-                    push_to_free_queue(static_cast<int>(core_id), buf_dev);
-                } else {
-                    LOG_WARN("PMU collector: unknown buffer 0x%lx from core %u", buf_dev, core_id);
-                }
-
-                head = (head + 1) % PLATFORM_PMU_READYQUEUE_SIZE;
-                hdr->queue_heads[t] = head;
-
-                // Write updated head back to device
-                profiling_copy_to_device(&dev_hdr->queue_heads[t], &head, sizeof(uint32_t));
-
-                found_any = true;
-            }
-        }
-
-        if (!found_any) {
-            if (execution_complete_.load(std::memory_order_acquire)) {
-                // Done — exit after one final drain pass
-                break;
-            }
-            std::this_thread::sleep_for(std::chrono::microseconds(kPollIntervalUs));
-            idle_ms += kPollIntervalUs / 1000;
-            if (idle_ms >= kIdleTimeoutMs) {
-                LOG_WARN("PMU collector: idle timeout (%d ms), stopping", kIdleTimeoutMs);
-                break;
-            }
-        } else {
-            idle_ms = 0;
-        }
-    }
-
-    LOG_INFO_V0("PMU collector thread exiting");
-}
-
-// ---------------------------------------------------------------------------
-// drain_remaining_buffers: after collector thread exits, pick up leftovers
-// ---------------------------------------------------------------------------
-
-void PmuCollector::drain_remaining_buffers() {
-    if (shm_host_ == nullptr) {
-        return;
-    }
-
-    // Sync entire shared memory region from device
-    profiling_copy_from_device(shm_host_, shm_dev_, shm_size_);
-
-    PmuDataHeader *hdr = pmu_header_host();
-
-    // Drain any ready_queue entries the collector thread may have missed
-    for (int t = 0; t < num_threads_; t++) {
-        __sync_synchronize();
-        uint32_t head = hdr->queue_heads[t];
-        uint32_t tail = hdr->queue_tails[t];
-
-        while (head != tail) {
-            const PmuReadyQueueEntry &entry = hdr->queues[t][head % PLATFORM_PMU_READYQUEUE_SIZE];
-            uint32_t core_id = entry.core_index;
-            uint64_t buf_dev = entry.buffer_ptr;
-
-            if (drained_bufs_.find(buf_dev) == drained_bufs_.end()) {
-                void *buf_host = resolve_host_ptr(buf_dev);
-                if (buf_host != nullptr) {
-                    profiling_copy_from_device(buf_host, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
-                    write_buffer_to_csv(static_cast<int>(core_id), t, buf_host);
-                    drained_bufs_.insert(buf_dev);
-                }
-            }
-
-            head = (head + 1) % PLATFORM_PMU_READYQUEUE_SIZE;
-            hdr->queue_heads[t] = head;
-        }
-    }
-
-    // Also check current_buf_ptr for each core (AICPU may have flushed but
-    // not enqueued if the ready_queue was observed full during flush)
+    // After stop(), pmu_aicpu_flush_buffers should have either enqueued the
+    // active buffer (success → current_buf_ptr=0) or counted it as dropped
+    // and cleared it. A non-zero pointer with non-zero count means records
+    // AICPU neither delivered nor accounted for — a device-side flush bug.
+    int leftover_active = 0;
     for (int c = 0; c < num_cores_; c++) {
-        PmuBufferState *state = pmu_state_host(c);
-        __sync_synchronize();
+        PmuBufferState *state = pmu_state(c);
         uint64_t buf_dev = state->current_buf_ptr;
-        if (buf_dev == 0 || drained_bufs_.count(buf_dev) > 0) {
-            continue;
+        if (buf_dev == 0) continue;
+
+        void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_dev));
+        if (host_ptr == nullptr) continue;
+
+        profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
+        uint32_t count = reinterpret_cast<const PmuBuffer *>(host_ptr)->count;
+        if (count == 0) continue;
+
+        LOG_ERROR(
+            "PMU reconcile: core %d has un-flushed buffer (current_buf_ptr=0x%lx, count=%u) after "
+            "stop() — device flush failed",
+            c, static_cast<unsigned long>(buf_dev), count
+        );
+        leftover_active++;
+    }
+
+    if (leftover_active > 0) {
+        LOG_ERROR("PMU reconcile: %d core(s) had un-cleared current_buf_ptr — see prior errors", leftover_active);
+    }
+
+    // Cross-check device-side totals against host CSV.  PMU is single-kind
+    // (one per-core pool), so reconcile_one is invoked once; the lambda
+    // shape matches L2PerfCollector::reconcile_counters so the two
+    // single-arch implementations stay diff-able.
+    auto reconcile_one = [&](int unit_count, auto get_state, uint64_t collected, bool optional) {
+        uint64_t total_device = 0;
+        uint64_t dropped_device = 0;
+        uint64_t mismatch_device = 0;
+        for (int i = 0; i < unit_count; i++) {
+            PmuBufferState *state = get_state(i);
+            total_device += state->total_record_count;
+            dropped_device += state->dropped_record_count;
+            mismatch_device += state->mismatch_record_count;
         }
-        void *buf_host = resolve_host_ptr(buf_dev);
-        if (buf_host != nullptr) {
-            profiling_copy_from_device(buf_host, reinterpret_cast<void *>(buf_dev), sizeof(PmuBuffer));
-            const PmuBuffer *buf = reinterpret_cast<const PmuBuffer *>(buf_host);
-            if (buf->count > 0) {
-                write_buffer_to_csv(c, -1, buf_host);
-                drained_bufs_.insert(buf_dev);
-            }
+
+        if (optional && total_device == 0 && collected == 0 && dropped_device == 0 && mismatch_device == 0) {
+            return;
         }
-    }
 
-    if (csv_file_.is_open()) {
-        csv_file_.flush();
-    }
+        if (dropped_device > 0) {
+            LOG_WARN(
+                "PMU reconcile: %lu records dropped on device side (free_queue empty or ready_queue full). "
+                "Increase PLATFORM_PMU_BUFFERS_PER_CORE / PLATFORM_PMU_READYQUEUE_SIZE if this is frequent.",
+                static_cast<unsigned long>(dropped_device)
+            );
+        }
+        if (mismatch_device > 0) {
+            LOG_ERROR(
+                "PMU reconcile: %lu records lost to AICore staging-slot task_id mismatch — "
+                "completion-before-dispatch invariant violated",
+                static_cast<unsigned long>(mismatch_device)
+            );
+        }
+        uint64_t accounted = collected + dropped_device + mismatch_device;
+        if (accounted != total_device) {
+            LOG_WARN(
+                "PMU reconcile: record count mismatch (collected=%lu + dropped=%lu + mismatch=%lu != "
+                "device_total=%lu, silent_loss=%ld) — AICore/AICPU race",
+                static_cast<unsigned long>(collected), static_cast<unsigned long>(dropped_device),
+                static_cast<unsigned long>(mismatch_device), static_cast<unsigned long>(total_device),
+                static_cast<long>(total_device) - static_cast<long>(accounted)
+            );
+        } else {
+            LOG_INFO_V0(
+                "PMU reconcile: record counts match (collected=%lu, dropped=%lu, mismatch=%lu, device_total=%lu)",
+                static_cast<unsigned long>(collected), static_cast<unsigned long>(dropped_device),
+                static_cast<unsigned long>(mismatch_device), static_cast<unsigned long>(total_device)
+            );
+        }
+    };
 
-    // Cross-check device-side totals against what we wrote to CSV.
-    // Invariant: sum(total_record_count) == collected + sum(dropped_record_count).
-    uint64_t total_device = 0;
-    uint64_t dropped_device = 0;
-    for (int c = 0; c < num_cores_; c++) {
-        PmuBufferState *state = pmu_state_host(c);
-        __sync_synchronize();
-        total_device += state->total_record_count;
-        dropped_device += state->dropped_record_count;
-    }
-
-    if (dropped_device > 0) {
-        LOG_WARN(
-            "PMU collector: %lu records dropped on device side (free_queue empty or ready_queue full). "
-            "Increase PLATFORM_PMU_BUFFERS_PER_CORE / PLATFORM_PMU_READYQUEUE_SIZE if this is frequent.",
-            static_cast<unsigned long>(dropped_device)
-        );
-    }
-    if (total_collected_ + dropped_device != total_device) {
-        LOG_WARN(
-            "PMU collector: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu)",
-            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
-            static_cast<unsigned long>(total_device)
-        );
-    } else {
-        LOG_INFO_V0(
-            "PMU collector: record counts match (collected=%lu, dropped=%lu, device_total=%lu)",
-            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
-            static_cast<unsigned long>(total_device)
-        );
-    }
-
-    LOG_INFO_V0("PMU collector: drain_remaining_buffers complete");
+    reconcile_one(
+        num_cores_,
+        [this](int c) {
+            return pmu_state(c);
+        },
+        total_collected_, /*optional=*/false
+    );
 }
 
 // ---------------------------------------------------------------------------
 // finalize
 // ---------------------------------------------------------------------------
 
-void PmuCollector::finalize(PmuUnregisterCallback /*unregister_cb*/, PmuFreeCallback free_cb, void *user_data) {
-    if (!initialized_) {
-        return;
-    }
+void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data) {
+    if (!initialized_) return;
+
+    // Stop mgmt + collector threads if the caller didn't already (idempotent).
+    stop();
 
     if (csv_file_.is_open()) {
         csv_file_.close();
     }
 
-    PmuFreeCallback cb = free_cb != nullptr ? free_cb : free_cb_;
-    void *ud = free_cb != nullptr ? user_data : user_data_;
-
-    // Free individual PmuBuffers
-    for (auto &entry : buf_pool_) {
-        if (entry.dev_ptr != nullptr && cb != nullptr) {
-            cb(entry.dev_ptr, ud);
+    auto release_dev = [&](void *p) {
+        if (p == nullptr) return;
+        if (unregister_cb != nullptr) {
+            unregister_cb(p, device_id_);
         }
-        if (entry.host_ptr != nullptr) {
-            std::free(entry.host_ptr);
+        if (free_cb != nullptr) {
+            free_cb(p, user_data);
         }
-    }
-    buf_pool_.clear();
+    };
 
-    // Free shared header region
-    if (shm_dev_ != nullptr && cb != nullptr) {
-        cb(shm_dev_, ud);
-    }
+    // Free buffers still parked in per-core free_queues / current_buf_ptr.
+    // Release the device pointer only — the paired host shadow stays in
+    // dev_to_host_ and is freed by clear_mappings() below (single source of
+    // truth for shadow lifetime, no double-free).
     if (shm_host_ != nullptr) {
-        std::free(shm_host_);
+        for (int c = 0; c < num_cores_; c++) {
+            PmuBufferState *state = pmu_state(c);
+
+            release_dev(reinterpret_cast<void *>(state->current_buf_ptr));
+            state->current_buf_ptr = 0;
+
+            rmb();
+            uint32_t head = state->free_queue.head;
+            uint32_t tail = state->free_queue.tail;
+            uint32_t queued = tail - head;
+            if (queued > PLATFORM_PMU_SLOT_COUNT) queued = PLATFORM_PMU_SLOT_COUNT;
+            for (uint32_t i = 0; i < queued; i++) {
+                uint32_t slot = (head + i) % PLATFORM_PMU_SLOT_COUNT;
+                release_dev(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+                state->free_queue.buffer_ptrs[slot] = 0;
+            }
+            state->free_queue.head = tail;
+        }
     }
-    shm_dev_ = nullptr;
-    shm_host_ = nullptr;
+
+    // Release framework-owned buffers (recycled pool, ready_queue,
+    // done_queue). release_owned_buffers also frees their host shadows.
+    manager_.release_owned_buffers([&](void *p) {
+        release_dev(p);
+    });
+
+    // Free per-core PmuAicoreRings (no host shadow paired). The rings were
+    // allocated directly via alloc_cb (not alloc_single_buffer), so no entry
+    // exists in dev_to_host_ for them.
+    for (auto *ring_dev : aicore_rings_dev_) {
+        if (ring_dev != nullptr) {
+            release_dev(ring_dev);
+        }
+    }
+    aicore_rings_dev_.clear();
+
+    // Free the per-core ring-address table (device side; host shadow lives
+    // in dev_to_host_ and is freed by clear_mappings below).
+    if (aicore_ring_addrs_dev_ != nullptr) {
+        release_dev(aicore_ring_addrs_dev_);
+        aicore_ring_addrs_dev_ = nullptr;
+    }
+    aicore_ring_addrs_host_ = nullptr;
+
+    // Free shared header region (device only — shadow stays in
+    // dev_to_host_ until clear_mappings).
+    if (shm_dev_ != nullptr) {
+        release_dev(shm_dev_);
+        shm_dev_ = nullptr;
+    }
+
+    // Free remaining host shadows (per-state buffers + shm region).
+    manager_.clear_mappings();
 
     initialized_ = false;
+    clear_memory_context();
     LOG_INFO_V0("PMU collector finalized");
 }

--- a/src/a5/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a5/platform/src/host/tensor_dump_collector.cpp
@@ -11,21 +11,25 @@
 
 /**
  * @file tensor_dump_collector.cpp
- * @brief Host-side tensor dump collector implementation
+ * @brief Host-side tensor dump collector implementation. The mgmt-thread +
+ *        buffer-pool machinery lives in profiling_common::BufferPoolManager
+ *        parameterized by DumpModule (host/tensor_dump_collector.h); the
+ *        poll loop lives in profiling_common::ProfilerBase. This file owns
+ *        the per-buffer on_buffer_collected callback, arena reads, and disk
+ *        export.
  *
- * Mirrors l2_perf_collector.cpp patterns:
- * - DumpMemoryManager: background thread polling dump ready queues
- * - TensorDumpCollector: lifecycle management, arena reads, file export
- *
- * A5 specifics: all device memory access goes through host shadow
- * buffers + explicit profiling_copy_{to,from}_device() hooks,
- * instead of SVM (halHostRegister).
+ * a5 specifics: device↔host transfers go through profiling_copy.h. The
+ * framework's mgmt loop mirrors the shm region per tick and pulls each
+ * popped DumpMetaBuffer's contents on demand. on_buffer_collected pulls
+ * the relevant portion of the originating thread's arena before reading
+ * tensor records (arena buffers live outside the shm region).
  */
 
 #include "host/tensor_dump_collector.h"
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -36,426 +40,78 @@
 #include "common/unified_log.h"
 
 // =============================================================================
-// DumpMemoryManager
-// =============================================================================
-
-DumpMemoryManager::~DumpMemoryManager() {
-    if (running_.load()) {
-        stop();
-    }
-}
-
-void DumpMemoryManager::register_mapping(void *dev_ptr, void *host_ptr) { dev_to_host_[dev_ptr] = host_ptr; }
-
-void *DumpMemoryManager::resolve_host_ptr(void *dev_ptr) {
-    auto it = dev_to_host_.find(dev_ptr);
-    if (it != dev_to_host_.end()) {
-        return it->second;
-    }
-    LOG_ERROR("DumpMemoryManager: no host mapping for dev_ptr=%p", dev_ptr);
-    return nullptr;
-}
-
-void *DumpMemoryManager::alloc_and_register(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size);
-    if (dev_ptr == nullptr) {
-        LOG_WARN(
-            "DumpMemoryManager: alloc failed for %zu bytes, "
-            "increase PLATFORM_DUMP_BUFFERS_PER_THREAD to reduce tensor dump data loss",
-            size
-        );
-        *host_ptr_out = nullptr;
-        return nullptr;
-    }
-
-    if (register_cb_ != nullptr) {
-        void *host_ptr = nullptr;
-        int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
-        if (rc != 0 || host_ptr == nullptr) {
-            LOG_ERROR("DumpMemoryManager: register failed: %d", rc);
-            free_buffer(dev_ptr);
-            *host_ptr_out = nullptr;
-            return nullptr;
-        }
-        *host_ptr_out = host_ptr;
-    } else {
-        void *host_ptr = std::malloc(size);
-        if (host_ptr == nullptr) {
-            LOG_ERROR("DumpMemoryManager: host shadow alloc failed for %zu bytes", size);
-            free_buffer(dev_ptr);
-            *host_ptr_out = nullptr;
-            return nullptr;
-        }
-        std::memset(host_ptr, 0, size);
-        profiling_copy_to_device(dev_ptr, host_ptr, size);
-        *host_ptr_out = host_ptr;
-    }
-
-    dev_to_host_[dev_ptr] = *host_ptr_out;
-    return dev_ptr;
-}
-
-void DumpMemoryManager::free_buffer(void *dev_ptr) {
-    if (dev_ptr == nullptr) return;
-
-    if (free_cb_ != nullptr) {
-        auto it = dev_to_host_.find(dev_ptr);
-        if (it != dev_to_host_.end()) {
-            if (register_cb_ == nullptr && it->second != nullptr && it->second != dev_ptr) {
-                std::free(it->second);
-            }
-            dev_to_host_.erase(it);
-        }
-        free_cb_(dev_ptr);
-    }
-}
-
-void DumpMemoryManager::process_dump_entry(
-    DumpDataHeader * /*header*/, int thread_idx, const DumpReadyQueueEntry &entry
-) {
-    void *dev_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
-    void *host_ptr = resolve_host_ptr(dev_ptr);
-    if (host_ptr != nullptr) {
-        profiling_copy_from_device(host_ptr, dev_ptr, sizeof(DumpMetaBuffer));
-    }
-
-    DumpReadyBufferInfo info;
-    info.thread_index = entry.thread_index;
-    info.dev_buffer_ptr = dev_ptr;
-    info.host_buffer_ptr = host_ptr;
-    info.buffer_seq = entry.buffer_seq;
-
-    {
-        std::lock_guard<std::mutex> lock(ready_mutex_);
-        ready_queue_.push(info);
-    }
-    ready_cv_.notify_one();
-
-    // Replenish: fill free_queue to capacity
-    DumpBufferState *state = get_dump_buffer_state(shared_mem_host_, thread_idx);
-    DumpBufferState *dev_state = get_dump_buffer_state(shared_mem_dev_, thread_idx);
-    profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
-
-    rmb();
-    uint32_t fq_head = state->free_queue.head;
-    uint32_t fq_tail = state->free_queue.tail;
-    uint32_t fq_used = fq_tail - fq_head;
-
-    while (fq_used < PLATFORM_DUMP_SLOT_COUNT) {
-        void *new_dev = nullptr;
-        if (!recycled_dump_buffers_.empty()) {
-            new_dev = recycled_dump_buffers_.back();
-            recycled_dump_buffers_.pop_back();
-        } else {
-            int batch = PLATFORM_DUMP_BUFFERS_PER_THREAD - PLATFORM_DUMP_SLOT_COUNT;
-            if (batch < 1) {
-                batch = 1;
-            }
-            for (int i = 0; i < batch; i++) {
-                void *host = nullptr;
-                void *dev = alloc_and_register(sizeof(DumpMetaBuffer), &host);
-                if (dev == nullptr) {
-                    break;
-                }
-                recycled_dump_buffers_.push_back(dev);
-            }
-            if (!recycled_dump_buffers_.empty()) {
-                new_dev = recycled_dump_buffers_.back();
-                recycled_dump_buffers_.pop_back();
-            }
-        }
-        if (new_dev == nullptr) {
-            break;
-        }
-
-        // Zero the count on host shadow and push to device
-        void *new_host = resolve_host_ptr(new_dev);
-        if (new_host != nullptr) {
-            reinterpret_cast<DumpMetaBuffer *>(new_host)->count = 0;
-            uint32_t zero = 0;
-            profiling_copy_to_device(
-                reinterpret_cast<char *>(new_dev) + offsetof(DumpMetaBuffer, count), &zero, sizeof(uint32_t)
-            );
-        }
-
-        state->free_queue.buffer_ptrs[fq_tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(new_dev);
-        wmb();
-        fq_tail++;
-        state->free_queue.tail = fq_tail;
-        wmb();
-
-        // Write slot and tail back to device
-        uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev);
-        profiling_copy_to_device(
-            &dev_state->free_queue.buffer_ptrs[(fq_tail - 1) % PLATFORM_DUMP_SLOT_COUNT], &slot_val, sizeof(uint64_t)
-        );
-        uint32_t new_tail = fq_tail;
-        profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-
-        fq_used++;
-    }
-}
-
-void DumpMemoryManager::mgmt_loop() {
-    if (set_device_cb_ != nullptr) {
-        set_device_cb_(device_id_);
-    }
-
-    DumpDataHeader *header = get_dump_header(shared_mem_host_);
-    DumpDataHeader *dev_header = get_dump_header(shared_mem_dev_);
-    uint64_t total_entries_processed = 0;
-
-    while (running_.load()) {
-        bool did_work = false;
-
-        // 1. Recycle done queue
-        {
-            std::lock_guard<std::mutex> lock(done_mutex_);
-            while (!done_queue_.empty()) {
-                void *dev_ptr = done_queue_.front();
-                done_queue_.pop();
-                recycled_dump_buffers_.push_back(dev_ptr);
-                did_work = true;
-            }
-        }
-
-        // 2. Poll all threads' ready queues (copy tails from device)
-        profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
-
-        for (int t = 0; t < num_dump_threads_; t++) {
-            rmb();
-            uint32_t head = header->queue_heads[t];
-            uint32_t tail = header->queue_tails[t];
-
-            if (head >= PLATFORM_DUMP_READYQUEUE_SIZE || tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
-                LOG_ERROR(
-                    "DumpMemoryManager: invalid queue indices for thread %d: head=%u tail=%u (max=%d)", t, head, tail,
-                    PLATFORM_DUMP_READYQUEUE_SIZE
-                );
-                continue;
-            }
-
-            while (head != tail) {
-                DumpReadyQueueEntry entry;
-                profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(DumpReadyQueueEntry));
-
-                process_dump_entry(header, t, entry);
-
-                head = (head + 1) % PLATFORM_DUMP_READYQUEUE_SIZE;
-                header->queue_heads[t] = head;
-                wmb();
-
-                // Write updated head back to device
-                profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
-
-                did_work = true;
-                total_entries_processed++;
-
-                // Re-read tail in case more entries arrived
-                profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
-                rmb();
-                tail = header->queue_tails[t];
-                if (tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
-                    LOG_ERROR("DumpMemoryManager: invalid tail for thread %d: %u", t, tail);
-                    break;
-                }
-            }
-        }
-
-        // 3. Push recycled buffers into free queues that have space
-        for (int t = 0; t < num_dump_threads_ && !recycled_dump_buffers_.empty(); t++) {
-            DumpBufferState *state = get_dump_buffer_state(shared_mem_host_, t);
-            DumpBufferState *dev_state = get_dump_buffer_state(shared_mem_dev_, t);
-            profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
-            rmb();
-            uint32_t fq_head = state->free_queue.head;
-            uint32_t fq_tail = state->free_queue.tail;
-            uint32_t fq_used = fq_tail - fq_head;
-
-            while (fq_used < PLATFORM_DUMP_SLOT_COUNT && !recycled_dump_buffers_.empty()) {
-                void *new_dev = recycled_dump_buffers_.back();
-                recycled_dump_buffers_.pop_back();
-
-                void *new_host = resolve_host_ptr(new_dev);
-                if (new_host != nullptr) {
-                    reinterpret_cast<DumpMetaBuffer *>(new_host)->count = 0;
-                    uint32_t zero = 0;
-                    profiling_copy_to_device(
-                        reinterpret_cast<char *>(new_dev) + offsetof(DumpMetaBuffer, count), &zero, sizeof(uint32_t)
-                    );
-                }
-
-                state->free_queue.buffer_ptrs[fq_tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(new_dev);
-                wmb();
-                fq_tail++;
-                state->free_queue.tail = fq_tail;
-                wmb();
-
-                uint64_t slot_val = reinterpret_cast<uint64_t>(new_dev);
-                profiling_copy_to_device(
-                    &dev_state->free_queue.buffer_ptrs[(fq_tail - 1) % PLATFORM_DUMP_SLOT_COUNT], &slot_val,
-                    sizeof(uint64_t)
-                );
-                uint32_t new_tail = fq_tail;
-                profiling_copy_to_device(&dev_state->free_queue.tail, &new_tail, sizeof(uint32_t));
-
-                fq_used++;
-                did_work = true;
-            }
-        }
-
-        if (!did_work) {
-            std::this_thread::sleep_for(std::chrono::microseconds(10));
-        }
-    }
-
-    // Final drain: process any remaining entries
-    profiling_copy_from_device(header->queue_tails, dev_header->queue_tails, sizeof(header->queue_tails));
-    for (int t = 0; t < num_dump_threads_; t++) {
-        rmb();
-        uint32_t head = header->queue_heads[t];
-        uint32_t tail = header->queue_tails[t];
-        if (head >= PLATFORM_DUMP_READYQUEUE_SIZE || tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
-            LOG_ERROR("DumpMemoryManager drain: invalid queue indices for thread %d: head=%u tail=%u", t, head, tail);
-            continue;
-        }
-        while (head != tail) {
-            DumpReadyQueueEntry entry;
-            profiling_copy_from_device(&entry, &dev_header->queues[t][head], sizeof(DumpReadyQueueEntry));
-            process_dump_entry(header, t, entry);
-            head = (head + 1) % PLATFORM_DUMP_READYQUEUE_SIZE;
-            header->queue_heads[t] = head;
-            wmb();
-            profiling_copy_to_device(&dev_header->queue_heads[t], &head, sizeof(uint32_t));
-            profiling_copy_from_device(&header->queue_tails[t], &dev_header->queue_tails[t], sizeof(uint32_t));
-            rmb();
-            tail = header->queue_tails[t];
-            if (tail >= PLATFORM_DUMP_READYQUEUE_SIZE) {
-                LOG_ERROR("DumpMemoryManager drain: invalid tail for thread %d: %u", t, tail);
-                break;
-            }
-        }
-    }
-
-    LOG_DEBUG("Dump memory manager: %lu ready entries processed", total_entries_processed);
-}
-
-void DumpMemoryManager::start(
-    void *shared_mem_host, void *shared_mem_dev, int num_dump_threads, DumpAllocCallback alloc_cb,
-    DumpRegisterCallback register_cb, DumpFreeCallback free_cb, int device_id, DumpSetDeviceCallback set_device_cb
-) {
-    shared_mem_host_ = shared_mem_host;
-    shared_mem_dev_ = shared_mem_dev;
-    num_dump_threads_ = num_dump_threads;
-    alloc_cb_ = alloc_cb;
-    register_cb_ = register_cb;
-    free_cb_ = free_cb;
-    device_id_ = device_id;
-    set_device_cb_ = set_device_cb;
-
-    LOG_INFO_V0("Starting dump memory manager (device=%d, threads=%d)", device_id, num_dump_threads);
-    running_.store(true);
-    mgmt_thread_ = std::thread(&DumpMemoryManager::mgmt_loop, this);
-}
-
-void DumpMemoryManager::stop() {
-    running_.store(false);
-    if (mgmt_thread_.joinable()) {
-        mgmt_thread_.join();
-    }
-}
-
-bool DumpMemoryManager::try_pop_ready(DumpReadyBufferInfo &info) {
-    std::lock_guard<std::mutex> lock(ready_mutex_);
-    if (ready_queue_.empty()) {
-        return false;
-    }
-    info = ready_queue_.front();
-    ready_queue_.pop();
-    return true;
-}
-
-bool DumpMemoryManager::wait_pop_ready(DumpReadyBufferInfo &info, std::chrono::milliseconds timeout) {
-    std::unique_lock<std::mutex> lock(ready_mutex_);
-    if (ready_cv_.wait_for(lock, timeout, [this] {
-            return !ready_queue_.empty();
-        })) {
-        info = ready_queue_.front();
-        ready_queue_.pop();
-        return true;
-    }
-    return false;
-}
-
-void DumpMemoryManager::notify_copy_done(void *dev_buffer_ptr) {
-    std::lock_guard<std::mutex> lock(done_mutex_);
-    done_queue_.push(dev_buffer_ptr);
-}
-
-// =============================================================================
 // TensorDumpCollector
 // =============================================================================
 
-TensorDumpCollector::~TensorDumpCollector() {
-    if (memory_manager_.is_running()) {
-        memory_manager_.stop();
-    }
-}
+TensorDumpCollector::~TensorDumpCollector() { stop(); }
 
 void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size);
+    void *dev_ptr = alloc_cb_(size, user_data_);
     if (dev_ptr == nullptr) {
+        if (host_ptr_out) *host_ptr_out = nullptr;
         return nullptr;
     }
 
+    void *host_ptr = nullptr;
     if (register_cb_ != nullptr) {
-        void *host_ptr = nullptr;
         int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
-            free_cb_(dev_ptr);
+            LOG_ERROR("TensorDumpCollector: register failed: %d", rc);
+            free_cb_(dev_ptr, user_data_);
+            if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
-        if (host_ptr_out) {
-            *host_ptr_out = host_ptr;
-        }
     } else {
-        void *host_ptr = std::malloc(size);
+        // a5 default: malloc a paired shadow, zero it, push zeros to device
+        // so the device buffer starts in a known state.
+        host_ptr = std::malloc(size);
         if (host_ptr == nullptr) {
-            free_cb_(dev_ptr);
+            LOG_ERROR("TensorDumpCollector: host shadow alloc failed for %zu bytes", size);
+            free_cb_(dev_ptr, user_data_);
+            if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
         std::memset(host_ptr, 0, size);
         profiling_copy_to_device(dev_ptr, host_ptr, size);
-        if (host_ptr_out) {
-            *host_ptr_out = host_ptr;
-        }
     }
 
+    if (host_ptr_out) *host_ptr_out = host_ptr;
     return dev_ptr;
 }
 
 int TensorDumpCollector::initialize(
     int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
-    DumpFreeCallback free_cb, DumpSetDeviceCallback set_device_cb
+    DumpFreeCallback free_cb, void *user_data, const std::string &output_prefix
 ) {
+    if (shm_host_ != nullptr) {
+        LOG_ERROR("TensorDumpCollector already initialized");
+        return -1;
+    }
+
     num_dump_threads_ = num_dump_threads;
-    device_id_ = device_id;
-    alloc_cb_ = alloc_cb;
-    register_cb_ = register_cb;
-    free_cb_ = free_cb;
-    set_device_cb_ = set_device_cb;
+    output_prefix_ = output_prefix;
+
+    // Stash the memory context on the base up-front so alloc_single_buffer
+    // (which reads alloc_cb_/register_cb_/free_cb_/user_data_/device_id_)
+    // sees consistent values during init. shm_host_ stays nullptr until the
+    // shm allocation succeeds — that nullptr guard makes a post-failure
+    // start(tf) a no-op without further bookkeeping.
+    set_memory_context(
+        alloc_cb, register_cb, free_cb, user_data, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+    );
 
     // Allocate dump shared memory (header + buffer states)
     size_t shm_size = calc_dump_data_size(num_dump_threads);
-    dump_shared_mem_dev_ = alloc_single_buffer(shm_size, &dump_shared_mem_host_);
-    if (dump_shared_mem_dev_ == nullptr) {
+    void *shm_host_local = nullptr;
+    void *shm_dev_local = alloc_single_buffer(shm_size, &shm_host_local);
+    if (shm_dev_local == nullptr) {
         LOG_ERROR("Failed to allocate dump shared memory (%zu bytes)", shm_size);
         return -1;
     }
 
     // Initialize header on host shadow
-    memset(dump_shared_mem_host_, 0, shm_size);
-    DumpDataHeader *header = get_dump_header(dump_shared_mem_host_);
+    std::memset(shm_host_local, 0, shm_size);
+    DumpDataHeader *header = get_dump_header(shm_host_local);
     header->magic = TENSOR_DUMP_MAGIC;
     header->num_dump_threads = static_cast<uint32_t>(num_dump_threads);
     header->records_per_buffer = PLATFORM_DUMP_RECORDS_PER_BUFFER;
@@ -463,7 +119,8 @@ int TensorDumpCollector::initialize(
     uint64_t arena_size = calc_dump_arena_size();
     header->arena_size_per_thread = arena_size;
 
-    // Allocate per-thread arenas
+    // Allocate per-thread arenas (device + host shadow). Track the dev↔host
+    // mapping so on_buffer_collected can pull arena bytes via the framework.
     arenas_.resize(num_dump_threads);
     for (int t = 0; t < num_dump_threads; t++) {
         ArenaInfo &ai = arenas_[t];
@@ -474,8 +131,7 @@ int TensorDumpCollector::initialize(
             return -1;
         }
 
-        // Set arena info in buffer state (host shadow)
-        DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+        DumpBufferState *state = get_dump_buffer_state(shm_host_local, t);
         state->arena_base = reinterpret_cast<uint64_t>(ai.dev_ptr);
         state->arena_size = arena_size;
         state->arena_write_offset = 0;
@@ -489,7 +145,7 @@ int TensorDumpCollector::initialize(
 
     // Allocate initial DumpMetaBuffers and push into free_queues
     for (int t = 0; t < num_dump_threads; t++) {
-        DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+        DumpBufferState *state = get_dump_buffer_state(shm_host_local, t);
 
         for (int b = 0; b < PLATFORM_DUMP_BUFFERS_PER_THREAD; b++) {
             void *host_ptr = nullptr;
@@ -499,22 +155,27 @@ int TensorDumpCollector::initialize(
                 return -1;
             }
 
-            memory_manager_.register_mapping(dev_ptr, host_ptr);
+            manager_.register_mapping(dev_ptr, host_ptr);
 
             if (b < PLATFORM_DUMP_SLOT_COUNT) {
-                // Push into SPSC free_queue
                 uint32_t tail = state->free_queue.tail;
                 state->free_queue.buffer_ptrs[tail % PLATFORM_DUMP_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
                 state->free_queue.tail = tail + 1;
             } else {
-                // Remaining go to recycled pool
-                memory_manager_.recycled_dump_buffers_.push_back(dev_ptr);
+                manager_.push_recycled(0, dev_ptr);
             }
         }
     }
 
-    // Copy the entire initialized shared memory region to device
-    profiling_copy_to_device(dump_shared_mem_dev_, dump_shared_mem_host_, shm_size);
+    // Push the entire initialized shm region (header + BufferStates +
+    // free_queue contents) to device.
+    profiling_copy_to_device(shm_dev_local, shm_host_local, shm_size);
+
+    // Publish shm pointers on the base now that the region is ready. start(tf)
+    // gates on shm_host_ being non-null, so this re-set_memory_context call
+    // is the moment the collector becomes startable.
+    dump_shared_mem_dev_ = shm_dev_local;
+    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_dev_local, shm_host_local, shm_size, device_id);
 
     LOG_INFO_V0(
         "Tensor dump initialized: %d threads, arena=%lu MB/thread, %d buffers/thread", num_dump_threads,
@@ -524,28 +185,32 @@ int TensorDumpCollector::initialize(
     return 0;
 }
 
-void TensorDumpCollector::start_memory_manager() {
-    execution_complete_.store(false);
-    memory_manager_.start(
-        dump_shared_mem_host_, dump_shared_mem_dev_, num_dump_threads_, alloc_cb_, register_cb_, free_cb_, device_id_,
-        set_device_cb_
-    );
+void TensorDumpCollector::start_writer_thread_once() {
+    if (writer_started_) return;
+    writer_started_ = true;
+
+    // `output_prefix_` is captured at initialize() time and is the per-task
+    // uniqueness boundary; the dump dir name is fixed (`<prefix>/tensor_dump`).
+    std::string base_name = "tensor_dump";
+    run_dir_ = std::filesystem::path(output_prefix_) / base_name;
+    std::filesystem::create_directories(run_dir_);
+    bin_file_.open(run_dir_ / (base_name + ".bin"), std::ios::binary);
+    next_bin_offset_ = 0;
+
+    writer_done_.store(false);
+    bytes_written_.store(0);
+    run_start_time_ = std::chrono::steady_clock::now();
+    last_progress_time_ = run_start_time_;
+    buffers_collected_ = 0;
+
+    writer_thread_ = std::thread(&TensorDumpCollector::writer_loop, this);
 }
 
 void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
-    // Track processed buffer pointers to prevent double-processing
-    // (flush + drain can deliver a buffer that scan_remaining also sees)
-    if (processed_buffers_.count(info.dev_buffer_ptr)) {
-        return;
-    }
-    processed_buffers_.insert(info.dev_buffer_ptr);
-
     DumpMetaBuffer *buf = reinterpret_cast<DumpMetaBuffer *>(info.host_buffer_ptr);
     uint32_t count = buf->count;
 
-    if (count == 0) {
-        return;
-    }
+    if (count == 0) return;
 
     if (count > PLATFORM_DUMP_RECORDS_PER_BUFFER) {
         LOG_ERROR(
@@ -555,17 +220,14 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         return;
     }
 
-    // Copy arena data from device to host shadow for this thread
+    // a5: pull the relevant portion of the originating thread's arena from
+    // device. arena_write_offset was mirrored into shm_host_ at the top of
+    // the mgmt tick that produced this entry, so it is safe to read here.
     int thread_idx = static_cast<int>(info.thread_index);
-    if (thread_idx < static_cast<int>(arenas_.size())) {
+    if (thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
         ArenaInfo &ai = arenas_[thread_idx];
-        // Read arena_write_offset from device to know how much to copy
-        DumpBufferState *dev_state = get_dump_buffer_state(dump_shared_mem_dev_, thread_idx);
-        DumpBufferState state_copy;
-        profiling_copy_from_device(&state_copy, dev_state, sizeof(DumpBufferState));
-        uint64_t write_offset = state_copy.arena_write_offset;
-
-        // Copy arena data (up to min(write_offset, arena_size) bytes)
+        DumpBufferState *state = get_dump_buffer_state(shm_host_, thread_idx);
+        uint64_t write_offset = state->arena_write_offset;
         uint64_t bytes_to_copy = (write_offset < ai.size) ? write_offset : ai.size;
         if (bytes_to_copy > 0) {
             profiling_copy_from_device(ai.host_ptr, ai.dev_ptr, bytes_to_copy);
@@ -590,17 +252,15 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         if (dt.truncated && ++total_truncated_count_ == 1) {
             LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
         }
-        memcpy(dt.raw_shapes, rec.raw_shapes, sizeof(dt.raw_shapes));
-        memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
-        memcpy(dt.offsets, rec.offsets, sizeof(dt.offsets));
+        std::memcpy(dt.raw_shapes, rec.raw_shapes, sizeof(dt.raw_shapes));
+        std::memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
+        std::memcpy(dt.offsets, rec.offsets, sizeof(dt.offsets));
 
-        // Read tensor data from arena host shadow
-        if (thread_idx < static_cast<int>(arenas_.size())) {
+        if (thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
             ArenaInfo &ai = arenas_[thread_idx];
             char *arena_host = reinterpret_cast<char *>(ai.host_ptr);
             uint64_t arena_sz = ai.size;
 
-            // Check if data was overwritten (offset too old)
             uint64_t high_water = ai.high_water;
             if (high_water > arena_sz && rec.payload_offset < high_water - arena_sz) {
                 dt.overwritten = true;
@@ -618,16 +278,14 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
                 dt.bytes.resize(rec.payload_size);
                 uint64_t pos = rec.payload_offset % arena_sz;
                 if (pos + rec.payload_size <= arena_sz) {
-                    memcpy(dt.bytes.data(), arena_host + pos, rec.payload_size);
+                    std::memcpy(dt.bytes.data(), arena_host + pos, rec.payload_size);
                 } else {
-                    // Wraparound read
                     uint64_t first = arena_sz - pos;
-                    memcpy(dt.bytes.data(), arena_host + pos, first);
-                    memcpy(dt.bytes.data() + first, arena_host, rec.payload_size - first);
+                    std::memcpy(dt.bytes.data(), arena_host + pos, first);
+                    std::memcpy(dt.bytes.data() + first, arena_host, rec.payload_size - first);
                 }
             }
 
-            // Update high-water mark
             uint64_t end_offset = rec.payload_offset + rec.payload_size;
             if (end_offset > ai.high_water) {
                 ai.high_water = end_offset;
@@ -661,6 +319,82 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
     }
 }
 
+void TensorDumpCollector::on_buffer_collected(const DumpReadyBufferInfo &info) {
+    start_writer_thread_once();
+    process_dump_buffer(info);
+    buffers_collected_++;
+
+    auto now = std::chrono::steady_clock::now();
+    if (std::chrono::duration_cast<std::chrono::seconds>(now - last_progress_time_).count() >= 5) {
+        auto elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(now - run_start_time_).count();
+        LOG_INFO_V0(
+            "Collecting: %zu tensors, %.1f GB written (%lds)", collected_.size(), bytes_written_.load() / 1e9, elapsed_s
+        );
+        last_progress_time_ = now;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// reconcile_counters: passive sanity-check + dropped accounting
+// ---------------------------------------------------------------------------
+
+void TensorDumpCollector::reconcile_counters() {
+    if (shm_host_ == nullptr) return;
+
+    // Pull the latest BufferStates (current_buf_ptr, dropped_record_count)
+    // before the per-thread loop so leftovers reflect post-stop() device
+    // state.
+    if (manager_.shared_mem_dev() != nullptr && shm_size_ > 0) {
+        profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
+    }
+    rmb();
+
+    uint32_t dropped_total = 0;
+    int leftover_active = 0;
+    // After stop(), dump_tensor_flush should have either enqueued the
+    // active buffer (success → current_buf_ptr=0) or counted it as dropped
+    // and cleared it. A non-zero pointer with non-zero count means records
+    // AICPU neither delivered nor accounted for — a device-side flush bug.
+    for (int t = 0; t < num_dump_threads_; t++) {
+        DumpBufferState *state = get_dump_buffer_state(shm_host_, t);
+
+        total_dropped_record_count_ += state->dropped_record_count;
+        dropped_total += state->dropped_record_count;
+
+        uint64_t cur_ptr = state->current_buf_ptr;
+        if (cur_ptr == 0) continue;
+
+        void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(cur_ptr));
+        if (host_ptr == nullptr) continue;
+
+        profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(cur_ptr), sizeof(DumpMetaBuffer));
+        uint32_t count = reinterpret_cast<DumpMetaBuffer *>(host_ptr)->count;
+        if (count == 0) continue;
+
+        LOG_ERROR(
+            "Dump reconcile: thread %d has un-flushed buffer (current_buf_ptr=0x%lx, count=%u) after "
+            "stop() — device flush failed",
+            t, static_cast<unsigned long>(cur_ptr), count
+        );
+        leftover_active++;
+    }
+
+    if (dropped_total > 0) {
+        LOG_WARN(
+            "Dump reconcile: %u records dropped on device side. "
+            "Increase PLATFORM_DUMP_BUFFERS_PER_THREAD or PLATFORM_DUMP_READYQUEUE_SIZE.",
+            dropped_total
+        );
+    }
+    if (leftover_active > 0) {
+        LOG_ERROR("Dump reconcile: %d thread(s) had un-cleared current_buf_ptr — see prior errors", leftover_active);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Writer thread + export
+// ---------------------------------------------------------------------------
+
 static const char *tensor_dump_role_name(TensorDumpRole role) {
     switch (role) {
     case TensorDumpRole::INPUT:
@@ -687,181 +421,11 @@ static std::string dims_to_string(const uint32_t dims[], int ndims) {
     std::ostringstream ss;
     ss << "[";
     for (int d = 0; d < ndims; d++) {
-        if (d > 0) {
-            ss << ", ";
-        }
+        if (d > 0) ss << ", ";
         ss << dims[d];
     }
     ss << "]";
     return ss.str();
-}
-
-void TensorDumpCollector::poll_and_collect(const std::string &output_path) {
-    const auto wait_timeout = std::chrono::milliseconds(100);
-    const auto idle_timeout = std::chrono::seconds(PLATFORM_DUMP_TIMEOUT_SECONDS);
-    uint64_t buffers_collected = 0;
-    auto start_time = std::chrono::steady_clock::now();
-    auto last_progress_time = start_time;
-    bool idle_timer_started = false;
-    std::chrono::steady_clock::time_point idle_start;
-
-    // Set up the run directory and start writer thread. Caller-provided
-    // `output_path` is the per-task uniqueness boundary (no timestamp).
-    run_dir_ = std::filesystem::path(output_path) / "tensor_dump";
-    std::filesystem::create_directories(run_dir_);
-    std::string base_name = run_dir_.filename().string();
-    bin_file_.open(run_dir_ / (base_name + ".bin"), std::ios::binary);
-    next_bin_offset_ = 0;
-
-    writer_done_.store(false);
-    bytes_written_.store(0);
-    writer_thread_ = std::thread(&TensorDumpCollector::writer_loop, this);
-
-    while (true) {
-        DumpReadyBufferInfo info;
-        if (memory_manager_.try_pop_ready(info)) {
-            process_dump_buffer(info);
-            memory_manager_.notify_copy_done(info.dev_buffer_ptr);
-            buffers_collected++;
-            idle_timer_started = false;
-
-            auto now = std::chrono::steady_clock::now();
-            if (std::chrono::duration_cast<std::chrono::seconds>(now - last_progress_time).count() >= 5) {
-                auto elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(now - start_time).count();
-                LOG_INFO_V0(
-                    "Collecting: %zu tensors, %.1f GB written (%lds)", collected_.size(), bytes_written_.load() / 1e9,
-                    elapsed_s
-                );
-                last_progress_time = now;
-            }
-        } else {
-            if (!memory_manager_.wait_pop_ready(info, wait_timeout)) {
-                if (execution_complete_.load()) {
-                    DumpReadyBufferInfo drain_info;
-                    while (memory_manager_.try_pop_ready(drain_info)) {
-                        process_dump_buffer(drain_info);
-                        memory_manager_.notify_copy_done(drain_info.dev_buffer_ptr);
-                        buffers_collected++;
-                    }
-                    break;
-                }
-
-                if (!idle_timer_started) {
-                    idle_start = std::chrono::steady_clock::now();
-                    idle_timer_started = true;
-                }
-                auto idle_elapsed = std::chrono::steady_clock::now() - idle_start;
-                if (idle_elapsed >= idle_timeout) {
-                    LOG_ERROR(
-                        "Tensor dump collection idle timeout after %ld seconds",
-                        std::chrono::duration_cast<std::chrono::seconds>(idle_elapsed).count()
-                    );
-                    LOG_ERROR(
-                        "Collected %lu buffers and %zu tensors before timeout", buffers_collected, collected_.size()
-                    );
-                    break;
-                }
-                continue;
-            }
-            process_dump_buffer(info);
-            memory_manager_.notify_copy_done(info.dev_buffer_ptr);
-            buffers_collected++;
-            idle_timer_started = false;
-        }
-    }
-
-    // Stop writer thread and wait for it to drain
-    writer_done_.store(true);
-    write_cv_.notify_one();
-    while (writer_thread_.joinable()) {
-        if (write_queue_.empty()) {
-            writer_thread_.join();
-            break;
-        }
-        auto elapsed_s =
-            std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - start_time).count();
-        LOG_INFO_V0(
-            "Writing to disk: %.1f GB written, %zu tensors remaining (%lds)", bytes_written_.load() / 1e9,
-            write_queue_.size(), elapsed_s
-        );
-        std::this_thread::sleep_for(std::chrono::seconds(10));
-    }
-
-    bin_file_.close();
-
-    auto elapsed_ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count();
-    LOG_INFO_V0(
-        "Collected %zu tensors, wrote %.1f GB to disk (%.1fs)", collected_.size(), bytes_written_.load() / 1e9,
-        elapsed_ms / 1000.0
-    );
-}
-
-void TensorDumpCollector::signal_execution_complete() { execution_complete_.store(true); }
-
-void TensorDumpCollector::stop_memory_manager() { memory_manager_.stop(); }
-
-void TensorDumpCollector::drain_remaining_buffers() {
-    DumpReadyBufferInfo info;
-    while (memory_manager_.try_pop_ready(info)) {
-        process_dump_buffer(info);
-        memory_manager_.notify_copy_done(info.dev_buffer_ptr);
-    }
-}
-
-void TensorDumpCollector::scan_remaining_dump_buffers() {
-    uint32_t dropped_total = 0;
-    // Scan current_buf_ptr for each thread for partial buffers not yet enqueued
-    for (int t = 0; t < num_dump_threads_; t++) {
-        DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
-
-        // Copy buffer state from device to get the latest values
-        DumpBufferState *dev_state = get_dump_buffer_state(dump_shared_mem_dev_, t);
-        profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
-
-        // Accumulate dropped-record counts
-        total_dropped_record_count_ += state->dropped_record_count;
-        dropped_total += state->dropped_record_count;
-
-        uint64_t cur_ptr = state->current_buf_ptr;
-        if (cur_ptr == 0) {
-            continue;
-        }
-
-        void *dev_ptr = reinterpret_cast<void *>(cur_ptr);
-        void *host_ptr = memory_manager_.resolve_host_ptr(dev_ptr);
-        if (host_ptr == nullptr) {
-            continue;
-        }
-
-        // Copy the buffer from device to host shadow
-        profiling_copy_from_device(host_ptr, dev_ptr, sizeof(DumpMetaBuffer));
-
-        // Copy arena data for this thread
-        ArenaInfo &ai = arenas_[t];
-        uint64_t write_offset = state->arena_write_offset;
-        uint64_t bytes_to_copy = (write_offset < ai.size) ? write_offset : ai.size;
-        if (bytes_to_copy > 0) {
-            profiling_copy_from_device(ai.host_ptr, ai.dev_ptr, bytes_to_copy);
-        }
-
-        DumpMetaBuffer *buf = reinterpret_cast<DumpMetaBuffer *>(host_ptr);
-        if (buf->count > 0) {
-            DumpReadyBufferInfo info;
-            info.thread_index = static_cast<uint32_t>(t);
-            info.dev_buffer_ptr = dev_ptr;
-            info.host_buffer_ptr = host_ptr;
-            info.buffer_seq = state->current_buf_seq;
-            process_dump_buffer(info);
-        }
-    }
-    if (dropped_total > 0) {
-        LOG_WARN(
-            "Dump collector: %u records dropped on device side. "
-            "Increase PLATFORM_DUMP_BUFFERS_PER_THREAD or PLATFORM_DUMP_READYQUEUE_SIZE.",
-            dropped_total
-        );
-    }
 }
 
 static std::string get_dtype_name_from_raw(uint8_t dtype) { return get_dtype_name(static_cast<DataType>(dtype)); }
@@ -900,13 +464,45 @@ void TensorDumpCollector::writer_loop() {
 }
 
 int TensorDumpCollector::export_dump_files() {
+    // Stop the writer thread (started lazily in on_buffer_collected). Safe
+    // to skip when writer_started_ is false (collector ran but produced no
+    // buffers, or never started at all).
+    if (writer_started_) {
+        writer_done_.store(true);
+        write_cv_.notify_one();
+        while (writer_thread_.joinable()) {
+            if (write_queue_.empty()) {
+                writer_thread_.join();
+                break;
+            }
+            auto elapsed_s =
+                std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - run_start_time_)
+                    .count();
+            LOG_INFO_V0(
+                "Writing to disk: %.1f GB written, %zu tensors remaining (%lds)", bytes_written_.load() / 1e9,
+                write_queue_.size(), elapsed_s
+            );
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+
+        bin_file_.close();
+
+        auto elapsed_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - run_start_time_)
+                .count();
+        LOG_INFO_V0(
+            "Collected %zu tensors, wrote %.1f GB to disk (%.1fs)", collected_.size(), bytes_written_.load() / 1e9,
+            elapsed_ms / 1000.0
+        );
+    }
+
     if (collected_.empty()) {
         LOG_WARN("No tensor dump data to export");
+        writer_started_ = false;
         return 0;
     }
     auto export_start = std::chrono::steady_clock::now();
 
-    // Sort by task_id then subtask_id then func_id.
     std::sort(collected_.begin(), collected_.end(), [](const DumpedTensor &a, const DumpedTensor &b) {
         if (a.task_id != b.task_id) return a.task_id < b.task_id;
         if (a.subtask_id != b.subtask_id) return a.subtask_id < b.subtask_id;
@@ -942,7 +538,6 @@ int TensorDumpCollector::export_dump_files() {
         }
     }
 
-    // Write JSON manifest (txt/bin files already written by writer thread)
     std::string base_name = run_dir_.filename().string();
     std::ofstream json(run_dir_ / (base_name + ".json"));
     json << "{\n";
@@ -1004,55 +599,44 @@ int TensorDumpCollector::export_dump_files() {
 
     // Clear state so subsequent runs don't accumulate data from previous runs
     collected_.clear();
-    processed_buffers_.clear();
     total_dropped_record_count_ = 0;
     total_truncated_count_ = 0;
     total_overwrite_count_ = 0;
+    writer_started_ = false;
     for (auto &ai : arenas_) {
         ai.high_water = 0;
     }
     return 0;
 }
 
-int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb) {
-    (void)unregister_cb;
-    // Stop memory manager if still running
-    if (memory_manager_.is_running()) {
-        memory_manager_.stop();
-    }
+int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb, void *user_data) {
+    if (shm_host_ == nullptr) return 0;
 
-    std::unordered_set<void *> released_meta_buffers;
-    auto release_meta_buffer = [&](void *ptr) {
-        if (ptr == nullptr || !released_meta_buffers.insert(ptr).second) {
-            return;
+    // Stop mgmt + collector threads if the caller didn't already (idempotent).
+    stop();
+
+    auto release_dev = [&](void *p) {
+        if (p == nullptr) return;
+        if (unregister_cb != nullptr) {
+            unregister_cb(p, device_id_);
         }
-        // Free host shadow if non-SVM
-        auto it = memory_manager_.dev_to_host_.find(ptr);
-        if (it != memory_manager_.dev_to_host_.end()) {
-            if (register_cb_ == nullptr && it->second != nullptr && it->second != ptr) {
-                std::free(it->second);
-            }
-            memory_manager_.dev_to_host_.erase(it);
-        }
-        if (free_cb) {
-            free_cb(ptr);
+        if (free_cb != nullptr) {
+            free_cb(p, user_data);
         }
     };
 
-    // Free DumpMetaBuffers still in free_queues and current_buf_ptr
-    if (dump_shared_mem_host_) {
+    // Free DumpMetaBuffers still in per-thread free_queues / current_buf_ptr.
+    // These are owned by AICPU at runtime; the framework tracks them via
+    // dev_to_host_ but doesn't enumerate them in release_owned_buffers.
+    // Release the device pointer only — the paired host shadow stays in
+    // dev_to_host_ and is freed by clear_mappings() below.
+    if (shm_host_ != nullptr) {
         for (int t = 0; t < num_dump_threads_; t++) {
-            DumpBufferState *state = get_dump_buffer_state(dump_shared_mem_host_, t);
+            DumpBufferState *state = get_dump_buffer_state(shm_host_, t);
 
-            // Copy latest state from device
-            DumpBufferState *dev_state = get_dump_buffer_state(dump_shared_mem_dev_, t);
-            profiling_copy_from_device(state, dev_state, sizeof(DumpBufferState));
-
-            // Free current buffer if any
-            release_meta_buffer(reinterpret_cast<void *>(state->current_buf_ptr));
+            release_dev(reinterpret_cast<void *>(state->current_buf_ptr));
             state->current_buf_ptr = 0;
 
-            // Free all buffers remaining in free_queue
             rmb();
             uint32_t head = state->free_queue.head;
             uint32_t tail = state->free_queue.tail;
@@ -1062,73 +646,48 @@ int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFree
             }
             for (uint32_t i = 0; i < queued; i++) {
                 uint32_t slot = (head + i) % PLATFORM_DUMP_SLOT_COUNT;
-                release_meta_buffer(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+                release_dev(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
                 state->free_queue.buffer_ptrs[slot] = 0;
             }
             state->free_queue.head = tail;
         }
     }
 
-    // Free buffers still queued for host processing
-    {
-        std::lock_guard<std::mutex> lock(memory_manager_.ready_mutex_);
-        while (!memory_manager_.ready_queue_.empty()) {
-            release_meta_buffer(memory_manager_.ready_queue_.front().dev_buffer_ptr);
-            memory_manager_.ready_queue_.pop();
-        }
-    }
+    // Release framework-owned buffers (recycled pools, ready_queue,
+    // done_queue). release_owned_buffers also frees the paired host shadows
+    // for these (and erases their mappings).
+    manager_.release_owned_buffers([&](void *p) {
+        release_dev(p);
+    });
 
-    // Free buffers held by memory manager (done_queue + recycled pool)
-    {
-        std::lock_guard<std::mutex> lock(memory_manager_.done_mutex_);
-        while (!memory_manager_.done_queue_.empty()) {
-            void *ptr = memory_manager_.done_queue_.front();
-            memory_manager_.done_queue_.pop();
-            release_meta_buffer(ptr);
-        }
-    }
-    for (void *ptr : memory_manager_.recycled_dump_buffers_) {
-        release_meta_buffer(ptr);
-    }
-    memory_manager_.recycled_dump_buffers_.clear();
-    memory_manager_.dev_to_host_.clear();
-
-    // Free arenas (device + host shadow)
+    // Free arenas (device only — shadows tracked in dev_to_host_).
     for (auto &ai : arenas_) {
-        if (ai.dev_ptr) {
-            if (register_cb_ == nullptr && ai.host_ptr != nullptr && ai.host_ptr != ai.dev_ptr) {
-                std::free(ai.host_ptr);
-            }
-            if (free_cb) {
-                free_cb(ai.dev_ptr);
-            }
+        if (ai.dev_ptr != nullptr) {
+            release_dev(ai.dev_ptr);
             ai.dev_ptr = nullptr;
             ai.host_ptr = nullptr;
         }
     }
     arenas_.clear();
 
-    // Free shared memory (device + host shadow)
-    if (dump_shared_mem_dev_) {
-        if (register_cb_ == nullptr && dump_shared_mem_host_ != nullptr &&
-            dump_shared_mem_host_ != dump_shared_mem_dev_) {
-            std::free(dump_shared_mem_host_);
-        }
-        if (free_cb) {
-            free_cb(dump_shared_mem_dev_);
-        }
+    // Free shared memory region (device only — shadow stays in
+    // dev_to_host_ until clear_mappings).
+    if (dump_shared_mem_dev_ != nullptr) {
+        release_dev(dump_shared_mem_dev_);
         dump_shared_mem_dev_ = nullptr;
-        dump_shared_mem_host_ = nullptr;
     }
+
+    // Free remaining host shadows: per-state buffers + arenas + shm region.
+    manager_.clear_mappings();
 
     // Reset state
     num_dump_threads_ = 0;
-    execution_complete_.store(false);
     collected_.clear();
-    processed_buffers_.clear();
     total_dropped_record_count_ = 0;
     total_truncated_count_ = 0;
     total_overwrite_count_ = 0;
+    writer_started_ = false;
+    clear_memory_context();
 
     return 0;
 }

--- a/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "aicore/l2_perf_collector_aicore.h"
 #include "aicore/pmu_collector_aicore.h"
 #include "common/l2_perf_profiling.h"
@@ -54,9 +55,17 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
     dcci(my_hank, SINGLE_CACHE_LINE, CACHELINE_OUT);
 
-    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
-    bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
-    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
+    // Cache profiling state once after Phase 3. The L2 / PMU rings and the
+    // PMU MMIO base are all stable for the entire run (host-resolved at
+    // AICore kernel entry from KernelArgs::regs[physical_core_id]), so
+    // they are safe to cache here.
+    uint32_t profiling_flag = get_aicore_profiling_flag();
+    bool l2_perf_enabled = GET_PROFILING_FLAG(profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
+    bool dump_tensor_enabled = GET_PROFILING_FLAG(profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(profiling_flag, PROFILING_FLAG_PMU);
+    __gm__ L2PerfAicoreRing *l2_perf_ring = l2_perf_enabled ? get_aicore_l2_perf_ring() : nullptr;
+    __gm__ PmuAicoreRing *pmu_ring = pmu_enabled ? get_aicore_pmu_ring() : nullptr;
+    uint64_t pmu_reg_base = pmu_enabled ? get_aicore_pmu_reg_base() : 0;
 
     volatile uint32_t task_id = AICPU_IDLE_TASK_ID;
     volatile uint32_t last_task_id = AICPU_IDLE_TASK_ID;
@@ -89,12 +98,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             if (pmu_enabled) {
                 pmu_aicore_end();
-                dcci(my_hank, SINGLE_CACHE_LINE);
-                // Read pmu_buffer_addr / pmu_reg_base per-task (mirrors how
-                // perf_records_addr is read below): by the time AICPU dispatches
-                // a real task_id, pmu_aicpu_init has already published these.
-                __gm__ PmuBuffer *pmu_buf = reinterpret_cast<__gm__ PmuBuffer *>(my_hank->pmu_buffer_addr);
-                pmu_aicore_record_task(pmu_buf, my_hank->pmu_reg_base, actual_task_id);
+                pmu_aicore_record_task(pmu_ring, pmu_reg_base, actual_task_id);
             }
 
             if (dump_tensor_enabled) {
@@ -102,10 +106,8 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             }
 
             if (l2_perf_enabled) {
-                dcci(my_hank, SINGLE_CACHE_LINE);
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ L2PerfBuffer *l2_perf_buf = (__gm__ L2PerfBuffer *)my_hank->l2_perf_records_addr;
-                l2_perf_aicore_record_task(l2_perf_buf, actual_task_id, start_time, end_time);
+                l2_perf_aicore_record_task(l2_perf_ring, actual_task_id, start_time, end_time);
             }
 
             last_task_id = task_id;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -68,7 +68,7 @@ struct AicpuExecutor {
 #if PTO2_PROFILING
     // Physical core ids keyed by logical worker id. Populated by discover_cores()
     // and handed to pmu_aicpu_init() so the platform can resolve per-core PMU
-    // MMIO bases from the host-supplied pmu_reg_addrs table.
+    // MMIO bases from `get_platform_regs()`.
     uint32_t physical_core_ids_[MAX_CORES_PER_THREAD]{};
 #endif
 
@@ -354,14 +354,14 @@ int AicpuExecutor::init(Runtime *runtime) {
         dispatch_timestamps_[i] = 0;
     }
     if (is_l2_swimlane_enabled()) {
-        l2_perf_aicpu_init_profiling(runtime);
+        l2_perf_aicpu_init(runtime->worker_count);
     }
 #if PTO2_PROFILING
     if (is_dump_tensor_enabled()) {
         dump_tensor_init(thread_num_);
     }
     if (is_pmu_enabled()) {
-        pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
+        pmu_aicpu_init(physical_core_ids_, cores_total_num_);
         LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
     }
 #endif
@@ -730,7 +730,6 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 // pending task's record to maintain buffer ordering.
                 if (l2_perf_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    L2PerfBuffer *l2_perf_buf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
 
                     if (prev_running_id != AICPU_TASK_INVALID) {
                         Task *prev_task = &runtime.tasks[prev_running_id];
@@ -739,9 +738,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                             fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
                         }
                         if (l2_perf_aicpu_complete_record(
-                                l2_perf_buf, static_cast<uint32_t>(prev_running_id),
-                                static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                core_id, static_cast<uint32_t>(prev_running_id), static_cast<uint64_t>(prev_running_id),
+                                prev_task->func_id, h->core_type, dispatch_timestamps_[core_id], finish_ts, fanout_arr,
+                                prev_task->fanout_count
                             ) != 0) {
                             LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
@@ -758,9 +757,9 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
                     if (l2_perf_aicpu_complete_record(
-                            l2_perf_buf, static_cast<uint32_t>(completed_task_id),
-                            static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            core_id, static_cast<uint32_t>(completed_task_id), static_cast<uint64_t>(completed_task_id),
+                            task->func_id, h->core_type, dispatch_timestamps_[core_id], finish_ts, fanout_arr,
+                            task->fanout_count
                         ) != 0) {
                         LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
@@ -842,16 +841,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                     // Profiling: complete the implicit task's AICore record
                     if (l2_perf_enabled) {
                         uint64_t finish_ts = get_sys_cnt_aicpu();
-                        L2PerfBuffer *l2_perf_buf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
                         Task *prev_task = &runtime.tasks[prev_running_id];
                         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                         for (int i = 0; i < prev_task->fanout_count; i++) {
                             fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
                         }
                         if (l2_perf_aicpu_complete_record(
-                                l2_perf_buf, static_cast<uint32_t>(prev_running_id),
-                                static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                core_id, static_cast<uint32_t>(prev_running_id), static_cast<uint64_t>(prev_running_id),
+                                prev_task->func_id, h->core_type, dispatch_timestamps_[core_id], finish_ts, fanout_arr,
+                                prev_task->fanout_count
                             ) != 0) {
                             LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
@@ -888,16 +886,15 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                 if (l2_perf_enabled) {
                     uint64_t finish_ts = get_sys_cnt_aicpu();
-                    L2PerfBuffer *l2_perf_buf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
                     Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
                     for (int i = 0; i < task->fanout_count; i++) {
                         fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
                     }
                     if (l2_perf_aicpu_complete_record(
-                            l2_perf_buf, static_cast<uint32_t>(completed_task_id),
-                            static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            core_id, static_cast<uint32_t>(completed_task_id), static_cast<uint64_t>(completed_task_id),
+                            task->func_id, h->core_type, dispatch_timestamps_[core_id], finish_ts, fanout_arr,
+                            task->fanout_count
                         ) != 0) {
                         LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -37,7 +37,6 @@
 #include <atomic>
 
 #include "common/core_type.h"
-#include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
 #include "tensor_info.h"
 
@@ -101,36 +100,29 @@
  * The structure is cache-line aligned (64 bytes) to prevent false sharing
  * between cores and optimize cache coherency operations.
  *
- * enable_profiling_flag bit definitions (umbrella bitmask — "profiling"
- * is the umbrella, each bit is a parallel diagnostics sub-feature):
- * - bit0: tensor dump enabled
- * - bit1: L2 swimlane enabled
- * - bit2: PMU enabled
+ * Profiling state lives outside this struct: enablement bits and per-core
+ * ring/reg addresses travel through `KernelArgs::enable_profiling_flag` +
+ * `KernelArgs::aicore_* per-core address arrays`, which the AICore kernel entry
+ * forwards into platform-owned per-core slots
+ * (`aicore/aicore_profiling_state.h`). Adding a profiling sub-feature does
+ * not require touching this struct anymore.
  *
  * Field Access Patterns:
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
  * - task: Written by AICPU, read by AICore (0 = no task assigned)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
- * - l2_perf_records_addr: Written by AICPU, read by AICore (performance records address)
- * - physical_core_id: Written by AICPU, read by AICore (physical core ID)
- * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
- * - pmu_buffer_addr: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
- * - pmu_reg_base: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
+ * - physical_core_id: Written by AICore (Phase 2), read by AICPU
+ * - aicpu_regs_ready / aicore_regs_ready: handshake sequence flags
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                  // Task pointer: 0=no task, non-zero=Task* address
-    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;  // Performance records address
-    volatile uint32_t physical_core_id;      // Physical core ID
-    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
-    volatile uint32_t
-        enable_profiling_flag;          // Umbrella diagnostics bitmask; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
-    volatile uint64_t pmu_buffer_addr;  // Per-core PmuBuffer device address (for AICore-side PMU record)
-    volatile uint64_t pmu_reg_base;     // Per-core PMU MMIO base (for AICore-side PMU register reads)
+    volatile uint32_t aicpu_ready;        // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;        // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;               // Task pointer: 0=no task, non-zero=Task* address
+    volatile CoreType core_type;          // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint32_t physical_core_id;   // Physical core ID
+    volatile uint32_t aicpu_regs_ready;   // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;  // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "aicore/aicore.h"
+#include "aicore/aicore_profiling_state.h"
 #include "aicore/l2_perf_collector_aicore.h"
 #include "aicore/pmu_collector_aicore.h"
 #include "common/l2_perf_profiling.h"
@@ -90,9 +91,17 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
     // Cache per-core dispatch payload pointer (set by AICPU before aicpu_ready)
     __gm__ PTO2DispatchPayload *payload = reinterpret_cast<__gm__ PTO2DispatchPayload *>(my_hank->task);
 
-    bool l2_perf_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
-    bool dump_tensor_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
-    bool pmu_enabled = GET_PROFILING_FLAG(my_hank->enable_profiling_flag, PROFILING_FLAG_PMU);
+    // Cache profiling state once after Phase 3. The L2 / PMU rings and the
+    // PMU MMIO base are all stable for the entire run (host-resolved at
+    // AICore kernel entry from KernelArgs::regs[physical_core_id]), so
+    // they are safe to cache here.
+    uint32_t profiling_flag = get_aicore_profiling_flag();
+    bool l2_perf_enabled = GET_PROFILING_FLAG(profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
+    bool dump_tensor_enabled = GET_PROFILING_FLAG(profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
+    bool pmu_enabled = GET_PROFILING_FLAG(profiling_flag, PROFILING_FLAG_PMU);
+    __gm__ L2PerfAicoreRing *l2_perf_ring = l2_perf_enabled ? get_aicore_l2_perf_ring() : nullptr;
+    __gm__ PmuAicoreRing *pmu_ring = pmu_enabled ? get_aicore_pmu_ring() : nullptr;
+    uint64_t pmu_reg_base = pmu_enabled ? get_aicore_pmu_reg_base() : 0;
 
     // Phase 4: Main execution loop - poll register for tasks until exit signal
     // Register encoding: AICPU_IDLE_TASK_ID=idle, task_id=task, AICORE_EXIT_SIGNAL=exit
@@ -136,11 +145,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
 
             if (pmu_enabled) {
                 pmu_aicore_end();
-                // Read pmu_buffer_addr / pmu_reg_base per-task (mirrors how
-                // perf_records_addr is read below): by the time AICPU dispatches
-                // a real task_id, pmu_aicpu_init has already published these.
-                __gm__ PmuBuffer *pmu_buf = reinterpret_cast<__gm__ PmuBuffer *>(my_hank->pmu_buffer_addr);
-                pmu_aicore_record_task(pmu_buf, my_hank->pmu_reg_base, task_id);
+                pmu_aicore_record_task(pmu_ring, pmu_reg_base, task_id);
             }
 
             if (dump_tensor_enabled) {
@@ -150,8 +155,7 @@ __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, in
             // Performance profiling: record task execution
             if (l2_perf_enabled) {
                 uint64_t end_time = get_sys_cnt_aicore();
-                __gm__ L2PerfBuffer *l2_perf_buf = (__gm__ L2PerfBuffer *)my_hank->l2_perf_records_addr;
-                l2_perf_aicore_record_task(l2_perf_buf, task_id, start_time, end_time);
+                l2_perf_aicore_record_task(l2_perf_ring, task_id, start_time, end_time);
             }
 
             last_reg_val = reg_val;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -622,10 +622,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             submitted_tasks = total_tasks;
 #endif
 
-            if (is_l2_swimlane_enabled() && total_tasks > 0) {
-                l2_perf_aicpu_update_total_tasks(static_cast<uint32_t>(total_tasks));
-            }
-
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
         }
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -35,7 +35,6 @@
 #include <string.h>  // for memset
 
 #include "common/core_type.h"
-#include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
 #include "pto2_dispatch_payload.h"
 #include "task_args.h"
@@ -83,34 +82,29 @@ constexpr int RUNTIME_DEFAULT_READY_QUEUE_SHARDS = PLATFORM_MAX_AICPU_THREADS - 
  * The structure is cache-line aligned (64 bytes) to prevent false sharing
  * between cores and optimize cache coherency operations.
  *
- * enable_profiling_flag bit definitions (umbrella bitmask — "profiling"
- * is the umbrella, each bit is a parallel diagnostics sub-feature):
- * - bit0: tensor dump enabled
- * - bit1: L2 swimlane enabled
- * - bit2: PMU enabled (reserved on a5; a2a3 wires through device_runner)
+ * Profiling state lives outside this struct: enablement bits and per-core
+ * ring/reg addresses travel through `KernelArgs::enable_profiling_flag` +
+ * `KernelArgs::aicore_* per-core address arrays`, which the AICore kernel entry
+ * forwards into platform-owned per-core slots
+ * (`aicore/aicore_profiling_state.h`). Adding a profiling sub-feature does
+ * not require touching this struct anymore.
  *
  * Field Access Patterns:
  * - aicpu_ready: Written by AICPU, read by AICore
  * - aicore_done: Written by AICore, read by AICPU
- * - task: Written by AICPU, read by AICore (0 = not ready, non-zero = PTO2DispatchPayload*)
+ * - task: Written by AICPU, read by AICore (Init: PTO2DispatchPayload*; runtime: unused)
  * - core_type: Written by AICPU, read by AICore (CoreType::AIC or CoreType::AIV)
- * - enable_profiling_flag: Written by host/AICPU init, read by AICore (bitmask)
- * - pmu_buffer_addr: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
- * - pmu_reg_base: Written by AICPU at PMU init (before aicpu_regs_ready=1), read by AICore
+ * - physical_core_id: Written by AICore (Phase 2), read by AICPU
+ * - aicpu_regs_ready / aicore_regs_ready: handshake sequence flags
  */
 struct Handshake {
-    volatile uint32_t aicpu_ready;           // AICPU ready signal: 0=not ready, 1=ready
-    volatile uint32_t aicore_done;           // AICore ready signal: 0=not ready, core_id+1=ready
-    volatile uint64_t task;                  // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
-    volatile CoreType core_type;             // Core type: CoreType::AIC or CoreType::AIV
-    volatile uint64_t l2_perf_records_addr;  // Performance records address
-    volatile uint32_t physical_core_id;      // Physical core ID
-    volatile uint32_t aicpu_regs_ready;      // AICPU register init done: 0=pending, 1=done
-    volatile uint32_t aicore_regs_ready;     // AICore ID reported: 0=pending, 1=done
-    volatile uint32_t
-        enable_profiling_flag;          // Generic profiling-related flags; bit0=dump_tensor, bit1=l2_swimlane, bit2=pmu
-    volatile uint64_t pmu_buffer_addr;  // Per-core PmuBuffer device address (for AICore-side PMU record)
-    volatile uint64_t pmu_reg_base;     // Per-core PMU MMIO base (for AICore-side PMU register reads)
+    volatile uint32_t aicpu_ready;        // AICPU ready signal: 0=not ready, 1=ready
+    volatile uint32_t aicore_done;        // AICore ready signal: 0=not ready, core_id+1=ready
+    volatile uint64_t task;               // Init: PTO2DispatchPayload* (set before aicpu_ready); runtime: unused
+    volatile CoreType core_type;          // Core type: CoreType::AIC or CoreType::AIV
+    volatile uint32_t physical_core_id;   // Physical core ID
+    volatile uint32_t aicpu_regs_ready;   // AICPU register init done: 0=pending, 1=done
+    volatile uint32_t aicore_regs_ready;  // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -157,9 +157,7 @@ void SchedulerContext::complete_slot_task(
 #if PTO2_SCHED_PROFILING
         uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
-        Handshake *h = &hank[core_id];
         uint64_t finish_ts = get_sys_cnt_aicpu();
-        L2PerfBuffer *pbuf = reinterpret_cast<L2PerfBuffer *>(h->l2_perf_records_addr);
 
         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
         int32_t fanout_n = 0;
@@ -171,7 +169,7 @@ void SchedulerContext::complete_slot_task(
 
         int32_t perf_slot_idx = static_cast<int32_t>(subslot);
         if (l2_perf_aicpu_complete_record(
-                pbuf, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
+                core_id, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
                 slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanout_arr,
                 fanout_n
             ) != 0) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -162,15 +162,6 @@ void SchedulerContext::dispatch_subtask_to_core(
 #endif
         tracker.change_core_state(core_offset);
     }
-#if PTO2_PROFILING
-    if (l2_perf.l2_perf_enabled) {
-        if (core_exec_state.dispatch_count >= PLATFORM_PROF_BUFFER_SIZE) {
-            l2_perf_aicpu_switch_buffer(runtime, core_id, thread_idx);
-            core_exec_state.dispatch_count = 0;
-        }
-        core_exec_state.dispatch_count++;
-    }
-#endif
 
     LOG_DEBUG(
         "Thread %d: Dispatched %s %s task %" PRId64 " kernel_id=[%d,%d,%d] block_idx=%d/total_blocks=%d to"
@@ -347,8 +338,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
 #if PTO2_PROFILING
         if (is_l2_swimlane_enabled()) {
-            l2_perf_aicpu_init_profiling(runtime);
-            l2_perf_aicpu_init_phase_profiling(runtime, sched_thread_num_);
+            l2_perf_aicpu_init(runtime->worker_count);
+            l2_perf_aicpu_init_phase(runtime->worker_count, sched_thread_num_);
             l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
         }
 #endif
@@ -357,7 +348,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
         }
         if (is_pmu_enabled()) {
-            pmu_aicpu_init(runtime->workers, physical_core_ids_, cores_total_num_);
+            pmu_aicpu_init(physical_core_ids_, cores_total_num_);
             LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
         }
 #endif


### PR DESCRIPTION
## Summary

Brings a5's profiling stack to the same shape as a2a3 (PRs #705 / #709 / #714):

- **Host CRTP framework**: `L2PerfCollector` / `PmuCollector` / `TensorDumpCollector` now derive from `ProfilerBase<Derived, Module>` over a shared `BufferPoolManager<Module>` under `src/a5/platform/include/host/profiling_common/`. Mgmt + poll threads + buffer pool logic deduplicated across three collectors.
- **Stable AICore staging ring**: AICore writes per-task records to a per-core `L2PerfAicoreRing` / `PmuAicoreRing` allocated once by the host; address is published via `KernelArgs::aicore_*_ring_addrs[block_idx]` and never reassigned. Decouples AICore writes from AICPU's rotating records buffer, and fixes the latent PMU buffer-flip bug where AICore kept writing to the stale buffer.
- **Profiling out of `Handshake`**: enablement bits + per-core address arrays moved from runtime `Handshake` to `KernelArgs` + AICore platform-owned slots (`aicore_profiling_state.h`). Adding a new profiling field no longer touches the runtime sync protocol. AICore resolves its PMU MMIO base directly from the existing `KernelArgs::regs` table at kernel entry (`regs[get_physical_core_id()]`), so there is no separate per-core `pmu_reg_addrs` table and no AICPU-fill-after-handshake dependency — the reg base is stable from Phase 1, and `aicore_execute` caches it at Phase 3 alongside the rings.
- **Three-bucket reconcile**: `L2PerfBufferState` and `PmuBufferState` now track `total / dropped / mismatch`; collectors cross-check `collected + dropped + mismatch == device_total` per pool, matching a2a3.

a5's transport channel still differs from a2a3 (no `halHostRegister` on DAV_3510). The framework absorbs that as:
- `MemoryOps` carries 5 callbacks (adds `copy_to_device` / `copy_from_device`)
- mgmt loop mirrors the shm region per tick via `profiling_copy.h`
- `release_owned_buffers` frees the paired host-shadow `malloc()`

## Docs

- `docs/profiling-framework.md` §8 — new a5-specifics section
- `docs/dfx/{pmu-profiling,l2-swimlane-profiling,tensor-dump}.md` §5.x — a5 transport channel + lifecycle + reconcile semantics updated to match the code as it stands

## Naming note

a5's new `KernelArgs` fields are named `*_addrs` (plural) for the per-core address arrays: `aicore_l2_perf_ring_addrs`, `aicore_pmu_ring_addrs`. a2a3's `aicore_ring_addr` (singular but pointing to an array) is logged for a follow-up a2a3 rename PR; not touched here per the arch-independence rule.

## Test plan

- [x] `python -m simpler_setup.build_runtimes --platform a5sim` — host_build_graph + tensormap_and_ringbuffer build clean
- [ ] a5sim CI (`./ci.sh -p a5sim`)
- [ ] a5 hardware smoke
- [ ] Verify reconcile equation `collected + dropped + mismatch == device_total` matches per pool on a representative case