### PR TITLE
Cleanup: collapse IWorker into ChipWorker; drop dead _run_as_child

### DIFF
--- a/docs/hierarchical_level_runtime.md
+++ b/docs/hierarchical_level_runtime.md
@@ -11,8 +11,8 @@ For details of each component's internals, see:
 
 - [orchestrator.md](orchestrator.md) — submit flow, TensorMap, Scope, Ring, task state machine
 - [scheduler.md](scheduler.md) — dispatch loop, queues, completion handling
-- [worker-manager.md](worker-manager.md) — WorkerThread pool, THREAD/PROCESS modes, fork + mailbox
-- [task-flow.md](task-flow.md) — Callable / TaskArgs / CallConfig data flow, IWorker interface
+- [worker-manager.md](worker-manager.md) — WorkerThread pool, fork + mailbox
+- [task-flow.md](task-flow.md) — Callable / TaskArgs / CallConfig data flow, execution leaves
 
 For the L2 chip-level details (host `.so`, AICPU, AICore), see
 [chip-level-arch.md](chip-level-arch.md).
@@ -114,7 +114,7 @@ memory region, signals the pre-forked Python child, and spin-polls
 
 See [worker-manager.md](worker-manager.md) for the dispatch state machine,
 fork ordering, and mailbox layout. See [task-flow.md](task-flow.md) for
-what flows through `IWorker::run`.
+what flows through `ChipWorker::run`.
 
 ---
 
@@ -136,8 +136,8 @@ what flows through `IWorker::run`.
                  │                                 │ pop ready_queue
                  │                                 │ pick idle WorkerThread
                  │                                 │ wt.dispatch(slot_id) ──────► WorkerThread
-                 │                                 │                              worker->run(callable, view, config)
-                 │                                 │                              (blocking, THREAD or PROCESS mode)
+                 │                                 │                              encode mailbox → spin-poll TASK_DONE
+                 │                                 │                              (blocking; child runs the kernel)
                  │                                 │◄── completion_queue ────── on_complete_(slot_id)
                  │                                 │ on_task_complete:
                  │                                 │   fanout release
@@ -153,7 +153,7 @@ Communication channels:
 | Orch → Scheduler | wiring_queue (mutex + CV) | slot id |
 | Scheduler → WorkerThread | WorkerThread internal queue | slot id |
 | WorkerThread → Scheduler | completion_queue (mutex + CV) | slot id |
-| WorkerThread ↔ child (PROCESS mode) | shm mailbox (state + error + task data) | encoded blob |
+| WorkerThread ↔ child | shm mailbox (state + error + task data) | encoded blob |
 | Python ↔ C++ | nanobind bindings | TaskArgs / CallConfig / callable handle |
 | Tensor data | `torch.share_memory_()` or host malloc | zero-copy shared address |
 
@@ -161,11 +161,11 @@ Communication channels:
 
 ## 4. Recursive Composition
 
-A `Worker` is itself an `IWorker`, so a higher-level `Worker` can register it
-as a NEXT_LEVEL child. The Python `Worker.add_worker(child)` stores an
-un-init'd child Worker; on first `run()`, the parent forks a child process
-that inits the inner Worker and enters a mailbox-polling loop
-(`_child_worker_loop`).
+A higher-level `Worker` can register a lower-level `Worker` as a
+NEXT_LEVEL child through the same mailbox protocol L3 uses for chip
+children. The Python `Worker.add_worker(child)` stores an un-init'd child
+Worker; on first `run()`, the parent forks a child process that inits the
+inner Worker and enters a mailbox-polling loop (`_child_worker_loop`).
 
 ```python
 # L3 child: sub-only (or with chips via device_ids)
@@ -217,7 +217,7 @@ walk-through.
 | Callable registration | maintains `py_registry[cid]` for sub callables | — |
 | Orchestration DAG | user's orch fn, `submit_*` calls | `Orchestrator::submit_*` engine |
 | Scheduling | — | `Scheduler` thread, queues, `WorkerThread` pool |
-| Dispatch | — | `WorkerManager::dispatch`, THREAD/PROCESS mode |
+| Dispatch | — | `WorkerThread::dispatch_process`, mailbox IPC |
 | Runtime execution | — | `ChipWorker` via dlsym'd runtime `.so` |
 
 Python handles **when** things happen (fork ordering, lifecycle). C++ handles
@@ -283,6 +283,6 @@ device allocation algorithm.
 | `src/common/hierarchical/ring.{h,cpp}` | slot allocator |
 | `src/common/hierarchical/tensormap.{h,cpp}` | base_ptr → producer slot |
 | `src/common/hierarchical/scope.{h,cpp}` | scope lifetime management |
-| `src/common/worker/chip_worker.{h,cpp}` | L2 `ChipWorker` (IWorker leaf, runs in the forked chip child) |
+| `src/common/worker/chip_worker.{h,cpp}` | L2 `ChipWorker` (kernel-running leaf, runs in the forked chip child) |
 | `python/bindings/` | nanobind exposure of C++ engine to Python |
 | `python/simpler/worker.py` | Python `Worker` factory + lifecycle wrapper |

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -669,9 +669,9 @@ instead of stalling forever. Default timeout: 10 s.
    `submit_*`. Phases after submit (slot storage, dispatch, execution) do not
    see tags.
 3. **Slot is parent-heap**: all `TaskSlotState` state is in the parent
-   process's heap. Child processes (PROCESS mode workers) never read slot
-   state; they receive task data via the mailbox (see
-   [worker-manager.md](worker-manager.md) §4).
+   process's heap. Forked child workers never read slot state; they
+   receive task data via the mailbox (see
+   [worker-manager.md](worker-manager.md) §3).
 4. **Ring.alloc is the only blocking point in Orch**: `submit_*` never
    blocks except on ring pressure.
 5. **Scope.register_task is idempotent per slot per scope level**: each

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -213,8 +213,8 @@ void Scheduler::dispatch_ready() {
 Dispatch hands off a `WorkerDispatch {slot, group_index}` to a
 `WorkerThread`. The WorkerThread reads
 `ring.slot_state(slot).{callable, task_args, config}` on its own thread
-and executes — see [worker-manager.md](worker-manager.md) §3 for THREAD
-mode and §4 for PROCESS mode.
+and encodes it into the per-WT mailbox — see
+[worker-manager.md](worker-manager.md) §3 for the dispatch protocol.
 
 **Pick-idle back-pressure**: when `pick_n_idle` returns fewer workers
 than the task needs, the slot is pushed back onto *its* queue and that
@@ -318,11 +318,12 @@ void Scheduler::stop() {
 ## 8. Completion channel from WorkerThread
 
 ```cpp
-// In WorkerThread, after worker->run() returns:
+// In WorkerThread, after the mailbox round-trip returns TASK_DONE:
 void WorkerThread::loop() {
     for (;;) {
         TaskSlot sid = queue_.pop();
-        // ... run worker (see worker-manager.md for THREAD/PROCESS) ...
+        // dispatch_process: encode mailbox, spin-poll TASK_DONE
+        // (see worker-manager.md §3 for the mailbox protocol)
         scheduler_->completion_queue_.push(sid);   // notify Scheduler
     }
 }

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -4,7 +4,7 @@ This document specifies **what data flows through the hierarchical runtime and
 what shapes it takes at each stage**. It covers:
 
 - The three handles carried through every level: `Callable`, `TaskArgs`, `CallConfig`
-- The `IWorker` interface and its three implementations
+- The `ChipWorker::run` execution leaf at L2
 - The L2 ABI edge where internal formats are converted to `ChipStorageTaskArgs`
 - Recursive composition for L4+
 - A single end-to-end walkthrough
@@ -14,8 +14,7 @@ scheduled), see:
 
 - [orchestrator.md](orchestrator.md) — submit flow, Ring, TensorMap, Scope
 - [scheduler.md](scheduler.md) — dispatch loop, queues, completion handling
-- [worker-manager.md](worker-manager.md) — WorkerThread, THREAD/PROCESS
-  modes, mailbox mechanics
+- [worker-manager.md](worker-manager.md) — WorkerThread, mailbox IPC mechanics
 - [hierarchical_level_runtime.md](hierarchical_level_runtime.md) — level model
   and how components compose
 
@@ -27,7 +26,7 @@ Every task flowing through any level carries exactly three pieces of data:
 
 | Handle | Type | What it is |
 | ------ | ---- | ---------- |
-| `Callable` | `uint64_t` (opaque) | What the target worker should execute — interpretation depends on the receiving `IWorker` subclass |
+| `Callable` | `uint64_t` (opaque) | What the target worker should execute — interpretation depends on the receiving worker type |
 | `TaskArgs` | user builder class | Tensors + scalars + per-tensor tags (IN/OUT/INOUT/etc.) |
 | `CallConfig` | small POD | Execution knobs (block_dim, aicpu_thread_num, profiling/dump/PMU flags, …) |
 
@@ -44,20 +43,15 @@ using Callable = uint64_t;
 
 Opaque 64-bit handle. What it actually is depends on the destination worker:
 
-| Context | `Callable` encodes | Who casts it | How |
-| ------- | ------------------ | ------------ | --- |
-| `w3.submit_next_level(cb, …)` dispatched to `ChipWorker` (L2) | `ChipCallable*` — C++ object with compiled kernels | `ChipWorker::run` | `reinterpret_cast<ChipCallable*>(callable)` |
-| `w4.submit_next_level(cb, …)` dispatched to `Worker(level=3)` (L3 as L4 child) | `OrchFn` — Python orchestration function pointer | `Worker::run` | `reinterpret_cast<OrchFn>(callable)` |
-| `w3.submit_sub(cb, …)` dispatched to `SubWorker` | `uint64_t` callable_id indexing `py_registry_` | `SubWorker::run` | direct use as integer |
+| Context | `Callable` encodes | How it's consumed |
+| ------- | ------------------ | ----------------- |
+| `w3.submit_next_level(cid, …)` dispatched to a chip child (L2) | `int32_t` cid returned by `Worker.register(ChipCallable)` | `ChipWorker::run(cid, …)` in the forked child looks up the prepared callable |
+| `w4.submit_next_level(cid, …)` dispatched to an L3 `Worker` child | `int32_t` cid returned by `Worker.register(orch_fn)` (Python orch fn) | `_child_worker_loop` looks up the orch fn in the child's COW registry and calls `inner_worker.run(orch_fn, …)` |
+| `w3.submit_sub(cid, …)` dispatched to a SUB child | `int32_t` cid indexing the Python callable registry | `_sub_worker_loop` calls `fn(args)` with the decoded `TaskArgs` |
 
-Where `OrchFn` is:
-
-```cpp
-using OrchFn = void (*)(Orchestrator*, TaskArgsView, const CallConfig&);
-```
-
-The `submit_*` API uses `Callable` (uint64) uniformly — no `void*` / `int32_t`
-split, no three-way cast.
+All three paths share one mailbox wire format — the cid is written into
+`MAILBOX_OFF_CALLABLE` and the child does the dispatch in its own
+address space.
 
 ### Lifetime — pre-fork registration
 
@@ -99,7 +93,7 @@ public:
 | **① User submit** | `TaskArgs` object (builder) | Python/C++ parent heap | user orch fn | Orchestrator |
 | **② Slot storage** | `TaskArgs` object (inside `slot.task_args`) | parent heap | Orchestrator.submit moves it here | WorkerThread at dispatch |
 | **③ Dispatch wire (PROCESS only)** | length-prefixed blob | shm mailbox (MAP_SHARED) | parent WorkerThread encodes | forked child decodes |
-| **④ L2 ABI edge** | `ChipStorageTaskArgs` POD (1672 B) | child stack | `ChipWorker::run` assembles | `pto2_run_runtime` consumes |
+| **④ L2 ABI edge** | `ChipStorageTaskArgs` POD | child stack | `ChipWorker::run` assembles | `pto2_run_runtime` consumes |
 
 ### Tags stripped at submit
 
@@ -121,8 +115,8 @@ No tags, no pickle, no schema versioning — pure memcpy.
 
 ### TaskArgsView — the interface type
 
-Both THREAD mode (from `TaskArgs::view()`) and PROCESS mode (from `read_blob`)
-yield the same view type:
+The parent-side encoder (from `TaskArgs::view()`) and the child-side
+decoder (over the mailbox blob bytes) yield the same view type:
 
 ```cpp
 struct TaskArgsView {
@@ -140,8 +134,8 @@ mode:
   backing inside `slot.task_args`
 - **PROCESS**: `tensors` points into the shm mailbox blob region
 
-View does **not** own memory. Valid for the duration of a single `IWorker::run`
-call.
+View does **not** own memory. Valid for the duration of a single
+`ChipWorker::run` call in the forked child.
 
 ### Conversion diagram
 
@@ -151,30 +145,22 @@ call.
      │ Orchestrator::submit_next_level (tags consumed)
      ▼
 ② slot.task_args: TaskArgs           — parent heap, stored in slot
-
-     ┌── THREAD mode ─────────────────────────────────────┐
-     │  view = slot.task_args.view()                       │
-     │    (pointers into slot's vector backing)            │
-     └─────────────────────────────────────────────────────┘
-                     OR
-     ┌── PROCESS mode ────────────────────────────────────┐
-     │  write_blob(mailbox, slot.task_args)                │
-     │    (memcpy into shm mailbox)                        │
-     │  child reads mailbox:                               │
-     │  view = read_blob(mailbox_bytes)                    │
-     │    (pointers into shm mailbox)                      │
-     └─────────────────────────────────────────────────────┘
-
-     │ (both paths yield TaskArgsView)
+     │
+     │ WorkerThread::dispatch_process: memcpy into shm mailbox blob
+     │   layout = [int32 T][int32 S][ContinuousTensor × T][uint64 × S]
      ▼
-    IWorker::run(callable, view, config)
+③ shm mailbox bytes (MAP_SHARED)     — visible to forked child
+     │
+     │ child decodes header → builds TaskArgsView over the blob bytes
+     ▼
+    ChipWorker::run(cid, view, config)         (in the forked child)
 
-     │ (ChipWorker only, at L2 ABI)
+     │ (L2 ABI edge)
      ▼
 ④ ChipStorageTaskArgs POD — child stack
      │ memcpy view.tensors, view.scalars into struct
      ▼
-    pto2_run_runtime(callable, &chip_storage, &config)
+    pto2_run_runtime(cid, &chip_storage, &config)
 ```
 
 ---
@@ -196,52 +182,46 @@ Propagated by value throughout:
 
 1. User builds `CallConfig` and passes into `submit_next_level`
 2. Orchestrator stores it inline in `slot.config` (POD copy)
-3. Dispatch: THREAD passes `const slot.config &`; PROCESS memcpy into mailbox
+3. Dispatch: `WorkerThread::dispatch_process` memcpys the slot's `CallConfig`
+   into the shm mailbox
 4. Child reads `CallConfig` from mailbox by value
-5. `IWorker::run` receives `const CallConfig&`; passed on to `pto2_run_runtime`
-   at the L2 edge
+5. `ChipWorker::run` receives `const CallConfig&`; passed on to
+   `pto2_run_runtime` at the L2 edge
 
 Same type at every level. Used directly at the L2 runtime ABI.
 
 ---
 
-## 5. `IWorker` — the unified execution interface
+## 5. Execution leaves — what runs the kernel
+
+There is no abstract `IWorker` interface; dispatch ends in one of two
+concrete leaves, each consumed by its own Python child loop.
+
+### `ChipWorker` (NEXT_LEVEL, L2 leaf)
+
+Wraps a dlsym'd `runtime.so`. `_chip_process_loop` instantiates one
+`ChipWorker` per chip child and calls its `run` on every dispatch.
+`run()` assembles a `ChipStorageTaskArgs` POD from the decoded view and
+calls `pto2_run_runtime`:
 
 ```cpp
-class IWorker {
-public:
-    virtual ~IWorker() = default;
-    virtual void run(Callable callable,
-                     TaskArgsView args,
-                     const CallConfig &config) = 0;
-};
-```
-
-Three implementations:
-
-### `ChipWorker` (L2 leaf)
-
-Wraps a dlsym'd `runtime.so`. `run()` assembles `ChipStorageTaskArgs` from the
-view and calls `pto2_run_runtime`:
-
-```cpp
-void ChipWorker::run(Callable cb, TaskArgsView view, const CallConfig &config) override {
+void ChipWorker::run(int32_t cid, TaskArgsView view, const CallConfig &config) {
     ChipStorageTaskArgs chip_storage;
     chip_storage.tensor_count_ = view.tensor_count;
     chip_storage.scalar_count_ = view.scalar_count;
     memcpy(chip_storage.tensors_, view.tensors, view.tensor_count * sizeof(ContinuousTensor));
     memcpy(chip_storage.scalars_, view.scalars, view.scalar_count * sizeof(uint64_t));
-    pto2_run_runtime(reinterpret_cast<ChipCallable*>(cb), &chip_storage, &config);
+    pto2_run_runtime(cid, &chip_storage, &config);
 }
 ```
 
-~1.6 KB memcpy per task; negligible.
+One memcpy of a few KB per task; negligible.
 
-### `SubWorker` (Python callable leaf)
+### SUB-type child loop (Python callable leaf)
 
-SubWorker execution is handled entirely in Python. The forked child process
-runs ``_sub_worker_loop`` which reads the args blob from the shared-memory
-mailbox, decodes it into a ``TaskArgs`` object, and passes it to the
+SUB execution is handled entirely in Python. The forked child process
+runs `_sub_worker_loop` which reads the args blob from the shared-memory
+mailbox, decodes it into a `TaskArgs` object, and passes it to the
 registered callable:
 
 ```python
@@ -249,33 +229,19 @@ fn(args)    # args: TaskArgs decoded from the mailbox blob
 ```
 
 The callable receives the same `TaskArgs` that was submitted via
-`orch.submit_sub(cid, args)`, with tags stripped (tags are consumed by the
-Orchestrator at submit time). There is no C++ `SubWorker` class — the
-Python child loop and callable registry are the entire implementation.
+`orch.submit_sub(cid, args)`, with tags stripped (tags are consumed by
+the Orchestrator at submit time). There is no C++ class for SUB workers
+— the Python child loop and callable registry are the entire
+implementation; the child inherits the Python registry through fork COW.
 
-Child inherits the Python registry through fork COW; the registry lookup works
-with no IPC.
+### L4+ recursion — no extra leaf type
 
-### `Worker` (L3+ composite)
-
-Runs one DAG per `run` invocation. The `Callable` is the user's orch fn:
-
-```cpp
-void Worker::run(Callable cb, TaskArgsView args, const CallConfig &config) override {
-    orchestrator_.scope_begin();
-    reinterpret_cast<OrchFn>(cb)(&orchestrator_, args, config);   // user orch fn
-    orchestrator_.drain();
-    orchestrator_.scope_end();
-}
-```
-
-User convenience overload:
-
-```cpp
-void Worker::run(const Task &task) {
-    run(reinterpret_cast<Callable>(task.orch), task.task_args.view(), task.config);
-}
-```
+A higher-level `Worker` is **not** itself an execution leaf. When L4
+dispatches to an L3 child, the child process runs `_child_worker_loop`,
+which looks up the registered orch fn for that cid and calls
+`inner_worker.run(orch_fn, args, config)` — i.e. the L3 `Worker.run`
+Python method, not a C++ leaf. The kernel-running leaves stay at L2
+(`ChipWorker`); higher levels just compose more scheduling engines.
 
 ---
 
@@ -312,37 +278,22 @@ fanout wiring), see [orchestrator.md](orchestrator.md).
 ## 7. Data flow through dispatch
 
 After the scheduler picks an idle `WorkerThread` and calls `wt->dispatch(sid)`,
-the WorkerThread reads task data from the slot and hands it to
-`IWorker::run`:
-
-### THREAD mode — zero-copy
-
-`TaskArgs::view()` returns pointers into the slot's vector backing. No encode,
-no memcpy beyond `CallConfig` value-passing.
-
-```cpp
-worker_->run(slot.callable, slot.task_args.view(), slot.config);
-```
-
-### PROCESS mode — encode once to mailbox
-
-Parent-side WorkerThread encodes callable + config + TaskArgs blob into a
-shm mailbox; child reads the blob back as a view:
+the parent-side WorkerThread encodes `(cid, CallConfig, TaskArgs)` into
+the per-WT shm mailbox and the forked child decodes it:
 
 ```text
-slot.callable   ─┐
-slot.config     ─┼─► memcpy into shm mailbox ─► child reads view ─► worker_->run(cb, view, config)
-slot.task_args  ─┘    (write_blob)                (read_blob)
+slot.callable_id ─┐
+slot.config      ─┼─► memcpy into shm mailbox ─► child decodes ─► ChipWorker::run(cid, view, cfg)
+slot.task_args   ─┘    (dispatch_process)         (_chip_process_loop)
 ```
 
-For SUB workers in PROCESS mode, the child is a Python process running
-``_sub_worker_loop``. The mailbox carries the same blob format, but the
-Python child decodes it via ``_read_args_from_mailbox`` into a ``TaskArgs``
-object and calls ``fn(args)`` directly — the dispatch path bypasses
-``IWorker`` entirely.
+For SUB children the same mailbox layout is reused; the Python child
+runs `_sub_worker_loop`, which decodes the args blob via
+`_read_args_from_mailbox` into a `TaskArgs` object and calls
+`fn(args)` directly — no C++ leaf involved.
 
 The mailbox layout, fork ordering, and child loop are in
-[worker-manager.md](worker-manager.md) §4.
+[worker-manager.md](worker-manager.md).
 
 ### Memory partitioning
 
@@ -350,10 +301,10 @@ The mailbox layout, fork ordering, and child loop are in
 | ------ | -------- | ------- | -------- |
 | `Ring` slot-state pool (`std::deque<unique_ptr<TaskSlotState>>`) | parent heap | Orchestrator, Scheduler, WorkerThread parent side | monotonic task-id; reset at `Worker.run` drain |
 | `slot.task_args` (single) or `task_args_list[N]` (group, vector-backed) | parent heap | same | until slot reaches CONSUMED |
-| per-WT mailbox (PROCESS only) | shm MAP_SHARED | parent WorkerThread writes, child reads | lifetime of WorkerThread |
+| per-WT mailbox | shm MAP_SHARED | parent WorkerThread writes, child reads | lifetime of WorkerThread |
 | **HeapRing[0..3]** (user OUTPUT auto-alloc + `orch.alloc`) | **4 separate shm MAP_SHARED mmaps**, one per scope-layer ring | output to user code; inherited by forked children | per-ring FIFO via `rings_[r].last_alive`; scope depth picks the ring |
 | tensor data bytes (user-provided) | torch shm (`share_memory_()` or equiv) | kernel reads/writes | user-managed |
-| `Callable` target (ChipCallable / OrchFn / Python fn) | parent heap | child via fork COW | pre-fork registered |
+| Registered callables (ChipCallable / orch fn / Python fn) | parent heap | child via fork COW or `CTRL_REGISTER` IPC | pre-fork or dynamically registered |
 
 Slot state lives inside `Ring` as `std::deque<std::unique_ptr<…>>` so
 `push_back` never invalidates pointers to live slots.
@@ -381,12 +332,10 @@ reclaim independently of outer-scope tasks. See
 
 ## 8. Data flow on completion
 
-When `IWorker::run` returns, the WorkerThread signals completion:
-
-- **THREAD mode**: direct call to `on_complete_(slot_id)`, which pushes to
-  `Scheduler::completion_queue_`
-- **PROCESS mode**: child writes `TASK_DONE` to mailbox; parent WorkerThread
-  sees it, calls `on_complete_(slot_id)`
+When the child finishes the kernel, it writes `TASK_DONE` to the mailbox;
+the parent's `WorkerThread::dispatch_process` exits its spin-poll and
+calls `on_complete_(slot_id)`, which pushes the slot onto
+`Scheduler::completion_queue_`.
 
 At this point:
 
@@ -402,10 +351,12 @@ release), see [scheduler.md](scheduler.md) §6.
 
 ## 9. Recursive composition (L4+)
 
-`Worker` implements `IWorker`, so a higher-level `Worker` can register a
-lower-level `Worker` as a NEXT_LEVEL child. The dispatch is structurally
-identical to how L3 dispatches to `ChipWorker` — via a shared-memory
-mailbox and a forked child process loop.
+A higher-level `Worker` registers a lower-level `Worker` as a
+NEXT_LEVEL child via a mailbox just like L3 does for `ChipWorker`. The
+parent side is uniform — `WorkerThread::dispatch_process` doesn't care
+what kind of child is on the other end of the mailbox. The forked
+child runs `_child_worker_loop`, which delegates each dispatched cid to
+`inner_worker.run(...)` — i.e. another full scheduling engine inside.
 
 ### Setup
 
@@ -458,7 +409,7 @@ L4 parent process
                                              └─ _start_hierarchical() forks L3's sub children
 ```
 
-### Dispatch walkthrough (PROCESS mode)
+### Dispatch walkthrough
 
 | Step | Where | What happens |
 | ---- | ----- | ------------ |
@@ -508,7 +459,7 @@ w3.init()    # fork chip_0 here
 w3.run(my_orch, args, CallConfig(block_dim=3))
 ```
 
-Step-by-step (PROCESS mode, one chip worker):
+Step-by-step (one chip worker):
 
 | Step | Where | What happens |
 | ---- | ----- | ------------ |
@@ -548,10 +499,10 @@ runtime: `ChipStorageTaskArgs` (`task_args.h:157`) is already declared with
 
 ### Why no `WorkerPayload` wrapper
 
-`IWorker::run` takes `(Callable, TaskArgsView, const CallConfig&)` directly.
+`ChipWorker::run` takes `(cid, TaskArgsView, const CallConfig&)` directly.
 Wrapping them in a struct added no value and made mailbox serialization
-indirect. Task identity (slot_id) is held by the WorkerThread for the
-completion callback, not passed into the IWorker.
+indirect. Task identity (slot_id) is held by the parent's WorkerThread
+for the completion callback, not passed into the child.
 
 ### Why slots on heap, mailbox on shm
 
@@ -571,10 +522,11 @@ time.
 
 ### Why `TaskArgsView` is just pointers + counts
 
-View is constructed at both ends of dispatch (from `TaskArgs::view()` and
-from `read_blob()`). Making it POD (24 B) lets it pass by value through
-`IWorker::run`. The underlying `ContinuousTensor[]` lives either in the
-vector's heap backing or inline in the mailbox blob — view doesn't care.
+View is constructed at both ends of the mailbox handshake (from
+`TaskArgs::view()` on the parent side for encoding, from a decoded
+mailbox blob on the child side). Making it POD (24 B) lets it pass by
+value through `ChipWorker::run`. The underlying `ContinuousTensor[]`
+lives in the mailbox blob bytes on the child side — view doesn't care.
 
 ---
 
@@ -584,8 +536,8 @@ vector's heap backing or inline in the mailbox blob — view doesn't care.
   model, three-component composition
 - [orchestrator.md](orchestrator.md) — how `submit_*` actually builds the DAG
 - [scheduler.md](scheduler.md) — how dispatched slots get worker threads
-- [worker-manager.md](worker-manager.md) — `WorkerThread`, THREAD/PROCESS
-  modes, mailbox layout, fork ordering
+- [worker-manager.md](worker-manager.md) — `WorkerThread`, mailbox
+  layout, fork ordering
 - [chip-level-arch.md](chip-level-arch.md) — L2 single-chip: three-program
   model (host / AICPU / AICore)
 - [`../src/common/task_interface/task_args.h`](../src/common/task_interface/task_args.h)

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -4,13 +4,13 @@
 of a `Worker` engine. `WorkerManager` owns two pools of `WorkerThread`s (one
 for next-level workers, one for sub workers); each `WorkerThread` drives a
 shared-memory mailbox that a forked Python child consumes — the child runs
-the real `IWorker` in its own address space.
+the real worker (a `ChipWorker` for NEXT_LEVEL, a Python callable for SUB)
+in its own address space.
 
 For the high-level role of this layer among the three engine components, see
-[hierarchical_level_runtime.md](hierarchical_level_runtime.md). For what the
-`IWorker` implementations actually do with task data, see
-[task-flow.md](task-flow.md). For where dispatched tasks come from, see
-[scheduler.md](scheduler.md).
+[hierarchical_level_runtime.md](hierarchical_level_runtime.md). For what
+runs on the other side of the mailbox, see [task-flow.md](task-flow.md).
+For where dispatched tasks come from, see [scheduler.md](scheduler.md).
 
 ---
 
@@ -20,7 +20,8 @@ For the high-level role of this layer among the three engine components, see
 class WorkerManager {
 public:
     // Registration (before init). `mailbox` is a MAILBOX_SIZE-byte
-    // MAP_SHARED region; the real IWorker lives in the forked child.
+    // MAP_SHARED region; the real worker (a `ChipWorker` for NEXT_LEVEL,
+    // a Python callable for SUB) lives in the forked child.
     void add_next_level(void *mailbox);
     void add_sub       (void *mailbox);
 
@@ -51,7 +52,7 @@ private:
 
 ## 2. `WorkerThread`
 
-One WorkerThread per IWorker instance.
+One WorkerThread per registered mailbox (i.e. per forked child worker).
 
 ```cpp
 struct WorkerDispatch {
@@ -152,8 +153,9 @@ Total ~nanoseconds overhead; the wait is dominated by actual kernel execution.
 The child loop lives in Python — see `_chip_process_loop` and
 `_sub_worker_loop` in `python/simpler/worker.py`. Each child polls
 `MAILBOX_OFF_STATE`, decodes the args blob on `TASK_READY`, runs the
-real `IWorker` (`ChipWorker` for chip children) or registered Python
-callable (sub workers), writes back any error, and publishes `TASK_DONE`.
+real worker (a `ChipWorker.run(cid, …)` call for chip children, the
+registered Python callable for sub workers), writes back any error,
+and publishes `TASK_DONE`.
 The child inherits the parent's full address space at fork time, so:
 
 - ChipCallable objects (pre-fork allocated) are COW-visible at the same VA
@@ -191,22 +193,25 @@ the C++ dispatcher thread — it does not own the child process.
 
 ---
 
-## 4. Adding a new IWorker type
+## 4. Adding a new worker kind
 
-To add a new worker kind (e.g., a RemoteWorker over RPC):
+To add a new worker type (e.g., a RemoteWorker over RPC):
 
-1. Implement `IWorker::run(callable, TaskArgsView, const CallConfig&)` on the
-   new class
-2. Decode the mailbox in a child-process loop (mirroring
-   `_chip_process_loop`) so the parent talks to it through the same
-   handshake as `ChipWorker`
-3. Register the mailbox via `manager.add_next_level(mailbox)` or
-   `manager.add_sub(mailbox)`
+1. Define the kernel-running entry point (a C++ class with a `run` method
+   or a Python callable — there is no abstract interface to inherit from).
+2. Write a child-process loop (mirroring `_chip_process_loop` or
+   `_sub_worker_loop`) that polls the mailbox, decodes the args blob, and
+   invokes that entry point.
+3. Register the per-child mailbox via `manager.add_next_level(mailbox)`
+   or `manager.add_sub(mailbox)`.
+
+The parent side (WorkerManager / WorkerThread) doesn't change — it
+only knows the mailbox protocol, not who runs the kernel on the other
+end.
 
 ### 4.1 Nested fork ordering (L4+ Worker children)
 
-When an L4 Worker has L3 Worker children (PROCESS mode), the fork sequence
-nests:
+When an L4 Worker has L3 Worker children, the fork sequence nests:
 
 ```text
 L4 parent process
@@ -249,13 +254,13 @@ children never do. Putting the slot in shm would force cross-process atomics
 and shm-safe containers for no benefit. See
 [task-flow.md](task-flow.md) §11 for full rationale.
 
-### 5.3 Why one WorkerThread per IWorker?
+### 5.3 Why one WorkerThread per child?
 
-Alternative: N workers share one dispatch queue. Rejected because:
+Alternative: N children share one dispatch queue. Rejected because:
 
-- `WorkerThread` queue is the natural unit of backpressure — if worker `i` is
+- `WorkerThread` queue is the natural unit of backpressure — if child `i` is
   slow, its queue fills up and scheduler falls back to another
-- Simpler mental model: one IWorker = one thread that drives it
+- Simpler mental model: one child = one thread that drives it
 - Zero contention on queue access (only one producer, one consumer per queue)
 
 ---
@@ -264,6 +269,6 @@ Alternative: N workers share one dispatch queue. Rejected because:
 
 - [hierarchical_level_runtime.md](hierarchical_level_runtime.md) — where this
   layer fits in the three-component engine
-- [task-flow.md](task-flow.md) — what `IWorker::run` receives
+- [task-flow.md](task-flow.md) — what `ChipWorker::run` receives
 - [scheduler.md](scheduler.md) — the producer of `WorkerThread::dispatch`
   calls

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -17,8 +17,9 @@
  *
  * Python callers register sub-workers via `add_next_level_worker(mailbox_ptr)`
  * / `add_sub_worker(mailbox_ptr)`. Each mailbox addresses a MAILBOX_SIZE-byte
- * MAP_SHARED region; the real IWorker lives in a forked Python child consuming
- * the mailbox via `_chip_process_loop` / `_sub_worker_loop`.
+ * MAP_SHARED region; the real worker (a `ChipWorker` for NEXT_LEVEL, a Python
+ * callable for SUB) lives in a forked Python child consuming the mailbox via
+ * `_chip_process_loop` / `_sub_worker_loop`.
  */
 
 #pragma once

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -1539,17 +1539,6 @@ class Worker:
             return 0
         return self._chip_worker.host_dlopen_count
 
-    def _run_as_child(self, cid: int, args, config) -> None:
-        """Called from C++ _Worker::run when this Worker is a THREAD-mode child.
-
-        Looks up the orch function from the callable registry and delegates
-        to ``self.run(orch_fn, args, config)``.
-        """
-        orch_fn = self._callable_registry.get(cid)
-        if orch_fn is None:
-            raise KeyError(f"callable id {cid} not found in registry")
-        self.run(orch_fn, args, config)
-
     # ------------------------------------------------------------------
     # close
     # ------------------------------------------------------------------

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -10,7 +10,7 @@
  */
 
 /**
- * Distributed runtime — shared types and IWorker interface.
+ * Distributed runtime — shared scheduling types.
  *
  * Every level in the hierarchy (L3 HostWorker, L4, L5, …) runs the same
  * scheduling engine.  This header defines:
@@ -18,15 +18,13 @@
  *   - TaskSlotState: per-task scheduling bookkeeping (stores TaskArgs
  *                        directly — no separate dispatch carrier struct)
  *   - ReadyQueue: Orch→Scheduler notification channel
- *   - IWorker: abstract interface implemented by ChipWorker (the in-child
- *              worker invoked from `_chip_process_loop`)
  *
- * IWorker::run takes (callable_id, TaskArgsView, CallConfig) — the cid is the
- * value returned by ``Worker.register()``; the callable must have been
- * prepared via ``prepare_callable`` before dispatch.  TaskArgs is encoded
- * into the per-WorkerThread shm mailbox with inline std::memcpy of
+ * Dispatch encodes (callable_id, CallConfig, TaskArgs) into the
+ * per-WorkerThread shm mailbox with inline std::memcpy of
  * [int32 T][int32 S][ContinuousTensor × T][uint64 × S]; the forked child
- * decodes the same layout to rebuild the view.
+ * decodes the same layout to rebuild a TaskArgsView and runs the cid
+ * (returned by `Worker.register()`, prepared via `prepare_callable`) on
+ * its `ChipWorker` instance.
  */
 
 #pragma once
@@ -216,24 +214,4 @@ private:
     std::mutex mu_;
     std::condition_variable cv_;
     bool shutdown_{false};
-};
-
-// =============================================================================
-// IWorker — abstract interface
-// =============================================================================
-
-class IWorker {
-public:
-    virtual ~IWorker() = default;
-
-    // Execute one task synchronously. Invoked in the forked child process
-    // by `_chip_process_loop`, blocking until the task is complete.
-    //
-    // `callable_id` is the cid returned by ``Worker.register()``; the
-    // callable must have been prepared via ``prepare_callable()`` before
-    // this call.
-    //
-    // slot_id is not a parameter — completion routing is owned by
-    // WorkerThread / Scheduler at a higher layer.
-    virtual void run(int32_t callable_id, TaskArgsView args, const CallConfig &config) = 0;
 };

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -20,8 +20,10 @@
  * Public surface:
  *   - add_worker(type, mailbox)    — register a sub-worker (before init).
  *                                    `mailbox` is a MAILBOX_SIZE-byte
- *                                    MAP_SHARED region; the real IWorker
- *                                    lives in the forked child.
+ *                                    MAP_SHARED region; the real worker
+ *                                    (a `ChipWorker` for NEXT_LEVEL, a
+ *                                    Python callable for SUB) lives in
+ *                                    the forked child.
  *   - init() / close()             — lifecycle
  *   - get_orchestrator()           — accessor used by the Python facade
  *                                    (scope_begin / drain / scope_end live
@@ -69,8 +71,9 @@ public:
     Worker &operator=(const Worker &) = delete;
 
     // Register a sub-worker before calling init(). `mailbox` is a
-    // MAILBOX_SIZE-byte MAP_SHARED region; the real IWorker lives in the
-    // forked child and consumes the mailbox via the Python child loop.
+    // MAILBOX_SIZE-byte MAP_SHARED region; the real worker (a `ChipWorker`
+    // for NEXT_LEVEL, a Python callable for SUB) lives in the forked
+    // child and consumes the mailbox via the Python child loop.
     void add_worker(WorkerType type, void *mailbox);
 
     // Start the scheduler thread. Must be called AFTER the parent has forked

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -19,8 +19,8 @@
  * Each WorkerThread encodes `(callable, config, args_blob)` into a
  * pre-forked child's shared-memory mailbox, signals TASK_READY, and
  * spin-polls TASK_DONE. The child process loop (Python) reads the
- * mailbox and calls the appropriate IWorker / Python callable in its
- * own address space.
+ * mailbox and runs the cid on its `ChipWorker` (NEXT_LEVEL) or the
+ * registered Python callable (SUB) in its own address space.
  */
 
 #pragma once
@@ -150,7 +150,8 @@ public:
     // Start the worker thread.
     //
     // `mailbox` points to a MAILBOX_SIZE-byte MAP_SHARED region managed
-    // by the Python facade — the real IWorker lives in the forked child
+    // by the Python facade — the real worker (a `ChipWorker` for
+    // NEXT_LEVEL, a Python callable for SUB) lives in the forked child
     // and consumes the mailbox via `_chip_process_loop` / `_sub_worker_loop`.
     //
     // `ring` is a borrowed pointer to the engine's slot-state pool —
@@ -239,7 +240,8 @@ public:
     using OnCompleteFn = std::function<void(TaskSlot)>;
 
     // Register a worker. `mailbox` is a MAILBOX_SIZE-byte MAP_SHARED
-    // region; the real IWorker lives in the forked child.
+    // region; the real worker (a `ChipWorker` for NEXT_LEVEL, a Python
+    // callable for SUB) lives in the forked child.
     void add_next_level(void *mailbox);
     void add_sub(void *mailbox);
 

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -181,7 +181,7 @@ using TaskArgs = TaskArgsTpl<ContinuousTensor, uint64_t, 0, 0, TensorArgType>;
 using ChipStorageTaskArgs = TaskArgsTpl<ContinuousTensor, uint64_t, CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS>;
 
 // ============================================================================
-// TaskArgsView — zero-copy view used by IWorker::run and the wire format
+// TaskArgsView — zero-copy view used by ChipWorker::run and the wire format
 // ============================================================================
 //
 // View-only: refers to externally owned tensor + scalar arrays. No tags

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -21,7 +21,7 @@
 #include "../task_interface/task_args.h"
 #include "types.h"
 
-class ChipWorker : public IWorker {
+class ChipWorker {
 public:
     ChipWorker() = default;
     ~ChipWorker();
@@ -48,10 +48,10 @@ public:
     /// Terminal — the object cannot be reused after this.
     void finalize();
 
-    // IWorker: launch a cid previously staged via prepare_callable.
+    // Launch a cid previously staged via prepare_callable.
     // Materializes a ChipStorageTaskArgs from `args` (one memcpy of T*40B + S*8B
     // into a stack POD), then delegates to the overload below.
-    void run(int32_t callable_id, TaskArgsView args, const CallConfig &config) override;
+    void run(int32_t callable_id, TaskArgsView args, const CallConfig &config);
     // Same launch, but the caller already holds the runtime.so-ABI POD —
     // skip the view→storage memcpy and hand the pointer straight to the C ABI.
     // Used by the ChipStorageTaskArgs path in the nanobind binding.

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -37,12 +37,12 @@
 // The production dispatch path writes (callable, config, args_blob) into a
 // MAILBOX_SIZE-byte shared region and spin-polls TASK_DONE; the real child
 // (`_chip_process_loop` in python/simpler/worker.py) decodes the mailbox and
-// runs an IWorker. For unit testing the Scheduler / WorkerManager state
-// machine in isolation, we replace the forked child with a thread inside
+// dispatches to a `ChipWorker`. For unit testing the Scheduler / WorkerManager
+// state machine in isolation, we replace the forked child with a thread inside
 // the test process that mimics the same handshake but blocks until the
 // test thread releases it via `complete()`.
 //
-// API parity with the previous IWorker-based MockWorker:
+// API parity with the previous MockWorker:
 //   - dispatched[i].callable / .tensor_key — recorded on TASK_READY
 //   - is_running                            — atomic flag the test polls
 //   - wait_running()                        — spin-wait until is_running flips


### PR DESCRIPTION
## Summary

Two follow-ups to #719 (THREAD mode removal) and #797 (run_prepared collapse):

1. **`IWorker` is gone.** After #719 (no THREAD-mode polymorphic call) and #797 (no trampoline), the abstract interface had one implementer (`ChipWorker`) and zero polymorphic call sites — `WorkerThread` holds only a `void *mailbox`, not an `IWorker*`. The parent-side "uniformity" comes from the mailbox byte protocol, not from a C++ vtable. Keeping `IWorker` was ceremony.

2. **`_run_as_child` is gone (again).** PR #710 re-added it to `python/simpler/worker.py` with the original docstring (`Called from C++ _Worker::run when this Worker is a THREAD-mode child`), but the C++ callback path it described was already deleted by #719. Zero callers, confirmed by grep.

## What changed

**C++**
- `types.h`: delete `class IWorker` (just `virtual ~IWorker() = default` + the abstract `run`). Top-of-file doc rewritten to describe the dispatch wire layout instead of an interface.
- `chip_worker.h`: drop `: public IWorker`; `run(cid, view, cfg)` becomes a non-virtual member. Comments retouched.
- `worker.h`, `worker_manager.h`, `worker_bind.h`, `task_args.h`, `test_scheduler.cpp`: reword the "the real IWorker lives in the forked child" sites to name `ChipWorker` / Python callable directly.

**Python**
- `python/simpler/worker.py`: delete `_run_as_child` (10 lines, zero callers).

**Docs**
- `task-flow.md`: rewrite Section 5 (was "`IWorker` — the unified execution interface") into "Execution leaves — what runs the kernel". `ChipWorker` is the only kernel-running leaf; SUB is a Python-only child loop; L4+ recursion is mailbox-IPC, not a leaf type. Removes the long-standing lie "Worker implements IWorker".
- `worker-manager.md`: drop "one WorkerThread per IWorker"; rewrite §4 "Adding a new IWorker type" → "Adding a new worker kind".
- `hierarchical_level_runtime.md`: drop "A Worker is itself an IWorker"; describe L4→L3 as mailbox-IPC composition.
- While editing adjacent prose, also sweep a handful of pre-existing `THREAD/PROCESS mode` doc lies that I missed in #719's doc cleanup (`task-flow.md`, `scheduler.md`, `hierarchical_level_runtime.md`, `orchestrator.md`).

## Test plan

- [x] `pip install --no-build-isolation -e .` clean on macOS arm64.
- [x] `ctest --test-dir tests/ut/cpp/build -LE requires_hardware` — 24/24 pass.
- [x] `pytest tests/ut/py/test_chip_worker.py tests/ut/py/test_worker/` — 108 passed, 3 skipped.
- [x] Grep audit: zero hits for `IWorker`, `_run_as_child`, `THREAD/PROCESS`, `Mode::THREAD`, `set_run_callback`, `run_callback_` across `src/`, `python/`, `tests/`, `docs/`.
- [ ] CI: full Linux `pytest` + `ctest`.
- [ ] CI: hardware sanity — no runtime behavior change expected (no polymorphism removed that had non-`ChipWorker` instances; `_run_as_child` had no callers).