### PR TITLE
Support: CI gate for PTO2 profiling flag combinations + fix two unused-param bugs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,138 @@ jobs:
           fi
           exit $rc
 
+  # ---------- Profiling sub-flags smoke (compile + run) ----------
+  # PTO2_PROFILING / PTO2_ORCH_PROFILING / PTO2_SCHED_PROFILING /
+  # PTO2_TENSORMAP_PROFILING are compile-time gates in src/{a2a3,a5}/runtime/
+  # tensormap_and_ringbuffer/runtime/pto_runtime2_types.h. The defaults
+  # (PTO2_PROFILING=1, sub-flags=0) are exercised by every CI job, but the
+  # non-default branches are dead coverage today — a developer flipping any
+  # of them for perf debugging or to minimize logging overhead had no gate
+  # protecting the gated code from drift (renamed fields, changed signatures,
+  # format-string mismatches in LOG_INFO summaries, dead parameters caught
+  # only by -Wunused-parameter -Werror).
+  #
+  # All combos run sequentially in a single job (not a matrix) so the
+  # apt/python/pip setup cost is paid once, not 12×. Failures across combos
+  # are accumulated and reported together at the end — first failure does
+  # not abort the rest.
+  #
+  # Combos walk the macro hierarchy explicitly (not just "all on" or "all
+  # off") so log scrubbing the failing leg pinpoints the specific gate:
+  #
+  #   PTO2_PROFILING (default=1, covered by every other CI job)
+  #   ├── pto2-off:         -DPTO2_PROFILING=0   (no profiling at all)
+  #   ├── orch:             -DPTO2_ORCH_PROFILING=1
+  #   │   └── orch-tensormap:  + -DPTO2_TENSORMAP_PROFILING=1
+  #   ├── sched:            -DPTO2_SCHED_PROFILING=1
+  #   ├── orch-sched:       ORCH=1 + SCHED=1   (both sub-flags on, tensormap off)
+  #   └── all-on:           ORCH=1 + SCHED=1 + TENSORMAP=1
+  #
+  # Each combo rebuilds the sim runtime with its CXXFLAGS and runs the
+  # smallest full-pipeline example (vector_example) — exercises orchestrator,
+  # scheduler, AICore dispatch, and completion paths gated by the macros.
+  #
+  # Verified locally that each combo's compile_commands.json contains *only*
+  # its declared -D flags, the resulting libaicpu_kernel.so contains *only*
+  # the matching profiling log strings, and pytest output emits *only* the
+  # corresponding profiling block — no cross-contamination from cmake cache.
+  profiling-flags-smoke:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.a2a3_changed == 'true' || needs.detect-changes.outputs.a5_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up C++ compiler
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y ninja-build
+          sudo apt-get install -y g++-15 || sudo apt-get install -y g++
+          if ! command -v g++-15; then sudo ln -s "$(which g++)" /usr/local/bin/g++-15; fi
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Cache pip packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies (editable so simpler_setup always resolves to source tree)
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          # Editable install (`-e .`) avoids a cwd-dependent footgun: with a
+          # plain wheel install, `import simpler_setup` from a non-source-tree
+          # cwd resolves to the wheel-internal copy (PROJECT_ROOT = _assets/),
+          # silently reading runtime .so files from the wheel instead of the
+          # build/lib/ that our combo loop overwrites. With editable mode the
+          # shim always redirects to source-tree paths, regardless of cwd.
+          # pyproject.toml sets editable.rebuild=false so import-time auto
+          # rebuilds cannot clobber our profiling-on binaries.
+          #
+          # Build isolation (pip default, no --no-build-isolation) pulls
+          # scikit-build-core into a throwaway env automatically — matches the
+          # `pre-commit` job's `pip install .` pattern and works on a fresh
+          # CI runner that has no build deps pre-installed.
+          pip install -e '.[test]'
+
+      - name: Run all profiling flag combos × 2 arches
+        run: |
+          # Combo names paired with their CXX defines. Parallel arrays (not
+          # an associative array) so the loop iteration order is deterministic
+          # and the log reads top-to-bottom in hierarchy order.
+          COMBO_NAMES=(pto2-off orch orch-tensormap sched orch-sched all-on)
+          COMBO_DEFS=(
+            "-DPTO2_PROFILING=0"
+            "-DPTO2_ORCH_PROFILING=1"
+            "-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1"
+            "-DPTO2_SCHED_PROFILING=1"
+            "-DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1"
+            "-DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1"
+          )
+          ARCHES=(a2a3sim a5sim)
+          FAIL=()
+
+          for ARCH in "${ARCHES[@]}"; do
+            ARCH_DIR=${ARCH%sim}
+            for i in "${!COMBO_NAMES[@]}"; do
+              NAME=${COMBO_NAMES[$i]}
+              DEFS=${COMBO_DEFS[$i]}
+              echo "::group::$ARCH / $NAME — CXX defines: $DEFS"
+              if ! CXX="g++ $DEFS" python simpler_setup/build_runtimes.py --platforms "$ARCH"; then
+                echo "::error::Build failed: $ARCH / $NAME"
+                FAIL+=("$ARCH/$NAME (build)")
+                echo "::endgroup::"
+                continue
+              fi
+              if ! python -m pytest \
+                   "examples/${ARCH_DIR}/tensormap_and_ringbuffer/vector_example/test_vector_example.py" \
+                   --platform "$ARCH" --device 0-1 -p no:xdist \
+                   --pto-session-timeout 600 --clone-protocol https; then
+                echo "::error::Smoke failed: $ARCH / $NAME"
+                FAIL+=("$ARCH/$NAME (pytest)")
+              fi
+              echo "::endgroup::"
+            done
+          done
+
+          echo ""
+          echo "==== SUMMARY ===="
+          if [ ${#FAIL[@]} -gt 0 ]; then
+            printf 'FAILED: %s\n' "${FAIL[@]}"
+            exit 1
+          fi
+          echo "All $((${#COMBO_NAMES[@]} * ${#ARCHES[@]})) combos passed."
+
   # ---------- Unit tests (a2a3 hardware, Python + C++) ----------
   ut-a2a3:
     runs-on: [self-hosted, a2a3]

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -239,7 +239,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
 // Try to dispatch a task from thread-local queue to a core
 inline bool AicpuExecutor::try_dispatch_task(
     int core_id, uint64_t reg_addr, CoreType core_type, int thread_idx, int *local_queue, int &head, int &ready_count,
-    bool l2_perf_enabled, Runtime &runtime
+    bool l2_perf_enabled, [[maybe_unused]] Runtime &runtime
 ) {
     if (ready_count <= 0) {
         return false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -67,9 +67,9 @@ SlotTransition SchedulerContext::decide_slot_transition(
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
-    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
-    int32_t core_id, Handshake *hank, int32_t &completed_this_turn, PTO2TaskSlotState *deferred_release_slot_states[],
-    int32_t &deferred_release_count, PTO2LocalReadyBuffer *local_bufs
+    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
+    int32_t thread_idx, int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
+    PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count, PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
     ,
     uint64_t dispatch_ts

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -6,6 +6,21 @@ This document describes the profiling macro hierarchy and logging control in the
 
 PTO Runtime2 uses a hierarchical profiling system with compile-time macros to control profiling code compilation and log output. The `enable_l2_swimlane` runtime flag controls data collection (performance buffers, shared memory writes) but does NOT control log output.
 
+### CI coverage
+
+The default CI build leaves `PTO2_PROFILING=1` (base) and the three sub-flags (`PTO2_ORCH_PROFILING`, `PTO2_SCHED_PROFILING`, `PTO2_TENSORMAP_PROFILING`) at `0`. The `profiling-flags-smoke` job in `.github/workflows/ci.yml` exercises the non-default combinations and runs the smallest full-pipeline example (`examples/<arch>/tensormap_and_ringbuffer/vector_example/`) against the rebuilt binaries:
+
+| Combo | `CXX` defines |
+| ----- | ------------- |
+| `pto2-off` | `-DPTO2_PROFILING=0` |
+| `orch` | `-DPTO2_ORCH_PROFILING=1` |
+| `orch-tensormap` | `-DPTO2_ORCH_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1` |
+| `sched` | `-DPTO2_SCHED_PROFILING=1` |
+| `orch-sched` | `-DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1` |
+| `all-on` | `-DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1` |
+
+Each combo runs sequentially on both `a2a3sim` and `a5sim` inside a single CI job (12 iterations total in one bash loop, not a matrix — apt/python/pip setup is paid once instead of 12 times). Failures across iterations are accumulated and reported together at the end. Compile failures, format-string mismatches, runtime crashes, or output-shape regressions in any individually gated code path show up there with the failing leg attributing the specific switch.
+
 ## Profiling Macro Hierarchy
 
 ```text

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -67,9 +67,9 @@ SlotTransition SchedulerContext::decide_slot_transition(
 
 // Complete one slot's task: subtask counting, mixed completion, deferred release, profiling.
 void SchedulerContext::complete_slot_task(
-    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, PTO2SubtaskSlot subslot, int32_t thread_idx,
-    int32_t core_id, Handshake *hank, int32_t &completed_this_turn, PTO2TaskSlotState *deferred_release_slot_states[],
-    int32_t &deferred_release_count, PTO2LocalReadyBuffer *local_bufs
+    PTO2TaskSlotState &slot_state, int32_t expected_reg_task_id, [[maybe_unused]] PTO2SubtaskSlot subslot,
+    int32_t thread_idx, int32_t core_id, Handshake *hank, int32_t &completed_this_turn,
+    PTO2TaskSlotState *deferred_release_slot_states[], int32_t &deferred_release_count, PTO2LocalReadyBuffer *local_bufs
 #if PTO2_PROFILING
     ,
     uint64_t dispatch_ts


### PR DESCRIPTION
## Problem

`PTO2_PROFILING` (base, default=1) and the three sub-flags `PTO2_ORCH_PROFILING`, `PTO2_SCHED_PROFILING`, `PTO2_TENSORMAP_PROFILING` (default=0) are compile-time gates in `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`. The default state (`PTO2_PROFILING=1`, sub-flags=0) is exercised by every CI job. The non-default combinations are **dead coverage** today — 309 source sites (139 `#if PTO2_PROFILING` + 170 `#if sub-flag`) had no gate protecting them from drift.

The new gate **caught two pre-existing `-Werror=unused-parameter` bugs** at `PTO2_PROFILING=0`, fixed here in the same commit:

| Site | Param | Used only inside |
| --- | --- | --- |
| `src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp:242` (`try_dispatch_task`) | `Runtime &runtime` | `#if PTO2_PROFILING` |
| `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp:70` (`complete_slot_task`) | `PTO2SubtaskSlot subslot` | `#if PTO2_PROFILING` |

Both fixed with `[[maybe_unused]]` (already used in the codebase, see `orchestration/pto_orchestration_api.h:395-396`). No signature change, no behavior change.

## CI matrix

The matrix walks the macro hierarchy explicitly so a failing leg attributes the specific gate:

```text
PTO2_PROFILING (default=1, covered by every other CI job)
├── pto2-off:         -DPTO2_PROFILING=0
├── orch:             -DPTO2_ORCH_PROFILING=1
│   └── orch-tensormap:  + -DPTO2_TENSORMAP_PROFILING=1
├── sched:            -DPTO2_SCHED_PROFILING=1
└── all-on:           -DPTO2_ORCH_PROFILING=1 -DPTO2_SCHED_PROFILING=1 -DPTO2_TENSORMAP_PROFILING=1
```

× `a2a3sim` + `a5sim` = **10 matrix legs**. Each rebuilds the sim runtime with its `CXXFLAGS` and runs the smallest full-pipeline example (`examples/<arch>/tensormap_and_ringbuffer/vector_example/`) — exercises orchestrator + scheduler + AICore dispatch + completion paths.

`simpler_setup/toolchain.py:65-73` plumbs `CXX` env-var flags through cmake's `CMAKE_CXX_FLAGS` via `shlex.split`, so `CXX="g++ -DPTO2_..."` does the right thing without any code changes.

## Local verification

For each of the 10 combos:

- All builds clean. All pytest smokes pass in ~5s each.
- For sub-flag combos, `compile_commands.json` contains *only* the declared `-D` flags, `libaicpu_kernel.so` contains *only* the matching profiling log strings, and `pytest -s` output emits *only* the corresponding profiling block. No cross-contamination from cmake cache.
- For `pto2-off`, all profiling-on log strings (`Scheduler Phase Breakdown`, `Orchestrator Profiling`, `TensorMap Lookup Stats`, `sched_start`, `orch_start`, `Scheduler summary`) are absent from the `.so` — confirming the disabled code path is what got compiled.

Doc updated at `src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md` with the 5-combo matrix table.

## Out of scope

- `ENABLE_PROFILING` macro in paged-attention orch test/example code (separate audit item).