### PR TITLE
Fix: flush deferred_release batch at scheduler exit

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -653,6 +653,19 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
     }
 
+    // Drain any entries left in the deferred-release batch. The in-loop flush
+    // only fires on idle iterations and on buffer-full; a loop exit while the
+    // last iteration made progress can leave entries un-released. Drop them
+    // here so every consumed producer slot completes its on_task_release
+    // regardless of which loop-exit path fired.
+    while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+        (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+#else
+        sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+#endif
+    }
+
 #if PTO2_PROFILING
     // Final-drain: emit any pop_hit / pop_miss accrued since the last
     // dispatch emit (typically the trailing idle loops while waiting for

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -661,6 +661,19 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
     }
 
+    // Drain any entries left in the deferred-release batch. The in-loop flush
+    // only fires on idle iterations and on buffer-full; a loop exit while the
+    // last iteration made progress can leave entries un-released. Drop them
+    // here so every consumed producer slot completes its on_task_release
+    // regardless of which loop-exit path fired.
+    while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+        (void)sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+#else
+        sched_->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+#endif
+    }
+
 #if PTO2_PROFILING
     // Final-drain: emit any pop_hit / pop_miss accrued since the last
     // dispatch emit (typically the trailing idle loops while waiting for


### PR DESCRIPTION
## Summary

The dispatch loop accumulates released producer slot states into
\`deferred_release_slot_states[]\` and flushes the batch on two triggers:
buffer-full (in-place loop) and idle iterations (the \`else !made_progress\`
branch). Neither runs when the loop exits while the final iteration made
progress, so any entries remaining in the batch never get their
\`on_task_release\` called.

This PR drains the batch immediately after the main \`while(true)\`. Every
loop-exit path now sees an empty deferred-release buffer when
\`run_scheduler_thread\` returns. The timeout path (\`handle_timeout_exit\`)
is reached from inside the idle branch after its in-place drain, so it
remains correct.

No observable behavior change today — the \`on_task_release\` side effects
the missed entries skipped have no live consumer after #775 removed
\`fanin_edges_total\`. Fix lands now so the contract "every consumed
producer slot completes \`on_task_release\` before the scheduler thread
exits" holds regardless of which loop-exit path fired, removing a latent
trap for future code that relies on it.

Mirror change in a2a3 and a5 (~13 lines each).

## Test plan

- [x] Local rebuild (\`pip install --no-build-isolation -e .\`) — both arches compile
- [x] \`pytest tests/st/a2a3/tensormap_and_ringbuffer --platform a2a3sim --device 0-1 -k 'not L3'\` → 24 passed
- [x] \`pytest tests/st/a5/tensormap_and_ringbuffer --platform a5sim --device 0-1 -k 'not L3'\` → 16 passed
- [x] \`test_l2_swimlane --platform a2a3sim --enable-l2-swimlane --enable-dep-gen\` differential gate green