### PR TITLE
Feature:  Add unified tensor and args dump support

### DIFF
--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -21,15 +21,18 @@ saw, without the timing distortion of inline printing.
   dispatch, outputs snapshotted after FIN; `INOUT` tensors at both
   stages.
 - **Logical shape preserved.** Records carry dtype, shape,
-  `raw_shape`, offsets, and `is_contiguous` so non-contiguous views
-  are reconstructable.
-- **Manifest + binary payload.** A single JSON manifest plus one
-  `.bin` payload per run; each manifest entry has `bin_offset` /
-  `bin_size` into the payload.
-- **Cross-architecture.** Same `--dump-tensor` flag, same on-disk
-  format on `a2a3` and `a5`. Both runtimes are wired through.
+  `strides`, `start_offset`, and `is_contiguous` so logical views are
+  reconstructable.
+- **Manifest + binary payload.** `--dump-tensor` writes a JSON
+  manifest plus one `.bin` payload per run; tensor entries carry
+  `bin_offset` / `bin_size`, while scalar entries stay manifest-only.
+- **Unified scalar args.** Scalar callable slots are emitted as
+  `kind: scalar`, `stage: before_dispatch`, zero-dim records in
+  `tensor_dump.json`; there is no separate args-only manifest.
+- **Cross-architecture.** Same flags and on-disk layout family on
+  `a2a3` and `a5`. Both runtimes are wired through.
 
-Enable in one line:
+Enable dump capture in one line:
 
 ```bash
 python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor
@@ -49,16 +52,12 @@ pytest tests/st/<case> --platform a5sim --dump-tensor
 pytest examples/a5/host_build_graph/vector_example --platform a5sim --dump-tensor
 ```
 
-The flag flips `CallConfig::enable_dump_tensor`. The host then
+`--dump-tensor` flips `CallConfig::enable_dump_tensor`. The host
 allocates dump storage, publishes its base address through
-`kernel_args.dump_data_base`, and sets
-`PROFILING_FLAG_DUMP_TENSOR` in each worker handshake's
-`enable_profiling_flag`. The on-device AICPU kernel reads both:
-the storage base via `set_platform_dump_base()` and the enable bit
-via `set_enable_dump_tensor(GET_PROFILING_FLAG(...))`. AICore
-executors read the same handshake bit to insert a
-`pipe_barrier(PIPE_ALL)` before FIN when dump is on, so
-`AFTER_COMPLETION` snapshots see the kernel's final writes.
+`kernel_args.dump_data_base`, and sets `PROFILING_FLAG_DUMP_TENSOR`
+in the worker profiling bitmask. AICPU reads the storage base via
+`set_platform_dump_base()` and the enable state via
+`set_dump_tensor_enabled(...)`.
 
 ### 3.2 Select Specific Task Tensors
 
@@ -107,12 +106,15 @@ The dump artifacts land under the per-task output prefix
 ```text
 <output_prefix>/
 └── tensor_dump/
-    ├── tensor_dump.json
-    └── tensor_dump.bin
+    ├── tensor_dump.json  # unified tensor/scalar manifest (`--dump-tensor`)
+    └── tensor_dump.bin   # raw tensor payload (`--dump-tensor`)
 ```
 
 Filenames are fixed (no per-file timestamp) — the directory is the
-per-task uniqueness boundary.
+per-task uniqueness boundary. `--dump-tensor` emits both files in the
+same `tensor_dump/` directory.
+
+#### `tensor_dump.json` — Unified manifest
 
 `tensor_dump.json` is the manifest; its `bin_file` field points at
 the sibling binary payload.
@@ -139,15 +141,14 @@ Example manifest (one input tensor captured before dispatch):
   "tensors": [
     {
       "task_id": "0x0000000200000a00",
-      "subtask_id": 1,
       "role": "input",
       "stage": "before_dispatch",
-      "func_id": 0,
       "arg_index": 0,
+      "kind": "tensor",
       "dtype": "float32",
       "shape": [16384],
-      "raw_shape": [16384],
-      "offsets": [0],
+      "strides": [1],
+      "start_offset": 0,
       "is_contiguous": true,
       "truncated": false,
       "overwritten": false,
@@ -160,15 +161,19 @@ Example manifest (one input tensor captured before dispatch):
 
 Key fields:
 
-- `task_id` / `subtask_id` / `func_id` — runtime task identity. Use
-  to correlate with swimlane / PMU output. `subtask_id` distinguishes
-  AIC / AIV0 / AIV1 within a single task.
-- `arg_index` — position in the formal callable signature.
+- `task_id` — runtime task identity. Use to correlate with swimlane / PMU
+  output.
+- `arg_index` — position in the formal callable signature. For scalar
+  entries this equals `payload.tensor_count + scalar_index`.
 - `role` / `stage` — `input` / `output` / `inout`, captured
   `before_dispatch` / `after_completion`.
-- `dtype` / `shape` / `raw_shape` / `offsets` / `is_contiguous` —
-  view geometry. `bin_size` is `numel × elem_size` of the *logical*
-  view, gathered if non-contiguous.
+- `kind` — `tensor` for arena-backed payloads, `scalar` for
+  zero-dim `before_dispatch` scalar args stored directly in the
+  manifest.
+- `dtype` / `shape` / `strides` / `start_offset` /
+  `is_contiguous` — logical view geometry. Tensor `bin_size` is
+  `numel × elem_size` of the *logical* view, gathered if
+  non-contiguous; scalar entries have `bin_size = 0`.
 - `bin_offset` — byte offset into `tensor_dump.bin` where the
   payload starts.
 - `truncated` / `overwritten` — set when the tensor exceeded arena
@@ -187,7 +192,7 @@ uses its `bin_file` field to find the payload:
 python -m simpler_setup.tools.dump_viewer
 
 # Filter and save matching tensors to human-readable .txt files
-python -m simpler_setup.tools.dump_viewer --func 0 --stage before --role input --export
+python -m simpler_setup.tools.dump_viewer --stage before --role input --export
 
 # Export one specific entry by its manifest index
 python -m simpler_setup.tools.dump_viewer --index 42
@@ -204,8 +209,8 @@ spreadsheet.
 
 ### 3.4 Add dump support to a new test
 
-Only `host_build_graph` needs explicit wiring; other runtimes pick
-up metadata automatically.
+Only `host_build_graph` needs explicit wiring; other runtimes derive
+tensor view metadata automatically.
 
 ```cpp
 // In orchestration C++ (host_build_graph only)
@@ -234,13 +239,17 @@ What you can read out of `tensor_dump.json` + `tensor_dump.bin`:
 
 - **Per-task input snapshots** (`role: input`, `stage:
   before_dispatch`) — what each kernel was given.
+- **Per-dispatch scalar args** (`kind: scalar`, `stage:
+  before_dispatch`) — the raw callable-slot scalar values AICPU
+  handed to the kernel.
 - **Per-task output snapshots** (`role: output`, `stage:
   after_completion`) — what each kernel produced. The barrier
   ensures these reflect the kernel's final writes.
 - **`INOUT` deltas** — same arg captured at both stages; diff
   before vs after to see exactly what the kernel modified.
-- **Non-contiguous view reconstruction** — `raw_shape` / `offsets`
-  / `is_contiguous` plus the gathered logical-contiguous payload.
+- **Logical view reconstruction** — `shape` / `strides` /
+  `start_offset` / `is_contiguous` plus the gathered
+  logical-contiguous payload.
 - **Per-task identity** — `task_id` / `subtask_id` / `func_id`
   correlates dump entries with swimlane and PMU rows.
 - **Loss accounting** — `truncated` / `overwritten` per-record
@@ -318,8 +327,9 @@ Each runtime's scheduler dispatch code calls
 ```
 
 `dump_tensors_for_task` walks the formal callable signature,
-matches each non-scalar slot to a `TensorDumpInfo` (dtype + shape + offsets + device address), and calls `dump_tensor_record` for
-slots that match the current stage.
+matches each non-scalar slot to a `TensorDumpInfo` (dtype + shape +
+strides + start offset + device address), and calls
+`dump_tensor_record` for slots that match the current stage.
 
 When dump is enabled, AICore executors also issue
 `pipe_barrier(PIPE_ALL)` after kernel execution and before writing
@@ -564,7 +574,9 @@ Tensor Dump is opt-in and zero-overhead when disabled — without
 AICore skip the dump-specific code paths. The `pipe_barrier(PIPE_ALL)`
 before FIN is also gated on the same handshake bit.
 
-When enabled, the per-task overhead is dominated by:
+With `--dump-tensor`, AICPU records full `BEFORE_DISPATCH` /
+`AFTER_COMPLETION` tensor payloads plus manifest-only
+`BEFORE_DISPATCH` scalar args. The per-task overhead is dominated by:
 
 - The `BEFORE_DISPATCH` / `AFTER_COMPLETION` payload memcpy into
   the per-thread arena (contiguous fast-path; logical traversal for

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,7 +69,7 @@ If a module is pure C++ with no Python binding, test in **ut-cpp** (`tests/ut/cp
 
 Scene tests support advanced CLI options for benchmarking, profiling, and runtime control. These work identically in both pytest and standalone mode.
 
-> "Profiling" is the umbrella for three parallel diagnostics sub-features: `--enable-l2-swimlane` (L2 swimlane), `--dump-tensor` (per-task tensor I/O), and `--enable-pmu` (PMU CSV). They are independent and can be combined.
+> "Profiling" is the umbrella for three parallel diagnostics sub-features: `--enable-l2-swimlane` (L2 swimlane), `--dump-tensor` (unified tensor/scalar dump), and `--enable-pmu` (PMU CSV). They are independent and can be combined.
 
 ### pytest
 
@@ -87,7 +87,7 @@ pytest --platform a2a3sim --log-level debug                        # verbose C++
 python test_xxx.py -p a2a3sim                                    # default: 1 round + golden
 python test_xxx.py -p a2a3 -d 0 --rounds 100 --skip-golden       # benchmark mode
 python test_xxx.py -p a2a3 --enable-l2-swimlane                         # L2 swimlane (first round)
-python test_xxx.py -p a2a3 --dump-tensor                         # dump per-task tensor I/O
+python test_xxx.py -p a2a3 --dump-tensor                         # dump unified tensor/scalar artifacts
 python test_xxx.py -p a2a3 --enable-pmu 4                        # PMU CSV (MEMORY)
 python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ logging
 ```
@@ -105,7 +105,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--manual` | | `exclude` | `exclude`/`include`/`only` for manual cases |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
 | `--enable-l2-swimlane [PERF_LEVEL]` | | `0` | Enable L2 swimlane collection on first round only. The flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md#31-enable-l2-swimlane) for the level table. Each test case gets its own `outputs/<case>_<ts>/` directory under which `l2_swimlane_records.json` lands; parallel runs never collide. |
-| `--dump-tensor` | | false | Dump per-task tensor I/O during runtime execution |
+| `--dump-tensor` | | false | Dump tensors plus scalar args into unified runtime artifacts |
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
 | `--log-level LEVEL` | | `v5` | Simpler logger threshold. Accepts `debug` / `V0..V9` / `info` / `warn` / `error` / `null` (case-insensitive). pytest's own CLI validator does `int(getattr(logging, level.upper(), level))`, so the V tiers and `NUL`/`NULL` are exposed as attributes on the `logging` module via `setattr` (registration in `conftest.py` runs before pytest's option machinery). `logging.addLevelName` is also called so `%(levelname)s` formatters print `V3` instead of `Level 18`, but it is not what makes the CLI parser accept the value. The "simpler" Python logger is the single source of truth; the value is snapshotted into the platform SO at `Worker.init()` time (not per `Worker.run()`) and pushed to host `HostLogger`, runner state, and (onboard) CANN `dlog_setlevel`. AICPU receives it via `KernelArgs.log_info_v`. Changing the Python logger level after `Worker.init()` does not retroactively affect that worker. See [Log levels](#log-levels). |

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -11,7 +11,6 @@
 
 Filters (freely combinable):
     --task   Filter by task_id (hex, e.g. 0x0000000200000a00)
-    --func   Filter by func_id (int)
     --stage  Filter by stage (before / after)
     --role   Filter by role (input / output / inout)
     --arg    Filter by arg_index (int)
@@ -26,11 +25,11 @@ Usage:
     # List all tensors in a specific dump dir
     python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump/
 
-    # List before-dispatch inputs of func_id=3 (latest dir)
-    python -m simpler_setup.tools.dump_viewer --func 3 --stage before --role input
+    # List before-dispatch inputs of task_id 0x... (latest dir)
+    python -m simpler_setup.tools.dump_viewer --task 0x0000000200000a00 --stage before --role input
 
     # Export them to txt
-    python -m simpler_setup.tools.dump_viewer outputs/<case>/tensor_dump/ --func 3 --stage before --export
+    python -m simpler_setup.tools.dump_viewer outputs/<case>/tensor_dump/ --stage before --export
 
     # Export a specific tensor by index
     python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump/ --index 42 --export
@@ -94,17 +93,15 @@ def tensor_filename(t: dict) -> str:
     role_map = {"input": "in", "output": "out", "inout": "inout"}
     stage_str = stage_map.get(t["stage"], t["stage"])
     role_str = role_map.get(t["role"], t["role"])
-    return f"task_{t['task_id']}_s{t['subtask_id']}_{stage_str}_{role_str}{t['arg_index']}.txt"
+    return f"task_{t['task_id']}_{stage_str}_{role_str}{t['arg_index']}.txt"
 
 
 def write_tensor(tensor: dict, bin_path: Path, out):
     t = tensor
     out.write(f"# task_id: {t['task_id']}\n")
-    out.write(f"# subtask_id: {t['subtask_id']}\n")
     out.write(f"# role: {t['role']}\n")
     out.write(f"# stage: {t['stage']}\n")
     out.write(f"# arg_index: {t['arg_index']}\n")
-    out.write(f"# func_id: {t['func_id']}\n")
     out.write(f"# dtype: {t['dtype']}\n")
     out.write(f"# is_contiguous: {t['is_contiguous']}\n")
     out.write(f"# shape: {t['shape']}\n")
@@ -182,15 +179,15 @@ def collect_valid_values(tensors: list, field: str) -> list:
 
 def list_tensors(tensors: list):
     print(
-        f"{'idx':>6}  {'task_id':>18}  {'s':>1}  {'stage':>7}  {'role':>5}"
-        f"  {'arg':>3}  {'func':>4}  {'dtype':>8}  {'shape':<20}  {'bytes':>10}"
+        f"{'idx':>6}  {'task_id':>18}  {'stage':>7}  {'role':>5}"
+        f"  {'arg':>3}  {'dtype':>8}  {'shape':<20}  {'bytes':>10}"
     )
     print("-" * 100)
     for i, t in enumerate(tensors):
         stage_short = "before" if t["stage"] == "before_dispatch" else "after"
         print(
-            f"{i:>6}  {t['task_id']:>18}  {t['subtask_id']:>1}  {stage_short:>7}  {t['role']:>5}  "
-            f"{t['arg_index']:>3}  {t['func_id']:>4}  {t['dtype']:>8}  {str(t['shape']):<20}  {t['bin_size']:>10}"
+            f"{i:>6}  {t['task_id']:>18}  {stage_short:>7}  {t['role']:>5}  "
+            f"{t['arg_index']:>3}  {t['dtype']:>8}  {str(t['shape']):<20}  {t['bin_size']:>10}"
         )
 
 
@@ -217,14 +214,6 @@ def _apply_filters(tensors: list, args: argparse.Namespace) -> list:
             print(f"  Valid task_ids (showing first {len(sample)}): {', '.join(sample)}", file=sys.stderr)
             sys.exit(1)
         filtered = [t for t in filtered if t["task_id"] == args.task]
-
-    if args.func is not None:
-        valid = collect_valid_values(filtered, "func_id")
-        if str(args.func) not in valid:
-            print(f"Error: --func {args.func} not found in current selection.", file=sys.stderr)
-            print(f"  Valid func_ids: {', '.join(valid)}", file=sys.stderr)
-            sys.exit(1)
-        filtered = [t for t in filtered if t["func_id"] == args.func]
 
     if args.stage:
         stage_map = {"before": "before_dispatch", "after": "after_completion"}
@@ -263,7 +252,6 @@ def main():
         help="Path to outputs/<case>_<ts>/tensor_dump directory (default: latest outputs/*/tensor_dump dir)",
     )
     parser.add_argument("--task", "-t", help="Filter by task_id (e.g. 0x0000000200000a00)")
-    parser.add_argument("--func", "-f", type=int, help="Filter by func_id")
     parser.add_argument("--stage", "-s", help="Filter by stage (before / after)")
     parser.add_argument("--role", "-r", help="Filter by role (input / output / inout)")
     parser.add_argument("--arg", "-a", type=int, help="Filter by arg_index")
@@ -272,12 +260,12 @@ def main():
     args = parser.parse_args()
 
     dump_dir = _resolve_dump_dir(args.dump_dir)
-    manifest_files = list(dump_dir.glob("*.json"))
-    if not manifest_files:
-        print(f"Error: no manifest JSON found in {dump_dir}", file=sys.stderr)
+    manifest_path = dump_dir / "tensor_dump.json"
+    if not manifest_path.exists():
+        print(f"Error: tensor_dump.json not found in {dump_dir}", file=sys.stderr)
         sys.exit(1)
 
-    with open(manifest_files[0]) as f:
+    with open(manifest_path) as f:
         manifest = json.load(f)
 
     bin_path = dump_dir / manifest.get("bin_file", "tensors.bin")
@@ -298,7 +286,7 @@ def main():
         sys.exit(1)
 
     # --- Export or list ---
-    has_filters = any([args.task, args.func is not None, args.stage, args.role, args.arg is not None])
+    has_filters = any([args.task, args.stage, args.role, args.arg is not None])
 
     if args.export or args.index is not None:
         for t in filtered:

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -71,6 +71,11 @@ enum class TensorDumpStage : uint8_t {
     AFTER_COMPLETION = 1,
 };
 
+enum class TensorDumpKind : uint8_t {
+    TENSOR = 0,
+    SCALAR = 1,
+};
+
 using TensorDumpArgMask = uint64_t;
 
 // Bitmask stored in the platform-owned mask pool when orchestration selects
@@ -90,31 +95,30 @@ constexpr uint32_t TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK = TENSOR_DUMP_MASK_PO
  * Per-tensor metadata + payload reference.
  *
  * Cache line 1 (64B): identifiers, payload location, compact scalar metadata
- * Cache line 2 (64B): logical/source layout arrays
+ * Cache line 2 (64B): strides and shapes
  */
 struct alignas(64) TensorDumpRecord {
     // === Cache line 1 (64B) ===
     uint64_t task_id;         // PTO2 encoding or plain task index
-    uint8_t subtask_id;       // PTO2SubtaskSlot raw value (AIC=0, AIV0=1, AIV1=2)
     uint8_t role;             // TensorDumpRole (formal callable signature)
     uint8_t stage;            // TensorDumpStage (before/after execution)
     uint8_t ndims;            // Number of dimensions
-    uint32_t func_id;         // Kernel function identifier
-    uint32_t arg_index;       // Position in PTO2TaskPayload::tensors[]
+    uint32_t arg_index;       // Position in the callable signature
     uint8_t dtype;            // DataType raw enum value
     uint8_t truncated;        // 1 if payload was truncated (tensor > arena capacity)
     uint8_t is_contiguous;    // 1 when source view is already PyTorch-contiguous
     uint8_t pad0_align;       // Explicit alignment before 64-bit payload offsets
     uint64_t payload_offset;  // Monotonic byte offset into thread arena
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
-    uint8_t pad0[24];         // Preserve 64B cache-line layout
+    uint64_t scalar_value;    // Valid when kind == TensorDumpKind::SCALAR
+    uint8_t kind;             // TensorDumpKind
+    uint8_t pad0[15];         // Preserve 64B cache-line layout + scalar_value + kind
 
     // === Cache line 2 (64B) — strided view descriptor ===
-    // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 + 16 = 64B.
+    // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 = 48B.
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
-    uint8_t pad1[16];                          // Pad to 128 bytes
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(TensorDumpRecord) == 128, "TensorDumpRecord must be 128 bytes (2 cache lines)");
@@ -148,7 +152,7 @@ struct DumpFreeQueue {
     volatile uint64_t buffer_ptrs[PLATFORM_DUMP_SLOT_COUNT];
     volatile uint32_t head;  // Consumer read position (Device increments)
     volatile uint32_t tail;  // Producer write position (Host increments)
-    uint32_t pad[13];        // Pad to 128 bytes
+    uint32_t pad[22];        // Pad to 128 bytes (32+4+4+88=128)
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(DumpFreeQueue) == 128, "DumpFreeQueue must be 128 bytes");
@@ -240,14 +244,15 @@ struct DumpDataHeader {
  */
 struct TensorDumpInfo {
     uint64_t task_id;
-    uint8_t subtask_id;
     TensorDumpRole role;
     TensorDumpStage stage;
     uint8_t dtype;
     uint8_t ndims;
-    uint32_t func_id;
     uint32_t arg_index;
     uint64_t buffer_addr;
+    uint64_t scalar_value;
+    uint8_t kind;
+    uint8_t pad[15];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -188,9 +188,8 @@ inline void AicpuExecutor::resolve_task_dependencies(
             int tensor_buffer_count =
                 collect_task_tensor_buffer_addrs(runtime, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
             dump_tensors_for_task(
-                thread_idx, static_cast<uint64_t>(task->task_id), 0, task->num_args, task->func_id, *callable,
-                tensor_info, tensor_info_count, tensor_buffer_addrs, tensor_buffer_count,
-                TensorDumpStage::AFTER_COMPLETION
+                thread_idx, static_cast<uint64_t>(task->task_id), task->num_args, *callable, tensor_info,
+                tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::AFTER_COMPLETION
             );
         }
     }
@@ -275,9 +274,8 @@ inline bool AicpuExecutor::try_dispatch_task(
                 int tensor_buffer_count =
                     collect_task_tensor_buffer_addrs(runtime, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
                 dump_tensors_for_task(
-                    thread_idx, static_cast<uint64_t>(task_id), 0, task->num_args, task->func_id, *callable,
-                    tensor_info, tensor_info_count, tensor_buffer_addrs, tensor_buffer_count,
-                    TensorDumpStage::BEFORE_DISPATCH
+                    thread_idx, static_cast<uint64_t>(task_id), task->num_args, *callable, tensor_info,
+                    tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::BEFORE_DISPATCH
                 );
             }
         }

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -75,6 +75,11 @@ enum class TensorDumpStage : uint8_t {
     AFTER_COMPLETION = 1,
 };
 
+enum class TensorDumpKind : uint8_t {
+    TENSOR = 0,
+    SCALAR = 1,
+};
+
 using TensorDumpArgMask = uint64_t;
 
 // Bitmask stored in the platform-owned mask pool when orchestration selects
@@ -94,31 +99,30 @@ constexpr uint32_t TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK = TENSOR_DUMP_MASK_PO
  * Per-tensor metadata + payload reference.
  *
  * Cache line 1 (64B): identifiers, payload location, compact scalar metadata
- * Cache line 2 (64B): logical/source layout arrays
+ * Cache line 2 (64B): strides and shapes
  */
 struct alignas(64) TensorDumpRecord {
     // === Cache line 1 (64B) ===
     uint64_t task_id;         // PTO2 encoding or plain task index
-    uint8_t subtask_id;       // PTO2SubtaskSlot raw value (AIC=0, AIV0=1, AIV1=2)
     uint8_t role;             // TensorDumpRole (formal callable signature)
     uint8_t stage;            // TensorDumpStage (before/after execution)
     uint8_t ndims;            // Number of dimensions
-    uint32_t func_id;         // Kernel function identifier
-    uint32_t arg_index;       // Position in PTO2TaskPayload::tensors[]
+    uint32_t arg_index;       // Position in the callable signature
     uint8_t dtype;            // DataType raw enum value
     uint8_t truncated;        // 1 if payload was truncated (tensor > arena capacity)
     uint8_t is_contiguous;    // 1 when source view is already PyTorch-contiguous
     uint8_t pad0_align;       // Explicit alignment before 64-bit payload offsets
     uint64_t payload_offset;  // Monotonic byte offset into thread arena
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
-    uint8_t pad0[24];         // Preserve 64B cache-line layout
+    uint64_t scalar_value;    // Valid when kind == TensorDumpKind::SCALAR
+    uint8_t kind;             // TensorDumpKind
+    uint8_t pad0[15];         // Preserve 64B cache-line layout + scalar_value + kind
 
     // === Cache line 2 (64B) — strided view descriptor ===
-    // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 + 16 = 64B.
+    // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 = 48B.
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
-    uint8_t pad1[16];                          // Pad to 128 bytes
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(TensorDumpRecord) == 128, "TensorDumpRecord must be 128 bytes (2 cache lines)");
@@ -244,14 +248,15 @@ struct DumpDataHeader {
  */
 struct TensorDumpInfo {
     uint64_t task_id;
-    uint8_t subtask_id;
     TensorDumpRole role;
     TensorDumpStage stage;
     uint8_t dtype;
     uint8_t ndims;
-    uint32_t func_id;
     uint32_t arg_index;
     uint64_t buffer_addr;
+    uint64_t scalar_value;
+    uint8_t kind;
+    uint8_t pad[15];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -189,9 +189,8 @@ inline void AicpuExecutor::resolve_task_dependencies(
             int tensor_buffer_count =
                 collect_task_tensor_buffer_addrs(runtime, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
             dump_tensors_for_task(
-                thread_idx, static_cast<uint64_t>(task->task_id), 0, task->num_args, task->func_id, *callable,
-                tensor_info, tensor_info_count, tensor_buffer_addrs, tensor_buffer_count,
-                TensorDumpStage::AFTER_COMPLETION
+                thread_idx, static_cast<uint64_t>(task->task_id), task->num_args, *callable, tensor_info,
+                tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::AFTER_COMPLETION
             );
         }
     }
@@ -273,9 +272,8 @@ inline bool AicpuExecutor::try_dispatch_task(
                 int tensor_buffer_count =
                     collect_task_tensor_buffer_addrs(*runtime_, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
                 dump_tensors_for_task(
-                    thread_idx, static_cast<uint64_t>(task_id), 0, task->num_args, task->func_id, *callable,
-                    tensor_info, tensor_info_count, tensor_buffer_addrs, tensor_buffer_count,
-                    TensorDumpStage::BEFORE_DISPATCH
+                    thread_idx, static_cast<uint64_t>(task_id), task->num_args, *callable, tensor_info,
+                    tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::BEFORE_DISPATCH
                 );
             }
         }

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -133,7 +133,8 @@ inline void dump_tensors_for_task(
 
     rmb();
 
-    int32_t payload_index = 0;
+    int32_t arg_index = 0;
+    int32_t tensor_index = 0;
     for (int raw_subtask_id = 0; raw_subtask_id < MaxSubtaskSlots; raw_subtask_id++) {
         if (!is_subtask_active(slot_state.active_mask, raw_subtask_id)) {
             continue;
@@ -143,12 +144,15 @@ inline void dump_tensors_for_task(
         for (int32_t sig_idx = 0; sig_idx < callable.sig_count(); sig_idx++) {
             ArgDirection dir = callable.sig(sig_idx);
             if (dir == ArgDirection::SCALAR) {
+                arg_index++;
                 continue;
             }
             TensorDumpRole role;
-            if (get_tensor_dump_role_from_direction(dir, &role) && should_dump_tensor_at_stage(role, stage) &&
-                should_dump_tensor_arg(dump_arg_mask, payload_index)) {
-                const auto &t = pl.tensors[payload_index];
+            bool dump_tensor = get_tensor_dump_role_from_direction(dir, &role) &&
+                               should_dump_tensor_at_stage(role, stage) &&
+                               should_dump_tensor_arg(dump_arg_mask, tensor_index);
+            if (dump_tensor) {
+                const auto &t = pl.tensors[tensor_index];
                 TensorDumpInfo info = {};
                 info.buffer_addr = t.buffer.addr;
                 info.dtype = static_cast<uint8_t>(t.dtype);
@@ -159,23 +163,37 @@ inline void dump_tensors_for_task(
                     info.strides[d] = t.strides[d];
                 }
                 info.task_id = slot_state.task->task_id.raw;
-                info.subtask_id = raw_subtask_id;
-                info.func_id = slot_state.task->kernel_id[slot_idx];
-                info.arg_index = static_cast<uint32_t>(payload_index);
+                info.arg_index = static_cast<uint32_t>(arg_index);
                 info.role = role;
                 info.stage = stage;
+                info.kind = static_cast<uint8_t>(TensorDumpKind::TENSOR);
                 dump_tensor_record(thread_idx, info);
             }
-            payload_index++;
+            arg_index++;
+            tensor_index++;
+        }
+        if (stage == TensorDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
+            for (int32_t i = 0; i < pl.scalar_count; i++) {
+                TensorDumpInfo info = {};
+                info.task_id = slot_state.task->task_id.raw;
+                info.role = TensorDumpRole::INPUT;
+                info.stage = stage;
+                info.dtype = static_cast<uint8_t>(DataType::UINT64);
+                info.ndims = 0;
+                info.arg_index = static_cast<uint32_t>(pl.tensor_count + i);
+                info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
+                info.scalar_value = pl.scalars[i];
+                dump_tensor_record(thread_idx, info);
+            }
         }
     }
 }
 
 template <typename TensorInfoT>
 inline void dump_tensors_for_task(
-    int32_t thread_idx, uint64_t task_id, uint8_t subtask_id, int32_t task_arg_count, int32_t func_id,
-    const CoreCallable &callable, const TensorInfoT *tensor_info, int32_t tensor_info_count,
-    const uint64_t *buffer_addrs, int32_t buffer_count, TensorDumpStage stage
+    int32_t thread_idx, uint64_t task_id, int32_t task_arg_count, const CoreCallable &callable,
+    const TensorInfoT *tensor_info, int32_t tensor_info_count, const uint64_t *buffer_addrs, int32_t buffer_count,
+    TensorDumpStage stage
 ) {
     int32_t sig_count = callable.sig_count();
     if (task_arg_count < sig_count) {
@@ -237,13 +255,11 @@ inline void dump_tensors_for_task(
         const auto &t = tensor_info[tensor_arg_index];
         TensorDumpInfo info = {};
         info.task_id = task_id;
-        info.subtask_id = subtask_id;
         info.role = role;
         info.stage = stage;
         info.dtype = static_cast<uint8_t>(t.dtype);
         info.ndims = t.ndims;
-        info.func_id = static_cast<uint32_t>(func_id);
-        info.arg_index = static_cast<uint32_t>(tensor_arg_index);
+        info.arg_index = static_cast<uint32_t>(sig_idx);
         info.buffer_addr = buffer_addrs[tensor_arg_index];
         // TensorInfo (host_build_graph) still carries (raw_shapes, offsets)
         // implicitly describing a row-major-aligned sub-region. Translate to

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -147,13 +147,13 @@ using DumpFreeCallback = profiling_common::ProfFreeCallback;
  */
 struct DumpedTensor {
     uint64_t task_id;
-    uint8_t subtask_id;
-    uint32_t func_id;
     uint32_t arg_index;
     TensorDumpRole role;
     TensorDumpStage stage;
     uint8_t dtype;
     uint8_t ndims;
+    TensorDumpKind kind;
+    uint64_t scalar_value;
     uint64_t start_offset;                     // 1D element offset of the view origin
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dim (> 0, type-enforced)

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -509,8 +509,11 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     uint64_t copy_bytes = bytes;
     bool truncated = false;
     bool is_contiguous = tensor_dump_is_contiguous(info);
+    bool is_scalar = static_cast<TensorDumpKind>(info.kind) == TensorDumpKind::SCALAR;
 
-    if (bytes > state->arena_size) {
+    if (is_scalar) {
+        copy_bytes = 0;
+    } else if (bytes > state->arena_size) {
         // Tensor larger than entire arena — copy a partial sample
         copy_bytes = state->arena_size / 2;
         truncated = true;
@@ -523,15 +526,15 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     char *arena = reinterpret_cast<char *>(state->arena_base);
     uint64_t arena_sz = state->arena_size;
     CircularArenaWriter writer = {arena, arena_sz, offset, 0};
-    write_tensor_dump_logical_prefix(&writer, info, elem_sz, copy_bytes);
+    if (!is_scalar && copy_bytes > 0) {
+        write_tensor_dump_logical_prefix(&writer, info, elem_sz, copy_bytes);
+    }
     wmb();
 
     // Append metadata record
     uint32_t idx = buf->count;
     TensorDumpRecord *rec = &buf->records[idx];
     rec->task_id = info.task_id;
-    rec->subtask_id = info.subtask_id;
-    rec->func_id = info.func_id;
     rec->arg_index = info.arg_index;
     rec->is_contiguous = is_contiguous ? 1 : 0;
     rec->role = static_cast<uint8_t>(info.role);
@@ -541,6 +544,8 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     rec->truncated = truncated ? 1 : 0;
     rec->payload_offset = offset;
     rec->payload_size = copy_bytes;
+    rec->scalar_value = is_scalar ? info.scalar_value : 0;
+    rec->kind = info.kind;
     rec->start_offset = info.start_offset;
     for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
         rec->shapes[d] = info.shapes[d];

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -215,13 +215,13 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
 
         DumpedTensor dt;
         dt.task_id = rec.task_id;
-        dt.subtask_id = rec.subtask_id;
-        dt.func_id = rec.func_id;
         dt.arg_index = rec.arg_index;
         dt.role = static_cast<TensorDumpRole>(rec.role);
         dt.stage = static_cast<TensorDumpStage>(rec.stage);
         dt.dtype = rec.dtype;
         dt.ndims = rec.ndims;
+        dt.kind = static_cast<TensorDumpKind>(rec.kind);
+        dt.scalar_value = rec.scalar_value;
         dt.is_contiguous = (rec.is_contiguous != 0);
         dt.truncated = (rec.truncated != 0);
         dt.overwritten = false;
@@ -232,7 +232,7 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         std::memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
         std::memcpy(dt.strides, rec.strides, sizeof(dt.strides));
 
-        if (thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
+        if (dt.kind == TensorDumpKind::TENSOR && thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
             ArenaInfo &ai = arenas_[thread_idx];
             char *arena_host = reinterpret_cast<char *>(ai.host_ptr);
             uint64_t arena_sz = ai.size;
@@ -246,8 +246,6 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
                         "Increase PLATFORM_DUMP_BUFFERS_PER_THREAD."
                     );
                 }
-            } else {
-                dt.overwritten = false;
             }
 
             if (!dt.overwritten && rec.payload_size > 0) {
@@ -270,7 +268,7 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
 
         dt.payload_size = dt.bytes.size();
 
-        bool has_payload = !dt.overwritten && !dt.bytes.empty();
+        bool has_payload = dt.kind == TensorDumpKind::TENSOR && !dt.overwritten && !dt.bytes.empty();
         dt.bin_offset = has_payload ? next_bin_offset_ : 0;
         if (has_payload) {
             next_bin_offset_ += dt.payload_size;
@@ -393,6 +391,16 @@ static const char *tensor_dump_stage_name(TensorDumpStage stage) {
     return "unknown";
 }
 
+static const char *tensor_dump_kind_name(TensorDumpKind kind) {
+    switch (kind) {
+    case TensorDumpKind::TENSOR:
+        return "tensor";
+    case TensorDumpKind::SCALAR:
+        return "scalar";
+    }
+    return "unknown";
+}
+
 static std::string dims_to_string(const uint32_t dims[], int ndims) {
     std::ostringstream ss;
     ss << "[";
@@ -481,8 +489,6 @@ int TensorDumpCollector::export_dump_files() {
 
     std::sort(collected_.begin(), collected_.end(), [](const DumpedTensor &a, const DumpedTensor &b) {
         if (a.task_id != b.task_id) return a.task_id < b.task_id;
-        if (a.subtask_id != b.subtask_id) return a.subtask_id < b.subtask_id;
-        if (a.func_id != b.func_id) return a.func_id < b.func_id;
         if (a.stage != b.stage) return static_cast<uint8_t>(a.stage) < static_cast<uint8_t>(b.stage);
         if (a.arg_index != b.arg_index) return a.arg_index < b.arg_index;
         return static_cast<uint8_t>(a.role) < static_cast<uint8_t>(b.role);
@@ -548,13 +554,16 @@ int TensorDumpCollector::export_dump_files() {
         first_entry = false;
 
         json << "    {\"task_id\": \"0x" << std::hex << std::setfill('0') << std::setw(16) << dt.task_id << std::dec
-             << "\", \"subtask_id\": " << static_cast<uint32_t>(dt.subtask_id) << ", \"func_id\": " << dt.func_id
-             << ", \"role\": \"" << tensor_dump_role_name(dt.role) << "\", \"stage\": \""
-             << tensor_dump_stage_name(dt.stage) << "\", \"arg_index\": " << dt.arg_index << ", \"dtype\": \""
-             << dtype_name << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false")
-             << ", \"shape\": " << shape_str << ", \"strides\": " << strides_str
-             << ", \"start_offset\": " << dt.start_offset << ", \"numel\": " << numel
-             << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
+             << "\", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
+             << "\", \"stage\": \"" << tensor_dump_stage_name(dt.stage) << "\", \"kind\": \""
+             << tensor_dump_kind_name(dt.kind) << "\", \"dtype\": \"" << dtype_name
+             << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false") << ", \"shape\": " << shape_str
+             << ", \"strides\": " << strides_str << ", \"start_offset\": " << dt.start_offset
+             << ", \"numel\": " << numel;
+        if (dt.kind == TensorDumpKind::SCALAR) {
+            json << ", \"value\": " << dt.scalar_value;
+        }
+        json << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
              << ", \"truncated\": " << (dt.truncated ? "true" : "false")
              << ", \"overwritten\": " << (dt.overwritten ? "true" : "false") << "}";
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
@@ -11,10 +11,10 @@
 ``tensor_dump/`` directory.
 
 Re-uses ``vector_example`` (5 submit_task calls). With ``--dump-tensor`` the
-AICPU writer captures every task's tensor I/O into a manifest + raw-byte
+AICPU writer captures task dump records into a unified manifest + raw-byte
 payload pair under ``<output_prefix>/tensor_dump/``. Smoke asserts:
-manifest exists + parses, the ``bin_file`` field it names exists, and at
-least one entry was captured.
+manifest exists + parses, the ``bin_file`` field it names exists, entries
+use the unified schema, and no legacy args-only manifest is emitted.
 """
 
 import json
@@ -109,7 +109,18 @@ class TestTensorDump(SceneTestCase):
         # the collector's chosen schema across runtimes, but we know
         # vector_example reads/writes ≥1 tensor and the manifest can't be empty
         # if anything was captured. Robust to schema add/remove of new fields.
+        tensors = data.get("tensors", [])
+        assert tensors, f"tensor_dump.json has no entries: {data}"
         assert bin_path.stat().st_size > 0, "tensor_dump.bin is empty"
+        assert not (dump_dir / "args_dump.json").exists(), "args_dump.json should not be emitted"
+        assert not (dump_dir / "kernel_args_dump.json").exists(), "kernel_args_dump.json should not be emitted"
+
+        assert all("kind" in t for t in tensors), tensors
+
+        scalar_entries = [t for t in tensors if t.get("kind") == "scalar"]
+        assert all(t.get("stage") == "before_dispatch" for t in scalar_entries), scalar_entries
+        assert all(t.get("bin_size") == 0 for t in scalar_entries), scalar_entries
+        assert all("value" in t for t in scalar_entries), scalar_entries
 
         # ---- Tool smoke: dump_viewer ----
         # Exit-code-only check; the no-filter default lists every captured


### PR DESCRIPTION
### Summary

This PR adds scalar value dump support to the unified tensor dump pipeline. `--dump-tensor` now captures scalar arguments at the `BEFORE_DISPATCH` stage alongside tensor metadata, using a new `kind` field to distinguish `tensor` from `scalar` records. The `kernel_args_dump.json` path is removed; all dump output goes to `tensor_dump.json` + `tensor_dump.bin`. Supports A2A3 and A5 sim paths.

### Design

- **Scalar via BEFORE_DISPATCH** — scalar args captured in existing `dump_tensors_for_task` traversal, no new stage needed.
- **`kind` field** — `TensorDumpRecord` and JSON manifest use `kind: "tensor" | "scalar"` to distinguish record types.
- **Scalar payload** — `scalar_value` field stores uint64 raw value; `bin_size = 0` indicates no binary payload.
- **Dual-platform coverage** — A2A3 and A5 sim paths wired through.
- **Unified output** — single `tensor_dump.json` + `tensor_dump.bin`, no separate kernel_args_dump.json.

### Scope

~14 files across A2A3 and A5 device/runtime/platform layers.

### Verification

PagedAttention SmallCase validation:
- a2a3sim ✅
- a5sim ✅
- a2a3onboard ✅