### PR TITLE
Refactor: drop user_data + hoist release_one_buffer to ProfilerBase

### DIFF
--- a/src/a2a3/platform/include/host/dep_gen_collector.h
+++ b/src/a2a3/platform/include/host/dep_gen_collector.h
@@ -129,14 +129,16 @@ struct DepGenModule {
 };
 
 // ---------------------------------------------------------------------------
-// Memory operation callbacks (injected by DeviceRunner — same signatures as
-// PmuAlloc/Register/Free, in keeping with subsystem conventions)
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals (halHost*).
 // ---------------------------------------------------------------------------
 
-using DepGenAllocCallback = void *(*)(size_t size, void *user_data);
-using DepGenRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-using DepGenUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-using DepGenFreeCallback = int (*)(void *dev_ptr, void *user_data);
+using DepGenAllocCallback = profiling_common::ProfAllocCallback;
+using DepGenRegisterCallback = profiling_common::ProfRegisterCallback;
+using DepGenUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using DepGenFreeCallback = profiling_common::ProfFreeCallback;
 
 // ---------------------------------------------------------------------------
 // DepGenCollector
@@ -167,13 +169,12 @@ public:
      * @param alloc_cb        Memory allocation callback
      * @param register_cb     halHostRegister callback (nullptr in sim)
      * @param free_cb         Memory free callback
-     * @param user_data       Opaque pointer forwarded to callbacks
      * @param device_id       Device ID
      * @return 0 on success, non-zero on failure
      */
     int init(
-        int num_threads, DepGenAllocCallback alloc_cb, DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb,
-        void *user_data, int device_id
+        int num_threads, const DepGenAllocCallback &alloc_cb, DepGenRegisterCallback register_cb,
+        const DepGenFreeCallback &free_cb, int device_id
     );
 
     /**
@@ -203,7 +204,7 @@ public:
     /**
      * Free all device memory and release the in-memory record buffer. Idempotent.
      */
-    void finalize(DepGenUnregisterCallback unregister_cb, DepGenFreeCallback free_cb, void *user_data);
+    void finalize(DepGenUnregisterCallback unregister_cb, const DepGenFreeCallback &free_cb);
 
     /**
      * @return true if init() succeeded and finalize() has not run.

--- a/src/a2a3/platform/include/host/l2_perf_collector.h
+++ b/src/a2a3/platform/include/host/l2_perf_collector.h
@@ -156,45 +156,14 @@ struct L2PerfModule {
     }
 };
 
-/**
- * Memory allocation callback for performance profiling.
- *
- * @param size       Memory size in bytes
- * @param user_data  Opaque allocator context
- * @return Allocated device memory pointer, or nullptr on failure
- */
-using L2PerfAllocCallback = void *(*)(size_t size, void *user_data);
-
-/**
- * Memory registration callback (host-visible mapping). nullptr in sim mode
- * (dev pointer is directly host-accessible). Stateless: HAL state is global,
- * so no user_data is threaded through.
- *
- * @param dev_ptr        Device memory pointer
- * @param size           Memory size in bytes
- * @param device_id      Device ID
- * @param[out] host_ptr  Host-mapped pointer
- * @return 0 on success, error code on failure
- */
-using L2PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Memory unregister callback. May be nullptr. Stateless (see register_cb).
- *
- * @param dev_ptr    Device memory pointer
- * @param device_id  Device ID
- * @return 0 on success, error code on failure
- */
-using L2PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Memory free callback.
- *
- * @param dev_ptr    Device memory pointer
- * @param user_data  Opaque allocator context
- * @return 0 on success, error code on failure
- */
-using L2PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals (halHost*).
+using L2PerfAllocCallback = profiling_common::ProfAllocCallback;
+using L2PerfRegisterCallback = profiling_common::ProfRegisterCallback;
+using L2PerfUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using L2PerfFreeCallback = profiling_common::ProfFreeCallback;
 
 // =============================================================================
 // L2PerfCollector
@@ -267,9 +236,8 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_aicore, int device_id, L2PerfLevel l2_perf_level, L2PerfAllocCallback alloc_cb,
-        L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, void *user_data,
-        const std::string &output_prefix
+        int num_aicore, int device_id, L2PerfLevel l2_perf_level, const L2PerfAllocCallback &alloc_cb,
+        L2PerfRegisterCallback register_cb, const L2PerfFreeCallback &free_cb, const std::string &output_prefix
     );
 
     /**
@@ -298,7 +266,7 @@ public:
      * @param user_data      Opaque pointer forwarded to callbacks
      * @return 0 on success, error code on failure
      */
-    int finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data);
+    int finalize(L2PerfUnregisterCallback unregister_cb, const L2PerfFreeCallback &free_cb);
 
     /**
      * @return true if initialize() succeeded and finalize() has not run.
@@ -378,18 +346,10 @@ private:
     uint64_t total_perf_collected_{0};
     uint64_t total_phase_collected_{0};
 
-    // Allocate a single buffer (L2PerfBuffer or PhaseBuffer) and register it
+    // Allocate a single buffer (L2PerfBuffer or PhaseBuffer) and register it.
+    // The RAII counterpart ``release_one_buffer`` lives on ProfilerBase and
+    // is shared with every other collector.
     void *alloc_single_buffer(size_t size, void **host_ptr_out);
-
-    // RAII counterpart of ``alloc_single_buffer``: unregister the host
-    // mapping (if there is one) then release the device memory. Every
-    // release site in ``finalize`` funnels through here so each
-    // ``halHostRegister`` call has a matching ``halHostUnregister`` — when
-    // a session-scoped Worker re-enters ``initialize`` for a second test,
-    // the Ascend HAL's per-device registration table is empty again.
-    void release_one_buffer(
-        void *dev_ptr, L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data
-    );
 
     // Per-buffer-kind handlers used by on_buffer_collected.
     void copy_perf_buffer(const ReadyBufferInfo &info);

--- a/src/a2a3/platform/include/host/pmu_collector.h
+++ b/src/a2a3/platform/include/host/pmu_collector.h
@@ -146,32 +146,14 @@ struct PmuModule {
 // Memory operation callbacks (injected by DeviceRunner)
 // ---------------------------------------------------------------------------
 
-/**
- * Allocate device memory.
- *
- * @param size       Bytes to allocate
- * @param user_data  Opaque allocator context
- * @return Device pointer, or nullptr on failure
- */
-using PmuAllocCallback = void *(*)(size_t size, void *user_data);
-
-/**
- * Register device memory for host-visible access. nullptr in sim mode
- * (dev pointer is directly host-accessible). Stateless: HAL state is global,
- * so no user_data is threaded through.
- */
-using PmuRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Unregister a previously registered host-visible mapping. May be nullptr.
- * Stateless (see register_cb).
- */
-using PmuUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Free device memory.
- */
-using PmuFreeCallback = int (*)(void *dev_ptr, void *user_data);
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals (halHost*).
+using PmuAllocCallback = profiling_common::ProfAllocCallback;
+using PmuRegisterCallback = profiling_common::ProfRegisterCallback;
+using PmuUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using PmuFreeCallback = profiling_common::ProfFreeCallback;
 
 // ---------------------------------------------------------------------------
 // PmuCollector
@@ -212,8 +194,8 @@ public:
      * @return 0 on success, non-zero on failure
      */
     int init(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, PmuAllocCallback alloc_cb,
-        PmuRegisterCallback register_cb, PmuFreeCallback free_cb, void *user_data, int device_id
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
+        const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
     );
 
     /**
@@ -244,7 +226,7 @@ public:
     /**
      * Free all device memory and unregister mappings. Idempotent.
      */
-    void finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data);
+    void finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCallback &free_cb);
 
     /**
      * @return true if init() succeeded and finalize() has not run.

--- a/src/a2a3/platform/include/host/profiling_common/profiler_base.h
+++ b/src/a2a3/platform/include/host/profiling_common/profiler_base.h
@@ -84,7 +84,7 @@
  *
  * Lifecycle (the only correct teardown order):
  *   1. Derived::init() — on the success path, calls set_memory_context() to
- *      stash the alloc/reg/free callbacks, user_data, shm_host pointer and
+ *      stash the alloc/reg/free callbacks, shm_host pointer and
  *      device_id on the base. If init aborts before that, start(tf) becomes
  *      a no-op (shm_host_ stays nullptr).
  *   2. start(tf) — atomically: (a) assembles a MemoryOps from the stashed
@@ -137,12 +137,19 @@
 
 namespace profiling_common {
 
-// Common subsystem callback signatures. All three collectors (PMU / TensorDump
-// / L2Perf) used to declare their own typedefs with identical shapes; these
-// are the canonical types stashed in ProfilerBase via set_memory_context().
-using ProfAllocCallback = void *(*)(size_t size, void *user_data);
+// Common subsystem callback signatures. All four collectors (PMU / TensorDump
+// / L2Perf / DepGen) used to declare their own typedefs with identical
+// shapes; these are the canonical types stashed in ProfilerBase via
+// set_memory_context().
+//
+// Alloc / free use std::function so callers can bind state (e.g. their
+// MemoryAllocator) directly via lambda capture. Register / unregister stay
+// as plain function pointers — they wrap stateless HAL globals (halHost*),
+// so the captureless C-callback shape matches their actual nature.
+using ProfAllocCallback = std::function<void *(size_t size)>;
 using ProfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr_out);
-using ProfFreeCallback = int (*)(void *dev_ptr, void *user_data);
+using ProfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+using ProfFreeCallback = std::function<int(void *dev_ptr)>;
 
 // Result of Module::resolve_entry. Carries everything the unified
 // process_entry algorithm needs to (a) refill the originating pool's free
@@ -322,13 +329,12 @@ public:
      * no-op.
      */
     void set_memory_context(
-        ProfAllocCallback alloc_cb, ProfRegisterCallback register_cb, ProfFreeCallback free_cb, void *user_data,
+        const ProfAllocCallback &alloc_cb, ProfRegisterCallback register_cb, const ProfFreeCallback &free_cb,
         void *shm_host, int device_id
     ) {
         alloc_cb_ = alloc_cb;
         register_cb_ = register_cb;
         free_cb_ = free_cb;
-        user_data_ = user_data;
         shm_host_ = shm_host;
         device_id_ = device_id;
     }
@@ -341,7 +347,6 @@ public:
         alloc_cb_ = nullptr;
         register_cb_ = nullptr;
         free_cb_ = nullptr;
-        user_data_ = nullptr;
         shm_host_ = nullptr;
         device_id_ = -1;
     }
@@ -361,12 +366,8 @@ public:
         if (shm_host_ == nullptr) return;
 
         MemoryOps ops;
-        ops.alloc = [cb = alloc_cb_, ud = user_data_](size_t size) {
-            return cb(size, ud);
-        };
-        ops.free_ = [cb = free_cb_, ud = user_data_](void *dev_ptr) {
-            return cb(dev_ptr, ud);
-        };
+        ops.alloc = alloc_cb_;
+        ops.free_ = free_cb_;
         if (register_cb_ != nullptr) {
             ops.reg = register_cb_;
         } else {
@@ -426,9 +427,35 @@ protected:
     ProfAllocCallback alloc_cb_{nullptr};
     ProfRegisterCallback register_cb_{nullptr};
     ProfFreeCallback free_cb_{nullptr};
-    void *user_data_{nullptr};
     void *shm_host_{nullptr};
     int device_id_{-1};
+
+    /**
+     * RAII counterpart of ``alloc_single_buffer``: unregister the host
+     * mapping (if there is one) then release the device memory. Each
+     * Derived's ``finalize()`` funnels every release site through here so
+     * the framework never frees a dev_ptr without first taking down the
+     * matching ``halHostRegister`` slot — leak in a session-scoped Worker
+     * that re-enters ``init`` would otherwise blow the per-device
+     * registration table.
+     *
+     * Caller still gates by whatever per-Derived flag tracks "did this
+     * collector actually register" (e.g. PMU's ``buffers_registered_``)
+     * by passing nullptr for ``unregister_cb`` when no registration was
+     * installed at init.
+     */
+    void release_one_buffer(void *dev_ptr, ProfUnregisterCallback unregister_cb, const ProfFreeCallback &free_cb) {
+        if (dev_ptr == nullptr) return;
+        if (unregister_cb != nullptr) {
+            int rc = unregister_cb(dev_ptr, device_id_);
+            if (rc != 0) {
+                LOG_ERROR("halHostUnregister failed for dev_ptr %p: %d", dev_ptr, rc);
+            }
+        }
+        if (free_cb) {
+            free_cb(dev_ptr);
+        }
+    }
 
 private:
     /**

--- a/src/a2a3/platform/include/host/tensor_dump_collector.h
+++ b/src/a2a3/platform/include/host/tensor_dump_collector.h
@@ -116,38 +116,14 @@ struct DumpModule {
 // Memory operation callbacks (injected by DeviceRunner)
 // ---------------------------------------------------------------------------
 
-/**
- * Allocate device memory.
- *
- * @param size       Bytes to allocate
- * @param user_data  Opaque allocator context
- * @return Device pointer, or nullptr on failure
- */
-using DumpAllocCallback = void *(*)(size_t size, void *user_data);
-
-/**
- * Register device memory for host-visible access. nullptr in sim mode
- * (dev pointer is directly host-accessible). Stateless: HAL state is global,
- * so no user_data is threaded through.
- *
- * @param dev_ptr        Device memory pointer
- * @param size           Bytes
- * @param device_id      Device ID
- * @param[out] host_ptr  Host-mapped pointer
- * @return 0 on success, error code on failure
- */
-using DumpRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Unregister a previously registered host-visible mapping. May be nullptr.
- * Stateless (see register_cb).
- */
-using DumpUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Free device memory.
- */
-using DumpFreeCallback = int (*)(void *dev_ptr, void *user_data);
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals (halHost*).
+using DumpAllocCallback = profiling_common::ProfAllocCallback;
+using DumpRegisterCallback = profiling_common::ProfRegisterCallback;
+using DumpUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using DumpFreeCallback = profiling_common::ProfFreeCallback;
 
 // =============================================================================
 // TensorDumpCollector
@@ -213,8 +189,8 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
-        DumpFreeCallback free_cb, void *user_data, const std::string &output_prefix
+        int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
+        const DumpFreeCallback &free_cb, const std::string &output_prefix
     );
 
     /**
@@ -248,7 +224,7 @@ public:
      * DumpMetaBuffers held by the framework or still in per-pool free
      * queues). Idempotent on a collector that was never initialized.
      */
-    int finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb, void *user_data);
+    int finalize(DumpUnregisterCallback unregister_cb, const DumpFreeCallback &free_cb);
 
     /**
      * @return true if initialize() succeeded and finalize() has not run.

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -1235,9 +1235,8 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
 }
 
 int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
 
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
@@ -1253,13 +1252,12 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
     int rc = l2_perf_collector_.initialize(
-        num_aicore, device_id, l2_perf_level_, alloc_cb, register_cb, free_cb, &mem_alloc_, output_prefix_
+        num_aicore, device_id, l2_perf_level_, alloc_cb, register_cb, free_cb, output_prefix_
     );
     if (rc != 0) {
         return rc;
@@ -1274,9 +1272,8 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.sche_cpu_num;
 
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
 
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
@@ -1292,14 +1289,11 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, alloc_cb, register_cb, free_cb, &mem_alloc_, output_prefix_
-    );
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, register_cb, free_cb, output_prefix_);
     if (rc != 0) {
         return rc;
     }
@@ -1311,9 +1305,8 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
 int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
 ) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
 
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
@@ -1329,14 +1322,12 @@ int DeviceRunner::init_pmu(
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = pmu_collector_.init(
-        num_cores, num_threads, csv_path, event_type, alloc_cb, register_cb, free_cb, &mem_alloc_, device_id
-    );
+    int rc =
+        pmu_collector_.init(num_cores, num_threads, csv_path, event_type, alloc_cb, register_cb, free_cb, device_id);
     if (rc != 0) {
         return rc;
     }
@@ -1346,9 +1337,8 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
 
     auto register_cb = [](void *dev_ptr, size_t size, int device_id, void **host_ptr) -> int {
@@ -1364,12 +1354,11 @@ int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
         return fn(dev_ptr, size, DEV_SVM_MAP_HOST, device_id, host_ptr);
     };
 
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dep_gen_collector_.init(num_threads, alloc_cb, register_cb, free_cb, &mem_alloc_, device_id);
+    int rc = dep_gen_collector_.init(num_threads, alloc_cb, register_cb, free_cb, device_id);
     if (rc != 0) {
         return rc;
     }
@@ -1386,21 +1375,20 @@ void DeviceRunner::finalize_collectors() {
         }
         return 0;
     };
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
     if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+        l2_perf_collector_.finalize(unregister_cb, free_cb);
     }
     if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+        dump_collector_.finalize(unregister_cb, free_cb);
     }
     if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+        pmu_collector_.finalize(unregister_cb, free_cb);
     }
     if (dep_gen_collector_.is_initialized()) {
-        dep_gen_collector_.finalize(unregister_cb, free_cb, &mem_alloc_);
+        dep_gen_collector_.finalize(unregister_cb, free_cb);
     }
 }

--- a/src/a2a3/platform/onboard/host/memory_allocator.cpp
+++ b/src/a2a3/platform/onboard/host/memory_allocator.cpp
@@ -31,7 +31,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -41,7 +41,7 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
         return 0;
@@ -58,7 +58,7 @@ int MemoryAllocator::free(void *ptr) {
 }
 
 int MemoryAllocator::finalize() {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     int last_error = 0;
     for (void *ptr : ptr_set_) {
         int rc = rtFree(ptr);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -1057,18 +1057,16 @@ uint64_t DeviceRunner::upload_chip_callable_buffer(const ChipCallable *callable)
 // =============================================================================
 
 int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
     // Simulation: dev pointer is directly host-accessible, no register pass-through.
     int rc = l2_perf_collector_.initialize(
-        num_aicore, device_id, l2_perf_level_, alloc_cb, nullptr, free_cb, &mem_alloc_, output_prefix_
+        num_aicore, device_id, l2_perf_level_, alloc_cb, nullptr, free_cb, output_prefix_
     );
     if (rc != 0) {
         return rc;
@@ -1083,18 +1081,14 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.sche_cpu_num;
 
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, alloc_cb, nullptr, free_cb, &mem_alloc_, output_prefix_
-    );
+    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb, output_prefix_);
     if (rc != 0) {
         return rc;
     }
@@ -1106,17 +1100,14 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
 int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int /*device_id*/
 ) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
-    int rc =
-        pmu_collector_.init(num_cores, num_threads, csv_path, event_type, alloc_cb, nullptr, free_cb, &mem_alloc_, -1);
+    int rc = pmu_collector_.init(num_cores, num_threads, csv_path, event_type, alloc_cb, nullptr, free_cb, -1);
     if (rc != 0) {
         return rc;
     }
@@ -1126,18 +1117,16 @@ int DeviceRunner::init_pmu(
 }
 
 int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
-    auto alloc_cb = [](size_t size, void *user_data) -> void * {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->alloc(size);
+    auto alloc_cb = [this](size_t size) -> void * {
+        return mem_alloc_.alloc(size);
     };
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
     // Sim shares an address space with the AICPU thread, so register_cb is
     // not needed (mirrors PMU's nullptr in sim).
-    int rc = dep_gen_collector_.init(num_threads, alloc_cb, nullptr, free_cb, &mem_alloc_, -1);
+    int rc = dep_gen_collector_.init(num_threads, alloc_cb, nullptr, free_cb, -1);
     if (rc != 0) {
         return rc;
     }
@@ -1149,21 +1138,20 @@ int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
 void DeviceRunner::finalize_collectors() {
     // Free through MemoryAllocator so finalize() can audit. Sim shares an
     // address space with the AICPU thread, so no host unregister is needed.
-    auto free_cb = [](void *dev_ptr, void *user_data) -> int {
-        auto *allocator = static_cast<MemoryAllocator *>(user_data);
-        return allocator->free(dev_ptr);
+    auto free_cb = [this](void *dev_ptr) -> int {
+        return mem_alloc_.free(dev_ptr);
     };
 
     if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+        l2_perf_collector_.finalize(nullptr, free_cb);
     }
     if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+        dump_collector_.finalize(nullptr, free_cb);
     }
     if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+        pmu_collector_.finalize(nullptr, free_cb);
     }
     if (dep_gen_collector_.is_initialized()) {
-        dep_gen_collector_.finalize(nullptr, free_cb, &mem_alloc_);
+        dep_gen_collector_.finalize(nullptr, free_cb);
     }
 }

--- a/src/a2a3/platform/sim/host/memory_allocator.cpp
+++ b/src/a2a3/platform/sim/host/memory_allocator.cpp
@@ -28,7 +28,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -38,7 +38,7 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
         return 0;
@@ -50,7 +50,7 @@ int MemoryAllocator::free(void *ptr) {
 }
 
 int MemoryAllocator::finalize() {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     for (void *ptr : ptr_set_) {
         std::free(ptr);
     }

--- a/src/a2a3/platform/src/host/dep_gen_collector.cpp
+++ b/src/a2a3/platform/src/host/dep_gen_collector.cpp
@@ -36,8 +36,8 @@ DepGenCollector::~DepGenCollector() { stop(); }
 // ---------------------------------------------------------------------------
 
 int DepGenCollector::init(
-    int num_threads, DepGenAllocCallback alloc_cb, DepGenRegisterCallback register_cb, DepGenFreeCallback free_cb,
-    void *user_data, int device_id
+    int num_threads, const DepGenAllocCallback &alloc_cb, DepGenRegisterCallback register_cb,
+    const DepGenFreeCallback &free_cb, int device_id
 ) {
     if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("DepGenCollector::init: invalid arguments");
@@ -54,7 +54,7 @@ int DepGenCollector::init(
     // dep_gen is single-instance: just one DepGenBufferState after the header.
     const int num_instances = 1;
     shm_size_ = calc_dep_gen_shm_size(num_instances);
-    shm_dev_ = alloc_cb(shm_size_, user_data);
+    shm_dev_ = alloc_cb(shm_size_);
     if (shm_dev_ == nullptr) {
         LOG_ERROR("DepGenCollector: failed to allocate dep_gen shared memory (%zu bytes)", shm_size_);
         return -1;
@@ -64,7 +64,7 @@ int DepGenCollector::init(
         int rc = register_cb(shm_dev_, shm_size_, device_id, &shm_host_);
         if (rc != 0) {
             LOG_ERROR("DepGenCollector: halHostRegister for dep_gen SHM failed: %d", rc);
-            free_cb(shm_dev_, user_data);
+            free_cb(shm_dev_);
             shm_dev_ = nullptr;
             return rc;
         }
@@ -82,7 +82,7 @@ int DepGenCollector::init(
     DepGenBufferState *state = dep_gen_state(0);
 
     for (int b = 0; b < PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE; b++) {
-        void *dev_ptr = alloc_cb(buf_size, user_data);
+        void *dev_ptr = alloc_cb(buf_size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("DepGenCollector: failed to allocate DepGenBuffer b=%d", b);
             return -1;
@@ -93,7 +93,7 @@ int DepGenCollector::init(
             int rc = register_cb(dev_ptr, buf_size, device_id, &host_ptr);
             if (rc != 0) {
                 LOG_ERROR("DepGenCollector: halHostRegister for DepGenBuffer b=%d failed: %d", b, rc);
-                free_cb(dev_ptr, user_data);
+                free_cb(dev_ptr);
                 return rc;
             }
         }
@@ -114,7 +114,7 @@ int DepGenCollector::init(
     }
 
     initialized_ = true;
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_host_, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, shm_host_, device_id);
 
     LOG_INFO_V0(
         "DepGen collector initialized: %d threads, SHM=0x%lx (records held in memory until replay)", num_threads,
@@ -211,7 +211,7 @@ bool DepGenCollector::reconcile_counters() {
 // finalize
 // ---------------------------------------------------------------------------
 
-void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, DepGenFreeCallback free_cb, void *user_data) {
+void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, const DepGenFreeCallback &free_cb) {
     if (!initialized_) return;
 
     stop();
@@ -225,12 +225,7 @@ void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, DepGenFre
     // Same pattern as PmuCollector: walk owned buffers, then the free_queue
     // and current_buf_ptr, releasing each unique device pointer once.
     auto release_buf = [&](void *p) {
-        if (buffers_registered_ && unregister_cb != nullptr) {
-            unregister_cb(p, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(p, user_data);
-        }
+        release_one_buffer(p, buffers_registered_ ? unregister_cb : nullptr, free_cb);
     };
     manager_.release_owned_buffers(release_buf);
 
@@ -258,12 +253,7 @@ void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, DepGenFre
     manager_.clear_mappings();
 
     if (shm_dev_ != nullptr) {
-        if (shm_registered_ && unregister_cb != nullptr) {
-            unregister_cb(shm_dev_, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(shm_dev_, user_data);
-        }
+        release_one_buffer(shm_dev_, shm_registered_ ? unregister_cb : nullptr, free_cb);
         shm_dev_ = nullptr;
         shm_host_ = nullptr;
     }

--- a/src/a2a3/platform/src/host/l2_perf_collector.cpp
+++ b/src/a2a3/platform/src/host/l2_perf_collector.cpp
@@ -55,7 +55,7 @@ L2PerfCollector::~L2PerfCollector() {
 }
 
 void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
+    void *dev_ptr = alloc_cb_(size);
     if (dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
         *host_ptr_out = nullptr;
@@ -80,26 +80,9 @@ void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
     return dev_ptr;
 }
 
-void L2PerfCollector::release_one_buffer(
-    void *dev_ptr, L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data
-) {
-    if (dev_ptr == nullptr) {
-        return;
-    }
-    if (unregister_cb != nullptr) {
-        int rc = unregister_cb(dev_ptr, device_id_);
-        if (rc != 0) {
-            LOG_ERROR("halHostUnregister failed for dev_ptr %p: %d", dev_ptr, rc);
-        }
-    }
-    if (free_cb != nullptr) {
-        free_cb(dev_ptr, user_data);
-    }
-}
-
 int L2PerfCollector::initialize(
-    int num_aicore, int device_id, L2PerfLevel l2_perf_level, L2PerfAllocCallback alloc_cb,
-    L2PerfRegisterCallback register_cb, L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
+    int num_aicore, int device_id, L2PerfLevel l2_perf_level, const L2PerfAllocCallback &alloc_cb,
+    L2PerfRegisterCallback register_cb, const L2PerfFreeCallback &free_cb, const std::string &output_prefix
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("L2PerfCollector already initialized");
@@ -122,7 +105,7 @@ int L2PerfCollector::initialize(
     // sees consistent values during init. shm_host_ stays nullptr until the
     // shm allocation succeeds — the nullptr guard makes a post-failure
     // start(tf) a no-op.
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, /*shm_host=*/nullptr, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, /*shm_host=*/nullptr, device_id);
 
     // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
     int num_phase_threads = PLATFORM_MAX_AICPU_THREADS;
@@ -136,7 +119,7 @@ int L2PerfCollector::initialize(
     LOG_DEBUG("  Total shared memory:  %zu bytes (%zu KB)", total_size, total_size / 1024);
 
     // Step 2: Allocate shared memory for slot arrays
-    void *perf_dev_ptr = alloc_cb(total_size, user_data);
+    void *perf_dev_ptr = alloc_cb(total_size);
     if (perf_dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate shared memory (%zu bytes)", total_size);
         return -1;
@@ -796,7 +779,7 @@ int L2PerfCollector::export_swimlane_json() {
     return 0;
 }
 
-int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data) {
+int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, const L2PerfFreeCallback &free_cb) {
     if (shm_host_ == nullptr) {
         return 0;
     }
@@ -815,12 +798,12 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     // a reused Worker fail at rc=8 from halHostRegister.
 
     // Free standalone aicore_ring_addr table
-    release_one_buffer(aicore_ring_addr_table_dev_, unregister_cb, free_cb, user_data);
+    release_one_buffer(aicore_ring_addr_table_dev_, unregister_cb, free_cb);
     aicore_ring_addr_table_dev_ = nullptr;
 
     // Release framework-owned buffers (recycled pools, done_queue, ready_queue).
-    manager_.release_owned_buffers([this, unregister_cb, free_cb, user_data](void *p) {
-        release_one_buffer(p, unregister_cb, free_cb, user_data);
+    manager_.release_owned_buffers([this, unregister_cb, free_cb](void *p) {
+        release_one_buffer(p, unregister_cb, free_cb);
     });
 
     // Per-core: current buffer + staging ring + free_queue slots — these
@@ -828,10 +811,10 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     for (int i = 0; i < num_aicore_; i++) {
         L2PerfBufferState *state = get_perf_buffer_state(shm_host_, i);
 
-        release_one_buffer(reinterpret_cast<void *>(state->current_buf_ptr), unregister_cb, free_cb, user_data);
+        release_one_buffer(reinterpret_cast<void *>(state->current_buf_ptr), unregister_cb, free_cb);
         state->current_buf_ptr = 0;
 
-        release_one_buffer(reinterpret_cast<void *>(state->aicore_ring_ptr), unregister_cb, free_cb, user_data);
+        release_one_buffer(reinterpret_cast<void *>(state->aicore_ring_ptr), unregister_cb, free_cb);
         state->aicore_ring_ptr = 0;
 
         rmb();
@@ -843,9 +826,7 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
         }
         for (uint32_t k = 0; k < queued; k++) {
             uint32_t slot = (head + k) % PLATFORM_PROF_SLOT_COUNT;
-            release_one_buffer(
-                reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]), unregister_cb, free_cb, user_data
-            );
+            release_one_buffer(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]), unregister_cb, free_cb);
             state->free_queue.buffer_ptrs[slot] = 0;
         }
         state->free_queue.head = tail;
@@ -855,7 +836,7 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     for (int t = 0; t < num_phase_threads; t++) {
         PhaseBufferState *state = get_phase_buffer_state(shm_host_, num_aicore_, t);
 
-        release_one_buffer(reinterpret_cast<void *>(state->current_buf_ptr), unregister_cb, free_cb, user_data);
+        release_one_buffer(reinterpret_cast<void *>(state->current_buf_ptr), unregister_cb, free_cb);
         state->current_buf_ptr = 0;
 
         rmb();
@@ -867,9 +848,7 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
         }
         for (uint32_t k = 0; k < queued; k++) {
             uint32_t slot = (head + k) % PLATFORM_PROF_SLOT_COUNT;
-            release_one_buffer(
-                reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]), unregister_cb, free_cb, user_data
-            );
+            release_one_buffer(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]), unregister_cb, free_cb);
             state->free_queue.buffer_ptrs[slot] = 0;
         }
         state->free_queue.head = tail;
@@ -879,7 +858,7 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     // ProfilerBase's set_memory_context handed register_cb == nullptr iff the
     // caller doesn't intend to register, so checking unregister_cb inside
     // release_one_buffer is sufficient — no separate ``was_registered_`` flag.
-    release_one_buffer(perf_shared_mem_dev_, unregister_cb, free_cb, user_data);
+    release_one_buffer(perf_shared_mem_dev_, unregister_cb, free_cb);
     LOG_DEBUG("Main shm released");
 
     perf_shared_mem_dev_ = nullptr;

--- a/src/a2a3/platform/src/host/pmu_collector.cpp
+++ b/src/a2a3/platform/src/host/pmu_collector.cpp
@@ -37,8 +37,8 @@ PmuCollector::~PmuCollector() { stop(); }
 // ---------------------------------------------------------------------------
 
 int PmuCollector::init(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, PmuAllocCallback alloc_cb,
-    PmuRegisterCallback register_cb, PmuFreeCallback free_cb, void *user_data, int device_id
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
+    const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
 ) {
     if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
@@ -59,7 +59,7 @@ int PmuCollector::init(
 
     // ---- Allocate shared header + buffer-state region ----
     shm_size_ = calc_pmu_data_size(num_cores);
-    shm_dev_ = alloc_cb(shm_size_, user_data);
+    shm_dev_ = alloc_cb(shm_size_);
     if (shm_dev_ == nullptr) {
         LOG_ERROR("PmuCollector: failed to allocate PMU shared memory (%zu bytes)", shm_size_);
         return -1;
@@ -69,7 +69,7 @@ int PmuCollector::init(
         int rc = register_cb(shm_dev_, shm_size_, device_id, &shm_host_);
         if (rc != 0) {
             LOG_ERROR("PmuCollector: halHostRegister for PMU SHM failed: %d", rc);
-            free_cb(shm_dev_, user_data);
+            free_cb(shm_dev_);
             shm_dev_ = nullptr;
             return rc;
         }
@@ -90,7 +90,7 @@ int PmuCollector::init(
         PmuBufferState *state = pmu_state(c);
 
         for (int b = 0; b < PLATFORM_PMU_BUFFERS_PER_CORE; b++) {
-            void *dev_ptr = alloc_cb(buf_size, user_data);
+            void *dev_ptr = alloc_cb(buf_size);
             if (dev_ptr == nullptr) {
                 LOG_ERROR("PmuCollector: failed to allocate PmuBuffer c=%d b=%d", c, b);
                 return -1;
@@ -101,7 +101,7 @@ int PmuCollector::init(
                 int rc = register_cb(dev_ptr, buf_size, device_id, &host_ptr);
                 if (rc != 0) {
                     LOG_ERROR("PmuCollector: halHostRegister for PmuBuffer c=%d b=%d failed: %d", c, b, rc);
-                    free_cb(dev_ptr, user_data);
+                    free_cb(dev_ptr);
                     return rc;
                 }
             }
@@ -149,7 +149,7 @@ int PmuCollector::init(
     // a MemoryOps from these and launch mgmt + poll threads. PmuModule's alloc
     // fallback in process_entry can then grow the buffer pool on demand if
     // both the per-core free_queue and the recycled pool drain.
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_host_, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, shm_host_, device_id);
 
     LOG_INFO_V0(
         "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
@@ -180,7 +180,7 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
     }
     if (n == 0) return;
 
-    std::lock_guard<std::mutex> lock(csv_mutex_);
+    std::scoped_lock<std::mutex> lock(csv_mutex_);
     ensure_csv_open_unlocked();
     if (!csv_file_.is_open()) return;
     total_collected_ += n;
@@ -295,7 +295,7 @@ void PmuCollector::reconcile_counters() {
 // finalize
 // ---------------------------------------------------------------------------
 
-void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data) {
+void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCallback &free_cb) {
     if (!initialized_) return;
 
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
@@ -309,12 +309,7 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback
     // each PmuBuffer individually at init time (when register_cb was set), so
     // unregister each one here before freeing.
     auto release_buf = [&](void *p) {
-        if (buffers_registered_ && unregister_cb != nullptr) {
-            unregister_cb(p, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(p, user_data);
-        }
+        release_one_buffer(p, buffers_registered_ ? unregister_cb : nullptr, free_cb);
     };
     manager_.release_owned_buffers(release_buf);
 
@@ -344,14 +339,9 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback
     }
     manager_.clear_mappings();
 
-    // Free shared header region.
+    // Free shared header region via the shared RAII helper.
     if (shm_dev_ != nullptr) {
-        if (shm_registered_ && unregister_cb != nullptr) {
-            unregister_cb(shm_dev_, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(shm_dev_, user_data);
-        }
+        release_one_buffer(shm_dev_, shm_registered_ ? unregister_cb : nullptr, free_cb);
         shm_dev_ = nullptr;
         shm_host_ = nullptr;
     }

--- a/src/a2a3/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a2a3/platform/src/host/tensor_dump_collector.cpp
@@ -40,7 +40,7 @@
 TensorDumpCollector::~TensorDumpCollector() { stop(); }
 
 void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
+    void *dev_ptr = alloc_cb_(size);
     if (dev_ptr == nullptr) {
         return nullptr;
     }
@@ -49,7 +49,7 @@ void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out)
     if (register_cb_ != nullptr) {
         int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
         if (rc != 0) {
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             return nullptr;
         }
     }
@@ -61,18 +61,18 @@ void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out)
 }
 
 int TensorDumpCollector::initialize(
-    int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
-    DumpFreeCallback free_cb, void *user_data, const std::string &output_prefix
+    int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
+    const DumpFreeCallback &free_cb, const std::string &output_prefix
 ) {
     num_dump_threads_ = num_dump_threads;
     output_prefix_ = output_prefix;
 
     // Stash the memory context on the base up-front so alloc_single_buffer (and
-    // any other helper that reads alloc_cb_/register_cb_/free_cb_/user_data_)
+    // any other helper that reads alloc_cb_/register_cb_/free_cb_)
     // sees consistent values during init. shm_host_ stays nullptr until the
     // shm allocation succeeds — that nullptr guard makes a post-failure
     // start(tf) a no-op without further bookkeeping.
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, /*shm_host=*/nullptr, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, /*shm_host=*/nullptr, device_id);
 
     // Allocate dump shared memory (header + buffer states)
     size_t shm_size = calc_dump_data_size(num_dump_threads);
@@ -242,14 +242,14 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         DumpedTensor meta = dt;
         meta.bytes.clear();
         {
-            std::lock_guard<std::mutex> lock(collected_mutex_);
+            std::scoped_lock<std::mutex> lock(collected_mutex_);
             collected_.push_back(std::move(meta));
         }
 
         // Enqueue full tensor (with payload) to writer thread
         if (has_payload) {
             {
-                std::lock_guard<std::mutex> lock(write_mutex_);
+                std::scoped_lock<std::mutex> lock(write_mutex_);
                 write_queue_.push(std::move(dt));
             }
             write_cv_.notify_one();
@@ -564,21 +564,19 @@ int TensorDumpCollector::export_dump_files() {
     return 0;
 }
 
-int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb, void *user_data) {
+int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const DumpFreeCallback &free_cb) {
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
     stop();
 
+    // DumpMetaBuffers appear in multiple lists (per-thread free_queues,
+    // recycled pool); dedup so each dev_ptr funnels through the shared
+    // ProfilerBase RAII helper exactly once.
     std::unordered_set<void *> released_meta_buffers;
     auto release_meta_buffer = [&](void *ptr) {
         if (ptr == nullptr || !released_meta_buffers.insert(ptr).second) {
             return;
         }
-        if (was_registered_ && unregister_cb) {
-            unregister_cb(ptr, device_id_);
-        }
-        if (free_cb) {
-            free_cb(ptr, user_data);
-        }
+        release_one_buffer(ptr, was_registered_ ? unregister_cb : nullptr, free_cb);
     };
 
     // Free DumpMetaBuffers still in free_queues and current_buf_ptr
@@ -613,29 +611,19 @@ int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFree
     });
     manager_.clear_mappings();
 
-    // Free arenas
+    // Free arenas through the shared RAII helper.
     for (auto &ai : arenas_) {
         if (ai.dev_ptr) {
-            if (unregister_cb) {
-                unregister_cb(ai.dev_ptr, device_id_);
-            }
-            if (free_cb) {
-                free_cb(ai.dev_ptr, user_data);
-            }
+            release_one_buffer(ai.dev_ptr, unregister_cb, free_cb);
             ai.dev_ptr = nullptr;
             ai.host_ptr = nullptr;
         }
     }
     arenas_.clear();
 
-    // Free shared memory
+    // Free shared memory through the same helper.
     if (dump_shared_mem_dev_) {
-        if (was_registered_ && unregister_cb) {
-            unregister_cb(dump_shared_mem_dev_, device_id_);
-        }
-        if (free_cb) {
-            free_cb(dump_shared_mem_dev_, user_data);
-        }
+        release_one_buffer(dump_shared_mem_dev_, was_registered_ ? unregister_cb : nullptr, free_cb);
         dump_shared_mem_dev_ = nullptr;
         shm_host_ = nullptr;
     }

--- a/src/a5/platform/include/host/l2_perf_collector.h
+++ b/src/a5/platform/include/host/l2_perf_collector.h
@@ -161,32 +161,16 @@ struct L2PerfModule {
     }
 };
 
-/**
- * Memory allocation callback for performance profiling.
- *
- * @param size       Memory size in bytes
- * @param user_data  Opaque allocator context
- * @return Allocated device memory pointer, or nullptr on failure
- */
-using L2PerfAllocCallback = void *(*)(size_t size, void *user_data);
-
-/**
- * Memory registration callback (host-visible mapping). nullptr on a5 — the
- * framework allocates a paired host shadow via malloc + memset 0 +
- * copy_to_device. Stateless: HAL state is global, so no user_data is
- * threaded through.
- */
-using L2PerfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Memory unregister callback. May be nullptr. Stateless (see register_cb).
- */
-using L2PerfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Memory free callback.
- */
-using L2PerfFreeCallback = int (*)(void *dev_ptr, void *user_data);
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals. On a5 onboard the runner passes
+// register_cb=nullptr and the framework installs a malloc-shadow + DMA
+// fallback (default_host_shadow_register).
+using L2PerfAllocCallback = profiling_common::ProfAllocCallback;
+using L2PerfRegisterCallback = profiling_common::ProfRegisterCallback;
+using L2PerfUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using L2PerfFreeCallback = profiling_common::ProfFreeCallback;
 
 // =============================================================================
 // L2PerfCollector
@@ -250,8 +234,8 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
-        L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
+        int num_aicore, int device_id, const L2PerfAllocCallback &alloc_cb, L2PerfRegisterCallback register_cb,
+        const L2PerfFreeCallback &free_cb, const std::string &output_prefix
     );
 
     /**
@@ -280,7 +264,7 @@ public:
      * @param user_data      Opaque pointer forwarded to callbacks
      * @return 0 on success, error code on failure
      */
-    int finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data);
+    int finalize(L2PerfUnregisterCallback unregister_cb, const L2PerfFreeCallback &free_cb);
 
     /**
      * @return true if initialize() succeeded and finalize() has not run.

--- a/src/a5/platform/include/host/pmu_collector.h
+++ b/src/a5/platform/include/host/pmu_collector.h
@@ -152,33 +152,16 @@ struct PmuModule {
 // Memory operation callbacks (injected by DeviceRunner)
 // ---------------------------------------------------------------------------
 
-/**
- * Allocate device memory.
- *
- * @param size       Bytes to allocate
- * @param user_data  Opaque allocator context
- * @return Device pointer, or nullptr on failure
- */
-using PmuAllocCallback = void *(*)(size_t size, void *user_data);
-
-/**
- * Register device memory for host-visible access. nullptr on a5 — the
- * framework allocates a paired host shadow via malloc + memset 0 +
- * copy_to_device. Stateless: HAL state is global, so no user_data is
- * threaded through.
- */
-using PmuRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Unregister a previously registered host-visible mapping. May be nullptr.
- * Stateless (see register_cb).
- */
-using PmuUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Free device memory.
- */
-using PmuFreeCallback = int (*)(void *dev_ptr, void *user_data);
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals. On a5 onboard the runner passes
+// register_cb=nullptr and the framework installs a malloc-shadow + DMA
+// fallback (default_host_shadow_register).
+using PmuAllocCallback = profiling_common::ProfAllocCallback;
+using PmuRegisterCallback = profiling_common::ProfRegisterCallback;
+using PmuUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using PmuFreeCallback = profiling_common::ProfFreeCallback;
 
 // ---------------------------------------------------------------------------
 // PmuCollector
@@ -219,8 +202,8 @@ public:
      * @return 0 on success, non-zero on failure
      */
     int init(
-        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, PmuAllocCallback alloc_cb,
-        PmuRegisterCallback register_cb, PmuFreeCallback free_cb, void *user_data, int device_id
+        int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
+        const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
     );
 
     /**
@@ -258,7 +241,7 @@ public:
     /**
      * Free all device memory and unregister mappings. Idempotent.
      */
-    void finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data);
+    void finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCallback &free_cb);
 
     /**
      * @return true if init() succeeded and finalize() has not run.

--- a/src/a5/platform/include/host/profiling_common/profiler_base.h
+++ b/src/a5/platform/include/host/profiling_common/profiler_base.h
@@ -84,7 +84,7 @@
  *
  * Lifecycle (the only correct teardown order):
  *   1. Derived::init() — on the success path, calls set_memory_context() to
- *      stash the alloc/reg/free callbacks, user_data, shm_dev/host pointers,
+ *      stash the alloc/reg/free callbacks, shm_dev/host pointers,
  *      shm_size and device_id on the base. If init aborts before that,
  *      start(tf) becomes a no-op (shm_host_ stays nullptr).
  *   2. start(tf) — atomically: (a) assembles a MemoryOps from the stashed
@@ -161,12 +161,19 @@
 
 namespace profiling_common {
 
-// Common subsystem callback signatures. All three collectors (PMU / TensorDump
-// / L2Perf) used to declare their own typedefs with identical shapes; these
-// are the canonical types stashed in ProfilerBase via set_memory_context().
-using ProfAllocCallback = void *(*)(size_t size, void *user_data);
+// Common subsystem callback signatures. All four collectors (PMU / TensorDump
+// / L2Perf / DepGen) used to declare their own typedefs with identical
+// shapes; these are the canonical types stashed in ProfilerBase via
+// set_memory_context().
+//
+// Alloc / free use std::function so callers can bind state (e.g. their
+// MemoryAllocator) directly via lambda capture. Register / unregister stay
+// as plain function pointers — they wrap stateless HAL globals (halHost*),
+// so the captureless C-callback shape matches their actual nature.
+using ProfAllocCallback = std::function<void *(size_t size)>;
 using ProfRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr_out);
-using ProfFreeCallback = int (*)(void *dev_ptr, void *user_data);
+using ProfUnregisterCallback = int (*)(void *dev_ptr, int device_id);
+using ProfFreeCallback = std::function<int(void *dev_ptr)>;
 
 /**
  * Default a5 host-shadow register: malloc a paired shadow, zero it, and push
@@ -423,13 +430,12 @@ public:
      * host-shadow register in that case (malloc + memset 0 + copy_to_device).
      */
     void set_memory_context(
-        ProfAllocCallback alloc_cb, ProfRegisterCallback register_cb, ProfFreeCallback free_cb, void *user_data,
+        const ProfAllocCallback &alloc_cb, ProfRegisterCallback register_cb, const ProfFreeCallback &free_cb,
         void *shm_dev, void *shm_host, size_t shm_size, int device_id
     ) {
         alloc_cb_ = alloc_cb;
         register_cb_ = register_cb;
         free_cb_ = free_cb;
-        user_data_ = user_data;
         shm_dev_ = shm_dev;
         shm_host_ = shm_host;
         shm_size_ = shm_size;
@@ -444,7 +450,6 @@ public:
         alloc_cb_ = nullptr;
         register_cb_ = nullptr;
         free_cb_ = nullptr;
-        user_data_ = nullptr;
         shm_dev_ = nullptr;
         shm_host_ = nullptr;
         shm_size_ = 0;
@@ -466,12 +471,8 @@ public:
         if (shm_host_ == nullptr) return;
 
         MemoryOps ops;
-        ops.alloc = [cb = alloc_cb_, ud = user_data_](size_t size) {
-            return cb(size, ud);
-        };
-        ops.free_ = [cb = free_cb_, ud = user_data_](void *dev_ptr) {
-            return cb(dev_ptr, ud);
-        };
+        ops.alloc = alloc_cb_;
+        ops.free_ = free_cb_;
         if (register_cb_ != nullptr) {
             ops.reg = register_cb_;
         } else {
@@ -542,11 +543,32 @@ protected:
     ProfAllocCallback alloc_cb_{nullptr};
     ProfRegisterCallback register_cb_{nullptr};
     ProfFreeCallback free_cb_{nullptr};
-    void *user_data_{nullptr};
     void *shm_dev_{nullptr};
     void *shm_host_{nullptr};
     size_t shm_size_{0};
     int device_id_{-1};
+
+    /**
+     * RAII counterpart of ``alloc_single_buffer``: unregister the host
+     * mapping (if there is one) then release the device memory. Each
+     * Derived's ``finalize()`` funnels every release site through here so
+     * the framework never frees a dev_ptr without first taking down the
+     * matching ``halHostRegister`` slot. On a5 onboard ``register_cb`` is
+     * always nullptr so the unregister branch is a no-op — the helper is
+     * shared with a2a3 anyway for code uniformity.
+     */
+    void release_one_buffer(void *dev_ptr, ProfUnregisterCallback unregister_cb, const ProfFreeCallback &free_cb) {
+        if (dev_ptr == nullptr) return;
+        if (unregister_cb != nullptr) {
+            int rc = unregister_cb(dev_ptr, device_id_);
+            if (rc != 0) {
+                LOG_ERROR("halHostUnregister failed for dev_ptr %p: %d", dev_ptr, rc);
+            }
+        }
+        if (free_cb) {
+            free_cb(dev_ptr);
+        }
+    }
 
 private:
     /**

--- a/src/a5/platform/include/host/tensor_dump_collector.h
+++ b/src/a5/platform/include/host/tensor_dump_collector.h
@@ -127,33 +127,16 @@ struct DumpModule {
 // Memory operation callbacks (injected by DeviceRunner)
 // ---------------------------------------------------------------------------
 
-/**
- * Allocate device memory.
- *
- * @param size       Bytes to allocate
- * @param user_data  Opaque allocator context
- * @return Device pointer, or nullptr on failure
- */
-using DumpAllocCallback = void *(*)(size_t size, void *user_data);
-
-/**
- * Register device memory for host-visible access. nullptr on a5 — the
- * framework allocates a paired host shadow via malloc + memset 0 +
- * copy_to_device. Kept in the public surface for interface parity with
- * a2a3 so future host-mapped backends can plug in here.
- */
-using DumpRegisterCallback = int (*)(void *dev_ptr, size_t size, int device_id, void **host_ptr);
-
-/**
- * Unregister a previously registered host-visible mapping. nullptr on a5;
- * kept for interface parity with a2a3.
- */
-using DumpUnregisterCallback = int (*)(void *dev_ptr, int device_id);
-
-/**
- * Free device memory.
- */
-using DumpFreeCallback = int (*)(void *dev_ptr, void *user_data);
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals. On a5 onboard the runner passes
+// register_cb=nullptr and the framework installs a malloc-shadow + DMA
+// fallback (default_host_shadow_register).
+using DumpAllocCallback = profiling_common::ProfAllocCallback;
+using DumpRegisterCallback = profiling_common::ProfRegisterCallback;
+using DumpUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using DumpFreeCallback = profiling_common::ProfFreeCallback;
 
 // =============================================================================
 // TensorDumpCollector
@@ -219,8 +202,8 @@ public:
      * @return 0 on success, error code on failure
      */
     int initialize(
-        int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
-        DumpFreeCallback free_cb, void *user_data, const std::string &output_prefix
+        int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
+        const DumpFreeCallback &free_cb, const std::string &output_prefix
     );
 
     /**
@@ -255,7 +238,7 @@ public:
      * DumpMetaBuffers held by the framework or still in per-pool free
      * queues). Idempotent on a collector that was never initialized.
      */
-    int finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb, void *user_data);
+    int finalize(DumpUnregisterCallback unregister_cb, const DumpFreeCallback &free_cb);
 
     /**
      * @return true if initialize() succeeded and finalize() has not run.

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -179,15 +179,16 @@ int AicpuSoInfo::finalize() {
 // =============================================================================
 
 // rtMalloc / rtFree wrappers shared by all three profiling subsystems.
-// `user_data` is unused on a5 onboard but kept in the signature to match
-// the framework's canonical alloc/free callback shape.
-static void *prof_alloc_cb(size_t size, void * /*user_data*/) {
+// a5 onboard goes directly through CANN runtime — no per-allocation tracking,
+// so the framework's std::function alloc / free shapes match plain function
+// pointers here.
+static void *prof_alloc_cb(size_t size) {
     void *ptr = nullptr;
     int rc = rtMalloc(&ptr, size, RT_MEMORY_HBM, 0);
     return (rc == 0) ? ptr : nullptr;
 }
 
-static int prof_free_cb(void *dev_ptr, void * /*user_data*/) { return rtFree(dev_ptr); }
+static int prof_free_cb(void *dev_ptr) { return rtFree(dev_ptr); }
 
 DeviceRunner::~DeviceRunner() { finalize(); }
 
@@ -863,13 +864,13 @@ int DeviceRunner::finalize() {
     // Cleanup all profiling subsystems (free shm + per-buffer dev/host
     // shadows). All three collectors share the same alloc/free shape.
     if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
+        l2_perf_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
     if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
+        dump_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
     if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
+        pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
 
     // Free all remaining allocations (including handshake buffer and binGmAddr)
@@ -1038,8 +1039,7 @@ void DeviceRunner::finalize_collectors() {
 
 int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
     int rc = l2_perf_collector_.initialize(
-        num_aicore, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
-        output_prefix_
+        num_aicore, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_
     );
     if (rc == 0) {
         kernel_args_.args.l2_perf_data_base =
@@ -1054,8 +1054,7 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.sche_cpu_num;
 
     int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
-        output_prefix_
+        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_
     );
     if (rc != 0) {
         return rc;
@@ -1069,8 +1068,7 @@ int DeviceRunner::init_pmu(
     int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id
 ) {
     int rc = pmu_collector_.init(
-        num_cores, num_threads, csv_path, event_type, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb,
-        /*user_data=*/nullptr, device_id
+        num_cores, num_threads, csv_path, event_type, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, device_id
     );
     if (rc == 0) {
         kernel_args_.args.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());

--- a/src/a5/platform/onboard/host/memory_allocator.cpp
+++ b/src/a5/platform/onboard/host/memory_allocator.cpp
@@ -31,7 +31,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -41,7 +41,7 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
         return 0;
@@ -58,7 +58,7 @@ int MemoryAllocator::free(void *ptr) {
 }
 
 int MemoryAllocator::finalize() {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     int last_error = 0;
     for (void *ptr : ptr_set_) {
         int rc = rtFree(ptr);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -99,12 +99,12 @@ bool create_temp_so_file(const std::string &path_template, const uint8_t *data, 
 // DeviceRunner Implementation
 // =============================================================================
 
-// malloc / free wrappers shared by all three profiling subsystems.
-// `user_data` is unused in sim but kept in the signature to match the
-// framework's canonical alloc/free callback shape.
-static void *prof_alloc_cb(size_t size, void * /*user_data*/) { return std::malloc(size); }
+// malloc / free wrappers shared by all three profiling subsystems. Plain
+// function pointers convert implicitly into the framework's std::function
+// alloc / free shapes.
+static void *prof_alloc_cb(size_t size) { return std::malloc(size); }
 
-static int prof_free_cb(void *dev_ptr, void * /*user_data*/) {
+static int prof_free_cb(void *dev_ptr) {
     std::free(dev_ptr);
     return 0;
 }
@@ -808,13 +808,13 @@ int DeviceRunner::finalize() {
 
     // Cleanup all profiling subsystems.
     if (l2_perf_collector_.is_initialized()) {
-        l2_perf_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
+        l2_perf_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
     if (dump_collector_.is_initialized()) {
-        dump_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
+        dump_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
     if (pmu_collector_.is_initialized()) {
-        pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
+        pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
 
     // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
@@ -980,8 +980,7 @@ void DeviceRunner::finalize_collectors() {
 
 int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
     int rc = l2_perf_collector_.initialize(
-        num_aicore, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
-        output_prefix_
+        num_aicore, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_
     );
     if (rc == 0) {
         kernel_args_.l2_perf_data_base = reinterpret_cast<uint64_t>(l2_perf_collector_.get_l2_perf_setup_device_ptr());
@@ -995,8 +994,7 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.sche_cpu_num;
 
     int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr,
-        output_prefix_
+        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_
     );
     if (rc != 0) {
         return rc;
@@ -1011,7 +1009,7 @@ int DeviceRunner::init_pmu(
 ) {
     int rc = pmu_collector_.init(
         num_cores, num_threads, csv_path, event_type, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb,
-        /*user_data=*/nullptr, /*device_id=*/-1
+        /*device_id=*/-1
     );
     if (rc == 0) {
         kernel_args_.pmu_data_base = reinterpret_cast<uint64_t>(pmu_collector_.get_pmu_shm_device_ptr());

--- a/src/a5/platform/sim/host/memory_allocator.cpp
+++ b/src/a5/platform/sim/host/memory_allocator.cpp
@@ -28,7 +28,7 @@ void *MemoryAllocator::alloc(size_t size) {
         return nullptr;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     ptr_set_.insert(ptr);
     return ptr;
 }
@@ -38,7 +38,7 @@ int MemoryAllocator::free(void *ptr) {
         return 0;
     }
 
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     auto it = ptr_set_.find(ptr);
     if (it == ptr_set_.end()) {
         return 0;
@@ -50,7 +50,7 @@ int MemoryAllocator::free(void *ptr) {
 }
 
 int MemoryAllocator::finalize() {
-    std::lock_guard<std::mutex> lk(mu_);
+    std::scoped_lock<std::mutex> lk(mu_);
     for (void *ptr : ptr_set_) {
         std::free(ptr);
     }

--- a/src/a5/platform/src/host/l2_perf_collector.cpp
+++ b/src/a5/platform/src/host/l2_perf_collector.cpp
@@ -63,7 +63,7 @@ L2PerfCollector::~L2PerfCollector() {
 }
 
 void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
+    void *dev_ptr = alloc_cb_(size);
     if (dev_ptr == nullptr) {
         LOG_ERROR("Failed to allocate buffer (%zu bytes)", size);
         if (host_ptr_out) *host_ptr_out = nullptr;
@@ -75,7 +75,7 @@ void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
         int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("Buffer registration failed: %d", rc);
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
@@ -84,7 +84,7 @@ void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
         host_ptr = std::malloc(size);
         if (host_ptr == nullptr) {
             LOG_ERROR("Host shadow alloc failed for %zu bytes", size);
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
@@ -99,8 +99,8 @@ void *L2PerfCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
 }
 
 int L2PerfCollector::initialize(
-    int num_aicore, int device_id, L2PerfAllocCallback alloc_cb, L2PerfRegisterCallback register_cb,
-    L2PerfFreeCallback free_cb, void *user_data, const std::string &output_prefix
+    int num_aicore, int device_id, const L2PerfAllocCallback &alloc_cb, L2PerfRegisterCallback register_cb,
+    const L2PerfFreeCallback &free_cb, const std::string &output_prefix
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("L2PerfCollector already initialized");
@@ -120,12 +120,12 @@ int L2PerfCollector::initialize(
     total_phase_collected_ = 0;
 
     // Stash the memory context on the base up-front so alloc_single_buffer
-    // (which reads alloc_cb_/register_cb_/free_cb_/user_data_/device_id_)
+    // (which reads alloc_cb_/register_cb_/free_cb_/device_id_)
     // sees consistent values during init. shm_host_ stays nullptr until the
     // shm allocation succeeds — that nullptr guard makes a post-failure
     // start(tf) a no-op.
     set_memory_context(
-        alloc_cb, register_cb, free_cb, user_data, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+        alloc_cb, register_cb, free_cb, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
     );
 
     // Step 1: Calculate shared memory size (slot arrays only, no actual buffers)
@@ -186,7 +186,7 @@ int L2PerfCollector::initialize(
 
         // Allocate the per-core staging ring (no host shadow needed: AICore
         // writes, AICPU reads — host never touches the ring directly).
-        void *ring_dev = alloc_cb(sizeof(L2PerfAicoreRing), user_data);
+        void *ring_dev = alloc_cb(sizeof(L2PerfAicoreRing));
         if (ring_dev == nullptr) {
             LOG_ERROR("Failed to allocate L2PerfAicoreRing for core %d", i);
             return -1;
@@ -251,7 +251,7 @@ int L2PerfCollector::initialize(
 
     // Step 7: Publish shm pointers on the base now that the region is ready.
     perf_shared_mem_dev_ = perf_dev_ptr;
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, perf_dev_ptr, perf_host_ptr, total_size, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, perf_dev_ptr, perf_host_ptr, total_size, device_id);
 
     collected_perf_records_.assign(num_aicore_, {});
     collected_phase_records_.assign(PLATFORM_MAX_AICPU_THREADS, {});
@@ -757,7 +757,7 @@ int L2PerfCollector::export_swimlane_json() {
 // finalize
 // ---------------------------------------------------------------------------
 
-int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFreeCallback free_cb, void *user_data) {
+int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, const L2PerfFreeCallback &free_cb) {
     if (shm_host_ == nullptr) return 0;
 
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
@@ -766,13 +766,7 @@ int L2PerfCollector::finalize(L2PerfUnregisterCallback unregister_cb, L2PerfFree
     LOG_DEBUG("Cleaning up performance profiling resources");
 
     auto release_dev = [&](void *p) {
-        if (p == nullptr) return;
-        if (unregister_cb != nullptr) {
-            unregister_cb(p, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(p, user_data);
-        }
+        release_one_buffer(p, unregister_cb, free_cb);
     };
 
     // Free buffers still parked in per-core / per-thread free_queues and as

--- a/src/a5/platform/src/host/pmu_collector.cpp
+++ b/src/a5/platform/src/host/pmu_collector.cpp
@@ -39,7 +39,7 @@
 PmuCollector::~PmuCollector() { stop(); }
 
 void *PmuCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
+    void *dev_ptr = alloc_cb_(size);
     if (dev_ptr == nullptr) {
         if (host_ptr_out) *host_ptr_out = nullptr;
         return nullptr;
@@ -50,7 +50,7 @@ void *PmuCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
         int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("PmuCollector: register failed: %d", rc);
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
@@ -58,7 +58,7 @@ void *PmuCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
         host_ptr = std::malloc(size);
         if (host_ptr == nullptr) {
             LOG_ERROR("PmuCollector: host shadow alloc failed for %zu bytes", size);
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
@@ -76,8 +76,8 @@ void *PmuCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
 // ---------------------------------------------------------------------------
 
 int PmuCollector::init(
-    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, PmuAllocCallback alloc_cb,
-    PmuRegisterCallback register_cb, PmuFreeCallback free_cb, void *user_data, int device_id
+    int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type,
+    const PmuAllocCallback &alloc_cb, PmuRegisterCallback register_cb, const PmuFreeCallback &free_cb, int device_id
 ) {
     if (num_cores <= 0 || num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("PmuCollector::init: invalid arguments");
@@ -102,7 +102,7 @@ int PmuCollector::init(
     // consistent values during init. shm_host_ stays nullptr until the shm
     // allocation succeeds — start(tf) gates on shm_host_.
     set_memory_context(
-        alloc_cb, register_cb, free_cb, user_data, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+        alloc_cb, register_cb, free_cb, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
     );
 
     // ---- Allocate shared header + buffer-state region ----
@@ -139,7 +139,7 @@ int PmuCollector::init(
         PmuBufferState *state = get_pmu_buffer_state(shm_host_local, c);
 
         // Allocate the per-core stable PmuAicoreRing (no host shadow needed).
-        void *ring_dev = alloc_cb(sizeof(PmuAicoreRing), user_data);
+        void *ring_dev = alloc_cb(sizeof(PmuAicoreRing));
         if (ring_dev == nullptr) {
             LOG_ERROR("PmuCollector: failed to allocate PmuAicoreRing for core %d", c);
             return -1;
@@ -199,7 +199,7 @@ int PmuCollector::init(
     // Re-set_memory_context now that the shm region is ready. start(tf)
     // gates on shm_host_ being non-null, so this is the moment the
     // collector becomes startable.
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_dev_local, shm_host_local, shm_size, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, shm_dev_local, shm_host_local, shm_size, device_id);
 
     LOG_INFO_V0(
         "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
@@ -230,7 +230,7 @@ void PmuCollector::write_buffer_to_csv(int core_id, int thread_idx, const void *
     }
     if (n == 0) return;
 
-    std::lock_guard<std::mutex> lock(csv_mutex_);
+    std::scoped_lock<std::mutex> lock(csv_mutex_);
     ensure_csv_open_unlocked();
     if (!csv_file_.is_open()) return;
     total_collected_ += n;
@@ -379,7 +379,7 @@ void PmuCollector::reconcile_counters() {
 // finalize
 // ---------------------------------------------------------------------------
 
-void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback free_cb, void *user_data) {
+void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, const PmuFreeCallback &free_cb) {
     if (!initialized_) return;
 
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
@@ -390,13 +390,7 @@ void PmuCollector::finalize(PmuUnregisterCallback unregister_cb, PmuFreeCallback
     }
 
     auto release_dev = [&](void *p) {
-        if (p == nullptr) return;
-        if (unregister_cb != nullptr) {
-            unregister_cb(p, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(p, user_data);
-        }
+        release_one_buffer(p, unregister_cb, free_cb);
     };
 
     // Free buffers still parked in per-core free_queues / current_buf_ptr.

--- a/src/a5/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a5/platform/src/host/tensor_dump_collector.cpp
@@ -46,7 +46,7 @@
 TensorDumpCollector::~TensorDumpCollector() { stop(); }
 
 void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out) {
-    void *dev_ptr = alloc_cb_(size, user_data_);
+    void *dev_ptr = alloc_cb_(size);
     if (dev_ptr == nullptr) {
         if (host_ptr_out) *host_ptr_out = nullptr;
         return nullptr;
@@ -57,7 +57,7 @@ void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out)
         int rc = register_cb_(dev_ptr, size, device_id_, &host_ptr);
         if (rc != 0 || host_ptr == nullptr) {
             LOG_ERROR("TensorDumpCollector: register failed: %d", rc);
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
@@ -67,7 +67,7 @@ void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out)
         host_ptr = std::malloc(size);
         if (host_ptr == nullptr) {
             LOG_ERROR("TensorDumpCollector: host shadow alloc failed for %zu bytes", size);
-            free_cb_(dev_ptr, user_data_);
+            free_cb_(dev_ptr);
             if (host_ptr_out) *host_ptr_out = nullptr;
             return nullptr;
         }
@@ -80,8 +80,8 @@ void *TensorDumpCollector::alloc_single_buffer(size_t size, void **host_ptr_out)
 }
 
 int TensorDumpCollector::initialize(
-    int num_dump_threads, int device_id, DumpAllocCallback alloc_cb, DumpRegisterCallback register_cb,
-    DumpFreeCallback free_cb, void *user_data, const std::string &output_prefix
+    int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
+    const DumpFreeCallback &free_cb, const std::string &output_prefix
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("TensorDumpCollector already initialized");
@@ -92,12 +92,12 @@ int TensorDumpCollector::initialize(
     output_prefix_ = output_prefix;
 
     // Stash the memory context on the base up-front so alloc_single_buffer
-    // (which reads alloc_cb_/register_cb_/free_cb_/user_data_/device_id_)
+    // (which reads alloc_cb_/register_cb_/free_cb_/device_id_)
     // sees consistent values during init. shm_host_ stays nullptr until the
     // shm allocation succeeds — that nullptr guard makes a post-failure
     // start(tf) a no-op without further bookkeeping.
     set_memory_context(
-        alloc_cb, register_cb, free_cb, user_data, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+        alloc_cb, register_cb, free_cb, /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
     );
 
     // Allocate dump shared memory (header + buffer states)
@@ -175,7 +175,7 @@ int TensorDumpCollector::initialize(
     // gates on shm_host_ being non-null, so this re-set_memory_context call
     // is the moment the collector becomes startable.
     dump_shared_mem_dev_ = shm_dev_local;
-    set_memory_context(alloc_cb, register_cb, free_cb, user_data, shm_dev_local, shm_host_local, shm_size, device_id);
+    set_memory_context(alloc_cb, register_cb, free_cb, shm_dev_local, shm_host_local, shm_size, device_id);
 
     LOG_INFO_V0(
         "Tensor dump initialized: %d threads, arena=%lu MB/thread, %d buffers/thread", num_dump_threads,
@@ -304,14 +304,14 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         DumpedTensor meta = dt;
         meta.bytes.clear();
         {
-            std::lock_guard<std::mutex> lock(collected_mutex_);
+            std::scoped_lock<std::mutex> lock(collected_mutex_);
             collected_.push_back(std::move(meta));
         }
 
         // Enqueue full tensor (with payload) to writer thread
         if (has_payload) {
             {
-                std::lock_guard<std::mutex> lock(write_mutex_);
+                std::scoped_lock<std::mutex> lock(write_mutex_);
                 write_queue_.push(std::move(dt));
             }
             write_cv_.notify_one();
@@ -609,20 +609,14 @@ int TensorDumpCollector::export_dump_files() {
     return 0;
 }
 
-int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, DumpFreeCallback free_cb, void *user_data) {
+int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const DumpFreeCallback &free_cb) {
     if (shm_host_ == nullptr) return 0;
 
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
     stop();
 
     auto release_dev = [&](void *p) {
-        if (p == nullptr) return;
-        if (unregister_cb != nullptr) {
-            unregister_cb(p, device_id_);
-        }
-        if (free_cb != nullptr) {
-            free_cb(p, user_data);
-        }
+        release_one_buffer(p, unregister_cb, free_cb);
     };
 
     // Free DumpMetaBuffers still in per-thread free_queues / current_buf_ptr.


### PR DESCRIPTION
## Summary

Two interlocking cleanups across all four profiling collectors
(L2 perf, PMU, TensorDump, DepGen on a2a3; L2 perf, PMU, TensorDump
on a5).

### 1. Drop the \`void *user_data\` indirection

\`ProfilerBase\` already wraps the C-callback shape into
\`std::function\` internally when it builds the \`MemoryOps\` it hands
to \`BufferPoolManager\`. The only reason \`user_data\` survived in
the public surface was the typedef family
\`Prof{Alloc,Free}Callback = T (*)(args..., void *user_data)\`.

In practice every \`DeviceRunner\` call site passed \`&mem_alloc_\`
(or \`nullptr\` on a5, where the runner uses raw
\`rt{Malloc,Free}\` / \`malloc\`), so the indirection carried zero
information through 8+ initialize / finalize parameters and 16+
internal release-site calls.

- \`ProfAllocCallback\` and \`ProfFreeCallback\` switch to
  \`std::function\` so callers bind allocator state directly via
  lambda capture. Register / unregister stay as plain function
  pointers because they wrap stateless HAL globals (\`halHost*\`).
- Each collector's per-subsystem typedef now aliases the canonical
  \`profiling_common::Prof{Alloc,Register,Unregister,Free}Callback\`.
- \`initialize\` / \`finalize\` / \`set_memory_context\` take alloc /
  free by \`const &\` (std::function copy is non-trivial) and lose
  the trailing \`void *user_data\` parameter on all 7 collector cpps.
- \`DeviceRunner\` rewrites every alloc / free lambda to a two-line
  \`[this](...) { return mem_alloc_.alloc/free(...); }\` capture (or
  plain function pointer where state-free).

### 2. Hoist \`release_one_buffer\` to \`ProfilerBase\`

\`L2PerfCollector\` used to own this RAII helper privately
(introduced in #804 to plug the per-buffer \`halHostRegister\` leak).
The three sibling collectors each inlined the same pattern as a
\`release_buf\` / \`release_meta_buffer\` lambda. The helper now
lives on the shared base; every collector funnels its release sites
through it. Per-collector \`buffers_registered_\` /
\`shm_registered_\` / \`was_registered_\` flags still gate the
unregister branch when \`register_cb\` was \`nullptr\` at init.

### Drive-by

Bumps \`std::lock_guard<std::mutex>\` → \`std::scoped_lock\` in the
four files clang-tidy's \`modernize-use-scoped-lock\` flagged when
they were re-linted by the hook (\`MemoryAllocator\` a2a3+a5
onboard+sim; PMU and TensorDump cpps).

### Why \`MemoryAllocator\` stays

It is not dead weight: the destructor frees any tracked pointer that
escaped explicit cleanup (RAII safety net), and the tracking set is
the single source of truth for the per-allocator leak audit. The
refactor keeps both intact — only \`user_data\` (the indirection
through which callbacks reached it) is removed.

## Diff

26 files / **+342 / −523** (∆ −181 LoC).

## Test plan

- [x] Local rebuild for both arches (\`pip install --no-build-isolation -e .\`)
- [x] \`pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/ --platform a2a3sim --enable-l2-swimlane --enable-dep-gen --dump-tensor --enable-pmu 2\` (4 dfx smokes pass)
- [x] \`pytest tests/st/a2a3/tensormap_and_ringbuffer --platform a2a3sim --device 0-1 -k 'not L3'\` → 25 passed
- [x] \`pytest tests/st/a5/tensormap_and_ringbuffer --platform a5sim --device 0-1 -k 'not L3'\` → 16 passed
- [ ] Onboard runs via CI on push (the change-of-interest there is that the four collectors still pair register / unregister correctly through the hoisted helper)