### PR TITLE
Refactor: converge async completion API to 3 interfaces, isolate SDMA backend

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -74,6 +74,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
 
     __gm__ int32_t *remote_counter = comm_remote_ptr(comm_ctx, local_counter, peer_rank);
-    pto2_send_notification(remote_counter, 1, pto::comm::NotifyOp::AtomicAdd);
+    send_notification(remote_counter, 1, pto::comm::NotifyOp::AtomicAdd);
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -59,5 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 #endif
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
-    pto2_send_notification(peer_counter, 1, pto::comm::NotifyOp::AtomicAdd);
+    send_notification(peer_counter, 1, pto::comm::NotifyOp::AtomicAdd);
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
@@ -66,7 +66,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     AsyncCtx async_ctx = get_async_ctx(args);
     send_request_entry(
         async_ctx,
-        SdmaTget(local_global, remote_global, scratch_tile,
-                 reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace))
+        SdmaTget(local_global, remote_global, scratch_tile, reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace))
     );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
@@ -18,8 +18,6 @@
 #define __aicore__ [aicore]
 #endif
 
-#include <pto/comm/pto_comm_inst.hpp>
-#include <pto/npu/comm/async/sdma/sdma_types.hpp>
 #include <pto/pto-inst.hpp>
 
 #include "backend/sdma/sdma_completion_kernel.h"
@@ -56,7 +54,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     using FlatShape = Shape<1, 1, 1, 1, kElems>;
     using FlatStride = Stride<kElems, kElems, kElems, kElems, 1>;
     using GlobalData = GlobalTensor<float, FlatShape, FlatStride>;
-    using ScratchTile = Tile<TileType::Vec, uint8_t, 1, pto::comm::sdma::UB_ALIGN_SIZE>;
+    using ScratchTile = Tile<TileType::Vec, uint8_t, 1, SDMA_SCRATCH_ALIGNMENT>;
 
     __gm__ float *remote_in = comm_remote_ptr(comm_ctx, local_in, peer_rank);
     GlobalData remote_global(remote_in);
@@ -65,15 +63,10 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     ScratchTile scratch_tile;
     TASSIGN(scratch_tile, 0x0);
 
-    pto::comm::AsyncSession session;
-    __gm__ uint8_t *sdma_workspace = reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace);
-    if (!pto::comm::BuildAsyncSession(scratch_tile, sdma_workspace, session, 0)) {
-        pipe_barrier(PIPE_ALL);
-        return;
-    }
-
-    pto::comm::AsyncEvent event = pto::comm::TGET_ASYNC(local_global, remote_global, session);
     AsyncCtx async_ctx = get_async_ctx(args);
-    defer_pto_async_event(async_ctx, event, session);
-    defer_flush(async_ctx);
+    send_request_entry(
+        async_ctx,
+        SdmaTget(local_global, remote_global, scratch_tile,
+                 reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace))
+    );
 }

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
@@ -22,6 +22,7 @@
 #include <pto/npu/comm/async/sdma/sdma_types.hpp>
 #include <pto/pto-inst.hpp>
 
+#include "backend/sdma/sdma_completion_kernel.h"
 #include "platform_comm/comm_context.h"
 #include "pto_async_kernel_api.h"
 #include "tensor.h"

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -7,12 +7,13 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""SDMA TGET_ASYNC deferred completion smoke test for onboard a2a3.
+"""SDMA deferred completion smoke test for onboard a2a3.
 
 Each rank stages its input inside the HCCL window.  The deferred producer
-TGET_ASYNCs the peer rank's input into local ``out`` and registers the PTO
-AsyncEvent through ``defer_pto_async_event``.  The consumer depends on the
-producer output and writes ``result = out + 1``.  Correct ``out`` and ``result``
+builds an ``SdmaRequestDescriptor`` via ``SdmaTget`` and submits it through
+``send_request_entry``, which registers the resulting AsyncEvent's GM flag(s)
+on the task's deferred-wait slab.  The consumer depends on the producer
+output and writes ``result = out + 1``.  Correct ``out`` and ``result``
 therefore validate both the SDMA completion polling and the deferred-release
 dependency path.
 """

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/aiv/kernel_producer_notify.cpp
@@ -74,6 +74,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
 
     __gm__ int32_t *remote_counter = comm_remote_ptr(comm_ctx, local_counter, peer_rank);
-    pto2_send_notification(remote_counter, 1, pto::comm::NotifyOp::AtomicAdd);
+    send_notification(remote_counter, 1, pto::comm::NotifyOp::AtomicAdd);
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/aiv/kernel_producer.cpp
@@ -59,5 +59,5 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 #endif
 
     __gm__ int32_t *peer_counter = comm_remote_ptr(ctx, local_counter, peer_rank);
-    pto2_send_notification(peer_counter, 1, pto::comm::NotifyOp::AtomicAdd);
+    send_notification(peer_counter, 1, pto::comm::NotifyOp::AtomicAdd);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -52,7 +52,7 @@
 
 #include <stdint.h>
 
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_task_id.h"
 
 #ifndef __gm__
@@ -95,7 +95,7 @@ struct AsyncCtx {
     uint32_t completion_capacity;
     PTO2TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionIngressBuffer *buffer) {
+    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -91,11 +91,11 @@ struct GlobalContext {
 struct AsyncCtx {
     volatile __gm__ uint32_t *completion_count;
     volatile __gm__ int32_t *completion_error_code;
-    volatile __gm__ PTO2DeferredCompletionEntry *completion_entries;
+    volatile __gm__ DeferredCompletionEntry *completion_entries;
     uint32_t completion_capacity;
     PTO2TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ PTO2DeferredCompletionIngressBuffer *buffer) {
+    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionIngressBuffer *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {
@@ -105,7 +105,7 @@ struct AsyncCtx {
         ctx.completion_count = &buffer->count;
         ctx.completion_error_code = &buffer->error_code;
         ctx.completion_entries = &buffer->entries[0];
-        ctx.completion_capacity = PTO2_MAX_COMPLETIONS_PER_TASK;
+        ctx.completion_capacity = MAX_COMPLETIONS_PER_TASK;
         return ctx;
     }
 };

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -77,8 +77,7 @@ struct AICoreCompletionMailbox {
 };
 
 static_assert(
-    sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0,
-    "AICoreCompletionMailbox size must be cache-line aligned"
+    sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0, "AICoreCompletionMailbox size must be cache-line aligned"
 );
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -9,20 +9,20 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
-#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
 
 #include <stdint.h>
 
 #include "pto_constants.h"
 #include "pto_task_id.h"
 
-#define COMPLETION_INGRESS_CAPACITY 4096u
-#define COMPLETION_INGRESS_MASK (COMPLETION_INGRESS_CAPACITY - 1u)
+#define AICORE_COMPLETION_MAILBOX_CAPACITY 4096u
+#define AICORE_COMPLETION_MAILBOX_MASK (AICORE_COMPLETION_MAILBOX_CAPACITY - 1u)
 
 static_assert(
-    (COMPLETION_INGRESS_CAPACITY & (COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
-    "COMPLETION_INGRESS_CAPACITY must be a power of two"
+    (AICORE_COMPLETION_MAILBOX_CAPACITY & (AICORE_COMPLETION_MAILBOX_CAPACITY - 1u)) == 0,
+    "AICORE_COMPLETION_MAILBOX_CAPACITY must be a power of two"
 );
 
 inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
@@ -33,8 +33,9 @@ inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 #define COMPLETION_ENGINE_CCU 3u
 
 #define COMPLETION_TYPE_COUNTER 0
+#define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
 
-struct CompletionIngressEntry {
+struct AICoreCompletionMailboxMessage {
     volatile uint64_t seq;
     PTO2TaskId task_token;
     uint64_t addr;
@@ -44,7 +45,7 @@ struct CompletionIngressEntry {
     uint32_t _pad[6];
 };
 
-static_assert(sizeof(CompletionIngressEntry) == PTO2_ALIGN_SIZE, "CompletionIngressEntry layout drift");
+static_assert(sizeof(AICoreCompletionMailboxMessage) == PTO2_ALIGN_SIZE, "AICoreCompletionMailboxMessage layout drift");
 
 struct DeferredCompletionEntry {
     uint64_t addr;
@@ -56,28 +57,28 @@ struct DeferredCompletionEntry {
 
 static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
 
-struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionIngressBuffer {
+struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
     volatile uint32_t count;
     volatile int32_t error_code;
     DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
 };
 
 static_assert(
-    sizeof(DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
-    "DeferredCompletionIngressBuffer size must preserve array element cache-line boundaries"
+    sizeof(DeferredCompletionSlab) % PTO2_ALIGN_SIZE == 0,
+    "DeferredCompletionSlab size must preserve array element cache-line boundaries"
 );
 
-struct CompletionIngressQueue {
+struct AICoreCompletionMailbox {
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
     uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
-    alignas(PTO2_ALIGN_SIZE) CompletionIngressEntry entries[COMPLETION_INGRESS_CAPACITY];
+    alignas(PTO2_ALIGN_SIZE) AICoreCompletionMailboxMessage entries[AICORE_COMPLETION_MAILBOX_CAPACITY];
 };
 
 static_assert(
-    sizeof(CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
-    "CompletionIngressQueue size must be cache-line aligned"
+    sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0,
+    "AICoreCompletionMailbox size must be cache-line aligned"
 );
 
-#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_KERNEL_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_KERNEL_H_
+
+#include <stdint.h>
+
+#include <pto/comm/async_common/async_event_impl.hpp>
+#include <pto/npu/comm/async/sdma/sdma_async_intrin.hpp>
+
+#include "pto_async_kernel_api.h"
+#include "pto_completion_ingress.h"
+#include "pto_runtime_status.h"
+
+#ifndef __aicore__
+#define __aicore__
+#endif
+#ifndef __gm__
+#define __gm__
+#endif
+
+// SDMA backend kernel-side helpers. PR-D rewrites the example to use the
+// merged send_request_entry overload instead of these lower-level helpers;
+// they remain here for the transitional commit.
+inline __aicore__ void defer_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
+    defer_condition(
+        ctx, reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
+        COMPLETION_TYPE_SDMA_EVENT_RECORD
+    );
+}
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ void
+defer_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session) {
+    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        (void)event.Wait(session);
+        return;
+    }
+    if (event.handle == 0) {
+        return;
+    }
+
+    const uint32_t engine = static_cast<uint32_t>(event.engine);
+    if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::SDMA)) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return;
+    }
+
+    ::pto::comm::sdma::detail::UbTmpBuf tmp_buf;
+    uint32_t sync_id = 0;
+    __gm__ uint8_t *recv_workspace = nullptr;
+    uint32_t queue_num = 0;
+    if (!::pto::comm::sdma::detail::PrepareEventCheck(
+            session.sdmaSession, tmp_buf, sync_id, recv_workspace, queue_num
+        )) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return;
+    }
+    for (uint32_t queue_id = 0; queue_id < queue_num; ++queue_id) {
+        defer_sdma_event_record(ctx, ::pto::comm::sdma::detail::GetEventRecord(recv_workspace, queue_id));
+    }
+}
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_KERNEL_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -71,6 +71,10 @@ defer_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncS
     }
 }
 
+// Re-exposed PTO-ISA constant so examples / callers don't need to include
+// <pto/npu/comm/async/sdma/sdma_types.hpp> just to spell their scratch tile.
+inline constexpr uint32_t SDMA_SCRATCH_ALIGNMENT = pto::comm::sdma::UB_ALIGN_SIZE;
+
 enum class SdmaOp : uint8_t {
     TGET = 0,
     TPUT = 1,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -63,8 +63,8 @@ inline __aicore__ SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> Sdma
     const DstTensor &dst, const SrcTensor &src, const ScratchTileT &scratch, __gm__ uint8_t *workspace,
     uint32_t sync_id = 0
 ) {
-    return SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{SdmaOp::TGET, dst, src, scratch, workspace,
-                                                                     sync_id};
+    return SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{SdmaOp::TGET, dst,       src,
+                                                                     scratch,      workspace, sync_id};
 }
 
 template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
@@ -72,15 +72,16 @@ inline __aicore__ SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> Sdma
     const DstTensor &dst, const SrcTensor &src, const ScratchTileT &scratch, __gm__ uint8_t *workspace,
     uint32_t sync_id = 0
 ) {
-    return SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{SdmaOp::TPUT, dst, src, scratch, workspace,
-                                                                     sync_id};
+    return SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{SdmaOp::TPUT, dst,       src,
+                                                                     scratch,      workspace, sync_id};
 }
 
 namespace pto2::detail {
 
 inline __aicore__ void register_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
-    CompletionToken token{reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
-                          COMPLETION_TYPE_SDMA_EVENT_RECORD, 0};
+    CompletionToken token{
+        reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_SDMA_EVENT_RECORD, 0
+    };
     (void)register_completion_condition(ctx, token);
 }
 
@@ -123,23 +124,19 @@ register_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsy
 // AsyncCtx deferred-wait slab and flushes. Returns false on submit/session
 // failure (also records the error in ctx.completion_error_code).
 template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
-inline __aicore__ bool send_request_entry(
-    AsyncCtx &ctx, const SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> &desc
-) {
-    ScratchTileT scratch = desc.scratch;
+inline __aicore__ bool
+send_request_entry(AsyncCtx &ctx, SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> desc) {
     pto::comm::AsyncSession session;
-    if (!pto::comm::BuildAsyncSession(scratch, desc.workspace, session, desc.sync_id)) {
+    if (!pto::comm::BuildAsyncSession(desc.scratch, desc.workspace, session, desc.sync_id)) {
         pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
         return false;
     }
 
-    DstTensor dst = desc.dst;
-    SrcTensor src = desc.src;
     pto::comm::AsyncEvent event;
     if (desc.op == SdmaOp::TGET) {
-        event = pto::comm::TGET_ASYNC(dst, src, session);
+        event = pto::comm::TGET_ASYNC(desc.dst, desc.src, session);
     } else {
-        event = pto::comm::TPUT_ASYNC(dst, src, session);
+        event = pto::comm::TPUT_ASYNC(desc.dst, desc.src, session);
     }
     pto2::detail::register_pto_async_event(ctx, event, session);
     pto2::detail::defer_flush(ctx);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -28,49 +28,6 @@
 #define __gm__
 #endif
 
-// SDMA backend kernel-side helpers. Public entry point is the
-// send_request_entry overload below; the defer_* helpers are kept exposed
-// only because the deferred-event demo still references them directly.
-// PR-E will privatize them once all callers move to send_request_entry.
-inline __aicore__ void defer_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
-    defer_condition(
-        ctx, reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
-        COMPLETION_TYPE_SDMA_EVENT_RECORD
-    );
-}
-
-template <typename PtoAsyncEvent, typename PtoAsyncSession>
-inline __aicore__ void
-defer_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session) {
-    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
-        (void)event.Wait(session);
-        return;
-    }
-    if (event.handle == 0) {
-        return;
-    }
-
-    const uint32_t engine = static_cast<uint32_t>(event.engine);
-    if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::SDMA)) {
-        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
-        return;
-    }
-
-    ::pto::comm::sdma::detail::UbTmpBuf tmp_buf;
-    uint32_t sync_id = 0;
-    __gm__ uint8_t *recv_workspace = nullptr;
-    uint32_t queue_num = 0;
-    if (!::pto::comm::sdma::detail::PrepareEventCheck(
-            session.sdmaSession, tmp_buf, sync_id, recv_workspace, queue_num
-        )) {
-        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
-        return;
-    }
-    for (uint32_t queue_id = 0; queue_id < queue_num; ++queue_id) {
-        defer_sdma_event_record(ctx, ::pto::comm::sdma::detail::GetEventRecord(recv_workspace, queue_id));
-    }
-}
-
 // Re-exposed PTO-ISA constant so examples / callers don't need to include
 // <pto/npu/comm/async/sdma/sdma_types.hpp> just to spell their scratch tile.
 inline constexpr uint32_t SDMA_SCRATCH_ALIGNMENT = pto::comm::sdma::UB_ALIGN_SIZE;
@@ -83,8 +40,8 @@ enum class SdmaOp : uint8_t {
 // SdmaRequestDescriptor bundles everything send_request_entry needs to drive
 // one SDMA transfer + completion registration. It is a template because the
 // destination / source / scratch types carry tensor shape & stride at compile
-// time; CTAD or the SdmaTget()/SdmaTput() helpers below avoid spelling them
-// out at the call site.
+// time; the SdmaTget() / SdmaTput() helpers below let callers skip the
+// template arguments.
 //
 // sync_id selects which event-record slot inside the workspace the engine
 // writes into. Concurrent dispatches must use distinct sync_ids; today every
@@ -119,6 +76,48 @@ inline __aicore__ SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> Sdma
                                                                      sync_id};
 }
 
+namespace pto2::detail {
+
+inline __aicore__ void register_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
+    CompletionToken token{reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
+                          COMPLETION_TYPE_SDMA_EVENT_RECORD, 0};
+    (void)register_completion_condition(ctx, token);
+}
+
+template <typename PtoAsyncEvent, typename PtoAsyncSession>
+inline __aicore__ void
+register_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session) {
+    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        (void)event.Wait(session);
+        return;
+    }
+    if (event.handle == 0) {
+        return;
+    }
+
+    const uint32_t engine = static_cast<uint32_t>(event.engine);
+    if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::SDMA)) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return;
+    }
+
+    ::pto::comm::sdma::detail::UbTmpBuf tmp_buf;
+    uint32_t sync_id = 0;
+    __gm__ uint8_t *recv_workspace = nullptr;
+    uint32_t queue_num = 0;
+    if (!::pto::comm::sdma::detail::PrepareEventCheck(
+            session.sdmaSession, tmp_buf, sync_id, recv_workspace, queue_num
+        )) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return;
+    }
+    for (uint32_t queue_id = 0; queue_id < queue_num; ++queue_id) {
+        register_sdma_event_record(ctx, ::pto::comm::sdma::detail::GetEventRecord(recv_workspace, queue_id));
+    }
+}
+
+}  // namespace pto2::detail
+
 // SDMA overload of the runtime's send_request_entry. Submits the descriptor
 // to PTO-ISA, then registers the resulting AsyncEvent's GM flag(s) into the
 // AsyncCtx deferred-wait slab and flushes. Returns false on submit/session
@@ -130,7 +129,7 @@ inline __aicore__ bool send_request_entry(
     ScratchTileT scratch = desc.scratch;
     pto::comm::AsyncSession session;
     if (!pto::comm::BuildAsyncSession(scratch, desc.workspace, session, desc.sync_id)) {
-        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        pto2::detail::defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
         return false;
     }
 
@@ -142,8 +141,8 @@ inline __aicore__ bool send_request_entry(
     } else {
         event = pto::comm::TPUT_ASYNC(dst, src, session);
     }
-    defer_pto_async_event(ctx, event, session);
-    defer_flush(ctx);
+    pto2::detail::register_pto_async_event(ctx, event, session);
+    pto2::detail::defer_flush(ctx);
     return true;
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -18,7 +18,7 @@
 #include <pto/npu/comm/async/sdma/sdma_async_intrin.hpp>
 
 #include "pto_async_kernel_api.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_runtime_status.h"
 
 #ifndef __aicore__

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -28,9 +28,10 @@
 #define __gm__
 #endif
 
-// SDMA backend kernel-side helpers. PR-D rewrites the example to use the
-// merged send_request_entry overload instead of these lower-level helpers;
-// they remain here for the transitional commit.
+// SDMA backend kernel-side helpers. Public entry point is the
+// send_request_entry overload below; the defer_* helpers are kept exposed
+// only because the deferred-event demo still references them directly.
+// PR-E will privatize them once all callers move to send_request_entry.
 inline __aicore__ void defer_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
     defer_condition(
         ctx, reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
@@ -68,6 +69,78 @@ defer_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncS
     for (uint32_t queue_id = 0; queue_id < queue_num; ++queue_id) {
         defer_sdma_event_record(ctx, ::pto::comm::sdma::detail::GetEventRecord(recv_workspace, queue_id));
     }
+}
+
+enum class SdmaOp : uint8_t {
+    TGET = 0,
+    TPUT = 1,
+};
+
+// SdmaRequestDescriptor bundles everything send_request_entry needs to drive
+// one SDMA transfer + completion registration. It is a template because the
+// destination / source / scratch types carry tensor shape & stride at compile
+// time; CTAD or the SdmaTget()/SdmaTput() helpers below avoid spelling them
+// out at the call site.
+//
+// sync_id selects which event-record slot inside the workspace the engine
+// writes into. Concurrent dispatches must use distinct sync_ids; today every
+// caller submits one request per kernel invocation so passing 0 is safe.
+// Future work (see .docs/25.comm-api-refactor/03.implementation-plan.md §5.2)
+// will fold sync_id allocation into the adapter.
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+struct SdmaRequestDescriptor {
+    SdmaOp op;
+    DstTensor dst;
+    SrcTensor src;
+    ScratchTileT scratch;
+    __gm__ uint8_t *workspace;
+    uint32_t sync_id;
+};
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> SdmaTget(
+    const DstTensor &dst, const SrcTensor &src, const ScratchTileT &scratch, __gm__ uint8_t *workspace,
+    uint32_t sync_id = 0
+) {
+    return SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{SdmaOp::TGET, dst, src, scratch, workspace,
+                                                                     sync_id};
+}
+
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> SdmaTput(
+    const DstTensor &dst, const SrcTensor &src, const ScratchTileT &scratch, __gm__ uint8_t *workspace,
+    uint32_t sync_id = 0
+) {
+    return SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT>{SdmaOp::TPUT, dst, src, scratch, workspace,
+                                                                     sync_id};
+}
+
+// SDMA overload of the runtime's send_request_entry. Submits the descriptor
+// to PTO-ISA, then registers the resulting AsyncEvent's GM flag(s) into the
+// AsyncCtx deferred-wait slab and flushes. Returns false on submit/session
+// failure (also records the error in ctx.completion_error_code).
+template <typename DstTensor, typename SrcTensor, typename ScratchTileT>
+inline __aicore__ bool send_request_entry(
+    AsyncCtx &ctx, const SdmaRequestDescriptor<DstTensor, SrcTensor, ScratchTileT> &desc
+) {
+    ScratchTileT scratch = desc.scratch;
+    pto::comm::AsyncSession session;
+    if (!pto::comm::BuildAsyncSession(scratch, desc.workspace, session, desc.sync_id)) {
+        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
+        return false;
+    }
+
+    DstTensor dst = desc.dst;
+    SrcTensor src = desc.src;
+    pto::comm::AsyncEvent event;
+    if (desc.op == SdmaOp::TGET) {
+        event = pto::comm::TGET_ASYNC(dst, src, session);
+    } else {
+        event = pto::comm::TPUT_ASYNC(dst, src, session);
+    }
+    defer_pto_async_event(ctx, event, session);
+    defer_flush(ctx);
+    return true;
 }
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_KERNEL_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_SCHEDULER_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_SCHEDULER_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "aicpu/platform_regs.h"
+#include "pto_completion_ingress.h"
+#include "pto_completion_token.h"
+#include "pto_runtime_status.h"
+
+// runtime-side mirror of the PTO-ISA SdmaEventRecord. SDMA backend is the only
+// allowed holder of this ABI knowledge; the generic scheduler dispatches into
+// the helpers below through the completion ops table.
+struct SdmaEventRecord {
+    uint32_t flag;
+    uint32_t sq_tail;
+    uint64_t channel_info;
+};
+
+static_assert(sizeof(SdmaEventRecord) == 16, "SDMA event record ABI drift");
+static_assert(offsetof(SdmaEventRecord, sq_tail) == 4, "SDMA event record ABI drift");
+
+inline uintptr_t sdma_completion_cache_line(const volatile void *addr) {
+    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
+}
+
+inline CompletionPollResult poll_sdma_event_record(uint64_t record_addr) {
+    if (record_addr == 0) {
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+    volatile SdmaEventRecord *record =
+        reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
+    cache_invalidate_range(reinterpret_cast<const void *>(sdma_completion_cache_line(record)), PTO2_ALIGN_SIZE);
+    uint32_t flag = __atomic_load_n(&record->flag, __ATOMIC_ACQUIRE);
+    return {flag != 0 ? CompletionPollState::READY : CompletionPollState::PENDING, PTO2_ERROR_NONE};
+}
+
+inline void retire_sdma_event_record(uint64_t record_addr) {
+    if (record_addr == 0) return;
+    volatile SdmaEventRecord *record =
+        reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
+    cache_invalidate_range(reinterpret_cast<const void *>(sdma_completion_cache_line(record)), PTO2_ALIGN_SIZE);
+    uint32_t completed_tail = __atomic_load_n(&record->sq_tail, __ATOMIC_ACQUIRE);
+    uint64_t channel_info_addr = __atomic_load_n(&record->channel_info, __ATOMIC_ACQUIRE);
+
+    volatile uint64_t *record_head = reinterpret_cast<volatile uint64_t *>(record);
+    __atomic_store_n(record_head, 0ULL, __ATOMIC_RELEASE);
+    cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(record_head)), sizeof(uint64_t));
+
+    if (channel_info_addr == 0) return;
+    uint64_t packed = (static_cast<uint64_t>(completed_tail) << 32) | static_cast<uint64_t>(completed_tail);
+    volatile uint64_t *channel_info = reinterpret_cast<volatile uint64_t *>(static_cast<uintptr_t>(channel_info_addr));
+    __atomic_store_n(channel_info, packed, __ATOMIC_RELEASE);
+    cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(channel_info)), sizeof(uint64_t));
+}
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_SCHEDULER_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h
@@ -16,7 +16,7 @@
 #include <cstdint>
 
 #include "aicpu/platform_regs.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -78,7 +78,7 @@ inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const Comple
         return false;
     }
 
-    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
+    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
     slot->addr = token.addr;
     slot->expected_value = token.expected_value;
     slot->engine = token.engine;
@@ -102,15 +102,15 @@ inline __aicore__ void defer_condition(
 
 inline __aicore__ void defer_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
     defer_condition(
-        ctx, reinterpret_cast<uint64_t>(counter_addr), expected, PTO2_COMPLETION_ENGINE_SDMA,
-        PTO2_COMPLETION_TYPE_COUNTER
+        ctx, reinterpret_cast<uint64_t>(counter_addr), expected, COMPLETION_ENGINE_SDMA,
+        COMPLETION_TYPE_COUNTER
     );
 }
 
 inline __aicore__ void defer_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
     defer_condition(
-        ctx, reinterpret_cast<uint64_t>(record_addr), 0, PTO2_COMPLETION_ENGINE_SDMA,
-        PTO2_COMPLETION_TYPE_SDMA_EVENT_RECORD
+        ctx, reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
+        COMPLETION_TYPE_SDMA_EVENT_RECORD
     );
 }
 
@@ -180,7 +180,7 @@ inline __aicore__ void defer_flush(AsyncCtx &ctx) {
         flush_bytes += static_cast<uint32_t>(sizeof(*ctx.completion_error_code));
     }
     if (ctx.completion_entries != nullptr) {
-        flush_bytes += count * static_cast<uint32_t>(sizeof(PTO2DeferredCompletionEntry));
+        flush_bytes += count * static_cast<uint32_t>(sizeof(DeferredCompletionEntry));
     }
     defer_flush_range(ctx.completion_count, flush_bytes);
 #if defined(__CPU_SIM)
@@ -196,7 +196,7 @@ inline __aicore__ void defer_flush(AsyncCtx &ctx) {
 }
 
 inline __aicore__ void
-pto2_send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
+send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
     __gm__ int32_t *counter = reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ void *>(remote_counter_addr));
     pto::comm::Signal signal(counter);
     pto::comm::TNOTIFY(signal, value, notify_op);
@@ -204,7 +204,7 @@ pto2_send_notification(volatile __gm__ void *remote_counter_addr, int32_t value,
 
 inline __aicore__ void
 save_expected_notification_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected_value) {
-    defer_condition(ctx, counter_addr, expected_value, PTO2_COMPLETION_ENGINE_SDMA, PTO2_COMPLETION_TYPE_COUNTER);
+    defer_condition(ctx, counter_addr, expected_value, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER);
     defer_flush(ctx);
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -107,52 +107,6 @@ inline __aicore__ void defer_counter(AsyncCtx &ctx, volatile __gm__ void *counte
     );
 }
 
-inline __aicore__ void defer_sdma_event_record(AsyncCtx &ctx, volatile __gm__ void *record_addr) {
-    defer_condition(
-        ctx, reinterpret_cast<uint64_t>(record_addr), 0, COMPLETION_ENGINE_SDMA,
-        COMPLETION_TYPE_SDMA_EVENT_RECORD
-    );
-}
-
-#if defined(PTO_COMM_ASYNC_COMMON_ASYNC_EVENT_IMPL_HPP)
-template <typename PtoAsyncEvent, typename PtoAsyncSession>
-inline __aicore__ void
-defer_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &event, const PtoAsyncSession &session) {
-    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
-        (void)event.Wait(session);
-        return;
-    }
-    if (event.handle == 0) {
-        return;
-    }
-
-    const uint32_t engine = static_cast<uint32_t>(event.engine);
-    if (engine != static_cast<uint32_t>(::pto::comm::DmaEngine::SDMA)) {
-        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
-        return;
-    }
-
-    ::pto::comm::sdma::detail::UbTmpBuf tmp_buf;
-    uint32_t sync_id = 0;
-    __gm__ uint8_t *recv_workspace = nullptr;
-    uint32_t queue_num = 0;
-    if (!::pto::comm::sdma::detail::PrepareEventCheck(
-            session.sdmaSession, tmp_buf, sync_id, recv_workspace, queue_num
-        )) {
-        defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
-        return;
-    }
-    for (uint32_t queue_id = 0; queue_id < queue_num; ++queue_id) {
-        defer_sdma_event_record(ctx, ::pto::comm::sdma::detail::GetEventRecord(recv_workspace, queue_id));
-    }
-}
-#else
-template <typename PtoAsyncEvent, typename PtoAsyncSession>
-inline __aicore__ void defer_pto_async_event(AsyncCtx &ctx, const PtoAsyncEvent &, const PtoAsyncSession &) {
-    defer_error(ctx, PTO2_ERROR_ASYNC_COMPLETION_INVALID);
-}
-#endif
-
 inline __aicore__ void defer_flush_range(volatile __gm__ void *addr, uint32_t size_bytes) {
     if (addr == nullptr || size_bytes == 0) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -29,6 +29,12 @@
 #define __gm__
 #endif
 
+// Public surface: get_async_ctx, async_ctx_is_deferred,
+// register_completion_condition, send_notification,
+// save_expected_notification_counter. Everything else lives in
+// pto2::detail and is reserved for backend adapters / internal use.
+namespace pto2::detail {
+
 inline __aicore__ void defer_load_ingress(AsyncCtx &ctx) {
     if (ctx.completion_count == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
@@ -39,72 +45,10 @@ inline __aicore__ void defer_load_ingress(AsyncCtx &ctx) {
 #endif
 }
 
-inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
-    __gm__ LocalContext *lc =
-        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
-    AsyncCtx ctx{};
-    ctx.completion_count = lc->async_ctx.completion_count;
-    ctx.completion_error_code = lc->async_ctx.completion_error_code;
-    ctx.completion_entries = lc->async_ctx.completion_entries;
-    ctx.completion_capacity = lc->async_ctx.completion_capacity;
-    ctx.task_token.raw = lc->async_ctx.task_token.raw;
-    defer_load_ingress(ctx);
-    return ctx;
-}
-
-inline __aicore__ bool async_ctx_is_deferred(const AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
-
 inline __aicore__ void defer_error(AsyncCtx &ctx, int32_t error_code) {
     if (ctx.task_token.is_valid() && ctx.completion_error_code != nullptr) {
         *ctx.completion_error_code = error_code;
     }
-}
-
-// Canonical writer: backend submit handlers build a CompletionToken and pass
-// it here. Writes one DeferredCompletionEntry to the AsyncCtx ingress slab and
-// bumps completion_count. Returns false on overflow (also stores
-// PTO2_ERROR_ASYNC_WAIT_OVERFLOW in ctx.completion_error_code) or when ctx is
-// not currently a deferred context.
-inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
-    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
-        return false;
-    }
-
-    uint32_t idx = *ctx.completion_count;
-    if (idx >= ctx.completion_capacity) {
-        if (ctx.completion_error_code != nullptr) {
-            *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-        }
-        return false;
-    }
-
-    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
-    slot->addr = token.addr;
-    slot->expected_value = token.expected_value;
-    slot->engine = token.engine;
-    slot->completion_type = token.completion_type;
-    slot->_pad = 0;
-    *ctx.completion_count = idx + 1;
-    return true;
-}
-
-inline __aicore__ void
-defer_condition(AsyncCtx &ctx, uint64_t addr, uint32_t expected, uint32_t engine, int32_t completion_type) {
-    CompletionToken token{addr, expected, engine, completion_type, 0};
-    (void)register_completion_condition(ctx, token);
-}
-
-inline __aicore__ void defer_condition(
-    AsyncCtx &ctx, volatile __gm__ void *addr, uint32_t expected, uint32_t engine, int32_t completion_type
-) {
-    defer_condition(ctx, reinterpret_cast<uint64_t>(addr), expected, engine, completion_type);
-}
-
-inline __aicore__ void defer_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected) {
-    defer_condition(
-        ctx, reinterpret_cast<uint64_t>(counter_addr), expected, COMPLETION_ENGINE_SDMA,
-        COMPLETION_TYPE_COUNTER
-    );
 }
 
 inline __aicore__ void defer_flush_range(volatile __gm__ void *addr, uint32_t size_bytes) {
@@ -149,6 +93,51 @@ inline __aicore__ void defer_flush(AsyncCtx &ctx) {
 #endif
 }
 
+}  // namespace pto2::detail
+
+inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
+    __gm__ LocalContext *lc =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
+    AsyncCtx ctx{};
+    ctx.completion_count = lc->async_ctx.completion_count;
+    ctx.completion_error_code = lc->async_ctx.completion_error_code;
+    ctx.completion_entries = lc->async_ctx.completion_entries;
+    ctx.completion_capacity = lc->async_ctx.completion_capacity;
+    ctx.task_token.raw = lc->async_ctx.task_token.raw;
+    pto2::detail::defer_load_ingress(ctx);
+    return ctx;
+}
+
+inline __aicore__ bool async_ctx_is_deferred(const AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
+
+// Canonical writer: backend submit handlers build a CompletionToken and pass
+// it here. Writes one DeferredCompletionEntry to the AsyncCtx ingress slab and
+// bumps completion_count. Returns false on overflow (also stores
+// PTO2_ERROR_ASYNC_WAIT_OVERFLOW in ctx.completion_error_code) or when ctx is
+// not currently a deferred context.
+inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
+    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        return false;
+    }
+
+    uint32_t idx = *ctx.completion_count;
+    if (idx >= ctx.completion_capacity) {
+        if (ctx.completion_error_code != nullptr) {
+            *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+        }
+        return false;
+    }
+
+    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
+    slot->addr = token.addr;
+    slot->expected_value = token.expected_value;
+    slot->engine = token.engine;
+    slot->completion_type = token.completion_type;
+    slot->_pad = 0;
+    *ctx.completion_count = idx + 1;
+    return true;
+}
+
 inline __aicore__ void
 send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
     __gm__ int32_t *counter = reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ void *>(remote_counter_addr));
@@ -158,8 +147,10 @@ send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto:
 
 inline __aicore__ void
 save_expected_notification_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected_value) {
-    defer_condition(ctx, counter_addr, expected_value, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER);
-    defer_flush(ctx);
+    CompletionToken token{reinterpret_cast<uint64_t>(counter_addr), expected_value, COMPLETION_ENGINE_SDMA,
+                          COMPLETION_TYPE_COUNTER, 0};
+    (void)register_completion_condition(ctx, token);
+    pto2::detail::defer_flush(ctx);
 }
 
 #endif  // PTO_ASYNC_KERNEL_API_H

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -18,7 +18,7 @@
 #include <pto/comm/pto_comm_inst.hpp>
 
 #include "intrinsic.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 
@@ -35,7 +35,7 @@
 // pto2::detail and is reserved for backend adapters / internal use.
 namespace pto2::detail {
 
-inline __aicore__ void defer_load_ingress(AsyncCtx &ctx) {
+inline __aicore__ void defer_load_slab(AsyncCtx &ctx) {
     if (ctx.completion_count == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
     uintptr_t line = reinterpret_cast<uintptr_t>(ctx.completion_count) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
@@ -104,14 +104,14 @@ inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
     ctx.completion_entries = lc->async_ctx.completion_entries;
     ctx.completion_capacity = lc->async_ctx.completion_capacity;
     ctx.task_token.raw = lc->async_ctx.task_token.raw;
-    pto2::detail::defer_load_ingress(ctx);
+    pto2::detail::defer_load_slab(ctx);
     return ctx;
 }
 
 inline __aicore__ bool async_ctx_is_deferred(const AsyncCtx &ctx) { return ctx.task_token.is_valid(); }
 
 // Canonical writer: backend submit handlers build a CompletionToken and pass
-// it here. Writes one DeferredCompletionEntry to the AsyncCtx ingress slab and
+// it here. Writes one DeferredCompletionEntry to the AsyncCtx slab and
 // bumps completion_count. Returns false on overflow (also stores
 // PTO2_ERROR_ASYNC_WAIT_OVERFLOW in ctx.completion_error_code) or when ctx is
 // not currently a deferred context.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -147,8 +147,9 @@ send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto:
 
 inline __aicore__ void
 save_expected_notification_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected_value) {
-    CompletionToken token{reinterpret_cast<uint64_t>(counter_addr), expected_value, COMPLETION_ENGINE_SDMA,
-                          COMPLETION_TYPE_COUNTER, 0};
+    CompletionToken token{
+        reinterpret_cast<uint64_t>(counter_addr), expected_value, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER, 0
+    };
     (void)register_completion_condition(ctx, token);
     pto2::detail::defer_flush(ctx);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -19,6 +19,7 @@
 
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
+#include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 
 #ifndef __aicore__
@@ -59,10 +60,14 @@ inline __aicore__ void defer_error(AsyncCtx &ctx, int32_t error_code) {
     }
 }
 
-inline __aicore__ void
-defer_condition(AsyncCtx &ctx, uint64_t addr, uint32_t expected, uint32_t engine, int32_t completion_type) {
+// Canonical writer: backend submit handlers build a CompletionToken and pass
+// it here. Writes one DeferredCompletionEntry to the AsyncCtx ingress slab and
+// bumps completion_count. Returns false on overflow (also stores
+// PTO2_ERROR_ASYNC_WAIT_OVERFLOW in ctx.completion_error_code) or when ctx is
+// not currently a deferred context.
+inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
     if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
-        return;
+        return false;
     }
 
     uint32_t idx = *ctx.completion_count;
@@ -70,16 +75,23 @@ defer_condition(AsyncCtx &ctx, uint64_t addr, uint32_t expected, uint32_t engine
         if (ctx.completion_error_code != nullptr) {
             *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
         }
-        return;
+        return false;
     }
 
     volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
-    slot->addr = addr;
-    slot->expected_value = expected;
-    slot->engine = engine;
-    slot->completion_type = completion_type;
+    slot->addr = token.addr;
+    slot->expected_value = token.expected_value;
+    slot->engine = token.engine;
+    slot->completion_type = token.completion_type;
     slot->_pad = 0;
     *ctx.completion_count = idx + 1;
+    return true;
+}
+
+inline __aicore__ void
+defer_condition(AsyncCtx &ctx, uint64_t addr, uint32_t expected, uint32_t engine, int32_t completion_type) {
+    CompletionToken token{addr, expected, engine, completion_type, 0};
+    (void)register_completion_condition(ctx, token);
 }
 
 inline __aicore__ void defer_condition(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -19,7 +19,7 @@
 #include "aicpu/platform_regs.h"
 #include "backend/sdma/sdma_completion_scheduler.h"
 #include "intrinsic.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_completion_token.h"
 #include "pto_runtime2_types.h"
 
@@ -30,14 +30,14 @@ struct CompletionStats;
 inline constexpr int32_t MAX_ASYNC_WAITS = 64;
 inline constexpr int32_t MAX_PENDING_COMPLETIONS = 128;
 
-inline bool completion_ingress_has_pending(volatile CompletionIngressQueue *completion_ingress) {
-    if (completion_ingress == nullptr) return false;
-    uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
-    uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
+inline bool aicore_completion_mailbox_has_pending(volatile AICoreCompletionMailbox *aicore_mailbox) {
+    if (aicore_mailbox == nullptr) return false;
+    uint64_t head = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
+    uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
     return tail < head;
 }
 
-inline uintptr_t completion_ingress_cache_line(const volatile void *addr) {
+inline uintptr_t mailbox_cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
 }
 
@@ -176,19 +176,19 @@ struct AsyncWaitList {
     }
 
     int32_t
-    drain_completion_ingress_locked(volatile CompletionIngressQueue *completion_ingress, int32_t &error_code) {
+    drain_aicore_completion_mailbox_locked(volatile AICoreCompletionMailbox *aicore_mailbox, int32_t &error_code) {
         error_code = PTO2_ERROR_NONE;
-        if (completion_ingress == nullptr) return 0;
+        if (aicore_mailbox == nullptr) return 0;
 
         int32_t drained = 0;
         while (true) {
-            uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
-            uint64_t head_snapshot = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+            uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
+            uint64_t head_snapshot = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
             if (tail >= head_snapshot) break;
 
             while (tail < head_snapshot) {
-                volatile CompletionIngressEntry *slot =
-                    &completion_ingress->entries[tail & COMPLETION_INGRESS_MASK];
+                volatile AICoreCompletionMailboxMessage *slot =
+                    &aicore_mailbox->entries[tail & AICORE_COMPLETION_MAILBOX_MASK];
                 uint64_t expected_seq = tail + 1;
                 uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
                 if (seq != expected_seq) return drained;
@@ -199,7 +199,7 @@ struct AsyncWaitList {
                 AsyncEngine engine = static_cast<AsyncEngine>(slot->engine);
 
                 __atomic_store_n(&slot->seq, 0, __ATOMIC_RELEASE);
-                __atomic_store_n(&completion_ingress->tail, tail + 1, __ATOMIC_RELEASE);
+                __atomic_store_n(&aicore_mailbox->tail, tail + 1, __ATOMIC_RELEASE);
                 drained++;
                 tail++;
 
@@ -343,7 +343,7 @@ struct AsyncWaitList {
                 volatile uint32_t *counter =
                     reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
                 cache_invalidate_range(
-                    reinterpret_cast<const void *>(completion_ingress_cache_line(counter)), sizeof(uint32_t)
+                    reinterpret_cast<const void *>(mailbox_cache_line(counter)), sizeof(uint32_t)
                 );
             }
             if (!append_condition_locked(
@@ -362,7 +362,7 @@ struct AsyncWaitList {
 
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
-        volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
         PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
         int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -23,12 +23,12 @@
 
 struct PTO2SchedulerState;
 struct PTO2LocalReadyBuffer;
-struct PTO2CompletionStats;
+struct CompletionStats;
 
-inline constexpr int32_t PTO2_MAX_ASYNC_WAITS = 64;
-inline constexpr int32_t PTO2_MAX_PENDING_COMPLETIONS = 128;
+inline constexpr int32_t MAX_ASYNC_WAITS = 64;
+inline constexpr int32_t MAX_PENDING_COMPLETIONS = 128;
 
-inline bool completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
+inline bool completion_ingress_has_pending(volatile CompletionIngressQueue *completion_ingress) {
     if (completion_ingress == nullptr) return false;
     uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
     uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
@@ -39,14 +39,14 @@ inline uintptr_t completion_ingress_cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
 }
 
-enum class PTO2CompletionPollState : uint8_t {
+enum class CompletionPollState : uint8_t {
     PENDING = 0,
     READY = 1,
     FAILED = 2,
 };
 
-struct PTO2CompletionPollResult {
-    PTO2CompletionPollState state{PTO2CompletionPollState::PENDING};
+struct CompletionPollResult {
+    CompletionPollState state{CompletionPollState::PENDING};
     int32_t error_code{PTO2_ERROR_NONE};
 };
 
@@ -54,30 +54,30 @@ struct PTO2CompletionPollResult {
 // detail into backend/sdma/. The poll/retire helpers below are the legacy
 // inline implementations; the new table-driven dispatch goes through the ops
 // table further down.
-struct PTO2SdmaEventRecord {
+struct SdmaEventRecord {
     uint32_t flag;
     uint32_t sq_tail;
     uint64_t channel_info;
 };
 
-static_assert(sizeof(PTO2SdmaEventRecord) == 16, "SDMA event record ABI drift");
-static_assert(offsetof(PTO2SdmaEventRecord, sq_tail) == 4, "SDMA event record ABI drift");
+static_assert(sizeof(SdmaEventRecord) == 16, "SDMA event record ABI drift");
+static_assert(offsetof(SdmaEventRecord, sq_tail) == 4, "SDMA event record ABI drift");
 
-inline PTO2CompletionPollResult poll_sdma_event_record(uint64_t record_addr) {
+inline CompletionPollResult poll_sdma_event_record(uint64_t record_addr) {
     if (record_addr == 0) {
-        return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
     }
-    volatile PTO2SdmaEventRecord *record =
-        reinterpret_cast<volatile PTO2SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
+    volatile SdmaEventRecord *record =
+        reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
     cache_invalidate_range(reinterpret_cast<const void *>(completion_ingress_cache_line(record)), PTO2_ALIGN_SIZE);
     uint32_t flag = __atomic_load_n(&record->flag, __ATOMIC_ACQUIRE);
-    return {flag != 0 ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING, PTO2_ERROR_NONE};
+    return {flag != 0 ? CompletionPollState::READY : CompletionPollState::PENDING, PTO2_ERROR_NONE};
 }
 
 inline void retire_sdma_event_record(uint64_t record_addr) {
     if (record_addr == 0) return;
-    volatile PTO2SdmaEventRecord *record =
-        reinterpret_cast<volatile PTO2SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
+    volatile SdmaEventRecord *record =
+        reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
     cache_invalidate_range(reinterpret_cast<const void *>(completion_ingress_cache_line(record)), PTO2_ALIGN_SIZE);
     uint32_t completed_tail = __atomic_load_n(&record->sq_tail, __ATOMIC_ACQUIRE);
     uint64_t channel_info_addr = __atomic_load_n(&record->channel_info, __ATOMIC_ACQUIRE);
@@ -93,123 +93,123 @@ inline void retire_sdma_event_record(uint64_t record_addr) {
     cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(channel_info)), sizeof(uint64_t));
 }
 
-struct PTO2CompletionCondition;
+struct CompletionCondition;
 
-using PTO2CompletionPollFn = PTO2CompletionPollResult (*)(const PTO2CompletionCondition &);
-using PTO2CompletionRetireFn = void (*)(PTO2CompletionCondition &);
+using CompletionPollFn = CompletionPollResult (*)(const CompletionCondition &);
+using CompletionRetireFn = void (*)(CompletionCondition &);
 
-struct PTO2CompletionBackendOps {
-    PTO2CompletionPollFn poll;
-    PTO2CompletionRetireFn retire;
+struct CompletionBackendOps {
+    CompletionPollFn poll;
+    CompletionRetireFn retire;
 };
 
-struct PTO2CompletionCondition {
-    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
-    int32_t completion_type{PTO2_COMPLETION_TYPE_COUNTER};
+struct CompletionCondition {
+    AsyncEngine engine{ASYNC_ENGINE_SDMA};
+    int32_t completion_type{COMPLETION_TYPE_COUNTER};
     bool satisfied{false};
     bool retired{false};
     volatile uint32_t *counter_addr{nullptr};
     uint64_t addr{0};
     uint32_t expected_value{0};
 
-    PTO2CompletionPollResult test() const;
+    CompletionPollResult test() const;
     void retire();
 };
 
 // Per-completion-type ops. PR-B moves SDMA_EVENT_RECORD ops out to
 // backend/sdma/; COUNTER stays here because it has no backend detail.
-inline PTO2CompletionPollResult counter_poll_op(const PTO2CompletionCondition &cond) {
+inline CompletionPollResult counter_poll_op(const CompletionCondition &cond) {
     if (cond.counter_addr == nullptr) {
-        return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
     }
     return {
-        *cond.counter_addr >= cond.expected_value ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING,
+        *cond.counter_addr >= cond.expected_value ? CompletionPollState::READY : CompletionPollState::PENDING,
         PTO2_ERROR_NONE
     };
 }
 
-inline void counter_retire_op(PTO2CompletionCondition & /*cond*/) {}
+inline void counter_retire_op(CompletionCondition & /*cond*/) {}
 
-inline PTO2CompletionPollResult sdma_event_record_poll_op(const PTO2CompletionCondition &cond) {
+inline CompletionPollResult sdma_event_record_poll_op(const CompletionCondition &cond) {
     return poll_sdma_event_record(cond.addr);
 }
 
-inline void sdma_event_record_retire_op(PTO2CompletionCondition &cond) {
+inline void sdma_event_record_retire_op(CompletionCondition &cond) {
     retire_sdma_event_record(cond.addr);
 }
 
-inline const PTO2CompletionBackendOps *completion_backend_ops_for(int completion_type) {
-    static const PTO2CompletionBackendOps kOps[] = {
-        {counter_poll_op, counter_retire_op},                      // PTO2_COMPLETION_TYPE_COUNTER = 0
-        {sdma_event_record_poll_op, sdma_event_record_retire_op},  // PTO2_COMPLETION_TYPE_SDMA_EVENT_RECORD = 1
+inline const CompletionBackendOps *completion_backend_ops_for(int completion_type) {
+    static const CompletionBackendOps kOps[] = {
+        {counter_poll_op, counter_retire_op},                      // COMPLETION_TYPE_COUNTER = 0
+        {sdma_event_record_poll_op, sdma_event_record_retire_op},  // COMPLETION_TYPE_SDMA_EVENT_RECORD = 1
     };
     constexpr int kOpsCount = static_cast<int>(sizeof(kOps) / sizeof(kOps[0]));
     if (completion_type < 0 || completion_type >= kOpsCount) return nullptr;
     return &kOps[completion_type];
 }
 
-inline PTO2CompletionPollResult PTO2CompletionCondition::test() const {
+inline CompletionPollResult CompletionCondition::test() const {
     if (satisfied) {
-        return {PTO2CompletionPollState::READY, PTO2_ERROR_NONE};
+        return {CompletionPollState::READY, PTO2_ERROR_NONE};
     }
-    const PTO2CompletionBackendOps *ops = completion_backend_ops_for(completion_type);
+    const CompletionBackendOps *ops = completion_backend_ops_for(completion_type);
     if (ops == nullptr || ops->poll == nullptr) {
-        return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
     }
     return ops->poll(*this);
 }
 
-inline void PTO2CompletionCondition::retire() {
+inline void CompletionCondition::retire() {
     if (retired) return;
-    const PTO2CompletionBackendOps *ops = completion_backend_ops_for(completion_type);
+    const CompletionBackendOps *ops = completion_backend_ops_for(completion_type);
     if (ops != nullptr && ops->retire != nullptr) {
         ops->retire(*this);
     }
     retired = true;
 }
 
-struct PTO2AsyncWaitEntry {
+struct AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};
     PTO2TaskId task_token{PTO2TaskId::invalid()};
-    PTO2CompletionCondition conditions[PTO2_MAX_COMPLETIONS_PER_TASK];
+    CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
     bool normal_done{false};
 };
 
-struct PTO2PendingCompletion {
+struct PendingCompletion {
     PTO2TaskId task_token{PTO2TaskId::invalid()};
     uint64_t addr{0};
     uint32_t expected_value{0};
-    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+    AsyncEngine engine{ASYNC_ENGINE_SDMA};
 };
 
-struct PTO2AsyncPollResult {
+struct AsyncPollResult {
     int32_t completed{0};
     int32_t error_code{PTO2_ERROR_NONE};
     PTO2TaskSlotState *failed_slot_state{nullptr};
 };
 
-inline const char *async_engine_name(PTO2AsyncEngine engine) {
+inline const char *async_engine_name(AsyncEngine engine) {
     switch (engine) {
-    case PTO2_ASYNC_ENGINE_SDMA:
+    case ASYNC_ENGINE_SDMA:
         return "SDMA";
-    case PTO2_ASYNC_ENGINE_ROCE:
+    case ASYNC_ENGINE_ROCE:
         return "ROCE";
-    case PTO2_ASYNC_ENGINE_URMA:
+    case ASYNC_ENGINE_URMA:
         return "URMA";
-    case PTO2_ASYNC_ENGINE_CCU:
+    case ASYNC_ENGINE_CCU:
         return "CCU";
     default:
         return "UNKNOWN";
     }
 }
 
-struct PTO2AsyncWaitList {
+struct AsyncWaitList {
     std::atomic<int32_t> busy{0};
-    PTO2AsyncWaitEntry entries[PTO2_MAX_ASYNC_WAITS];
+    AsyncWaitEntry entries[MAX_ASYNC_WAITS];
     int32_t count{0};
-    PTO2PendingCompletion pending_completions[PTO2_MAX_PENDING_COMPLETIONS];
+    PendingCompletion pending_completions[MAX_PENDING_COMPLETIONS];
     int32_t pending_completion_count{0};
 
     bool try_lock() {
@@ -219,7 +219,7 @@ struct PTO2AsyncWaitList {
 
     void unlock() { busy.store(0, std::memory_order_release); }
 
-    PTO2AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+    AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
         for (int32_t i = 0; i < count; i++) {
             if (entries[i].task_token == token) return &entries[i];
         }
@@ -227,7 +227,7 @@ struct PTO2AsyncWaitList {
     }
 
     int32_t
-    drain_completion_ingress_locked(volatile PTO2CompletionIngressQueue *completion_ingress, int32_t &error_code) {
+    drain_completion_ingress_locked(volatile CompletionIngressQueue *completion_ingress, int32_t &error_code) {
         error_code = PTO2_ERROR_NONE;
         if (completion_ingress == nullptr) return 0;
 
@@ -238,8 +238,8 @@ struct PTO2AsyncWaitList {
             if (tail >= head_snapshot) break;
 
             while (tail < head_snapshot) {
-                volatile PTO2CompletionIngressEntry *slot =
-                    &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
+                volatile CompletionIngressEntry *slot =
+                    &completion_ingress->entries[tail & COMPLETION_INGRESS_MASK];
                 uint64_t expected_seq = tail + 1;
                 uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
                 if (seq != expected_seq) return drained;
@@ -247,22 +247,22 @@ struct PTO2AsyncWaitList {
                 PTO2TaskId token{slot->task_token.raw};
                 uint64_t addr = slot->addr;
                 uint32_t expected_value = slot->expected_value;
-                PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
+                AsyncEngine engine = static_cast<AsyncEngine>(slot->engine);
 
                 __atomic_store_n(&slot->seq, 0, __ATOMIC_RELEASE);
                 __atomic_store_n(&completion_ingress->tail, tail + 1, __ATOMIC_RELEASE);
                 drained++;
                 tail++;
 
-                PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
+                AsyncWaitEntry *entry = find_entry_by_token(token);
                 if (entry != nullptr) {
-                    if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+                    if (entry->condition_count >= MAX_COMPLETIONS_PER_TASK) {
                         error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
                         return drained;
                     }
-                    PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
+                    CompletionCondition &cond = entry->conditions[entry->condition_count++];
                     cond.engine = engine;
-                    cond.completion_type = PTO2_COMPLETION_TYPE_COUNTER;
+                    cond.completion_type = COMPLETION_TYPE_COUNTER;
                     cond.satisfied = false;
                     cond.retired = false;
                     cond.addr = addr;
@@ -272,11 +272,11 @@ struct PTO2AsyncWaitList {
                     continue;
                 }
 
-                if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
+                if (pending_completion_count >= MAX_PENDING_COMPLETIONS) {
                     error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                     return drained;
                 }
-                PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
+                PendingCompletion &pending = pending_completions[pending_completion_count++];
                 pending.task_token = token;
                 pending.addr = addr;
                 pending.expected_value = expected_value;
@@ -286,14 +286,14 @@ struct PTO2AsyncWaitList {
         return drained;
     }
 
-    void absorb_pending_completions_locked(PTO2AsyncWaitEntry &entry) {
+    void absorb_pending_completions_locked(AsyncWaitEntry &entry) {
         int32_t write = 0;
         for (int32_t i = 0; i < pending_completion_count; i++) {
             if (pending_completions[i].task_token == entry.task_token) {
-                if (entry.condition_count < PTO2_MAX_COMPLETIONS_PER_TASK) {
-                    PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+                if (entry.condition_count < MAX_COMPLETIONS_PER_TASK) {
+                    CompletionCondition &cond = entry.conditions[entry.condition_count++];
                     cond.engine = pending_completions[i].engine;
-                    cond.completion_type = PTO2_COMPLETION_TYPE_COUNTER;
+                    cond.completion_type = COMPLETION_TYPE_COUNTER;
                     cond.satisfied = false;
                     cond.retired = false;
                     cond.addr = pending_completions[i].addr;
@@ -313,20 +313,20 @@ struct PTO2AsyncWaitList {
     enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
     bool append_condition_locked(
-        PTO2AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, PTO2AsyncEngine engine,
+        AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine,
         int32_t completion_type, int32_t &error_code
     ) {
-        if (entry.condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+        if (entry.condition_count >= MAX_COMPLETIONS_PER_TASK) {
             error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
             return false;
         }
-        PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+        CompletionCondition &cond = entry.conditions[entry.condition_count++];
         cond.engine = engine;
         cond.completion_type = completion_type;
         cond.satisfied = false;
         cond.retired = false;
         cond.addr = addr;
-        cond.counter_addr = completion_type == PTO2_COMPLETION_TYPE_COUNTER ?
+        cond.counter_addr = completion_type == COMPLETION_TYPE_COUNTER ?
                                 reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr)) :
                                 nullptr;
         cond.expected_value = expected_value;
@@ -366,13 +366,13 @@ struct PTO2AsyncWaitList {
                 return RegisterResult::Error;
             }
         }
-        PTO2AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
+        AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
         if (entry == nullptr && deferred_count == 0) {
             unlock();
             return RegisterResult::NotDeferred;
         }
         if (entry == nullptr) {
-            if (count >= PTO2_MAX_ASYNC_WAITS) {
+            if (count >= MAX_ASYNC_WAITS) {
                 error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                 unlock();
                 return RegisterResult::Error;
@@ -389,8 +389,8 @@ struct PTO2AsyncWaitList {
         }
 
         for (uint32_t i = 0; i < deferred_count; ++i) {
-            volatile PTO2DeferredCompletionEntry *deferred = &async_ctx.completion_entries[i];
-            if (deferred->completion_type == PTO2_COMPLETION_TYPE_COUNTER) {
+            volatile DeferredCompletionEntry *deferred = &async_ctx.completion_entries[i];
+            if (deferred->completion_type == COMPLETION_TYPE_COUNTER) {
                 volatile uint32_t *counter =
                     reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
                 cache_invalidate_range(
@@ -398,7 +398,7 @@ struct PTO2AsyncWaitList {
                 );
             }
             if (!append_condition_locked(
-                    *entry, deferred->addr, deferred->expected_value, static_cast<PTO2AsyncEngine>(deferred->engine),
+                    *entry, deferred->addr, deferred->expected_value, static_cast<AsyncEngine>(deferred->engine),
                     deferred->completion_type, error_code
                 )) {
                 unlock();
@@ -412,8 +412,8 @@ struct PTO2AsyncWaitList {
     }
 
     template <bool Profiling>
-    PTO2AsyncPollResult poll_and_complete(
-        volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+    AsyncPollResult poll_and_complete(
+        volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
         PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
         int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -50,6 +50,10 @@ struct PTO2CompletionPollResult {
     int32_t error_code{PTO2_ERROR_NONE};
 };
 
+// SdmaEventRecord layout mirror — kept here until PR-B relocates SDMA backend
+// detail into backend/sdma/. The poll/retire helpers below are the legacy
+// inline implementations; the new table-driven dispatch goes through the ops
+// table further down.
 struct PTO2SdmaEventRecord {
     uint32_t flag;
     uint32_t sq_tail;
@@ -89,6 +93,16 @@ inline void retire_sdma_event_record(uint64_t record_addr) {
     cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(channel_info)), sizeof(uint64_t));
 }
 
+struct PTO2CompletionCondition;
+
+using PTO2CompletionPollFn = PTO2CompletionPollResult (*)(const PTO2CompletionCondition &);
+using PTO2CompletionRetireFn = void (*)(PTO2CompletionCondition &);
+
+struct PTO2CompletionBackendOps {
+    PTO2CompletionPollFn poll;
+    PTO2CompletionRetireFn retire;
+};
+
 struct PTO2CompletionCondition {
     PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
     int32_t completion_type{PTO2_COMPLETION_TYPE_COUNTER};
@@ -98,33 +112,61 @@ struct PTO2CompletionCondition {
     uint64_t addr{0};
     uint32_t expected_value{0};
 
-    PTO2CompletionPollResult test() const {
-        if (satisfied) {
-            return {PTO2CompletionPollState::READY, PTO2_ERROR_NONE};
-        }
-        if (completion_type == PTO2_COMPLETION_TYPE_COUNTER) {
-            if (counter_addr == nullptr) {
-                return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
-            }
-            return {
-                *counter_addr >= expected_value ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING,
-                PTO2_ERROR_NONE
-            };
-        }
-        if (completion_type == PTO2_COMPLETION_TYPE_SDMA_EVENT_RECORD) {
-            return poll_sdma_event_record(addr);
-        }
+    PTO2CompletionPollResult test() const;
+    void retire();
+};
+
+// Per-completion-type ops. PR-B moves SDMA_EVENT_RECORD ops out to
+// backend/sdma/; COUNTER stays here because it has no backend detail.
+inline PTO2CompletionPollResult counter_poll_op(const PTO2CompletionCondition &cond) {
+    if (cond.counter_addr == nullptr) {
         return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
     }
+    return {
+        *cond.counter_addr >= cond.expected_value ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING,
+        PTO2_ERROR_NONE
+    };
+}
 
-    void retire() {
-        if (retired) return;
-        if (completion_type == PTO2_COMPLETION_TYPE_SDMA_EVENT_RECORD) {
-            retire_sdma_event_record(addr);
-        }
-        retired = true;
+inline void counter_retire_op(PTO2CompletionCondition & /*cond*/) {}
+
+inline PTO2CompletionPollResult sdma_event_record_poll_op(const PTO2CompletionCondition &cond) {
+    return poll_sdma_event_record(cond.addr);
+}
+
+inline void sdma_event_record_retire_op(PTO2CompletionCondition &cond) {
+    retire_sdma_event_record(cond.addr);
+}
+
+inline const PTO2CompletionBackendOps *completion_backend_ops_for(int completion_type) {
+    static const PTO2CompletionBackendOps kOps[] = {
+        {counter_poll_op, counter_retire_op},                      // PTO2_COMPLETION_TYPE_COUNTER = 0
+        {sdma_event_record_poll_op, sdma_event_record_retire_op},  // PTO2_COMPLETION_TYPE_SDMA_EVENT_RECORD = 1
+    };
+    constexpr int kOpsCount = static_cast<int>(sizeof(kOps) / sizeof(kOps[0]));
+    if (completion_type < 0 || completion_type >= kOpsCount) return nullptr;
+    return &kOps[completion_type];
+}
+
+inline PTO2CompletionPollResult PTO2CompletionCondition::test() const {
+    if (satisfied) {
+        return {PTO2CompletionPollState::READY, PTO2_ERROR_NONE};
     }
-};
+    const PTO2CompletionBackendOps *ops = completion_backend_ops_for(completion_type);
+    if (ops == nullptr || ops->poll == nullptr) {
+        return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+    }
+    return ops->poll(*this);
+}
+
+inline void PTO2CompletionCondition::retire() {
+    if (retired) return;
+    const PTO2CompletionBackendOps *ops = completion_backend_ops_for(completion_type);
+    if (ops != nullptr && ops->retire != nullptr) {
+        ops->retire(*this);
+    }
+    retired = true;
+}
 
 struct PTO2AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -83,9 +83,7 @@ inline CompletionPollResult sdma_event_record_poll_op(const CompletionCondition 
     return poll_sdma_event_record(cond.addr);
 }
 
-inline void sdma_event_record_retire_op(CompletionCondition &cond) {
-    retire_sdma_event_record(cond.addr);
-}
+inline void sdma_event_record_retire_op(CompletionCondition &cond) { retire_sdma_event_record(cond.addr); }
 
 inline const CompletionBackendOps *completion_backend_ops_for(int completion_type) {
     static const CompletionBackendOps kOps[] = {
@@ -262,8 +260,8 @@ struct AsyncWaitList {
     enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
     bool append_condition_locked(
-        AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine,
-        int32_t completion_type, int32_t &error_code
+        AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine, int32_t completion_type,
+        int32_t &error_code
     ) {
         if (entry.condition_count >= MAX_COMPLETIONS_PER_TASK) {
             error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
@@ -342,9 +340,7 @@ struct AsyncWaitList {
             if (deferred->completion_type == COMPLETION_TYPE_COUNTER) {
                 volatile uint32_t *counter =
                     reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
-                cache_invalidate_range(
-                    reinterpret_cast<const void *>(mailbox_cache_line(counter)), sizeof(uint32_t)
-                );
+                cache_invalidate_range(reinterpret_cast<const void *>(mailbox_cache_line(counter)), sizeof(uint32_t));
             }
             if (!append_condition_locked(
                     *entry, deferred->addr, deferred->expected_value, static_cast<AsyncEngine>(deferred->engine),
@@ -362,9 +358,9 @@ struct AsyncWaitList {
 
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
-        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-        PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
-        int32_t &deferred_release_count, int32_t deferred_release_capacity
+        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+        PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
+        int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
         ,
         int thread_idx

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -17,8 +17,10 @@
 #include <cstdint>
 
 #include "aicpu/platform_regs.h"
+#include "backend/sdma/sdma_completion_scheduler.h"
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
+#include "pto_completion_token.h"
 #include "pto_runtime2_types.h"
 
 struct PTO2SchedulerState;
@@ -37,60 +39,6 @@ inline bool completion_ingress_has_pending(volatile CompletionIngressQueue *comp
 
 inline uintptr_t completion_ingress_cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
-}
-
-enum class CompletionPollState : uint8_t {
-    PENDING = 0,
-    READY = 1,
-    FAILED = 2,
-};
-
-struct CompletionPollResult {
-    CompletionPollState state{CompletionPollState::PENDING};
-    int32_t error_code{PTO2_ERROR_NONE};
-};
-
-// SdmaEventRecord layout mirror — kept here until PR-B relocates SDMA backend
-// detail into backend/sdma/. The poll/retire helpers below are the legacy
-// inline implementations; the new table-driven dispatch goes through the ops
-// table further down.
-struct SdmaEventRecord {
-    uint32_t flag;
-    uint32_t sq_tail;
-    uint64_t channel_info;
-};
-
-static_assert(sizeof(SdmaEventRecord) == 16, "SDMA event record ABI drift");
-static_assert(offsetof(SdmaEventRecord, sq_tail) == 4, "SDMA event record ABI drift");
-
-inline CompletionPollResult poll_sdma_event_record(uint64_t record_addr) {
-    if (record_addr == 0) {
-        return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
-    }
-    volatile SdmaEventRecord *record =
-        reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
-    cache_invalidate_range(reinterpret_cast<const void *>(completion_ingress_cache_line(record)), PTO2_ALIGN_SIZE);
-    uint32_t flag = __atomic_load_n(&record->flag, __ATOMIC_ACQUIRE);
-    return {flag != 0 ? CompletionPollState::READY : CompletionPollState::PENDING, PTO2_ERROR_NONE};
-}
-
-inline void retire_sdma_event_record(uint64_t record_addr) {
-    if (record_addr == 0) return;
-    volatile SdmaEventRecord *record =
-        reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
-    cache_invalidate_range(reinterpret_cast<const void *>(completion_ingress_cache_line(record)), PTO2_ALIGN_SIZE);
-    uint32_t completed_tail = __atomic_load_n(&record->sq_tail, __ATOMIC_ACQUIRE);
-    uint64_t channel_info_addr = __atomic_load_n(&record->channel_info, __ATOMIC_ACQUIRE);
-
-    volatile uint64_t *record_head = reinterpret_cast<volatile uint64_t *>(record);
-    __atomic_store_n(record_head, 0ULL, __ATOMIC_RELEASE);
-    cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(record_head)), sizeof(uint64_t));
-
-    if (channel_info_addr == 0) return;
-    uint64_t packed = (static_cast<uint64_t>(completed_tail) << 32) | static_cast<uint64_t>(completed_tail);
-    volatile uint64_t *channel_info = reinterpret_cast<volatile uint64_t *>(static_cast<uintptr_t>(channel_info_addr));
-    __atomic_store_n(channel_info, packed, __ATOMIC_RELEASE);
-    cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(channel_info)), sizeof(uint64_t));
 }
 
 struct CompletionCondition;
@@ -116,8 +64,9 @@ struct CompletionCondition {
     void retire();
 };
 
-// Per-completion-type ops. PR-B moves SDMA_EVENT_RECORD ops out to
-// backend/sdma/; COUNTER stays here because it has no backend detail.
+// Per-completion-type ops. SDMA_EVENT_RECORD detail lives in
+// backend/sdma/sdma_completion_scheduler.h; the op wrappers below are thin
+// glue mapping CompletionCondition.addr into the backend's raw-addr helpers.
 inline CompletionPollResult counter_poll_op(const CompletionCondition &cond) {
     if (cond.counter_addr == nullptr) {
         return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
@@ -17,25 +17,25 @@
 #include "pto_constants.h"
 #include "pto_task_id.h"
 
-#define PTO2_COMPLETION_INGRESS_CAPACITY 4096u
-#define PTO2_COMPLETION_INGRESS_MASK (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)
+#define COMPLETION_INGRESS_CAPACITY 4096u
+#define COMPLETION_INGRESS_MASK (COMPLETION_INGRESS_CAPACITY - 1u)
 
 static_assert(
-    (PTO2_COMPLETION_INGRESS_CAPACITY & (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
-    "PTO2_COMPLETION_INGRESS_CAPACITY must be a power of two"
+    (COMPLETION_INGRESS_CAPACITY & (COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
+    "COMPLETION_INGRESS_CAPACITY must be a power of two"
 );
 
-inline constexpr int32_t PTO2_MAX_COMPLETIONS_PER_TASK = 64;
+inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 
-#define PTO2_COMPLETION_ENGINE_SDMA 0u
-#define PTO2_COMPLETION_ENGINE_ROCE 1u
-#define PTO2_COMPLETION_ENGINE_URMA 2u
-#define PTO2_COMPLETION_ENGINE_CCU 3u
+#define COMPLETION_ENGINE_SDMA 0u
+#define COMPLETION_ENGINE_ROCE 1u
+#define COMPLETION_ENGINE_URMA 2u
+#define COMPLETION_ENGINE_CCU 3u
 
-#define PTO2_COMPLETION_TYPE_COUNTER 0
-#define PTO2_COMPLETION_TYPE_SDMA_EVENT_RECORD 1
+#define COMPLETION_TYPE_COUNTER 0
+#define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
 
-struct PTO2CompletionIngressEntry {
+struct CompletionIngressEntry {
     volatile uint64_t seq;
     PTO2TaskId task_token;
     uint64_t addr;
@@ -45,9 +45,9 @@ struct PTO2CompletionIngressEntry {
     uint32_t _pad[6];
 };
 
-static_assert(sizeof(PTO2CompletionIngressEntry) == PTO2_ALIGN_SIZE, "PTO2CompletionIngressEntry layout drift");
+static_assert(sizeof(CompletionIngressEntry) == PTO2_ALIGN_SIZE, "CompletionIngressEntry layout drift");
 
-struct PTO2DeferredCompletionEntry {
+struct DeferredCompletionEntry {
     uint64_t addr;
     uint32_t expected_value;
     uint32_t engine;
@@ -55,30 +55,30 @@ struct PTO2DeferredCompletionEntry {
     uint32_t _pad;
 };
 
-static_assert(sizeof(PTO2DeferredCompletionEntry) == 24, "PTO2DeferredCompletionEntry layout drift");
+static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
 
-struct alignas(PTO2_ALIGN_SIZE) PTO2DeferredCompletionIngressBuffer {
+struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionIngressBuffer {
     volatile uint32_t count;
     volatile int32_t error_code;
-    PTO2DeferredCompletionEntry entries[PTO2_MAX_COMPLETIONS_PER_TASK];
+    DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
 };
 
 static_assert(
-    sizeof(PTO2DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
-    "PTO2DeferredCompletionIngressBuffer size must preserve array element cache-line boundaries"
+    sizeof(DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
+    "DeferredCompletionIngressBuffer size must preserve array element cache-line boundaries"
 );
 
-struct PTO2CompletionIngressQueue {
+struct CompletionIngressQueue {
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
     uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
-    alignas(PTO2_ALIGN_SIZE) PTO2CompletionIngressEntry entries[PTO2_COMPLETION_INGRESS_CAPACITY];
+    alignas(PTO2_ALIGN_SIZE) CompletionIngressEntry entries[COMPLETION_INGRESS_CAPACITY];
 };
 
 static_assert(
-    sizeof(PTO2CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
-    "PTO2CompletionIngressQueue size must be cache-line aligned"
+    sizeof(CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
+    "CompletionIngressQueue size must be cache-line aligned"
 );
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_runtime_status.h"
 
 // CompletionToken is the runtime-internal POD that backend submit handlers

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -15,6 +15,7 @@
 #include <stdint.h>
 
 #include "pto_completion_ingress.h"
+#include "pto_runtime_status.h"
 
 // CompletionToken is the runtime-internal POD that backend submit handlers
 // produce and the generic register_completion_condition() consumes. It is the
@@ -28,6 +29,17 @@ struct CompletionToken {
     uint32_t engine;
     int32_t completion_type;
     uint64_t backend_cookie;
+};
+
+enum class CompletionPollState : uint8_t {
+    PENDING = 0,
+    READY = 1,
+    FAILED = 2,
+};
+
+struct CompletionPollResult {
+    CompletionPollState state{CompletionPollState::PENDING};
+    int32_t error_code{PTO2_ERROR_NONE};
 };
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_
+
+#include <stdint.h>
+
+#include "pto_completion_ingress.h"
+
+// CompletionToken is the runtime-internal POD that backend submit handlers
+// produce and the generic register_completion_condition() consumes. It is the
+// ABI contract for "this is one completion to wait on" — independent of which
+// backend (SDMA, RoCE, notification counter, ...) generated it. Each backend's
+// (poll, retire) pair is registered in pto_async_wait.h's ops table, keyed by
+// completion_type.
+struct CompletionToken {
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint64_t backend_cookie;
+};
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -311,7 +311,7 @@ runtime_create_custom(PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t 
     // Connect orchestrator to scheduler (for simulated mode)
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
     if (!rt->completion_ingress) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();
@@ -354,7 +354,7 @@ PTO2Runtime *runtime_create_from_sm(
 
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
     if (!rt->completion_ingress) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -311,8 +311,8 @@ runtime_create_custom(PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t 
     // Connect orchestrator to scheduler (for simulated mode)
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
-    if (!rt->completion_ingress) {
+    rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(calloc(1, sizeof(AICoreCompletionMailbox)));
+    if (!rt->aicore_mailbox) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();
         free(rt->gm_heap);
@@ -354,8 +354,8 @@ PTO2Runtime *runtime_create_from_sm(
 
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
-    if (!rt->completion_ingress) {
+    rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(calloc(1, sizeof(AICoreCompletionMailbox)));
+    if (!rt->aicore_mailbox) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();
         free(rt);
@@ -371,7 +371,7 @@ void runtime_destroy(PTO2Runtime *rt) {
     rt->scheduler.destroy();
     rt->orchestrator.destroy();
 
-    free(rt->completion_ingress);
+    free(rt->aicore_mailbox);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -42,7 +42,7 @@
 #include "pto_tensormap.h"
 #include "scheduler/pto_scheduler.h"
 #include "pto_orchestrator.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 
 // =============================================================================
 // Runtime Context
@@ -106,7 +106,7 @@ struct PTO2Runtime {
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
-    CompletionIngressQueue *completion_ingress;
+    AICoreCompletionMailbox *aicore_mailbox;
 
     // GM Heap for output buffers
     void *gm_heap;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -106,7 +106,7 @@ struct PTO2Runtime {
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
-    PTO2CompletionIngressQueue *completion_ingress;
+    CompletionIngressQueue *completion_ingress;
 
     // GM Heap for output buffers
     void *gm_heap;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -34,7 +34,7 @@
 #include "pto_constants.h"
 #include "pto_runtime_status.h"
 #include "pto2_dispatch_payload.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -46,14 +46,14 @@
 #define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 
 typedef enum {
-    PTO2_ASYNC_ENGINE_SDMA = 0,
-    PTO2_ASYNC_ENGINE_ROCE = 1,
-    PTO2_ASYNC_ENGINE_URMA = 2,
-    PTO2_ASYNC_ENGINE_CCU = 3,
-    PTO2_NUM_ASYNC_ENGINES = 4,
-} PTO2AsyncEngine;
+    ASYNC_ENGINE_SDMA = 0,
+    ASYNC_ENGINE_ROCE = 1,
+    ASYNC_ENGINE_URMA = 2,
+    ASYNC_ENGINE_CCU = 3,
+    NUM_ASYNC_ENGINES = 4,
+} AsyncEngine;
 
-enum class PTO2CompletionType : int32_t {
+enum class CompletionType : int32_t {
     COUNTER = 0,
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1019,7 +1019,7 @@ struct PTO2SchedulerState {
 
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
-    volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
     PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
     int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
@@ -1031,7 +1031,7 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
     if (!try_lock()) return result;
 
     int32_t drain_err = PTO2_ERROR_NONE;
-    drain_completion_ingress_locked(completion_ingress, drain_err);
+    drain_aicore_completion_mailbox_locked(aicore_mailbox, drain_err);
     if (drain_err != PTO2_ERROR_NONE) {
         result.error_code = drain_err;
         unlock();
@@ -1045,7 +1045,7 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
             CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
             if (cond.completion_type == COMPLETION_TYPE_COUNTER && cond.counter_addr != nullptr) {
-                uintptr_t counter_line = completion_ingress_cache_line(cond.counter_addr);
+                uintptr_t counter_line = mailbox_cache_line(cond.counter_addr);
                 if (counter_line != last_invalidated_counter_line) {
                     cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
                     last_invalidated_counter_line = counter_line;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1019,9 +1019,8 @@ struct PTO2SchedulerState {
 
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
-    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-    PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
-    int32_t deferred_release_capacity
+    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+    PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
     ,
     int thread_idx

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -504,7 +504,7 @@ static_assert(sizeof(PTO2SpscQueue) == 256, "PTO2SpscQueue must be exactly 4 cac
 /**
  * Statistics returned by mixed-task completion processing
  */
-struct PTO2CompletionStats {
+struct CompletionStats {
     int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
     int32_t tasks_enqueued;     // Number of consumers that became READY
     int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
@@ -597,7 +597,7 @@ struct PTO2SchedulerState {
     );
     static_assert(sizeof(WiringState) == 576, "WiringState must be exactly 9 cache lines (576B)");
 
-    alignas(64) PTO2AsyncWaitList async_wait_list;
+    alignas(64) AsyncWaitList async_wait_list;
 
     // Statistics (cold path, isolated from hot-path fields)
 #if PTO2_SCHED_PROFILING
@@ -901,7 +901,7 @@ struct PTO2SchedulerState {
      * Handles fanout notification, fanin release, and self-consumption check.
      */
 #if PTO2_SCHED_PROFILING
-    PTO2CompletionStats
+    CompletionStats
 #else
     void
 #endif
@@ -914,7 +914,7 @@ struct PTO2SchedulerState {
         PTO2LocalReadyBuffer *local_bufs = nullptr
     ) {
 #if PTO2_SCHED_PROFILING
-        PTO2CompletionStats stats = {0, 0, 0, true};
+        CompletionStats stats = {0, 0, 0, true};
 #endif
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
@@ -1018,8 +1018,8 @@ struct PTO2SchedulerState {
 // See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
 template <bool Profiling>
-inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
-    volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+inline AsyncPollResult AsyncWaitList::poll_and_complete(
+    volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
     PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
     int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
@@ -1027,7 +1027,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
     int thread_idx
 #endif
 ) {
-    PTO2AsyncPollResult result;
+    AsyncPollResult result;
     if (!try_lock()) return result;
 
     int32_t drain_err = PTO2_ERROR_NONE;
@@ -1039,26 +1039,26 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
     }
 
     for (int32_t i = count - 1; i >= 0; --i) {
-        PTO2AsyncWaitEntry &entry = entries[i];
+        AsyncWaitEntry &entry = entries[i];
         uintptr_t last_invalidated_counter_line = static_cast<uintptr_t>(-1);
         for (int32_t c = 0; c < entry.condition_count; c++) {
-            PTO2CompletionCondition &cond = entry.conditions[c];
+            CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
-            if (cond.completion_type == PTO2_COMPLETION_TYPE_COUNTER && cond.counter_addr != nullptr) {
+            if (cond.completion_type == COMPLETION_TYPE_COUNTER && cond.counter_addr != nullptr) {
                 uintptr_t counter_line = completion_ingress_cache_line(cond.counter_addr);
                 if (counter_line != last_invalidated_counter_line) {
                     cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
                     last_invalidated_counter_line = counter_line;
                 }
             }
-            PTO2CompletionPollResult poll = cond.test();
-            if (poll.state == PTO2CompletionPollState::FAILED) {
+            CompletionPollResult poll = cond.test();
+            if (poll.state == CompletionPollState::FAILED) {
                 result.error_code = poll.error_code;
                 result.failed_slot_state = entry.slot_state;
                 unlock();
                 return result;
             }
-            if (poll.state == PTO2CompletionPollState::READY) {
+            if (poll.state == CompletionPollState::READY) {
                 cond.satisfied = true;
                 cond.retire();
                 entry.waiting_completion_count--;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -846,7 +846,7 @@ int32_t SchedulerContext::init(
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
-    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
+    memset(deferred_slab_per_core_, 0, sizeof(deferred_slab_per_core_));
 
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
@@ -878,7 +878,7 @@ void SchedulerContext::deinit() {
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
-    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
+    memset(deferred_slab_per_core_, 0, sizeof(deferred_slab_per_core_));
 
     // Reset sync-start drain coordination — a previous run that aborted mid-drain
     // would otherwise leave dirty pending/elected/ack state for the next reuse.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -83,18 +83,18 @@ void SchedulerContext::complete_slot_task(
     bool mixed_complete = sched_->on_subtask_complete(slot_state);
     if (slot_state.payload != nullptr) {
         int32_t reg_err = PTO2_ERROR_NONE;
-        PTO2AsyncWaitList::RegisterResult reg_result;
-        volatile PTO2DeferredCompletionIngressBuffer *deferred_ingress =
+        AsyncWaitList::RegisterResult reg_result;
+        volatile DeferredCompletionIngressBuffer *deferred_ingress =
             &deferred_ingress_per_core_[core_id][expected_reg_task_id & 1];
         AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);
-            if (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped) {
+            if (reg_result == AsyncWaitList::RegisterResult::Skipped) {
                 SPIN_WAIT_HINT();
             }
-        } while (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped);
+        } while (reg_result == AsyncWaitList::RegisterResult::Skipped);
 
-        if (reg_result == PTO2AsyncWaitList::RegisterResult::Error) {
+        if (reg_result == AsyncWaitList::RegisterResult::Error) {
             int32_t expected = PTO2_ERROR_NONE;
             sched_->sm_header->sched_error_code.compare_exchange_strong(
                 expected, reg_err, std::memory_order_acq_rel, std::memory_order_acquire
@@ -103,7 +103,7 @@ void SchedulerContext::complete_slot_task(
             return;
         }
 
-        if (mixed_complete && reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
+        if (mixed_complete && reg_result == AsyncWaitList::RegisterResult::Registered) {
             return;
         }
     }
@@ -122,7 +122,7 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
 #if PTO2_SCHED_PROFILING
-        PTO2CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
+        CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
         l2_perf.notify_edges_total += cstats.fanout_edges;
         if (cstats.fanout_edges > l2_perf.notify_max_degree) l2_perf.notify_max_degree = cstats.fanout_edges;
         l2_perf.notify_tasks_enqueued += cstats.tasks_enqueued;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -84,9 +84,9 @@ void SchedulerContext::complete_slot_task(
     if (slot_state.payload != nullptr) {
         int32_t reg_err = PTO2_ERROR_NONE;
         AsyncWaitList::RegisterResult reg_result;
-        volatile DeferredCompletionIngressBuffer *deferred_ingress =
-            &deferred_ingress_per_core_[core_id][expected_reg_task_id & 1];
-        AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
+        volatile DeferredCompletionSlab *deferred_slab =
+            &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);
             if (reg_result == AsyncWaitList::RegisterResult::Skipped) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -84,8 +84,7 @@ void SchedulerContext::complete_slot_task(
     if (slot_state.payload != nullptr) {
         int32_t reg_err = PTO2_ERROR_NONE;
         AsyncWaitList::RegisterResult reg_result;
-        volatile DeferredCompletionSlab *deferred_slab =
-            &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
         AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -128,7 +128,7 @@ private:
     // the same runtime lifetime as payload_per_core_, but is kept out of the
     // dispatch payload so normal task dispatch layout and cache footprint stay
     // unchanged.
-    PTO2DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
+    DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
 
     // sync_start drain coordination
     SyncStartDrainState drain_state_;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -16,7 +16,7 @@
 
 #include "scheduler/pto_scheduler.h"
 
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto2_dispatch_payload.h"
 
 // These macros are defined in runtime.h, but we cannot include it here
@@ -128,7 +128,7 @@ private:
     // the same runtime lifetime as payload_per_core_, but is kept out of the
     // dispatch payload so normal task dispatch layout and cache footprint stay
     // unchanged.
-    DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
+    DeferredCompletionSlab deferred_slab_per_core_[RUNTIME_MAX_WORKER][2];
 
     // sync_start drain coordination
     SyncStartDrainState drain_state_;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -132,7 +132,7 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    PTO2DeferredCompletionIngressBuffer *deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
+    DeferredCompletionIngressBuffer *deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
     deferred_ingress->count = 0;
     deferred_ingress->error_code = PTO2_ERROR_NONE;
     AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
@@ -431,7 +431,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
             (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
-            PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
+            AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
                 rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -132,10 +132,10 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    DeferredCompletionIngressBuffer *deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
-    deferred_ingress->count = 0;
-    deferred_ingress->error_code = PTO2_ERROR_NONE;
-    AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
+    DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][buf_idx];
+    deferred_slab->count = 0;
+    deferred_slab->error_code = PTO2_ERROR_NONE;
+    AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
     build_payload(payload, slot_state, subslot, async_ctx);
 
     if (to_pending) {
@@ -429,10 +429,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
         }
 
-        if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
+        if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
             (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
             AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
-                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
+                rt_->aicore_mailbox, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP
 #if PTO2_SCHED_PROFILING
                 ,

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -52,7 +52,7 @@
 
 #include <stdint.h>
 
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_task_id.h"
 
 #ifndef __gm__
@@ -95,7 +95,7 @@ struct AsyncCtx {
     uint32_t completion_capacity;
     PTO2TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionIngressBuffer *buffer) {
+    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionSlab *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -91,11 +91,11 @@ struct GlobalContext {
 struct AsyncCtx {
     volatile __gm__ uint32_t *completion_count;
     volatile __gm__ int32_t *completion_error_code;
-    volatile __gm__ PTO2DeferredCompletionEntry *completion_entries;
+    volatile __gm__ DeferredCompletionEntry *completion_entries;
     uint32_t completion_capacity;
     PTO2TaskId task_token;
 
-    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ PTO2DeferredCompletionIngressBuffer *buffer) {
+    static inline AsyncCtx make(PTO2TaskId task_token, volatile __gm__ DeferredCompletionIngressBuffer *buffer) {
         AsyncCtx ctx{};
         ctx.task_token = task_token;
         if (buffer == nullptr) {
@@ -105,7 +105,7 @@ struct AsyncCtx {
         ctx.completion_count = &buffer->count;
         ctx.completion_error_code = &buffer->error_code;
         ctx.completion_entries = &buffer->entries[0];
-        ctx.completion_capacity = PTO2_MAX_COMPLETIONS_PER_TASK;
+        ctx.completion_capacity = MAX_COMPLETIONS_PER_TASK;
         return ctx;
     }
 };

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -9,20 +9,20 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 
-#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
-#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
 
 #include <stdint.h>
 
 #include "pto_constants.h"
 #include "pto_task_id.h"
 
-#define COMPLETION_INGRESS_CAPACITY 4096u
-#define COMPLETION_INGRESS_MASK (COMPLETION_INGRESS_CAPACITY - 1u)
+#define AICORE_COMPLETION_MAILBOX_CAPACITY 4096u
+#define AICORE_COMPLETION_MAILBOX_MASK (AICORE_COMPLETION_MAILBOX_CAPACITY - 1u)
 
 static_assert(
-    (COMPLETION_INGRESS_CAPACITY & (COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
-    "COMPLETION_INGRESS_CAPACITY must be a power of two"
+    (AICORE_COMPLETION_MAILBOX_CAPACITY & (AICORE_COMPLETION_MAILBOX_CAPACITY - 1u)) == 0,
+    "AICORE_COMPLETION_MAILBOX_CAPACITY must be a power of two"
 );
 
 inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
@@ -33,9 +33,8 @@ inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 #define COMPLETION_ENGINE_CCU 3u
 
 #define COMPLETION_TYPE_COUNTER 0
-#define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
 
-struct CompletionIngressEntry {
+struct AICoreCompletionMailboxMessage {
     volatile uint64_t seq;
     PTO2TaskId task_token;
     uint64_t addr;
@@ -45,7 +44,7 @@ struct CompletionIngressEntry {
     uint32_t _pad[6];
 };
 
-static_assert(sizeof(CompletionIngressEntry) == PTO2_ALIGN_SIZE, "CompletionIngressEntry layout drift");
+static_assert(sizeof(AICoreCompletionMailboxMessage) == PTO2_ALIGN_SIZE, "AICoreCompletionMailboxMessage layout drift");
 
 struct DeferredCompletionEntry {
     uint64_t addr;
@@ -57,28 +56,28 @@ struct DeferredCompletionEntry {
 
 static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
 
-struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionIngressBuffer {
+struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
     volatile uint32_t count;
     volatile int32_t error_code;
     DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
 };
 
 static_assert(
-    sizeof(DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
-    "DeferredCompletionIngressBuffer size must preserve array element cache-line boundaries"
+    sizeof(DeferredCompletionSlab) % PTO2_ALIGN_SIZE == 0,
+    "DeferredCompletionSlab size must preserve array element cache-line boundaries"
 );
 
-struct CompletionIngressQueue {
+struct AICoreCompletionMailbox {
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
     uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
-    alignas(PTO2_ALIGN_SIZE) CompletionIngressEntry entries[COMPLETION_INGRESS_CAPACITY];
+    alignas(PTO2_ALIGN_SIZE) AICoreCompletionMailboxMessage entries[AICORE_COMPLETION_MAILBOX_CAPACITY];
 };
 
 static_assert(
-    sizeof(CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
-    "CompletionIngressQueue size must be cache-line aligned"
+    sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0,
+    "AICoreCompletionMailbox size must be cache-line aligned"
 );
 
-#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -76,8 +76,7 @@ struct AICoreCompletionMailbox {
 };
 
 static_assert(
-    sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0,
-    "AICoreCompletionMailbox size must be cache-line aligned"
+    sizeof(AICoreCompletionMailbox) % PTO2_ALIGN_SIZE == 0, "AICoreCompletionMailbox size must be cache-line aligned"
 );
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -128,8 +128,9 @@ send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto:
 
 inline __aicore__ void
 save_expected_notification_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected_value) {
-    CompletionToken token{reinterpret_cast<uint64_t>(counter_addr), expected_value, COMPLETION_ENGINE_SDMA,
-                          COMPLETION_TYPE_COUNTER, 0};
+    CompletionToken token{
+        reinterpret_cast<uint64_t>(counter_addr), expected_value, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER, 0
+    };
     (void)register_completion_condition(ctx, token);
     pto2::detail::defer_flush(ctx);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -65,7 +65,7 @@ inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const Comple
         return false;
     }
 
-    volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
+    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
     slot->addr = token.addr;
     slot->expected_value = token.expected_value;
     slot->engine = token.engine;
@@ -109,7 +109,7 @@ inline __aicore__ void defer_flush(AsyncCtx &ctx) {
         flush_bytes += static_cast<uint32_t>(sizeof(*ctx.completion_error_code));
     }
     if (ctx.completion_entries != nullptr) {
-        flush_bytes += count * static_cast<uint32_t>(sizeof(PTO2DeferredCompletionEntry));
+        flush_bytes += count * static_cast<uint32_t>(sizeof(DeferredCompletionEntry));
     }
     defer_flush_range(ctx.completion_count, flush_bytes);
 #if defined(__CPU_SIM)
@@ -125,7 +125,7 @@ inline __aicore__ void defer_flush(AsyncCtx &ctx) {
 }
 
 inline __aicore__ void
-pto2_send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
+send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
     __gm__ int32_t *counter = reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ void *>(remote_counter_addr));
     pto::comm::Signal signal(counter);
     pto::comm::TNOTIFY(signal, value, notify_op);
@@ -133,7 +133,7 @@ pto2_send_notification(volatile __gm__ void *remote_counter_addr, int32_t value,
 
 inline __aicore__ void
 save_expected_notification_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected_value) {
-    defer_condition(ctx, counter_addr, expected_value, PTO2_COMPLETION_ENGINE_SDMA, PTO2_COMPLETION_TYPE_COUNTER);
+    defer_condition(ctx, counter_addr, expected_value, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER);
     defer_flush(ctx);
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -18,7 +18,7 @@
 #include <pto/comm/pto_comm_inst.hpp>
 
 #include "intrinsic.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 
@@ -34,7 +34,7 @@
 // lives in pto2::detail and is reserved for backend adapters / internal use.
 namespace pto2::detail {
 
-inline __aicore__ void defer_load_ingress(AsyncCtx &ctx) {
+inline __aicore__ void defer_load_slab(AsyncCtx &ctx) {
     if (ctx.completion_count == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
     uintptr_t line = reinterpret_cast<uintptr_t>(ctx.completion_count) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
@@ -92,7 +92,7 @@ inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
     __gm__ LocalContext *lc =
         reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
     AsyncCtx ctx = lc->async_ctx;
-    pto2::detail::defer_load_ingress(ctx);
+    pto2::detail::defer_load_slab(ctx);
     return ctx;
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -29,6 +29,11 @@
 #define __gm__
 #endif
 
+// Public surface: get_async_ctx, register_completion_condition,
+// send_notification, save_expected_notification_counter. Everything else
+// lives in pto2::detail and is reserved for backend adapters / internal use.
+namespace pto2::detail {
+
 inline __aicore__ void defer_load_ingress(AsyncCtx &ctx) {
     if (ctx.completion_count == nullptr) return;
 #if defined(__CCE_KT_TEST__) || defined(__CCE_AICORE__) || defined(__DAV_C220__)
@@ -37,49 +42,6 @@ inline __aicore__ void defer_load_ingress(AsyncCtx &ctx) {
 #else
     __asm__ __volatile__("" ::: "memory");
 #endif
-}
-
-inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
-    __gm__ LocalContext *lc =
-        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
-    AsyncCtx ctx = lc->async_ctx;
-    defer_load_ingress(ctx);
-    return ctx;
-}
-
-// Canonical writer: backend submit handlers build a CompletionToken and pass
-// it here. Writes one DeferredCompletionEntry to the AsyncCtx ingress slab and
-// bumps completion_count. Returns false on overflow (also stores
-// PTO2_ERROR_ASYNC_WAIT_OVERFLOW in ctx.completion_error_code) or when ctx is
-// not currently a deferred context.
-inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
-    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
-        return false;
-    }
-
-    uint32_t idx = *ctx.completion_count;
-    if (idx >= ctx.completion_capacity) {
-        if (ctx.completion_error_code != nullptr) {
-            *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-        }
-        return false;
-    }
-
-    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
-    slot->addr = token.addr;
-    slot->expected_value = token.expected_value;
-    slot->engine = token.engine;
-    slot->completion_type = token.completion_type;
-    slot->_pad = 0;
-    *ctx.completion_count = idx + 1;
-    return true;
-}
-
-inline __aicore__ void defer_condition(
-    AsyncCtx &ctx, volatile __gm__ void *addr, uint32_t expected, uint32_t engine, int32_t completion_type
-) {
-    CompletionToken token{reinterpret_cast<uint64_t>(addr), expected, engine, completion_type, 0};
-    (void)register_completion_condition(ctx, token);
 }
 
 inline __aicore__ void defer_flush_range(volatile __gm__ void *addr, uint32_t size_bytes) {
@@ -124,6 +86,39 @@ inline __aicore__ void defer_flush(AsyncCtx &ctx) {
 #endif
 }
 
+}  // namespace pto2::detail
+
+inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
+    __gm__ LocalContext *lc =
+        reinterpret_cast<__gm__ LocalContext *>(static_cast<uintptr_t>(args[PAYLOAD_LOCAL_CONTEXT_INDEX]));
+    AsyncCtx ctx = lc->async_ctx;
+    pto2::detail::defer_load_ingress(ctx);
+    return ctx;
+}
+
+inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
+    if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
+        return false;
+    }
+
+    uint32_t idx = *ctx.completion_count;
+    if (idx >= ctx.completion_capacity) {
+        if (ctx.completion_error_code != nullptr) {
+            *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+        }
+        return false;
+    }
+
+    volatile __gm__ DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
+    slot->addr = token.addr;
+    slot->expected_value = token.expected_value;
+    slot->engine = token.engine;
+    slot->completion_type = token.completion_type;
+    slot->_pad = 0;
+    *ctx.completion_count = idx + 1;
+    return true;
+}
+
 inline __aicore__ void
 send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto::comm::NotifyOp notify_op) {
     __gm__ int32_t *counter = reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ void *>(remote_counter_addr));
@@ -133,8 +128,10 @@ send_notification(volatile __gm__ void *remote_counter_addr, int32_t value, pto:
 
 inline __aicore__ void
 save_expected_notification_counter(AsyncCtx &ctx, volatile __gm__ void *counter_addr, uint32_t expected_value) {
-    defer_condition(ctx, counter_addr, expected_value, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER);
-    defer_flush(ctx);
+    CompletionToken token{reinterpret_cast<uint64_t>(counter_addr), expected_value, COMPLETION_ENGINE_SDMA,
+                          COMPLETION_TYPE_COUNTER, 0};
+    (void)register_completion_condition(ctx, token);
+    pto2::detail::defer_flush(ctx);
 }
 
 #endif  // PTO_ASYNC_KERNEL_API_H

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -19,6 +19,7 @@
 
 #include "intrinsic.h"
 #include "pto_completion_ingress.h"
+#include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 
 #ifndef __aicore__
@@ -46,11 +47,14 @@ inline __aicore__ AsyncCtx get_async_ctx(__gm__ int64_t *args) {
     return ctx;
 }
 
-inline __aicore__ void defer_condition(
-    AsyncCtx &ctx, volatile __gm__ void *addr, uint32_t expected, uint32_t engine, int32_t completion_type
-) {
+// Canonical writer: backend submit handlers build a CompletionToken and pass
+// it here. Writes one DeferredCompletionEntry to the AsyncCtx ingress slab and
+// bumps completion_count. Returns false on overflow (also stores
+// PTO2_ERROR_ASYNC_WAIT_OVERFLOW in ctx.completion_error_code) or when ctx is
+// not currently a deferred context.
+inline __aicore__ bool register_completion_condition(AsyncCtx &ctx, const CompletionToken &token) {
     if (ctx.task_token.is_invalid() || ctx.completion_count == nullptr || ctx.completion_entries == nullptr) {
-        return;
+        return false;
     }
 
     uint32_t idx = *ctx.completion_count;
@@ -58,16 +62,24 @@ inline __aicore__ void defer_condition(
         if (ctx.completion_error_code != nullptr) {
             *ctx.completion_error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
         }
-        return;
+        return false;
     }
 
     volatile __gm__ PTO2DeferredCompletionEntry *slot = &ctx.completion_entries[idx];
-    slot->addr = reinterpret_cast<uint64_t>(addr);
-    slot->expected_value = expected;
-    slot->engine = engine;
-    slot->completion_type = completion_type;
+    slot->addr = token.addr;
+    slot->expected_value = token.expected_value;
+    slot->engine = token.engine;
+    slot->completion_type = token.completion_type;
     slot->_pad = 0;
     *ctx.completion_count = idx + 1;
+    return true;
+}
+
+inline __aicore__ void defer_condition(
+    AsyncCtx &ctx, volatile __gm__ void *addr, uint32_t expected, uint32_t engine, int32_t completion_type
+) {
+    CompletionToken token{reinterpret_cast<uint64_t>(addr), expected, engine, completion_type, 0};
+    (void)register_completion_condition(ctx, token);
 }
 
 inline __aicore__ void defer_flush_range(volatile __gm__ void *addr, uint32_t size_bytes) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -17,7 +17,7 @@
 #include <cstdint>
 
 #include "intrinsic.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_runtime2_types.h"
 
 struct PTO2SchedulerState;
@@ -27,10 +27,10 @@ struct CompletionStats;
 inline constexpr int32_t MAX_ASYNC_WAITS = 64;
 inline constexpr int32_t MAX_PENDING_COMPLETIONS = 128;
 
-inline bool completion_ingress_has_pending(volatile CompletionIngressQueue *completion_ingress) {
-    if (completion_ingress == nullptr) return false;
-    uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
-    uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
+inline bool aicore_completion_mailbox_has_pending(volatile AICoreCompletionMailbox *aicore_mailbox) {
+    if (aicore_mailbox == nullptr) return false;
+    uint64_t head = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
+    uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
     return tail < head;
 }
 
@@ -124,19 +124,19 @@ struct AsyncWaitList {
     }
 
     int32_t
-    drain_completion_ingress_locked(volatile CompletionIngressQueue *completion_ingress, int32_t &error_code) {
+    drain_aicore_completion_mailbox_locked(volatile AICoreCompletionMailbox *aicore_mailbox, int32_t &error_code) {
         error_code = PTO2_ERROR_NONE;
-        if (completion_ingress == nullptr) return 0;
+        if (aicore_mailbox == nullptr) return 0;
 
         int32_t drained = 0;
         while (true) {
-            uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
-            uint64_t head_snapshot = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
+            uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
+            uint64_t head_snapshot = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
             if (tail >= head_snapshot) break;
 
             while (tail < head_snapshot) {
-                volatile CompletionIngressEntry *slot =
-                    &completion_ingress->entries[tail & COMPLETION_INGRESS_MASK];
+                volatile AICoreCompletionMailboxMessage *slot =
+                    &aicore_mailbox->entries[tail & AICORE_COMPLETION_MAILBOX_MASK];
                 uint64_t expected_seq = tail + 1;
                 uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
                 if (seq != expected_seq) return drained;
@@ -147,7 +147,7 @@ struct AsyncWaitList {
                 AsyncEngine engine = static_cast<AsyncEngine>(slot->engine);
 
                 __atomic_store_n(&slot->seq, 0, __ATOMIC_RELEASE);
-                __atomic_store_n(&completion_ingress->tail, tail + 1, __ATOMIC_RELEASE);
+                __atomic_store_n(&aicore_mailbox->tail, tail + 1, __ATOMIC_RELEASE);
                 drained++;
                 tail++;
 
@@ -291,7 +291,7 @@ struct AsyncWaitList {
 
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
-        volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
         PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
         int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -22,91 +22,91 @@
 
 struct PTO2SchedulerState;
 struct PTO2LocalReadyBuffer;
-struct PTO2CompletionStats;
+struct CompletionStats;
 
-inline constexpr int32_t PTO2_MAX_ASYNC_WAITS = 64;
-inline constexpr int32_t PTO2_MAX_PENDING_COMPLETIONS = 128;
+inline constexpr int32_t MAX_ASYNC_WAITS = 64;
+inline constexpr int32_t MAX_PENDING_COMPLETIONS = 128;
 
-inline bool completion_ingress_has_pending(volatile PTO2CompletionIngressQueue *completion_ingress) {
+inline bool completion_ingress_has_pending(volatile CompletionIngressQueue *completion_ingress) {
     if (completion_ingress == nullptr) return false;
     uint64_t head = __atomic_load_n(&completion_ingress->head, __ATOMIC_ACQUIRE);
     uint64_t tail = __atomic_load_n(&completion_ingress->tail, __ATOMIC_ACQUIRE);
     return tail < head;
 }
 
-enum class PTO2CompletionPollState : uint8_t {
+enum class CompletionPollState : uint8_t {
     PENDING = 0,
     READY = 1,
     FAILED = 2,
 };
 
-struct PTO2CompletionPollResult {
-    PTO2CompletionPollState state{PTO2CompletionPollState::PENDING};
+struct CompletionPollResult {
+    CompletionPollState state{CompletionPollState::PENDING};
     int32_t error_code{PTO2_ERROR_NONE};
 };
 
-struct PTO2CompletionCondition {
-    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+struct CompletionCondition {
+    AsyncEngine engine{ASYNC_ENGINE_SDMA};
     bool satisfied{false};
     volatile uint32_t *counter_addr{nullptr};
     uint32_t expected_value{0};
 
-    PTO2CompletionPollResult test() const {
+    CompletionPollResult test() const {
         if (satisfied) {
-            return {PTO2CompletionPollState::READY, PTO2_ERROR_NONE};
+            return {CompletionPollState::READY, PTO2_ERROR_NONE};
         }
         if (counter_addr == nullptr) {
-            return {PTO2CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
+            return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
         }
         return {
-            *counter_addr >= expected_value ? PTO2CompletionPollState::READY : PTO2CompletionPollState::PENDING,
+            *counter_addr >= expected_value ? CompletionPollState::READY : CompletionPollState::PENDING,
             PTO2_ERROR_NONE
         };
     }
 };
 
-struct PTO2AsyncWaitEntry {
+struct AsyncWaitEntry {
     PTO2TaskSlotState *slot_state{nullptr};
     PTO2TaskId task_token{PTO2TaskId::invalid()};
-    PTO2CompletionCondition conditions[PTO2_MAX_COMPLETIONS_PER_TASK];
+    CompletionCondition conditions[MAX_COMPLETIONS_PER_TASK];
     int32_t condition_count{0};
     int32_t waiting_completion_count{0};
     bool normal_done{false};
 };
 
-struct PTO2PendingCompletion {
+struct PendingCompletion {
     PTO2TaskId task_token{PTO2TaskId::invalid()};
     uint64_t addr{0};
     uint32_t expected_value{0};
-    PTO2AsyncEngine engine{PTO2_ASYNC_ENGINE_SDMA};
+    AsyncEngine engine{ASYNC_ENGINE_SDMA};
 };
 
-struct PTO2AsyncPollResult {
+struct AsyncPollResult {
     int32_t completed{0};
     int32_t error_code{PTO2_ERROR_NONE};
     PTO2TaskSlotState *failed_slot_state{nullptr};
 };
 
-inline const char *async_engine_name(PTO2AsyncEngine engine) {
+inline const char *async_engine_name(AsyncEngine engine) {
     switch (engine) {
-    case PTO2_ASYNC_ENGINE_SDMA:
+    case ASYNC_ENGINE_SDMA:
         return "SDMA";
-    case PTO2_ASYNC_ENGINE_ROCE:
+    case ASYNC_ENGINE_ROCE:
         return "ROCE";
-    case PTO2_ASYNC_ENGINE_URMA:
+    case ASYNC_ENGINE_URMA:
         return "URMA";
-    case PTO2_ASYNC_ENGINE_CCU:
+    case ASYNC_ENGINE_CCU:
         return "CCU";
     default:
         return "UNKNOWN";
     }
 }
 
-struct PTO2AsyncWaitList {
+struct AsyncWaitList {
     std::atomic<int32_t> busy{0};
-    PTO2AsyncWaitEntry entries[PTO2_MAX_ASYNC_WAITS];
+    AsyncWaitEntry entries[MAX_ASYNC_WAITS];
     int32_t count{0};
-    PTO2PendingCompletion pending_completions[PTO2_MAX_PENDING_COMPLETIONS];
+    PendingCompletion pending_completions[MAX_PENDING_COMPLETIONS];
     int32_t pending_completion_count{0};
 
     bool try_lock() {
@@ -116,7 +116,7 @@ struct PTO2AsyncWaitList {
 
     void unlock() { busy.store(0, std::memory_order_release); }
 
-    PTO2AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
+    AsyncWaitEntry *find_entry_by_token(PTO2TaskId token) {
         for (int32_t i = 0; i < count; i++) {
             if (entries[i].task_token == token) return &entries[i];
         }
@@ -124,7 +124,7 @@ struct PTO2AsyncWaitList {
     }
 
     int32_t
-    drain_completion_ingress_locked(volatile PTO2CompletionIngressQueue *completion_ingress, int32_t &error_code) {
+    drain_completion_ingress_locked(volatile CompletionIngressQueue *completion_ingress, int32_t &error_code) {
         error_code = PTO2_ERROR_NONE;
         if (completion_ingress == nullptr) return 0;
 
@@ -135,8 +135,8 @@ struct PTO2AsyncWaitList {
             if (tail >= head_snapshot) break;
 
             while (tail < head_snapshot) {
-                volatile PTO2CompletionIngressEntry *slot =
-                    &completion_ingress->entries[tail & PTO2_COMPLETION_INGRESS_MASK];
+                volatile CompletionIngressEntry *slot =
+                    &completion_ingress->entries[tail & COMPLETION_INGRESS_MASK];
                 uint64_t expected_seq = tail + 1;
                 uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
                 if (seq != expected_seq) return drained;
@@ -144,20 +144,20 @@ struct PTO2AsyncWaitList {
                 PTO2TaskId token{slot->task_token.raw};
                 uint64_t addr = slot->addr;
                 uint32_t expected_value = slot->expected_value;
-                PTO2AsyncEngine engine = static_cast<PTO2AsyncEngine>(slot->engine);
+                AsyncEngine engine = static_cast<AsyncEngine>(slot->engine);
 
                 __atomic_store_n(&slot->seq, 0, __ATOMIC_RELEASE);
                 __atomic_store_n(&completion_ingress->tail, tail + 1, __ATOMIC_RELEASE);
                 drained++;
                 tail++;
 
-                PTO2AsyncWaitEntry *entry = find_entry_by_token(token);
+                AsyncWaitEntry *entry = find_entry_by_token(token);
                 if (entry != nullptr) {
-                    if (entry->condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+                    if (entry->condition_count >= MAX_COMPLETIONS_PER_TASK) {
                         error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
                         return drained;
                     }
-                    PTO2CompletionCondition &cond = entry->conditions[entry->condition_count++];
+                    CompletionCondition &cond = entry->conditions[entry->condition_count++];
                     cond.engine = engine;
                     cond.satisfied = false;
                     cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
@@ -166,11 +166,11 @@ struct PTO2AsyncWaitList {
                     continue;
                 }
 
-                if (pending_completion_count >= PTO2_MAX_PENDING_COMPLETIONS) {
+                if (pending_completion_count >= MAX_PENDING_COMPLETIONS) {
                     error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                     return drained;
                 }
-                PTO2PendingCompletion &pending = pending_completions[pending_completion_count++];
+                PendingCompletion &pending = pending_completions[pending_completion_count++];
                 pending.task_token = token;
                 pending.addr = addr;
                 pending.expected_value = expected_value;
@@ -180,12 +180,12 @@ struct PTO2AsyncWaitList {
         return drained;
     }
 
-    void absorb_pending_completions_locked(PTO2AsyncWaitEntry &entry) {
+    void absorb_pending_completions_locked(AsyncWaitEntry &entry) {
         int32_t write = 0;
         for (int32_t i = 0; i < pending_completion_count; i++) {
             if (pending_completions[i].task_token == entry.task_token) {
-                if (entry.condition_count < PTO2_MAX_COMPLETIONS_PER_TASK) {
-                    PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+                if (entry.condition_count < MAX_COMPLETIONS_PER_TASK) {
+                    CompletionCondition &cond = entry.conditions[entry.condition_count++];
                     cond.engine = pending_completions[i].engine;
                     cond.satisfied = false;
                     cond.counter_addr =
@@ -204,13 +204,13 @@ struct PTO2AsyncWaitList {
     enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
     bool append_condition_locked(
-        PTO2AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, PTO2AsyncEngine engine, int32_t &error_code
+        AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine, int32_t &error_code
     ) {
-        if (entry.condition_count >= PTO2_MAX_COMPLETIONS_PER_TASK) {
+        if (entry.condition_count >= MAX_COMPLETIONS_PER_TASK) {
             error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
             return false;
         }
-        PTO2CompletionCondition &cond = entry.conditions[entry.condition_count++];
+        CompletionCondition &cond = entry.conditions[entry.condition_count++];
         cond.engine = engine;
         cond.satisfied = false;
         cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
@@ -251,13 +251,13 @@ struct PTO2AsyncWaitList {
                 return RegisterResult::Error;
             }
         }
-        PTO2AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
+        AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
         if (entry == nullptr && deferred_count == 0) {
             unlock();
             return RegisterResult::NotDeferred;
         }
         if (entry == nullptr) {
-            if (count >= PTO2_MAX_ASYNC_WAITS) {
+            if (count >= MAX_ASYNC_WAITS) {
                 error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                 unlock();
                 return RegisterResult::Error;
@@ -274,9 +274,9 @@ struct PTO2AsyncWaitList {
         }
 
         for (uint32_t i = 0; i < deferred_count; ++i) {
-            volatile PTO2DeferredCompletionEntry *deferred = &async_ctx.completion_entries[i];
+            volatile DeferredCompletionEntry *deferred = &async_ctx.completion_entries[i];
             if (!append_condition_locked(
-                    *entry, deferred->addr, deferred->expected_value, static_cast<PTO2AsyncEngine>(deferred->engine),
+                    *entry, deferred->addr, deferred->expected_value, static_cast<AsyncEngine>(deferred->engine),
                     error_code
                 )) {
                 unlock();
@@ -290,8 +290,8 @@ struct PTO2AsyncWaitList {
     }
 
     template <bool Profiling>
-    PTO2AsyncPollResult poll_and_complete(
-        volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+    AsyncPollResult poll_and_complete(
+        volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
         PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
         int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -59,8 +59,7 @@ struct CompletionCondition {
             return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
         }
         return {
-            *counter_addr >= expected_value ? CompletionPollState::READY : CompletionPollState::PENDING,
-            PTO2_ERROR_NONE
+            *counter_addr >= expected_value ? CompletionPollState::READY : CompletionPollState::PENDING, PTO2_ERROR_NONE
         };
     }
 };
@@ -291,9 +290,9 @@ struct AsyncWaitList {
 
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
-        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-        PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states,
-        int32_t &deferred_release_count, int32_t deferred_release_capacity
+        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+        PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
+        int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
         ,
         int thread_idx

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_ingress.h
@@ -17,24 +17,24 @@
 #include "pto_constants.h"
 #include "pto_task_id.h"
 
-#define PTO2_COMPLETION_INGRESS_CAPACITY 4096u
-#define PTO2_COMPLETION_INGRESS_MASK (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)
+#define COMPLETION_INGRESS_CAPACITY 4096u
+#define COMPLETION_INGRESS_MASK (COMPLETION_INGRESS_CAPACITY - 1u)
 
 static_assert(
-    (PTO2_COMPLETION_INGRESS_CAPACITY & (PTO2_COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
-    "PTO2_COMPLETION_INGRESS_CAPACITY must be a power of two"
+    (COMPLETION_INGRESS_CAPACITY & (COMPLETION_INGRESS_CAPACITY - 1u)) == 0,
+    "COMPLETION_INGRESS_CAPACITY must be a power of two"
 );
 
-inline constexpr int32_t PTO2_MAX_COMPLETIONS_PER_TASK = 64;
+inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
 
-#define PTO2_COMPLETION_ENGINE_SDMA 0u
-#define PTO2_COMPLETION_ENGINE_ROCE 1u
-#define PTO2_COMPLETION_ENGINE_URMA 2u
-#define PTO2_COMPLETION_ENGINE_CCU 3u
+#define COMPLETION_ENGINE_SDMA 0u
+#define COMPLETION_ENGINE_ROCE 1u
+#define COMPLETION_ENGINE_URMA 2u
+#define COMPLETION_ENGINE_CCU 3u
 
-#define PTO2_COMPLETION_TYPE_COUNTER 0
+#define COMPLETION_TYPE_COUNTER 0
 
-struct PTO2CompletionIngressEntry {
+struct CompletionIngressEntry {
     volatile uint64_t seq;
     PTO2TaskId task_token;
     uint64_t addr;
@@ -44,9 +44,9 @@ struct PTO2CompletionIngressEntry {
     uint32_t _pad[6];
 };
 
-static_assert(sizeof(PTO2CompletionIngressEntry) == PTO2_ALIGN_SIZE, "PTO2CompletionIngressEntry layout drift");
+static_assert(sizeof(CompletionIngressEntry) == PTO2_ALIGN_SIZE, "CompletionIngressEntry layout drift");
 
-struct PTO2DeferredCompletionEntry {
+struct DeferredCompletionEntry {
     uint64_t addr;
     uint32_t expected_value;
     uint32_t engine;
@@ -54,30 +54,30 @@ struct PTO2DeferredCompletionEntry {
     uint32_t _pad;
 };
 
-static_assert(sizeof(PTO2DeferredCompletionEntry) == 24, "PTO2DeferredCompletionEntry layout drift");
+static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
 
-struct alignas(PTO2_ALIGN_SIZE) PTO2DeferredCompletionIngressBuffer {
+struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionIngressBuffer {
     volatile uint32_t count;
     volatile int32_t error_code;
-    PTO2DeferredCompletionEntry entries[PTO2_MAX_COMPLETIONS_PER_TASK];
+    DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
 };
 
 static_assert(
-    sizeof(PTO2DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
-    "PTO2DeferredCompletionIngressBuffer size must preserve array element cache-line boundaries"
+    sizeof(DeferredCompletionIngressBuffer) % PTO2_ALIGN_SIZE == 0,
+    "DeferredCompletionIngressBuffer size must preserve array element cache-line boundaries"
 );
 
-struct PTO2CompletionIngressQueue {
+struct CompletionIngressQueue {
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
     alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
     uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
-    alignas(PTO2_ALIGN_SIZE) PTO2CompletionIngressEntry entries[PTO2_COMPLETION_INGRESS_CAPACITY];
+    alignas(PTO2_ALIGN_SIZE) CompletionIngressEntry entries[COMPLETION_INGRESS_CAPACITY];
 };
 
 static_assert(
-    sizeof(PTO2CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
-    "PTO2CompletionIngressQueue size must be cache-line aligned"
+    sizeof(CompletionIngressQueue) % PTO2_ALIGN_SIZE == 0,
+    "CompletionIngressQueue size must be cache-line aligned"
 );
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_INGRESS_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_
+
+#include <stdint.h>
+
+#include "pto_completion_ingress.h"
+
+// CompletionToken is the runtime-internal POD that backend submit handlers
+// produce and the generic register_completion_condition() consumes. It is the
+// ABI contract for "this is one completion to wait on" — independent of which
+// backend (SDMA, RoCE, notification counter, ...) generated it. Each backend's
+// (poll, retire) pair is registered in pto_async_wait.h's ops table, keyed by
+// completion_type.
+struct CompletionToken {
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint64_t backend_cookie;
+};
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_COMPLETION_TOKEN_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 
 // CompletionToken is the runtime-internal POD that backend submit handlers
 // produce and the generic register_completion_condition() consumes. It is the

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -311,7 +311,7 @@ runtime_create_custom(PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t 
     // Connect orchestrator to scheduler (for simulated mode)
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
     if (!rt->completion_ingress) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();
@@ -354,7 +354,7 @@ PTO2Runtime *runtime_create_from_sm(
 
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<PTO2CompletionIngressQueue *>(calloc(1, sizeof(PTO2CompletionIngressQueue)));
+    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
     if (!rt->completion_ingress) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -311,8 +311,8 @@ runtime_create_custom(PTO2RuntimeMode mode, uint64_t task_window_size, uint64_t 
     // Connect orchestrator to scheduler (for simulated mode)
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
-    if (!rt->completion_ingress) {
+    rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(calloc(1, sizeof(AICoreCompletionMailbox)));
+    if (!rt->aicore_mailbox) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();
         free(rt->gm_heap);
@@ -354,8 +354,8 @@ PTO2Runtime *runtime_create_from_sm(
 
     rt->orchestrator.set_scheduler(&rt->scheduler);
 
-    rt->completion_ingress = static_cast<CompletionIngressQueue *>(calloc(1, sizeof(CompletionIngressQueue)));
-    if (!rt->completion_ingress) {
+    rt->aicore_mailbox = static_cast<AICoreCompletionMailbox *>(calloc(1, sizeof(AICoreCompletionMailbox)));
+    if (!rt->aicore_mailbox) {
         rt->scheduler.destroy();
         rt->orchestrator.destroy();
         free(rt);
@@ -371,7 +371,7 @@ void runtime_destroy(PTO2Runtime *rt) {
     rt->scheduler.destroy();
     rt->orchestrator.destroy();
 
-    free(rt->completion_ingress);
+    free(rt->aicore_mailbox);
 
     if (rt->gm_heap_owned && rt->gm_heap) {
         free(rt->gm_heap);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -42,7 +42,7 @@
 #include "pto_tensormap.h"
 #include "scheduler/pto_scheduler.h"
 #include "pto_orchestrator.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 
 // =============================================================================
 // Runtime Context
@@ -106,7 +106,7 @@ struct PTO2Runtime {
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
-    CompletionIngressQueue *completion_ingress;
+    AICoreCompletionMailbox *aicore_mailbox;
 
     // GM Heap for output buffers
     void *gm_heap;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -106,7 +106,7 @@ struct PTO2Runtime {
     PTO2SharedMemoryHandle *sm_handle;
     PTO2OrchestratorState orchestrator;
     PTO2SchedulerState scheduler;
-    PTO2CompletionIngressQueue *completion_ingress;
+    CompletionIngressQueue *completion_ingress;
 
     // GM Heap for output buffers
     void *gm_heap;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -34,7 +34,7 @@
 #include "pto_constants.h"
 #include "pto_runtime_status.h"
 #include "pto2_dispatch_payload.h"
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 #include "pto_submit_types.h"
 #include "pto_task_id.h"
 #include "pto_types.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -48,14 +48,14 @@
 #define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 
 typedef enum {
-    PTO2_ASYNC_ENGINE_SDMA = 0,
-    PTO2_ASYNC_ENGINE_ROCE = 1,
-    PTO2_ASYNC_ENGINE_URMA = 2,
-    PTO2_ASYNC_ENGINE_CCU = 3,
-    PTO2_NUM_ASYNC_ENGINES = 4,
-} PTO2AsyncEngine;
+    ASYNC_ENGINE_SDMA = 0,
+    ASYNC_ENGINE_ROCE = 1,
+    ASYNC_ENGINE_URMA = 2,
+    ASYNC_ENGINE_CCU = 3,
+    NUM_ASYNC_ENGINES = 4,
+} AsyncEngine;
 
-enum class PTO2CompletionType : int32_t {
+enum class CompletionType : int32_t {
     COUNTER = 0,
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1019,9 +1019,8 @@ struct PTO2SchedulerState {
 
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
-    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
-    PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
-    int32_t deferred_release_capacity
+    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+    PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
     ,
     int thread_idx

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1019,7 +1019,7 @@ struct PTO2SchedulerState {
 
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
-    volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched,
     PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
     int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
@@ -1031,7 +1031,7 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
     if (!try_lock()) return result;
 
     int32_t drain_err = PTO2_ERROR_NONE;
-    drain_completion_ingress_locked(completion_ingress, drain_err);
+    drain_aicore_completion_mailbox_locked(aicore_mailbox, drain_err);
     if (drain_err != PTO2_ERROR_NONE) {
         result.error_code = drain_err;
         unlock();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -504,7 +504,7 @@ static_assert(sizeof(PTO2SpscQueue) == 256, "PTO2SpscQueue must be exactly 4 cac
 /**
  * Statistics returned by mixed-task completion processing
  */
-struct PTO2CompletionStats {
+struct CompletionStats {
     int32_t fanout_edges;       // Number of fanout edges traversed (notify consumers)
     int32_t tasks_enqueued;     // Number of consumers that became READY
     int32_t fanin_edges;        // Number of fanin edges traversed (release producers)
@@ -597,7 +597,7 @@ struct PTO2SchedulerState {
     );
     static_assert(sizeof(WiringState) == 576, "WiringState must be exactly 9 cache lines (576B)");
 
-    alignas(64) PTO2AsyncWaitList async_wait_list;
+    alignas(64) AsyncWaitList async_wait_list;
 
     // Statistics (cold path, isolated from hot-path fields)
 #if PTO2_SCHED_PROFILING
@@ -901,7 +901,7 @@ struct PTO2SchedulerState {
      * Handles fanout notification, fanin release, and self-consumption check.
      */
 #if PTO2_SCHED_PROFILING
-    PTO2CompletionStats
+    CompletionStats
 #else
     void
 #endif
@@ -914,7 +914,7 @@ struct PTO2SchedulerState {
         PTO2LocalReadyBuffer *local_bufs = nullptr
     ) {
 #if PTO2_SCHED_PROFILING
-        PTO2CompletionStats stats = {0, 0, 0, true};
+        CompletionStats stats = {0, 0, 0, true};
 #endif
 #if PTO2_SCHED_PROFILING
         extern uint64_t g_sched_lock_cycle[], g_sched_fanout_cycle[];
@@ -1018,8 +1018,8 @@ struct PTO2SchedulerState {
 // See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
 template <bool Profiling>
-inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
-    volatile PTO2CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
+inline AsyncPollResult AsyncWaitList::poll_and_complete(
+    volatile CompletionIngressQueue *completion_ingress, PTO2SchedulerState *sched,
     PTO2LocalReadyBuffer *local_bufs, PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
     int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
@@ -1027,7 +1027,7 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
     int thread_idx
 #endif
 ) {
-    PTO2AsyncPollResult result;
+    AsyncPollResult result;
     if (!try_lock()) return result;
 
     int32_t drain_err = PTO2_ERROR_NONE;
@@ -1039,18 +1039,18 @@ inline PTO2AsyncPollResult PTO2AsyncWaitList::poll_and_complete(
     }
 
     for (int32_t i = count - 1; i >= 0; --i) {
-        PTO2AsyncWaitEntry &entry = entries[i];
+        AsyncWaitEntry &entry = entries[i];
         for (int32_t c = 0; c < entry.condition_count; c++) {
-            PTO2CompletionCondition &cond = entry.conditions[c];
+            CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
-            PTO2CompletionPollResult poll = cond.test();
-            if (poll.state == PTO2CompletionPollState::FAILED) {
+            CompletionPollResult poll = cond.test();
+            if (poll.state == CompletionPollState::FAILED) {
                 result.error_code = poll.error_code;
                 result.failed_slot_state = entry.slot_state;
                 unlock();
                 return result;
             }
-            if (poll.state == PTO2CompletionPollState::READY) {
+            if (poll.state == CompletionPollState::READY) {
                 cond.satisfied = true;
                 entry.waiting_completion_count--;
             }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -838,7 +838,7 @@ int32_t SchedulerContext::init(
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
-    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
+    memset(deferred_slab_per_core_, 0, sizeof(deferred_slab_per_core_));
 
     // Initialize per-core GlobalContext (sub_block_id) based on cluster position.
     // This is done once at startup and never modified afterwards.
@@ -870,7 +870,7 @@ void SchedulerContext::deinit() {
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
-    memset(deferred_ingress_per_core_, 0, sizeof(deferred_ingress_per_core_));
+    memset(deferred_slab_per_core_, 0, sizeof(deferred_slab_per_core_));
 
     // Reset sync-start drain coordination — a previous run that aborted mid-drain
     // would otherwise leave dirty pending/elected/ack state for the next reuse.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -83,18 +83,18 @@ void SchedulerContext::complete_slot_task(
     bool mixed_complete = sched_->on_subtask_complete(slot_state);
     if (slot_state.payload != nullptr) {
         int32_t reg_err = PTO2_ERROR_NONE;
-        PTO2AsyncWaitList::RegisterResult reg_result;
-        volatile PTO2DeferredCompletionIngressBuffer *deferred_ingress =
+        AsyncWaitList::RegisterResult reg_result;
+        volatile DeferredCompletionIngressBuffer *deferred_ingress =
             &deferred_ingress_per_core_[core_id][expected_reg_task_id & 1];
         AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);
-            if (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped) {
+            if (reg_result == AsyncWaitList::RegisterResult::Skipped) {
                 SPIN_WAIT_HINT();
             }
-        } while (reg_result == PTO2AsyncWaitList::RegisterResult::Skipped);
+        } while (reg_result == AsyncWaitList::RegisterResult::Skipped);
 
-        if (reg_result == PTO2AsyncWaitList::RegisterResult::Error) {
+        if (reg_result == AsyncWaitList::RegisterResult::Error) {
             int32_t expected = PTO2_ERROR_NONE;
             sched_->sm_header->sched_error_code.compare_exchange_strong(
                 expected, reg_err, std::memory_order_acq_rel, std::memory_order_acquire
@@ -103,7 +103,7 @@ void SchedulerContext::complete_slot_task(
             return;
         }
 
-        if (mixed_complete && reg_result == PTO2AsyncWaitList::RegisterResult::Registered) {
+        if (mixed_complete && reg_result == AsyncWaitList::RegisterResult::Registered) {
             return;
         }
     }
@@ -122,7 +122,7 @@ void SchedulerContext::complete_slot_task(
         }
 #endif
 #if PTO2_SCHED_PROFILING
-        PTO2CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
+        CompletionStats cstats = sched_->on_mixed_task_complete(slot_state, thread_idx, local_bufs);
         l2_perf.notify_edges_total += cstats.fanout_edges;
         if (cstats.fanout_edges > l2_perf.notify_max_degree) l2_perf.notify_max_degree = cstats.fanout_edges;
         l2_perf.notify_tasks_enqueued += cstats.tasks_enqueued;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -84,9 +84,9 @@ void SchedulerContext::complete_slot_task(
     if (slot_state.payload != nullptr) {
         int32_t reg_err = PTO2_ERROR_NONE;
         AsyncWaitList::RegisterResult reg_result;
-        volatile DeferredCompletionIngressBuffer *deferred_ingress =
-            &deferred_ingress_per_core_[core_id][expected_reg_task_id & 1];
-        AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
+        volatile DeferredCompletionSlab *deferred_slab =
+            &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);
             if (reg_result == AsyncWaitList::RegisterResult::Skipped) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -84,8 +84,7 @@ void SchedulerContext::complete_slot_task(
     if (slot_state.payload != nullptr) {
         int32_t reg_err = PTO2_ERROR_NONE;
         AsyncWaitList::RegisterResult reg_result;
-        volatile DeferredCompletionSlab *deferred_slab =
-            &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
         AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
         do {
             reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -127,7 +127,7 @@ private:
     // the same runtime lifetime as payload_per_core_, but is kept out of the
     // dispatch payload so normal task dispatch layout and cache footprint stay
     // unchanged.
-    PTO2DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
+    DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
 
     // sync_start drain coordination
     SyncStartDrainState drain_state_;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -16,7 +16,7 @@
 
 #include "scheduler/pto_scheduler.h"
 
-#include "pto_completion_ingress.h"
+#include "aicore_completion_mailbox.h"
 
 // These macros are defined in runtime.h, but we cannot include it here
 // (it pulls in Handshake which we only forward-declare).  Mirror the
@@ -127,7 +127,7 @@ private:
     // the same runtime lifetime as payload_per_core_, but is kept out of the
     // dispatch payload so normal task dispatch layout and cache footprint stay
     // unchanged.
-    DeferredCompletionIngressBuffer deferred_ingress_per_core_[RUNTIME_MAX_WORKER][2];
+    DeferredCompletionSlab deferred_slab_per_core_[RUNTIME_MAX_WORKER][2];
 
     // sync_start drain coordination
     SyncStartDrainState drain_state_;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -136,10 +136,10 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    DeferredCompletionIngressBuffer *deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
-    deferred_ingress->count = 0;
-    deferred_ingress->error_code = PTO2_ERROR_NONE;
-    AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
+    DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][buf_idx];
+    deferred_slab->count = 0;
+    deferred_slab->error_code = PTO2_ERROR_NONE;
+    AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
     build_payload(payload, slot_state, subslot, async_ctx);
 
     if (to_pending) {
@@ -448,10 +448,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
         }
 
-        if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
+        if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
             (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
             AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
-                rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
+                rt_->aicore_mailbox, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP
 #if PTO2_SCHED_PROFILING
                 ,

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -136,7 +136,7 @@ void SchedulerContext::dispatch_subtask_to_core(
 
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
-    PTO2DeferredCompletionIngressBuffer *deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
+    DeferredCompletionIngressBuffer *deferred_ingress = &deferred_ingress_per_core_[core_id][buf_idx];
     deferred_ingress->count = 0;
     deferred_ingress->error_code = PTO2_ERROR_NONE;
     AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_ingress);
@@ -450,7 +450,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         if (rt_ != nullptr && rt_->completion_ingress != nullptr &&
             (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
-            PTO2AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
+            AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
                 rt_->completion_ingress, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP
 #if PTO2_SCHED_PROFILING


### PR DESCRIPTION
PR-696 landed the SDMA `AsyncEvent` → GM flag mechanism but kept the
plumbing exposed: examples pulled PTO-ISA detail directly, the scheduler
hard-coded a `switch` on `completion_type`, and there was no
user-level "submit + auto-register completion" entry. This PR converges
the kernel-facing API to 3 interfaces (the originally-planned
request/completion pair is merged into one — the intermediate `tag`
had no other use) and isolates SDMA detail behind `backend/sdma/`.

### Commits

| Summary |
|--|
| `CompletionToken` POD + table-driven scheduler dispatch |
| Drop `pto2_` / `PTO2_` prefixes in the async/completion subsystem |
| Move SDMA detail into `backend/sdma/` |
| Add `SdmaRequestDescriptor` + `send_request_entry` SDMA overload |
| Rewrite `sdma_async_completion_demo` against the new API |
| Privatize `defer_*` helpers into `pto2::detail` |
| Rename `CompletionIngressQueue` → `AICoreCompletionMailbox` |

### Public kernel API after this PR

Three user-facing interfaces:

- `send_notification(remote_counter, value, op)`
- `save_expected_notification_counter(ctx, addr, expected)`
- `send_request_entry(ctx, SdmaRequestDescriptor)` —
  in `backend/sdma/sdma_completion_kernel.h`; further backends add
  their own overload.

Plus `get_async_ctx` to materialize the context and
`register_completion_condition` as the backend-adapter registration
entry.

### Verification

- a2a3 + a5 onboard runtimes build clean.
- a2a3-onboard demos `sdma_async_completion_demo`, `async_notify_demo`,
  `deferred_notify_demo` all pass with `max_diff = 0`.
- Audit greps under `src/` and `examples/` for `BuildAsyncSession`,
  `TGET_ASYNC`, `sdma::detail::`, `SdmaEventRecord`, and any
  `ingress` token come back empty (outside `backend/sdma/`).
