### PR TITLE
ci: bump PTO_ISA_COMMIT to ddafa8da and point at hw-native-sys/pto-isa

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PTO_ISA_COMMIT: 50d9c806c3e351d5039c9f0f02a267590420b4d9
+  PTO_ISA_COMMIT: ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8
 
 jobs:
   # ---------- Pre-commit hooks (format, lint, clang-tidy) ----------

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -36,10 +36,10 @@ pytest examples --platform a2a3sim --clone-protocol https
 
 ```bash
 mkdir -p build
-git clone --branch main git@github.com:PTO-ISA/pto-isa.git build/pto-isa
+git clone --branch main git@github.com:hw-native-sys/pto-isa.git build/pto-isa
 
 # Or use HTTPS
-git clone --branch main https://github.com/PTO-ISA/pto-isa.git build/pto-isa
+git clone --branch main https://github.com/hw-native-sys/pto-isa.git build/pto-isa
 
 # Set environment variable (optional - auto-detected if in standard location)
 export PTO_ISA_ROOT=$(pwd)/build/pto-isa

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -31,8 +31,8 @@ from .environment import PROJECT_ROOT
 
 logger = logging.getLogger(__name__)
 
-_PTO_ISA_HTTPS = "https://github.com/PTO-ISA/pto-isa.git"
-_PTO_ISA_SSH = "git@github.com:PTO-ISA/pto-isa.git"
+_PTO_ISA_HTTPS = "https://github.com/hw-native-sys/pto-isa.git"
+_PTO_ISA_SSH = "git@github.com:hw-native-sys/pto-isa.git"
 
 
 def get_pto_isa_clone_path() -> Path:


### PR DESCRIPTION
## Summary

The pto-isa repo was renamed from `PTO-ISA/pto-isa` to `hw-native-sys/pto-isa`. GitHub still serves the old name via redirect, but the pinned `PTO_ISA_COMMIT` (`50d9c806`) was rewritten out of history and now returns "No commit found". `checkout_pto_isa_commit` swallows that failure with a `logger.warning`, so the four scene-test retry blocks ended up re-running pytest against the same PTO-ISA HEAD that just failed — exactly the green-on-failure symptom #805 describes.

- `simpler_setup/pto_isa.py`: point `_PTO_ISA_HTTPS` / `_PTO_ISA_SSH` at `hw-native-sys/pto-isa`.
- `docs/getting-started.md`: sync the manual-clone snippet.
- `.github/workflows/ci.yml`: bump `PTO_ISA_COMMIT` to `ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8` — the current `hw-native-sys/pto-isa` `main` ("Fix quantization enum compilation issues", 2026-05-19) — so the retry actually checks out a real commit.

The retry mechanism stays. Per maintainer guidance the feature is intentional; the only bug was the dead pin.

## Testing

- [ ] `st-sim-a2a3` / `st-sim-a5` retry path checks out `ddafa8da` cleanly
- [ ] `st-onboard-a2a3` / `st-onboard-a5` retry path checks out `ddafa8da` cleanly
- [ ] First-time clone (no `build/pto-isa`) succeeds via the new SSH/HTTPS URLs

Refs #805.