### PR TITLE
Refactor: rename multi-comm-domain types for prefix consistency

### DIFF
--- a/docs/multi-comm-domain-implementation.md
+++ b/docs/multi-comm-domain-implementation.md
@@ -18,7 +18,7 @@ comm_plan = CommDomainPlan(
             worker_indices=[0, 1],
             window_size=tp_window_size,
             buffers=[
-                ChipBufferSpec("scratch", "float32", count, nbytes),
+                CommBufferSpec("scratch", "float32", count, nbytes),
             ],
         ),
     ],
@@ -69,7 +69,7 @@ Implemented:
 - Symmetric buffer layout: every participant in one domain receives the same
   named buffer layout.
 - Multiple domains per chip: a chip can publish more than one
-  `ChipCommDomainContext`.
+  `ChipDomainContext`.
 - Overlapping domains: the same chip may have independent ranks in different
   domains.
 - `ChipBootstrapConfig.comm`: takes the derived list from

--- a/docs/multi-comm-domain.md
+++ b/docs/multi-comm-domain.md
@@ -89,7 +89,7 @@ The useful mapping for Simpler is:
 | ------------ | ---------------- |
 | global rank from launcher | L3 `worker=i` index |
 | Megatron TP/DP/PP group | `CommDomain(name, worker_indices)` |
-| PyTorch `ProcessGroup` | `ChipCommDomainContext` exposed to L3 |
+| PyTorch `ProcessGroup` | `ChipDomainContext` exposed to L3 |
 | NCCL communicator | HCCL/HCOMM communicator handle |
 | NCCL group-local rank | `CommContext.rankId` / `domain_rank` |
 | NCCL group size | `CommContext.rankNum` / `domain_size` |
@@ -275,7 +275,7 @@ The new public surface expresses the same single-domain case as one
 `CommDomain` named `"default"`:
 
 - `CommDomain(name="default", worker_indices=[0, 1], window_size=...)`;
-- one or more per-domain `ChipBufferSpec` entries, usually a `scratch`
+- one or more per-domain `CommBufferSpec` entries, usually a `scratch`
   window;
 - optional per-chip host staging information keyed by domain name.
 
@@ -494,8 +494,8 @@ comm_plan = CommDomainPlan(
             worker_indices=[0, 1],
             window_size=...,
             buffers=[
-                ChipBufferSpec(name="scratch", nbytes=...),
-                ChipBufferSpec(name="signals", nbytes=...),
+                CommBufferSpec(name="scratch", nbytes=...),
+                CommBufferSpec(name="signals", nbytes=...),
             ],
         ),
     ],
@@ -607,12 +607,12 @@ The public domain name is not the backend communicator identity.  The parent
 derives a deterministic internal numeric `sub_comm_id` for each domain, using
 sorted domain-name order.  The initial RMA path mainly needs the same sorted
 order to compute `window_offset`, while `sub_comm_id` remains available as an
-internal backend identity.  `ChipCommDomainContext` exposes the public name
+internal backend identity.  `ChipDomainContext` exposes the public name
 and domain-local rank information, not `sub_comm_id`.
 
 The domain participant list is backend construction metadata in the derived
 chip config.  It is not a kernel-visible rank map and it is not exposed
-through `ChipCommDomainContext`.  Kernel code communicates only with dense
+through `ChipDomainContext`.  Kernel code communicates only with dense
 domain ranks.
 
 All domains are bootstrapped eagerly during `Worker.init()`.  After init
@@ -643,7 +643,7 @@ chip child i / ChipWorker.bootstrap_context()
       derive domain CommContext from base context, rank_ids, and window_offset
       local_base = base_local_window + domain.window_offset
       carve domain buffer_ptrs from local_base
-      record ChipCommDomainContext(name, domain_rank, domain_size, ...)
+      record ChipDomainContext(name, domain_rank, domain_size, ...)
   publish all domain contexts to the parent bootstrap mailbox
         |
         v
@@ -659,7 +659,7 @@ explicit bootstrap usage, such as host staging, the caller may still construct
 same parent plan with `plan.bootstrap_for_worker(worker_idx)`.
 
 The hidden base communicator is a control-plane object.  It has no exposed
-buffers, no `ChipCommDomainContext`, and no entry in `ctx.domains`.  It exists
+buffers, no `ChipDomainContext`, and no entry in `ctx.domains`.  It exists
 only so the backend can expose one common L3 rank space and base window.  A
 chip that is not a member of a particular domain still joins the hidden base
 communicator when the L3 plan has communication domains, but it does not
@@ -677,8 +677,8 @@ ChipContext(
     device_id=...,
     worker_index=...,
     domains={
-        "tp0": ChipCommDomainContext(...),
-        "ep0": ChipCommDomainContext(...),
+        "tp0": ChipDomainContext(...),
+        "ep0": ChipDomainContext(...),
     },
 )
 ```
@@ -686,7 +686,7 @@ ChipContext(
 A domain context should contain:
 
 ```python
-ChipCommDomainContext(
+ChipDomainContext(
     name: str,
     domain_rank: int,
     domain_size: int,
@@ -830,7 +830,7 @@ struct ChipDomainBootstrapConfig {
     size_t window_size;
     size_t window_offset;             // offset inside the hidden base window
     size_t base_window_size;          // same on every chip in the L3 plan
-    std::vector<ChipBufferSpec> buffers;
+    std::vector<CommBufferSpec> buffers;
 };
 ```
 
@@ -858,7 +858,7 @@ the first PTO-ISA RMA implementation:
 - base-window slicing creates one backend window and then derives
   kernel-visible domain contexts from rank selection and byte offsets.
 
-All three routes can produce the same `ChipCommDomainContext` shape.  The
+All three routes can produce the same `ChipDomainContext` shape.  The
 first implementation chooses base-window slicing because it matches the
 PTO-ISA kernel ABI and avoids repeated overlapping MC2 allocations.
 
@@ -936,7 +936,7 @@ worker = Worker(
                 name="default",
                 worker_indices=list(range(len(device_ids))),
                 window_size=window_size,
-                buffers=[ChipBufferSpec("scratch", ...)],
+                buffers=[CommBufferSpec("scratch", ...)],
             ),
         ],
     ),
@@ -952,13 +952,13 @@ comm_plan = CommDomainPlan(
             name="tp",
             worker_indices=[0, 1],
             window_size=tp_window,
-            buffers=[ChipBufferSpec("tp_scratch", ...)],
+            buffers=[CommBufferSpec("tp_scratch", ...)],
         ),
         CommDomain(
             name="ep",
             worker_indices=[0, 2],
             window_size=ep_window,
-            buffers=[ChipBufferSpec("ep_scratch", ...)],
+            buffers=[CommBufferSpec("ep_scratch", ...)],
         ),
     ],
 )
@@ -983,7 +983,7 @@ plan = CommDomainPlan(
             worker_indices=[0, 1],
             window_size=window_size,
             buffers=[
-                ChipBufferSpec(
+                CommBufferSpec(
                     name="notify_counter",
                     dtype="int32",
                     count=1,
@@ -1082,13 +1082,13 @@ comm_plan = CommDomainPlan(
             name="tp",
             worker_indices=[0, 1],
             window_size=tp_window,
-            buffers=[ChipBufferSpec("scratch", ...)],
+            buffers=[CommBufferSpec("scratch", ...)],
         ),
         CommDomain(
             name="pp",
             worker_indices=[1, 2],
             window_size=pp_window,
-            buffers=[ChipBufferSpec("scratch", ...)],
+            buffers=[CommBufferSpec("scratch", ...)],
         ),
     ],
 )
@@ -1187,7 +1187,7 @@ The caller should receive the first error after best-effort cleanup completes.
 ## Implementation Slices
 
 1. Add dataclasses for public `CommDomainPlan`, public `CommDomain`,
-   returned `ChipCommDomainContext`, plus an internal derived
+   returned `ChipDomainContext`, plus an internal derived
    `ChipDomainBootstrapConfig`.
 2. Change L3 worker construction to accept `comm_plan` as the single
    parent-level domain plan.

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -18,9 +18,9 @@ import torch
 from simpler.task_interface import (
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -118,7 +118,7 @@ def run(
                 name="default",
                 worker_indices=list(range(nranks)),
                 window_size=4 * 1024,
-                buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+                buffers=[CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
             )
         ]
     )

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -20,9 +20,9 @@ from simpler.task_interface import (
     ArgDirection,
     CallConfig,
     ChipBootstrapConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -129,8 +129,8 @@ def run(
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                    ChipBufferSpec(
+                    CommBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+                    CommBufferSpec(
                         name="notify_counter",
                         dtype="int32",
                         count=1,

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -29,8 +29,8 @@ from simpler.task_interface import (
     ArgDirection,
     CallConfig,
     ChipBootstrapConfig,
-    ChipBufferSpec,
     ChipCallable,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -142,7 +142,7 @@ def run(
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="input_window",
                         dtype="float32",
                         count=N,

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -18,9 +18,9 @@ import torch
 from simpler.task_interface import (
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -113,7 +113,7 @@ def run(platform: str = "a5", device_ids: list[int] | None = None, pto_isa_commi
                 name="default",
                 worker_indices=list(range(nranks)),
                 window_size=4 * 1024,
-                buffers=[ChipBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
+                buffers=[CommBufferSpec(name="notify_counter", dtype="int32", count=1, nbytes=4)],
             )
         ]
     )

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -20,9 +20,9 @@ from simpler.task_interface import (
     ArgDirection,
     CallConfig,
     ChipBootstrapConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -129,8 +129,8 @@ def run(
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
-                    ChipBufferSpec(
+                    CommBufferSpec(name="mailbox", dtype="float32", count=N, nbytes=mailbox_nbytes),
+                    CommBufferSpec(
                         name="notify_counter",
                         dtype="int32",
                         count=1,

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -44,9 +44,9 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -167,7 +167,7 @@ def run(
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="scratch",
                         dtype="float32",
                         count=ALLREDUCE_COUNT,

--- a/examples/workers/l3/domain_rank_map/main.py
+++ b/examples/workers/l3/domain_rank_map/main.py
@@ -40,9 +40,9 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
-    ChipCommDomainContext,
+    ChipDomainContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -89,7 +89,7 @@ def _make_comm_plan() -> CommDomainPlan:
                 worker_indices=worker_indices,
                 window_size=max(SCRATCH_NBYTES, 4096),
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="scratch",
                         dtype="float32",
                         count=COUNT,
@@ -132,7 +132,7 @@ def build_allreduce_callable(platform: str) -> ChipCallable:
     )
 
 
-def _add_domain_scratch(args: TaskArgs, domain: ChipCommDomainContext) -> None:
+def _add_domain_scratch(args: TaskArgs, domain: ChipDomainContext) -> None:
     args.add_tensor(
         ContinuousTensor.make(
             data=domain.buffer_ptrs["scratch"],

--- a/examples/workers/l3/dual_domain_overlap/main.py
+++ b/examples/workers/l3/dual_domain_overlap/main.py
@@ -36,10 +36,10 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
-    ChipCommDomainContext,
     ChipContext,
+    ChipDomainContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -158,7 +158,7 @@ def _make_comm_plan() -> CommDomainPlan:
                 worker_indices=worker_indices,
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="scratch",
                         dtype="float32",
                         count=COUNT,
@@ -171,7 +171,7 @@ def _make_comm_plan() -> CommDomainPlan:
     )
 
 
-def _add_domain_scratch(args: TaskArgs, domain: ChipCommDomainContext) -> None:
+def _add_domain_scratch(args: TaskArgs, domain: ChipDomainContext) -> None:
     args.add_tensor(
         ContinuousTensor.make(
             data=domain.buffer_ptrs["scratch"],

--- a/examples/workers/l3/ep_dispatch_combine/main.py
+++ b/examples/workers/l3/ep_dispatch_combine/main.py
@@ -67,9 +67,9 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -487,7 +487,7 @@ def run(
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="scratch",
                         dtype="float32",
                         count=SCRATCH_NBYTES // 4,

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -41,9 +41,9 @@ import torch  # noqa: E402
 from simpler.task_interface import (  # noqa: E402
     ArgDirection,
     CallConfig,
-    ChipBufferSpec,
     ChipCallable,
     ChipContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     ContinuousTensor,
@@ -188,7 +188,7 @@ def run(
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="scratch",
                         dtype="float32",
                         count=scratch_count,

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -265,20 +265,20 @@ inline void bind_worker(nb::module_ &m) {
         .value("SUCCESS", ChipBootstrapMailboxState::SUCCESS)
         .value("ERROR", ChipBootstrapMailboxState::ERROR);
 
-    nb::class_<ChipBootstrapDomainResult>(m, "ChipBootstrapDomainResult")
+    nb::class_<ChipDomainBootstrapResult>(m, "ChipDomainBootstrapResult")
         .def(nb::init<>())
         .def(
             nb::init<std::string, int32_t, int32_t, uint64_t, uint64_t, uint64_t, std::vector<uint64_t>>(),
             nb::arg("name"), nb::arg("domain_rank"), nb::arg("domain_size"), nb::arg("device_ctx"),
             nb::arg("local_window_base"), nb::arg("actual_window_size"), nb::arg("buffer_ptrs")
         )
-        .def_rw("name", &ChipBootstrapDomainResult::name)
-        .def_rw("domain_rank", &ChipBootstrapDomainResult::domain_rank)
-        .def_rw("domain_size", &ChipBootstrapDomainResult::domain_size)
-        .def_rw("device_ctx", &ChipBootstrapDomainResult::device_ctx)
-        .def_rw("local_window_base", &ChipBootstrapDomainResult::local_window_base)
-        .def_rw("actual_window_size", &ChipBootstrapDomainResult::actual_window_size)
-        .def_rw("buffer_ptrs", &ChipBootstrapDomainResult::buffer_ptrs);
+        .def_rw("name", &ChipDomainBootstrapResult::name)
+        .def_rw("domain_rank", &ChipDomainBootstrapResult::domain_rank)
+        .def_rw("domain_size", &ChipDomainBootstrapResult::domain_size)
+        .def_rw("device_ctx", &ChipDomainBootstrapResult::device_ctx)
+        .def_rw("local_window_base", &ChipDomainBootstrapResult::local_window_base)
+        .def_rw("actual_window_size", &ChipDomainBootstrapResult::actual_window_size)
+        .def_rw("buffer_ptrs", &ChipDomainBootstrapResult::buffer_ptrs);
 
     nb::class_<ChipBootstrapChannel>(m, "ChipBootstrapChannel")
         .def(
@@ -299,7 +299,7 @@ inline void bind_worker(nb::module_ &m) {
         )
         .def(
             "write_success_domains",
-            [](ChipBootstrapChannel &self, const std::vector<ChipBootstrapDomainResult> &domains) {
+            [](ChipBootstrapChannel &self, const std::vector<ChipDomainBootstrapResult> &domains) {
                 self.write_success_domains(domains);
             },
             nb::arg("domains")

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -87,10 +87,10 @@ __all__ = [
     "CommDomain",
     "CommDomainPlan",
     "ChipDomainBootstrapConfig",
-    "ChipBufferSpec",
+    "CommBufferSpec",
     "HostBufferStaging",
     "ChipBootstrapConfig",
-    "ChipCommDomainContext",
+    "ChipDomainContext",
     "ChipBootstrapResult",
     # Worker-level chip bootstrap orchestration
     "ChipContext",
@@ -140,7 +140,7 @@ def scalar_to_uint64(value) -> int:
 
 
 @dataclass
-class ChipBufferSpec:
+class CommBufferSpec:
     """A named slice of the per-rank communicator window.
 
     Buffers are placed sequentially inside the window in declaration order —
@@ -183,7 +183,7 @@ class CommDomain:
     name: str
     worker_indices: list[int]
     window_size: int
-    buffers: list[ChipBufferSpec] = field(default_factory=list)
+    buffers: list[CommBufferSpec] = field(default_factory=list)
 
 
 @dataclass
@@ -198,7 +198,7 @@ class ChipDomainBootstrapConfig:
     window_size: int
     window_offset: int = 0
     base_window_size: int = 0
-    buffers: list[ChipBufferSpec] = field(default_factory=list)
+    buffers: list[CommBufferSpec] = field(default_factory=list)
     host_inputs: list[HostBufferStaging] = field(default_factory=list)
     host_outputs: list[HostBufferStaging] = field(default_factory=list)
 
@@ -363,7 +363,7 @@ class ChipBootstrapConfig:
 
 
 @dataclass
-class ChipCommDomainContext:
+class ChipDomainContext:
     name: str
     domain_rank: int
     domain_size: int
@@ -377,7 +377,7 @@ class ChipCommDomainContext:
 class ChipBootstrapResult:
     """Return value of `ChipWorker.bootstrap_context`."""
 
-    domains: dict[str, ChipCommDomainContext] = field(default_factory=dict)
+    domains: dict[str, ChipDomainContext] = field(default_factory=dict)
 
 
 @dataclass
@@ -393,7 +393,7 @@ class ChipContext:
 
     device_id: int
     worker_index: int
-    domains: dict[str, ChipCommDomainContext] = field(default_factory=dict)
+    domains: dict[str, ChipDomainContext] = field(default_factory=dict)
 
 
 # Process-wide RTLD_GLOBAL preload registry. host_runtime.so resolves its
@@ -690,7 +690,7 @@ class ChipWorker:
                             domain.input_staging(spec.name)
                         except KeyError:
                             raise ValueError(
-                                f"ChipBufferSpec(domain={domain.name!r}, name={spec.name!r}, "
+                                f"CommBufferSpec(domain={domain.name!r}, name={spec.name!r}, "
                                 "load_from_host=True) requires matching HostBufferStaging in host_inputs; none found"
                             ) from None
                     if spec.store_to_host:
@@ -698,7 +698,7 @@ class ChipWorker:
                             domain.output_staging(spec.name)
                         except KeyError:
                             raise ValueError(
-                                f"ChipBufferSpec(domain={domain.name!r}, name={spec.name!r}, "
+                                f"CommBufferSpec(domain={domain.name!r}, name={spec.name!r}, "
                                 "store_to_host=True) requires matching HostBufferStaging in host_outputs; none found"
                             ) from None
 
@@ -709,7 +709,7 @@ class ChipWorker:
                 )
             handles: list[int] = []
             self._comm_handles = handles
-            domains: dict[str, ChipCommDomainContext] = {}
+            domains: dict[str, ChipDomainContext] = {}
             if cfg.comm == []:
                 base_rank, base_size, rootinfo_path = self._base_comm_params(cfg)
                 base = self.comm_init(base_rank, base_size, rootinfo_path)
@@ -752,7 +752,7 @@ class ChipWorker:
                     actual_size = domain.window_size
                     buffer_ptrs = self._carve_domain_buffers(domain, local_base, actual_size)
                     self._stage_domain_inputs(domain, buffer_ptrs)
-                    domains[domain.name] = ChipCommDomainContext(
+                    domains[domain.name] = ChipDomainContext(
                         name=domain.name,
                         domain_rank=domain.domain_rank,
                         domain_size=domain.domain_size,
@@ -764,11 +764,11 @@ class ChipWorker:
             result = ChipBootstrapResult(domains=domains)
             if channel is not None:
                 if hasattr(channel, "write_success_domains"):
-                    from _task_interface import ChipBootstrapDomainResult  # pyright: ignore[reportMissingImports]
+                    from _task_interface import ChipDomainBootstrapResult  # pyright: ignore[reportMissingImports]
 
                     channel.write_success_domains(
                         [
-                            ChipBootstrapDomainResult(
+                            ChipDomainBootstrapResult(
                                 d.name,
                                 d.domain_rank,
                                 d.domain_size,

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -84,8 +84,8 @@ from .task_interface import (
     CallConfig,
     ChipBootstrapConfig,
     ChipCallable,
-    ChipCommDomainContext,
     ChipContext,
+    ChipDomainContext,
     ChipWorker,
     CommDomainPlan,
     TaskArgs,
@@ -1268,10 +1268,10 @@ class Worker:
         cfg: ChipBootstrapConfig,
         *,
         chip_idx: int,
-    ) -> dict[str, ChipCommDomainContext]:
+    ) -> dict[str, ChipDomainContext]:
         if hasattr(channel, "domains"):
             raw_domains = channel.domains
-            domains: dict[str, ChipCommDomainContext] = {}
+            domains: dict[str, ChipDomainContext] = {}
             expected = {d.name: d for d in ChipWorker._domain_bootstrap_configs(cfg)}
             for raw in raw_domains:
                 name = str(raw.name)
@@ -1284,7 +1284,7 @@ class Worker:
                         f"chip {chip_idx} domain {name!r} buffer count mismatch: "
                         f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
                     )
-                domains[name] = ChipCommDomainContext(
+                domains[name] = ChipDomainContext(
                     name=name,
                     domain_rank=int(raw.domain_rank),
                     domain_size=int(raw.domain_size),
@@ -1311,7 +1311,7 @@ class Worker:
                 f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
             )
         return {
-            domain_cfg.name: ChipCommDomainContext(
+            domain_cfg.name: ChipDomainContext(
                 name=domain_cfg.name,
                 domain_rank=domain_cfg.domain_rank,
                 domain_size=domain_cfg.domain_size,

--- a/src/common/hierarchical/chip_bootstrap_channel.cpp
+++ b/src/common/hierarchical/chip_bootstrap_channel.cpp
@@ -106,7 +106,7 @@ size_t checked_buffer_count(int32_t raw_count, size_t max_buffer_count) {
 // ChipBootstrapChannel
 // =============================================================================
 
-ChipBootstrapDomainResult::ChipBootstrapDomainResult(
+ChipDomainBootstrapResult::ChipDomainBootstrapResult(
     std::string domain_name, int32_t rank, int32_t size, uint64_t ctx, uint64_t window_base, uint64_t window_size,
     std::vector<uint64_t> ptrs
 ) :
@@ -141,13 +141,13 @@ void ChipBootstrapChannel::write_success(
     if (buffer_ptrs.size() > max_buffer_count_) {
         throw std::invalid_argument("buffer_ptrs exceeds max_buffer_count");
     }
-    ChipBootstrapDomainResult domain(
+    ChipDomainBootstrapResult domain(
         "default", 0, 1, device_ctx, local_window_base, actual_window_size, std::vector<uint64_t>(buffer_ptrs)
     );
     write_success_domains({domain});
 }
 
-void ChipBootstrapChannel::write_success_domains(const std::vector<ChipBootstrapDomainResult> &domains) {
+void ChipBootstrapChannel::write_success_domains(const std::vector<ChipDomainBootstrapResult> &domains) {
     if (domains.size() > CHIP_BOOTSTRAP_MAX_DOMAINS) {
         throw std::invalid_argument("domain count exceeds CHIP_BOOTSTRAP_MAX_DOMAINS");
     }
@@ -254,10 +254,10 @@ int32_t ChipBootstrapChannel::domain_count() const {
     return count;
 }
 
-std::vector<ChipBootstrapDomainResult> ChipBootstrapChannel::domains() const {
+std::vector<ChipDomainBootstrapResult> ChipBootstrapChannel::domains() const {
     auto *base = static_cast<const char *>(mailbox_);
     int32_t count = domain_count();
-    std::vector<ChipBootstrapDomainResult> results;
+    std::vector<ChipDomainBootstrapResult> results;
     results.reserve(static_cast<size_t>(count));
     std::unordered_set<std::string> names;
     names.reserve(static_cast<size_t>(count));
@@ -296,7 +296,7 @@ std::vector<ChipBootstrapDomainResult> ChipBootstrapChannel::domains() const {
             );
         }
 
-        ChipBootstrapDomainResult result(
+        ChipDomainBootstrapResult result(
             name, read_i32(record + DOMAIN_OFF_DOMAIN_RANK), read_i32(record + DOMAIN_OFF_DOMAIN_SIZE),
             read_u64(record + DOMAIN_OFF_DEVICE_CTX), read_u64(record + DOMAIN_OFF_LOCAL_WINDOW_BASE),
             read_u64(record + DOMAIN_OFF_ACTUAL_WINDOW_SIZE), std::move(ptrs)
@@ -310,7 +310,7 @@ std::vector<ChipBootstrapDomainResult> ChipBootstrapChannel::domains() const {
     return results;
 }
 
-ChipBootstrapDomainResult ChipBootstrapChannel::domain(const std::string &name) const {
+ChipDomainBootstrapResult ChipBootstrapChannel::domain(const std::string &name) const {
     for (auto &domain : domains()) {
         if (domain.name == name) {
             return domain;

--- a/src/common/hierarchical/chip_bootstrap_channel.h
+++ b/src/common/hierarchical/chip_bootstrap_channel.h
@@ -62,7 +62,7 @@ enum class ChipBootstrapMailboxState : int32_t {
     ERROR = 2,
 };
 
-struct ChipBootstrapDomainResult {
+struct ChipDomainBootstrapResult {
     std::string name;
     int32_t domain_rank = 0;
     int32_t domain_size = 0;
@@ -71,8 +71,8 @@ struct ChipBootstrapDomainResult {
     uint64_t actual_window_size = 0;
     std::vector<uint64_t> buffer_ptrs;
 
-    ChipBootstrapDomainResult() = default;
-    ChipBootstrapDomainResult(
+    ChipDomainBootstrapResult() = default;
+    ChipDomainBootstrapResult(
         std::string domain_name, int32_t rank, int32_t size, uint64_t ctx, uint64_t window_base, uint64_t window_size,
         std::vector<uint64_t> ptrs
     );
@@ -88,15 +88,15 @@ public:
         uint64_t device_ctx, uint64_t local_window_base, uint64_t actual_window_size,
         const std::vector<uint64_t> &buffer_ptrs
     );
-    void write_success_domains(const std::vector<ChipBootstrapDomainResult> &domains);
+    void write_success_domains(const std::vector<ChipDomainBootstrapResult> &domains);
     void write_error(int32_t error_code, const std::string &message);
 
     // Read side (parent process).
     ChipBootstrapMailboxState state() const;
     int32_t error_code() const;
     int32_t domain_count() const;
-    std::vector<ChipBootstrapDomainResult> domains() const;
-    ChipBootstrapDomainResult domain(const std::string &name) const;
+    std::vector<ChipDomainBootstrapResult> domains() const;
+    ChipDomainBootstrapResult domain(const std::string &name) const;
     uint64_t device_ctx() const;
     uint64_t local_window_base() const;
     uint64_t actual_window_size() const;

--- a/tests/ut/py/test_worker/test_bootstrap_context_hw.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_hw.py
@@ -15,7 +15,7 @@ runtime on 2 Ascend devices.  The critical assertions are:
   1. ``bootstrap_context`` returns a non-null ``device_ctx`` and
      ``local_window_base`` (HCCL actually allocated GVA-visible windows).
   2. ``actual_window_size`` is at least the requested size.
-  3. A single ``ChipBufferSpec`` slices the window so
+  3. A single ``CommBufferSpec`` slices the window so
      ``buffer_ptrs[0] == local_window_base``.
 
 Deliberately **no** ``comm_barrier``.  The paired ``comm_*`` UT
@@ -52,8 +52,8 @@ def _bootstrap_rank_entry(  # noqa: PLR0913
     try:
         from simpler.task_interface import (
             ChipBootstrapConfig,
-            ChipBufferSpec,
             ChipWorker,
+            CommBufferSpec,
             CommDomain,
             CommDomainPlan,
         )
@@ -69,7 +69,7 @@ def _bootstrap_rank_entry(  # noqa: PLR0913
                     worker_indices=list(range(nranks)),
                     window_size=window_size,
                     buffers=[
-                        ChipBufferSpec(
+                        CommBufferSpec(
                             name="x",
                             dtype="float32",
                             count=buffer_nbytes // 4,

--- a/tests/ut/py/test_worker/test_bootstrap_context_sim.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_sim.py
@@ -80,8 +80,8 @@ def _rank_entry(  # noqa: PLR0913
         from simpler.task_interface import (
             ChipBootstrapChannel,
             ChipBootstrapConfig,
-            ChipBufferSpec,
             ChipWorker,
+            CommBufferSpec,
             CommDomain,
             CommDomainPlan,
             HostBufferStaging,
@@ -97,7 +97,7 @@ def _rank_entry(  # noqa: PLR0913
                     name="default",
                     worker_indices=list(range(nranks)),
                     window_size=window_size,
-                    buffers=[ChipBufferSpec(**s) for s in buffer_specs],
+                    buffers=[CommBufferSpec(**s) for s in buffer_specs],
                 )
             ]
         )
@@ -245,7 +245,7 @@ def _multi_domain_rank_entry(
 ) -> None:
     result: dict[str, object] = {"rank": worker_idx, "ok": False}
     try:
-        from simpler.task_interface import ChipBootstrapConfig, ChipBufferSpec, ChipWorker, CommDomain, CommDomainPlan
+        from simpler.task_interface import ChipBootstrapConfig, ChipWorker, CommBufferSpec, CommDomain, CommDomainPlan
 
         plan = CommDomainPlan(
             domains=[
@@ -253,13 +253,13 @@ def _multi_domain_rank_entry(
                     name="tp",
                     worker_indices=[0, 1],
                     window_size=4096,
-                    buffers=[ChipBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
+                    buffers=[CommBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
                 ),
                 CommDomain(
                     name="pp",
                     worker_indices=[1, 2],
                     window_size=4096,
-                    buffers=[ChipBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
+                    buffers=[CommBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
                 ),
             ]
         )
@@ -451,8 +451,8 @@ def _store_rank_entry(  # noqa: PLR0913
     try:
         from simpler.task_interface import (
             ChipBootstrapConfig,
-            ChipBufferSpec,
             ChipWorker,
+            CommBufferSpec,
             CommDomain,
             CommDomainPlan,
             HostBufferStaging,
@@ -461,7 +461,7 @@ def _store_rank_entry(  # noqa: PLR0913
         worker = ChipWorker()
         worker.init(rank, bins)
 
-        domain_buffers = [ChipBufferSpec(**s) for s in buffer_specs]
+        domain_buffers = [CommBufferSpec(**s) for s in buffer_specs]
         plan = CommDomainPlan(
             domains=[
                 CommDomain(
@@ -669,9 +669,9 @@ def _missing_output_staging_rank_entry(
         from simpler.task_interface import (
             ChipBootstrapChannel,
             ChipBootstrapConfig,
-            ChipBufferSpec,
             ChipDomainBootstrapConfig,
             ChipWorker,
+            CommBufferSpec,
         )
 
         worker = ChipWorker()
@@ -691,7 +691,7 @@ def _missing_output_staging_rank_entry(
                         rank_ids=[0],
                         window_size=4096,
                         buffers=[
-                            ChipBufferSpec(
+                            CommBufferSpec(
                                 name="y",
                                 dtype="float32",
                                 count=1,

--- a/tests/ut/py/test_worker/test_comm_domain_plan.py
+++ b/tests/ut/py/test_worker/test_comm_domain_plan.py
@@ -11,9 +11,9 @@ import pytest
 from _task_interface import _ChipWorker
 from simpler.task_interface import (
     ChipBootstrapConfig,
-    ChipBufferSpec,
-    ChipCommDomainContext,
     ChipContext,
+    ChipDomainContext,
+    CommBufferSpec,
     CommDomain,
     CommDomainPlan,
     HostBufferStaging,
@@ -21,7 +21,7 @@ from simpler.task_interface import (
 
 
 def _buffer(name: str = "scratch"):
-    return ChipBufferSpec(name=name, dtype="float32", count=4, nbytes=16)
+    return CommBufferSpec(name=name, dtype="float32", count=4, nbytes=16)
 
 
 class TestCommDomainPlan:
@@ -171,7 +171,7 @@ class TestCommDomainPlan:
             device_id=1,
             worker_index=1,
             domains={
-                "tp": ChipCommDomainContext(
+                "tp": ChipDomainContext(
                     name="tp",
                     domain_rank=1,
                     domain_size=2,
@@ -180,7 +180,7 @@ class TestCommDomainPlan:
                     actual_window_size=4096,
                     buffer_ptrs={"scratch": 0x2000},
                 ),
-                "pp": ChipCommDomainContext(
+                "pp": ChipDomainContext(
                     name="pp",
                     domain_rank=0,
                     domain_size=2,

--- a/tests/ut/py/test_worker/test_worker_distributed_hw.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_hw.py
@@ -28,7 +28,7 @@ import pytest
 @pytest.mark.platforms(["a2a3"])
 @pytest.mark.device_count(2)
 def test_worker_chip_bootstrap(st_device_ids):
-    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
+    from simpler.task_interface import CommBufferSpec, CommDomain, CommDomainPlan
     from simpler.worker import Worker
 
     assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
@@ -44,7 +44,7 @@ def test_worker_chip_bootstrap(st_device_ids):
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="x",
                         dtype="float32",
                         count=buffer_nbytes // 4,

--- a/tests/ut/py/test_worker/test_worker_distributed_sim.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_sim.py
@@ -72,7 +72,7 @@ def _make_comm_plan(nranks: int, window_size: int = 4096):
     The buffer carves the window at offset 0, so we get a deterministic
     `buffer_ptrs["x"] == local_window_base` invariant to assert on.
     """
-    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
+    from simpler.task_interface import CommBufferSpec, CommDomain, CommDomainPlan
 
     return CommDomainPlan(
         domains=[
@@ -81,7 +81,7 @@ def _make_comm_plan(nranks: int, window_size: int = 4096):
                 worker_indices=list(range(nranks)),
                 window_size=window_size,
                 buffers=[
-                    ChipBufferSpec(
+                    CommBufferSpec(
                         name="x",
                         dtype="float32",
                         count=16,
@@ -94,7 +94,7 @@ def _make_comm_plan(nranks: int, window_size: int = 4096):
 
 
 def _make_bad_store_plan(nranks: int):
-    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
+    from simpler.task_interface import CommBufferSpec, CommDomain, CommDomainPlan
 
     return CommDomainPlan(
         domains=[
@@ -105,7 +105,7 @@ def _make_bad_store_plan(nranks: int):
                 # Missing matching host_outputs intentionally exercises the
                 # bootstrap_context staging-symmetry error path.
                 buffers=[
-                    ChipBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
+                    CommBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
                 ],
             )
         ]
@@ -113,7 +113,7 @@ def _make_bad_store_plan(nranks: int):
 
 
 def _make_store_plan(nranks: int):
-    from simpler.task_interface import ChipBufferSpec, CommDomain, CommDomainPlan
+    from simpler.task_interface import CommBufferSpec, CommDomain, CommDomainPlan
 
     return CommDomainPlan(
         domains=[
@@ -122,7 +122,7 @@ def _make_store_plan(nranks: int):
                 worker_indices=list(range(nranks)),
                 window_size=4096,
                 buffers=[
-                    ChipBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
+                    CommBufferSpec(name="x", dtype="float32", count=1, nbytes=4, store_to_host=True),
                 ],
             )
         ]


### PR DESCRIPTION
## Summary

- Naming follow-up for #752. Pure mechanical rename, no behaviour change.
- After #752 the new surface mixed `Comm*` (declarative topology) and `Chip*` (per-chip runtime) prefixes — three names straddled the boundary. This commit puts each one on the correct side.

## Renames

| Before | After | Why |
| --- | --- | --- |
| `ChipBufferSpec` | `CommBufferSpec` | Lives in `CommDomain.buffers` — it is part of the declarative side and belongs with `CommDomain` / `CommDomainPlan`. |
| `ChipCommDomainContext` | `ChipDomainContext` | Drop redundant `Comm` infix; mirrors the existing `ChipContext` pattern. |
| `ChipBootstrapDomainResult` | `ChipDomainBootstrapResult` | Symmetric with `ChipDomainBootstrapConfig` (Domain-Bootstrap word order). |

Result: a consistent rule readers can apply on sight —
- `Comm*` = declaration (domains, plans, buffer slots)
- `Chip*` = per-chip runtime state
- `*BootstrapConfig` / `*BootstrapResult` = bootstrap protocol I/O

No backwards-compat aliases. #752 only just landed; the new surface has no external consumers yet, so the system-prompt rule against shim aliases applies cleanly.

## Scope

22 files, 114/114 lines:

- C++: `src/common/hierarchical/chip_bootstrap_channel.{h,cpp}`
- nanobind: `python/bindings/worker_bind.h`
- Python: `python/simpler/{task_interface,worker}.py`
- Examples: 5 L3 worker demos + 5 sim notify/SDMA demos
- Tests: 5 worker unit/integration test files
- Docs: `docs/multi-comm-domain.md`, `docs/multi-comm-domain-implementation.md`

## Test plan

- [x] `pip install --no-build-isolation -e .` rebuilds nanobind extension clean
- [x] `pytest tests/ut/py/test_worker/test_comm_domain_plan.py` (10 passed)
- [x] `pytest tests/ut/py/test_worker/test_bootstrap_context_sim.py` (6 passed, includes the multi-domain integration case)
- [x] `pytest tests/ut/py/test_worker/` (94 passed, 1 skipped — only the `_hw.py` skip, expected on local macOS)
- [x] `pre-commit run` clean: clang-format / clang-tidy / cpplint / markdownlint / ruff / pyright all pass
- [ ] CI: a2a3 onboard / a2a3 sim / a5 onboard / a5 sim