### PR TITLE
Refactor: a2a3 + a5 Tensor to strided (stride + start_offset) model

### DIFF
--- a/simpler_setup/tools/deps_to_graph.py
+++ b/simpler_setup/tools/deps_to_graph.py
@@ -125,13 +125,13 @@ def _load_deps_edges(deps_path):
             ``--show-tensor-info`` view renders as compartments inside each
             task node.
 
-    Raises ValueError if ``version`` is not 2 — v1 is no longer supported.
+    Raises ValueError if ``version`` is not 3 — older versions are no longer supported.
     """
     with open(deps_path) as f:
         data = json.load(f)
     version = data.get("version")
-    if version != 2:
-        raise ValueError(f"deps.json version={version!r}; only v2 is supported (regenerate with current dep_gen)")
+    if version != 3:
+        raise ValueError(f"deps.json version={version!r}; only v3 is supported (regenerate with current dep_gen)")
     edges_raw = data.get("edges", [])
     seen: set[tuple[int, int]] = set()
     edges: list[tuple[int, int]] = []
@@ -400,33 +400,40 @@ def _arg_row_html(arg, tensor_table, side):
     tname = _short_tensor_label(tid, tensor_table)
     dtype = arg.get("dtype")
     shape = arg.get("shape")
-    offset = arg.get("offset")
-    raw_shape = None
+    # v3 schema: per-slot strided descriptor (start_offset is uint64 quoted as
+    # string, stride is per-dim int32 array). Older v2 args used a multi-dim
+    # `offset` array — viewers consuming older logs should bump producer first.
+    start_offset = arg.get("start_offset")
+    strides = arg.get("strides")
+    buffer_numel = None
     if isinstance(tid, int) and tid in tensor_table:
         tt = tensor_table[tid]
-        raw_shape = tt.get("raw_shapes")
+        buffer_numel = tt.get("buffer_numel")
         if dtype is None:
             dtype = tt.get("dtype")
-    # Backfilled OUTPUT slots have tensor_id but no captured shape/offset —
-    # treat them as accessing the whole underlying buffer (the runtime
-    # materializes an unsliced output buffer).
+    # Backfilled OUTPUT slots have tensor_id but no captured shape/stride —
+    # treat them as accessing the whole underlying buffer.
     if arg.get("inferred"):
-        if shape is None:
-            shape = raw_shape or []
-        if offset is None:
-            offset = [0] * len(shape) if shape else []
+        if shape is None and buffer_numel is not None:
+            shape = [int(buffer_numel)]
+        if start_offset is None:
+            start_offset = "0"
+        if strides is None and shape:
+            strides = [1] * len(shape)
 
     dtype_str = f":{dtype.lower()}" if isinstance(dtype, str) else ""
     inferred_mark = " ?" if arg.get("inferred") else ""
     head = f"arg{idx} {arg_type}{inferred_mark} {tname}{dtype_str}"
-    raw_line = f"raw: {_format_dims(raw_shape) if isinstance(raw_shape, list) else '[]'}"
+    storage_line = f"storage: {buffer_numel} elems" if buffer_numel is not None else "storage: ?"
     shape_line = f"shape: {_format_dims(shape) if isinstance(shape, list) else '[]'}"
-    offset_line = f"offset: {_format_dims(offset) if isinstance(offset, list) else '[]'}"
+    strides_line = f"strides: {_format_dims(strides) if isinstance(strides, list) else '[]'}"
+    offset_line = f"start_offset: {start_offset if start_offset is not None else '?'} (elem)"
 
     body = (
         f'{_html_escape(head)}<BR ALIGN="LEFT"/>'
-        f'<FONT POINT-SIZE="9">{_html_escape(raw_line)}<BR ALIGN="LEFT"/>'
+        f'<FONT POINT-SIZE="9">{_html_escape(storage_line)}<BR ALIGN="LEFT"/>'
         f'{_html_escape(shape_line)}<BR ALIGN="LEFT"/>'
+        f'{_html_escape(strides_line)}<BR ALIGN="LEFT"/>'
         f'{_html_escape(offset_line)}<BR ALIGN="LEFT"/></FONT>'
     )
     return f'<TR><TD ALIGN="LEFT" PORT="{port}" BGCOLOR="{bg}">{body}</TD></TR>'

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -108,8 +108,8 @@ def write_tensor(tensor: dict, bin_path: Path, out):
     out.write(f"# dtype: {t['dtype']}\n")
     out.write(f"# is_contiguous: {t['is_contiguous']}\n")
     out.write(f"# shape: {t['shape']}\n")
-    out.write(f"# raw_shape: {t['raw_shape']}\n")
-    out.write(f"# offsets: {t['offsets']}\n")
+    out.write(f"# strides: {t['strides']}\n")
+    out.write(f"# start_offset: {t['start_offset']}\n")
 
     if t.get("overwritten"):
         out.write("# DATA OVERWRITTEN (host too slow)\n")

--- a/src/a2a3/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/tensor_dump_aicpu.h
@@ -131,11 +131,10 @@ inline void dump_tensors_for_task(
                 info.buffer_addr = t.buffer.addr;
                 info.dtype = static_cast<uint8_t>(t.dtype);
                 info.ndims = static_cast<uint8_t>(t.ndims);
-                const uint32_t *raw_shapes = t.get_raw_shapes();
+                info.start_offset = t.start_offset;
                 for (uint32_t d = 0; d < t.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
                     info.shapes[d] = t.shapes[d];
-                    info.offsets[d] = t.is_all_offset_zero ? 0 : t.offsets[d];
-                    info.raw_shapes[d] = raw_shapes[d];
+                    info.strides[d] = t.strides[d];
                 }
                 info.task_id = slot_state.task->task_id.raw;
                 info.subtask_id = raw_subtask_id;
@@ -224,11 +223,20 @@ inline void dump_tensors_for_task(
         info.func_id = static_cast<uint32_t>(func_id);
         info.arg_index = static_cast<uint32_t>(tensor_arg_index);
         info.buffer_addr = buffer_addrs[tensor_arg_index];
-        for (uint32_t d = 0; d < t.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
+        // TensorInfo (host_build_graph) still carries (raw_shapes, offsets)
+        // implicitly describing a row-major-aligned sub-region. Translate to
+        // (start_offset, strides[]) on the fly:
+        //   strides[d] = prod(raw_shapes[d+1..])
+        //   start_offset = Σ offsets[d] · strides[d]
+        uint64_t s = 1;
+        uint64_t start = 0;
+        for (int32_t d = static_cast<int32_t>(t.ndims) - 1; d >= 0 && d < PLATFORM_DUMP_MAX_DIMS; --d) {
             info.shapes[d] = t.shapes[d];
-            info.offsets[d] = t.offsets[d];
-            info.raw_shapes[d] = t.raw_shapes[d];
+            info.strides[d] = static_cast<int32_t>(s);
+            start += static_cast<uint64_t>(t.offsets[d]) * s;
+            s *= t.raw_shapes[d];
         }
+        info.start_offset = start;
         dump_tensor_record(thread_idx, info);
         tensor_arg_index++;
     }

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -91,17 +91,18 @@ struct alignas(64) TensorDumpRecord {
     uint32_t arg_index;       // Position in PTO2TaskPayload::tensors[]
     uint8_t dtype;            // DataType raw enum value
     uint8_t truncated;        // 1 if payload was truncated (tensor > arena capacity)
-    uint8_t is_contiguous;    // 1 when source view is already contiguous
+    uint8_t is_contiguous;    // 1 when source view is already PyTorch-contiguous
     uint8_t pad0_align;       // Explicit alignment before 64-bit payload offsets
     uint64_t payload_offset;  // Monotonic byte offset into thread arena
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
     uint8_t pad0[24];         // Preserve 64B cache-line layout
 
-    // === Cache line 2 (64B) ===
-    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];      // Current view shape
-    uint32_t offsets[PLATFORM_DUMP_MAX_DIMS];     // Multi-dimensional offsets
-    uint32_t raw_shapes[PLATFORM_DUMP_MAX_DIMS];  // Underlying source layout shape
-    uint8_t pad1[4];                              // Pad to 128 bytes
+    // === Cache line 2 (64B) — strided view descriptor ===
+    // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 + 16 = 64B.
+    uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
+    uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
+    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
+    uint8_t pad1[16];                          // Pad to 128 bytes
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(TensorDumpRecord) == 128, "TensorDumpRecord must be 128 bytes (2 cache lines)");
@@ -235,9 +236,9 @@ struct TensorDumpInfo {
     uint32_t func_id;
     uint32_t arg_index;
     uint64_t buffer_addr;
-    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t offsets[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t raw_shapes[PLATFORM_DUMP_MAX_DIMS];
+    uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
+    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
+    uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
 };
 
 // =============================================================================

--- a/src/a2a3/platform/include/host/tensor_dump_collector.h
+++ b/src/a2a3/platform/include/host/tensor_dump_collector.h
@@ -141,9 +141,9 @@ struct DumpedTensor {
     TensorDumpStage stage;
     uint8_t dtype;
     uint8_t ndims;
-    uint32_t raw_shapes[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t offsets[PLATFORM_DUMP_MAX_DIMS];
+    uint64_t start_offset;                     // 1D element offset of the view origin
+    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
+    uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dim (> 0, type-enforced)
     bool is_contiguous;
     bool truncated;
     bool overwritten;

--- a/src/a2a3/platform/src/aicpu/tensor_dump_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/tensor_dump_aicpu.cpp
@@ -254,36 +254,27 @@ static inline uint64_t get_tensor_dump_num_elements(const TensorDumpInfo &info) 
     return elements;
 }
 
+// PyTorch-style contiguous: strides[d] == prod(shapes[d+1..]) for all d.
 static inline bool tensor_dump_is_contiguous(const TensorDumpInfo &info) {
-    if (info.ndims == 0) {
-        return true;
-    }
-    for (uint32_t d = 1; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-        if (info.shapes[d] != info.raw_shapes[d]) {
-            return false;
-        }
+    if (info.ndims == 0) return true;
+    uint64_t expected = 1;
+    for (int32_t d = static_cast<int32_t>(info.ndims) - 1; d >= 0 && d < PLATFORM_DUMP_MAX_DIMS; --d) {
+        if (info.strides[d] != expected) return false;
+        expected *= info.shapes[d];
     }
     return true;
-}
-
-static inline uint64_t tensor_dump_start_offset_elements(const TensorDumpInfo &info) {
-    uint64_t result = 0;
-    uint64_t stride = 1;
-    for (int d = static_cast<int>(info.ndims) - 1; d >= 0; d--) {
-        result += static_cast<uint64_t>(info.offsets[d]) * stride;
-        stride *= info.raw_shapes[d];
-    }
-    return result;
 }
 
 static inline void write_tensor_dump_contiguous_prefix(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint64_t copy_bytes
 ) {
-    uint64_t start_offset = tensor_dump_start_offset_elements(info);
-    const char *src = reinterpret_cast<const char *>(info.buffer_addr) + start_offset * elem_sz;
+    const char *src = reinterpret_cast<const char *>(info.buffer_addr) + info.start_offset * elem_sz;
     writer->write(src, copy_bytes);
 }
 
+// Recursive per-dim gather: at dim d we step shapes[d] times with element step
+// strides[d]. Inner-most dim writes `shapes[d]` contiguous elements (only valid
+// when strides[innermost] == 1 — non-unit innermost stride degrades to per-element).
 static void gather_tensor_dump_dim(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint32_t dim,
     uint64_t base_element_index, uint64_t *remaining_bytes
@@ -292,21 +283,30 @@ static void gather_tensor_dump_dim(
         return;
     }
     if (dim + 1 >= info.ndims) {
-        uint64_t row_start = base_element_index + info.offsets[dim];
-        const char *src = reinterpret_cast<const char *>(info.buffer_addr) + row_start * elem_sz;
-        uint64_t row_bytes = static_cast<uint64_t>(info.shapes[dim]) * elem_sz;
-        uint64_t bytes_to_copy = (row_bytes < *remaining_bytes) ? row_bytes : *remaining_bytes;
-        writer->write(src, bytes_to_copy);
-        *remaining_bytes -= bytes_to_copy;
+        // Innermost dim: if strides[dim] == 1 the row is contiguous in memory and
+        // a single memcpy works. Otherwise emit element-by-element.
+        const uint32_t s = info.strides[dim];
+        if (s == 1) {
+            const char *src = reinterpret_cast<const char *>(info.buffer_addr) + base_element_index * elem_sz;
+            uint64_t row_bytes =
+                static_cast<uint64_t>(info.shapes[dim]) * elem_sz;  // promote first to avoid uint32 overflow
+            uint64_t bytes_to_copy = (row_bytes < *remaining_bytes) ? row_bytes : *remaining_bytes;
+            writer->write(src, bytes_to_copy);
+            *remaining_bytes -= bytes_to_copy;
+        } else {
+            for (uint32_t i = 0; i < info.shapes[dim] && *remaining_bytes >= elem_sz; i++) {
+                uint64_t pos = base_element_index + static_cast<uint64_t>(i) * static_cast<uint64_t>(s);
+                const char *src = reinterpret_cast<const char *>(info.buffer_addr) + pos * elem_sz;
+                writer->write(src, elem_sz);
+                *remaining_bytes -= elem_sz;
+            }
+        }
         return;
     }
 
-    uint64_t inner_stride = 1;
-    for (uint32_t d = dim + 1; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-        inner_stride *= info.raw_shapes[d];
-    }
+    const int32_t s = info.strides[dim];
     for (uint32_t i = 0; i < info.shapes[dim] && *remaining_bytes > 0; i++) {
-        uint64_t next_base = base_element_index + (static_cast<uint64_t>(info.offsets[dim]) + i) * inner_stride;
+        uint64_t next_base = base_element_index + static_cast<uint64_t>(i) * static_cast<uint64_t>(s);
         gather_tensor_dump_dim(writer, info, elem_sz, dim + 1, next_base, remaining_bytes);
     }
 }
@@ -321,9 +321,9 @@ static inline void write_tensor_dump_logical_prefix(
         write_tensor_dump_contiguous_prefix(writer, info, elem_sz, copy_bytes);
         return;
     }
-
+    // Walk the view origin first; per-dim recursion adds (i * strides[d]) for each axis.
     uint64_t remaining_bytes = copy_bytes;
-    gather_tensor_dump_dim(writer, info, elem_sz, 0, 0, &remaining_bytes);
+    gather_tensor_dump_dim(writer, info, elem_sz, 0, info.start_offset, &remaining_bytes);
 }
 
 void dump_tensor_init(int num_dump_threads) {
@@ -437,10 +437,10 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     rec->truncated = truncated ? 1 : 0;
     rec->payload_offset = offset;
     rec->payload_size = copy_bytes;
+    rec->start_offset = info.start_offset;
     for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-        rec->raw_shapes[d] = info.raw_shapes[d];
         rec->shapes[d] = info.shapes[d];
-        rec->offsets[d] = info.offsets[d];
+        rec->strides[d] = info.strides[d];
     }
     buf->count = idx + 1;
     wmb();

--- a/src/a2a3/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a2a3/platform/src/host/tensor_dump_collector.cpp
@@ -185,9 +185,9 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         if (dt.truncated && ++total_truncated_count_ == 1) {
             LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
         }
-        memcpy(dt.raw_shapes, rec.raw_shapes, sizeof(dt.raw_shapes));
+        dt.start_offset = rec.start_offset;
         memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
-        memcpy(dt.offsets, rec.offsets, sizeof(dt.offsets));
+        memcpy(dt.strides, rec.strides, sizeof(dt.strides));
 
         // Read tensor data from arena
         int thread_idx = static_cast<int>(info.thread_index);
@@ -242,14 +242,14 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         DumpedTensor meta = dt;
         meta.bytes.clear();
         {
-            std::scoped_lock<std::mutex> lock(collected_mutex_);
+            std::scoped_lock lock(collected_mutex_);
             collected_.push_back(std::move(meta));
         }
 
         // Enqueue full tensor (with payload) to writer thread
         if (has_payload) {
             {
-                std::scoped_lock<std::mutex> lock(write_mutex_);
+                std::scoped_lock lock(write_mutex_);
                 write_queue_.push(std::move(dt));
             }
             write_cv_.notify_one();
@@ -521,8 +521,7 @@ int TensorDumpCollector::export_dump_files() {
         uint64_t numel = get_num_elements(dt);
 
         std::string shape_str = dims_to_string(dt.shapes, dt.ndims);
-        std::string raw_shape_str = dims_to_string(dt.raw_shapes, dt.ndims);
-        std::string offsets_str = dims_to_string(dt.offsets, dt.ndims);
+        std::string strides_str = dims_to_string(dt.strides, dt.ndims);
 
         if (!first_entry) json << ",\n";
         first_entry = false;
@@ -532,9 +531,10 @@ int TensorDumpCollector::export_dump_files() {
              << ", \"role\": \"" << tensor_dump_role_name(dt.role) << "\", \"stage\": \""
              << tensor_dump_stage_name(dt.stage) << "\", \"arg_index\": " << dt.arg_index << ", \"dtype\": \""
              << dtype_name << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false")
-             << ", \"shape\": " << shape_str << ", \"raw_shape\": " << raw_shape_str << ", \"offsets\": " << offsets_str
-             << ", \"numel\": " << numel << ", \"bin_offset\": " << dt.bin_offset
-             << ", \"bin_size\": " << dt.payload_size << ", \"truncated\": " << (dt.truncated ? "true" : "false")
+             << ", \"shape\": " << shape_str << ", \"strides\": " << strides_str
+             << ", \"start_offset\": " << dt.start_offset << ", \"numel\": " << numel
+             << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
+             << ", \"truncated\": " << (dt.truncated ? "true" : "false")
              << ", \"overwritten\": " << (dt.overwritten ? "true" : "false") << "}";
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -142,6 +142,10 @@ const char *overlap_status_str(OverlapStatus s) {
 // One annotated edge. consumer_* always populated. producer_* populated for
 // TENSORMAP source only — the explicit/creator emit paths don't have a
 // matched tensormap entry to copy from.
+//
+// Slice description follows the strided Tensor model: (start_offset, strides[])
+// in element units. Byte offset of element coords[] is
+//   (start_offset + Σ coords[i] · strides[i]) · dtype_bytes
 struct EdgeAnnot {
     uint64_t pred;
     uint64_t succ;
@@ -153,27 +157,28 @@ struct EdgeAnnot {
     uint8_t consumer_dtype;
     uint32_t consumer_ndims;
     uint32_t consumer_shape[RUNTIME_MAX_TENSOR_DIMS];
-    uint32_t consumer_offset[RUNTIME_MAX_TENSOR_DIMS];
+    uint64_t consumer_start_offset;  // 1D element offset
+    uint32_t consumer_strides[RUNTIME_MAX_TENSOR_DIMS];
     // Producer side (the slice the producer wrote, from the tensormap entry).
     // Only populated when source == TENSORMAP.
     uint32_t producer_ndims;
     uint32_t producer_shape[RUNTIME_MAX_TENSOR_DIMS];
-    uint32_t producer_offset[RUNTIME_MAX_TENSOR_DIMS];
+    uint64_t producer_start_offset;
+    uint32_t producer_strides[RUNTIME_MAX_TENSOR_DIMS];
 };
 
-// One entry in the v2 tensors[] table: the underlying buffer, keyed by
-// (buffer_addr, version). raw_shapes describes the underlying buffer; per-edge
-// fields describe the slice.
+// One entry in the tensors[] table: the underlying storage, keyed by
+// (buffer_addr, version). buffer_numel is the storage element count;
+// per-edge fields describe the slice (start_offset + stride).
 struct TensorTableEntry {
     uint64_t tensor_id;
     uint64_t buffer_addr;
+    uint64_t buffer_numel;  // storage size in elements (= buffer.size / dtype_bytes)
     int32_t version;
     uint8_t dtype;
-    uint32_t ndims;
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];
 };
 
-// One arg slot of a task, captured for the v2 `tasks[].args[]` block so
+// One arg slot of a task, captured for the `tasks[].args[]` block so
 // downstream viewers can render per-task input / output compartments without
 // having to scan every edge. `has_tensor_info` is false only for OUTPUT slots:
 // the runtime hasn't materialized a Tensor yet at submit_task time, so the
@@ -186,7 +191,8 @@ struct TaskArgEntry {
     uint8_t dtype;
     uint32_t ndims;
     uint32_t shape[RUNTIME_MAX_TENSOR_DIMS];
-    uint32_t offset[RUNTIME_MAX_TENSOR_DIMS];
+    uint64_t start_offset;  // 1D element offset
+    uint32_t strides[RUNTIME_MAX_TENSOR_DIMS];
 };
 
 struct TaskTableEntry {
@@ -231,10 +237,9 @@ uint64_t make_tensor_id(uint64_t buffer_addr, int32_t version) {
 }
 
 // Register a tensor in the v2 tensors[] table on first sight of (addr,
-// version). raw_shapes / dtype come from the consumer-side Tensor blob, which
-// is the only source carrying the full underlying-buffer description (the
-// producer-side PTO2TensorMapEntry intentionally drops raw_shapes to save a
-// cache line). Subsequent sightings of the same (addr, version) are no-ops.
+// version). buffer_numel describes the underlying storage size in elements;
+// per-edge fields describe the slice via (start_offset, strides[]). Subsequent
+// sightings of the same (addr, version) are no-ops.
 uint64_t register_tensor(
     std::unordered_map<uint64_t, size_t> &index_by_id, std::vector<TensorTableEntry> &table, const Tensor &t
 ) {
@@ -248,24 +253,22 @@ uint64_t register_tensor(
     e.buffer_addr = t.buffer.addr;
     e.version = t.version;
     e.dtype = static_cast<uint8_t>(t.dtype);
-    e.ndims = t.ndims;
-    const uint32_t *raw = t.get_raw_shapes();
-    for (uint32_t i = 0; i < t.ndims && i < RUNTIME_MAX_TENSOR_DIMS; i++) {
-        e.raw_shapes[i] = raw[i];
-    }
+    const uint64_t elem_size = get_element_size(t.dtype);
+    e.buffer_numel = (elem_size == 0) ? 0 : (t.buffer.size / elem_size);
     index_by_id[id] = table.size();
     table.push_back(e);
     return id;
 }
 
-// Copy a Tensor's slice description (shape + offset, expanded when the zero
-// fast path is set) into an EdgeAnnot's consumer_* fields.
+// Copy a Tensor's slice description (shape + start_offset + stride) into an
+// EdgeAnnot's consumer_* fields.
 void fill_consumer(EdgeAnnot &e, const Tensor &t) {
     e.consumer_dtype = static_cast<uint8_t>(t.dtype);
     e.consumer_ndims = t.ndims;
+    e.consumer_start_offset = t.start_offset;
     for (uint32_t i = 0; i < t.ndims && i < RUNTIME_MAX_TENSOR_DIMS; i++) {
         e.consumer_shape[i] = t.shapes[i];
-        e.consumer_offset[i] = t.is_all_offset_zero ? 0 : t.offsets[i];
+        e.consumer_strides[i] = t.strides[i];
     }
 }
 
@@ -273,9 +276,10 @@ void fill_consumer(EdgeAnnot &e, const Tensor &t) {
 // fields. Only called from the TENSORMAP emit path.
 void fill_producer(EdgeAnnot &e, const PTO2TensorMapEntry &entry) {
     e.producer_ndims = entry.ndims;
+    e.producer_start_offset = entry.start_offset;
     for (uint32_t i = 0; i < entry.ndims && i < RUNTIME_MAX_TENSOR_DIMS; i++) {
         e.producer_shape[i] = entry.shapes[i];
-        e.producer_offset[i] = entry.is_all_offset_zero ? 0 : entry.offsets[i];
+        e.producer_strides[i] = entry.strides[i];
     }
 }
 
@@ -301,7 +305,11 @@ bool write_deps_json_v2(
         LOG_ERROR("dep_gen replay: failed to open '%s' for write", path);
         return false;
     }
-    out << "{\"version\":2";
+    // Schema v3: strided tensor representation.
+    //   tensors[*]:   buffer_numel replaces raw_shapes (storage size in elements)
+    //   edges[*]:     consumer/producer_offset[]  ->  start_offset (uint64) + strides[] (int32)
+    //   tasks[*].args[*]: offset[]  ->  start_offset + strides[]
+    out << "{\"version\":3";
 
     out << ",\"tasks\":[";
     for (size_t i = 0; i < tasks.size(); i++) {
@@ -324,8 +332,9 @@ bool write_deps_json_v2(
                 out << ",\"dtype\":\"" << get_dtype_name(static_cast<DataType>(arg.dtype)) << '"';
                 out << ",\"shape\":";
                 write_uint_array(out, arg.shape, arg.ndims);
-                out << ",\"offset\":";
-                write_uint_array(out, arg.offset, arg.ndims);
+                out << ",\"start_offset\":\"" << arg.start_offset << '"';
+                out << ",\"strides\":";
+                write_uint_array(out, arg.strides, arg.ndims);
             }
             out << '}';
         }
@@ -341,9 +350,7 @@ bool write_deps_json_v2(
         out << ",\"buffer_addr\":\"" << t.buffer_addr << '"';
         out << ",\"version\":" << t.version;
         out << ",\"dtype\":\"" << get_dtype_name(static_cast<DataType>(t.dtype)) << '"';
-        out << ",\"ndims\":" << t.ndims;
-        out << ",\"raw_shapes\":";
-        write_uint_array(out, t.raw_shapes, t.ndims);
+        out << ",\"buffer_numel\":\"" << t.buffer_numel << '"';
         out << '}';
     }
     out << ']';
@@ -363,14 +370,16 @@ bool write_deps_json_v2(
             out << ",\"consumer_dtype\":\"" << get_dtype_name(static_cast<DataType>(e.consumer_dtype)) << '"';
             out << ",\"consumer_shape\":";
             write_uint_array(out, e.consumer_shape, e.consumer_ndims);
-            out << ",\"consumer_offset\":";
-            write_uint_array(out, e.consumer_offset, e.consumer_ndims);
+            out << ",\"consumer_start_offset\":\"" << e.consumer_start_offset << '"';
+            out << ",\"consumer_strides\":";
+            write_uint_array(out, e.consumer_strides, e.consumer_ndims);
         }
         if (e.source == EdgeSource::TENSORMAP) {
             out << ",\"producer_shape\":";
             write_uint_array(out, e.producer_shape, e.producer_ndims);
-            out << ",\"producer_offset\":";
-            write_uint_array(out, e.producer_offset, e.producer_ndims);
+            out << ",\"producer_start_offset\":\"" << e.producer_start_offset << '"';
+            out << ",\"producer_strides\":";
+            write_uint_array(out, e.producer_strides, e.producer_ndims);
         }
         out << '}';
     }
@@ -547,9 +556,10 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 slot.tensor_id = make_tensor_id(t.buffer.addr, t.version);
                 slot.dtype = static_cast<uint8_t>(t.dtype);
                 slot.ndims = t.ndims;
+                slot.start_offset = t.start_offset;
                 for (uint32_t d = 0; d < t.ndims && d < RUNTIME_MAX_TENSOR_DIMS; d++) {
                     slot.shape[d] = t.shapes[d];
-                    slot.offset[d] = t.is_all_offset_zero ? 0 : t.offsets[d];
+                    slot.strides[d] = t.strides[d];
                 }
             }
             task_entry.args.push_back(slot);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -50,24 +50,11 @@ inline Tensor make_tensor_external(
     void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false,
     int32_t version = 0
 ) {
-    static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return {
-        addr,
-        total * get_element_size(dtype),
-        shapes,
-        shapes,
-        zero_offsets,
-        ndims,
-        dtype,
-        version,
-        /*is_all_offset_zero=*/true,
-        /*is_raw_eq_shapes=*/true,
-        manual_dep
-    };
+    return {addr, total * get_element_size(dtype), shapes, ndims, dtype, version, manual_dep};
 }
 
 // Convert ContinuousTensor to Tensor

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -39,10 +39,6 @@
 #include "pto_task_id.h"
 #include "pto_types.h"
 
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-#include "aicpu/device_time.h"
-#endif
-
 // Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
 // ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
 // all threads share host CPU cores, so we yield to prevent starvation.
@@ -84,6 +80,10 @@
 
 #if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
 #error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
+#endif
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
 #endif
 
 // =============================================================================
@@ -274,7 +274,6 @@ struct PTO2TaskPayload {
                 tensors[i].owner_task_id = result.task_id();
                 result.materialize_output(tensors[i]);
             }
-            tensors[i].update_start_offset();
         }
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -71,47 +71,83 @@ extern uint64_t g_insert_count;
 /**
  * TensorMap entry structure — cache-line optimized for lookup
  *
- * Cache line 1 (64B, lookup hot path):
- *   next_in_bucket, producer_task_id, buffer_addr — chain traversal + validity + hash match
- *   version, ndims, is_all_offset_zero, bucket_index — overlap fast path
- *   shapes[5] — overlap comparison
+ * Cache line 1 (64B, lookup hot path) mirrors Tensor cache line 1 byte-for-byte
+ * from byte 16 onward, so that `memcpy(this, &tensor, 64)` populates everything
+ * we need for overlap checks. Bytes [0, 16) carry entry-only fields (hash
+ * bucket head + chain pointer) that overlap Tensor::buffer (addr in [0, 8) is
+ * the hash key, size in [8, 16) is unused by the entry — we repurpose it for
+ * `next_in_bucket`).
  *
- * Cache line 2 (64B, insert/remove/slow-path only):
- *   prev_in_bucket, next_in_task, prev_in_task — chain manipulation
- *   offsets[5] — only read when !is_all_offset_zero
+ *   buffer_addr / next_in_bucket / producer_task_id   — chain traversal + match
+ *   start_offset                                       — overlap byte range begin
+ *   version, ndims, dtype, manual_dep, is_contiguous   — overlap fast path
+ *   shapes[5]                                          — overlap comparison (line 1)
  *
- * When is_all_offset_zero is true, lookup touches only cache line 1.
- * Entry size: 128B (2 cache lines) vs previous 192B (3 cache lines with embedded Tensor).
+ * Cache line 2 (64B, slow-path / non-contiguous overlap):
+ *   prev_in_bucket / next_in_task / prev_in_task       — chain manipulation
+ *   bucket_index                                       — bookkeeping
+ *   extent_elem_cache                                  — overlap byte range end
+ *   strides[5]                                          — reserved for L2 overlap (PR-2)
+ *
+ * When both entry & probe are `is_contiguous && start_offset == 0`, the overlap
+ * check derives `extent_elem = prod(shapes)` from cache line 1 alone.
+ *
+ * Entry size: 128B (2 cache lines), matches Tensor.
  */
 struct alignas(64) PTO2TensorMapEntry {
-    // === Cache line 1 (64B) — lookup hot path ===
-    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
-    PTO2TensorMapEntry *next_in_bucket;  // 8B: next entry in hash bucket chain
-    PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
-    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
-    uint32_t __padding0__;               // 4B: occupies Tensor::start_offset high half
-    int32_t version;                     // 4B: tensor version for overlap detection
-    uint32_t ndims;                      // 4B: number of dimensions
-    DataType __padding_dtype__;          // 1B: occupies Tensor::dtype
-    bool is_all_offset_zero;             // 1B: fast-path flag
-    uint8_t __padding1__[2];
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
+    // === Cache line 1 (64B) — lookup hot path; mirrors Tensor line 1 from byte 16 ===
+    uint64_t buffer_addr;                // 8B [0, 8):   tensor base address (hash key, mirrors Tensor::buffer.addr)
+    PTO2TensorMapEntry *next_in_bucket;  // 8B [8, 16):  next entry in hash bucket chain (overlays Tensor::buffer.size)
+    PTO2TaskId producer_task_id;         // 8B [16,24):  mirrors Tensor::owner_task_id slot
+    uint64_t start_offset;               // 8B [24,32):  mirrors Tensor::start_offset (element offset)
+    int32_t version;                     // 4B [32,36):  mirrors Tensor::version
+    uint32_t ndims;                      // 4B [36,40):  mirrors Tensor::ndims
+    DataType dtype;                      // 1B [40,41):  mirrors Tensor::dtype
+    bool manual_dep;                     // 1B [41,42):  mirrors Tensor::manual_dep
+    bool is_contiguous;                  // 1B [42,43):  mirrors Tensor::is_contiguous
+    uint8_t __padding1__;                // 1B [43,44):  mirrors Tensor padding
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B [44,64): mirrors Tensor::shapes
 
-    // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry *prev_in_bucket;         // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry *next_in_task;           // 8B: next entry for same task
-    PTO2TensorMapEntry *prev_in_task;           // 8B: prev entry for same task
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
-    // padding: 20B to fill 64B
+    // === Cache line 2 (64B) — chain manipulation + non-contiguous overlap data ===
+    PTO2TensorMapEntry *prev_in_bucket;         // 8B [64, 72)
+    PTO2TensorMapEntry *next_in_task;           // 8B [72, 80)
+    PTO2TensorMapEntry *prev_in_task;           // 8B [80, 88)
+    int32_t bucket_index;                       // 4B [88, 92): -1 when unlinked
+    uint32_t __padding2__;                      // 4B [92, 96)
+    uint64_t extent_elem_cache;                 // 8B [96,104): non-contiguous extent (mirrors Tensor)
+    uint32_t strides[RUNTIME_MAX_TENSOR_DIMS];  // 20B [104,124): element strides, mirrors Tensor::strides
+    uint8_t __padding3__[4];                    // 4B [124,128)
 
     /**
      * Copy overlap-relevant fields from a Tensor into this entry.
+     *
+     * 64B memcpy of Tensor cache line 1 populates buffer_addr (byte [0,8)),
+     * producer_task_id, start_offset, version, ndims, dtype, manual_dep,
+     * is_contiguous and shapes[]. Byte [8,16) holds Tensor::buffer.size in
+     * the source and gets written into next_in_bucket; that's harmless
+     * because link_entry() overwrites next_in_bucket immediately after.
+     *
+     * Cache line 2 (stride / extent_elem_cache) is derived from line 1 when
+     * the source is canonically contiguous (is_contiguous && start_offset==0),
+     * so the producer Tensor's cache line 2 stays cold during insert. Only
+     * non-contiguous producers pay one extra line 2 read.
      */
     void copy_from_tensor(const Tensor &tensor) {
         memcpy(this, &tensor, 64);
-        if (!tensor.is_all_offset_zero) {
+        if (tensor.is_contiguous && tensor.start_offset == 0) {
+            uint64_t numel = 1;
+            for (uint32_t i = 0; i < tensor.ndims; i++)
+                numel *= tensor.shapes[i];
+            extent_elem_cache = numel;
+            uint32_t s = 1;
+            for (int32_t i = static_cast<int32_t>(tensor.ndims) - 1; i >= 0; i--) {
+                strides[i] = s;
+                s *= tensor.shapes[i];
+            }
+        } else {
+            extent_elem_cache = tensor.extent_elem_cache;
             for (uint32_t i = 0; i < tensor.ndims; i++) {
-                offsets[i] = tensor.offsets[i];
+                strides[i] = tensor.strides[i];
             }
         }
     }
@@ -119,11 +155,51 @@ struct alignas(64) PTO2TensorMapEntry {
     void copy_tensor_create_info(const TensorCreateInfo &tensor_create_info, uint64_t addr) {
         memcpy(this, &tensor_create_info, 64);
         buffer_addr = addr;
+        // Create-info outputs are always contiguous with start_offset = 0;
+        // extent_elem = prod(shapes); stride is row-major.
+        uint64_t numel = 1;
+        for (uint32_t i = 0; i < tensor_create_info.ndims; i++) {
+            numel *= tensor_create_info.shapes[i];
+        }
+        extent_elem_cache = numel;
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(tensor_create_info.ndims) - 1; i >= 0; i--) {
+            strides[i] = s;
+            s *= tensor_create_info.shapes[i];
+        }
+    }
+
+    /**
+     * Effective element extent of this entry.
+     * Contiguous-aligned views compute it from shapes alone (line 1 hit only);
+     * non-contiguous views read the cached value from line 2.
+     */
+    uint64_t effective_extent_elem() const {
+        if (is_contiguous) {
+            uint64_t n = 1;
+            for (uint32_t i = 0; i < ndims; i++)
+                n *= shapes[i];
+            return n;
+        }
+        return extent_elem_cache;
     }
 
     /**
      * Check overlap between input tensor and this entry (the producer output).
-     * Mirrors Tensor::is_overlap() logic but operates on entry fields directly.
+     *
+     * Three-level cascade:
+     *   L1 — O(1) byte-range intersection. Disjoint -> NO_OVERLAP.
+     *   L2 — O(ndims) hyper-rectangle precise check, eligible only when both
+     *        sides share the same canonical row-major axis layout (same
+     *        dtype/ndims/strides[], stride descends as integer multiples,
+     *        start_offset decomposes cleanly under the reference shape).
+     *        Yields NO_OVERLAP / COVERED / OTHER per-dim.
+     *   L3 — Non-hyper-rectangle pairs (transpose/permute mismatch, slice
+     *        with step, etc): conservative OTHER. Exact enumeration via
+     *        contiguous-segment merge is scheduled for a follow-up.
+     *
+     * COVERED is returned when `input` completely contains `entry` per-dim
+     * — dep_compute uses this to retire the now-redundant entry.
      */
     OverlapStatus check_overlap(const Tensor &input) const {
         debug_assert(input.buffer.addr == buffer_addr);
@@ -131,39 +207,113 @@ struct alignas(64) PTO2TensorMapEntry {
         if (input.version > version) {
             return OverlapStatus::OTHER;
         }
-        // Fast path: both have zero offsets → ranges are [0, shape[i])
-        if (input.is_all_offset_zero && is_all_offset_zero) {
-            bool contains = true;
-            for (uint32_t i = 0; i < ndims; i++) {
-                if (input.shapes[i] < shapes[i]) {
-                    contains = false;
-                    break;
-                }
-            }
-            return contains ? OverlapStatus::COVERED : OverlapStatus::OTHER;
+
+        // -------- L1: byte-range intersection (O(1) fast reject) --------
+        const uint64_t in_begin = input.start_offset;
+        const uint64_t in_end = input.start_offset + input.extent_elem();
+        const uint64_t ent_begin = start_offset;
+        const uint64_t ent_end = start_offset + effective_extent_elem();
+        Segment in_range_bytes{in_begin, in_end};
+        Segment ent_range_bytes{ent_begin, ent_end};
+        if (!in_range_bytes.line_segment_intersection(ent_range_bytes)) {
+            return OverlapStatus::NO_OVERLAP;
         }
-        // Slow path: at least one has non-zero offsets
-        bool contains = true;
+
+        // -------- L2 prereqs: same axis layout? --------
+        if (input.dtype != dtype || input.ndims != ndims || ndims == 0) {
+            return OverlapStatus::OTHER;
+        }
         for (uint32_t i = 0; i < ndims; i++) {
-            uint64_t in_off = input.is_all_offset_zero ? 0 : input.offsets[i];
-            uint64_t ent_off = is_all_offset_zero ? 0 : offsets[i];
-            Segment in_range{in_off, in_off + static_cast<uint64_t>(input.shapes[i])};
-            Segment ent_range{ent_off, ent_off + static_cast<uint64_t>(shapes[i])};
-            if (!in_range.line_segment_intersection(ent_range)) {
+            if (input.strides[i] != strides[i]) return OverlapStatus::OTHER;
+        }
+        // strides[ndims-1] must be 1 and strides[i-1] must be an integer
+        // multiple of strides[i] for the row-major reference-shape derivation
+        // below to hold. This rejects slice-with-step (strides[d] != prev factor)
+        // and any view chain that scrambles the axis order. (strides is
+        // uint32_t with the > 0 invariant enforced at construction, so no
+        // sign check needed.)
+        if (strides[ndims - 1] != 1) return OverlapStatus::OTHER;
+        for (uint32_t i = 1; i < ndims; i++) {
+            if (strides[i - 1] % strides[i] != 0) return OverlapStatus::OTHER;
+        }
+
+        // Derive reference shape A from stride. By construction stride is
+        // row-major over A: strides[i] = prod(A[i+1..ndims-1]). So
+        //   A[i] = strides[i-1] / strides[i]   for i >= 1
+        //   A[0] = (buffer.size / dtype_bytes) / strides[0]
+        // input.buffer.size is the storage size; entry shares the same buffer
+        // (debug-asserted by buffer.addr equality at the top), so we read it
+        // from input rather than mirroring buffer.size into the entry.
+        //
+        // Note on buffer padding: runtime allocators may over-allocate
+        // `buffer.size` (cache-line / 1024B alignment, ring-buffer slot
+        // rounding, etc). When that happens, `numel_storage` is larger than
+        // the true logical extent and `ref_shapes[0]` ends up generously over-
+        // sized. This is intentional: ref_shapes is only used as an *upper
+        // bound* in the in-bounds checks below; the actual overlap test (the
+        // per-dim line-segment intersection on the real start_offset /
+        // shapes / stride further down) is unaffected. A larger-than-truth
+        // ref_shapes[0] simply makes the bounds check more permissive — it
+        // can never cause a false NO_OVERLAP nor a false COVERED.
+        uint32_t ref_shapes[RUNTIME_MAX_TENSOR_DIMS] = {};
+        for (uint32_t i = 1; i < ndims; i++) {
+            ref_shapes[i] = strides[i - 1] / strides[i];
+        }
+        const uint64_t elem_size = get_element_size(dtype);
+        if (elem_size == 0) return OverlapStatus::OTHER;
+        const uint64_t numel_storage = input.buffer.size / elem_size;
+        const uint32_t stride0 = strides[0];  // > 0 by Tensor invariant
+        if (numel_storage % stride0 != 0) return OverlapStatus::OTHER;
+        ref_shapes[0] = static_cast<uint32_t>(numel_storage / stride0);
+
+        // Decompose start_offset into row-major multi-dim offsets. By the same
+        // relation strides[i] = prod(ref_shapes[i+1..]) so dividing by strides[i]
+        // (no inner loop) yields each axis offset directly.
+        uint32_t in_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+        uint32_t ent_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+        uint64_t in_remain = input.start_offset;
+        uint64_t ent_remain = start_offset;
+        for (uint32_t i = 0; i < ndims; i++) {
+            const uint32_t s = strides[i];
+            in_offsets[i] = static_cast<uint32_t>(in_remain / s);
+            ent_offsets[i] = static_cast<uint32_t>(ent_remain / s);
+            in_remain %= s;
+            ent_remain %= s;
+        }
+        if (in_remain != 0 || ent_remain != 0) return OverlapStatus::OTHER;
+
+        // Validate that each side fits within ref_shapes (defense in depth —
+        // a well-formed view always satisfies this).
+        for (uint32_t i = 0; i < ndims; i++) {
+            if (static_cast<uint64_t>(in_offsets[i]) + input.shapes[i] > ref_shapes[i]) return OverlapStatus::OTHER;
+            if (static_cast<uint64_t>(ent_offsets[i]) + shapes[i] > ref_shapes[i]) return OverlapStatus::OTHER;
+        }
+
+        // -------- L2 core: per-dim line-segment intersection --------
+        bool input_contains_entry = true;
+        for (uint32_t i = 0; i < ndims; i++) {
+            Segment in_seg{in_offsets[i], static_cast<uint64_t>(in_offsets[i]) + input.shapes[i]};
+            Segment ent_seg{ent_offsets[i], static_cast<uint64_t>(ent_offsets[i]) + shapes[i]};
+            if (!in_seg.line_segment_intersection(ent_seg)) {
                 return OverlapStatus::NO_OVERLAP;
-            } else if (!in_range.contains(ent_range)) {
-                contains = false;
+            }
+            if (!in_seg.contains(ent_seg)) {
+                input_contains_entry = false;
             }
         }
-        return contains ? OverlapStatus::COVERED : OverlapStatus::OTHER;
+        return input_contains_entry ? OverlapStatus::COVERED : OverlapStatus::OTHER;
     }
 };
 
 static_assert(sizeof(PTO2TensorMapEntry) == 128, "TensorMapEntry must be exactly 2 cache lines (128 bytes)");
 static_assert(offsetof(PTO2TensorMapEntry, buffer_addr) == offsetof(Tensor, buffer.addr));
+static_assert(offsetof(PTO2TensorMapEntry, producer_task_id) == offsetof(Tensor, owner_task_id));
+static_assert(offsetof(PTO2TensorMapEntry, start_offset) == offsetof(Tensor, start_offset));
 static_assert(offsetof(PTO2TensorMapEntry, version) == offsetof(Tensor, version));
 static_assert(offsetof(PTO2TensorMapEntry, ndims) == offsetof(Tensor, ndims));
-static_assert(offsetof(PTO2TensorMapEntry, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
+static_assert(offsetof(PTO2TensorMapEntry, dtype) == offsetof(Tensor, dtype));
+static_assert(offsetof(PTO2TensorMapEntry, manual_dep) == offsetof(Tensor, manual_dep));
+static_assert(offsetof(PTO2TensorMapEntry, is_contiguous) == offsetof(Tensor, is_contiguous));
 static_assert(offsetof(PTO2TensorMapEntry, shapes) == offsetof(Tensor, shapes));
 static_assert(
     offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)"

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -53,12 +53,12 @@ struct Segment {
  * TensorCreateInfo — submit-time create-info for runtime-allocated outputs.
  *
  * Carries the metadata required to materialize a fresh contiguous output:
- * dtype, ndims, raw_shapes (== shapes), manual_dep, and an optional
- * initial value fill.
+ * dtype, ndims, shapes, manual_dep, and an optional initial value fill.
  *
- * Layout (64B) is aligned with Tensor cacheline 1 so that
- * init_from_create_info() can copy the entire cacheline with a single memcpy,
- * then overwrite buffer/owner metadata and refresh start_offset later.
+ * Layout (64B) is aligned with Tensor cache line 1 so that
+ * init_from_create_info() can copy the entire cache line with a single memcpy,
+ * then overwrite buffer/owner metadata and compute the contiguous stride in
+ * cache line 2.
  *
  * Arg::add_output() stores a pointer to this object, so the original
  * must remain valid (not a temporary) until after the submit call.
@@ -66,18 +66,20 @@ struct Segment {
 class alignas(64) TensorCreateInfo {
 public:
     TensorCreateInfo(
-        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false
+        const uint32_t shapes_in[], uint32_t ndims_in, DataType dtype_in = DataType::FLOAT32, bool manual_dep_in = false
     ) :
         initial_value(0),
         has_initial_value(false),
+        __pad2__(0),
+        start_offset(0),  // mirrors Tensor::start_offset; pre-zeroed for create-info outputs
         version(0),
-        ndims(ndims),
-        dtype(dtype),
-        is_all_offset_zero(true),
-        is_raw_eq_shapes(true),
-        manual_dep(manual_dep) {
-        for (uint32_t i = 0; i < ndims; i++) {
-            raw_shapes[i] = shapes[i];
+        ndims(ndims_in),
+        dtype(dtype_in),
+        manual_dep(manual_dep_in),
+        is_contiguous(true),  // mirrors Tensor::is_contiguous; pre-set for create-info outputs
+        __pad_flags__(0) {
+        for (uint32_t i = 0; i < ndims_in; i++) {
+            shapes[i] = shapes_in[i];
         }
     }
 
@@ -92,7 +94,7 @@ public:
     uint64_t buffer_size_bytes() const {
         uint64_t total = 1;
         for (uint32_t i = 0; i < ndims; i++) {
-            total *= raw_shapes[i];
+            total *= shapes[i];
         }
         return total * get_element_size(dtype);
     }
@@ -101,21 +103,21 @@ public:
     // --- Bytes [0, 32): TensorCreateInfo-only fields ---
     // These occupy the same positions as Tensor::buffer, Tensor::owner_task_id,
     // and Tensor::start_offset. The runtime overwrites owner metadata after the
-    // memcpy and refreshes start_offset during payload materialization.
+    // memcpy and recomputes start_offset / stride during payload materialization.
     uint64_t initial_value;
     bool has_initial_value;
     uint8_t __pad1__[7];
-    uint64_t __pad2__;  // → Tensor::owner_task_id
-    uint64_t __pad3__;  // → Tensor::start_offset (zeroed)
+    uint64_t __pad2__;      // → Tensor::owner_task_id (overwritten post-memcpy)
+    uint64_t start_offset;  // mirrors Tensor::start_offset; always 0 for create-info outputs
 
-    // --- Bytes [32, 64): Matches Tensor cacheline 1 layout ---
+    // --- Bytes [32, 64): Matches Tensor cache line 1 layout ---
     int32_t version;  // Always 0 for create-info outputs
     uint32_t ndims;
     DataType dtype;
-    bool is_all_offset_zero;  // Always true for create-info outputs
-    bool is_raw_eq_shapes;    // Always true for create-info outputs
     bool manual_dep;
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // → Tensor::shapes
+    bool is_contiguous;  // Always true for create-info outputs
+    uint8_t __pad_flags__;
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // → Tensor::shapes
 
     TensorCreateInfo() = default;
 
@@ -127,24 +129,30 @@ static_assert(sizeof(TensorCreateInfo) == 64);
 /**
  * Tensor descriptor for Task input/output (128B = 2 cache lines)
  *
- * Describes a memory access pattern on Global Memory (GM) using
- * raw_shapes (underlying buffer dimensions), shapes (current view dimensions),
- * and offsets (multi-dimensional offset into the buffer).
+ * Describes a strided memory access pattern on Global Memory (GM) using:
+ *   - `buffer`: underlying memory allocation (addr/size in bytes)
+ *   - `start_offset`: 1D element offset of the view origin from `buffer.addr`
+ *   - `shapes[i]`, `strides[i]`: per-dim view shape and **element** stride
  *
- * - `buffer` contains the underlying memory allocation (addr in bytes, size in bytes)
- * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
- * - `dtype` specifies element type for interpreting buffer contents
+ * Stride semantics:
+ *   - Element-granularity (matches start_offset). Byte offset of element
+ *     `coords[]` is `(start_offset + Σ coords[i] · strides[i]) · dtype_bytes`.
+ *   - strides[i] > 0 STRICTLY. Broadcast (stride=0) and negative slice step
+ *     (stride<0) are NOT supported.
  *
- * Fast-path flags (all on cache line 1):
- * - is_all_offset_zero: when true, offsets[] are implicitly zero — skip offset read/write
- * - is_raw_eq_shapes: when true, raw_shapes[] == shapes[] — skip raw_shapes read/write,
- *   use shapes[] wherever raw_shapes would be needed
- * - manual_dep: when true, keep creator retention only and skip OverlapMap dependency tracking
+ * Fast-path flags on cache line 1:
+ *   - manual_dep: when true, dependency tracking is creator-only (skip OverlapMap)
+ *   - is_contiguous: cached PyTorch-style contiguous flag — i.e.
+ *     `strides[i] == prod(shapes[i+1..ndims-1])`. When true AND start_offset==0,
+ *     all hot paths can compute extent_elem from `shapes` alone and never read
+ *     cache line 2. NOTE: this is strictly tighter than the pre-#808
+ *     `shapes[i] == raw_shapes[i]` test, but equivalent on every view the old
+ *     (raw_shapes-based) encoding could express; the two only diverge on
+ *     post-#808-only views (transpose / permute / slice-with-step results).
  *
- * When BOTH flags are true, cache line 2 is never accessed.
- *
- * Layout: cache line 1 holds hot-path fields (buffer, owner_task_id, start_offset,
- * version, ndims, dtype, flags, shapes); cache line 2 holds warm-path fields (raw_shapes, offsets).
+ * Layout: cache line 1 holds hot-path fields (buffer, owner_task_id,
+ * start_offset, version, ndims, dtype, flags, shapes); cache line 2 holds
+ * stride + cached extent_elem.
  *
  * Construction:
  * Users cannot default-construct or directly construct a Tensor.
@@ -152,142 +160,148 @@ static_assert(sizeof(TensorCreateInfo) == 64);
  *   - make_tensor_external(...)
  *   - from_tensor_arg(...)
  *   - TaskOutputTensors returned by submit(...)
- *   - Tensor::view() / reshape() / transpose() on an existing valid Tensor
+ *   - Tensor::view() / reshape() / transpose() / permute() / slice() on an existing valid Tensor
  */
 struct alignas(64) Tensor {
     // === Cache line 1 (64B) — hot path ===
     PTOBufferHandle buffer;    // Underlying memory buffer (addr in bytes, size in bytes)
     PTO2TaskId owner_task_id;  // Creator task; PTO2TaskId::invalid() for external tensors
-    uint64_t start_offset;     // Cached 1D element offset (precomputed from raw_shapes + offsets)
+    uint64_t start_offset;     // 1D ELEMENT offset of the view origin into `buffer`
     int32_t version;           // Tensor version for overlap detection
     uint32_t ndims;            // Number of dimensions used
     DataType dtype;            // Data type of tensor elements
-    bool is_all_offset_zero;   // True when all offsets[] are zero (skip offset read/write)
-    bool is_raw_eq_shapes;     // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
     bool manual_dep;           // True when dependency tracking is creator-only (skip OverlapMap lookup/insert)
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension
+    bool is_contiguous;        // Cached: strides[] == row_major_stride(shapes)
+    uint8_t _pad_cl1;          // Pad to align shapes[5] at byte 44
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension (elements)
 
-    // === Cache line 2 (64B) — warm path ===
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
-    uint8_t _pad_cl2[24];                          // Tail padding (bytes 104–127)
+    // === Cache line 2 (64B) — warm path (view metadata) ===
+    // Field order: place the 8B-aligned cache before the 4B-aligned strides[]
+    // to avoid 4B padding between them (sizeof(Tensor) must stay 128).
+    uint64_t extent_elem_cache;                 // Cached extent_elem (see extent_elem()); maintained by ops
+    uint32_t strides[RUNTIME_MAX_TENSOR_DIMS];  // Element stride per dimension; ALWAYS > 0 (type-enforced)
+    uint8_t _pad_cl2[36];                       // Reserved for future extension
 
-    // --- Copy / move / destroy are public (valid tensors can be freely copied) ---
+    // --- Copy / move / destroy ---
+    // Kept trivially copyable (default copy = byte-for-byte) so other modules
+    // (PTO2TensorMapEntry::copy_from_tensor, TensorCreateInfo memcpy path)
+    // can rely on memcpy semantics. The contiguous fast-path optimization
+    // lives in `init(const Tensor&)`; call sites that care should use
+    // `result.init(*this)` instead of the default copy ctor.
     Tensor(const Tensor &) = default;
     Tensor &operator=(const Tensor &) = default;
     Tensor(Tensor &&) = default;
     Tensor &operator=(Tensor &&) = default;
     ~Tensor() = default;
 
-    /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
-    /// Avoids cache line 2 access for the common case.
-    const uint32_t *get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
+    // ========================================================================
+    // Accessors / helpers
+    // ========================================================================
 
-    // --- Initialization (operates on already-constructed Tensor) ---
-    void init(
-        void *addr, uint64_t buffer_size_bytes, const uint32_t in_raw_shapes[], const uint32_t in_shapes[],
-        const uint32_t in_offsets[], uint32_t in_ndims, DataType in_dtype, int32_t in_version,
-        bool in_is_all_offset_zero = false, bool in_is_raw_eq_shapes = false, bool in_manual_dep = false
+    /// Number of logical elements covered by the view (NOT the extent).
+    /// ndims > 0 is a construction-time invariant (see init_external /
+    /// init_from_create_info), so the loop always runs at least once.
+    uint64_t numel() const {
+        uint64_t total = 1;
+        for (uint32_t i = 0; i < ndims; i++)
+            total *= shapes[i];
+        return total;
+    }
+
+    /// Element extent — the smallest M such that every reachable element lies in [start_offset, start_offset+M).
+    /// For strides[i]>0: extent_elem = 1 + Σ (shapes[i]-1) · strides[i].
+    uint64_t extent_elem() const {
+        if (is_contiguous) return numel();  // fast path: line 2 not needed when contiguous
+        return extent_elem_cache;
+    }
+
+    // ========================================================================
+    // Initialization (operates on already-constructed Tensor)
+    // ========================================================================
+
+    /// Initialize as a contiguous tensor that covers `shapes[]` starting at `addr`.
+    /// stride is set to row_major(shapes); start_offset = 0; is_contiguous = true.
+    /// Enforces the ndims > 0 invariant relied upon by every downstream op.
+    void init_external(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_shapes[], uint32_t in_ndims, DataType in_dtype,
+        int32_t in_version, bool in_manual_dep = false
     ) {
+        always_assert(in_ndims > 0 && in_ndims <= RUNTIME_MAX_TENSOR_DIMS);
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
         ndims = in_ndims;
         dtype = in_dtype;
         version = in_version;
-        is_all_offset_zero = in_is_all_offset_zero;
-        is_raw_eq_shapes = in_is_raw_eq_shapes;
         manual_dep = in_manual_dep;
-        for (uint32_t i = 0; i < in_ndims; i++) {
-            shapes[i] = in_shapes[i];
-        }
-        if (!in_is_raw_eq_shapes) {
-            for (uint32_t i = 0; i < in_ndims; i++) {
-                raw_shapes[i] = in_raw_shapes[i];
-            }
-        }
-        if (!in_is_all_offset_zero) {
-            for (uint32_t i = 0; i < in_ndims; i++) {
-                offsets[i] = in_offsets[i];
-            }
-        }
+        is_contiguous = true;
+        _pad_cl1 = 0;
+        start_offset = 0;
         owner_task_id = PTO2TaskId::invalid();
+        // Single reverse pass: write shapes, accumulate row-major stride, and
+        // track numel — `s` ends as prod(shapes) which is also extent_elem
+        // for a contiguous view.
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(in_ndims) - 1; i >= 0; --i) {
+            shapes[i] = in_shapes[i];
+            strides[i] = s;
+            s *= in_shapes[i];
+        }
+        extent_elem_cache = s;
     }
 
-    void init(const Tensor &other) {
-        memcpy(this, &other, 64);  // fast copy cache line 1
-        if (!other.is_raw_eq_shapes) {
-            for (uint32_t i = 0; i < other.ndims; i++) {
-                raw_shapes[i] = other.raw_shapes[i];
+    /// Deep copy with contiguous fast-path optimization.
+    ///
+    /// Always copies cache line 1 (always needed: buffer, shapes, dtype, ...).
+    /// When `other` is in canonical contiguous form (is_contiguous &&
+    /// start_offset == 0), cache line 2 (stride / extent_elem_cache) is fully
+    /// derivable from line 1, so we **skip reading other's cache line 2** and
+    /// write dst's line 2 from the local shapes instead. Non-contiguous source
+    /// pays one line 2 read; contiguous source does not.
+    void init_from(const Tensor &other) {
+        init_from_line1(other);
+        if (other.is_contiguous && other.start_offset == 0) {
+            // Derive line 2 from line 1: stride = row-major of shapes; extent = numel.
+            uint32_t s = 1;
+            for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
+                strides[i] = s;
+                s *= shapes[i];
             }
-        }
-        if (!other.is_all_offset_zero) {
-            for (uint32_t i = 0; i < other.ndims; i++) {
-                offsets[i] = other.offsets[i];
-            }
-        }
-    }
-
-    void init_with_view(
-        const Tensor &other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false
-    ) {
-        buffer = other.buffer;
-        ndims = other.ndims;
-        dtype = other.dtype;
-        version = other.version;
-        manual_dep = in_manual_dep;
-        // view always diverges shapes from raw_shapes, so is_raw_eq_shapes = false.
-        // Read parent's effective raw_shapes (avoids parent cache line 2 when parent is_raw_eq_shapes).
-        is_raw_eq_shapes = false;
-        const uint32_t *parent_raw = other.get_raw_shapes();
-        for (uint32_t i = 0; i < ndims; i++) {
-            raw_shapes[i] = parent_raw[i];
-            shapes[i] = view_shapes[i];
-        }
-        // Compute offsets and zero-flag
-        bool all_zero = true;
-        if (other.is_all_offset_zero) {
-            for (uint32_t i = 0; i < ndims; i++) {
-                if (view_offsets[i] != 0) {
-                    all_zero = false;
-                    break;
-                }
-            }
-            if (!all_zero) {
-                for (uint32_t i = 0; i < ndims; i++) {
-                    offsets[i] = view_offsets[i];
-                }
-            }
+            extent_elem_cache = s;
         } else {
-            all_zero = false;
-            for (uint32_t i = 0; i < ndims; i++) {
-                offsets[i] = other.offsets[i] + view_offsets[i];
+            extent_elem_cache = other.extent_elem_cache;
+            for (uint32_t i = 0; i < other.ndims; i++) {
+                strides[i] = other.strides[i];
             }
+            // _pad_cl2 left stale on purpose — reserved bytes are not
+            // semantically read by any consumer.
         }
-        is_all_offset_zero = all_zero;
-        owner_task_id = other.owner_task_id;
     }
 
-    /// Compute 1D flat element offset from multi-dimensional indices.
-    /// Uses Horner's method (forward traversal, no stride variable).
-    uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
-        if (in_ndims == 0) return 0;
-        const uint32_t *rs = get_raw_shapes();
-        uint64_t offset = 0;
-        if (is_all_offset_zero) {
-            for (uint32_t d = 0; d < in_ndims; d++)
-                offset = offset * rs[d] + indices[d];
-        } else {
-            for (uint32_t d = 0; d < in_ndims; d++)
-                offset = offset * rs[d] + indices[d] + offsets[d];
-        }
-        return offset;
-    }
+    /// View ops use this: copy cache line 1 only, leaving cache line 2 (stride,
+    /// extent_elem_cache) untouched. The op then mutates shapes / start_offset
+    /// in place and calls `refresh_derived()` to recompute line 2 once. This
+    /// avoids the wasted line 2 writes that `init_from()` would do just before
+    /// the op overwrites them.
+    void init_from_line1(const Tensor &other) { memcpy(this, &other, 64); }
+
+    /// Backward-compat alias used by orchestrator hot paths that need a full
+    /// deep copy. Equivalent to `init_from(other)`.
+    void copy(const Tensor &other) { init_from(other); }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
-    /// Single 64B memcpy covers the entire cacheline 1, then buffer is overwritten.
+    /// Single 64B memcpy covers cache line 1; ci pre-initialises start_offset (=0)
+    /// and is_contiguous (=true) in its line-1 slots so they need no reset here.
+    /// Cache line 2 (stride/extent) is computed from `ci.shapes` in a single reverse pass.
     void init_from_create_info(const TensorCreateInfo &ci, void *addr, uint64_t buffer_size) {
+        always_assert(ci.ndims > 0 && ci.ndims <= RUNTIME_MAX_TENSOR_DIMS);
         memcpy(this, &ci, 64);
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
         owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
+            strides[i] = s;
+            s *= shapes[i];
+        }
+        extent_elem_cache = s;
         if (ci.has_initial_value) {
             fill_initial_value(ci.initial_value);
         }
@@ -310,96 +324,135 @@ struct alignas(64) Tensor {
         }
     }
 
-    // --- Operations ---
-    void update_start_offset() {
-        if (is_all_offset_zero) {
-            start_offset = 0;
-            return;
+    // ========================================================================
+    // Address / offset computation
+    // ========================================================================
+
+    /// Compute 1D flat ELEMENT offset of `indices[]` from `buffer.addr`.
+    /// Callers multiply by `get_element_size(dtype)` to obtain a byte offset.
+    /// Works for any view (transpose / permute / slice / reshape).
+    uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
+        uint64_t elem_off = start_offset;
+        for (uint32_t d = 0; d < in_ndims; d++) {
+            elem_off += static_cast<uint64_t>(indices[d]) * static_cast<uint64_t>(strides[d]);
         }
-        const uint32_t *rs = get_raw_shapes();
-        uint64_t result = 0;
-        uint64_t stride = 1;
-        for (int i = static_cast<int>(ndims) - 1; i >= 0; i--) {
-            result += offsets[i] * stride;
-            stride *= rs[i];
-        }
-        start_offset = result;
+        return elem_off;
     }
 
-    void copy(const Tensor &other) { init(other); }
+    // ========================================================================
+    // View operations (zero-copy metadata rewrites)
+    // ========================================================================
 
-    Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
+    /// Sub-tensor at per-dim offsets, with new per-dim shape.
+    /// Updates start_offset += Σ off[i]·strides[i]; shapes := new_shape; stride unchanged.
+    /// Each (offset[i], new_shape[i]) must stay within the current shapes[i] —
+    /// i.e. a view cannot expand any dimension beyond what the parent view sees.
+    Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) const {
         Tensor result;
-        result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
-        return result;
-    }
-
-    bool is_contiguous() const {
-        if (is_raw_eq_shapes || ndims == 0) {
-            return true;
+        // Copy line 1 only; stride from *this is still in result's line 2 garbage
+        // — we need to bring it forward explicitly since view keeps stride.
+        result.init_from_line1(*this);
+        for (uint32_t i = 0; i < ndims; i++) {
+            debug_assert(view_offsets[i] + view_shapes[i] <= shapes[i]);
+            result.start_offset += static_cast<uint64_t>(view_offsets[i]) * static_cast<uint64_t>(strides[i]);
+            result.shapes[i] = view_shapes[i];
+            result.strides[i] = strides[i];
         }
-        for (uint32_t i = 1; i < ndims; i++) {
-            if (shapes[i] != raw_shapes[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    bool valid_reshape(const uint32_t new_shapes[], uint32_t new_ndims) const {
-        uint64_t x = numel();
-        uint64_t y = 1;
-        for (uint32_t i = 0; i < new_ndims; i++) {
-            y *= new_shapes[i];
-        }
-        return x == y;
-    }
-
-    Tensor reshape(const uint32_t new_shapes[], uint32_t new_ndims, bool manual_dep = false) const {
-        debug_assert(valid_reshape(new_shapes, new_ndims));
-        always_assert(is_contiguous());
-        Tensor result;
-        result.copy(*this);
-        result.ndims = new_ndims;
-        result.is_all_offset_zero = true;
-        result.is_raw_eq_shapes = true;
-        result.manual_dep = manual_dep;
-        for (uint32_t i = 0; i < new_ndims; i++) {
-            result.shapes[i] = new_shapes[i];
-        }
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
+        result.assert_in_buffer_bounds();
         return result;
     }
 
     bool valid_transpose(uint32_t x, uint32_t y) const { return x < ndims && y < ndims; }
 
-    Tensor transpose(uint32_t x, uint32_t y, bool manual_dep = false) const {
+    /// Swap two dimensions: shapes/stride swapped together. start_offset unchanged.
+    Tensor transpose(uint32_t x, uint32_t y, bool in_manual_dep = false) const {
         debug_assert(valid_transpose(x, y));
         Tensor result;
-        result.copy(*this);
-        result.manual_dep = manual_dep;
-        // transpose swaps the same dims in both arrays, so equality is preserved
+        result.init_from_line1(*this);
+        // Carry forward source's stride before swapping (line 2 was not memcpy'd).
+        for (uint32_t i = 0; i < ndims; i++)
+            result.strides[i] = strides[i];
         std::swap(result.shapes[x], result.shapes[y]);
-        if (!result.is_raw_eq_shapes) {
-            std::swap(result.raw_shapes[x], result.raw_shapes[y]);
-        }
-        if (!result.is_all_offset_zero) {
-            std::swap(result.offsets[x], result.offsets[y]);
-        }
+        std::swap(result.strides[x], result.strides[y]);
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
         return result;
     }
 
-    uint64_t numel() const {
-        if (ndims == 0) {
-            return 0;
-        }
-        uint64_t total = 1;
+    /// Permute dimensions according to `order[]` (length = ndims).
+    /// Both shapes and stride are reordered in-place; start_offset unchanged.
+    Tensor permute(const uint32_t order[], bool in_manual_dep = false) const {
+        Tensor result;
+        result.init_from_line1(*this);
         for (uint32_t i = 0; i < ndims; i++) {
-            total *= shapes[i];
+            debug_assert(order[i] < ndims);
+            result.shapes[i] = shapes[order[i]];
+            result.strides[i] = strides[order[i]];
         }
-        return total;
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
+        return result;
     }
 
-    bool is_same_memref(const Tensor &other) const { return buffer.addr == other.buffer.addr; }
+    /// Slice dimension `dim` with `[start, end)` and positive `step`.
+    /// strides[dim] *= step; shapes[dim] = ⌈(end-start)/step⌉; start_offset += start·strides[dim_old].
+    Tensor slice(uint32_t dim, uint32_t start, uint32_t end, uint32_t step = 1, bool in_manual_dep = false) const {
+        debug_assert(dim < ndims);
+        debug_assert(step >= 1);
+        debug_assert(end > start);
+        debug_assert(end <= shapes[dim]);
+        Tensor result;
+        result.init_from_line1(*this);
+        // Carry forward source's stride before patching the sliced dim.
+        for (uint32_t i = 0; i < ndims; i++)
+            result.strides[i] = strides[i];
+        const uint32_t old_stride_d = strides[dim];
+        result.start_offset += static_cast<uint64_t>(start) * static_cast<uint64_t>(old_stride_d);
+        const uint32_t new_len = (end - start + step - 1) / step;
+        result.shapes[dim] = new_len;
+        result.strides[dim] = static_cast<uint32_t>(static_cast<uint64_t>(old_stride_d) * step);
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
+        result.assert_in_buffer_bounds();
+        return result;
+    }
+
+    bool valid_reshape(const uint32_t new_shapes[], uint32_t new_ndims) const {
+        uint64_t x = numel();
+        uint64_t y = 1;
+        for (uint32_t i = 0; i < new_ndims; i++)
+            y *= new_shapes[i];
+        return x == y;
+    }
+
+    /// Reshape — zero-copy only if source is_contiguous; otherwise asserts.
+    /// Materialize fallback (allocating a contiguous copy) is NOT in this op;
+    /// callers must reach contiguous via a copy before calling reshape on a
+    /// non-contiguous view.
+    Tensor reshape(const uint32_t new_shapes[], uint32_t new_ndims, bool in_manual_dep = false) const {
+        debug_assert(valid_reshape(new_shapes, new_ndims));
+        always_assert(is_contiguous);
+        Tensor result;
+        result.init_from_line1(*this);
+        result.ndims = new_ndims;
+        result.manual_dep = in_manual_dep;
+        // Single reverse pass: write new shapes, accumulate row-major stride, track numel.
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(new_ndims) - 1; i >= 0; --i) {
+            result.shapes[i] = new_shapes[i];
+            result.strides[i] = s;
+            s *= new_shapes[i];
+        }
+        result.is_contiguous = true;
+        result.extent_elem_cache = s;
+        return result;
+    }
+
+    // ========================================================================
+    // Dump for diagnostics
+    // ========================================================================
 
     std::string dump() const {
         std::stringstream ss;
@@ -410,30 +463,18 @@ struct alignas(64) Tensor {
         ss << indent << "dtype: " << get_dtype_name(dtype) << '\n';
         ss << indent << "ndims: " << ndims << '\n';
         ss << indent << "version: " << version << '\n';
-
-        const uint32_t *rs = get_raw_shapes();
-        ss << indent << "raw_shapes: [";
-        for (uint32_t i = 0; i < ndims; i++) {
-            if (i > 0) {
-                ss << ", ";
-            }
-            ss << rs[i];
-        }
-        ss << "]" << '\n';
+        ss << indent << "start_offset: " << start_offset << " (elements)" << '\n';
+        ss << indent << "is_contiguous: " << (is_contiguous ? "true" : "false") << '\n';
         ss << indent << "shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
-            if (i > 0) {
-                ss << ", ";
-            }
+            if (i > 0) ss << ", ";
             ss << shapes[i];
         }
         ss << "]" << '\n';
-        ss << indent << "offsets: [";
+        ss << indent << "strides: [";
         for (uint32_t i = 0; i < ndims; i++) {
-            if (i > 0) {
-                ss << ", ";
-            }
-            ss << (is_all_offset_zero ? 0u : offsets[i]);
+            if (i > 0) ss << ", ";
+            ss << strides[i];
         }
         ss << "]" << '\n';
         ss << "}" << '\n';
@@ -446,14 +487,40 @@ private:
     Tensor() = default;
 
     Tensor(
-        void *addr, uint64_t buffer_size_bytes, const uint32_t raw_shapes[], const uint32_t shapes[],
-        const uint32_t offsets[], uint32_t ndims, DataType dtype, int32_t version, bool is_all_offset_zero = false,
-        bool is_raw_eq_shapes = false, bool manual_dep = false
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_shapes[], uint32_t in_ndims, DataType in_dtype,
+        int32_t in_version, bool in_manual_dep = false
     ) {
-        init(
-            addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version, is_all_offset_zero,
-            is_raw_eq_shapes, manual_dep
-        );
+        init_external(addr, buffer_size_bytes, in_shapes, in_ndims, in_dtype, in_version, in_manual_dep);
+    }
+
+    // ------------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------------
+
+    /// Recompute extent_elem_cache and is_contiguous from current shapes / stride.
+    /// Called after any op that mutates view metadata. Single reverse pass:
+    ///   extent_elem += (shapes[i] - 1) · strides[i]
+    ///   is_contiguous &&= (strides[i] == prod(shapes[i+1..]))
+    void refresh_derived() {
+        uint64_t e = 1;
+        uint64_t expected = 1;
+        bool contig = true;
+        for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
+            if (strides[i] != expected) contig = false;
+            if (shapes[i] > 0) {
+                e += static_cast<uint64_t>(shapes[i] - 1) * static_cast<uint64_t>(strides[i]);
+            }
+            expected *= shapes[i];
+        }
+        extent_elem_cache = e;
+        is_contiguous = contig;
+    }
+
+    /// Assert the view stays inside the underlying buffer (byte-range safety).
+    void assert_in_buffer_bounds() const {
+        const uint64_t elem_size = get_element_size(dtype);
+        const uint64_t buffer_elems = buffer.size / elem_size;
+        debug_assert(start_offset + extent_elem_cache <= buffer_elems);
     }
 
     // Friends that need to construct Tensors
@@ -464,16 +531,23 @@ private:
 };
 
 static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");
-static_assert(offsetof(Tensor, raw_shapes) == 64);
 static_assert(offsetof(Tensor, owner_task_id) == 16, "owner_task_id must be at bytes 16-23 (cacheline 1)");
 static_assert(offsetof(Tensor, start_offset) == 24, "start_offset must be at bytes 24-31 (cacheline 1)");
+static_assert(offsetof(Tensor, version) == 32);
+static_assert(offsetof(Tensor, ndims) == 36);
+static_assert(offsetof(Tensor, dtype) == 40);
+static_assert(offsetof(Tensor, manual_dep) == 41);
+static_assert(offsetof(Tensor, is_contiguous) == 42);
+static_assert(offsetof(Tensor, shapes) == 44, "shapes must start at byte 44 (cacheline 1)");
+static_assert(offsetof(Tensor, extent_elem_cache) == 64, "extent_elem_cache must start at byte 64 (cacheline 2)");
+static_assert(offsetof(Tensor, strides) == 72);
 
 // TensorCreateInfo layout must match Tensor cacheline 1 for memcpy optimization
 static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match Tensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, start_offset) == offsetof(Tensor, start_offset));
 static_assert(offsetof(TensorCreateInfo, version) == offsetof(Tensor, version));
 static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(Tensor, ndims));
 static_assert(offsetof(TensorCreateInfo, dtype) == offsetof(Tensor, dtype));
-static_assert(offsetof(TensorCreateInfo, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
-static_assert(offsetof(TensorCreateInfo, is_raw_eq_shapes) == offsetof(Tensor, is_raw_eq_shapes));
 static_assert(offsetof(TensorCreateInfo, manual_dep) == offsetof(Tensor, manual_dep));
-static_assert(offsetof(TensorCreateInfo, raw_shapes) == offsetof(Tensor, shapes));
+static_assert(offsetof(TensorCreateInfo, is_contiguous) == offsetof(Tensor, is_contiguous));
+static_assert(offsetof(TensorCreateInfo, shapes) == offsetof(Tensor, shapes));

--- a/src/a5/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/a5/platform/include/aicpu/tensor_dump_aicpu.h
@@ -131,11 +131,10 @@ inline void dump_tensors_for_task(
                 info.buffer_addr = t.buffer.addr;
                 info.dtype = static_cast<uint8_t>(t.dtype);
                 info.ndims = static_cast<uint8_t>(t.ndims);
-                const uint32_t *raw_shapes = t.get_raw_shapes();
+                info.start_offset = t.start_offset;
                 for (uint32_t d = 0; d < t.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
                     info.shapes[d] = t.shapes[d];
-                    info.offsets[d] = t.is_all_offset_zero ? 0 : t.offsets[d];
-                    info.raw_shapes[d] = raw_shapes[d];
+                    info.strides[d] = t.strides[d];
                 }
                 info.task_id = slot_state.task->task_id.raw;
                 info.subtask_id = raw_subtask_id;
@@ -224,11 +223,20 @@ inline void dump_tensors_for_task(
         info.func_id = static_cast<uint32_t>(func_id);
         info.arg_index = static_cast<uint32_t>(tensor_arg_index);
         info.buffer_addr = buffer_addrs[tensor_arg_index];
-        for (uint32_t d = 0; d < t.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
+        // TensorInfo (host_build_graph) still carries (raw_shapes, offsets)
+        // implicitly describing a row-major-aligned sub-region. Translate to
+        // (start_offset, strides[]) on the fly:
+        //   strides[d] = prod(raw_shapes[d+1..])
+        //   start_offset = Σ offsets[d] · strides[d]
+        uint64_t s = 1;
+        uint64_t start = 0;
+        for (int32_t d = static_cast<int32_t>(t.ndims) - 1; d >= 0 && d < PLATFORM_DUMP_MAX_DIMS; --d) {
             info.shapes[d] = t.shapes[d];
-            info.offsets[d] = t.offsets[d];
-            info.raw_shapes[d] = t.raw_shapes[d];
+            info.strides[d] = static_cast<int32_t>(s);
+            start += static_cast<uint64_t>(t.offsets[d]) * s;
+            s *= t.raw_shapes[d];
         }
+        info.start_offset = start;
         dump_tensor_record(thread_idx, info);
         tensor_arg_index++;
     }

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -95,17 +95,18 @@ struct alignas(64) TensorDumpRecord {
     uint32_t arg_index;       // Position in PTO2TaskPayload::tensors[]
     uint8_t dtype;            // DataType raw enum value
     uint8_t truncated;        // 1 if payload was truncated (tensor > arena capacity)
-    uint8_t is_contiguous;    // 1 when source view is already contiguous
+    uint8_t is_contiguous;    // 1 when source view is already PyTorch-contiguous
     uint8_t pad0_align;       // Explicit alignment before 64-bit payload offsets
     uint64_t payload_offset;  // Monotonic byte offset into thread arena
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
     uint8_t pad0[24];         // Preserve 64B cache-line layout
 
-    // === Cache line 2 (64B) ===
-    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];      // Current view shape
-    uint32_t offsets[PLATFORM_DUMP_MAX_DIMS];     // Multi-dimensional offsets
-    uint32_t raw_shapes[PLATFORM_DUMP_MAX_DIMS];  // Underlying source layout shape
-    uint8_t pad1[4];                              // Pad to 128 bytes
+    // === Cache line 2 (64B) — strided view descriptor ===
+    // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 + 16 = 64B.
+    uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
+    uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
+    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
+    uint8_t pad1[16];                          // Pad to 128 bytes
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(TensorDumpRecord) == 128, "TensorDumpRecord must be 128 bytes (2 cache lines)");
@@ -239,9 +240,9 @@ struct TensorDumpInfo {
     uint32_t func_id;
     uint32_t arg_index;
     uint64_t buffer_addr;
-    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t offsets[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t raw_shapes[PLATFORM_DUMP_MAX_DIMS];
+    uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
+    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
+    uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)
 };
 
 // =============================================================================

--- a/src/a5/platform/include/host/tensor_dump_collector.h
+++ b/src/a5/platform/include/host/tensor_dump_collector.h
@@ -154,9 +154,9 @@ struct DumpedTensor {
     TensorDumpStage stage;
     uint8_t dtype;
     uint8_t ndims;
-    uint32_t raw_shapes[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];
-    uint32_t offsets[PLATFORM_DUMP_MAX_DIMS];
+    uint64_t start_offset;                     // 1D element offset of the view origin
+    uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
+    uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dim (> 0, type-enforced)
     bool is_contiguous;
     bool truncated;
     bool overwritten;

--- a/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
+++ b/src/a5/platform/src/aicpu/tensor_dump_aicpu.cpp
@@ -255,36 +255,27 @@ static inline uint64_t get_tensor_dump_num_elements(const TensorDumpInfo &info) 
     return elements;
 }
 
+// PyTorch-style contiguous: strides[d] == prod(shapes[d+1..]) for all d.
 static inline bool tensor_dump_is_contiguous(const TensorDumpInfo &info) {
-    if (info.ndims == 0) {
-        return true;
-    }
-    for (uint32_t d = 1; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-        if (info.shapes[d] != info.raw_shapes[d]) {
-            return false;
-        }
+    if (info.ndims == 0) return true;
+    uint64_t expected = 1;
+    for (int32_t d = static_cast<int32_t>(info.ndims) - 1; d >= 0 && d < PLATFORM_DUMP_MAX_DIMS; --d) {
+        if (info.strides[d] != expected) return false;
+        expected *= info.shapes[d];
     }
     return true;
-}
-
-static inline uint64_t tensor_dump_start_offset_elements(const TensorDumpInfo &info) {
-    uint64_t result = 0;
-    uint64_t stride = 1;
-    for (int d = static_cast<int>(info.ndims) - 1; d >= 0; d--) {
-        result += static_cast<uint64_t>(info.offsets[d]) * stride;
-        stride *= info.raw_shapes[d];
-    }
-    return result;
 }
 
 static inline void write_tensor_dump_contiguous_prefix(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint64_t copy_bytes
 ) {
-    uint64_t start_offset = tensor_dump_start_offset_elements(info);
-    const char *src = reinterpret_cast<const char *>(info.buffer_addr) + start_offset * elem_sz;
+    const char *src = reinterpret_cast<const char *>(info.buffer_addr) + info.start_offset * elem_sz;
     writer->write(src, copy_bytes);
 }
 
+// Recursive per-dim gather: at dim d we step shapes[d] times with element step
+// strides[d]. Inner-most dim writes `shapes[d]` contiguous elements (only valid
+// when strides[innermost] == 1 — non-unit innermost stride degrades to per-element).
 static void gather_tensor_dump_dim(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint32_t dim,
     uint64_t base_element_index, uint64_t *remaining_bytes
@@ -293,21 +284,30 @@ static void gather_tensor_dump_dim(
         return;
     }
     if (dim + 1 >= info.ndims) {
-        uint64_t row_start = base_element_index + info.offsets[dim];
-        const char *src = reinterpret_cast<const char *>(info.buffer_addr) + row_start * elem_sz;
-        uint64_t row_bytes = static_cast<uint64_t>(info.shapes[dim]) * elem_sz;
-        uint64_t bytes_to_copy = (row_bytes < *remaining_bytes) ? row_bytes : *remaining_bytes;
-        writer->write(src, bytes_to_copy);
-        *remaining_bytes -= bytes_to_copy;
+        // Innermost dim: if strides[dim] == 1 the row is contiguous in memory and
+        // a single memcpy works. Otherwise emit element-by-element.
+        const uint32_t s = info.strides[dim];
+        if (s == 1) {
+            const char *src = reinterpret_cast<const char *>(info.buffer_addr) + base_element_index * elem_sz;
+            uint64_t row_bytes =
+                static_cast<uint64_t>(info.shapes[dim]) * elem_sz;  // promote first to avoid uint32 overflow
+            uint64_t bytes_to_copy = (row_bytes < *remaining_bytes) ? row_bytes : *remaining_bytes;
+            writer->write(src, bytes_to_copy);
+            *remaining_bytes -= bytes_to_copy;
+        } else {
+            for (uint32_t i = 0; i < info.shapes[dim] && *remaining_bytes >= elem_sz; i++) {
+                uint64_t pos = base_element_index + static_cast<uint64_t>(i) * static_cast<uint64_t>(s);
+                const char *src = reinterpret_cast<const char *>(info.buffer_addr) + pos * elem_sz;
+                writer->write(src, elem_sz);
+                *remaining_bytes -= elem_sz;
+            }
+        }
         return;
     }
 
-    uint64_t inner_stride = 1;
-    for (uint32_t d = dim + 1; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-        inner_stride *= info.raw_shapes[d];
-    }
+    const int32_t s = info.strides[dim];
     for (uint32_t i = 0; i < info.shapes[dim] && *remaining_bytes > 0; i++) {
-        uint64_t next_base = base_element_index + (static_cast<uint64_t>(info.offsets[dim]) + i) * inner_stride;
+        uint64_t next_base = base_element_index + static_cast<uint64_t>(i) * static_cast<uint64_t>(s);
         gather_tensor_dump_dim(writer, info, elem_sz, dim + 1, next_base, remaining_bytes);
     }
 }
@@ -322,9 +322,9 @@ static inline void write_tensor_dump_logical_prefix(
         write_tensor_dump_contiguous_prefix(writer, info, elem_sz, copy_bytes);
         return;
     }
-
+    // Walk the view origin first; per-dim recursion adds (i * strides[d]) for each axis.
     uint64_t remaining_bytes = copy_bytes;
-    gather_tensor_dump_dim(writer, info, elem_sz, 0, 0, &remaining_bytes);
+    gather_tensor_dump_dim(writer, info, elem_sz, 0, info.start_offset, &remaining_bytes);
 }
 
 void dump_tensor_init(int num_dump_threads) {
@@ -438,10 +438,10 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     rec->truncated = truncated ? 1 : 0;
     rec->payload_offset = offset;
     rec->payload_size = copy_bytes;
+    rec->start_offset = info.start_offset;
     for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
-        rec->raw_shapes[d] = info.raw_shapes[d];
         rec->shapes[d] = info.shapes[d];
-        rec->offsets[d] = info.offsets[d];
+        rec->strides[d] = info.strides[d];
     }
     buf->count = idx + 1;
     wmb();

--- a/src/a5/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a5/platform/src/host/tensor_dump_collector.cpp
@@ -252,9 +252,9 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         if (dt.truncated && ++total_truncated_count_ == 1) {
             LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
         }
-        std::memcpy(dt.raw_shapes, rec.raw_shapes, sizeof(dt.raw_shapes));
+        dt.start_offset = rec.start_offset;
         std::memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
-        std::memcpy(dt.offsets, rec.offsets, sizeof(dt.offsets));
+        std::memcpy(dt.strides, rec.strides, sizeof(dt.strides));
 
         if (thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
             ArenaInfo &ai = arenas_[thread_idx];
@@ -566,8 +566,7 @@ int TensorDumpCollector::export_dump_files() {
         uint64_t numel = get_num_elements(dt);
 
         std::string shape_str = dims_to_string(dt.shapes, dt.ndims);
-        std::string raw_shape_str = dims_to_string(dt.raw_shapes, dt.ndims);
-        std::string offsets_str = dims_to_string(dt.offsets, dt.ndims);
+        std::string strides_str = dims_to_string(dt.strides, dt.ndims);
 
         if (!first_entry) json << ",\n";
         first_entry = false;
@@ -577,9 +576,10 @@ int TensorDumpCollector::export_dump_files() {
              << ", \"role\": \"" << tensor_dump_role_name(dt.role) << "\", \"stage\": \""
              << tensor_dump_stage_name(dt.stage) << "\", \"arg_index\": " << dt.arg_index << ", \"dtype\": \""
              << dtype_name << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false")
-             << ", \"shape\": " << shape_str << ", \"raw_shape\": " << raw_shape_str << ", \"offsets\": " << offsets_str
-             << ", \"numel\": " << numel << ", \"bin_offset\": " << dt.bin_offset
-             << ", \"bin_size\": " << dt.payload_size << ", \"truncated\": " << (dt.truncated ? "true" : "false")
+             << ", \"shape\": " << shape_str << ", \"strides\": " << strides_str
+             << ", \"start_offset\": " << dt.start_offset << ", \"numel\": " << numel
+             << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
+             << ", \"truncated\": " << (dt.truncated ? "true" : "false")
              << ", \"overwritten\": " << (dt.overwritten ? "true" : "false") << "}";
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -50,24 +50,11 @@ inline Tensor make_tensor_external(
     void *addr, const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false,
     int32_t version = 0
 ) {
-    static uint32_t zero_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
     uint64_t total = 1;
     for (uint32_t i = 0; i < ndims; i++) {
         total *= shapes[i];
     }
-    return {
-        addr,
-        total * get_element_size(dtype),
-        shapes,
-        shapes,
-        zero_offsets,
-        ndims,
-        dtype,
-        version,
-        /*is_all_offset_zero=*/true,
-        /*is_raw_eq_shapes=*/true,
-        manual_dep
-    };
+    return {addr, total * get_element_size(dtype), shapes, ndims, dtype, version, manual_dep};
 }
 
 // Convert ContinuousTensor to Tensor

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -39,10 +39,6 @@
 #include "pto_task_id.h"
 #include "pto_types.h"
 
-#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
-#include "aicpu/device_time.h"
-#endif
-
 // Spin-wait hint for AICPU threads.  On real hardware the AICPU has dedicated
 // ARM A55 cores — no OS yield is needed, so the hint is a no-op.  In simulation
 // all threads share host CPU cores, so we yield to prevent starvation.
@@ -84,6 +80,10 @@
 
 #if PTO2_TENSORMAP_PROFILING && !PTO2_ORCH_PROFILING
 #error "PTO2_TENSORMAP_PROFILING requires PTO2_ORCH_PROFILING=1"
+#endif
+
+#if PTO2_ORCH_PROFILING || PTO2_SCHED_PROFILING
+#include "aicpu/device_time.h"
 #endif
 
 // =============================================================================
@@ -274,7 +274,6 @@ struct PTO2TaskPayload {
                 tensors[i].owner_task_id = result.task_id();
                 result.materialize_output(tensors[i]);
             }
-            tensors[i].update_start_offset();
         }
         // Round up to cache line boundary. Both arrays are 1024B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h
@@ -71,47 +71,83 @@ extern uint64_t g_insert_count;
 /**
  * TensorMap entry structure — cache-line optimized for lookup
  *
- * Cache line 1 (64B, lookup hot path):
- *   next_in_bucket, producer_task_id, buffer_addr — chain traversal + validity + hash match
- *   version, ndims, is_all_offset_zero, bucket_index — overlap fast path
- *   shapes[5] — overlap comparison
+ * Cache line 1 (64B, lookup hot path) mirrors Tensor cache line 1 byte-for-byte
+ * from byte 16 onward, so that `memcpy(this, &tensor, 64)` populates everything
+ * we need for overlap checks. Bytes [0, 16) carry entry-only fields (hash
+ * bucket head + chain pointer) that overlap Tensor::buffer (addr in [0, 8) is
+ * the hash key, size in [8, 16) is unused by the entry — we repurpose it for
+ * `next_in_bucket`).
  *
- * Cache line 2 (64B, insert/remove/slow-path only):
- *   prev_in_bucket, next_in_task, prev_in_task — chain manipulation
- *   offsets[5] — only read when !is_all_offset_zero
+ *   buffer_addr / next_in_bucket / producer_task_id   — chain traversal + match
+ *   start_offset                                       — overlap byte range begin
+ *   version, ndims, dtype, manual_dep, is_contiguous   — overlap fast path
+ *   shapes[5]                                          — overlap comparison (line 1)
  *
- * When is_all_offset_zero is true, lookup touches only cache line 1.
- * Entry size: 128B (2 cache lines) vs previous 192B (3 cache lines with embedded Tensor).
+ * Cache line 2 (64B, slow-path / non-contiguous overlap):
+ *   prev_in_bucket / next_in_task / prev_in_task       — chain manipulation
+ *   bucket_index                                       — bookkeeping
+ *   extent_elem_cache                                  — overlap byte range end
+ *   strides[5]                                          — reserved for L2 overlap (PR-2)
+ *
+ * When both entry & probe are `is_contiguous && start_offset == 0`, the overlap
+ * check derives `extent_elem = prod(shapes)` from cache line 1 alone.
+ *
+ * Entry size: 128B (2 cache lines), matches Tensor.
  */
 struct alignas(64) PTO2TensorMapEntry {
-    // === Cache line 1 (64B) — lookup hot path ===
-    uint64_t buffer_addr;                // 8B: tensor base address (hash key)
-    PTO2TensorMapEntry *next_in_bucket;  // 8B: next entry in hash bucket chain
-    PTO2TaskId producer_task_id;         // 8B: raw (ring_id << 32) | local_id
-    int32_t bucket_index;                // 4B: bucket index (-1 if unlinked)
-    uint32_t __padding0__;               // 4B: occupies Tensor::start_offset high half
-    int32_t version;                     // 4B: tensor version for overlap detection
-    uint32_t ndims;                      // 4B: number of dimensions
-    DataType __padding_dtype__;          // 1B: occupies Tensor::dtype
-    bool is_all_offset_zero;             // 1B: fast-path flag
-    uint8_t __padding1__[2];
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B: shape per dimension
+    // === Cache line 1 (64B) — lookup hot path; mirrors Tensor line 1 from byte 16 ===
+    uint64_t buffer_addr;                // 8B [0, 8):   tensor base address (hash key, mirrors Tensor::buffer.addr)
+    PTO2TensorMapEntry *next_in_bucket;  // 8B [8, 16):  next entry in hash bucket chain (overlays Tensor::buffer.size)
+    PTO2TaskId producer_task_id;         // 8B [16,24):  mirrors Tensor::owner_task_id slot
+    uint64_t start_offset;               // 8B [24,32):  mirrors Tensor::start_offset (element offset)
+    int32_t version;                     // 4B [32,36):  mirrors Tensor::version
+    uint32_t ndims;                      // 4B [36,40):  mirrors Tensor::ndims
+    DataType dtype;                      // 1B [40,41):  mirrors Tensor::dtype
+    bool manual_dep;                     // 1B [41,42):  mirrors Tensor::manual_dep
+    bool is_contiguous;                  // 1B [42,43):  mirrors Tensor::is_contiguous
+    uint8_t __padding1__;                // 1B [43,44):  mirrors Tensor padding
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // 20B [44,64): mirrors Tensor::shapes
 
-    // === Cache line 2 (64B) — insert/remove/slow-path ===
-    PTO2TensorMapEntry *prev_in_bucket;         // 8B: prev in hash bucket chain
-    PTO2TensorMapEntry *next_in_task;           // 8B: next entry for same task
-    PTO2TensorMapEntry *prev_in_task;           // 8B: prev entry for same task
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];  // 20B: only when !is_all_offset_zero
-    // padding: 20B to fill 64B
+    // === Cache line 2 (64B) — chain manipulation + non-contiguous overlap data ===
+    PTO2TensorMapEntry *prev_in_bucket;         // 8B [64, 72)
+    PTO2TensorMapEntry *next_in_task;           // 8B [72, 80)
+    PTO2TensorMapEntry *prev_in_task;           // 8B [80, 88)
+    int32_t bucket_index;                       // 4B [88, 92): -1 when unlinked
+    uint32_t __padding2__;                      // 4B [92, 96)
+    uint64_t extent_elem_cache;                 // 8B [96,104): non-contiguous extent (mirrors Tensor)
+    uint32_t strides[RUNTIME_MAX_TENSOR_DIMS];  // 20B [104,124): element strides, mirrors Tensor::strides
+    uint8_t __padding3__[4];                    // 4B [124,128)
 
     /**
      * Copy overlap-relevant fields from a Tensor into this entry.
+     *
+     * 64B memcpy of Tensor cache line 1 populates buffer_addr (byte [0,8)),
+     * producer_task_id, start_offset, version, ndims, dtype, manual_dep,
+     * is_contiguous and shapes[]. Byte [8,16) holds Tensor::buffer.size in
+     * the source and gets written into next_in_bucket; that's harmless
+     * because link_entry() overwrites next_in_bucket immediately after.
+     *
+     * Cache line 2 (stride / extent_elem_cache) is derived from line 1 when
+     * the source is canonically contiguous (is_contiguous && start_offset==0),
+     * so the producer Tensor's cache line 2 stays cold during insert. Only
+     * non-contiguous producers pay one extra line 2 read.
      */
     void copy_from_tensor(const Tensor &tensor) {
         memcpy(this, &tensor, 64);
-        if (!tensor.is_all_offset_zero) {
+        if (tensor.is_contiguous && tensor.start_offset == 0) {
+            uint64_t numel = 1;
+            for (uint32_t i = 0; i < tensor.ndims; i++)
+                numel *= tensor.shapes[i];
+            extent_elem_cache = numel;
+            uint32_t s = 1;
+            for (int32_t i = static_cast<int32_t>(tensor.ndims) - 1; i >= 0; i--) {
+                strides[i] = s;
+                s *= tensor.shapes[i];
+            }
+        } else {
+            extent_elem_cache = tensor.extent_elem_cache;
             for (uint32_t i = 0; i < tensor.ndims; i++) {
-                offsets[i] = tensor.offsets[i];
+                strides[i] = tensor.strides[i];
             }
         }
     }
@@ -119,11 +155,51 @@ struct alignas(64) PTO2TensorMapEntry {
     void copy_tensor_create_info(const TensorCreateInfo &tensor_create_info, uint64_t addr) {
         memcpy(this, &tensor_create_info, 64);
         buffer_addr = addr;
+        // Create-info outputs are always contiguous with start_offset = 0;
+        // extent_elem = prod(shapes); stride is row-major.
+        uint64_t numel = 1;
+        for (uint32_t i = 0; i < tensor_create_info.ndims; i++) {
+            numel *= tensor_create_info.shapes[i];
+        }
+        extent_elem_cache = numel;
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(tensor_create_info.ndims) - 1; i >= 0; i--) {
+            strides[i] = s;
+            s *= tensor_create_info.shapes[i];
+        }
+    }
+
+    /**
+     * Effective element extent of this entry.
+     * Contiguous-aligned views compute it from shapes alone (line 1 hit only);
+     * non-contiguous views read the cached value from line 2.
+     */
+    uint64_t effective_extent_elem() const {
+        if (is_contiguous) {
+            uint64_t n = 1;
+            for (uint32_t i = 0; i < ndims; i++)
+                n *= shapes[i];
+            return n;
+        }
+        return extent_elem_cache;
     }
 
     /**
      * Check overlap between input tensor and this entry (the producer output).
-     * Mirrors Tensor::is_overlap() logic but operates on entry fields directly.
+     *
+     * Three-level cascade:
+     *   L1 — O(1) byte-range intersection. Disjoint -> NO_OVERLAP.
+     *   L2 — O(ndims) hyper-rectangle precise check, eligible only when both
+     *        sides share the same canonical row-major axis layout (same
+     *        dtype/ndims/strides[], stride descends as integer multiples,
+     *        start_offset decomposes cleanly under the reference shape).
+     *        Yields NO_OVERLAP / COVERED / OTHER per-dim.
+     *   L3 — Non-hyper-rectangle pairs (transpose/permute mismatch, slice
+     *        with step, etc): conservative OTHER. Exact enumeration via
+     *        contiguous-segment merge is scheduled for a follow-up.
+     *
+     * COVERED is returned when `input` completely contains `entry` per-dim
+     * — dep_compute uses this to retire the now-redundant entry.
      */
     OverlapStatus check_overlap(const Tensor &input) const {
         debug_assert(input.buffer.addr == buffer_addr);
@@ -131,39 +207,113 @@ struct alignas(64) PTO2TensorMapEntry {
         if (input.version > version) {
             return OverlapStatus::OTHER;
         }
-        // Fast path: both have zero offsets → ranges are [0, shape[i])
-        if (input.is_all_offset_zero && is_all_offset_zero) {
-            bool contains = true;
-            for (uint32_t i = 0; i < ndims; i++) {
-                if (input.shapes[i] < shapes[i]) {
-                    contains = false;
-                    break;
-                }
-            }
-            return contains ? OverlapStatus::COVERED : OverlapStatus::OTHER;
+
+        // -------- L1: byte-range intersection (O(1) fast reject) --------
+        const uint64_t in_begin = input.start_offset;
+        const uint64_t in_end = input.start_offset + input.extent_elem();
+        const uint64_t ent_begin = start_offset;
+        const uint64_t ent_end = start_offset + effective_extent_elem();
+        Segment in_range_bytes{in_begin, in_end};
+        Segment ent_range_bytes{ent_begin, ent_end};
+        if (!in_range_bytes.line_segment_intersection(ent_range_bytes)) {
+            return OverlapStatus::NO_OVERLAP;
         }
-        // Slow path: at least one has non-zero offsets
-        bool contains = true;
+
+        // -------- L2 prereqs: same axis layout? --------
+        if (input.dtype != dtype || input.ndims != ndims || ndims == 0) {
+            return OverlapStatus::OTHER;
+        }
         for (uint32_t i = 0; i < ndims; i++) {
-            uint64_t in_off = input.is_all_offset_zero ? 0 : input.offsets[i];
-            uint64_t ent_off = is_all_offset_zero ? 0 : offsets[i];
-            Segment in_range{in_off, in_off + static_cast<uint64_t>(input.shapes[i])};
-            Segment ent_range{ent_off, ent_off + static_cast<uint64_t>(shapes[i])};
-            if (!in_range.line_segment_intersection(ent_range)) {
+            if (input.strides[i] != strides[i]) return OverlapStatus::OTHER;
+        }
+        // strides[ndims-1] must be 1 and strides[i-1] must be an integer
+        // multiple of strides[i] for the row-major reference-shape derivation
+        // below to hold. This rejects slice-with-step (strides[d] != prev factor)
+        // and any view chain that scrambles the axis order. (strides is
+        // uint32_t with the > 0 invariant enforced at construction, so no
+        // sign check needed.)
+        if (strides[ndims - 1] != 1) return OverlapStatus::OTHER;
+        for (uint32_t i = 1; i < ndims; i++) {
+            if (strides[i - 1] % strides[i] != 0) return OverlapStatus::OTHER;
+        }
+
+        // Derive reference shape A from stride. By construction stride is
+        // row-major over A: strides[i] = prod(A[i+1..ndims-1]). So
+        //   A[i] = strides[i-1] / strides[i]   for i >= 1
+        //   A[0] = (buffer.size / dtype_bytes) / strides[0]
+        // input.buffer.size is the storage size; entry shares the same buffer
+        // (debug-asserted by buffer.addr equality at the top), so we read it
+        // from input rather than mirroring buffer.size into the entry.
+        //
+        // Note on buffer padding: runtime allocators may over-allocate
+        // `buffer.size` (cache-line / 1024B alignment, ring-buffer slot
+        // rounding, etc). When that happens, `numel_storage` is larger than
+        // the true logical extent and `ref_shapes[0]` ends up generously over-
+        // sized. This is intentional: ref_shapes is only used as an *upper
+        // bound* in the in-bounds checks below; the actual overlap test (the
+        // per-dim line-segment intersection on the real start_offset /
+        // shapes / stride further down) is unaffected. A larger-than-truth
+        // ref_shapes[0] simply makes the bounds check more permissive — it
+        // can never cause a false NO_OVERLAP nor a false COVERED.
+        uint32_t ref_shapes[RUNTIME_MAX_TENSOR_DIMS] = {};
+        for (uint32_t i = 1; i < ndims; i++) {
+            ref_shapes[i] = strides[i - 1] / strides[i];
+        }
+        const uint64_t elem_size = get_element_size(dtype);
+        if (elem_size == 0) return OverlapStatus::OTHER;
+        const uint64_t numel_storage = input.buffer.size / elem_size;
+        const uint32_t stride0 = strides[0];  // > 0 by Tensor invariant
+        if (numel_storage % stride0 != 0) return OverlapStatus::OTHER;
+        ref_shapes[0] = static_cast<uint32_t>(numel_storage / stride0);
+
+        // Decompose start_offset into row-major multi-dim offsets. By the same
+        // relation strides[i] = prod(ref_shapes[i+1..]) so dividing by strides[i]
+        // (no inner loop) yields each axis offset directly.
+        uint32_t in_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+        uint32_t ent_offsets[RUNTIME_MAX_TENSOR_DIMS] = {};
+        uint64_t in_remain = input.start_offset;
+        uint64_t ent_remain = start_offset;
+        for (uint32_t i = 0; i < ndims; i++) {
+            const uint32_t s = strides[i];
+            in_offsets[i] = static_cast<uint32_t>(in_remain / s);
+            ent_offsets[i] = static_cast<uint32_t>(ent_remain / s);
+            in_remain %= s;
+            ent_remain %= s;
+        }
+        if (in_remain != 0 || ent_remain != 0) return OverlapStatus::OTHER;
+
+        // Validate that each side fits within ref_shapes (defense in depth —
+        // a well-formed view always satisfies this).
+        for (uint32_t i = 0; i < ndims; i++) {
+            if (static_cast<uint64_t>(in_offsets[i]) + input.shapes[i] > ref_shapes[i]) return OverlapStatus::OTHER;
+            if (static_cast<uint64_t>(ent_offsets[i]) + shapes[i] > ref_shapes[i]) return OverlapStatus::OTHER;
+        }
+
+        // -------- L2 core: per-dim line-segment intersection --------
+        bool input_contains_entry = true;
+        for (uint32_t i = 0; i < ndims; i++) {
+            Segment in_seg{in_offsets[i], static_cast<uint64_t>(in_offsets[i]) + input.shapes[i]};
+            Segment ent_seg{ent_offsets[i], static_cast<uint64_t>(ent_offsets[i]) + shapes[i]};
+            if (!in_seg.line_segment_intersection(ent_seg)) {
                 return OverlapStatus::NO_OVERLAP;
-            } else if (!in_range.contains(ent_range)) {
-                contains = false;
+            }
+            if (!in_seg.contains(ent_seg)) {
+                input_contains_entry = false;
             }
         }
-        return contains ? OverlapStatus::COVERED : OverlapStatus::OTHER;
+        return input_contains_entry ? OverlapStatus::COVERED : OverlapStatus::OTHER;
     }
 };
 
 static_assert(sizeof(PTO2TensorMapEntry) == 128, "TensorMapEntry must be exactly 2 cache lines (128 bytes)");
 static_assert(offsetof(PTO2TensorMapEntry, buffer_addr) == offsetof(Tensor, buffer.addr));
+static_assert(offsetof(PTO2TensorMapEntry, producer_task_id) == offsetof(Tensor, owner_task_id));
+static_assert(offsetof(PTO2TensorMapEntry, start_offset) == offsetof(Tensor, start_offset));
 static_assert(offsetof(PTO2TensorMapEntry, version) == offsetof(Tensor, version));
 static_assert(offsetof(PTO2TensorMapEntry, ndims) == offsetof(Tensor, ndims));
-static_assert(offsetof(PTO2TensorMapEntry, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
+static_assert(offsetof(PTO2TensorMapEntry, dtype) == offsetof(Tensor, dtype));
+static_assert(offsetof(PTO2TensorMapEntry, manual_dep) == offsetof(Tensor, manual_dep));
+static_assert(offsetof(PTO2TensorMapEntry, is_contiguous) == offsetof(Tensor, is_contiguous));
 static_assert(offsetof(PTO2TensorMapEntry, shapes) == offsetof(Tensor, shapes));
 static_assert(
     offsetof(PTO2TensorMapEntry, prev_in_bucket) == 64, "TensorMapEntry must be exactly 2 cache lines (128 bytes)"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor.h
@@ -53,12 +53,12 @@ struct Segment {
  * TensorCreateInfo — submit-time create-info for runtime-allocated outputs.
  *
  * Carries the metadata required to materialize a fresh contiguous output:
- * dtype, ndims, raw_shapes (== shapes), manual_dep, and an optional
- * initial value fill.
+ * dtype, ndims, shapes, manual_dep, and an optional initial value fill.
  *
- * Layout (64B) is aligned with Tensor cacheline 1 so that
- * init_from_create_info() can copy the entire cacheline with a single memcpy,
- * then overwrite buffer/owner metadata and refresh start_offset later.
+ * Layout (64B) is aligned with Tensor cache line 1 so that
+ * init_from_create_info() can copy the entire cache line with a single memcpy,
+ * then overwrite buffer/owner metadata and compute the contiguous stride in
+ * cache line 2.
  *
  * Arg::add_output() stores a pointer to this object, so the original
  * must remain valid (not a temporary) until after the submit call.
@@ -66,18 +66,20 @@ struct Segment {
 class alignas(64) TensorCreateInfo {
 public:
     TensorCreateInfo(
-        const uint32_t shapes[], uint32_t ndims, DataType dtype = DataType::FLOAT32, bool manual_dep = false
+        const uint32_t shapes_in[], uint32_t ndims_in, DataType dtype_in = DataType::FLOAT32, bool manual_dep_in = false
     ) :
         initial_value(0),
         has_initial_value(false),
+        __pad2__(0),
+        start_offset(0),  // mirrors Tensor::start_offset; pre-zeroed for create-info outputs
         version(0),
-        ndims(ndims),
-        dtype(dtype),
-        is_all_offset_zero(true),
-        is_raw_eq_shapes(true),
-        manual_dep(manual_dep) {
-        for (uint32_t i = 0; i < ndims; i++) {
-            raw_shapes[i] = shapes[i];
+        ndims(ndims_in),
+        dtype(dtype_in),
+        manual_dep(manual_dep_in),
+        is_contiguous(true),  // mirrors Tensor::is_contiguous; pre-set for create-info outputs
+        __pad_flags__(0) {
+        for (uint32_t i = 0; i < ndims_in; i++) {
+            shapes[i] = shapes_in[i];
         }
     }
 
@@ -92,7 +94,7 @@ public:
     uint64_t buffer_size_bytes() const {
         uint64_t total = 1;
         for (uint32_t i = 0; i < ndims; i++) {
-            total *= raw_shapes[i];
+            total *= shapes[i];
         }
         return total * get_element_size(dtype);
     }
@@ -101,21 +103,21 @@ public:
     // --- Bytes [0, 32): TensorCreateInfo-only fields ---
     // These occupy the same positions as Tensor::buffer, Tensor::owner_task_id,
     // and Tensor::start_offset. The runtime overwrites owner metadata after the
-    // memcpy and refreshes start_offset during payload materialization.
+    // memcpy and recomputes start_offset / stride during payload materialization.
     uint64_t initial_value;
     bool has_initial_value;
     uint8_t __pad1__[7];
-    uint64_t __pad2__;  // → Tensor::owner_task_id
-    uint64_t __pad3__;  // → Tensor::start_offset (zeroed)
+    uint64_t __pad2__;      // → Tensor::owner_task_id (overwritten post-memcpy)
+    uint64_t start_offset;  // mirrors Tensor::start_offset; always 0 for create-info outputs
 
-    // --- Bytes [32, 64): Matches Tensor cacheline 1 layout ---
+    // --- Bytes [32, 64): Matches Tensor cache line 1 layout ---
     int32_t version;  // Always 0 for create-info outputs
     uint32_t ndims;
     DataType dtype;
-    bool is_all_offset_zero;  // Always true for create-info outputs
-    bool is_raw_eq_shapes;    // Always true for create-info outputs
     bool manual_dep;
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // → Tensor::shapes
+    bool is_contiguous;  // Always true for create-info outputs
+    uint8_t __pad_flags__;
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // → Tensor::shapes
 
     TensorCreateInfo() = default;
 
@@ -127,24 +129,30 @@ static_assert(sizeof(TensorCreateInfo) == 64);
 /**
  * Tensor descriptor for Task input/output (128B = 2 cache lines)
  *
- * Describes a memory access pattern on Global Memory (GM) using
- * raw_shapes (underlying buffer dimensions), shapes (current view dimensions),
- * and offsets (multi-dimensional offset into the buffer).
+ * Describes a strided memory access pattern on Global Memory (GM) using:
+ *   - `buffer`: underlying memory allocation (addr/size in bytes)
+ *   - `start_offset`: 1D element offset of the view origin from `buffer.addr`
+ *   - `shapes[i]`, `strides[i]`: per-dim view shape and **element** stride
  *
- * - `buffer` contains the underlying memory allocation (addr in bytes, size in bytes)
- * - `raw_shapes[]`, `shapes[]`, `offsets[]` are in ELEMENTS
- * - `dtype` specifies element type for interpreting buffer contents
+ * Stride semantics:
+ *   - Element-granularity (matches start_offset). Byte offset of element
+ *     `coords[]` is `(start_offset + Σ coords[i] · strides[i]) · dtype_bytes`.
+ *   - strides[i] > 0 STRICTLY. Broadcast (stride=0) and negative slice step
+ *     (stride<0) are NOT supported.
  *
- * Fast-path flags (all on cache line 1):
- * - is_all_offset_zero: when true, offsets[] are implicitly zero — skip offset read/write
- * - is_raw_eq_shapes: when true, raw_shapes[] == shapes[] — skip raw_shapes read/write,
- *   use shapes[] wherever raw_shapes would be needed
- * - manual_dep: when true, keep creator retention only and skip OverlapMap dependency tracking
+ * Fast-path flags on cache line 1:
+ *   - manual_dep: when true, dependency tracking is creator-only (skip OverlapMap)
+ *   - is_contiguous: cached PyTorch-style contiguous flag — i.e.
+ *     `strides[i] == prod(shapes[i+1..ndims-1])`. When true AND start_offset==0,
+ *     all hot paths can compute extent_elem from `shapes` alone and never read
+ *     cache line 2. NOTE: this is strictly tighter than the pre-#808
+ *     `shapes[i] == raw_shapes[i]` test, but equivalent on every view the old
+ *     (raw_shapes-based) encoding could express; the two only diverge on
+ *     post-#808-only views (transpose / permute / slice-with-step results).
  *
- * When BOTH flags are true, cache line 2 is never accessed.
- *
- * Layout: cache line 1 holds hot-path fields (buffer, owner_task_id, start_offset,
- * version, ndims, dtype, flags, shapes); cache line 2 holds warm-path fields (raw_shapes, offsets).
+ * Layout: cache line 1 holds hot-path fields (buffer, owner_task_id,
+ * start_offset, version, ndims, dtype, flags, shapes); cache line 2 holds
+ * stride + cached extent_elem.
  *
  * Construction:
  * Users cannot default-construct or directly construct a Tensor.
@@ -152,142 +160,148 @@ static_assert(sizeof(TensorCreateInfo) == 64);
  *   - make_tensor_external(...)
  *   - from_tensor_arg(...)
  *   - TaskOutputTensors returned by submit(...)
- *   - Tensor::view() / reshape() / transpose() on an existing valid Tensor
+ *   - Tensor::view() / reshape() / transpose() / permute() / slice() on an existing valid Tensor
  */
 struct alignas(64) Tensor {
     // === Cache line 1 (64B) — hot path ===
     PTOBufferHandle buffer;    // Underlying memory buffer (addr in bytes, size in bytes)
     PTO2TaskId owner_task_id;  // Creator task; PTO2TaskId::invalid() for external tensors
-    uint64_t start_offset;     // Cached 1D element offset (precomputed from raw_shapes + offsets)
+    uint64_t start_offset;     // 1D ELEMENT offset of the view origin into `buffer`
     int32_t version;           // Tensor version for overlap detection
     uint32_t ndims;            // Number of dimensions used
     DataType dtype;            // Data type of tensor elements
-    bool is_all_offset_zero;   // True when all offsets[] are zero (skip offset read/write)
-    bool is_raw_eq_shapes;     // True when raw_shapes[] == shapes[] (skip raw_shapes read/write)
     bool manual_dep;           // True when dependency tracking is creator-only (skip OverlapMap lookup/insert)
-    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension
+    bool is_contiguous;        // Cached: strides[] == row_major_stride(shapes)
+    uint8_t _pad_cl1;          // Pad to align shapes[5] at byte 44
+    uint32_t shapes[RUNTIME_MAX_TENSOR_DIMS];  // Current view shape per dimension (elements)
 
-    // === Cache line 2 (64B) — warm path ===
-    uint32_t raw_shapes[RUNTIME_MAX_TENSOR_DIMS];  // Underlying buffer shape per dimension
-    uint32_t offsets[RUNTIME_MAX_TENSOR_DIMS];     // Multi-dimensional offset per dimension
-    uint8_t _pad_cl2[24];                          // Tail padding (bytes 104–127)
+    // === Cache line 2 (64B) — warm path (view metadata) ===
+    // Field order: place the 8B-aligned cache before the 4B-aligned strides[]
+    // to avoid 4B padding between them (sizeof(Tensor) must stay 128).
+    uint64_t extent_elem_cache;                 // Cached extent_elem (see extent_elem()); maintained by ops
+    uint32_t strides[RUNTIME_MAX_TENSOR_DIMS];  // Element stride per dimension; ALWAYS > 0 (type-enforced)
+    uint8_t _pad_cl2[36];                       // Reserved for future extension
 
-    // --- Copy / move / destroy are public (valid tensors can be freely copied) ---
+    // --- Copy / move / destroy ---
+    // Kept trivially copyable (default copy = byte-for-byte) so other modules
+    // (PTO2TensorMapEntry::copy_from_tensor, TensorCreateInfo memcpy path)
+    // can rely on memcpy semantics. The contiguous fast-path optimization
+    // lives in `init(const Tensor&)`; call sites that care should use
+    // `result.init(*this)` instead of the default copy ctor.
     Tensor(const Tensor &) = default;
     Tensor &operator=(const Tensor &) = default;
     Tensor(Tensor &&) = default;
     Tensor &operator=(Tensor &&) = default;
     ~Tensor() = default;
 
-    /// Return the effective raw_shapes pointer (shapes[] when is_raw_eq_shapes).
-    /// Avoids cache line 2 access for the common case.
-    const uint32_t *get_raw_shapes() const { return is_raw_eq_shapes ? shapes : raw_shapes; }
+    // ========================================================================
+    // Accessors / helpers
+    // ========================================================================
 
-    // --- Initialization (operates on already-constructed Tensor) ---
-    void init(
-        void *addr, uint64_t buffer_size_bytes, const uint32_t in_raw_shapes[], const uint32_t in_shapes[],
-        const uint32_t in_offsets[], uint32_t in_ndims, DataType in_dtype, int32_t in_version,
-        bool in_is_all_offset_zero = false, bool in_is_raw_eq_shapes = false, bool in_manual_dep = false
+    /// Number of logical elements covered by the view (NOT the extent).
+    /// ndims > 0 is a construction-time invariant (see init_external /
+    /// init_from_create_info), so the loop always runs at least once.
+    uint64_t numel() const {
+        uint64_t total = 1;
+        for (uint32_t i = 0; i < ndims; i++)
+            total *= shapes[i];
+        return total;
+    }
+
+    /// Element extent — the smallest M such that every reachable element lies in [start_offset, start_offset+M).
+    /// For strides[i]>0: extent_elem = 1 + Σ (shapes[i]-1) · strides[i].
+    uint64_t extent_elem() const {
+        if (is_contiguous) return numel();  // fast path: line 2 not needed when contiguous
+        return extent_elem_cache;
+    }
+
+    // ========================================================================
+    // Initialization (operates on already-constructed Tensor)
+    // ========================================================================
+
+    /// Initialize as a contiguous tensor that covers `shapes[]` starting at `addr`.
+    /// stride is set to row_major(shapes); start_offset = 0; is_contiguous = true.
+    /// Enforces the ndims > 0 invariant relied upon by every downstream op.
+    void init_external(
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_shapes[], uint32_t in_ndims, DataType in_dtype,
+        int32_t in_version, bool in_manual_dep = false
     ) {
+        always_assert(in_ndims > 0 && in_ndims <= RUNTIME_MAX_TENSOR_DIMS);
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size_bytes};
         ndims = in_ndims;
         dtype = in_dtype;
         version = in_version;
-        is_all_offset_zero = in_is_all_offset_zero;
-        is_raw_eq_shapes = in_is_raw_eq_shapes;
         manual_dep = in_manual_dep;
-        for (uint32_t i = 0; i < in_ndims; i++) {
-            shapes[i] = in_shapes[i];
-        }
-        if (!in_is_raw_eq_shapes) {
-            for (uint32_t i = 0; i < in_ndims; i++) {
-                raw_shapes[i] = in_raw_shapes[i];
-            }
-        }
-        if (!in_is_all_offset_zero) {
-            for (uint32_t i = 0; i < in_ndims; i++) {
-                offsets[i] = in_offsets[i];
-            }
-        }
+        is_contiguous = true;
+        _pad_cl1 = 0;
+        start_offset = 0;
         owner_task_id = PTO2TaskId::invalid();
+        // Single reverse pass: write shapes, accumulate row-major stride, and
+        // track numel — `s` ends as prod(shapes) which is also extent_elem
+        // for a contiguous view.
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(in_ndims) - 1; i >= 0; --i) {
+            shapes[i] = in_shapes[i];
+            strides[i] = s;
+            s *= in_shapes[i];
+        }
+        extent_elem_cache = s;
     }
 
-    void init(const Tensor &other) {
-        memcpy(this, &other, 64);  // fast copy cache line 1
-        if (!other.is_raw_eq_shapes) {
-            for (uint32_t i = 0; i < other.ndims; i++) {
-                raw_shapes[i] = other.raw_shapes[i];
+    /// Deep copy with contiguous fast-path optimization.
+    ///
+    /// Always copies cache line 1 (always needed: buffer, shapes, dtype, ...).
+    /// When `other` is in canonical contiguous form (is_contiguous &&
+    /// start_offset == 0), cache line 2 (stride / extent_elem_cache) is fully
+    /// derivable from line 1, so we **skip reading other's cache line 2** and
+    /// write dst's line 2 from the local shapes instead. Non-contiguous source
+    /// pays one line 2 read; contiguous source does not.
+    void init_from(const Tensor &other) {
+        init_from_line1(other);
+        if (other.is_contiguous && other.start_offset == 0) {
+            // Derive line 2 from line 1: stride = row-major of shapes; extent = numel.
+            uint32_t s = 1;
+            for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
+                strides[i] = s;
+                s *= shapes[i];
             }
-        }
-        if (!other.is_all_offset_zero) {
-            for (uint32_t i = 0; i < other.ndims; i++) {
-                offsets[i] = other.offsets[i];
-            }
-        }
-    }
-
-    void init_with_view(
-        const Tensor &other, const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false
-    ) {
-        buffer = other.buffer;
-        ndims = other.ndims;
-        dtype = other.dtype;
-        version = other.version;
-        manual_dep = in_manual_dep;
-        // view always diverges shapes from raw_shapes, so is_raw_eq_shapes = false.
-        // Read parent's effective raw_shapes (avoids parent cache line 2 when parent is_raw_eq_shapes).
-        is_raw_eq_shapes = false;
-        const uint32_t *parent_raw = other.get_raw_shapes();
-        for (uint32_t i = 0; i < ndims; i++) {
-            raw_shapes[i] = parent_raw[i];
-            shapes[i] = view_shapes[i];
-        }
-        // Compute offsets and zero-flag
-        bool all_zero = true;
-        if (other.is_all_offset_zero) {
-            for (uint32_t i = 0; i < ndims; i++) {
-                if (view_offsets[i] != 0) {
-                    all_zero = false;
-                    break;
-                }
-            }
-            if (!all_zero) {
-                for (uint32_t i = 0; i < ndims; i++) {
-                    offsets[i] = view_offsets[i];
-                }
-            }
+            extent_elem_cache = s;
         } else {
-            all_zero = false;
-            for (uint32_t i = 0; i < ndims; i++) {
-                offsets[i] = other.offsets[i] + view_offsets[i];
+            extent_elem_cache = other.extent_elem_cache;
+            for (uint32_t i = 0; i < other.ndims; i++) {
+                strides[i] = other.strides[i];
             }
+            // _pad_cl2 left stale on purpose — reserved bytes are not
+            // semantically read by any consumer.
         }
-        is_all_offset_zero = all_zero;
-        owner_task_id = other.owner_task_id;
     }
 
-    /// Compute 1D flat element offset from multi-dimensional indices.
-    /// Uses Horner's method (forward traversal, no stride variable).
-    uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
-        if (in_ndims == 0) return 0;
-        const uint32_t *rs = get_raw_shapes();
-        uint64_t offset = 0;
-        if (is_all_offset_zero) {
-            for (uint32_t d = 0; d < in_ndims; d++)
-                offset = offset * rs[d] + indices[d];
-        } else {
-            for (uint32_t d = 0; d < in_ndims; d++)
-                offset = offset * rs[d] + indices[d] + offsets[d];
-        }
-        return offset;
-    }
+    /// View ops use this: copy cache line 1 only, leaving cache line 2 (stride,
+    /// extent_elem_cache) untouched. The op then mutates shapes / start_offset
+    /// in place and calls `refresh_derived()` to recompute line 2 once. This
+    /// avoids the wasted line 2 writes that `init_from()` would do just before
+    /// the op overwrites them.
+    void init_from_line1(const Tensor &other) { memcpy(this, &other, 64); }
+
+    /// Backward-compat alias used by orchestrator hot paths that need a full
+    /// deep copy. Equivalent to `init_from(other)`.
+    void copy(const Tensor &other) { init_from(other); }
 
     /// Materialize a TensorCreateInfo into this Tensor (fresh contiguous output).
-    /// Single 64B memcpy covers the entire cacheline 1, then buffer is overwritten.
+    /// Single 64B memcpy covers cache line 1; ci pre-initialises start_offset (=0)
+    /// and is_contiguous (=true) in its line-1 slots so they need no reset here.
+    /// Cache line 2 (stride/extent) is computed from `ci.shapes` in a single reverse pass.
     void init_from_create_info(const TensorCreateInfo &ci, void *addr, uint64_t buffer_size) {
+        always_assert(ci.ndims > 0 && ci.ndims <= RUNTIME_MAX_TENSOR_DIMS);
         memcpy(this, &ci, 64);
         buffer = {reinterpret_cast<uint64_t>(addr), buffer_size};
         owner_task_id = PTO2TaskId::invalid();  // caller (orchestrator) overwrites with actual task_id
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
+            strides[i] = s;
+            s *= shapes[i];
+        }
+        extent_elem_cache = s;
         if (ci.has_initial_value) {
             fill_initial_value(ci.initial_value);
         }
@@ -310,96 +324,135 @@ struct alignas(64) Tensor {
         }
     }
 
-    // --- Operations ---
-    void update_start_offset() {
-        if (is_all_offset_zero) {
-            start_offset = 0;
-            return;
+    // ========================================================================
+    // Address / offset computation
+    // ========================================================================
+
+    /// Compute 1D flat ELEMENT offset of `indices[]` from `buffer.addr`.
+    /// Callers multiply by `get_element_size(dtype)` to obtain a byte offset.
+    /// Works for any view (transpose / permute / slice / reshape).
+    uint64_t compute_flat_offset(const uint32_t indices[], uint32_t in_ndims) const {
+        uint64_t elem_off = start_offset;
+        for (uint32_t d = 0; d < in_ndims; d++) {
+            elem_off += static_cast<uint64_t>(indices[d]) * static_cast<uint64_t>(strides[d]);
         }
-        const uint32_t *rs = get_raw_shapes();
-        uint64_t result = 0;
-        uint64_t stride = 1;
-        for (int i = static_cast<int>(ndims) - 1; i >= 0; i--) {
-            result += offsets[i] * stride;
-            stride *= rs[i];
-        }
-        start_offset = result;
+        return elem_off;
     }
 
-    void copy(const Tensor &other) { init(other); }
+    // ========================================================================
+    // View operations (zero-copy metadata rewrites)
+    // ========================================================================
 
-    Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool manual_dep = false) const {
+    /// Sub-tensor at per-dim offsets, with new per-dim shape.
+    /// Updates start_offset += Σ off[i]·strides[i]; shapes := new_shape; stride unchanged.
+    /// Each (offset[i], new_shape[i]) must stay within the current shapes[i] —
+    /// i.e. a view cannot expand any dimension beyond what the parent view sees.
+    Tensor view(const uint32_t view_shapes[], const uint32_t view_offsets[], bool in_manual_dep = false) const {
         Tensor result;
-        result.init_with_view(*this, view_shapes, view_offsets, manual_dep);
-        return result;
-    }
-
-    bool is_contiguous() const {
-        if (is_raw_eq_shapes || ndims == 0) {
-            return true;
+        // Copy line 1 only; stride from *this is still in result's line 2 garbage
+        // — we need to bring it forward explicitly since view keeps stride.
+        result.init_from_line1(*this);
+        for (uint32_t i = 0; i < ndims; i++) {
+            debug_assert(view_offsets[i] + view_shapes[i] <= shapes[i]);
+            result.start_offset += static_cast<uint64_t>(view_offsets[i]) * static_cast<uint64_t>(strides[i]);
+            result.shapes[i] = view_shapes[i];
+            result.strides[i] = strides[i];
         }
-        for (uint32_t i = 1; i < ndims; i++) {
-            if (shapes[i] != raw_shapes[i]) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    bool valid_reshape(const uint32_t new_shapes[], uint32_t new_ndims) const {
-        uint64_t x = numel();
-        uint64_t y = 1;
-        for (uint32_t i = 0; i < new_ndims; i++) {
-            y *= new_shapes[i];
-        }
-        return x == y;
-    }
-
-    Tensor reshape(const uint32_t new_shapes[], uint32_t new_ndims, bool manual_dep = false) const {
-        debug_assert(valid_reshape(new_shapes, new_ndims));
-        always_assert(is_contiguous());
-        Tensor result;
-        result.copy(*this);
-        result.ndims = new_ndims;
-        result.is_all_offset_zero = true;
-        result.is_raw_eq_shapes = true;
-        result.manual_dep = manual_dep;
-        for (uint32_t i = 0; i < new_ndims; i++) {
-            result.shapes[i] = new_shapes[i];
-        }
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
+        result.assert_in_buffer_bounds();
         return result;
     }
 
     bool valid_transpose(uint32_t x, uint32_t y) const { return x < ndims && y < ndims; }
 
-    Tensor transpose(uint32_t x, uint32_t y, bool manual_dep = false) const {
+    /// Swap two dimensions: shapes/stride swapped together. start_offset unchanged.
+    Tensor transpose(uint32_t x, uint32_t y, bool in_manual_dep = false) const {
         debug_assert(valid_transpose(x, y));
         Tensor result;
-        result.copy(*this);
-        result.manual_dep = manual_dep;
-        // transpose swaps the same dims in both arrays, so equality is preserved
+        result.init_from_line1(*this);
+        // Carry forward source's stride before swapping (line 2 was not memcpy'd).
+        for (uint32_t i = 0; i < ndims; i++)
+            result.strides[i] = strides[i];
         std::swap(result.shapes[x], result.shapes[y]);
-        if (!result.is_raw_eq_shapes) {
-            std::swap(result.raw_shapes[x], result.raw_shapes[y]);
-        }
-        if (!result.is_all_offset_zero) {
-            std::swap(result.offsets[x], result.offsets[y]);
-        }
+        std::swap(result.strides[x], result.strides[y]);
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
         return result;
     }
 
-    uint64_t numel() const {
-        if (ndims == 0) {
-            return 0;
-        }
-        uint64_t total = 1;
+    /// Permute dimensions according to `order[]` (length = ndims).
+    /// Both shapes and stride are reordered in-place; start_offset unchanged.
+    Tensor permute(const uint32_t order[], bool in_manual_dep = false) const {
+        Tensor result;
+        result.init_from_line1(*this);
         for (uint32_t i = 0; i < ndims; i++) {
-            total *= shapes[i];
+            debug_assert(order[i] < ndims);
+            result.shapes[i] = shapes[order[i]];
+            result.strides[i] = strides[order[i]];
         }
-        return total;
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
+        return result;
     }
 
-    bool is_same_memref(const Tensor &other) const { return buffer.addr == other.buffer.addr; }
+    /// Slice dimension `dim` with `[start, end)` and positive `step`.
+    /// strides[dim] *= step; shapes[dim] = ⌈(end-start)/step⌉; start_offset += start·strides[dim_old].
+    Tensor slice(uint32_t dim, uint32_t start, uint32_t end, uint32_t step = 1, bool in_manual_dep = false) const {
+        debug_assert(dim < ndims);
+        debug_assert(step >= 1);
+        debug_assert(end > start);
+        debug_assert(end <= shapes[dim]);
+        Tensor result;
+        result.init_from_line1(*this);
+        // Carry forward source's stride before patching the sliced dim.
+        for (uint32_t i = 0; i < ndims; i++)
+            result.strides[i] = strides[i];
+        const uint32_t old_stride_d = strides[dim];
+        result.start_offset += static_cast<uint64_t>(start) * static_cast<uint64_t>(old_stride_d);
+        const uint32_t new_len = (end - start + step - 1) / step;
+        result.shapes[dim] = new_len;
+        result.strides[dim] = static_cast<uint32_t>(static_cast<uint64_t>(old_stride_d) * step);
+        result.manual_dep = in_manual_dep;
+        result.refresh_derived();
+        result.assert_in_buffer_bounds();
+        return result;
+    }
+
+    bool valid_reshape(const uint32_t new_shapes[], uint32_t new_ndims) const {
+        uint64_t x = numel();
+        uint64_t y = 1;
+        for (uint32_t i = 0; i < new_ndims; i++)
+            y *= new_shapes[i];
+        return x == y;
+    }
+
+    /// Reshape — zero-copy only if source is_contiguous; otherwise asserts.
+    /// Materialize fallback (allocating a contiguous copy) is NOT in this op;
+    /// callers must reach contiguous via a copy before calling reshape on a
+    /// non-contiguous view.
+    Tensor reshape(const uint32_t new_shapes[], uint32_t new_ndims, bool in_manual_dep = false) const {
+        debug_assert(valid_reshape(new_shapes, new_ndims));
+        always_assert(is_contiguous);
+        Tensor result;
+        result.init_from_line1(*this);
+        result.ndims = new_ndims;
+        result.manual_dep = in_manual_dep;
+        // Single reverse pass: write new shapes, accumulate row-major stride, track numel.
+        uint32_t s = 1;
+        for (int32_t i = static_cast<int32_t>(new_ndims) - 1; i >= 0; --i) {
+            result.shapes[i] = new_shapes[i];
+            result.strides[i] = s;
+            s *= new_shapes[i];
+        }
+        result.is_contiguous = true;
+        result.extent_elem_cache = s;
+        return result;
+    }
+
+    // ========================================================================
+    // Dump for diagnostics
+    // ========================================================================
 
     std::string dump() const {
         std::stringstream ss;
@@ -410,30 +463,18 @@ struct alignas(64) Tensor {
         ss << indent << "dtype: " << get_dtype_name(dtype) << '\n';
         ss << indent << "ndims: " << ndims << '\n';
         ss << indent << "version: " << version << '\n';
-
-        const uint32_t *rs = get_raw_shapes();
-        ss << indent << "raw_shapes: [";
-        for (uint32_t i = 0; i < ndims; i++) {
-            if (i > 0) {
-                ss << ", ";
-            }
-            ss << rs[i];
-        }
-        ss << "]" << '\n';
+        ss << indent << "start_offset: " << start_offset << " (elements)" << '\n';
+        ss << indent << "is_contiguous: " << (is_contiguous ? "true" : "false") << '\n';
         ss << indent << "shapes: [";
         for (uint32_t i = 0; i < ndims; i++) {
-            if (i > 0) {
-                ss << ", ";
-            }
+            if (i > 0) ss << ", ";
             ss << shapes[i];
         }
         ss << "]" << '\n';
-        ss << indent << "offsets: [";
+        ss << indent << "strides: [";
         for (uint32_t i = 0; i < ndims; i++) {
-            if (i > 0) {
-                ss << ", ";
-            }
-            ss << (is_all_offset_zero ? 0u : offsets[i]);
+            if (i > 0) ss << ", ";
+            ss << strides[i];
         }
         ss << "]" << '\n';
         ss << "}" << '\n';
@@ -446,14 +487,40 @@ private:
     Tensor() = default;
 
     Tensor(
-        void *addr, uint64_t buffer_size_bytes, const uint32_t raw_shapes[], const uint32_t shapes[],
-        const uint32_t offsets[], uint32_t ndims, DataType dtype, int32_t version, bool is_all_offset_zero = false,
-        bool is_raw_eq_shapes = false, bool manual_dep = false
+        void *addr, uint64_t buffer_size_bytes, const uint32_t in_shapes[], uint32_t in_ndims, DataType in_dtype,
+        int32_t in_version, bool in_manual_dep = false
     ) {
-        init(
-            addr, buffer_size_bytes, raw_shapes, shapes, offsets, ndims, dtype, version, is_all_offset_zero,
-            is_raw_eq_shapes, manual_dep
-        );
+        init_external(addr, buffer_size_bytes, in_shapes, in_ndims, in_dtype, in_version, in_manual_dep);
+    }
+
+    // ------------------------------------------------------------------------
+    // Internal helpers
+    // ------------------------------------------------------------------------
+
+    /// Recompute extent_elem_cache and is_contiguous from current shapes / stride.
+    /// Called after any op that mutates view metadata. Single reverse pass:
+    ///   extent_elem += (shapes[i] - 1) · strides[i]
+    ///   is_contiguous &&= (strides[i] == prod(shapes[i+1..]))
+    void refresh_derived() {
+        uint64_t e = 1;
+        uint64_t expected = 1;
+        bool contig = true;
+        for (int32_t i = static_cast<int32_t>(ndims) - 1; i >= 0; --i) {
+            if (strides[i] != expected) contig = false;
+            if (shapes[i] > 0) {
+                e += static_cast<uint64_t>(shapes[i] - 1) * static_cast<uint64_t>(strides[i]);
+            }
+            expected *= shapes[i];
+        }
+        extent_elem_cache = e;
+        is_contiguous = contig;
+    }
+
+    /// Assert the view stays inside the underlying buffer (byte-range safety).
+    void assert_in_buffer_bounds() const {
+        const uint64_t elem_size = get_element_size(dtype);
+        const uint64_t buffer_elems = buffer.size / elem_size;
+        debug_assert(start_offset + extent_elem_cache <= buffer_elems);
     }
 
     // Friends that need to construct Tensors
@@ -464,16 +531,23 @@ private:
 };
 
 static_assert(sizeof(Tensor) == 128, "Tensor must be exactly 2 cache lines (128 bytes)");
-static_assert(offsetof(Tensor, raw_shapes) == 64);
 static_assert(offsetof(Tensor, owner_task_id) == 16, "owner_task_id must be at bytes 16-23 (cacheline 1)");
 static_assert(offsetof(Tensor, start_offset) == 24, "start_offset must be at bytes 24-31 (cacheline 1)");
+static_assert(offsetof(Tensor, version) == 32);
+static_assert(offsetof(Tensor, ndims) == 36);
+static_assert(offsetof(Tensor, dtype) == 40);
+static_assert(offsetof(Tensor, manual_dep) == 41);
+static_assert(offsetof(Tensor, is_contiguous) == 42);
+static_assert(offsetof(Tensor, shapes) == 44, "shapes must start at byte 44 (cacheline 1)");
+static_assert(offsetof(Tensor, extent_elem_cache) == 64, "extent_elem_cache must start at byte 64 (cacheline 2)");
+static_assert(offsetof(Tensor, strides) == 72);
 
 // TensorCreateInfo layout must match Tensor cacheline 1 for memcpy optimization
 static_assert(sizeof(TensorCreateInfo) == 64, "TensorCreateInfo must match Tensor cacheline 1 size (64 bytes)");
+static_assert(offsetof(TensorCreateInfo, start_offset) == offsetof(Tensor, start_offset));
 static_assert(offsetof(TensorCreateInfo, version) == offsetof(Tensor, version));
 static_assert(offsetof(TensorCreateInfo, ndims) == offsetof(Tensor, ndims));
 static_assert(offsetof(TensorCreateInfo, dtype) == offsetof(Tensor, dtype));
-static_assert(offsetof(TensorCreateInfo, is_all_offset_zero) == offsetof(Tensor, is_all_offset_zero));
-static_assert(offsetof(TensorCreateInfo, is_raw_eq_shapes) == offsetof(Tensor, is_raw_eq_shapes));
 static_assert(offsetof(TensorCreateInfo, manual_dep) == offsetof(Tensor, manual_dep));
-static_assert(offsetof(TensorCreateInfo, raw_shapes) == offsetof(Tensor, shapes));
+static_assert(offsetof(TensorCreateInfo, is_contiguous) == offsetof(Tensor, is_contiguous));
+static_assert(offsetof(TensorCreateInfo, shapes) == offsetof(Tensor, shapes));

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -152,11 +152,11 @@ class TestDepGen(SceneTestCase):
             return
         with deps_path.open() as f:
             deps = json.load(f)
-        # v2 is the only supported schema — annotated edges with tasks[] /
-        # tensors[] sidecars. Project annotated edges down to a (pred, succ)
-        # set for the existing structural checks; the annotation sanity check
-        # below verifies the tensor metadata path.
-        assert deps.get("version") == 2, f"deps.json version {deps.get('version')} != 2"
+        # v3 schema: annotated edges with tasks[] / tensors[] sidecars carrying
+        # strided slice descriptors (start_offset + stride[]). Project annotated
+        # edges down to a (pred, succ) set for the existing structural checks;
+        # the annotation sanity check below verifies the tensor metadata path.
+        assert deps.get("version") == 3, f"deps.json version {deps.get('version')} != 3"
         raw_edges = deps.get("edges", [])
         deps_edges = set()
         for e in raw_edges:
@@ -209,9 +209,9 @@ class TestDepGen(SceneTestCase):
                 f"edge {e.get('pred')}->{e.get('succ')} (source={source}) "
                 f"references tensor_id {tid} absent from tensors[]"
             )
-            # Annotated edges must carry consumer-side slice info.
-            assert "consumer_shape" in e and "consumer_offset" in e, (
-                f"edge {e.get('pred')}->{e.get('succ')} (source={source}) missing consumer_shape/offset"
+            # Annotated edges must carry consumer-side strided slice info.
+            assert "consumer_shape" in e and "consumer_start_offset" in e and "consumer_strides" in e, (
+                f"edge {e.get('pred')}->{e.get('succ')} (source={source}) missing consumer_shape/start_offset/strides"
             )
 
         # ---- fanout ⊆ deps validation gate ----


### PR DESCRIPTION
## Summary

Replaces the implicit `(raw_shapes, shapes, offsets)` view encoding on `Tensor` with an explicit NumPy/PyTorch-style `(start_offset, stride[], shapes[])` triple, enabling zero-copy `transpose / permute / slice-with-step`, PyTorch `is_contiguous` semantics, and a three-level overlap cascade in the TensorMap. Cache-line layout (128B, 2 lines) and host/device wire formats are preserved; contiguous fast paths still keep cache line 2 cold.

This PR covers **both architectures**: a2a3 lands first as an atomic commit (designed + verified end-to-end), then a5 follows as a mechanical mirror commit on top. The a5 mirror is shipped in the same PR (rather than a follow-up) because the a2a3 → a5 sync turned out to be a near-byte-identical patch apply on the 4 runtime headers and a small field-rename hunk in the 5 platform/dump files, so splitting reviews would not have reduced scope.

## Commits

- **`7019e058` — a2a3 改造**：full design + implementation (see commit message for the per-file change-log).
- **`18e79aff` — a5 mirror**：9 a5 mirror files; 7 applied via `git apply --3way` from the a2a3 patch (path-rewrite `src/a2a3/ → src/a5/`), 2 cherry-picked manually in `tensor_dump_collector.{h,cpp}` so a5's host-shadow memory-model code paths (~300 unchanged lines that diverge from a2a3 SVM) are preserved verbatim. The 4 a2a3 dep_gen / viewer files are skipped because a5 has no dep_gen infrastructure.

## Key changes (apply to both arch)

**Runtime**
- `tensor.h`: drop `raw_shapes / offsets / is_raw_eq_shapes / is_all_offset_zero`; add `start_offset` (element-grained), `stride[5]`, `is_contiguous` flag, `extent_elem_cache`. Rename `init()` overloads (`init_external` + `init_from` + `init_from_line1`) so view ops can skip rewriting cache line 2 just before `refresh_derived()`. Single-pass row-major + numel + extent accumulators across `init / reshape / refresh_derived`. `TensorCreateInfo` pre-zeros `start_offset` and sets `is_contiguous=true` so `init_from_create_info()` needs no resets post-memcpy.
- `pto_tensormap.h`: `PTO2TensorMapEntry` mirrors new Tensor line 1 (start_offset/dtype/manual_dep/is_contiguous); line 2 holds `extent_elem_cache + stride`. `bucket_index` moved to line 2 (off the lookup hot path). `check_overlap` rewritten as **L1 byte-range → L2 hyper-rectangle decompose (stride derives reference shape) → conservative OTHER**.
- `pto_runtime2_types.h`: drop `update_start_offset` call (ops maintain it now).
- `pto_orchestration_api.h`: `make_tensor_external` uses new ctor signature.

**Tensor dump**
- `TensorDumpInfo / TensorDumpRecord` drop `offsets / raw_shapes` and carry `start_offset + stride[]`; record line 2 reordered for 8B alignment without padding.
- aicpu helpers consume stride directly (no `raw_shapes` accumulation). Innermost `stride==1` keeps the contiguous memcpy fast path; non-unit innermost stride degrades to per-element gather.
- `DumpedTensor / collector JSON` output use `start_offset + stride`.

**a2a3-only (DepGen schema v3)** — a5 has no dep_gen infrastructure so these files are not mirrored:
- `dep_gen_replay.cpp`: `TensorTableEntry` stores `buffer_numel` instead of `raw_shapes`; `EdgeAnnot` and `TaskArgEntry` carry `start_offset + stride[]` instead of multi-dim `offset[]`. JSON bumped from v2 to v3.
- `test_dep_gen.py / deps_to_graph.py`: read the new schema; viewer renders `storage / shape / stride / start_offset`.
- `dump_viewer.py` reads the new fields.

## Test plan

**a2a3sim** (warm cache, original PR baseline)
- [x] a2a3sim core suite: `dummy_task / mixed_example / benchmark_bgemm / paged_attention / multi_round_paged_attention / batch_paged_attention` — all PASS
- [x] a2a3sim DFX suites: `dfx/tensor_dump --dump-tensor`, `dfx/dep_gen --enable-dep-gen` — PASS (verify new JSON schema)
- [x] a2a3 onboard (device 9): `batch_paged_attention --build` — PASS

**a5sim** (cold cache rebuild: `rm -rf build/ && pip install --no-build-isolation -e .`)
- [x] `examples/a5/tensormap_and_ringbuffer/` + `tests/st/a5/` full suite — **28 PASS** (4 mirror examples + 13 SPMD users + host_build_graph; `async_notify_demo` excluded as a pre-existing baseline failure that reproduces identically on a2a3sim cold cache — unrelated to this change)
- [x] `tests/ut/cpp/` — **25/25 PASS**, including `static_assert(sizeof(Tensor) == 128)` compile-time guard

**Cross-arch invariants**
- [x] `sizeof(Tensor) == 128`, `sizeof(TensorCreateInfo) == 64`, `sizeof(PTO2TensorMapEntry) == 128` all guarded by `static_assert` on both arches
- [x] `offsetof` asserts verify `TensorCreateInfo` line 1 layout matches `Tensor` layout (memcpy correctness)

## Follow-ups (out of scope)

- Optional L3 precise overlap (segment enumeration + double-pointer intersect) for non-hyper-rectangle pairs
- Separate baseline fix for `examples/{a2a3,a5}/.../async_notify_demo` (a2a3 ACL runtime hang + a5 kernel `pto::Stride` ADL ambiguity + a5 `AsyncCtx` ctor — see KNOWN_ISSUES for analysis; pre-existing on main, not caused by this PR)