### PR TITLE
Fix: emit swimlane orch_summary independent of PTO2_ORCH_PROFILING

### DIFF
--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -385,7 +385,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     func_id_to_name=None,
     verbose=False,
     scheduler_phases=None,
-    orchestrator_data=None,
     orchestrator_phases=None,
     core_to_thread=None,
     orchestrator_name=None,
@@ -404,7 +403,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
         func_id_to_name: Optional dict mapping func_id to function name
         verbose: Print progress information
         scheduler_phases: Optional list of per-thread phase record lists (version 2)
-        orchestrator_data: Optional dict with orchestrator summary (version 2)
         orchestrator_phases: Optional list of per-task orchestrator phase records (version 2)
         core_to_thread: Optional list mapping core_id (index) to scheduler thread index (-1 = unassigned)
 
@@ -764,7 +762,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                 events.append(event)
 
     # AICPU Orchestrator event (version 2)
-    if orchestrator_phases or orchestrator_data:
+    #
+    # Per-event AicpuPhaseRecord[] are the single source of truth. The
+    # cumulative aicpu_orchestrator summary still ships start/end_time and
+    # submit_count but no per-phase breakdown — anything that needs phase
+    # totals derives them by bucketing per-event entries on phase_id.
+    if orchestrator_phases:
         # Process metadata
         orch_process_label = f"AICPU {orchestrator_name}" if orchestrator_name else "AICPU Orchestrator"
         events.append(
@@ -774,30 +777,14 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
             {"args": {"sort_index": 1}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 4}
         )
 
-        # Normalize orchestrator_phases: support both per-thread nested format
-        # (list of lists) and legacy flat format (list of dicts)
-        orch_threads = orchestrator_phases if orchestrator_phases else []
-
         # Thread name metadata for each orchestrator thread
-        for orch_idx in range(len(orch_threads)):
+        for orch_idx in range(len(orchestrator_phases)):
             tid = 4000 + orch_idx
             name = f"Orch_{orch_idx}"
             events.append(
                 {"args": {"name": name}, "cat": "__metadata", "name": "thread_name", "ph": "M", "pid": 4, "tid": tid}
             )
-        if not orch_threads and orchestrator_data:
-            events.append(
-                {
-                    "args": {"name": orchestrator_name or "Orchestrator"},
-                    "cat": "__metadata",
-                    "name": "thread_name",
-                    "ph": "M",
-                    "pid": 4,
-                    "tid": 4000,
-                }
-            )
 
-    if orchestrator_phases:
         # Per-task orchestrator phase bars
         orch_phase_colors = {
             "orch_sync": "thread_state_iowait",  # orange
@@ -811,7 +798,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
             "orch_scope_end": "generic_work",
         }
 
-        for orch_idx, thread_records in enumerate(orch_threads):
+        for orch_idx, thread_records in enumerate(orchestrator_phases):
             tid = 4000 + orch_idx
             for record in thread_records:
                 phase = record.get("phase", "unknown")
@@ -842,39 +829,6 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                     "dur": dur,
                 }
                 events.append(event)
-
-    elif orchestrator_data:
-        # Fallback: cumulative summary as single bar
-        orch_start = orchestrator_data["start_time_us"]
-        orch_end = orchestrator_data["end_time_us"]
-        orch_dur = orch_end - orch_start
-        phase_us = orchestrator_data.get("phase_us", {})
-
-        # Build args with phase breakdown (cumulative totals, shown in detail panel)
-        orch_args = {
-            "submit_count": orchestrator_data.get("submit_count", 0),
-        }
-        total_phase_us = sum(phase_us.values())
-        if total_phase_us > 0:
-            for phase_name, dur in phase_us.items():
-                if dur > 0:
-                    pct = dur / total_phase_us * 100
-                    orch_args[f"{phase_name}_us"] = round(dur, 3)
-                    orch_args[f"{phase_name}_%"] = round(pct, 1)
-
-        # Total orchestrator bar
-        events.append(
-            {
-                "args": orch_args,
-                "cat": "orchestrator",
-                "name": f"Orchestrator({orchestrator_data.get('submit_count', 0)} tasks)",
-                "ph": "X",
-                "pid": 4,
-                "tid": 4000,
-                "ts": orch_start,
-                "dur": orch_dur,
-            }
-        )
 
     # AICPU View fanout arrows (duplicate AICore View flow events using AICPU timestamps)
     if has_aicpu_data:
@@ -1045,7 +999,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     if orchestrator_phases and scheduler_phases:
         orch_fanin_by_task = {}
         orch_params_by_task = {}
-        for orch_idx, thread_records in enumerate(orch_threads):
+        for orch_idx, thread_records in enumerate(orchestrator_phases):
             for record in thread_records:
                 phase = record.get("phase")
                 task_id = record.get("task_id", -1)
@@ -1283,7 +1237,6 @@ def main():
             args.verbose,
             orchestrator_name=orchestrator_name,
             scheduler_phases=data.get("aicpu_scheduler_phases"),
-            orchestrator_data=data.get("aicpu_orchestrator"),
             orchestrator_phases=data.get("aicpu_orchestrator_phases"),
             core_to_thread=data.get("core_to_thread"),
             deps_edges=deps_edges,

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -333,25 +333,20 @@ struct AicpuPhaseRecord {
 static_assert(sizeof(AicpuPhaseRecord) == 40, "AicpuPhaseRecord layout drift");
 
 /**
- * AICPU orchestrator cumulative summary
+ * AICPU orchestrator run summary
  *
- * Contains accumulated cycle counts from the orchestrator thread.
- * Written once after orchestration completes.
+ * Captures the orchestrator's overall run window. Per-phase breakdown is
+ * derived host-side by aggregating AicpuPhaseRecord entries filtered by
+ * phase_id, so per-phase cycle fields are not duplicated here. The
+ * device-side aggregate path under PTO2_ORCH_PROFILING (g_orch_*_cycle +
+ * LOG_INFO_V9) is independent and emits to the device log only.
  */
 struct AicpuOrchSummary {
-    uint64_t start_time;       // Orchestrator start timestamp
-    uint64_t end_time;         // Orchestrator end timestamp
-    uint64_t sync_cycle;       // sync_tensormap phase
-    uint64_t alloc_cycle;      // task_ring_alloc phase
-    uint64_t args_cycle;       // param_copy phase
-    uint64_t lookup_cycle;     // lookup+dep phase
-    uint64_t heap_cycle;       // heap_alloc phase
-    uint64_t insert_cycle;     // tensormap_insert phase
-    uint64_t fanin_cycle;      // fanin+ready phase
-    uint64_t scope_end_cycle;  // scope_end phase
-    int64_t submit_count;      // Total tasks submitted
-    uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t padding;          // Alignment padding
+    uint64_t start_time;   // Orchestrator start timestamp
+    uint64_t end_time;     // Orchestrator end timestamp
+    int64_t submit_count;  // Total tasks submitted
+    uint32_t magic;        // Validation magic (AICPU_PHASE_MAGIC)
+    uint32_t padding;      // Alignment padding
 } __attribute__((aligned(64)));
 
 constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -735,31 +735,17 @@ int L2PerfCollector::export_swimlane_json() {
 
         // AICPU orchestrator summary
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC) {
+            // Per-phase breakdown is no longer reported here; consumers that
+            // want it derive it from the aicpu_orchestrator_phases array by
+            // bucketing entries on phase_id, keeping per-event records as the
+            // single source of truth.
             double orch_start_us = cycles_to_us(collected_orch_summary_.start_time - base_time_cycles);
             double orch_end_us = cycles_to_us(collected_orch_summary_.end_time - base_time_cycles);
 
             outfile << ",\n  \"aicpu_orchestrator\": {\n";
             outfile << "    \"start_time_us\": " << std::fixed << std::setprecision(3) << orch_start_us << ",\n";
             outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
-            outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << ",\n";
-            outfile << "    \"phase_us\": {\n";
-            outfile << "      \"sync\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
-            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
-            outfile << "      \"params\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.args_cycle) << ",\n";
-            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
-            outfile << "      \"heap\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
-            outfile << "      \"insert\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
-            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
-            outfile << "    }\n";
+            outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << "\n";
             outfile << "  }";
         }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -572,10 +572,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
             LOG_INFO_V9(
-                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
-                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
-                static_cast<uint64_t>(p.fanin_atomic_count)
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus", thread_idx,
+                cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle)
             );
             LOG_INFO_V9(
                 "Thread %d:   avg/task       : %.3fus", thread_idx,
@@ -601,31 +600,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0
             );
 #endif
+#endif  // PTO2_ORCH_PROFILING
 
-#if PTO2_PROFILING
-            // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (is_l2_swimlane_enabled()) {
-                AicpuOrchSummary orch_summary = {};
-                orch_summary.start_time = orch_cycle_start;
-                orch_summary.end_time = orch_cycle_end;
-                orch_summary.sync_cycle = p.sync_cycle;
-                orch_summary.alloc_cycle = p.alloc_cycle;
-                orch_summary.args_cycle = p.args_cycle;
-                orch_summary.lookup_cycle = p.lookup_cycle;
-                orch_summary.heap_cycle = 0;  // Now included in alloc_cycle
-                orch_summary.insert_cycle = p.insert_cycle;
-                orch_summary.fanin_cycle = p.fanin_cycle;
-                orch_summary.scope_end_cycle = p.scope_end_cycle;
-                orch_summary.submit_count = p.submit_count;
-                l2_perf_aicpu_write_orch_summary(&orch_summary);
-            }
-#endif
-#endif
-
-            // Signal completion to the orchestrator state machine
-            rt_orchestration_done(rt);
-
-            // Latch task count from PTO2 shared memory
+            // Latch task count from PTO2 shared memory (used both by the
+            // swimlane orch_summary below and passed on to the scheduler).
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -633,9 +611,24 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                         rt->orchestrator.sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }
             }
+
 #if PTO2_PROFILING
             pto2_submitted_tasks = total_tasks;
+            // Write the orchestrator run window to swimlane shared memory.
+            // Per-phase breakdown is derived host-side from AicpuPhaseRecord[]
+            // (collected via l2_perf_aicpu_record_orch_phase under PTO2_PROFILING,
+            // independent of PTO2_ORCH_PROFILING), so it does NOT live here.
+            if (is_l2_swimlane_enabled()) {
+                AicpuOrchSummary orch_summary = {};
+                orch_summary.start_time = orch_cycle_start;
+                orch_summary.end_time = orch_cycle_end;
+                orch_summary.submit_count = total_tasks;
+                l2_perf_aicpu_write_orch_summary(&orch_summary);
+            }
 #endif
+
+            // Signal completion to the orchestrator state machine
+            rt_orchestration_done(rt);
 
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -92,8 +92,6 @@ uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
 uint64_t g_orch_args_atomic_count = 0;
-uint64_t g_orch_fanin_atomic_count = 0;
-uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc)       \
@@ -936,8 +934,6 @@ PTO2OrchProfilingData orchestrator_get_profiling() {
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.alloc_atomic_count = g_orch_alloc_atomic_count;
     d.args_atomic_count = g_orch_args_atomic_count;
-    d.fanin_atomic_count = g_orch_fanin_atomic_count;
-    d.finalize_atomic_count = g_orch_finalize_atomic_count;
     d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
@@ -950,8 +946,6 @@ PTO2OrchProfilingData orchestrator_get_profiling() {
     g_orch_fanin_wait_cycle = 0;
     g_orch_alloc_atomic_count = 0;
     g_orch_args_atomic_count = 0;
-    g_orch_fanin_atomic_count = 0;
-    g_orch_finalize_atomic_count = 0;
     g_orch_scope_end_atomic_count = 0;
     return d;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -151,8 +151,6 @@ struct PTO2OrchProfilingData {
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t args_atomic_count;
-    uint64_t fanin_atomic_count;
-    uint64_t finalize_atomic_count;
     uint64_t scope_end_atomic_count;
 };
 

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -324,25 +324,20 @@ struct AicpuPhaseRecord {
 static_assert(sizeof(AicpuPhaseRecord) == 40, "AicpuPhaseRecord layout drift");
 
 /**
- * AICPU orchestrator cumulative summary
+ * AICPU orchestrator run summary
  *
- * Contains accumulated cycle counts from the orchestrator thread.
- * Written once after orchestration completes.
+ * Captures the orchestrator's overall run window. Per-phase breakdown is
+ * derived host-side by aggregating AicpuPhaseRecord entries filtered by
+ * phase_id, so per-phase cycle fields are not duplicated here. The
+ * device-side aggregate path under PTO2_ORCH_PROFILING (g_orch_*_cycle +
+ * LOG_INFO_V9) is independent and emits to the device log only.
  */
 struct AicpuOrchSummary {
-    uint64_t start_time;       // Orchestrator start timestamp
-    uint64_t end_time;         // Orchestrator end timestamp
-    uint64_t sync_cycle;       // sync_tensormap phase
-    uint64_t alloc_cycle;      // task_ring_alloc phase
-    uint64_t args_cycle;       // param_copy phase
-    uint64_t lookup_cycle;     // lookup+dep phase
-    uint64_t heap_cycle;       // heap_alloc phase
-    uint64_t insert_cycle;     // tensormap_insert phase
-    uint64_t fanin_cycle;      // fanin+ready phase
-    uint64_t scope_end_cycle;  // scope_end phase
-    int64_t submit_count;      // Total tasks submitted
-    uint32_t magic;            // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t padding;          // Alignment padding
+    uint64_t start_time;   // Orchestrator start timestamp
+    uint64_t end_time;     // Orchestrator end timestamp
+    int64_t submit_count;  // Total tasks submitted
+    uint32_t magic;        // Validation magic (AICPU_PHASE_MAGIC)
+    uint32_t padding;      // Alignment padding
 } __attribute__((aligned(64)));
 
 constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -716,31 +716,17 @@ int L2PerfCollector::export_swimlane_json() {
         outfile << "  ]";
 
         if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC) {
+            // Per-phase breakdown is no longer reported here; consumers that
+            // want it derive it from the aicpu_orchestrator_phases array by
+            // bucketing entries on phase_id, keeping per-event records as the
+            // single source of truth.
             double orch_start_us = cycles_to_us(collected_orch_summary_.start_time - base_time_cycles);
             double orch_end_us = cycles_to_us(collected_orch_summary_.end_time - base_time_cycles);
 
             outfile << ",\n  \"aicpu_orchestrator\": {\n";
             outfile << "    \"start_time_us\": " << std::fixed << std::setprecision(3) << orch_start_us << ",\n";
             outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
-            outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << ",\n";
-            outfile << "    \"phase_us\": {\n";
-            outfile << "      \"sync\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.sync_cycle) << ",\n";
-            outfile << "      \"alloc\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.alloc_cycle) << ",\n";
-            outfile << "      \"params\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.args_cycle) << ",\n";
-            outfile << "      \"lookup\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.lookup_cycle) << ",\n";
-            outfile << "      \"heap\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.heap_cycle) << ",\n";
-            outfile << "      \"insert\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.insert_cycle) << ",\n";
-            outfile << "      \"fanin\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.fanin_cycle) << ",\n";
-            outfile << "      \"scope_end\": " << std::fixed << std::setprecision(3)
-                    << cycles_to_us(collected_orch_summary_.scope_end_cycle) << "\n";
-            outfile << "    }\n";
+            outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << "\n";
             outfile << "  }";
         }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -557,10 +557,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 cycles_to_us(p.args_cycle), p.args_cycle * 100.0 / total, static_cast<uint64_t>(p.args_atomic_count)
             );
             LOG_INFO_V9(
-                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus  atomics=%" PRIu64 "",
-                thread_idx, cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
-                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle),
-                static_cast<uint64_t>(p.fanin_atomic_count)
+                "Thread %d:   fanin+ready    : %.3fus (%.1f%%)  work=%.3fus wait=%.3fus", thread_idx,
+                cycles_to_us(p.fanin_cycle), p.fanin_cycle * 100.0 / total,
+                cycles_to_us(p.fanin_cycle - p.fanin_wait_cycle), cycles_to_us(p.fanin_wait_cycle)
             );
             LOG_INFO_V9(
                 "Thread %d:   avg/task       : %.3fus", thread_idx,
@@ -586,31 +585,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 tp.overlap_checks > 0 ? tp.overlap_hits * 100.0 / tp.overlap_checks : 0.0
             );
 #endif
+#endif  // PTO2_ORCH_PROFILING
 
-#if PTO2_PROFILING
-            // Write orchestrator summary to shared memory for host-side export (only if profiling enabled)
-            if (is_l2_swimlane_enabled()) {
-                AicpuOrchSummary orch_summary = {};
-                orch_summary.start_time = orch_cycle_start;
-                orch_summary.end_time = orch_cycle_end;
-                orch_summary.sync_cycle = p.sync_cycle;
-                orch_summary.alloc_cycle = p.alloc_cycle;
-                orch_summary.args_cycle = p.args_cycle;
-                orch_summary.lookup_cycle = p.lookup_cycle;
-                orch_summary.heap_cycle = 0;  // Now included in alloc_cycle
-                orch_summary.insert_cycle = p.insert_cycle;
-                orch_summary.fanin_cycle = p.fanin_cycle;
-                orch_summary.scope_end_cycle = p.scope_end_cycle;
-                orch_summary.submit_count = p.submit_count;
-                l2_perf_aicpu_write_orch_summary(&orch_summary);
-            }
-#endif
-#endif
-
-            // Signal completion to the orchestrator state machine
-            rt_orchestration_done(rt);
-
-            // Latch task count from PTO2 shared memory
+            // Latch task count from PTO2 shared memory (used both by the
+            // swimlane orch_summary below and passed on to the scheduler).
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -618,9 +596,24 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                         rt->orchestrator.sm_header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
                 }
             }
+
 #if PTO2_PROFILING
             submitted_tasks = total_tasks;
+            // Write the orchestrator run window to swimlane shared memory.
+            // Per-phase breakdown is derived host-side from AicpuPhaseRecord[]
+            // (collected via l2_perf_aicpu_record_orch_phase under PTO2_PROFILING,
+            // independent of PTO2_ORCH_PROFILING), so it does NOT live here.
+            if (is_l2_swimlane_enabled()) {
+                AicpuOrchSummary orch_summary = {};
+                orch_summary.start_time = orch_cycle_start;
+                orch_summary.end_time = orch_cycle_end;
+                orch_summary.submit_count = total_tasks;
+                l2_perf_aicpu_write_orch_summary(&orch_summary);
+            }
 #endif
+
+            // Signal completion to the orchestrator state machine
+            rt_orchestration_done(rt);
 
             sched_ctx_.on_orchestration_done(runtime, rt, thread_idx, total_tasks);
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -71,8 +71,6 @@ uint64_t g_orch_alloc_wait_cycle = 0;
 uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
 uint64_t g_orch_args_atomic_count = 0;
-uint64_t g_orch_fanin_atomic_count = 0;
-uint64_t g_orch_finalize_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
 #define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc)       \
@@ -885,8 +883,6 @@ PTO2OrchProfilingData orchestrator_get_profiling() {
     d.fanin_wait_cycle = g_orch_fanin_wait_cycle;
     d.alloc_atomic_count = g_orch_alloc_atomic_count;
     d.args_atomic_count = g_orch_args_atomic_count;
-    d.fanin_atomic_count = g_orch_fanin_atomic_count;
-    d.finalize_atomic_count = g_orch_finalize_atomic_count;
     d.scope_end_atomic_count = g_orch_scope_end_atomic_count;
 
     // Reset
@@ -899,8 +895,6 @@ PTO2OrchProfilingData orchestrator_get_profiling() {
     g_orch_fanin_wait_cycle = 0;
     g_orch_alloc_atomic_count = 0;
     g_orch_args_atomic_count = 0;
-    g_orch_fanin_atomic_count = 0;
-    g_orch_finalize_atomic_count = 0;
     g_orch_scope_end_atomic_count = 0;
     return d;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -151,8 +151,6 @@ struct PTO2OrchProfilingData {
     // Atomic operation counts per phase
     uint64_t alloc_atomic_count;
     uint64_t args_atomic_count;
-    uint64_t fanin_atomic_count;
-    uint64_t finalize_atomic_count;
     uint64_t scope_end_atomic_count;
 };
 


### PR DESCRIPTION
## Summary

`aicpu_executor` wrote `AicpuOrchSummary` to swimlane shared memory inside `#if PTO2_ORCH_PROFILING` — the device-side aggregate-log gate. The default build (`PTO2_PROFILING=1`, `PTO2_ORCH_PROFILING=0`) silently dropped the per-run `{start_time, end_time, submit_count}` window that the host JSON's `aicpu_orchestrator` block needs to render the swimlane.

The block also carried two layers of unnecessary coupling: per-phase cycle totals were duplicated into `AicpuOrchSummary` even though the same data is already available in the per-event `AicpuPhaseRecord[]` stream, and the host even-then re-emitted those numbers into a `phase_us` JSON field that the swimlane converter only consulted in a degenerate fallback path.

This PR collapses the swimlane data flow to a single source of truth:

- **`AicpuOrchSummary` shrinks to `{start_time, end_time, submit_count, magic, padding}`.** Per-event `AicpuPhaseRecord[]` is the only orchestrator-timing payload that crosses device→host. Consumers that want per-phase totals derive them by bucketing entries on `phase_id`.
- **`aicpu_executor`** sources `submit_count` from `current_task_index` (always available) instead of `g_orch_submit_count` (only under `PTO2_ORCH_PROFILING`). The swimlane `orch_summary` write is now guarded only by `PTO2_PROFILING` + `is_l2_swimlane_enabled()`. `total_tasks` is hoisted above `rt_orchestration_done` so it is reused for both the summary and the scheduler hand-off.
- **Host JSON `aicpu_orchestrator` drops the `phase_us` subfield.** The host-side bucket-sum that produced it is gone; the swimlane converter's fallback `elif` branch that consumed it is gone. 0-submit runs now omit the orchestrator lane entirely (more honest than rendering an empty bar with zero `phase_us`).
- **The device-side `PTO2_ORCH_PROFILING` aggregate path stays intact**: the surviving `g_orch_*_cycle` / `_atomic_count` accumulators, `orchestrator_get_profiling()`, and the `LOG_INFO_V9` phase-breakdown block all continue to compile and emit when that flag is on. It feeds device log only, never shared memory.
- **Dead code removed**: `g_orch_fanin_atomic_count` and `g_orch_finalize_atomic_count` were never incremented (the fanin counter moved to per-thread `g_sched_fanin_atomic_count[]` long ago; the finalize phase was retired). Their `PTO2OrchProfilingData` fields and the now-orphaned `atomics=` column on the fanin `LOG_INFO` line go with them.

Mirrored across a5 and a2a3.

## Why this layout

Two flags, two consumers, two data paths:

| Config | Per-event `AicpuPhaseRecord[]` | Device-LOG phase averages | Swimlane JSON `aicpu_orchestrator_phases` |
|---|---|---|---|
| Default + no swimlane | none | none | absent |
| Default + `--enable-l2-swimlane` | **collected** | none | populated; converter derives phase totals if asked |
| `PTO2_ORCH_PROFILING=1` + no swimlane | none | **printed** | absent |
| `PTO2_ORCH_PROFILING=1` + swimlane | collected | printed | populated; both paths independent |

The cheap-and-accurate device-side accumulator path is preserved for the "I want phase averages but not swimlane overhead" debug case. The swimlane path stops depending on it.

## Test plan

Verified locally on macOS sim (Linux CI will confirm onboard parity):

- [x] `a5sim` + `a2a3sim` vector_example, default config — passes
- [x] Both arches with `--enable-l2-swimlane` — passes; `merged_swimlane.json` renders 30 per-task orchestrator phase bars (`alloc(t0)`, `sync(t0)`, …) on the Orch_0 lane
- [x] Both arches built with `-DPTO2_ORCH_PROFILING=1` — orchestrator phase breakdown still prints to device log via the preserved `g_orch_*_cycle` accumulators
- [x] `swimlane_converter` runs clean against the new JSON shape (no `phase_us`)
- [ ] Onboard hardware (left for CI)