### PR TITLE
Refactor: drop unused PTO2_SPIN_VERBOSE_LOGGING toggle

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -42,11 +42,6 @@
 #include "pto_shared_memory.h"
 #include "common/unified_log.h"
 
-// Set to 1 to enable periodic BLOCKED/Unblocked messages during spin-wait.
-#ifndef PTO2_SPIN_VERBOSE_LOGGING
-#define PTO2_SPIN_VERBOSE_LOGGING 1
-#endif
-
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
@@ -146,7 +141,6 @@ public:
                 spin_count = 0;
                 prev_last_alive = last_alive;
             } else {
-#if PTO2_SPIN_VERBOSE_LOGGING
                 if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
                     LOG_WARN(
                         "[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
@@ -154,7 +148,6 @@ public:
                         blocked_on_heap ? "heap" : "task", spin_count
                     );
                 }
-#endif
                 if (spin_count >= PTO2_ALLOC_SPIN_LIMIT) {
                     report_deadlock(output_size, blocked_on_heap);
                     return {-1, -1, nullptr, nullptr};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -42,11 +42,6 @@
 #include "pto_shared_memory.h"
 #include "common/unified_log.h"
 
-// Set to 1 to enable periodic BLOCKED/Unblocked messages during spin-wait.
-#ifndef PTO2_SPIN_VERBOSE_LOGGING
-#define PTO2_SPIN_VERBOSE_LOGGING 1
-#endif
-
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
@@ -146,7 +141,6 @@ public:
                 spin_count = 0;
                 prev_last_alive = last_alive;
             } else {
-#if PTO2_SPIN_VERBOSE_LOGGING
                 if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
                     LOG_WARN(
                         "[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
@@ -154,7 +148,6 @@ public:
                         blocked_on_heap ? "heap" : "task", spin_count
                     );
                 }
-#endif
                 if (spin_count >= PTO2_ALLOC_SPIN_LIMIT) {
                     report_deadlock(output_size, blocked_on_heap);
                     return {-1, -1, nullptr, nullptr};


### PR DESCRIPTION
## Summary

- `PTO2_SPIN_VERBOSE_LOGGING` defaulted to `1` and had zero overrides anywhere in the tree: no CI flag, no `build_config.py`, no CMake `target_compile_definitions`, no entry in `simpler_setup/toolchain.py`, no docs telling anyone to flip it.
- The macro had a single use site in `pto_ring_buffer.h` and no `#else` branch, so disabling it just elided one `LOG_WARN` — a dead toggle.
- Inline the `LOG_WARN` unconditionally in both a2a3 and a5 copies of `pto_ring_buffer.h` and drop the macro entirely.

## Testing

- [x] Editable install (`pip install --no-build-isolation -e .`) — builds clean on macOS arm64.
- [x] `python simpler_setup/build_runtimes.py --platforms a2a3sim a5sim` — both arches' host/aicpu/aicore sim targets compile clean.
- [x] Pre-commit hooks pass (clang-format, clang-tidy, cpplint, header checks).