### PR TITLE
Support: allreduce_distributed arbitrary rank count (2..16)

### DIFF
--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -79,8 +79,8 @@ def parse_device_range(spec: str) -> list[int]:
         ids = list(range(lo, hi + 1))
     else:
         ids = [int(spec)]
-    if len(ids) != 2:
-        raise ValueError(f"allreduce_distributed needs exactly 2 devices, got {ids}")
+    if not (2 <= len(ids) <= 16):
+        raise ValueError(f"allreduce_distributed needs between 2 and 16 devices, got {len(ids)} ({ids})")
     return ids
 
 
@@ -235,7 +235,7 @@ def run(
                 chip_args.add_scalar(ctx.device_ctx)
                 orch.submit_next_level(chip_cid, chip_args, cfg, worker=i)
 
-        print("[allreduce] running 2-chip allreduce DAG...")
+        print(f"[allreduce] running {nranks}-chip allreduce DAG...")
         worker.run(orch_fn, args=None, config=CallConfig())
 
         expected = torch.tensor(expected_output(nranks), dtype=torch.float32)
@@ -264,7 +264,9 @@ def run(
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
-    parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
+    parser.add_argument(
+        "-d", "--device", default="0-1", help="Device range, e.g. '0-1' or '0-3'. 2 to 16 chips required."
+    )
     parser.add_argument(
         "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
     )

--- a/examples/workers/l3/allreduce_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_distributed/test_allreduce.py
@@ -15,7 +15,14 @@ from .main import run
 
 @pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
-@pytest.mark.device_count(2)
-def test_allreduce_distributed(st_device_ids, st_platform):
+@pytest.mark.parametrize(
+    "n_devices",
+    [
+        pytest.param(2, marks=pytest.mark.device_count(2)),
+        pytest.param(4, marks=pytest.mark.device_count(4)),
+    ],
+)
+def test_allreduce_distributed(st_platform, st_device_ids, n_devices):
+    assert len(st_device_ids) == n_devices
     rc = run([int(d) for d in st_device_ids], platform=st_platform)
     assert rc == 0


### PR DESCRIPTION
## Summary

Drop the 'exactly 2 devices' restriction in `examples/workers/l3/allreduce_distributed/`. The AIV kernel and the orchestration shim already treat `nranks` as a runtime scalar, so the change is Python-only.

- `main.py`: `parse_device_range` now accepts 2..16 devices; the `--device` help string and the `"running 2-chip"` log message generalize to `nranks`.
- `test_allreduce.py`: parametrize over `[2, 4]` using the standard `device_count` marker pattern — one `pytest.param` per case, each carrying its own `@pytest.mark.device_count(N)`. This keeps `st_device_ids` as the single allocation path and keeps the xdist resource scheduler (`conftest.py::_collect_resource_jobs`, which reads `device_count` off the marker) in sync with the actual per-case need.

## Why parametrize-with-marks instead of manual `device_pool.allocate`

`@pytest.mark.device_count(n)` is consumed in two places: `st_device_ids` (allocates/releases around the test) and `_collect_resource_jobs` (sizes the xdist subprocess slot). A test that bypasses the marker and calls `device_pool.allocate` directly looks like a 0-device job to the scheduler, which oversubscribes devices under parallel runs. Hanging the marker off each `pytest.param` lets every parametrized case declare its own device count without rewriting the L3 SceneTestCase scaffolding.

## Testing

- [ ] `pytest examples/workers/l3/allreduce_distributed --platform a2a3sim --device 0-3`
- [ ] `pytest examples/workers/l3/allreduce_distributed --platform a2a3 --device <range>` (onboard)
- [ ] `python examples/workers/l3/allreduce_distributed/main.py -p a2a3sim -d 0-3` (CLI, 4 ranks)