### PR TITLE
Refactor: drop AicpuOrchSummary, derive orchestrator timing from records

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -224,7 +224,7 @@ L2PerfBufferState[num_cores]                    (per-core perf state)
 
 [AicpuPhaseHeader + PhaseBufferState[num_threads]]  (optional)
 ├── magic / num_sched_threads
-├── orch_summary  (cumulative orchestrator cycles)
+├── core_to_thread[]  (core_id → scheduler thread index)
 └── per-thread phase buffers (PhaseBufferState aliases L2PerfBufferState;
                               `aicore_ring_ptr` / `mismatch_record_count`
                               unused for PHASE)
@@ -235,10 +235,13 @@ The records themselves are identical across architectures:
 - `L2PerfRecord` — per-task timing + fanout, 64-byte aligned.
 - `AicpuPhaseRecord` — per-iteration scheduler / orchestrator
   phase, 32 bytes.
-- `AicpuOrchSummary` — one-shot cumulative orchestrator cycles.
 
 This is the key reason a single `swimlane_converter` consumes
-both architectures' output unchanged.
+both architectures' output unchanged. Orchestrator timing is carried
+entirely by per-task `AicpuPhaseRecord` entries (ORCH_SYNC, ORCH_ALLOC,
+…); there is no separate shared-memory aggregate. The run-window
+envelope is emitted to device log via `LOG_INFO_V9
+"orch_start=… orch_end=… orch_cost=…"`.
 
 **Producer/consumer protocol on AICore.** AICore writes per-task
 timing into a stable per-core `L2PerfAicoreRing` at
@@ -323,7 +326,7 @@ start(tf)                          ← spawn mgmt + poll threads
 launch AICPU / AICore
 rtStreamSynchronize
 stop()                             ← join mgmt → join poll
-read_phase_header_metadata()       ← single-shot read of orch_summary +
+read_phase_header_metadata()       ← single-shot read of the
                                      core→thread mapping
 reconcile_counters()               ← three-bucket accounting for both
                                      PERF and PHASE pools (total /
@@ -384,8 +387,8 @@ The bulk `mirror_shm_to_device` is deliberately **not** called from
 the mgmt loop: it would race with AICPU writes to device-only
 fields (`current_buf_ptr`, `total/dropped/mismatch` counters,
 `queue_tails`, `free_queue.head`, `AicpuPhaseHeader::magic`,
-`orch_summary`, `core_to_thread[]`) and roll them back to whatever
-the host shadow held at the start of the tick. Per-buffer
+`core_to_thread[]`) and roll them back to whatever the host shadow
+held at the start of the tick. Per-buffer
 payloads (`L2PerfBuffer` / `PhaseBuffer`) are pulled on demand
 inside `ProfilerAlgorithms::process_entry` after a popped
 ready-entry resolves to its host shadow. `BufferPoolManager`'s
@@ -480,7 +483,7 @@ PHASE), same shape as a2a3.
 
 | Aspect | a2a3 | a5 |
 | ------ | ---- | -- |
-| Record shape | identical (`L2PerfRecord` / `AicpuPhaseRecord` / `AicpuOrchSummary`) | |
+| Record shape | identical (`L2PerfRecord` / `AicpuPhaseRecord`) | |
 | AICore WIP-slot protocol | identical | |
 | AICPU commit on FIN | identical | |
 | Buffer model | rotating pool (free + ready queues) per kind | identical |

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -332,9 +332,8 @@ changes capture that:
    **not** called from the mgmt loop — it would race with AICPU writes
    to device-only fields (`current_buf_ptr`, `total/dropped/mismatch`
    counters, `queue_tails`, `free_queue.head`,
-   `AicpuPhaseHeader::magic`, `orch_summary`, `core_to_thread[]`),
-   rolling them back to whatever the host shadow had at the start of
-   the tick. Per-buffer payloads (`L2PerfBuffer` / `PmuBuffer` /
+   `AicpuPhaseHeader::magic`, `core_to_thread[]`), rolling them back
+   to whatever the host shadow had at the start of the tick. Per-buffer payloads (`L2PerfBuffer` / `PmuBuffer` /
    `DumpMetaBuffer`) are still pulled on demand inside
    `ProfilerAlgorithms::process_entry` after resolving the host pointer
    for a popped ready entry. The bulk `mirror_shm_to_device` is kept

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -761,12 +761,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
                 }
                 events.append(event)
 
-    # AICPU Orchestrator event (version 2)
+    # AICPU Orchestrator lane (version 2)
     #
-    # Per-event AicpuPhaseRecord[] are the single source of truth. The
-    # cumulative aicpu_orchestrator summary still ships start/end_time and
-    # submit_count but no per-phase breakdown — anything that needs phase
-    # totals derives them by bucketing per-event entries on phase_id.
+    # Per-event AicpuPhaseRecord[] is the single source of truth for
+    # orchestrator timing. There is no separate aggregate summary — the
+    # device-side LOG_INFO_V9 "orch_start=… orch_end=… orch_cost=…" log
+    # line covers the run-window envelope for debugging without swimlane.
     if orchestrator_phases:
         # Process metadata
         orch_process_label = f"AICPU {orchestrator_name}" if orchestrator_name else "AICPU Orchestrator"
@@ -1161,17 +1161,18 @@ def _print_verbose_data_info(data, verbose):
     if data["version"] != 2:
         return
     scheduler_phases = data.get("aicpu_scheduler_phases")
-    orchestrator_data = data.get("aicpu_orchestrator")
     orchestrator_phases = data.get("aicpu_orchestrator_phases")
     core_to_thread = data.get("core_to_thread")
     if scheduler_phases:
         print(f"  Scheduler threads: {len(scheduler_phases)}")
         print(f"  Total phase records: {sum(len(t) for t in scheduler_phases)}")
-    if orchestrator_data:
-        print(f"  Orchestrator: {orchestrator_data.get('submit_count', 0)} tasks")
     if orchestrator_phases:
         print(f"  Orchestrator threads: {len(orchestrator_phases)}")
         print(f"  Total orchestrator phase records: {sum(len(t) for t in orchestrator_phases)}")
+        # submit_count is derivable as the number of orch_fanin records (one per submit).
+        submit_count = sum(1 for thread in orchestrator_phases for r in thread if r.get("phase") == "orch_fanin")
+        if submit_count:
+            print(f"  Orchestrator: {submit_count} tasks submitted")
     if core_to_thread:
         print(f"  Core-to-thread mapping: {len(core_to_thread)} cores")
 

--- a/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -137,16 +137,6 @@ void l2_perf_aicpu_record_phase(
 );
 
 /**
- * Write orchestrator cumulative summary
- *
- * Writes the orchestrator's accumulated profiling data to shared memory
- * for host-side collection.
- *
- * @param src Pointer to populated AicpuOrchSummary (magic field is set internally)
- */
-void l2_perf_aicpu_write_orch_summary(const AicpuOrchSummary *src);
-
-/**
  * Set orchestrator thread index for per-task phase recording
  *
  * Must be called once from the orchestrator thread before any

--- a/src/a2a3/platform/include/common/l2_perf_profiling.h
+++ b/src/a2a3/platform/include/common/l2_perf_profiling.h
@@ -33,7 +33,7 @@
  * ├─────────────────────────────────────────────────────────────┤
  * │ AicpuPhaseHeader (optional, present when phase profiling)   │
  * │  - magic, num_sched_threads, records_per_thread             │
- * │  - orch_summary                                             │
+ * │  - core_to_thread mapping                                   │
  * ├─────────────────────────────────────────────────────────────┤
  * │ PhaseBufferState[thread0]                                   │
  * │  - free_queue: SPSC queue of available buffer pointers      │
@@ -332,23 +332,6 @@ struct AicpuPhaseRecord {
 };
 static_assert(sizeof(AicpuPhaseRecord) == 40, "AicpuPhaseRecord layout drift");
 
-/**
- * AICPU orchestrator run summary
- *
- * Captures the orchestrator's overall run window. Per-phase breakdown is
- * derived host-side by aggregating AicpuPhaseRecord entries filtered by
- * phase_id, so per-phase cycle fields are not duplicated here. The
- * device-side aggregate path under PTO2_ORCH_PROFILING (g_orch_*_cycle +
- * LOG_INFO_V9) is independent and emits to the device log only.
- */
-struct AicpuOrchSummary {
-    uint64_t start_time;   // Orchestrator start timestamp
-    uint64_t end_time;     // Orchestrator end timestamp
-    int64_t submit_count;  // Total tasks submitted
-    uint32_t magic;        // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t padding;      // Alignment padding
-} __attribute__((aligned(64)));
-
 constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;        // "ACPH"
 constexpr int PLATFORM_PHASE_RECORDS_PER_THREAD = 16384;  // ~512KB per thread
 
@@ -375,7 +358,6 @@ struct AicpuPhaseHeader {
     uint32_t records_per_thread;                // Max records per PhaseBuffer
     uint32_t num_cores;                         // Total number of cores with valid assignments
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
-    AicpuOrchSummary orch_summary;              // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a2a3/platform/include/host/l2_perf_collector.h
+++ b/src/a2a3/platform/include/host/l2_perf_collector.h
@@ -214,8 +214,8 @@ using L2PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
  *   4. stop()                      — joins both threads in the correct order
  *                                    (mgmt first so its final-drain entries
  *                                    have a consumer).
- *   5. read_phase_header_metadata() — single-shot read of orch_summary +
- *                                    core→thread mapping from AicpuPhaseHeader.
+ *   5. read_phase_header_metadata() — single-shot read of the core→thread
+ *                                    mapping from AicpuPhaseHeader.
  *   6. reconcile_counters()        — device-side three-bucket accounting for
  *                                    both PERF and PHASE pools (total /
  *                                    collected / dropped).
@@ -313,8 +313,9 @@ public:
 
     /**
      * Read AICPU phase metadata that lives in AicpuPhaseHeader (not on the
-     * buffer pipeline): the orchestrator summary and core→thread mapping.
-     * Single-shot — must be called after stop() so orch_summary has settled.
+     * buffer pipeline): the core→thread mapping plus a has-data signal
+     * derived from accumulated per-event records. Single-shot — must be
+     * called after stop() so the shm region has settled.
      */
     void read_phase_header_metadata();
 
@@ -357,7 +358,6 @@ private:
 
     // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
-    AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)

--- a/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -376,7 +376,6 @@ void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads) {
     s_phase_header->num_cores = 0;
 
     memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
-    memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
     // Cache per-thread record pointers and clear buffers
     // Include all threads: scheduler + orchestrator (orchestrators may become schedulers)
@@ -558,25 +557,6 @@ void l2_perf_aicpu_record_phase(
     record->extra2 = extra2;
 
     buf->count = idx + 1;
-}
-
-void l2_perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
-    if (s_phase_header == nullptr) {
-        return;
-    }
-
-    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
-
-    memcpy(dst, src, sizeof(AicpuOrchSummary));
-    dst->magic = AICPU_PHASE_MAGIC;
-    dst->padding = 0;
-
-    wmb();
-
-    LOG_INFO_V0(
-        "Orchestrator summary written: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(src->submit_count),
-        cycles_to_us(src->end_time - src->start_time)
-    );
 }
 
 void l2_perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -496,28 +496,9 @@ void L2PerfCollector::read_phase_header_metadata() {
         }
     }
 
-    // Orchestrator summary (header-resident; not buffered).
-    collected_orch_summary_ = phase_header->orch_summary;
-    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
-    if (orch_valid) {
-        LOG_INFO_V0(
-            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
-            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
-        );
-    } else {
-        LOG_INFO_V0("  Orchestrator: no summary data");
-    }
-
-    bool has_accumulated = has_phase_data_;
-    if (!has_accumulated) {
-        for (const auto &v : collected_phase_records_) {
-            if (!v.empty()) {
-                has_accumulated = true;
-                break;
-            }
-        }
-    }
-    has_phase_data_ = (orch_valid || has_accumulated);
+    // has_phase_data_ is set by copy_phase_buffer() during the drain — every
+    // push into collected_phase_records_ goes through that single call site
+    // and toggles the flag. No re-scan needed here.
 
     // Core-to-thread mapping (header-resident; not buffered).
     int num_cores = static_cast<int>(phase_header->num_cores);
@@ -526,7 +507,7 @@ void L2PerfCollector::read_phase_header_metadata() {
         LOG_INFO_V0("  Core-to-thread mapping: %d cores", num_cores);
     }
 
-    LOG_INFO_V0("Phase metadata collection complete: orch_summary=%s", orch_valid ? "yes" : "no");
+    LOG_INFO_V0("Phase metadata collection complete: has_phase_data=%s", has_phase_data_ ? "yes" : "no");
 }
 
 int L2PerfCollector::export_swimlane_json() {
@@ -594,10 +575,6 @@ int L2PerfCollector::export_swimlane_json() {
                     base_time_cycles = pr.start_time;
                 }
             }
-        }
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
-            collected_orch_summary_.start_time < base_time_cycles) {
-            base_time_cycles = collected_orch_summary_.start_time;
         }
     }
 
@@ -733,21 +710,11 @@ int L2PerfCollector::export_swimlane_json() {
         }
         outfile << "  ]";
 
-        // AICPU orchestrator summary
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC) {
-            // Per-phase breakdown is no longer reported here; consumers that
-            // want it derive it from the aicpu_orchestrator_phases array by
-            // bucketing entries on phase_id, keeping per-event records as the
-            // single source of truth.
-            double orch_start_us = cycles_to_us(collected_orch_summary_.start_time - base_time_cycles);
-            double orch_end_us = cycles_to_us(collected_orch_summary_.end_time - base_time_cycles);
-
-            outfile << ",\n  \"aicpu_orchestrator\": {\n";
-            outfile << "    \"start_time_us\": " << std::fixed << std::setprecision(3) << orch_start_us << ",\n";
-            outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
-            outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << "\n";
-            outfile << "  }";
-        }
+        // Orchestrator timing is no longer emitted as a separate aggregate
+        // block. Per-event AicpuPhaseRecord[] entries (emitted as
+        // aicpu_orchestrator_phases below) are the single source of truth;
+        // the run-window envelope is still visible in the device-side
+        // LOG_INFO_V9 "Thread N: orch_start=… orch_end=… orch_cost=…" line.
 
         // Per-task orchestrator phase records (filtered from unified collected_phase_records_)
         bool has_orch_phases = false;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -602,8 +602,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 #endif  // PTO2_ORCH_PROFILING
 
-            // Latch task count from PTO2 shared memory (used both by the
-            // swimlane orch_summary below and passed on to the scheduler).
+            // Latch task count from PTO2 shared memory to hand off to the
+            // scheduler. The orchestrator's run window (start_time / end_time /
+            // submit_count) is no longer published to shared memory — the
+            // device LOG_INFO_V9 "orch_start=… orch_end=… orch_cost=…" line
+            // below carries the same envelope info for debugging, and
+            // host-side swimlane derives per-phase timing from the per-event
+            // AicpuPhaseRecord[] stream that already covers everything inside
+            // submit_task().
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -614,17 +620,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             pto2_submitted_tasks = total_tasks;
-            // Write the orchestrator run window to swimlane shared memory.
-            // Per-phase breakdown is derived host-side from AicpuPhaseRecord[]
-            // (collected via l2_perf_aicpu_record_orch_phase under PTO2_PROFILING,
-            // independent of PTO2_ORCH_PROFILING), so it does NOT live here.
-            if (is_l2_swimlane_enabled()) {
-                AicpuOrchSummary orch_summary = {};
-                orch_summary.start_time = orch_cycle_start;
-                orch_summary.end_time = orch_cycle_end;
-                orch_summary.submit_count = total_tasks;
-                l2_perf_aicpu_write_orch_summary(&orch_summary);
-            }
 #endif
 
             // Signal completion to the orchestrator state machine

--- a/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_perf_collector_aicpu.h
@@ -127,16 +127,6 @@ void l2_perf_aicpu_record_phase(
 );
 
 /**
- * Write orchestrator cumulative summary
- *
- * Writes the orchestrator's accumulated profiling data to shared memory
- * for host-side collection.
- *
- * @param src Pointer to populated AicpuOrchSummary (magic field is set internally)
- */
-void l2_perf_aicpu_write_orch_summary(const AicpuOrchSummary *src);
-
-/**
  * Set orchestrator thread index for per-task phase recording
  *
  * Must be called once from the orchestrator thread before any

--- a/src/a5/platform/include/common/l2_perf_profiling.h
+++ b/src/a5/platform/include/common/l2_perf_profiling.h
@@ -33,7 +33,7 @@
  * ├─────────────────────────────────────────────────────────────┤
  * │ AicpuPhaseHeader (optional, present when phase profiling)   │
  * │  - magic, num_sched_threads, records_per_thread             │
- * │  - orch_summary                                             │
+ * │  - core_to_thread mapping                                   │
  * ├─────────────────────────────────────────────────────────────┤
  * │ PhaseBufferState[thread0]                                   │
  * │  - free_queue: SPSC queue of available buffer pointers      │
@@ -323,23 +323,6 @@ struct AicpuPhaseRecord {
 };
 static_assert(sizeof(AicpuPhaseRecord) == 40, "AicpuPhaseRecord layout drift");
 
-/**
- * AICPU orchestrator run summary
- *
- * Captures the orchestrator's overall run window. Per-phase breakdown is
- * derived host-side by aggregating AicpuPhaseRecord entries filtered by
- * phase_id, so per-phase cycle fields are not duplicated here. The
- * device-side aggregate path under PTO2_ORCH_PROFILING (g_orch_*_cycle +
- * LOG_INFO_V9) is independent and emits to the device log only.
- */
-struct AicpuOrchSummary {
-    uint64_t start_time;   // Orchestrator start timestamp
-    uint64_t end_time;     // Orchestrator end timestamp
-    int64_t submit_count;  // Total tasks submitted
-    uint32_t magic;        // Validation magic (AICPU_PHASE_MAGIC)
-    uint32_t padding;      // Alignment padding
-} __attribute__((aligned(64)));
-
 constexpr uint32_t AICPU_PHASE_MAGIC = 0x41435048;  // "ACPH"
 
 /**
@@ -365,7 +348,6 @@ struct AicpuPhaseHeader {
     uint32_t records_per_thread;                // Max records per PhaseBuffer
     uint32_t num_cores;                         // Total number of cores with valid assignments
     int8_t core_to_thread[PLATFORM_MAX_CORES];  // core_id → scheduler thread index (-1 = unassigned)
-    AicpuOrchSummary orch_summary;              // Orchestrator cumulative data
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a5/platform/include/host/l2_perf_collector.h
+++ b/src/a5/platform/include/host/l2_perf_collector.h
@@ -206,7 +206,7 @@ using L2PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
  *   4. stop()                      — joins both threads in the correct
  *                                    order (mgmt first so its final-drain
  *                                    entries have a consumer).
- *   5. read_phase_header_metadata() — single-shot read of orch_summary +
+ *   5. read_phase_header_metadata() — single-shot read of the
  *                                    core→thread mapping from the
  *                                    AicpuPhaseHeader.
  *   6. reconcile_counters()        — leftover-active sanity check (a5 lacks
@@ -304,8 +304,9 @@ public:
 
     /**
      * Read AICPU phase metadata that lives in AicpuPhaseHeader (not on the
-     * buffer pipeline): the orchestrator summary and core→thread mapping.
-     * Single-shot — must be called after stop() so orch_summary has settled.
+     * buffer pipeline): the core→thread mapping plus a has-data signal
+     * derived from accumulated per-event records. Single-shot — must be
+     * called after stop() so the shm region has settled.
      * The shm region was last mirrored to host shadow at the end of mgmt's
      * final-drain pass.
      */
@@ -352,7 +353,6 @@ private:
 
     // AICPU phase profiling data (per-thread, mixed sched + orch records)
     std::vector<std::vector<AicpuPhaseRecord>> collected_phase_records_;
-    AicpuOrchSummary collected_orch_summary_{};
     bool has_phase_data_{false};
 
     // Core-to-thread mapping (core_id → scheduler thread index, -1 = unassigned)

--- a/src/a5/platform/include/host/profiling_common/profiler_base.h
+++ b/src/a5/platform/include/host/profiling_common/profiler_base.h
@@ -569,9 +569,9 @@ private:
      * The bulk `mirror_shm_to_device` deliberately is NOT called: it races
      * with AICPU writes to device-only fields (current_buf_ptr, total/dropped/
      * mismatch counters, queue_tails, free_queue.head, AicpuPhaseHeader::magic,
-     * orch_summary, core_to_thread[]) and rolls them back to whatever was
-     * mirrored in at the start of the tick. Each host-side modification is
-     * written back as a narrow field write inside Alg.
+     * core_to_thread[]) and rolls them back to whatever was mirrored in at
+     * the start of the tick. Each host-side modification is written back as
+     * a narrow field write inside Alg.
      *
      * On exit (mgmt_running_ → false) it does one final drain pass without
      * sleeping to flush any straggler entries the device pushed before

--- a/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/l2_perf_collector_aicpu.cpp
@@ -384,7 +384,6 @@ void l2_perf_aicpu_init_phase(int worker_count, int num_sched_threads) {
     s_phase_header->num_cores = 0;
 
     memset(s_phase_header->core_to_thread, -1, sizeof(s_phase_header->core_to_thread));
-    memset(&s_phase_header->orch_summary, 0, sizeof(AicpuOrchSummary));
 
     // Cache per-thread record pointers and clear buffers
     // Include all threads: scheduler + orchestrator (orchestrators may become schedulers)
@@ -568,25 +567,6 @@ void l2_perf_aicpu_record_phase(
 
     buf->count = idx + 1;
     wmb();
-}
-
-void l2_perf_aicpu_write_orch_summary(const AicpuOrchSummary *src) {
-    if (s_phase_header == nullptr) {
-        return;
-    }
-
-    AicpuOrchSummary *dst = &s_phase_header->orch_summary;
-
-    memcpy(dst, src, sizeof(AicpuOrchSummary));
-    dst->magic = AICPU_PHASE_MAGIC;
-    dst->padding = 0;
-
-    wmb();
-
-    LOG_INFO_V0(
-        "Orchestrator summary written: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(src->submit_count),
-        cycles_to_us(src->end_time - src->start_time)
-    );
 }
 
 void l2_perf_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -451,8 +451,8 @@ void L2PerfCollector::read_phase_header_metadata() {
     if (shm_host_ == nullptr) return;
 
     // Pull the AicpuPhaseHeader portion from device (the mgmt loop's final
-    // mirror covered it, but stop() may have raced with a final orch_summary
-    // write — re-mirror to be safe).
+    // mirror covered it, but re-mirror to be safe in case stop() raced with
+    // a final write of core_to_thread mapping).
     if (manager_.shared_mem_dev() != nullptr && shm_size_ > 0) {
         profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
     }
@@ -491,27 +491,9 @@ void L2PerfCollector::read_phase_header_metadata() {
         }
     }
 
-    collected_orch_summary_ = phase_header->orch_summary;
-    bool orch_valid = (collected_orch_summary_.magic == AICPU_PHASE_MAGIC);
-    if (orch_valid) {
-        LOG_INFO_V0(
-            "  Orchestrator: %" PRId64 " tasks, %.3fus", static_cast<int64_t>(collected_orch_summary_.submit_count),
-            cycles_to_us(collected_orch_summary_.end_time - collected_orch_summary_.start_time)
-        );
-    } else {
-        LOG_INFO_V0("  Orchestrator: no summary data");
-    }
-
-    bool has_accumulated = has_phase_data_;
-    if (!has_accumulated) {
-        for (const auto &v : collected_phase_records_) {
-            if (!v.empty()) {
-                has_accumulated = true;
-                break;
-            }
-        }
-    }
-    has_phase_data_ = (orch_valid || has_accumulated);
+    // has_phase_data_ is set by copy_phase_buffer() during the drain — every
+    // push into collected_phase_records_ goes through that single call site
+    // and toggles the flag. No re-scan needed here.
 
     int num_cores = static_cast<int>(phase_header->num_cores);
     if (num_cores > 0 && num_cores <= PLATFORM_MAX_CORES) {
@@ -519,7 +501,7 @@ void L2PerfCollector::read_phase_header_metadata() {
         LOG_INFO_V0("  Core-to-thread mapping: %d cores", num_cores);
     }
 
-    LOG_INFO_V0("Phase metadata collection complete: orch_summary=%s", orch_valid ? "yes" : "no");
+    LOG_INFO_V0("Phase metadata collection complete: has_phase_data=%s", has_phase_data_ ? "yes" : "no");
 }
 
 // ---------------------------------------------------------------------------
@@ -583,10 +565,6 @@ int L2PerfCollector::export_swimlane_json() {
                     base_time_cycles = pr.start_time;
                 }
             }
-        }
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC && collected_orch_summary_.start_time > 0 &&
-            collected_orch_summary_.start_time < base_time_cycles) {
-            base_time_cycles = collected_orch_summary_.start_time;
         }
     }
 
@@ -715,21 +693,11 @@ int L2PerfCollector::export_swimlane_json() {
         }
         outfile << "  ]";
 
-        if (collected_orch_summary_.magic == AICPU_PHASE_MAGIC) {
-            // Per-phase breakdown is no longer reported here; consumers that
-            // want it derive it from the aicpu_orchestrator_phases array by
-            // bucketing entries on phase_id, keeping per-event records as the
-            // single source of truth.
-            double orch_start_us = cycles_to_us(collected_orch_summary_.start_time - base_time_cycles);
-            double orch_end_us = cycles_to_us(collected_orch_summary_.end_time - base_time_cycles);
-
-            outfile << ",\n  \"aicpu_orchestrator\": {\n";
-            outfile << "    \"start_time_us\": " << std::fixed << std::setprecision(3) << orch_start_us << ",\n";
-            outfile << "    \"end_time_us\": " << std::fixed << std::setprecision(3) << orch_end_us << ",\n";
-            outfile << "    \"submit_count\": " << collected_orch_summary_.submit_count << "\n";
-            outfile << "  }";
-        }
-
+        // Orchestrator timing is no longer emitted as a separate aggregate
+        // block. Per-event AicpuPhaseRecord[] entries (emitted as
+        // aicpu_orchestrator_phases below) are the single source of truth;
+        // the run-window envelope is still visible in the device-side
+        // LOG_INFO_V9 "Thread N: orch_start=… orch_end=… orch_cost=…" line.
         bool has_orch_phases = false;
         for (const auto &v : collected_phase_records_) {
             for (const auto &r : v) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -587,8 +587,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 #endif  // PTO2_ORCH_PROFILING
 
-            // Latch task count from PTO2 shared memory (used both by the
-            // swimlane orch_summary below and passed on to the scheduler).
+            // Latch task count from PTO2 shared memory to hand off to the
+            // scheduler. The orchestrator's run window (start_time / end_time /
+            // submit_count) is no longer published to shared memory — the
+            // device LOG_INFO_V9 "orch_start=… orch_end=… orch_cost=…" line
+            // below carries the same envelope info for debugging, and
+            // host-side swimlane derives per-phase timing from the per-event
+            // AicpuPhaseRecord[] stream that already covers everything inside
+            // submit_task().
             int32_t total_tasks = 0;
             if (rt->orchestrator.sm_header) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -599,17 +605,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
 #if PTO2_PROFILING
             submitted_tasks = total_tasks;
-            // Write the orchestrator run window to swimlane shared memory.
-            // Per-phase breakdown is derived host-side from AicpuPhaseRecord[]
-            // (collected via l2_perf_aicpu_record_orch_phase under PTO2_PROFILING,
-            // independent of PTO2_ORCH_PROFILING), so it does NOT live here.
-            if (is_l2_swimlane_enabled()) {
-                AicpuOrchSummary orch_summary = {};
-                orch_summary.start_time = orch_cycle_start;
-                orch_summary.end_time = orch_cycle_end;
-                orch_summary.submit_count = total_tasks;
-                l2_perf_aicpu_write_orch_summary(&orch_summary);
-            }
 #endif
 
             // Signal completion to the orchestrator state machine


### PR DESCRIPTION
## Summary

Follow-up to #799. After that PR collapsed `phase_us` into per-event `AicpuPhaseRecord[]`, `AicpuOrchSummary`'s remaining fields (`start_time`, `end_time`, `submit_count`) became redundant — every signal they carried is already exposed by another channel:

| Signal | Without this PR (where it lives) | With this PR (still available where) |
|---|---|---|
| Orchestrator wall-time envelope | host JSON `aicpu_orchestrator.start_time_us/end_time_us` + device log `orch_start=… orch_end=… orch_cost=…` | device log `orch_cost=…` (PTO2_PROFILING, default on) |
| Per-phase totals | derive host-side from `aicpu_orchestrator_phases[]` (already implemented in #799 fallout) | identical — single source of truth |
| Submit count | host JSON `aicpu_orchestrator.submit_count` + device log `PTO2 total submitted tasks = N` | device log line + count `orch_fanin` records host-side |
| "User code between submits" overhead | derive as `orch_cost − sum(phase_us)` from JSON, OR `orch_cost − Orchestrator Profiling total=…` from device log, OR visually as gaps between phase bars in swimlane | identical for the two device-log paths and the swimlane visual path — only the JSON-arithmetic path is gone |

So the struct is doing nothing that another path doesn't already cover. Keeping it forced orchestrator to be asymmetric with scheduler — scheduler **never** had an analogous shared-memory aggregate, only per-event records + device-log envelope. After this PR the two are designed the same way.

## Changes

- Delete `struct AicpuOrchSummary` entirely (a5 + a2a3 common header)
- Delete `AicpuPhaseHeader::orch_summary` field + its `memset` during init
- Delete `l2_perf_aicpu_write_orch_summary()` declaration + implementation
- Delete the swimlane-side write block in `aicpu_executor.cpp` (the `orch_cycle_start`/`orch_cycle_end` captures stay — they still feed the existing `LOG_INFO_V9` envelope)
- Delete `L2PerfCollector::collected_orch_summary_` member, its reads, the `base_time_cycles` candidate logic, the `"  Orchestrator: %d tasks, %.3fus"` log line, and the entire `"aicpu_orchestrator": { ... }` JSON block
- Update `swimlane_converter.py`: drop the `orchestrator_data` parameter (no caller passes it anymore), derive orchestrator submit count from counting `orch_fanin` records in the stats print

Mirrored across a5 + a2a3. **14 files, +57/−217 (net −160 LOC).**

## Test plan

Verified locally on macOS sim:

- [x] `a5sim` + `a2a3sim` vector_example, default config — passes
- [x] Both arches with `--enable-l2-swimlane` — passes; swimlane JSON now contains only `aicpu_orchestrator_phases[]` (30 records for vector_example) with no `aicpu_orchestrator` block. `merged_swimlane.json` still renders all 30 per-task orchestrator phase bars on `Orch_0` lane via per-event records.
- [x] `a5sim` built with `-DPTO2_ORCH_PROFILING=1` — device-log "Orchestrator Profiling" phase block still prints with all per-phase percentages
- [x] swimlane_converter runs clean against the new JSON shape
- [ ] Onboard hardware (left for CI)