### PR TITLE
Fix: raise CHIP_MAX_TENSOR_ARGS to 128 and drop RUNTIME_MAX_TENSOR_PAIRS

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -863,7 +863,7 @@ int DeviceRunner::prepare_orch_so(Runtime &runtime) {
 
 int DeviceRunner::register_prepared_callable(
     int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name, const char *config_name,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     // The AICPU executor reserves `orch_so_table_[MAX_REGISTERED_CALLABLE_IDS]`
     // (declared in src/common/task_interface/callable_protocol.h) and indexes it by
@@ -925,13 +925,14 @@ int DeviceRunner::register_prepared_callable(
     state.func_name = (func_name != nullptr) ? func_name : "";
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     return 0;
 }
 
 int DeviceRunner::register_prepared_callable_host_orch(
     int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -953,6 +954,7 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
@@ -992,7 +994,7 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return {-1, nullptr};
+        return {-1, nullptr, nullptr, 0};
     }
     const auto &state = it->second;
 
@@ -1003,7 +1005,7 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return {-1, nullptr};
+            return {-1, nullptr, nullptr, 0};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
@@ -1015,7 +1017,10 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     // hbg path: host_orch_func_ptr travels back to the c_api caller, which
     // hands it to bind_prepared_to_runtime_impl. trb path: stays null and
     // the device-side orch SO is resolved from the symbol names above.
-    return {0, state.host_orch_func_ptr};
+    return {
+        0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
+        static_cast<int>(state.signature.size())
+    };
 }
 
 int DeviceRunner::finalize() {

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -444,7 +444,7 @@ public:
      */
     int register_prepared_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
-        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs
+        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
@@ -459,7 +459,7 @@ public:
      */
     int register_prepared_callable_host_orch(
         int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-        std::vector<std::pair<int, uint64_t>> kernel_addrs
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
@@ -583,6 +583,7 @@ private:
         std::string config_name;
         // common
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
+        std::vector<ArgDirection> signature;
         // hbg path (host already dlopen'd the orch SO)
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -46,7 +46,10 @@ extern "C" {
 int prepare_callable_impl(
     const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
 );
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
+int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count
+);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -196,16 +199,6 @@ int finalize_device(DeviceContextHandle ctx) {
     }
 }
 
-/* ===========================================================================
- * Internal helpers called from runtime_maker.cpp via Runtime.host_api
- * =========================================================================== */
-
-void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
-    if (runtime == NULL) return;
-    Runtime *r = static_cast<Runtime *>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size
@@ -289,12 +282,13 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         // leaves it null and fills orch_so_data + func_name/config_name.
         if (artifacts.host_dlopen_handle != nullptr) {
             return runner->register_prepared_callable_host_orch(
-                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
+                std::move(artifacts.signature)
             );
         }
         return runner->register_prepared_callable(
             callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-            artifacts.config_name.c_str(), std::move(kernel_addrs)
+            artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
         );
     } catch (...) {
         return -1;
@@ -336,15 +330,21 @@ int run_prepared(
 
         // Restore kernel addrs + orch symbol names + active_callable_id; the
         // returned host_orch_func_ptr is non-null only on the hbg path and is
-        // handed straight into bind_prepared_to_runtime_impl below.
-        auto [bind_rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
-        if (bind_rc != 0) {
+        // handed straight into bind_prepared_to_runtime_impl below. signature
+        // is the cached ChipCallable signature_[]; it's plumbed end-to-end for
+        // per-tensor direction decisions in runtime_maker but is currently
+        // unconsumed on both runtimes — see bind_prepared_to_runtime_impl.
+        auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        if (bind_result.rc != 0) {
             r->~Runtime();
-            return bind_rc;
+            return bind_result.rc;
         }
 
         // Per-run binding (tensor args, GM heap, SM alloc)
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
+        rc = bind_prepared_to_runtime_impl(
+            r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
+            bind_result.signature, bind_result.sig_count
+        );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -759,7 +759,7 @@ int DeviceRunner::prepare_orch_so(Runtime &runtime) {
 
 int DeviceRunner::register_prepared_callable(
     int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name, const char *config_name,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     // The AICPU executor reserves `orch_so_table_[MAX_REGISTERED_CALLABLE_IDS]`
     // (declared in src/common/task_interface/callable_protocol.h) and indexes it by
@@ -815,13 +815,14 @@ int DeviceRunner::register_prepared_callable(
     state.func_name = (func_name != nullptr) ? func_name : "";
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     return 0;
 }
 
 int DeviceRunner::register_prepared_callable_host_orch(
     int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -843,6 +844,7 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
@@ -882,20 +884,23 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return {-1, nullptr};
+        return {-1, nullptr, nullptr, 0};
     }
     const auto &state = it->second;
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return {-1, nullptr};
+            return {-1, nullptr, nullptr, 0};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return {0, state.host_orch_func_ptr};
+    return {
+        0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
+        static_cast<int>(state.signature.size())
+    };
 }
 
 int DeviceRunner::finalize() {

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -219,14 +219,14 @@ public:
 
     int register_prepared_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
-        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs
+        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
     // Host-orchestration sibling of register_prepared_callable; see
     // src/a2a3/platform/onboard/host/device_runner.h for the contract. Sim
     // shares the host-only dlopen path verbatim (no AICPU side effects).
     int register_prepared_callable_host_orch(
         int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-        std::vector<std::pair<int, uint64_t>> kernel_addrs
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
     int unregister_prepared_callable(int32_t callable_id);
     bool has_prepared_callable(int32_t callable_id) const;
@@ -277,6 +277,7 @@ private:
         std::string config_name;
         // common
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
+        std::vector<ArgDirection> signature;
         // hbg path
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -41,7 +41,10 @@ extern "C" {
 int prepare_callable_impl(
     const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
 );
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
+int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count
+);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -187,16 +190,6 @@ int destroy_comm_stream_ctx(DeviceContextHandle ctx, void *stream) {
     return 0;
 }
 
-/* ===========================================================================
- * Internal helpers called from runtime_maker.cpp via Runtime.host_api
- * =========================================================================== */
-
-void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
-    if (runtime == NULL) return;
-    Runtime *r = static_cast<Runtime *>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size
@@ -260,12 +253,13 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->register_prepared_callable_host_orch(
-                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
+                std::move(artifacts.signature)
             );
         } else {
             rc = runner->register_prepared_callable(
                 callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-                artifacts.config_name.c_str(), std::move(kernel_addrs)
+                artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
             );
         }
         pthread_setspecific(g_runner_key, nullptr);
@@ -300,14 +294,18 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        auto [rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        int rc = bind_result.rc;
         if (rc != 0) {
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
+        rc = bind_prepared_to_runtime_impl(
+            r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
+            bind_result.signature, bind_result.sig_count
+        );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -15,7 +15,7 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 
 1. Python tooling compiles kernels and orchestration into shared objects.
 2. `prepare_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and stores it in `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
-3. The orchestration function runs on the host and builds the graph. It allocates device buffers, copies input data to device, records output buffers with `record_tensor_pair(runtime, ...)`, adds tasks via `add_task(runtime, ...)`, and adds dependency edges via `add_successor(runtime, ...)`.
+3. The orchestration function runs on the host and builds the graph. Because it runs on host, it can (and sometimes must) dereference entry-tensor host pointers — e.g. to read a control tensor that drives per-block dispatch. So the orch owns its own H2D: it allocates device buffers, copies inputs to device, and registers outputs for copy-back via `record_tensor_pair(runtime, ...)`. It adds tasks via `add_task(runtime, ...)` and adds dependency edges via `add_successor(runtime, ...)`. (Contrast with `tensormap_and_ringbuffer`, where the orch runs on device AICPU and `runtime_maker.cpp` centralizes H2D using the chip-level `ArgDirection` signature.)
 4. The populated `Runtime` is copied to device memory by the platform layer. AICPU then runs the executor with this Runtime snapshot.
 
 ## Execution Flow (Device)

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -131,7 +131,7 @@ void runtime_add_successor(OrchestrationRuntime *runtime, int from_task, int to_
 }
 
 void runtime_record_tensor_pair(OrchestrationRuntime *runtime, void *host_ptr, void *dev_ptr, size_t size) {
-    unwrap_runtime(runtime)->record_tensor_pair(host_ptr, dev_ptr, size);
+    unwrap_runtime(runtime)->tensor_pairs_.push_back({host_ptr, dev_ptr, size});
 }
 
 int runtime_get_task_count(OrchestrationRuntime *runtime) { return unwrap_runtime(runtime)->get_task_count(); }
@@ -297,6 +297,7 @@ int prepare_callable_impl(
         return -1;
     }
     *out = PreparedCallableArtifacts{};
+    out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
@@ -358,7 +359,10 @@ int prepare_callable_impl(
  * DeviceRunner::bind_prepared_callable_to_runtime (which read it from
  * PreparedCallableState for this run's callable_id).
  */
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
+int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count
+) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -373,7 +377,7 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
         return -1;
     }
 
-    runtime->clear_tensor_pairs();
+    runtime->tensor_pairs_.clear();
 
     LOG_INFO_V0("=== Calling Orchestration Function ===");
     LOG_DEBUG(
@@ -387,17 +391,25 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
         &k_orchestration_runtime_ops, runtime, &tensor_info_builder, &tensor_allocation_builder
     };
 
+    // hbg orch runs on the host, so it may legitimately need to dereference
+    // entry-tensor host pointers (e.g. to drive per-block dispatch from a
+    // control tensor). Unlike TMARB, runtime_maker cannot pre-upload entry
+    // tensors here without breaking that pattern — the orch keeps ownership
+    // of H2D decisions and uses record_tensor_pair to register outputs for
+    // copy-back. signature is plumbed for future use but unused on this path.
+    (void)signature;
+    (void)sig_count;
     int rc = orch_func(reinterpret_cast<OrchestrationRuntime *>(&orchestration_runtime), *orch_args);
     if (rc != 0) {
         LOG_ERROR("Orchestration function failed with code %d", rc);
-        runtime->clear_tensor_pairs();
+        runtime->tensor_pairs_.clear();
         return rc;
     }
 
     rc = upload_tensor_allocation_storage(runtime, tensor_allocation_builder);
     if (rc != 0) {
         LOG_ERROR("Failed to upload tensor allocations: %d", rc);
-        runtime->clear_tensor_pairs();
+        runtime->tensor_pairs_.clear();
         return rc;
     }
 
@@ -408,7 +420,7 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
             runtime->host_api.device_free(runtime->get_tensor_allocation_storage());
             runtime->clear_tensor_allocation_storage();
         }
-        runtime->clear_tensor_pairs();
+        runtime->tensor_pairs_.clear();
         return rc;
     }
 
@@ -438,8 +450,8 @@ int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO_V0("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
-    int tensor_pair_count = runtime->get_tensor_pair_count();
+    TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
+    int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
 
     for (int i = 0; i < tensor_pair_count; i++) {
         const TensorPair &pair = tensor_pairs[i];
@@ -486,7 +498,7 @@ int validate_runtime_impl(Runtime *runtime) {
     }
 
     // Clear tensor pairs
-    runtime->clear_tensor_pairs();
+    runtime->tensor_pairs_.clear();
 
     LOG_INFO_V0("=== Finalize Complete ===");
 

--- a/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a2a3/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -33,6 +33,12 @@ typedef struct OrchestrationRuntimeOps {
         OrchestrationRuntime *runtime, int task_id, const TensorInfo *tensor_info, int tensor_count
     );
     void (*add_successor)(OrchestrationRuntime *runtime, int from_task, int to_task);
+    // Host-build-graph orch owns its entry-tensor H2D (the orch runs on host
+    // and may need host-side pointers for control tensors). This call
+    // registers a host<->device mapping so runtime_maker's validate path can
+    // D2H copy-back and free at finalize. TMARB has no equivalent — its
+    // runtime_maker handles tensor uploads directly because its orch is
+    // device-side.
     void (*record_tensor_pair)(OrchestrationRuntime *runtime, void *host_ptr, void *dev_ptr, size_t size);
     int (*get_task_count)(OrchestrationRuntime *runtime);
     void (*print_runtime)(OrchestrationRuntime *runtime);

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,7 +45,6 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
-    tensor_pair_count = 0;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;
     tensor_allocation_storage_ = nullptr;
@@ -208,28 +207,6 @@ void Runtime::print_runtime() const {
 
     LOG_DEBUG("========================================================================");
 }
-
-// =============================================================================
-// Tensor Pair Management
-// =============================================================================
-
-void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
-    if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
-        LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
-        return;
-    }
-    tensor_pairs[tensor_pair_count].host_ptr = host_ptr;
-    tensor_pairs[tensor_pair_count].dev_ptr = dev_ptr;
-    tensor_pairs[tensor_pair_count].size = size;
-    tensor_pair_count++;
-    LOG_DEBUG("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
-}
-
-TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
-
-int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
-
-void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Kernel Binary Address Management

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -35,6 +35,7 @@
 #include <string.h>  // for memset
 
 #include <atomic>
+#include <vector>
 
 #include "common/core_type.h"
 #include "common/l2_perf_profiling.h"
@@ -63,10 +64,6 @@
 
 #ifndef RUNTIME_MAX_WORKER
 #define RUNTIME_MAX_WORKER PLATFORM_MAX_CORES_PER_THREAD
-#endif
-
-#ifndef RUNTIME_MAX_TENSOR_PAIRS
-#define RUNTIME_MAX_TENSOR_PAIRS 64
 #endif
 
 #ifndef RUNTIME_MAX_FUNC_ID
@@ -216,10 +213,6 @@ private:
     int initial_ready_tasks[RUNTIME_MAX_TASKS];
     int initial_ready_count;
 
-    // Tensor pairs for host-device memory tracking
-    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-    int tensor_pair_count;
-
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
@@ -312,38 +305,6 @@ public:
      * Shows task table with fanin/fanout information.
      */
     void print_runtime() const;
-
-    // =========================================================================
-    // Tensor Pair Management
-    // =========================================================================
-
-    /**
-     * Record a host-device tensor pair for copy-back during finalize.
-     *
-     * @param host_ptr  Host memory pointer (destination for copy-back)
-     * @param dev_ptr   Device memory pointer (source for copy-back)
-     * @param size     Size of tensor in bytes
-     */
-    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
-
-    /**
-     * Get pointer to tensor pairs array.
-     *
-     * @return Pointer to tensor pairs array
-     */
-    TensorPair *get_tensor_pairs();
-
-    /**
-     * Get number of recorded tensor pairs.
-     *
-     * @return Number of tensor pairs
-     */
-    int get_tensor_pair_count() const;
-
-    /**
-     * Clear all recorded tensor pairs.
-     */
-    void clear_tensor_pairs();
 
     // =========================================================================
     // Tensor Info Metadata
@@ -519,6 +480,13 @@ public:
     }
     int32_t get_active_callable_id() const { return active_callable_id_; }
     bool register_new_callable_id() const { return register_new_callable_id_; }
+
+    // Host-side tensor ledger for D2H copy-back at finalize. Populated by
+    // runtime_maker.cpp from orch_args at bind time; iterated in
+    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
+    // Runtime image carries the std::vector control block as harmless
+    // garbage, identical to host_api above. No fixed cap.
+    std::vector<TensorPair> tensor_pairs_;
 };
 
 #endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -115,6 +115,7 @@ extern "C" int prepare_callable_impl(
         return -1;
     }
     *out = PreparedCallableArtifacts{};
+    out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
@@ -158,8 +159,10 @@ extern "C" int prepare_callable_impl(
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
-extern "C" int
-bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
+extern "C" int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection * /*signature*/, int /*sig_count*/
+) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -210,7 +213,7 @@ bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_
             runtime->host_api.device_free(dev_ptr);
             return -1;
         }
-        runtime->record_tensor_pair(host_ptr, dev_ptr, size);
+        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size});
         LOG_INFO_V0("  Tensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         t.data = reinterpret_cast<uint64_t>(dev_ptr);
@@ -277,7 +280,7 @@ bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_
         LOG_ERROR("Failed to allocate GM heap");
         return -1;
     }
-    runtime->record_tensor_pair(nullptr, gm_heap, total_heap_size);
+    runtime->tensor_pairs_.push_back({nullptr, gm_heap, total_heap_size});
     runtime->set_gm_heap(gm_heap);
 
     // Allocate PTO2 shared memory
@@ -290,7 +293,7 @@ bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_
         return -1;
     }
     runtime->set_gm_sm_ptr(sm_ptr);
-    runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
+    runtime->tensor_pairs_.push_back({nullptr, sm_ptr, static_cast<size_t>(sm_size)});
 
     // Set up device orchestration state
     runtime->set_orch_args(device_args);
@@ -328,8 +331,8 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO_V0("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
-    int tensor_pair_count = runtime->get_tensor_pair_count();
+    TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
+    int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
 
     LOG_INFO_V0("Tensor pairs to process: %d", tensor_pair_count);
 
@@ -423,7 +426,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     runtime->clear_registered_kernels();
 
     // Clear tensor pairs
-    runtime->clear_tensor_pairs();
+    runtime->tensor_pairs_.clear();
 
     LOG_INFO_V0("=== Finalize Complete ===");
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -34,6 +34,8 @@
 #include <stdio.h>   // for fprintf, printf
 #include <string.h>  // for memset
 
+#include <vector>
+
 #include "common/core_type.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
@@ -46,7 +48,6 @@
 
 #define RUNTIME_MAX_ARGS 128
 #define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
-#define RUNTIME_MAX_TENSOR_PAIRS 64
 #define RUNTIME_MAX_FUNC_ID 1024
 #define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 4MB max for orchestration SO
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
@@ -182,10 +183,6 @@ public:
     bool orch_to_sched;
 
 private:
-    // Tensor pairs for host-device memory tracking
-    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-    int tensor_pair_count;
-
     // Kernel binary tracking for cleanup
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
@@ -214,30 +211,6 @@ public:
      * Constructor - zero-initialize all arrays
      */
     Runtime();
-
-    // =========================================================================
-    // Tensor Pair Management
-    // =========================================================================
-
-    /**
-     * Record a host-device tensor pair for copy-back during finalize.
-     */
-    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
-
-    /**
-     * Get pointer to tensor pairs array.
-     */
-    TensorPair *get_tensor_pairs();
-
-    /**
-     * Get number of recorded tensor pairs.
-     */
-    int get_tensor_pair_count() const;
-
-    /**
-     * Clear all recorded tensor pairs.
-     */
-    void clear_tensor_pairs();
 
     // =========================================================================
     // Performance Profiling
@@ -303,6 +276,14 @@ public:
     // Host API function pointers for device memory operations
     // NOTE: Placed at end of class to avoid affecting device memory layout
     HostApi host_api;
+
+    // Host-side tensor ledger for D2H copy-back at finalize. Populated by
+    // runtime_maker.cpp from orch_args at bind time, then iterated in
+    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
+    // Runtime image carries the std::vector control block as harmless
+    // garbage, identical to host_api above. No fixed cap — grows with the
+    // chip-level entry-tensor count.
+    std::vector<TensorPair> tensor_pairs_;
 };
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -39,9 +39,6 @@ Runtime::Runtime() {
     dep_pool_size = 0;
     orch_to_sched = false;
 
-    // Initialize tensor pairs
-    tensor_pair_count = 0;
-
     // Initialize device orchestration state
     gm_sm_ptr_ = nullptr;
     gm_heap_ptr_ = nullptr;
@@ -64,28 +61,6 @@ Runtime::Runtime() {
         func_id_to_addr_[i] = 0;
     }
 }
-
-// =============================================================================
-// Tensor Pair Management
-// =============================================================================
-
-void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
-    if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
-        LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
-        return;
-    }
-    tensor_pairs[tensor_pair_count].host_ptr = host_ptr;
-    tensor_pairs[tensor_pair_count].dev_ptr = dev_ptr;
-    tensor_pairs[tensor_pair_count].size = size;
-    tensor_pair_count++;
-    LOG_INFO_V0("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
-}
-
-TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
-
-int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
-
-void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Device orchestration

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -644,7 +644,7 @@ int DeviceRunner::prepare_orch_so(Runtime &runtime) {
 
 int DeviceRunner::register_prepared_callable(
     int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name, const char *config_name,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     // The AICPU executor reserves `orch_so_table_[MAX_REGISTERED_CALLABLE_IDS]`
     // (declared in src/common/task_interface/callable_protocol.h) and indexes
@@ -706,13 +706,14 @@ int DeviceRunner::register_prepared_callable(
     state.func_name = (func_name != nullptr) ? func_name : "";
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     return 0;
 }
 
 int DeviceRunner::register_prepared_callable_host_orch(
     int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -734,6 +735,7 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
@@ -773,7 +775,7 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return {-1, nullptr};
+        return {-1, nullptr, nullptr, 0};
     }
     const auto &state = it->second;
 
@@ -785,7 +787,7 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return {-1, nullptr};
+            return {-1, nullptr, nullptr, 0};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
@@ -794,7 +796,10 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     // Stamp callable_id with is_new=false; prepare_orch_so refreshes the flag
     // with the authoritative first_sighting answer right before launch.
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return {0, state.host_orch_func_ptr};
+    return {
+        0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
+        static_cast<int>(state.signature.size())
+    };
 }
 
 int DeviceRunner::finalize() {

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -387,7 +387,7 @@ public:
      */
     int register_prepared_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
-        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs
+        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
@@ -397,7 +397,7 @@ public:
      */
     int register_prepared_callable_host_orch(
         int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-        std::vector<std::pair<int, uint64_t>> kernel_addrs
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /**
@@ -481,6 +481,7 @@ private:
         std::string config_name;
         // common
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
+        std::vector<ArgDirection> signature;
         // hbg path
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -46,7 +46,10 @@ extern "C" {
 int prepare_callable_impl(
     const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
 );
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
+int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count
+);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -228,16 +231,6 @@ int comm_destroy(void *handle) {
     return -1;
 }
 
-/* ===========================================================================
- * Internal helpers called from runtime_maker.cpp via Runtime.host_api
- * =========================================================================== */
-
-void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
-    if (runtime == NULL) return;
-    Runtime *r = static_cast<Runtime *>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size
@@ -311,12 +304,13 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 
         if (artifacts.host_dlopen_handle != nullptr) {
             return runner->register_prepared_callable_host_orch(
-                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
+                std::move(artifacts.signature)
             );
         }
         return runner->register_prepared_callable(
             callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-            artifacts.config_name.c_str(), std::move(kernel_addrs)
+            artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
         );
     } catch (...) {
         return -1;
@@ -358,15 +352,21 @@ int run_prepared(
 
         // Restore kernel addrs + orch symbol names + active_callable_id; the
         // returned host_orch_func_ptr is non-null only on the hbg path and is
-        // handed straight into bind_prepared_to_runtime_impl below.
-        auto [bind_rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
-        if (bind_rc != 0) {
+        // handed straight into bind_prepared_to_runtime_impl below. signature
+        // is the cached ChipCallable signature_[]; it's plumbed end-to-end for
+        // per-tensor direction decisions in runtime_maker but is currently
+        // unconsumed on both runtimes — see bind_prepared_to_runtime_impl.
+        auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        if (bind_result.rc != 0) {
             r->~Runtime();
-            return bind_rc;
+            return bind_result.rc;
         }
 
         // Per-run binding (tensor args, GM heap, SM alloc)
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
+        rc = bind_prepared_to_runtime_impl(
+            r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
+            bind_result.signature, bind_result.sig_count
+        );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -679,7 +679,7 @@ int DeviceRunner::prepare_orch_so(Runtime &runtime) {
 
 int DeviceRunner::register_prepared_callable(
     int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name, const char *config_name,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -731,13 +731,14 @@ int DeviceRunner::register_prepared_callable(
     state.func_name = (func_name != nullptr) ? func_name : "";
     state.config_name = (config_name != nullptr) ? config_name : "";
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     return 0;
 }
 
 int DeviceRunner::register_prepared_callable_host_orch(
     int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-    std::vector<std::pair<int, uint64_t>> kernel_addrs
+    std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR(
@@ -759,6 +760,7 @@ int DeviceRunner::register_prepared_callable_host_orch(
     state.host_dlopen_handle = host_dlopen_handle;
     state.host_orch_func_ptr = host_orch_func_ptr;
     state.kernel_addrs = std::move(kernel_addrs);
+    state.signature = std::move(signature);
     prepared_callables_.emplace(callable_id, std::move(state));
     ++host_dlopen_total_;
     LOG_INFO_V0("register_prepared_callable_host_orch: cid=%d (host dlopen #%zu)", callable_id, host_dlopen_total_);
@@ -798,20 +800,23 @@ BindPreparedCallableResult DeviceRunner::bind_prepared_callable_to_runtime(Runti
     auto it = prepared_callables_.find(callable_id);
     if (it == prepared_callables_.end()) {
         LOG_ERROR("bind_prepared_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return {-1, nullptr};
+        return {-1, nullptr, nullptr, 0};
     }
     const auto &state = it->second;
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_prepared_callable_to_runtime: func_id=%d out of range", kv.first);
-            return {-1, nullptr};
+            return {-1, nullptr, nullptr, 0};
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
     runtime.set_device_orch_func_name(state.func_name.c_str());
     runtime.set_device_orch_config_name(state.config_name.c_str());
     runtime.set_active_callable_id(callable_id, /*is_new=*/false);
-    return {0, state.host_orch_func_ptr};
+    return {
+        0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
+        static_cast<int>(state.signature.size())
+    };
 }
 
 int DeviceRunner::finalize() {

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -210,13 +210,13 @@ public:
      */
     int register_prepared_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,
-        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs
+        const char *config_name, std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /** Host-orchestration sibling for hbg variants. See a2a3 onboard. */
     int register_prepared_callable_host_orch(
         int32_t callable_id, void *host_dlopen_handle, void *host_orch_func_ptr,
-        std::vector<std::pair<int, uint64_t>> kernel_addrs
+        std::vector<std::pair<int, uint64_t>> kernel_addrs, std::vector<ArgDirection> signature
     );
 
     /** Drop prepared state for `callable_id`; trb refcounts SO, hbg dlcloses handle. */
@@ -275,6 +275,7 @@ private:
         std::string config_name;
         // common
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
+        std::vector<ArgDirection> signature;
         // hbg path
         void *host_dlopen_handle{nullptr};
         void *host_orch_func_ptr{nullptr};

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -41,7 +41,10 @@ extern "C" {
 int prepare_callable_impl(
     const ChipCallable *callable, uint64_t (*upload_fn)(const void *), PreparedCallableArtifacts *out
 );
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr);
+int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count
+);
 int validate_runtime_impl(Runtime *runtime);
 
 /* ===========================================================================
@@ -187,16 +190,6 @@ int destroy_comm_stream_ctx(DeviceContextHandle ctx, void *stream) {
     return 0;
 }
 
-/* ===========================================================================
- * Internal helpers called from runtime_maker.cpp via Runtime.host_api
- * =========================================================================== */
-
-void record_tensor_pair(RuntimeHandle runtime, void *host_ptr, void *dev_ptr, size_t size) {
-    if (runtime == NULL) return;
-    Runtime *r = static_cast<Runtime *>(runtime);
-    r->record_tensor_pair(host_ptr, dev_ptr, size);
-}
-
 int simpler_init(
     DeviceContextHandle ctx, int device_id, const uint8_t *aicpu_binary, size_t aicpu_size,
     const uint8_t *aicore_binary, size_t aicore_size
@@ -257,12 +250,13 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->register_prepared_callable_host_orch(
-                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs)
+                callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
+                std::move(artifacts.signature)
             );
         } else {
             rc = runner->register_prepared_callable(
                 callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),
-                artifacts.config_name.c_str(), std::move(kernel_addrs)
+                artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
             );
         }
         pthread_setspecific(g_runner_key, nullptr);
@@ -297,14 +291,18 @@ int run_prepared(
         r->host_api.copy_from_device = copy_from_device;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
-        auto [rc, host_orch_func_ptr] = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        int rc = bind_result.rc;
         if (rc != 0) {
             r->~Runtime();
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
-        rc = bind_prepared_to_runtime_impl(r, reinterpret_cast<const ChipStorageTaskArgs *>(args), host_orch_func_ptr);
+        rc = bind_prepared_to_runtime_impl(
+            r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
+            bind_result.signature, bind_result.sig_count
+        );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -15,7 +15,7 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 
 1. Python tooling compiles kernels and orchestration into shared objects.
 2. `prepare_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and stores it in `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
-3. The orchestration function runs on the host and builds the graph. It allocates device buffers, copies input data to device, records output buffers with `record_tensor_pair(runtime, ...)`, adds tasks via `add_task(runtime, ...)`, and adds dependency edges via `add_successor(runtime, ...)`.
+3. The orchestration function runs on the host and builds the graph. Because it runs on host, it can (and sometimes must) dereference entry-tensor host pointers — e.g. to read a control tensor that drives per-block dispatch. So the orch owns its own H2D: it allocates device buffers, copies inputs to device, and registers outputs for copy-back via `record_tensor_pair(runtime, ...)`. It adds tasks via `add_task(runtime, ...)` and adds dependency edges via `add_successor(runtime, ...)`. (Contrast with `tensormap_and_ringbuffer`, where the orch runs on device AICPU and `runtime_maker.cpp` centralizes H2D using the chip-level `ArgDirection` signature.)
 4. The populated `Runtime` is copied to device memory by the platform layer. AICPU then runs the executor with this Runtime snapshot.
 
 ## Execution Flow (Device)

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -131,7 +131,7 @@ void runtime_add_successor(OrchestrationRuntime *runtime, int from_task, int to_
 }
 
 void runtime_record_tensor_pair(OrchestrationRuntime *runtime, void *host_ptr, void *dev_ptr, size_t size) {
-    unwrap_runtime(runtime)->record_tensor_pair(host_ptr, dev_ptr, size);
+    unwrap_runtime(runtime)->tensor_pairs_.push_back({host_ptr, dev_ptr, size});
 }
 
 int runtime_get_task_count(OrchestrationRuntime *runtime) { return unwrap_runtime(runtime)->get_task_count(); }
@@ -297,6 +297,7 @@ int prepare_callable_impl(
         return -1;
     }
     *out = PreparedCallableArtifacts{};
+    out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
@@ -358,7 +359,10 @@ int prepare_callable_impl(
  * DeviceRunner::bind_prepared_callable_to_runtime (which read it from
  * PreparedCallableState for this run's callable_id).
  */
-int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
+int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count
+) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -373,7 +377,7 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
         return -1;
     }
 
-    runtime->clear_tensor_pairs();
+    runtime->tensor_pairs_.clear();
 
     LOG_INFO_V0("=== Calling Orchestration Function ===");
     LOG_DEBUG(
@@ -387,17 +391,25 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
         &k_orchestration_runtime_ops, runtime, &tensor_info_builder, &tensor_allocation_builder
     };
 
+    // hbg orch runs on the host, so it may legitimately need to dereference
+    // entry-tensor host pointers (e.g. to drive per-block dispatch from a
+    // control tensor). Unlike TMARB, runtime_maker cannot pre-upload entry
+    // tensors here without breaking that pattern — the orch keeps ownership
+    // of H2D decisions and uses record_tensor_pair to register outputs for
+    // copy-back. signature is plumbed for future use but unused on this path.
+    (void)signature;
+    (void)sig_count;
     int rc = orch_func(reinterpret_cast<OrchestrationRuntime *>(&orchestration_runtime), *orch_args);
     if (rc != 0) {
         LOG_ERROR("Orchestration function failed with code %d", rc);
-        runtime->clear_tensor_pairs();
+        runtime->tensor_pairs_.clear();
         return rc;
     }
 
     rc = upload_tensor_allocation_storage(runtime, tensor_allocation_builder);
     if (rc != 0) {
         LOG_ERROR("Failed to upload tensor allocations: %d", rc);
-        runtime->clear_tensor_pairs();
+        runtime->tensor_pairs_.clear();
         return rc;
     }
 
@@ -408,7 +420,7 @@ int bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *o
             runtime->host_api.device_free(runtime->get_tensor_allocation_storage());
             runtime->clear_tensor_allocation_storage();
         }
-        runtime->clear_tensor_pairs();
+        runtime->tensor_pairs_.clear();
         return rc;
     }
 
@@ -438,8 +450,8 @@ int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO_V0("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
-    int tensor_pair_count = runtime->get_tensor_pair_count();
+    TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
+    int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
 
     for (int i = 0; i < tensor_pair_count; i++) {
         const TensorPair &pair = tensor_pairs[i];
@@ -486,7 +498,7 @@ int validate_runtime_impl(Runtime *runtime) {
     }
 
     // Clear tensor pairs
-    runtime->clear_tensor_pairs();
+    runtime->tensor_pairs_.clear();
 
     LOG_INFO_V0("=== Finalize Complete ===");
 

--- a/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
+++ b/src/a5/runtime/host_build_graph/orchestration/orchestration_api.h
@@ -33,6 +33,12 @@ typedef struct OrchestrationRuntimeOps {
         OrchestrationRuntime *runtime, int task_id, const TensorInfo *tensor_info, int tensor_count
     );
     void (*add_successor)(OrchestrationRuntime *runtime, int from_task, int to_task);
+    // Host-build-graph orch owns its entry-tensor H2D (the orch runs on host
+    // and may need host-side pointers for control tensors). This call
+    // registers a host<->device mapping so runtime_maker's validate path can
+    // D2H copy-back and free at finalize. TMARB has no equivalent — its
+    // runtime_maker handles tensor uploads directly because its orch is
+    // device-side.
     void (*record_tensor_pair)(OrchestrationRuntime *runtime, void *host_ptr, void *dev_ptr, size_t size);
     int (*get_task_count)(OrchestrationRuntime *runtime);
     void (*print_runtime)(OrchestrationRuntime *runtime);

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,7 +45,6 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     sche_cpu_num = 1;
-    tensor_pair_count = 0;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;
     tensor_allocation_storage_ = nullptr;
@@ -208,28 +207,6 @@ void Runtime::print_runtime() const {
 
     LOG_DEBUG("========================================================================");
 }
-
-// =============================================================================
-// Tensor Pair Management
-// =============================================================================
-
-void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
-    if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
-        LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
-        return;
-    }
-    tensor_pairs[tensor_pair_count].host_ptr = host_ptr;
-    tensor_pairs[tensor_pair_count].dev_ptr = dev_ptr;
-    tensor_pairs[tensor_pair_count].size = size;
-    tensor_pair_count++;
-    LOG_DEBUG("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
-}
-
-TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
-
-int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
-
-void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Kernel Binary Address Management

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -35,6 +35,7 @@
 #include <string.h>  // for memset
 
 #include <atomic>
+#include <vector>
 
 #include "common/core_type.h"
 #include "common/l2_perf_profiling.h"
@@ -62,10 +63,6 @@
 
 #ifndef RUNTIME_MAX_WORKER
 #define RUNTIME_MAX_WORKER PLATFORM_MAX_CORES_PER_THREAD
-#endif
-
-#ifndef RUNTIME_MAX_TENSOR_PAIRS
-#define RUNTIME_MAX_TENSOR_PAIRS 64
 #endif
 
 #ifndef RUNTIME_MAX_FUNC_ID
@@ -230,10 +227,6 @@ private:
     int initial_ready_tasks[RUNTIME_MAX_TASKS];
     int initial_ready_count;
 
-    // Tensor pairs for host-device memory tracking
-    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-    int tensor_pair_count;
-
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
@@ -326,38 +319,6 @@ public:
      * Shows task table with fanin/fanout information.
      */
     void print_runtime() const;
-
-    // =========================================================================
-    // Tensor Pair Management
-    // =========================================================================
-
-    /**
-     * Record a host-device tensor pair for copy-back during finalize.
-     *
-     * @param host_ptr  Host memory pointer (destination for copy-back)
-     * @param dev_ptr   Device memory pointer (source for copy-back)
-     * @param size     Size of tensor in bytes
-     */
-    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
-
-    /**
-     * Get pointer to tensor pairs array.
-     *
-     * @return Pointer to tensor pairs array
-     */
-    TensorPair *get_tensor_pairs();
-
-    /**
-     * Get number of recorded tensor pairs.
-     *
-     * @return Number of tensor pairs
-     */
-    int get_tensor_pair_count() const;
-
-    /**
-     * Clear all recorded tensor pairs.
-     */
-    void clear_tensor_pairs();
 
     // =========================================================================
     // Tensor Info Metadata
@@ -525,6 +486,13 @@ public:
     }
     int32_t get_active_callable_id() const { return active_callable_id_; }
     bool register_new_callable_id() const { return register_new_callable_id_; }
+
+    // Host-side tensor ledger for D2H copy-back at finalize. Populated by
+    // runtime_maker.cpp from orch_args at bind time; iterated in
+    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
+    // Runtime image carries the std::vector control block as harmless
+    // garbage, identical to host_api above. No fixed cap.
+    std::vector<TensorPair> tensor_pairs_;
 };
 
 #endif  // SRC_A5_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -115,6 +115,7 @@ extern "C" int prepare_callable_impl(
         return -1;
     }
     *out = PreparedCallableArtifacts{};
+    out->signature.assign(callable->signature_, callable->signature_ + callable->sig_count());
 
     LOG_INFO_V0("Registering %d kernel(s) in prepare_callable_impl", callable->child_count());
     if (upload_and_collect_child_addrs(callable, upload_fn, &out->kernel_addrs) != 0) {
@@ -158,8 +159,10 @@ extern "C" int prepare_callable_impl(
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
-extern "C" int
-bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr) {
+extern "C" int bind_prepared_to_runtime_impl(
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection * /*signature*/, int /*sig_count*/
+) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
         return -1;
@@ -210,7 +213,7 @@ bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_
             runtime->host_api.device_free(dev_ptr);
             return -1;
         }
-        runtime->record_tensor_pair(host_ptr, dev_ptr, size);
+        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size});
         LOG_INFO_V0("  Tensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         t.data = reinterpret_cast<uint64_t>(dev_ptr);
@@ -277,7 +280,7 @@ bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_
         LOG_ERROR("Failed to allocate GM heap");
         return -1;
     }
-    runtime->record_tensor_pair(nullptr, gm_heap, total_heap_size);
+    runtime->tensor_pairs_.push_back({nullptr, gm_heap, total_heap_size});
     runtime->set_gm_heap(gm_heap);
 
     // Allocate PTO2 shared memory
@@ -290,7 +293,7 @@ bind_prepared_to_runtime_impl(Runtime *runtime, const ChipStorageTaskArgs *orch_
         return -1;
     }
     runtime->set_gm_sm_ptr(sm_ptr);
-    runtime->record_tensor_pair(nullptr, sm_ptr, static_cast<size_t>(sm_size));
+    runtime->tensor_pairs_.push_back({nullptr, sm_ptr, static_cast<size_t>(sm_size)});
 
     // Set up device orchestration state
     runtime->set_orch_args(device_args);
@@ -328,8 +331,8 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO_V0("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair *tensor_pairs = runtime->get_tensor_pairs();
-    int tensor_pair_count = runtime->get_tensor_pair_count();
+    TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
+    int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
 
     LOG_INFO_V0("Tensor pairs to process: %d", tensor_pair_count);
 
@@ -422,7 +425,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     runtime->clear_registered_kernels();
 
     // Clear tensor pairs
-    runtime->clear_tensor_pairs();
+    runtime->tensor_pairs_.clear();
 
     LOG_INFO_V0("=== Finalize Complete ===");
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -34,6 +34,8 @@
 #include <stdio.h>   // for fprintf, printf
 #include <string.h>  // for memset
 
+#include <vector>
+
 #include "common/core_type.h"
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
@@ -46,7 +48,6 @@
 
 #define RUNTIME_MAX_ARGS 128
 #define RUNTIME_MAX_WORKER 108  // 36 AIC + 72 AIV cores
-#define RUNTIME_MAX_TENSOR_PAIRS 64
 #define RUNTIME_MAX_FUNC_ID 1024
 #define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 1MB max for orchestration SO
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
@@ -196,10 +197,6 @@ public:
     bool orch_to_sched;
 
 private:
-    // Tensor pairs for host-device memory tracking
-    TensorPair tensor_pairs[RUNTIME_MAX_TENSOR_PAIRS];
-    int tensor_pair_count;
-
     // Kernel binary tracking for cleanup
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
     int registered_kernel_count_;
@@ -228,30 +225,6 @@ public:
      * Constructor - zero-initialize all arrays
      */
     Runtime();
-
-    // =========================================================================
-    // Tensor Pair Management
-    // =========================================================================
-
-    /**
-     * Record a host-device tensor pair for copy-back during finalize.
-     */
-    void record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size);
-
-    /**
-     * Get pointer to tensor pairs array.
-     */
-    TensorPair *get_tensor_pairs();
-
-    /**
-     * Get number of recorded tensor pairs.
-     */
-    int get_tensor_pair_count() const;
-
-    /**
-     * Clear all recorded tensor pairs.
-     */
-    void clear_tensor_pairs();
 
     // =========================================================================
     // Performance Profiling
@@ -317,6 +290,14 @@ public:
     // Host API function pointers for device memory operations
     // NOTE: Placed at end of class to avoid affecting device memory layout
     HostApi host_api;
+
+    // Host-side tensor ledger for D2H copy-back at finalize. Populated by
+    // runtime_maker.cpp from orch_args at bind time, then iterated in
+    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
+    // Runtime image carries the std::vector control block as harmless
+    // garbage, identical to host_api above. No fixed cap — grows with the
+    // chip-level entry-tensor count.
+    std::vector<TensorPair> tensor_pairs_;
 };
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -41,9 +41,6 @@ Runtime::Runtime() {
 
     // Initialize profiling state
 
-    // Initialize tensor pairs
-    tensor_pair_count = 0;
-
     // Initialize device orchestration state
     gm_sm_ptr_ = nullptr;
     gm_heap_ptr_ = nullptr;
@@ -66,28 +63,6 @@ Runtime::Runtime() {
         func_id_to_addr_[i] = 0;
     }
 }
-
-// =============================================================================
-// Tensor Pair Management
-// =============================================================================
-
-void Runtime::record_tensor_pair(void *host_ptr, void *dev_ptr, size_t size) {
-    if (tensor_pair_count >= RUNTIME_MAX_TENSOR_PAIRS) {
-        LOG_ERROR("[Runtime] Tensor pairs full (max=%d)", RUNTIME_MAX_TENSOR_PAIRS);
-        return;
-    }
-    tensor_pairs[tensor_pair_count].host_ptr = host_ptr;
-    tensor_pairs[tensor_pair_count].dev_ptr = dev_ptr;
-    tensor_pairs[tensor_pair_count].size = size;
-    tensor_pair_count++;
-    LOG_INFO_V0("Recorded tensor pair: host=%p dev=%p size=%zu", host_ptr, dev_ptr, size);
-}
-
-TensorPair *Runtime::get_tensor_pairs() { return tensor_pairs; }
-
-int Runtime::get_tensor_pair_count() const { return tensor_pair_count; }
-
-void Runtime::clear_tensor_pairs() { tensor_pair_count = 0; }
 
 // =============================================================================
 // Device orchestration

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -27,7 +27,11 @@ enum class ArgDirection : int32_t {
 };
 
 inline constexpr int CORE_MAX_TENSOR_ARGS = 16;
-inline constexpr int CHIP_MAX_TENSOR_ARGS = 64;
+// Chip-level entry-tensor cap. Sizes ChipCallable::signature_[] and
+// ChipStorageTaskArgs::tensors_[], both of which cross the host->device wire
+// as fixed POD — raising this is an additive ABI change (existing callers
+// still fit; transient storage grows by 64 * sizeof(ContinuousTensor)).
+inline constexpr int CHIP_MAX_TENSOR_ARGS = 128;
 inline constexpr int CORE_MAX_SCALAR_ARGS = 32;
 inline constexpr int CHIP_MAX_SCALAR_ARGS = 128;
 inline constexpr uint32_t CALLABLE_ALIGN = 64;

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <vector>
 
+#include "arg_direction.h"
 #include "callable.h"
 
 struct ChildKernelAddr {
@@ -55,6 +56,11 @@ struct ChildKernelAddr {
  */
 struct PreparedCallableArtifacts {
     std::vector<ChildKernelAddr> kernel_addrs;
+    // Chip-level entry-tensor directions, copied from ChipCallable::signature_[].
+    // Scalars are also present (ArgDirection::SCALAR) and follow the tensor
+    // entries. Consumed at bind time to decide H2D/D2H per tensor — see
+    // runtime_maker.cpp.
+    std::vector<ArgDirection> signature;
     void *host_dlopen_handle{nullptr};  // hbg only
     void *host_orch_func_ptr{nullptr};  // hbg only
     const void *orch_so_data{nullptr};  // trb only
@@ -80,6 +86,11 @@ struct PreparedCallableArtifacts {
 struct BindPreparedCallableResult {
     int rc{0};
     void *host_orch_func_ptr{nullptr};
+    // Pointer into PreparedCallableState's cached signature vector — valid
+    // until the callable_id is unregistered. Nullptr + 0 when the callable
+    // had no recorded signature (legacy path).
+    const ArgDirection *signature{nullptr};
+    int sig_count{0};
 };
 
 /**

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -239,6 +239,7 @@ add_hierarchical_test(test_scheduler  hierarchical/test_scheduler.cpp)
 # Types / task_interface tests (src/common/task_interface/)
 # ---------------------------------------------------------------------------
 add_task_interface_test(test_child_memory types/test_child_memory.cpp)
+add_task_interface_test(test_chip_max_tensor_args types/test_chip_max_tensor_args.cpp)
 
 # Contract test for upload_chip_callable_buffer caller-buffer immutability.
 # Pulls both task_interface (callable.h) and src/common (utils/fnv1a_64.h),

--- a/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
+++ b/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+// Regression test for #786: CHIP_MAX_TENSOR_ARGS was 64, which blocked the
+// DeepSeek-V4 decode-CSA orchestration at 69 entry tensors. After the bump
+// to 128 we verify (a) a ChipStorageTaskArgs accepts the 65th..128th tensor
+// and (b) view_to_chip_storage still rejects 129+.
+
+#include <stdexcept>
+
+#include <gtest/gtest.h>
+
+#include "task_args.h"
+
+namespace {
+
+ContinuousTensor make_tensor(uint64_t addr) {
+    ContinuousTensor t{};
+    t.data = addr;
+    t.shapes[0] = 1;
+    t.ndims = 1;
+    t.dtype = DataType::FLOAT32;
+    return t;
+}
+
+}  // namespace
+
+TEST(ChipMaxTensorArgs, CapIsAtLeast128) {
+    // The cap is the contract — the storage struct and the chip callable
+    // signature_[] array both size off it. Lock in 128 explicitly so a
+    // future change that lowers it is caught.
+    static_assert(CHIP_MAX_TENSOR_ARGS >= 128, "CHIP_MAX_TENSOR_ARGS regressed below 128 (see #786)");
+    EXPECT_GE(CHIP_MAX_TENSOR_ARGS, 128);
+}
+
+TEST(ChipMaxTensorArgs, ChipStorageHoldsAtLeast128Tensors) {
+    // Pre-#786 this throws std::out_of_range at the 65th add_tensor.
+    ChipStorageTaskArgs args;
+    for (int i = 0; i < 128; ++i) {
+        ASSERT_NO_THROW(args.add_tensor(make_tensor(static_cast<uint64_t>(0x1000 + i))));
+    }
+    EXPECT_EQ(args.tensor_count(), 128);
+    EXPECT_EQ(args.tensor(0).data, 0x1000u);
+    EXPECT_EQ(args.tensor(127).data, 0x1000u + 127);
+}
+
+TEST(ChipMaxTensorArgs, ChipStorageRejectsOverflow) {
+    ChipStorageTaskArgs args;
+    for (int i = 0; i < CHIP_MAX_TENSOR_ARGS; ++i) {
+        args.add_tensor(make_tensor(static_cast<uint64_t>(i)));
+    }
+    EXPECT_THROW(args.add_tensor(make_tensor(0xDEAD)), std::out_of_range);
+}
+
+TEST(ChipMaxTensorArgs, ViewToChipStorageAcceptsCap) {
+    std::vector<ContinuousTensor> tensors;
+    tensors.reserve(CHIP_MAX_TENSOR_ARGS);
+    for (int i = 0; i < CHIP_MAX_TENSOR_ARGS; ++i) {
+        tensors.push_back(make_tensor(static_cast<uint64_t>(0x2000 + i)));
+    }
+    TaskArgsView view{CHIP_MAX_TENSOR_ARGS, 0, tensors.data(), nullptr};
+
+    ChipStorageTaskArgs chip;
+    ASSERT_NO_THROW(chip = view_to_chip_storage(view));
+    EXPECT_EQ(chip.tensor_count(), CHIP_MAX_TENSOR_ARGS);
+    EXPECT_EQ(chip.tensor(CHIP_MAX_TENSOR_ARGS - 1).data, 0x2000u + CHIP_MAX_TENSOR_ARGS - 1);
+}
+
+TEST(ChipMaxTensorArgs, ViewToChipStorageRejectsOverflow) {
+    std::vector<ContinuousTensor> tensors(CHIP_MAX_TENSOR_ARGS + 1, make_tensor(0));
+    TaskArgsView view{CHIP_MAX_TENSOR_ARGS + 1, 0, tensors.data(), nullptr};
+    EXPECT_THROW(view_to_chip_storage(view), std::out_of_range);
+}


### PR DESCRIPTION
## Summary

Closes #786 by raising the chip-level entry-tensor cap and removing the parallel host-side ledger cap entirely. Also plumbs the `ArgDirection` signature end-to-end as groundwork for future per-tensor H2D/D2H decisions.

- **Bump `CHIP_MAX_TENSOR_ARGS` 64 → 128** in `arg_direction.h`. Directly unblocks the DeepSeek-V4 decode-CSA reproducer (69 entry tensors) called out in the issue. ABI-additive — existing fixed-POD storage grows but the first 64 slot layouts are unchanged.
- **Remove `RUNTIME_MAX_TENSOR_PAIRS`** for all 4 runtimes (`{a2a3,a5} × {host_build_graph, tensormap_and_ringbuffer}`). The fixed `TensorPair[N] + count + 4 accessor methods` are replaced by a public `std::vector<TensorPair> tensor_pairs_` at the end of `Runtime` (after `host_api`, same "host-only, not copied to device" placement). Eliminates the cap and the silent `LOG_ERROR`-on-overflow drop. The 2 internal allocations (`gm_heap`, `gm_sm_ptr`) no longer eat into a fixed budget.
- **Plumb `ArgDirection signature` end-to-end** as groundwork. `ChipCallable::signature_[]` is copied into `PreparedCallableArtifacts.signature`, threaded through `register_prepared_callable[_host_orch]` (8 signature changes across 4 platforms), stored in `PreparedCallableState`, returned in `BindPreparedCallableResult`, and passed into `bind_prepared_to_runtime_impl`. **Both runtimes mark it unused for now** — comment headers say so. Future PR can use it to skip H2D for pure `OUT` tensors and skip D2H ledger for pure `IN` tensors.
- **TMARB drops the orchestration-side `record_tensor_pair` API** — it was always called from `runtime_maker` itself, never from device-side orch.
- **`host_build_graph` keeps `record_tensor_pair`** as a thin wrapper around `tensor_pairs_.push_back()`. Its orch runs on host CPU and legitimately needs host pointers for control tensors (e.g. `paged_attention`'s `block_table`/`context_lens` drive per-block dispatch on the host before kernels run on device). Centralizing H2D in `runtime_maker` would break that pattern, so hbg keeps orch ownership of H2D.
- **Drop the dead `record_tensor_pair` extern "C" export** from all 4 platform `pto_runtime_c_api.cpp` (no dlsym consumer; lockstep across the 4 `host_runtime.so` ABI surfaces per the project convention).
- **Add `tests/ut/cpp/types/test_chip_max_tensor_args.cpp`** regression test: locks in `CHIP_MAX_TENSOR_ARGS >= 128`, verifies `ChipStorageTaskArgs::add_tensor` accepts the 65th..128th tensor and rejects the 129th, and `view_to_chip_storage` matches.
- **Update both `host_build_graph` `RUNTIME_LOGIC.md` docs** to contrast the hbg orch-driven H2D pattern against TMARB's `runtime_maker`-driven pattern.

## Testing

- [x] Local C++ build (`pip install --no-build-isolation -e .`) — passes for both sim platforms + Python bindings.
- [x] `test_chip_max_tensor_args` — 5/5 tests pass.
- [x] `test_child_memory`, `test_chip_callable_upload_immutable` (existing types/ UTs) — still pass.
- [ ] Linux CI: full sim + onboard test suites (macOS sim can't validate everything per `feedback_macos_sim_linux_gaps`).
- [ ] Out-of-tree: `python models/deepseek/v4/decode_csa.py -p a2a3 -d 0` on pypto-lib's `feat/decode-orchestration-swa-hca-csa` branch should compile and run past the 64-tensor block.

Fixes #786