### PR TITLE
Add: tiered --enable-l2-swimlane perf_level (0-4) for L2 swimlane

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -138,9 +138,13 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--enable-l2-swimlane",
-        action="store_true",
-        default=False,
-        help="Enable perf swimlane collection (first round only)",
+        nargs="?",
+        const=4,
+        default=0,
+        type=int,
+        metavar="PERF_LEVEL",
+        help="Enable L2 swimlane. Bare flag=level 4 (full). "
+        "1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases",
     )
     parser.addoption("--dump-tensor", action="store_true", default=False, help="Dump per-task tensor I/O at runtime")
     parser.addoption(
@@ -522,7 +526,7 @@ def pytest_collection_modifyitems(session, config, items):  # noqa: PLR0912
     # that all write l2_perf_records_<ts>.json to the same directory with
     # second-precision timestamps, so they trample each other. Block the
     # combination up front; waiting for a proper device-id-in-filename fix.
-    if config.getoption("--enable-l2-swimlane", default=False):
+    if config.getoption("--enable-l2-swimlane", default=0):
         l3_items = [
             i
             for i in items

--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -50,21 +50,55 @@ python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-l2-swimlane
 
 ### 3.1 Enable L2 swimlane
 
-```bash
-# Standalone runner
-python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-l2-swimlane
-python tests/st/<case>/test_<name>.py -p a5sim --enable-l2-swimlane
+`--enable-l2-swimlane` accepts an optional integer **perf_level**
+(0–4). A bare flag defaults to level 4 (full collection,
+backward-compatible with the old boolean behavior).
 
-# pytest
-pytest tests/st/<case> --platform a2a3 -d 0 --enable-l2-swimlane
-pytest examples/a5/host_build_graph/vector_example --platform a5sim --enable-l2-swimlane
+| Level | Collects | Notes |
+| ----- | -------- | ----- |
+| 0 | Nothing (disabled) | Default when flag is absent |
+| 1 | AICore timing only (start/end/task_id/func_id/core_type) | No AICPU timestamps, no fanout |
+| 2 | + dispatch_time, finish_time, fanout | Full per-task record |
+| 3 | + Scheduler phases (`SCHED_*`) | Skips orchestrator phases |
+| 4 | + Orchestrator phases | Full collection |
+
+> **Platform scope.** The tiered perf_level is currently
+> implemented on **a2a3 only**. The a5 backend (both `a5` onboard
+> and `a5sim`) has not been updated and still interprets
+> `--enable-l2-swimlane` as a plain boolean: bare flag = on,
+> absent = off. Passing an integer to a5 is silently treated as
+> "on" regardless of value.
+
+```bash
+# Standalone runner — full collection (level 4)
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-l2-swimlane
+
+# Standalone runner — AICore timing only (level 1)
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-l2-swimlane 1
+
+# Standalone runner — per-task with dispatch/fanout (level 2)
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-l2-swimlane 2
+
+# pytest — scheduler phases (level 3)
+pytest tests/st/<case> --platform a2a3 -d 0 --enable-l2-swimlane 3
+
+# a5 onboard / a5sim — boolean only (perf_level integer not honored on a5 yet)
+python tests/st/<case>/test_<name>.py -p a5 -d 0 --enable-l2-swimlane
+python tests/st/<case>/test_<name>.py -p a5sim --enable-l2-swimlane
 ```
 
-The flag flips `CallConfig::enable_l2_swimlane`. The host then
-allocates the per-core / per-thread shared region and publishes
-its base address through `kernel_args.l2_perf_data_base`. AICore
-writes timing into per-task WIP slots; AICPU commits the records
-on FIN and emits its own per-iteration phase records.
+The flag sets `CallConfig::enable_l2_swimlane` to the chosen
+level. The host then allocates the per-core / per-thread shared
+region and publishes its base address through
+`kernel_args.l2_perf_data_base`. AICore writes timing into
+per-task WIP slots; AICPU commits the records on FIN. Per-task
+dispatch/finish timestamps and fanout are recorded only at
+level >= 2, scheduler phase records only at level >= 3, and
+orchestrator phase records only at level >= 4.
+
+The JSON output `"version"` field directly reflects the
+perf_level: `1` = AICore timing only, `2` = +dispatch/fanout,
+`3` = +scheduler phases, `4` = +orchestrator phases.
 
 `--rounds > 1` collects only on the **first** round so warm-up
 runs are not double-counted.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,7 +109,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--case SEL` | | (all) | Case selector, repeatable: `Foo`, `ClassA::Foo`, `ClassA::` |
 | `--manual` | | `exclude` | `exclude`/`include`/`only` for manual cases |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
-| `--enable-l2-swimlane` | | false | Enable L2 swimlane collection on first round only. Each test case gets its own `outputs/<case>_<ts>/` directory under which `l2_perf_records.json` lands; parallel runs never collide. |
+| `--enable-l2-swimlane [PERF_LEVEL]` | | `0` | Enable L2 swimlane collection on first round only. On a2a3 the flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md#31-enable-l2-swimlane) for the level table. On a5 (both `a5` onboard and `a5sim`) the perf_level integer is not honored yet — the flag is treated as boolean (bare = on). Each test case gets its own `outputs/<case>_<ts>/` directory under which `l2_perf_records.json` lands; parallel runs never collide. |
 | `--dump-tensor` | | false | Dump per-task tensor I/O during runtime execution |
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--build` | | false | Compile runtime from source (not pre-built) |

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -578,8 +578,6 @@ NB_MODULE(_task_interface, m) {
         });
 
     // --- CallConfig ---
-    // The two enable_* fields are stored as int32 on the wire (see call_config.h).
-    // Expose them as Python `bool` via def_property so user-facing API is unchanged.
     nb::class_<CallConfig>(m, "CallConfig")
         .def(nb::init<>())
         .def_rw("block_dim", &CallConfig::block_dim)
@@ -587,10 +585,18 @@ NB_MODULE(_task_interface, m) {
         .def_prop_rw(
             "enable_l2_swimlane",
             [](const CallConfig &c) {
-                return static_cast<bool>(c.enable_l2_swimlane);
+                return c.enable_l2_swimlane;
             },
-            [](CallConfig &c, bool v) {
-                c.enable_l2_swimlane = v ? 1 : 0;
+            // Accept either an int perf_level (0-4) or a Python bool. `True` maps to
+            // level 4 (full collection) to preserve the pre-perf_level semantics for
+            // callers that still pass a boolean; `False` maps to 0.
+            [](CallConfig &c, nb::object v) {
+                if (PyBool_Check(v.ptr())) {
+                    c.enable_l2_swimlane = nb::cast<bool>(v) ? 4 : 0;
+                } else {
+                    int level = nb::cast<int>(v);
+                    c.enable_l2_swimlane = (level < 0) ? 0 : (level > 4) ? 4 : level;
+                }
             }
         )
         .def_prop_rw(
@@ -631,7 +637,7 @@ NB_MODULE(_task_interface, m) {
         .def("__repr__", [](const CallConfig &self) -> std::string {
             std::ostringstream os;
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
-               << ", enable_l2_swimlane=" << (self.enable_l2_swimlane ? "True" : "False")
+               << ", enable_l2_swimlane=" << self.enable_l2_swimlane
                << ", enable_dump_tensor=" << (self.enable_dump_tensor ? "True" : "False")
                << ", enable_pmu=" << self.enable_pmu << ", enable_dep_gen=" << (self.enable_dep_gen ? "True" : "False");
             if (self.output_prefix_set()) {

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -579,7 +579,7 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     cfg = CallConfig()
     cfg.block_dim = block_dim
     cfg.aicpu_thread_num = aicpu_tn
-    cfg.enable_l2_swimlane = bool(swl)
+    cfg.enable_l2_swimlane = swl
     cfg.enable_dump_tensor = bool(dt)
     cfg.enable_pmu = pmu
     cfg.enable_dep_gen = bool(dep_gen)

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -784,7 +784,7 @@ class SceneTestCase:
     def _build_config(
         self,
         config_dict,
-        enable_l2_swimlane=False,
+        enable_l2_swimlane=0,
         enable_dump_tensor=False,
         enable_pmu=0,
         enable_dep_gen=False,
@@ -832,7 +832,7 @@ class SceneTestCase:
         sub_ids=None,
         rounds=1,
         skip_golden=False,
-        enable_l2_swimlane=False,
+        enable_l2_swimlane=0,
         enable_dump_tensor=False,
         enable_pmu=0,
         enable_dep_gen=False,
@@ -873,7 +873,7 @@ class SceneTestCase:
         case,
         rounds=1,
         skip_golden=False,
-        enable_l2_swimlane=False,
+        enable_l2_swimlane=0,
         enable_dump_tensor=False,
         enable_pmu=0,
         enable_dep_gen=False,
@@ -916,7 +916,7 @@ class SceneTestCase:
 
             config = self._build_config(
                 config_dict,
-                enable_l2_swimlane=(enable_l2_swimlane and round_idx == 0),
+                enable_l2_swimlane=(enable_l2_swimlane if round_idx == 0 else 0),
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=(enable_dep_gen and round_idx == 0),
@@ -937,7 +937,7 @@ class SceneTestCase:
         case,
         rounds=1,
         skip_golden=False,
-        enable_l2_swimlane=False,
+        enable_l2_swimlane=0,
         enable_dump_tensor=False,
         enable_pmu=0,
         enable_dep_gen=False,
@@ -988,7 +988,7 @@ class SceneTestCase:
 
             config = self._build_config(
                 config_dict,
-                enable_l2_swimlane=(enable_l2_swimlane and round_idx == 0),
+                enable_l2_swimlane=(enable_l2_swimlane if round_idx == 0 else 0),
                 enable_dump_tensor=enable_dump_tensor,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=(enable_dep_gen and round_idx == 0),
@@ -1034,14 +1034,14 @@ class SceneTestCase:
         manual_mode = request.config.getoption("--manual", default="exclude")
         rounds = request.config.getoption("--rounds", default=1)
         skip_golden = request.config.getoption("--skip-golden", default=False)
-        enable_l2_swimlane = request.config.getoption("--enable-l2-swimlane", default=False)
+        enable_l2_swimlane = request.config.getoption("--enable-l2-swimlane", default=0)
         enable_dump_tensor = request.config.getoption("--dump-tensor", default=False)
         enable_pmu = request.config.getoption("--enable-pmu", default=0)
         enable_dep_gen = self._effective_enable_dep_gen(request, warn=True)
         if rounds > 1:
             if enable_l2_swimlane:
                 logger.warning("Profiling disabled: --rounds > 1")
-                enable_l2_swimlane = False
+                enable_l2_swimlane = 0
             if enable_dump_tensor:
                 logger.warning("Dump tensor disabled: --rounds > 1")
                 enable_dump_tensor = False
@@ -1130,7 +1130,14 @@ class SceneTestCase:
         parser.add_argument("--rounds", type=int, default=1, help="Run each case N times (default: 1)")
         parser.add_argument("--skip-golden", action="store_true", help="Skip golden comparison (benchmark mode)")
         parser.add_argument(
-            "--enable-l2-swimlane", action="store_true", help="Enable perf swimlane collection (first round only)"
+            "--enable-l2-swimlane",
+            nargs="?",
+            const=4,
+            default=0,
+            type=int,
+            metavar="PERF_LEVEL",
+            help="Enable L2 swimlane. Bare flag=level 4 (full). "
+            "1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases",
         )
         parser.add_argument("--dump-tensor", action="store_true", help="Dump per-task tensor I/O at runtime")
         parser.add_argument(
@@ -1205,7 +1212,7 @@ class SceneTestCase:
 
         if args.rounds > 1 and args.enable_l2_swimlane:
             logger.warning("Profiling disabled: --rounds > 1")
-            args.enable_l2_swimlane = False
+            args.enable_l2_swimlane = 0
         if args.rounds > 1 and args.enable_dep_gen:
             logger.warning("dep_gen disabled: --rounds > 1")
             args.enable_dep_gen = False
@@ -1372,7 +1379,7 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
     if args.skip_golden:
         common.append("--skip-golden")
     if args.enable_l2_swimlane:
-        common.append("--enable-l2-swimlane")
+        common += ["--enable-l2-swimlane", str(args.enable_l2_swimlane)]
     if args.dump_tensor:
         common.append("--dump-tensor")
     if args.enable_dep_gen:

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -109,8 +109,8 @@ def read_perf_data(filepath):
             raise ValueError(f"Missing required field: {field}")
 
     # Validate version
-    if data["version"] not in [1, 2]:
-        raise ValueError(f"Unsupported version: {data['version']} (expected 1 or 2)")
+    if data["version"] not in [1, 2, 3, 4]:
+        raise ValueError(f"Unsupported version: {data['version']} (expected 1, 2, 3, or 4)")
 
     return data
 

--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -30,13 +30,26 @@
 
 /**
  * L2 perf handshake setters — called by the host (sim) or the AICPU kernel
- * entry (onboard) before `l2_perf_aicpu_init()` so AICPU code can
- * read perf state without reaching into the generic `Runtime` struct.
+ * entry (onboard) before `l2_perf_aicpu_init()` so AICPU code can read perf
+ * state without reaching into the generic `Runtime` struct.
+ *
+ * Two-channel level transport (mirrors the PMU pattern):
+ *   - binary on/off — `enable_profiling_flag` bit1 → `set_l2_swimlane_enabled(bool)`
+ *     at kernel entry; queried via `is_l2_swimlane_enabled()`.
+ *   - granular L2PerfLevel — `L2PerfDataHeader::l2_perf_level`
+ *     (shared memory); read in `l2_perf_aicpu_init` and cached, then queried
+ *     via `get_l2_perf_level()` for
+ *     `>= AICPU_TIMING / SCHED_PHASES / ORCH_PHASES` gates.
  */
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base);
 extern "C" uint64_t get_platform_l2_perf_base();
 extern "C" void set_l2_swimlane_enabled(bool enable);
 extern "C" bool is_l2_swimlane_enabled();
+
+// Typed getter for the granular perf_level (promoted from the shared-memory
+// header inside l2_perf_aicpu_init). Gate sites should use this so the
+// comparison RHS is a named L2PerfLevel constant.
+L2PerfLevel get_l2_perf_level();
 
 /**
  * Initialize performance profiling

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -66,6 +66,28 @@
 #endif
 
 // =============================================================================
+// L2 perf_level — granularity ladder for the L2 swimlane profiler.
+//
+// Each level is a strict superset of the previous: higher levels add the data
+// described by their name on top of all lower-level data. Naming describes
+// what is NEWLY captured at that level (incremental view), so gate sites read
+// naturally — e.g. `if (level >= SCHED_PHASES)` means "this section runs when
+// scheduler phase records are being collected (or any higher tier)".
+//
+// Transported via `L2PerfDataHeader::l2_perf_level` (host → AICPU,
+// shared memory) and `CallConfig::enable_l2_swimlane` (Python → C). The wire
+// representation stays integer (uint32_t / int32_t) for ABI stability; this
+// enum is the canonical in-code type used for comparisons.
+// =============================================================================
+enum class L2PerfLevel : uint32_t {
+    DISABLED = 0,       // No collection at all
+    AICORE_TIMING = 1,  // AICore per-task start/end timestamps + task record buffer
+    AICPU_TIMING = 2,   // + AICPU dispatch/finish timestamps + fanout dependency list
+    SCHED_PHASES = 3,   // + scheduler main-loop phase records (SCHED_COMPLETE/DISPATCH/IDLE_WAIT)
+    ORCH_PHASES = 4,    // + orchestrator phase records
+};
+
+// =============================================================================
 // L2PerfRecord - Single Task Execution Record
 // =============================================================================
 
@@ -274,7 +296,10 @@ struct L2PerfDataHeader {
     volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // Producer write positions (AICPU modifies)
 
     // Metadata (Host initializes, Device read-only)
-    uint32_t num_cores;  // Actual number of cores launched
+    uint32_t num_cores;      // Actual number of cores launched
+    uint32_t l2_perf_level;  // 0=off, 1=AICore timing, 2=+dispatch/fanout,
+                             // 3=+sched phases, 4=+orch phases. Host writes
+                             // at init; AICPU reads in l2_perf_aicpu_init.
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a2a3/platform/include/host/l2_perf_collector.h
+++ b/src/a2a3/platform/include/host/l2_perf_collector.h
@@ -244,21 +244,32 @@ public:
      * BufferStates), pre-allocates initial L2PerfBuffers and PhaseBuffers,
      * and seeds the per-pool free_queues + the framework's recycled pools.
      *
-     * @param num_aicore     Number of AICore instances
-     * @param device_id      Device ID (forwarded to register_cb)
-     * @param alloc_cb       Device memory allocation callback
-     * @param register_cb    Memory registration callback (nullptr for simulation)
-     * @param free_cb        Device memory free callback
-     * @param user_data      Opaque pointer forwarded to callbacks
-     * @param output_prefix  Per-task directory; l2_perf_records.json lands here.
-     *                       Stored on the collector and consumed by
-     *                       export_swimlane_json(). Required (non-empty);
-     *                       CallConfig::validate() enforces this upstream.
+     * @param num_aicore               Number of AICore instances
+     * @param device_id                Device ID (forwarded to register_cb)
+     * @param l2_perf_level   Collection granularity (DISABLED / AICORE_TIMING
+     *                                 / AICPU_TIMING / SCHED_PHASES / ORCH_PHASES).
+     *                                 Written into
+     *                                 `L2PerfDataHeader::l2_perf_level`
+     *                                 so AICPU can promote it in
+     *                                 `l2_perf_aicpu_init`, AND cached on the
+     *                                 collector so `export_swimlane_json()`
+     *                                 can gate phase sections and stamp the
+     *                                 JSON `version`.
+     * @param alloc_cb                 Device memory allocation callback
+     * @param register_cb              Memory registration callback (nullptr for
+     *                                 simulation)
+     * @param free_cb                  Device memory free callback
+     * @param user_data                Opaque pointer forwarded to callbacks
+     * @param output_prefix            Per-task directory; l2_perf_records.json
+     *                                 lands here. Required (non-empty);
+     *                                 CallConfig::validate() enforces this
+     *                                 upstream.
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
-        L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
+        int num_aicore, int device_id, L2PerfLevel l2_perf_level, L2PerfAllocCallback alloc_cb,
+        L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, void *user_data,
+        const std::string &output_prefix
     );
 
     /**
@@ -348,6 +359,7 @@ private:
     void *aicore_ring_addr_table_dev_{nullptr};
 
     int num_aicore_{0};
+    L2PerfLevel l2_perf_level_{L2PerfLevel::DISABLED};
 
     // Per-task output directory captured at initialize() time. Consumed by
     // export_swimlane_json() to build <prefix>/l2_perf_records.json.

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -1259,7 +1259,7 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
     };
 
     int rc = l2_perf_collector_.initialize(
-        num_aicore, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, output_prefix_
+        num_aicore, device_id, l2_perf_level_, alloc_cb, register_cb, free_cb, &mem_alloc_, output_prefix_
     );
     if (rc != 0) {
         return rc;

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -278,7 +278,10 @@ public:
      * corresponding `enable_*_` members directly. Moved off the generic
      * Runtime struct / run() arg list so all three travel the same way.
      */
-    void set_l2_swimlane_enabled(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_l2_swimlane_enabled(int level) {
+        l2_perf_level_ = static_cast<L2PerfLevel>(level);
+        enable_l2_swimlane_ = (l2_perf_level_ != L2PerfLevel::DISABLED);
+    }
     void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
     void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
@@ -749,6 +752,7 @@ private:
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
     bool enable_dep_gen_{false};
+    L2PerfLevel l2_perf_level_{L2PerfLevel::DISABLED};             // resolved from set_l2_swimlane_enabled()
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                  // diagnostic artifact root directory
 };

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -352,7 +352,7 @@ int run_prepared(
             return rc;
         }
 
-        runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
+        runner->set_l2_swimlane_enabled(enable_l2_swimlane);
         runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
         runner->set_pmu_enabled(enable_pmu);
         runner->set_dep_gen_enabled(enable_dep_gen != 0);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -1067,8 +1067,9 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
     };
 
     // Simulation: dev pointer is directly host-accessible, no register pass-through.
-    int rc =
-        l2_perf_collector_.initialize(num_aicore, device_id, alloc_cb, nullptr, free_cb, &mem_alloc_, output_prefix_);
+    int rc = l2_perf_collector_.initialize(
+        num_aicore, device_id, l2_perf_level_, alloc_cb, nullptr, free_cb, &mem_alloc_, output_prefix_
+    );
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -158,7 +158,10 @@ public:
      * corresponding `enable_*_` members directly. Moved off the generic
      * Runtime struct / run() arg list so all three travel the same way.
      */
-    void set_l2_swimlane_enabled(bool enable) { enable_l2_swimlane_ = enable; }
+    void set_l2_swimlane_enabled(int level) {
+        l2_perf_level_ = static_cast<L2PerfLevel>(level);
+        enable_l2_swimlane_ = (l2_perf_level_ != L2PerfLevel::DISABLED);
+    }
     void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
     void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
@@ -377,6 +380,7 @@ private:
     bool enable_dump_tensor_{false};
     bool enable_pmu_{false};
     bool enable_dep_gen_{false};
+    L2PerfLevel l2_perf_level_{L2PerfLevel::DISABLED};             // resolved from set_l2_swimlane_enabled()
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};  // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                  // diagnostic artifact root directory
 };

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -314,7 +314,7 @@ int run_prepared(
             return rc;
         }
 
-        runner->set_l2_swimlane_enabled(enable_l2_swimlane != 0);
+        runner->set_l2_swimlane_enabled(enable_l2_swimlane);
         runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
         runner->set_pmu_enabled(enable_pmu);
         runner->set_dep_gen_enabled(enable_dep_gen != 0);

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -52,14 +52,21 @@ static int s_orch_thread_idx = -1;
 // L2 perf platform state. Published by the host (via dlsym'd setters on sim)
 // or by the AICPU kernel entry (onboard) before perf init runs, so downstream
 // perf code can discover enablement + device-base without reading the generic
-// Runtime struct.
+// Runtime struct. Two channels (mirrors PMU):
+//   - g_enable_l2_swimlane (bool) — set at kernel entry from the bitmask bit
+//   - g_l2_perf_level (L2PerfLevel) — promoted in
+//     l2_perf_aicpu_init from the shared-memory header so
+//     `>= AICPU_TIMING / SCHED_PHASES / ORCH_PHASES` gates have the granular
+//     value (exposed via get_l2_perf_level()).
 static uint64_t g_platform_l2_perf_base = 0;
 static bool g_enable_l2_swimlane = false;
+static L2PerfLevel g_l2_perf_level = L2PerfLevel::DISABLED;
 
 extern "C" void set_platform_l2_perf_base(uint64_t l2_perf_data_base) { g_platform_l2_perf_base = l2_perf_data_base; }
 extern "C" uint64_t get_platform_l2_perf_base() { return g_platform_l2_perf_base; }
 extern "C" void set_l2_swimlane_enabled(bool enable) { g_enable_l2_swimlane = enable; }
 extern "C" bool is_l2_swimlane_enabled() { return g_enable_l2_swimlane; }
+L2PerfLevel get_l2_perf_level() { return g_l2_perf_level; }
 
 /**
  * Enqueue ready buffer to per-thread queue
@@ -104,7 +111,15 @@ void l2_perf_aicpu_init(int worker_count) {
 
     s_l2_perf_header = get_l2_perf_header(l2_perf_base);
 
-    LOG_INFO_V0("Initializing performance profiling for %d cores (free queue)", worker_count);
+    // Read the granular perf_level from the shared-memory header (host wrote
+    // it in L2PerfCollector::initialize). The kernel-entry setter only seeded
+    // the binary g_enable_l2_swimlane via the bitmask bit.
+    g_l2_perf_level = static_cast<L2PerfLevel>(s_l2_perf_header->l2_perf_level);
+
+    LOG_INFO_V0(
+        "Initializing performance profiling for %d cores (free queue), l2_perf_level=%u", worker_count,
+        static_cast<uint32_t>(g_l2_perf_level)
+    );
 
     // Pop first buffer from free_queue for each core
     for (int i = 0; i < worker_count; i++) {
@@ -272,16 +287,23 @@ int l2_perf_aicpu_complete_record(
     record->task_id = task_id;
     record->func_id = func_id;
     record->core_type = core_type;
-    record->dispatch_time = dispatch_time;
-    record->finish_time = finish_time;
 
-    if (fanout != nullptr && fanout_count > 0) {
-        int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
-        for (int32_t i = 0; i < n; i++) {
-            record->fanout[i] = fanout[i];
+    // AICPU_TIMING and above: dispatch/finish timing and fanout dependency info
+    if (g_l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+        record->dispatch_time = dispatch_time;
+        record->finish_time = finish_time;
+        if (fanout != nullptr && fanout_count > 0) {
+            int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
+            for (int32_t i = 0; i < n; i++) {
+                record->fanout[i] = fanout[i];
+            }
+            record->fanout_count = n;
+        } else {
+            record->fanout_count = 0;
         }
-        record->fanout_count = n;
     } else {
+        record->dispatch_time = 0;
+        record->finish_time = 0;
         record->fanout_count = 0;
     }
 

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -81,8 +81,8 @@ void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
 }
 
 int L2PerfCollector::initialize(
-    int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
-    L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
+    int num_aicore, int device_id, L2PerfLevel l2_perf_level, L2PerfAllocCallback alloc_cb,
+    L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("L2PerfCollector already initialized");
@@ -97,6 +97,7 @@ int L2PerfCollector::initialize(
     }
 
     num_aicore_ = num_aicore;
+    l2_perf_level_ = l2_perf_level;
     output_prefix_ = output_prefix;
     total_perf_collected_ = 0;
 
@@ -154,11 +155,13 @@ int L2PerfCollector::initialize(
     }
 
     header->num_cores = num_aicore;
+    header->l2_perf_level = static_cast<uint32_t>(l2_perf_level_);
 
     LOG_DEBUG("Initialized L2PerfDataHeader:");
-    LOG_DEBUG("  num_cores:        %d", header->num_cores);
-    LOG_DEBUG("  buffer_capacity:  %d", PLATFORM_PROF_BUFFER_SIZE);
-    LOG_DEBUG("  queue capacity:   %d", PLATFORM_PROF_READYQUEUE_SIZE);
+    LOG_DEBUG("  num_cores:              %d", header->num_cores);
+    LOG_DEBUG("  l2_perf_level: %u", header->l2_perf_level);
+    LOG_DEBUG("  buffer_capacity:        %d", PLATFORM_PROF_BUFFER_SIZE);
+    LOG_DEBUG("  queue capacity:         %d", PLATFORM_PROF_READYQUEUE_SIZE);
 
     // Step 5: Initialize L2PerfBufferStates — 1 buffer per core in free_queue, rest to recycled pool
     for (int i = 0; i < num_aicore; i++) {
@@ -590,7 +593,7 @@ int L2PerfCollector::export_swimlane_json() {
     }
 
     // Step 7: Write JSON data
-    int version = has_phase_data_ ? 2 : 1;
+    int version = static_cast<int>(l2_perf_level_);
     outfile << "{\n";
     outfile << "  \"version\": " << version << ",\n";
     outfile << "  \"tasks\": [\n";
@@ -638,8 +641,8 @@ int L2PerfCollector::export_swimlane_json() {
     }
     outfile << "  ]";
 
-    // Step 8: Write phase profiling data (version 2)
-    if (has_phase_data_) {
+    // Step 8: Write phase profiling data (level >= 3)
+    if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
         auto sched_phase_name = [](AicpuPhaseId id) -> const char * {
             switch (id) {
             case AicpuPhaseId::SCHED_COMPLETE:
@@ -716,16 +719,18 @@ int L2PerfCollector::export_swimlane_json() {
         // the run-window envelope is still visible in the device-side
         // LOG_INFO_V9 "Thread N: orch_start=… orch_end=… orch_cost=…" line.
 
-        // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
+        // Per-task orchestrator phase records (level >= 4, filtered from unified collected_phase_records_)
         bool has_orch_phases = false;
-        for (const auto &v : collected_phase_records_) {
-            for (const auto &r : v) {
-                if (!is_scheduler_phase(r.phase_id)) {
-                    has_orch_phases = true;
-                    break;
+        if (l2_perf_level_ >= L2PerfLevel::ORCH_PHASES) {
+            for (const auto &v : collected_phase_records_) {
+                for (const auto &r : v) {
+                    if (!is_scheduler_phase(r.phase_id)) {
+                        has_orch_phases = true;
+                        break;
+                    }
                 }
+                if (has_orch_phases) break;
             }
-            if (has_orch_phases) break;
         }
         if (has_orch_phases) {
             outfile << ",\n  \"aicpu_orchestrator_phases\": [\n";

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -252,7 +252,7 @@ inline bool AicpuExecutor::try_dispatch_task(
 
     // Profiling: record the real AICPU dispatch point for this core. Buffer
     // rotation is handled inside l2_perf_aicpu_complete_record.
-    if (l2_perf_enabled) {
+    if (l2_perf_enabled && get_l2_perf_level() >= L2PerfLevel::AICPU_TIMING) {
         dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
     }
 
@@ -675,6 +675,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
     int verification_warning_count = 0;
     const int MAX_VERIFICATION_WARNINGS = 10;
     bool l2_perf_enabled = is_l2_swimlane_enabled();
+    L2PerfLevel l2_perf_level = get_l2_perf_level();
     // PMU runs require single-issue dispatch — overlapping in-flight tasks
     // pollute per-task PMU counters. Cached at function scope:
     // is_pmu_enabled() is extern "C" and the compiler cannot hoist it
@@ -700,11 +701,13 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
         "Thread %d: Initial state - local queue: %d AIC, %d AIV", thread_idx, cur_aic_ready_count, cur_aiv_ready_count
     );
 
-    // Initialize dispatch timestamps for all cores
-    uint64_t dispatch_start_time = get_sys_cnt_aicpu();
-    for (int i = 0; i < core_num; i++) {
-        int core_id = cur_thread_cores[i];
-        dispatch_timestamps_[core_id] = dispatch_start_time;
+    // Initialize dispatch timestamps for all cores (only needed at level >= 2)
+    if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+        uint64_t dispatch_start_time = get_sys_cnt_aicpu();
+        for (int i = 0; i < core_num; i++) {
+            int core_id = cur_thread_cores[i];
+            dispatch_timestamps_[core_id] = dispatch_start_time;
+        }
     }
 
     // Main execution loop with unified scheduling
@@ -732,43 +735,55 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 // published to the ring slot first, so complete it BEFORE the
                 // pending task's record to maintain buffer ordering.
                 if (l2_perf_enabled) {
-                    uint64_t finish_ts = get_sys_cnt_aicpu();
+                    uint64_t finish_ts = (l2_perf_level >= L2PerfLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
 
                     if (prev_running_id != AICPU_TASK_INVALID) {
                         Task *prev_task = &runtime.tasks[prev_running_id];
                         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                        for (int i = 0; i < prev_task->fanout_count; i++) {
-                            fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                        int fanout_count = 0;
+                        if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                            for (int i = 0; i < prev_task->fanout_count; i++) {
+                                fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                            }
+                            fanout_count = prev_task->fanout_count;
                         }
                         if (l2_perf_aicpu_complete_record(
                                 core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
                             ) != 0) {
                             LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
                                 prev_running_id
                             );
                         }
-                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                        if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                            dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                        }
                     }
 
-                    finish_ts = get_sys_cnt_aicpu();
+                    finish_ts = (l2_perf_level >= L2PerfLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
                     Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                    for (int i = 0; i < task->fanout_count; i++) {
-                        fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
+                    int fanout_count = 0;
+                    if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                        for (int i = 0; i < task->fanout_count; i++) {
+                            fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
+                        }
+                        fanout_count = task->fanout_count;
                     }
                     if (l2_perf_aicpu_complete_record(
                             core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
                         ) != 0) {
                         LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
                         );
                     }
-                    dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    }
                 }
 
                 cur_thread_completed++;
@@ -820,7 +835,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 made_progress = true;
 
                 // Update timestamp if didn't dispatch (try_dispatch_task updates it if dispatched)
-                if (!dispatched && l2_perf_enabled) {
+                if (!dispatched && l2_perf_enabled && l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
             } else if (reg_task_id == pending_task_ids_[core_id] && reg_state == TASK_ACK_STATE) {
@@ -843,23 +858,29 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (prev_running_id != AICPU_TASK_INVALID) {
                     // Profiling: complete the implicit task's AICore record
                     if (l2_perf_enabled) {
-                        uint64_t finish_ts = get_sys_cnt_aicpu();
+                        uint64_t finish_ts = (l2_perf_level >= L2PerfLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
                         Task *prev_task = &runtime.tasks[prev_running_id];
                         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                        for (int i = 0; i < prev_task->fanout_count; i++) {
-                            fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                        int fanout_count = 0;
+                        if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                            for (int i = 0; i < prev_task->fanout_count; i++) {
+                                fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
+                            }
+                            fanout_count = prev_task->fanout_count;
                         }
                         if (l2_perf_aicpu_complete_record(
                                 core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, prev_task->fanout_count
+                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
                             ) != 0) {
                             LOG_ERROR(
                                 "Core %d: l2_perf_aicpu_complete_record failed for implicit task %d", core_id,
                                 prev_running_id
                             );
                         }
-                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                        if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                            dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                        }
                     }
 
                     cur_thread_completed++;
@@ -888,22 +909,28 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 int completed_task_id = running_task_ids_[core_id];
 
                 if (l2_perf_enabled) {
-                    uint64_t finish_ts = get_sys_cnt_aicpu();
+                    uint64_t finish_ts = (l2_perf_level >= L2PerfLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
                     Task *task = &runtime.tasks[completed_task_id];
                     uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                    for (int i = 0; i < task->fanout_count; i++) {
-                        fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
+                    int fanout_count = 0;
+                    if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                        for (int i = 0; i < task->fanout_count; i++) {
+                            fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
+                        }
+                        fanout_count = task->fanout_count;
                     }
                     if (l2_perf_aicpu_complete_record(
                             core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, task->fanout_count
+                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
                         ) != 0) {
                         LOG_ERROR(
                             "Core %d: l2_perf_aicpu_complete_record failed for task %d", core_id, completed_task_id
                         );
                     }
-                    dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    if (l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
+                        dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
+                    }
                 }
 
                 cur_thread_completed++;
@@ -935,7 +962,7 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 made_progress = true;
 
                 // Update timestamp if didn't dispatch (try_dispatch_task updates it if dispatched)
-                if (!dispatched && l2_perf_enabled) {
+                if (!dispatched && l2_perf_enabled && l2_perf_level >= L2PerfLevel::AICPU_TIMING) {
                     dispatch_timestamps_[core_id] = get_sys_cnt_aicpu();
                 }
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -483,7 +483,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 
 #if PTO2_PROFILING
-            rt->orchestrator.enable_l2_swimlane = is_l2_swimlane_enabled();
+            rt->orchestrator.l2_perf_level = get_l2_perf_level();
 #endif
 
             // Total core counts = aic_count_ / aiv_count_ (set once at runtime init).
@@ -505,7 +505,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             sched_ctx_.wait_pto2_init_complete();
 
 #if PTO2_PROFILING
-            if (is_l2_swimlane_enabled()) {
+            if (get_l2_perf_level() >= L2PerfLevel::ORCH_PHASES) {
                 l2_perf_aicpu_set_orch_thread_idx(thread_idx);
             }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -4,7 +4,7 @@ This document describes the profiling macro hierarchy and logging control in the
 
 ## Overview
 
-PTO Runtime2 uses a hierarchical profiling system with compile-time macros to control profiling code compilation and log output. The `enable_l2_swimlane` runtime flag controls data collection (performance buffers, shared memory writes) but does NOT control log output.
+PTO Runtime2 uses a hierarchical profiling system with compile-time macros to control profiling code compilation and log output. The `enable_l2_swimlane` runtime flag (integer perf_level 0–4) controls data collection granularity (performance buffers, shared memory writes) but does NOT control log output.
 
 ## Profiling Macro Hierarchy
 
@@ -13,7 +13,7 @@ PTO2_PROFILING (base level, default=1)
 ├── PTO2_ORCH_PROFILING (orchestrator, default=0, requires PTO2_PROFILING=1)
 |   └──PTO2_TENSORMAP_PROFILING (tensormap, default=0, requires PTO2_ORCH_PROFILING=1)
 ├── PTO2_SCHED_PROFILING (scheduler, default=0, requires PTO2_PROFILING=1)
-└── --enable-l2-swimlane (Dump profiling merged swimlane json file for visualization, requires PTO2_PROFILING=1)
+└── --enable-l2-swimlane [PERF_LEVEL] (L2 swimlane data collection, 0-4, bare=4, requires PTO2_PROFILING=1)
 
 ```
 
@@ -231,35 +231,74 @@ Thread X:   overlap checks : XXX, hits=XXX (XX.X%)
 
 ---
 
-## Runtime Flag: enable_l2_swimlane
+## Runtime Flag: enable_l2_swimlane (perf_level)
 
-L2 swimlane enablement is published through the
-`KernelArgs::enable_profiling_flag` bitmask (bit1 = `PROFILING_FLAG_L2_SWIMLANE`).
-AICPU code reads it via `is_l2_swimlane_enabled()` (set at launch time
-by the platform from `kernel_args.l2_perf_data_base` + the bitmask). It
-controls **data collection**, NOT log output.
+`--enable-l2-swimlane` accepts an integer perf_level (0–4). Transport
+mirrors the PMU pattern — two independent channels (one binary, one int):
 
-### When enable_l2_swimlane=true
+- **Binary on/off** — `KernelArgs::enable_profiling_flag` bit1
+  (`PROFILING_FLAG_L2_SWIMLANE`). Set by the host whenever level > 0; read
+  by AICore (which only needs on/off to decide whether to write timing) and
+  by AICPU kernel entry via `set_l2_swimlane_enabled(bool)`.
+- **Granular level (0–4)** — `L2PerfDataHeader::l2_perf_level`
+  (shared memory). Host writes it in `L2PerfCollector::initialize`; AICPU
+  promotes it from the header in `l2_perf_aicpu_init` and exposes it via
+  `get_l2_perf_level()` (typed `L2PerfLevel`) for
+  `>= AICPU_TIMING / SCHED_PHASES / ORCH_PHASES` gates.
 
-- Performance buffers are allocated and written
-- Per-task timing data is collected
-- Phase profiling data is recorded
-- Orchestrator summary is written to shared memory
+On sim, the binary on/off travels via the dlsym'd `set_l2_swimlane_enabled`
+entry point; the granular level still goes through the shared-memory
+header just like on onboard.
 
-### When enable_l2_swimlane=false
+| Level | Collects |
+| ----- | -------- |
+| 0 | Nothing (disabled) |
+| 1 | AICore timing only (start/end/task_id/func_id/core_type) |
+| 2 | + dispatch_time, finish_time, fanout |
+| 3 | + Scheduler phases (`SCHED_*`) |
+| 4 | + Orchestrator phases (full) |
+
+Bare `--enable-l2-swimlane` = level 4 (backward compatible).
+
+### Level gating in AICPU code
+
+Use the strongly-typed `L2PerfLevel` enum so each gate names the
+content it depends on instead of relying on magic numbers:
+
+```cpp
+// Any level > 0: AICPU task record buffer init / flush.
+// Cheap binary check, available immediately after kernel entry.
+if (is_l2_swimlane_enabled()) { ... }
+
+// AICPU dispatch/finish timestamps + fanout.
+// Granular checks below require l2_perf_aicpu_init to have already run
+// (so the level has been promoted from the shared-memory header).
+if (get_l2_perf_level() >= L2PerfLevel::AICPU_TIMING) { ... }
+
+// Scheduler main-loop phase records (SCHED_*)
+if (get_l2_perf_level() >= L2PerfLevel::SCHED_PHASES) { ... }
+
+// Orchestrator phase records
+if (get_l2_perf_level() >= L2PerfLevel::ORCH_PHASES) { ... }
+```
+
+`L2PerfLevel` is defined in `common/l2_perf_profiling.h` with
+underlying type `uint32_t` (matches the `L2PerfDataHeader::l2_perf_level`
+shared-memory field and mirrors `PmuEventType : uint32_t`):
+
+| Enumerator | Underlying value |
+| ---------- | ---------------- |
+| `DISABLED` | 0 |
+| `AICORE_TIMING` | 1 |
+| `AICPU_TIMING` | 2 |
+| `SCHED_PHASES` | 3 |
+| `ORCH_PHASES` | 4 |
+
+### When enable_l2_swimlane=0
 
 - No performance data collection
 - No shared memory writes
 - Logs still print (controlled by macros only)
-
-### Usage
-
-```cpp
-// AICPU path — read enablement from the platform accessor, not the Runtime struct.
-if (is_l2_swimlane_enabled()) {
-    // ... perf-collection code ...
-}
-```
 
 ---
 
@@ -383,7 +422,7 @@ add_definitions(-DPTO2_ORCH_PROFILING=1)
 ### Runtime overhead
 
 - Logging: Negligible (device logs are asynchronous)
-- Data collection (`enable_l2_swimlane=true`): Low to moderate
+- Data collection (`enable_l2_swimlane>0`): Low to moderate
   - Performance buffer writes
   - Shared memory updates
   - Per-task timing measurements

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -115,8 +115,8 @@ __attribute__((weak, visibility("hidden"))) void
 l2_perf_aicpu_record_orch_phase(AicpuPhaseId, uint64_t, uint64_t, uint32_t, uint64_t) {}
 // submit_idx needed for swimlane task_id tagging (no cycle accumulation at this level)
 static uint32_t g_orch_submit_idx = 0;
-#define CYCLE_COUNT_START()                       \
-    bool _prof_active = orch->enable_l2_swimlane; \
+#define CYCLE_COUNT_START()                                                \
+    bool _prof_active = (orch->l2_perf_level >= L2PerfLevel::ORCH_PHASES); \
     uint64_t _t0 = _prof_active ? get_sys_cnt_aicpu() : 0, _t1 = 0
 #define CYCLE_COUNT_LAP(acc) \
     do {                     \

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -28,6 +28,7 @@
 #ifndef PTO_ORCHESTRATOR_H
 #define PTO_ORCHESTRATOR_H
 
+#include "common/l2_perf_profiling.h"
 #include "pto_ring_buffer.h"
 #include "pto_runtime2_types.h"
 #include "pto_submit_types.h"
@@ -76,8 +77,8 @@ struct PTO2OrchestratorState {
     int32_t total_cluster_count{0};  // AIC cores = MIX clusters
     int32_t total_aiv_count{0};      // AIV cores (= 2 × clusters on standard hardware)
 #if PTO2_PROFILING
-    // Runtime profiling switch copied from Runtime::enable_l2_swimlane.
-    bool enable_l2_swimlane;
+    // L2 perf_level copied from get_l2_perf_level().
+    L2PerfLevel l2_perf_level{L2PerfLevel::DISABLED};
 #endif
 
     // === GM HEAP (for output buffers) ===

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -806,10 +806,16 @@ int32_t SchedulerContext::init(
     regs_ = regs_base;
 
 #if PTO2_PROFILING
+    // l2_perf_aicpu_init promotes g_l2_perf_level from the shared-memory
+    // header — must be called BEFORE caching the level, otherwise the cached
+    // value would still be 0 (only the binary enable bit has been seeded by
+    // kernel.cpp at this point).
     if (is_l2_swimlane_enabled()) {
         l2_perf_aicpu_init(runtime->worker_count);
-        l2_perf_aicpu_init_phase(runtime->worker_count, sched_thread_num_);
-        l2_perf_aicpu_set_orch_thread_idx(sched_thread_num_);
+        l2_perf_level_ = get_l2_perf_level();
+        if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
+            l2_perf_aicpu_init_phase(runtime->worker_count, sched_thread_num_);
+        }
     }
 #endif
 
@@ -933,7 +939,7 @@ void SchedulerContext::on_orchestration_done(
     Runtime *runtime, PTO2Runtime *rt, int32_t thread_idx, int32_t total_tasks
 ) {
 #if PTO2_PROFILING
-    if (is_l2_swimlane_enabled()) {
+    if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
         // Flush orchestrator's phase record buffer
         l2_perf_aicpu_flush_phase_buffers(thread_idx);
     }
@@ -988,7 +994,7 @@ void SchedulerContext::on_orchestration_done(
     // Write core-to-thread mapping AFTER reassignment so the profiling data
     // reflects the final distribution (all active_sched_threads_, including
     // former orchestrator threads when orch_to_sched_ is enabled).
-    if (is_l2_swimlane_enabled()) {
+    if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
         l2_perf_aicpu_init_core_assignments(cores_total_num_);
         for (int32_t t = 0; t < active_sched_threads_; t++) {
             l2_perf_aicpu_write_core_assignments_for_thread(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -154,14 +154,17 @@ void SchedulerContext::complete_slot_task(
 #if PTO2_SCHED_PROFILING
         uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
-        uint64_t finish_ts = get_sys_cnt_aicpu();
-
+        uint64_t finish_ts = 0;
         uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
         int32_t fanout_n = 0;
-        PTO2DepListEntry *cur = slot_state.fanout_head;
-        while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
-            fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
-            cur = cur->next;
+
+        if (l2_perf_level_ >= L2PerfLevel::AICPU_TIMING) {
+            finish_ts = get_sys_cnt_aicpu();
+            PTO2DepListEntry *cur = slot_state.fanout_head;
+            while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
+                fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
+                cur = cur->next;
+            }
         }
 
         int32_t perf_slot_idx = static_cast<int32_t>(subslot);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -11,6 +11,7 @@
 #ifndef SCHEDULER_CONTEXT_H
 #define SCHEDULER_CONTEXT_H
 
+#include "common/l2_perf_profiling.h"
 #include "common/unified_log.h"
 #include "scheduler_types.h"
 
@@ -135,6 +136,9 @@ private:
 
 #if PTO2_PROFILING
     SchedL2PerfCounters sched_l2_perf_[MAX_AICPU_THREADS];
+    // Cached once at init() from get_l2_perf_level(), AFTER
+    // l2_perf_aicpu_init has promoted the level from the shared-memory header.
+    L2PerfLevel l2_perf_level_{L2PerfLevel::DISABLED};
 #endif
 
     // --- Task-execution tracking ---

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -126,9 +126,6 @@ void SchedulerContext::dispatch_subtask_to_core(
 ) {
     CoreTracker &tracker = core_trackers_[thread_idx];
     auto core_id = tracker.get_core_id_by_offset(core_offset);
-#if PTO2_PROFILING
-    auto &l2_perf = sched_l2_perf_[thread_idx];
-#endif
     CoreExecState &core_exec_state = core_exec_states_[core_id];
     core_exec_state.dispatch_seq++;
     uint32_t reg_task_id = core_exec_state.dispatch_seq & TASK_ID_MASK;
@@ -153,7 +150,7 @@ void SchedulerContext::dispatch_subtask_to_core(
         core_exec_state.pending_slot_state = &slot_state;
         core_exec_state.pending_reg_task_id = static_cast<int32_t>(reg_task_id);
 #if PTO2_PROFILING
-        if (l2_perf.l2_perf_enabled) {
+        if (l2_perf_level_ >= L2PerfLevel::AICPU_TIMING) {
             core_exec_state.pending_dispatch_timestamp = get_sys_cnt_aicpu();
         }
 #endif
@@ -162,7 +159,7 @@ void SchedulerContext::dispatch_subtask_to_core(
         core_exec_state.running_slot_state = &slot_state;
         core_exec_state.running_reg_task_id = static_cast<int32_t>(reg_task_id);
 #if PTO2_PROFILING
-        if (l2_perf.l2_perf_enabled) {
+        if (l2_perf_level_ >= L2PerfLevel::AICPU_TIMING) {
             core_exec_state.running_dispatch_timestamp = get_sys_cnt_aicpu();
         }
 #endif
@@ -368,7 +365,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #if PTO2_PROFILING
     auto &l2_perf = sched_l2_perf_[thread_idx];
     l2_perf.reset();
-    l2_perf.l2_perf_enabled = is_l2_swimlane_enabled();
+    l2_perf.l2_perf_enabled = (l2_perf_level_ != L2PerfLevel::DISABLED);
 #endif
 
     constexpr int LOCAL_READY_CAP_PER_TYPE = 64;
@@ -479,7 +476,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             CYCLE_COUNT_LAP(l2_perf.sched_idle_cycle);
         } else {
             CYCLE_COUNT_LAP(l2_perf.sched_complete_cycle);
-            if (l2_perf.l2_perf_enabled && l2_perf.phase_complete_count > 0) {
+            if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES && l2_perf.phase_complete_count > 0) {
                 l2_perf_aicpu_record_phase(
                     thread_idx, AicpuPhaseId::SCHED_COMPLETE, _t0_phase, _t1, l2_perf.sched_loop_count,
                     l2_perf.phase_complete_count
@@ -587,7 +584,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             CYCLE_COUNT_LAP(l2_perf.sched_idle_cycle);
         } else {
             CYCLE_COUNT_LAP(l2_perf.sched_dispatch_cycle);
-            if (l2_perf.l2_perf_enabled && l2_perf.phase_dispatch_count > 0) {
+            if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES && l2_perf.phase_dispatch_count > 0) {
                 // Per-emit pop deltas via snapshot diff; the cumulative
                 // pop_hit / pop_miss stay intact for the cold-path log.
                 uint64_t pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
@@ -643,7 +640,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
 #if PTO2_PROFILING
             CYCLE_COUNT_LAP(l2_perf.sched_idle_cycle);
-            if (l2_perf.l2_perf_enabled) {
+            if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
                 l2_perf_aicpu_record_phase(
                     thread_idx, AicpuPhaseId::SCHED_IDLE_WAIT, _t0_phase, _t1, l2_perf.sched_loop_count, 0
                 );
@@ -671,7 +668,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     // dispatch emit (typically the trailing idle loops while waiting for
     // orchestrator_done_) as a zero-duration synthetic dispatch record so
     // sum(record.pop_*) reconciles with the run-cumulative counter.
-    if (l2_perf.l2_perf_enabled) {
+    // Gate on SCHED_PHASES — at lower levels the phase buffer is never
+    // flushed (see below), so writing this record would be wasted work.
+    if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
         uint64_t final_pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
         uint64_t final_pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
         if (final_pop_hit_delta != 0 || final_pop_miss_delta != 0) {
@@ -692,7 +691,9 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         l2_perf_aicpu_flush_buffers(
             thread_idx, core_trackers_[thread_idx].core_ids(), core_trackers_[thread_idx].core_num()
         );
-        l2_perf_aicpu_flush_phase_buffers(thread_idx);
+        if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
+            l2_perf_aicpu_flush_phase_buffers(thread_idx);
+        }
     }
 #endif
 #if PTO2_PROFILING

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -88,7 +88,7 @@ class TestL2Swimlane(SceneTestCase):
 
     def test_run(self, st_platform, st_worker, request):
         super().test_run(st_platform, st_worker, request)
-        if not request.config.getoption("--enable-l2-swimlane", default=False):
+        if not request.config.getoption("--enable-l2-swimlane", default=0):
             return
         for case in self.CASES:
             if st_platform in case["platforms"]:
@@ -103,7 +103,7 @@ class TestL2Swimlane(SceneTestCase):
         assert perf.exists(), f"l2_perf_records.json missing under {matches[-1]} — swimlane capture failed?"
         with perf.open() as f:
             data = json.load(f)
-        assert data.get("version") in (1, 2), f"unexpected version: {data.get('version')}"
+        assert data.get("version") in (1, 2, 3, 4), f"unexpected version: {data.get('version')}"
         tasks = data.get("tasks")
         assert isinstance(tasks, list), "tasks field missing or not a list"
         assert len(tasks) == _EXPECTED_TASK_COUNT, (

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -21,19 +21,26 @@ class TestCallConfig:
         config = CallConfig()
         assert config.block_dim == 24
         assert config.aicpu_thread_num == 3
-        assert config.enable_l2_swimlane is False
+        assert config.enable_l2_swimlane == 0
         assert config.enable_dump_tensor is False
         assert config.enable_pmu == 0
         assert config.enable_dep_gen is False
 
     def test_setters(self):
+        # enable_l2_swimlane accepts both an int perf_level (0-4) and a Python
+        # bool. `True` maps to level 4 (preserves the pre-perf_level "fully on"
+        # semantics for legacy callers); explicit ints select a specific level.
         config = CallConfig()
         config.block_dim = 32
         config.aicpu_thread_num = 4
         config.enable_l2_swimlane = True
         assert config.block_dim == 32
         assert config.aicpu_thread_num == 4
-        assert config.enable_l2_swimlane is True
+        assert config.enable_l2_swimlane == 4
+        config.enable_l2_swimlane = 2
+        assert config.enable_l2_swimlane == 2
+        config.enable_l2_swimlane = False
+        assert config.enable_l2_swimlane == 0
 
     def test_diagnostics_subfeatures_are_parallel(self):
         # Guard against drift: the four diagnostics sub-features under the
@@ -43,12 +50,12 @@ class TestCallConfig:
         config.enable_dump_tensor = True
         config.enable_pmu = 2
         config.enable_dep_gen = True
-        assert config.enable_l2_swimlane is True
+        assert config.enable_l2_swimlane == 4
         assert config.enable_dump_tensor is True
         assert config.enable_pmu == 2
         assert config.enable_dep_gen is True
         r = repr(config)
-        assert "enable_l2_swimlane=True" in r
+        assert "enable_l2_swimlane=4" in r
         assert "enable_dump_tensor=True" in r
         assert "enable_pmu=2" in r
         assert "enable_dep_gen=True" in r
@@ -57,7 +64,7 @@ class TestCallConfig:
         config = CallConfig()
         r = repr(config)
         assert "block_dim=24" in r
-        assert "enable_l2_swimlane=False" in r
+        assert "enable_l2_swimlane=0" in r
 
 
 # ============================================================================


### PR DESCRIPTION
Convert --enable-l2-swimlane from a boolean to an integer perf_level
(0-4); bare flag stays backward-compatible by mapping to level 4
(full collection). Introduce a typed L2PerfLevel enum
(DISABLED/AICORE_TIMING/AICPU_TIMING/SCHED_PHASES/ORCH_PHASES) so
gate sites read "if (level >= SCHED_PHASES)" instead of magic ints.

Transport mirrors the PMU pattern with two channels: binary on/off
via KernelArgs::enable_profiling_flag bit1, and granular level via
L2PerfDataHeader::l2_perf_level in shared memory. AICPU promotes the
level from the header in l2_perf_aicpu_init and exposes it through
get_l2_perf_level(). Host-side L2PerfCollector caches the level to
gate JSON sections and stamps the JSON "version" field directly from
perf_level (swimlane_converter and tests now accept versions 1-4).

Apply level gates throughout AICPU code paths: skip dispatch/finish
timestamps and fanout copies below AICPU_TIMING, scheduler phase
records below SCHED_PHASES, and orchestrator phase records below
ORCH_PHASES. Update docs (l2-swimlane-profiling.md,
profiling_levels.md, testing.md) and tests. Note: the a5 backend is
not yet level-aware and still treats the flag as boolean.