### PR TITLE
Refactor: collapse dual-issue dispatch automatically when PMU is on

### DIFF
--- a/docs/dfx/pmu-profiling.md
+++ b/docs/dfx/pmu-profiling.md
@@ -447,32 +447,28 @@ the collector thread drains buffers concurrently with kernel execution.
 On a5 the copy hooks add `rtMemcpy` round-trips that a2a3's shared
 memory avoids, but these overlap with device execution.
 
-For meaningful per-task numbers on a2a3, also rebuild the runtime with
-`PTO2_DISABLE_DUAL_ISSUE=1` (see §7.1) — this serialization itself
-costs throughput, so keep dual-issue settings consistent across runs
-being compared.
+For meaningful per-task numbers on a2a3 the runtime collapses to
+single-issue dispatch automatically whenever `--enable-pmu` is set (see
+§7.1) — this serialization itself costs throughput, so PMU-on
+measurements are not comparable to PMU-off baselines.
 
 ## 7. Limitations
 
 ### 7.1 a2a3
 
 PMU collection assumes each logical AICore has at most one in-flight
-task. The default dual-issue dispatch can preload a pending task while
+task. The default dual-issue dispatch preloads a pending task while
 another task is still running on the same core, so per-core PMU
-registers can carry overlapping task windows. For accurate per-task
-counters, rebuild the runtime with:
-
-```text
-PTO2_DISABLE_DUAL_ISSUE=1
-```
+registers can carry overlapping task windows. To keep counters scoped
+to a single task, `--enable-pmu` automatically collapses dispatch to
+single-issue at runtime — both `host_build_graph` and
+`tensormap_and_ringbuffer` runtimes branch on `is_pmu_enabled()` in
+their dispatch path. No separate flag or rebuild is required.
 
 Notes on this constraint:
 
-- `--enable-pmu` enables collection; the dual-issue toggle is a
-  separate compile-time flag in the runtime headers
-  (`host_build_graph` and `tensormap_and_ringbuffer`).
-- Keep PMU comparisons consistent by using the same dual-issue
-  setting across all runs being compared.
+- PMU-on runs serialize dispatch per core, so throughput is lower than
+  PMU-off baselines. The two are not directly comparable.
 - `a2a3sim` exercises the export pipeline; counter values come from
   the simulation backend, not real hardware, so they are not suitable
   for performance analysis.
@@ -525,8 +521,11 @@ group does not populate the columns shown — check the `event_type`
 column and the per-architecture event table in §3.3.
 
 **Counter values look polluted on a2a3.** Dual-issue dispatch is
-overlapping tasks on the same core. Rebuild the runtime with
-`PTO2_DISABLE_DUAL_ISSUE=1` (§7.1).
+overlapping tasks on the same core. `--enable-pmu` should already
+collapse dispatch to single-issue at runtime (§7.1); if pollution
+persists, verify that `is_pmu_enabled()` returns true on every AICPU
+thread and that the dispatch loop branch in `scheduler_dispatch.cpp`
+and `aicpu_executor.cpp` hasn't been bypassed.
 
 **`record count mismatch (... diff=M)` on a5.** Slot-mismatch loss —
 this should be 0 on DAV_3510. Treat as a regression: see §7.2 for the

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -28,6 +28,10 @@
 #include "runtime.h"
 #include "spin_hint.h"
 
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+
 constexpr int MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 constexpr int MAX_CORES_PER_THREAD = PLATFORM_MAX_CORES_PER_THREAD;
 constexpr int MAX_CORES = PLATFORM_MAX_CORES;
@@ -671,6 +675,11 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
     int verification_warning_count = 0;
     const int MAX_VERIFICATION_WARNINGS = 10;
     bool l2_perf_enabled = is_l2_swimlane_enabled();
+    // PMU runs require single-issue dispatch — overlapping in-flight tasks
+    // pollute per-task PMU counters. Cached at function scope:
+    // is_pmu_enabled() is extern "C" and the compiler cannot hoist it
+    // across the dispatch loop on its own.
+    const bool pmu_active = is_pmu_enabled();
 
     // Extract array pointers as local variables for better readability and performance
     int *cur_ready_queue_aic = cur_ready_queue_aic_[thread_idx];
@@ -931,14 +940,11 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 }
             }
 
-            // Case 4: Dispatch new task if pending slot is available
-            // With PTO2_DISABLE_DUAL_ISSUE=1, additionally require the running
-            // slot to be empty so each core has at most one outstanding task.
-#if PTO2_DISABLE_DUAL_ISSUE
-            if (pending_task_ids_[core_id] == AICPU_TASK_INVALID && running_task_ids_[core_id] == AICPU_TASK_INVALID) {
-#else
-            if (pending_task_ids_[core_id] == AICPU_TASK_INVALID) {
-#endif
+            // Case 4: Dispatch new task if pending slot is available. When PMU
+            // is active we additionally require the running slot to be empty —
+            // see pmu_active comment above the dispatch loop.
+            if (pending_task_ids_[core_id] == AICPU_TASK_INVALID &&
+                (!unlikely(pmu_active) || running_task_ids_[core_id] == AICPU_TASK_INVALID)) {
                 if (h->core_type == CoreType::AIC && cur_aic_ready_count > 0) {
                     if (try_dispatch_task(
                             core_id, reg_addr, CoreType::AIC, thread_idx, cur_ready_queue_aic, cur_aic_head,

--- a/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/pto_runtime2_types.h
@@ -20,13 +20,4 @@
 #define PTO2_PROFILING 1
 #endif
 
-// Disable dual-issue (pipelined) AICPU->AICore dispatch. When 1, the
-// scheduler only dispatches to a core when both the running and pending
-// slots are empty, so each core has at most one outstanding task at any
-// time. Orthogonal to PTO2_PROFILING / PMU: PMU users must set this
-// explicitly, since overlapping in-flight tasks pollute PMU registers.
-#ifndef PTO2_DISABLE_DUAL_ISSUE
-#define PTO2_DISABLE_DUAL_ISSUE 0
-#endif
-
 #endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_PTO_RUNTIME2_TYPES_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -74,15 +74,6 @@
 #define PTO2_TENSORMAP_PROFILING 0
 #endif
 
-// Disable dual-issue (pipelined) AICPU->AICore dispatch. When 1, the
-// scheduler only loads the running slot and never pre-loads the pending
-// slot, so each core has at most one outstanding task at any time.
-// Orthogonal to PTO2_PROFILING / PMU: PMU users must set this explicitly,
-// since overlapping in-flight tasks pollute PMU registers.
-#ifndef PTO2_DISABLE_DUAL_ISSUE
-#define PTO2_DISABLE_DUAL_ISSUE 0
-#endif
-
 #if PTO2_ORCH_PROFILING && !PTO2_PROFILING
 #error "PTO2_ORCH_PROFILING requires PTO2_PROFILING=1"
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -28,6 +28,10 @@
 #include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 
+#ifndef unlikely
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#endif
+
 // =============================================================================
 // Dispatch helpers
 // =============================================================================
@@ -372,6 +376,12 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
     bool cores_released = false;
 
+    // PMU runs require single-issue dispatch — overlapping in-flight tasks
+    // pollute per-task PMU counters, so skip the PENDING pre-load phase.
+    // Cached at function scope: is_pmu_enabled() is extern "C" and the
+    // compiler cannot hoist it across the dispatch loop on its own.
+    const bool pmu_active = is_pmu_enabled();
+
 #if PTO2_PROFILING
     l2_perf.sched_start_ts = get_sys_cnt_aicpu();
 #endif
@@ -545,11 +555,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         for (int32_t si = 0; si < PTO2_NUM_RESOURCE_SHAPES && !entered_drain; si++) {
             PTO2ResourceShape shape = dispatch_order[si];
-#if PTO2_DISABLE_DUAL_ISSUE
-            for (auto phase : {CoreTracker::DispatchPhase::IDLE}) {
-#else
             for (auto phase : {CoreTracker::DispatchPhase::IDLE, CoreTracker::DispatchPhase::PENDING}) {
-#endif
+                if (phase == CoreTracker::DispatchPhase::PENDING && unlikely(pmu_active)) break;
                 dispatch_shape(
                     thread_idx, shape, phase, local_bufs[static_cast<int32_t>(shape)], tracker, entered_drain,
                     made_progress, try_pushed


### PR DESCRIPTION
## Summary

`PTO2_DISABLE_DUAL_ISSUE` was a compile-time gate with one real user: PMU. With the default (`=0`), `--enable-pmu` silently returned polluted counters because two in-flight tasks overlapped on the same core. Users had to recompile with `-DPTO2_DISABLE_DUAL_ISSUE=1` to fix this — a footgun documented only as "PMU users must set this explicitly."

This PR replaces the compile-time macro with a runtime branch on `is_pmu_enabled()` at both use sites:

- **`scheduler_dispatch.cpp`** — drop the `PENDING` dispatch phase when PMU is on, keeping `IDLE` only. Cache `is_pmu_enabled()` once per outer resource-shape iteration; mark `unlikely()` since PMU is off in all production runs and the CI default.
- **`aicpu_executor.cpp`** — additionally require the running slot to be empty when PMU is on, so each core has at most one outstanding task. `unlikely()` applied at the inline check.

Delete `PTO2_DISABLE_DUAL_ISSUE` from both runtimes' `pto_runtime2_types.h` and update `docs/dfx/pmu-profiling.md` (§6, §7.1, §8) to describe the automatic single-issue behavior.

## Effects

- PMU runs are correct by default; no rebuild required.
- The default dual-issue path is unchanged for production code.
- Two compile-time gates from the macro-coverage audit close — CI now exercises both branches through the existing `--enable-pmu` smoke in `.github/workflows/ci.yml`.

## Testing

- [x] `python simpler_setup/build_runtimes.py --platforms a2a3sim` — both `host_build_graph` and `tensormap_and_ringbuffer` compile clean.
- [x] `pytest tests/st/a2a3/.../dfx/pmu/test_pmu.py --platform a2a3sim --enable-pmu 2` passes (PMU-on / single-issue path).
- [x] Same test without `--enable-pmu` passes (PMU-off / dual-issue default path).
- [x] Pre-commit (clang-format, clang-tidy, cpplint, markdownlint) green.