### PR TITLE
Refactor: unify ChipWorker run/run_prepared on the single C++ contract

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -661,7 +661,7 @@ NB_MODULE(_task_interface, m) {
             },
             nb::arg("callable_id"), nb::arg("callable"),
             "Stage a ChipCallable under callable_id for cheap repeated launches "
-            "via run_prepared. Variants without per-callable_id support raise."
+            "via run. Variants without per-callable_id support raise."
         )
         .def(
             "prepare_callable_from_blob",
@@ -677,18 +677,18 @@ NB_MODULE(_task_interface, m) {
             "from shm without rebuilding a PyChipCallable wrapper."
         )
         .def(
-            "run_prepared",
+            "run",
             [](ChipWorker &self, int32_t callable_id, ChipStorageTaskArgs &args, const CallConfig &config) {
-                self.run_prepared(callable_id, &args, config);
+                self.run(callable_id, &args, config);
             },
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"),
             "Launch a callable_id previously staged via prepare_callable."
         )
         .def(
-            "run_prepared",
+            "run",
             [](ChipWorker &self, int32_t callable_id, TaskArgs &args, const CallConfig &config) {
                 TaskArgsView view = make_view(args);
-                self.run_prepared(callable_id, view, config);
+                self.run(callable_id, view, config);
             },
             nb::arg("callable_id"), nb::arg("args"), nb::arg("config"),
             "Launch a callable_id from a TaskArgs (used for in-process callers)."
@@ -700,11 +700,11 @@ NB_MODULE(_task_interface, m) {
                 // The mailbox region is the on-wire format `write_blob` produced;
                 // `read_blob` is the matching reader that returns a zero-copy
                 // TaskArgsView into the caller-owned bytes. Forwards to the
-                // existing `run_prepared(cid, view, config)` path so chip-child
+                // existing `run(cid, view, config)` path so chip-child
                 // loops never re-implement the tensor/scalar layout in Python
                 // (where it has historically dropped fields like child_memory).
                 TaskArgsView view = read_blob(reinterpret_cast<const uint8_t *>(args_blob_ptr), blob_capacity);
-                self.run_prepared(callable_id, view, config);
+                self.run(callable_id, view, config);
             },
             nb::arg("callable_id"), nb::arg("args_blob_ptr"), nb::arg("blob_capacity"), nb::arg("config"),
             "Launch a callable_id from a raw mailbox-blob pointer + capacity "
@@ -729,7 +729,7 @@ NB_MODULE(_task_interface, m) {
             "Number of distinct callable_ids the AICPU has dlopened for on the "
             "bound device. Equals 0 when not initialized or the runtime "
             "variant lacks per-cid registration. Tests assert this to verify "
-            "prepare_callable + repeated run_prepared do not redundantly dlopen."
+            "prepare_callable + repeated run do not redundantly dlopen."
         )
         .def_prop_ro(
             "host_dlopen_count", &ChipWorker::host_dlopen_count,

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -260,7 +260,7 @@ class ChipWorker:
         worker = ChipWorker()
         worker.init(device_id=0, bins=bins)
         worker.prepare_callable(callable_id=0, callable=chip_callable)
-        worker.run_prepared(callable_id=0, args=orch_args, config=CallConfig(block_dim=24))
+        worker.run(callable_id=0, args=orch_args, config=CallConfig(block_dim=24))
         worker.unregister_callable(callable_id=0)
         worker.finalize()
     """
@@ -340,12 +340,12 @@ class ChipWorker:
         """Stage a ChipCallable under ``callable_id`` for repeated cheap launches.
 
         Uploads the kernel binaries + the orchestration SO once; subsequent
-        ``run_prepared(callable_id, ...)`` skips that work. ``callable_id``
+        ``run(callable_id, ...)`` skips that work. ``callable_id``
         must be in ``[0, 64)``. Requires ``init()``.
         """
         self._impl.prepare_callable(int(callable_id), callable)
 
-    def run_prepared(self, callable_id, args, config=None, **kwargs):
+    def run(self, callable_id, args, config=None, **kwargs):
         """Launch a ``callable_id`` previously staged via ``prepare_callable``.
 
         Args:
@@ -358,7 +358,7 @@ class ChipWorker:
             config = CallConfig()
         for k, v in kwargs.items():
             setattr(config, k, v)
-        self._impl.run_prepared(int(callable_id), args, config)
+        self._impl.run(int(callable_id), args, config)
 
     def unregister_callable(self, callable_id):
         """Drop prepared state for ``callable_id`` and release its orch SO share."""

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -140,7 +140,7 @@ _CTRL_FREE = 1
 _CTRL_COPY_TO = 2
 _CTRL_COPY_FROM = 3
 # Pre-warm a chip child for cid=arg0 by calling
-# `prepare_callable(cid, registry[cid])` so the first run_prepared() does
+# `prepare_callable(cid, registry[cid])` so the first run() does
 # not pay the H2D upload cost.  Sent from the parent right after init()
 # (or whenever a new ChipCallable cid is registered).
 _CTRL_PREPARE = 4
@@ -224,7 +224,7 @@ def _read_args_from_mailbox(buf) -> TaskArgs:
     Used by the Python-targeted child loops (sub_worker, nested L4+ child)
     where the destination of `args` is a Python callable that needs a
     typed TaskArgs object.  The chip-child loops that immediately forward
-    to C++ run_prepared use the zero-copy `run_prepared_from_blob` path
+    to C++ run use the zero-copy `run_prepared_from_blob` path
     instead — see those loops for the matching comment.
 
     Delegates to the nanobind helper so the ContinuousTensor layout is
@@ -314,7 +314,7 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
     Per-callable_id dispatch: TASK_READY carries a cid in OFF_CALLABLE;
     the child looks the cid up in the COW-inherited Python ``registry``
     to get the ChipCallable, calls ``cw.prepare_callable(cid, callable)``
-    once, then ``cw.run_prepared(cid, args, cfg)``. ``_CTRL_PREPARE`` is
+    once, then ``cw.run(cid, args, cfg)``. ``_CTRL_PREPARE`` is
     the explicit pre-warm path (parent pushes after init() to amortise
     the first H2D upload); TASK_READY also lazy-prepares as a safety net.
     """
@@ -1350,7 +1350,7 @@ class Worker:
 
         Dispatch:
           - L2: ``callable`` is a cid returned by ``Worker.register(chip_callable)``.
-            Routes to ``_chip_worker.run_prepared(cid, args, cfg)``.
+            Routes to ``_chip_worker.run(cid, args, cfg)``.
           - L3+: ``callable`` is a Python orch fn invoked with the
             ``Orchestrator`` handle.
 
@@ -1362,7 +1362,7 @@ class Worker:
 
         if self.level == 2:
             assert self._chip_worker is not None
-            self._chip_worker.run_prepared(int(callable), args, cfg)
+            self._chip_worker.run(int(callable), args, cfg)
         else:
             self._start_hierarchical()
             assert self._orch is not None
@@ -1388,7 +1388,7 @@ class Worker:
 
     def prepare_callable(self, callable_id: int, callable) -> None:
         """L2 only: pre-stage a callable under ``callable_id`` (see
-        ``ChipWorker.prepare_callable``). Subsequent ``run_prepared`` skips
+        ``ChipWorker.prepare_callable``). Subsequent ``run`` skips
         per-run kernel/orch SO upload.
         """
         assert self._initialized, "Worker not initialized; call init() first"
@@ -1396,15 +1396,6 @@ class Worker:
             raise NotImplementedError("prepare_callable is L2-only")
         assert self._chip_worker is not None
         self._chip_worker.prepare_callable(callable_id, callable)
-
-    def run_prepared(self, callable_id: int, args=None, config=None) -> None:
-        """L2 only: launch a callable previously staged via ``prepare_callable``."""
-        assert self._initialized, "Worker not initialized; call init() first"
-        if self.level != 2:
-            raise NotImplementedError("run_prepared is L2-only")
-        assert self._chip_worker is not None
-        cfg = config if config is not None else CallConfig()
-        self._chip_worker.run_prepared(callable_id, args, cfg)
 
     def unregister_callable(self, callable_id: int) -> None:
         """L2 only: drop the prepared state for ``callable_id``.

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -231,7 +231,7 @@ public:
     //
     // `callable_id` is the cid returned by ``Worker.register()``; the
     // callable must have been prepared via ``prepare_callable()`` before
-    // this call. ChipWorker delegates to ``run_prepared(cid, …)``.
+    // this call.
     //
     // slot_id is not a parameter — completion routing is owned by
     // WorkerThread / Scheduler at a higher layer.

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -274,10 +274,6 @@ void ChipWorker::finalize() {
     finalized_ = true;
 }
 
-void ChipWorker::run(int32_t callable_id, TaskArgsView args, const CallConfig &config) {
-    run_prepared(callable_id, args, config);
-}
-
 void ChipWorker::prepare_callable(int32_t callable_id, const void *callable) {
     if (!initialized_) {
         throw std::runtime_error("ChipWorker not initialized; call init() first");
@@ -291,12 +287,12 @@ void ChipWorker::prepare_callable(int32_t callable_id, const void *callable) {
     }
 }
 
-void ChipWorker::run_prepared(int32_t callable_id, TaskArgsView args, const CallConfig &config) {
+void ChipWorker::run(int32_t callable_id, TaskArgsView args, const CallConfig &config) {
     ChipStorageTaskArgs chip_storage = view_to_chip_storage(args);
-    run_prepared(callable_id, &chip_storage, config);
+    run(callable_id, &chip_storage, config);
 }
 
-void ChipWorker::run_prepared(int32_t callable_id, const void *args, const CallConfig &config) {
+void ChipWorker::run(int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config) {
     config.validate();
     if (!initialized_) {
         throw std::runtime_error("ChipWorker not initialized; call init() first");

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -47,21 +47,24 @@ public:
     /// Terminal — the object cannot be reused after this.
     void finalize();
 
-    // IWorker: dispatch the prepared cid by delegating to run_prepared.
-    // The cid must already have been prepared via prepare_callable.
+    // IWorker: launch a cid previously staged via prepare_callable.
+    // Materializes a ChipStorageTaskArgs from `args` (one memcpy of T*40B + S*8B
+    // into a stack POD), then delegates to the overload below.
     void run(int32_t callable_id, TaskArgsView args, const CallConfig &config) override;
+    // Same launch, but the caller already holds the runtime.so-ABI POD —
+    // skip the view→storage memcpy and hand the pointer straight to the C ABI.
+    // Used by the ChipStorageTaskArgs path in the nanobind binding.
+    void run(int32_t callable_id, const ChipStorageTaskArgs *args, const CallConfig &config);
 
     // Per-callable_id preparation. Requires init() first and a callable_id
     // in [0, MAX_REGISTERED_CALLABLE_IDS) (cap 64).
     void prepare_callable(int32_t callable_id, const void *callable);
-    void run_prepared(int32_t callable_id, TaskArgsView args, const CallConfig &config);
-    void run_prepared(int32_t callable_id, const void *args, const CallConfig &config);
     void unregister_callable(int32_t callable_id);
 
     /// Number of distinct callable_ids the AICPU has been asked to dlopen for
     /// on the bound device. Returns 0 when not initialized or the runtime
     /// variant has no per-cid registration support. Used by tests to assert
-    /// that prepare_callable + repeated run_prepared do not trigger redundant
+    /// that prepare_callable + repeated run do not trigger redundant
     /// AICPU dlopens.
     size_t aicpu_dlopen_count() const;
 

--- a/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -7,12 +7,12 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""End-to-end test for ChipWorker.prepare_callable / run_prepared on host_build_graph.
+"""End-to-end test for ChipWorker.prepare_callable / run on host_build_graph.
 
 Mirrors tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable for the hbg
 variant: instead of the AICPU dlopening the orch SO once per cid, hbg dlopens
 on the host inside prepare_callable and replays the cached handle/fn pointer
-on every run_prepared. The dlopen counter to assert is `host_dlopen_count`,
+on every run. The dlopen counter to assert is `host_dlopen_count`,
 not `aicpu_dlopen_count` (which stays 0 — AICPU never sees the orch SO).
 """
 
@@ -35,7 +35,7 @@ _CID_SECONDARY = 1
 
 @scene_test(level=2, runtime="host_build_graph")
 class TestPreparedCallableHbg(SceneTestCase):
-    """Exercise prepare_callable / run_prepared / unregister_callable on hbg.
+    """Exercise prepare_callable / run / unregister_callable on hbg.
 
     Requires an isolated L2 ``Worker`` (cid table starts empty); this is
     provided by the directory-local ``conftest.py`` overriding ``st_worker``
@@ -124,7 +124,7 @@ class TestPreparedCallableHbg(SceneTestCase):
             golden_args = test_args.clone()
             self.compute_golden(golden_args, params)
 
-            worker.run_prepared(_CID_PRIMARY, chip_args, config=config)
+            worker.run(_CID_PRIMARY, chip_args, config=config)
             _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
         test_args = self.generate_args(params)
@@ -132,7 +132,7 @@ class TestPreparedCallableHbg(SceneTestCase):
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
 
-        worker.run_prepared(_CID_SECONDARY, chip_args, config=config)
+        worker.run(_CID_SECONDARY, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
         worker.unregister_callable(_CID_PRIMARY)
@@ -143,7 +143,7 @@ class TestPreparedCallableHbg(SceneTestCase):
     #
     # hbg increments host_dlopen_count on every register_prepared_callable_host_orch
     # invocation (i.e. each `prepare_callable` call), independent of how many
-    # times run_prepared is invoked afterwards. AICPU never dlopens the orch
+    # times run is invoked afterwards. AICPU never dlopens the orch
     # SO on this variant, so aicpu_dlopen_count stays at 0.
     # ------------------------------------------------------------------
 
@@ -160,7 +160,7 @@ class TestPreparedCallableHbg(SceneTestCase):
         chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
-        worker.run_prepared(cid, chip_args, config=config)
+        worker.run(cid, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
     def test_dlopen_count_same_cid_repeated_runs(self, st_platform, st_worker):

--- a/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -7,10 +7,10 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""End-to-end test for ChipWorker.prepare_callable / run_prepared / unregister_callable.
+"""End-to-end test for ChipWorker.prepare_callable / run / unregister_callable.
 
 Reuses the vector_example orchestration + AIV kernels. Exercises:
-  - prepare_callable once, then run_prepared twice (second run proves the
+  - prepare_callable once, then run twice (second run proves the
     AICPU-side dlopen cache / host-side orch SO dedup is working — no re-upload).
   - Two distinct callable_ids sharing the same orch SO binary: verifies both
     produce correct output independently.
@@ -38,7 +38,7 @@ _CID_SECONDARY = 1
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestPreparedCallable(SceneTestCase):
-    """Exercise prepare_callable / run_prepared / unregister_callable ABI.
+    """Exercise prepare_callable / run / unregister_callable ABI.
 
     Requires an isolated L2 ``Worker`` (cid table starts empty); this is
     provided by the directory-local ``conftest.py`` overriding ``st_worker``
@@ -120,23 +120,23 @@ class TestPreparedCallable(SceneTestCase):
         worker.prepare_callable(_CID_PRIMARY, callable_obj)
         worker.prepare_callable(_CID_SECONDARY, callable_obj)
 
-        # 2) run_prepared primary cid twice (second run proves dedup/cache hit)
+        # 2) run primary cid twice (second run proves dedup/cache hit)
         for _ in range(2):
             test_args = self.generate_args(params)
             chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
             golden_args = test_args.clone()
             self.compute_golden(golden_args, params)
 
-            worker.run_prepared(_CID_PRIMARY, chip_args, config=config)
+            worker.run(_CID_PRIMARY, chip_args, config=config)
             _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
-        # 3) run_prepared secondary cid — different slot, same SO, must also work
+        # 3) run secondary cid — different slot, same SO, must also work
         test_args = self.generate_args(params)
         chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
 
-        worker.run_prepared(_CID_SECONDARY, chip_args, config=config)
+        worker.run(_CID_SECONDARY, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
         # 4) unregister both — should not raise
@@ -168,7 +168,7 @@ class TestPreparedCallable(SceneTestCase):
         chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
-        worker.run_prepared(cid, chip_args, config=config)
+        worker.run(cid, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
     def test_dlopen_count_same_cid_repeated_runs(self, st_platform, st_worker):

--- a/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""End-to-end test for ChipWorker.prepare_callable / run_prepared on a5/host_build_graph.
+"""End-to-end test for ChipWorker.prepare_callable / run on a5/host_build_graph.
 
 Mirrors tests/st/a2a3/host_build_graph/prepared_callable for the a5 variant.
 Reuses the dump_tensor example kernels (a + b + 1) since a5/hbg has no
@@ -31,7 +31,7 @@ _CID_SECONDARY = 1
 
 @scene_test(level=2, runtime="host_build_graph")
 class TestPreparedCallableHbgA5(SceneTestCase):
-    """Exercise prepare_callable / run_prepared / unregister_callable on a5/hbg.
+    """Exercise prepare_callable / run / unregister_callable on a5/hbg.
 
     Requires an isolated L2 ``Worker`` (cid table starts empty); this is
     provided by the directory-local ``conftest.py`` overriding ``st_worker``
@@ -113,7 +113,7 @@ class TestPreparedCallableHbgA5(SceneTestCase):
             golden_args = test_args.clone()
             self.compute_golden(golden_args, params)
 
-            worker.run_prepared(_CID_PRIMARY, chip_args, config=config)
+            worker.run(_CID_PRIMARY, chip_args, config=config)
             _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
         test_args = self.generate_args(params)
@@ -121,7 +121,7 @@ class TestPreparedCallableHbgA5(SceneTestCase):
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
 
-        worker.run_prepared(_CID_SECONDARY, chip_args, config=config)
+        worker.run(_CID_SECONDARY, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
         worker.unregister_callable(_CID_PRIMARY)
@@ -140,7 +140,7 @@ class TestPreparedCallableHbgA5(SceneTestCase):
         chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
-        worker.run_prepared(cid, chip_args, config=config)
+        worker.run(cid, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
     def test_dlopen_count_same_cid_repeated_runs(self, st_platform, st_worker):

--- a/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -7,11 +7,11 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""End-to-end test for ChipWorker.prepare_callable / run_prepared / unregister_callable on a5/trb.
+"""End-to-end test for ChipWorker.prepare_callable / run / unregister_callable on a5/trb.
 
 Mirrors tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable. Reuses the
 vector_example orchestration + AIV kernels. Exercises:
-  - prepare_callable once, then run_prepared twice (second run proves the
+  - prepare_callable once, then run twice (second run proves the
     AICPU-side dlopen cache / host-side orch SO dedup is working — no re-upload).
   - Two distinct callable_ids sharing the same orch SO binary: verifies both
     produce correct output independently.
@@ -39,7 +39,7 @@ _CID_SECONDARY = 1
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestPreparedCallable(SceneTestCase):
-    """Exercise prepare_callable / run_prepared / unregister_callable ABI on a5/trb.
+    """Exercise prepare_callable / run / unregister_callable ABI on a5/trb.
 
     Requires an isolated L2 ``Worker`` (cid table starts empty); this is
     provided by the directory-local ``conftest.py`` overriding ``st_worker``
@@ -121,23 +121,23 @@ class TestPreparedCallable(SceneTestCase):
         worker.prepare_callable(_CID_PRIMARY, callable_obj)
         worker.prepare_callable(_CID_SECONDARY, callable_obj)
 
-        # 2) run_prepared primary cid twice (second run proves dedup/cache hit)
+        # 2) run primary cid twice (second run proves dedup/cache hit)
         for _ in range(2):
             test_args = self.generate_args(params)
             chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
             golden_args = test_args.clone()
             self.compute_golden(golden_args, params)
 
-            worker.run_prepared(_CID_PRIMARY, chip_args, config=config)
+            worker.run(_CID_PRIMARY, chip_args, config=config)
             _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
-        # 3) run_prepared secondary cid — different slot, same SO, must also work
+        # 3) run secondary cid — different slot, same SO, must also work
         test_args = self.generate_args(params)
         chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
 
-        worker.run_prepared(_CID_SECONDARY, chip_args, config=config)
+        worker.run(_CID_SECONDARY, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
         # 4) unregister both — should not raise
@@ -169,7 +169,7 @@ class TestPreparedCallable(SceneTestCase):
         chip_args, output_names = _build_chip_task_args(test_args, orch_sig)
         golden_args = test_args.clone()
         self.compute_golden(golden_args, params)
-        worker.run_prepared(cid, chip_args, config=config)
+        worker.run(cid, chip_args, config=config)
         _compare_outputs(test_args, golden_args, output_names, self.RTOL, self.ATOL)
 
     def test_dlopen_count_same_cid_repeated_runs(self, st_platform, st_worker):

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -113,14 +113,14 @@ class TestChipWorkerStateMachine:
         with pytest.raises(RuntimeError, match="not initialized"):
             worker.prepare_callable_from_blob(0, callable_obj.buffer_ptr())
 
-    def test_run_prepared_before_init_raises(self):
+    def test_run_before_init_raises(self):
         from _task_interface import ChipStorageTaskArgs  # noqa: PLC0415
 
         worker = _ChipWorker()
         config = CallConfig()
         args = ChipStorageTaskArgs()
         with pytest.raises(RuntimeError, match="not initialized"):
-            worker.run_prepared(0, args, config)
+            worker.run(0, args, config)
 
     def test_unregister_callable_before_init_raises(self):
         worker = _ChipWorker()


### PR DESCRIPTION
## Summary

`ChipWorker` had a `run` trampoline (overriding `IWorker::run`) that
delegated to `run_prepared` with the same `(cid, args, config)`
signature. The `_prepared` suffix carried no information at the C++
layer — having a `cid` already implies `prepare_callable` ran. The
distinction only had meaning at the Python `Worker.run(callable, args,
config)` layer, which resolves a Python callable → cid before
dispatching.

Collapse to a single name across C++ class methods and the Python
surface:

- `IWorker::run(cid, args, config)` — unchanged, the abstract contract.
- `ChipWorker`: drop the trampoline; rename both `run_prepared`
  overloads (`TaskArgsView` + raw `void *`) to `run`. The first
  becomes the direct `IWorker::run` override.
- nanobind binding: expose `run` (two overloads) instead of
  `run_prepared`. `run_prepared_from_blob` keeps its name — distinct
  zero-copy path forwarding to `self.run(...)`.
- `simpler.task_interface.ChipWorker`: rename the `run_prepared`
  wrapper to `run`.
- `simpler.worker.Worker`: drop the L2-only `run_prepared` shim;
  the generic `Worker.run(callable, args, config)` is now the
  single entry point for both L2 and L3+.

### Kept unchanged on purpose

- The C ABI dlsym symbol `run_prepared` (declared in
  `pto_runtime_c_api.h`, implemented per platform) — that's the
  private contract between `chip_worker.cpp` and `host_runtime.so`.
  Renaming it would touch all four
  `src/{a2a3,a5}/platform/{sim,onboard}/host/pto_runtime_c_api.cpp`
  files for no user-visible benefit.
- The C++ exception message `\"run_prepared failed with code N\"` —
  refers to the C ABI rc, and the `aicore_op_timeout` /
  `explicit_fatal` ST tests pattern-match on it.

## Testing

- [x] macOS sim: `pip install --no-build-isolation -e .` builds clean
- [x] `pytest tests/ut/py/test_chip_worker.py` — 14/14 pass
- [ ] CI: onboard ST coverage for `prepared_callable/` (a2a3 + a5
      × hbg + trb) — exercised by the four migrated test suites

## Diff scope

11 files changed, 57 insertions(+), 70 deletions(-). All test-suite
callsites of `worker.run_prepared(cid, args, cfg)` migrated to
`worker.run(...)`; the `test_run_prepared_before_init_raises` unit
test renamed to `test_run_before_init_raises`.