### PR TITLE
Fix: pool PTO2 GM heap and SM per Worker, removing per-run alloc/free

### DIFF
--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -1082,6 +1082,11 @@ int DeviceRunner::finalize() {
     // perf_cleanup guard; this is the backstop for the no-run-since-init case.
     finalize_collectors();
 
+    // Release per-Worker pooled GM heap / SM. Must precede mem_alloc_.finalize()
+    // so the pool frees through the still-live allocator, not after it.
+    gm_heap_pool_.release();
+    gm_sm_pool_.release();
+
     // Free all remaining allocations (including handshake buffer and binGmAddr)
     mem_alloc_.finalize();
 

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -44,6 +44,7 @@
 #include "common/l2_perf_profiling.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
+#include "pto_runtime2/device_pool.h"
 #include "host/function_cache.h"
 #include "host/memory_allocator.h"
 #include "host/l2_perf_collector.h"
@@ -190,8 +191,32 @@ struct AicpuSoInfo {
  */
 class DeviceRunner {
 public:
-    DeviceRunner() = default;
+    DeviceRunner() :
+        gm_heap_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ),
+        gm_sm_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ) {}
     ~DeviceRunner();
+
+    /**
+     * Per-Worker pooled GM heap / shared-memory buffer acquisition.
+     * Grows on demand, never shrinks; backed by `mem_alloc_` so the
+     * underlying allocations are released in `finalize()`.
+     */
+    void *acquire_pooled_gm_heap(size_t size) { return gm_heap_pool_.acquire(size); }
+    void *acquire_pooled_gm_sm(size_t size) { return gm_sm_pool_.acquire(size); }
 
     /**
      * Create a thread bound to this device.
@@ -544,6 +569,12 @@ private:
 
     // Memory management
     MemoryAllocator mem_alloc_;
+
+    // Per-Worker pooled PTO2 GM heap and shared-memory buffers. Constructed
+    // with closures bound to mem_alloc_; released explicitly in finalize()
+    // before mem_alloc_.finalize() so they do not free pointers a second time.
+    pto_runtime2::DevicePool gm_heap_pool_;
+    pto_runtime2::DevicePool gm_sm_pool_;
 
     // Device resources
     rtStream_t stream_aicpu_{nullptr};

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -107,6 +107,22 @@ static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     }
 }
 
+static void *acquire_pooled_gm_heap_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_heap(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void *acquire_pooled_gm_sm_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_sm(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 /* ===========================================================================
  * Public C API (resolved by ChipWorker via dlsym)
  * =========================================================================== */
@@ -326,6 +342,8 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
+        r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
+        r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         // Restore kernel addrs + orch symbol names + active_callable_id; the

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -951,6 +951,11 @@ int DeviceRunner::finalize() {
     // Close executor .so files (typically already closed by run(), this is a safety net)
     unload_executor_binaries();
 
+    // Release per-Worker pooled GM heap / SM. Must precede mem_alloc_.finalize()
+    // so the pool frees through the still-live allocator, not after it.
+    gm_heap_pool_.release();
+    gm_sm_pool_.release();
+
     // Free all remaining allocations
     mem_alloc_.finalize();
     clear_cpu_sim_shared_storage();

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -45,6 +45,7 @@
 
 #include "callable.h"
 #include "prepare_callable_common.h"
+#include "pto_runtime2/device_pool.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
@@ -73,8 +74,32 @@
  */
 class DeviceRunner {
 public:
-    DeviceRunner() = default;
+    DeviceRunner() :
+        gm_heap_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ),
+        gm_sm_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ) {}
     ~DeviceRunner();
+
+    /**
+     * Per-Worker pooled GM heap / shared-memory buffer acquisition.
+     * Grows on demand, never shrinks; backed by `mem_alloc_` so the
+     * underlying allocations are released in `finalize()`.
+     */
+    void *acquire_pooled_gm_heap(size_t size) { return gm_heap_pool_.acquire(size); }
+    void *acquire_pooled_gm_sm(size_t size) { return gm_sm_pool_.acquire(size); }
 
     /**
      * Create a thread bound to this device.
@@ -253,6 +278,12 @@ private:
 
     // Memory management
     MemoryAllocator mem_alloc_;
+
+    // Per-Worker pooled PTO2 GM heap and shared-memory buffers. Constructed
+    // with closures bound to mem_alloc_; released explicitly in finalize()
+    // before mem_alloc_.finalize() so they do not free pointers a second time.
+    pto_runtime2::DevicePool gm_heap_pool_;
+    pto_runtime2::DevicePool gm_sm_pool_;
 
     // Simulation state (no actual device resources)
     KernelArgs kernel_args_;

--- a/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/sim/host/pto_runtime_c_api.cpp
@@ -102,6 +102,22 @@ static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     }
 }
 
+static void *acquire_pooled_gm_heap_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_heap(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void *acquire_pooled_gm_sm_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_sm(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 /* ===========================================================================
  * Public C API (resolved by ChipWorker via dlsym)
  * =========================================================================== */
@@ -292,6 +308,8 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
+        r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
+        r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -135,6 +135,13 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Acquire a pooled per-Worker device buffer (PTO2 GM heap / shared memory).
+    // The host_build_graph runtime does not currently use these — the field
+    // exists only so the platform layer's pto_runtime_c_api.cpp can populate
+    // the same HostApi struct regardless of which runtime variant it is built
+    // against. Unset for this variant; do not call.
+    void *(*acquire_pooled_gm_heap)(size_t size);
+    void *(*acquire_pooled_gm_sm)(size_t size);
     // Single-shot upload of the entire ChipCallable buffer. `callable` is a
     // `const ChipCallable *` (declared void* to avoid pulling task_interface
     // headers into runtime.h). DeviceRunner walks child_offsets_ to compute

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -271,29 +271,29 @@ extern "C" int bind_prepared_to_runtime_impl(
     uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
     uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
 
-    // Allocate GM heap for orchestrator output buffers (all rings combined)
+    // Acquire pooled GM heap for orchestrator output buffers (all rings combined).
+    // Owned by DeviceRunner across runs; do NOT record in tensor_pairs_ — the
+    // free is deferred to DeviceRunner::finalize().
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
     int64_t t_heap_start = _now_ms();
-    void *gm_heap = runtime->host_api.device_malloc(total_heap_size);
+    void *gm_heap = runtime->host_api.acquire_pooled_gm_heap(total_heap_size);
     int64_t t_heap_end = _now_ms();
     if (gm_heap == nullptr) {
-        LOG_ERROR("Failed to allocate GM heap");
+        LOG_ERROR("Failed to acquire pooled GM heap");
         return -1;
     }
-    runtime->tensor_pairs_.push_back({nullptr, gm_heap, total_heap_size});
     runtime->set_gm_heap(gm_heap);
 
-    // Allocate PTO2 shared memory
+    // Acquire pooled PTO2 shared memory (same ownership rule as GM heap).
     int64_t t_sm_start = _now_ms();
     uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
-    void *sm_ptr = runtime->host_api.device_malloc(sm_size);
+    void *sm_ptr = runtime->host_api.acquire_pooled_gm_sm(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate PTO2 shared memory");
+        LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
         return -1;
     }
     runtime->set_gm_sm_ptr(sm_ptr);
-    runtime->tensor_pairs_.push_back({nullptr, sm_ptr, static_cast<size_t>(sm_size)});
 
     // Set up device orchestration state
     runtime->set_orch_args(device_args);
@@ -302,8 +302,8 @@ extern "C" int bind_prepared_to_runtime_impl(
 
     int64_t t_total_end = _now_ms();
     LOG_INFO_V0("TIMING: args_malloc_copy = %" PRId64 "ms", t_args_end - t_args_start);
-    LOG_INFO_V0("TIMING: gm_heap_alloc(1GB) = %" PRId64 "ms", t_heap_end - t_heap_start);
-    LOG_INFO_V0("TIMING: shared_mem_alloc = %" PRId64 "ms", t_sm_end - t_sm_start);
+    LOG_INFO_V0("TIMING: gm_heap_acquire = %" PRId64 "ms", t_heap_end - t_heap_start);
+    LOG_INFO_V0("TIMING: shared_mem_acquire = %" PRId64 "ms", t_sm_end - t_sm_start);
     LOG_INFO_V0("TIMING: total_init_runtime_impl = %" PRId64 "ms", t_total_end - t_total_start);
 
     return 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -119,6 +119,13 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Acquire a pooled per-Worker device buffer for the PTO2 GM heap / shared
+    // memory. The platform layer keeps the allocation alive across runs and
+    // grows it on demand; the returned pointer must NOT be passed to
+    // device_free or recorded in `tensor_pairs_`, because it is owned by the
+    // DeviceRunner and freed in `DeviceRunner::finalize()`.
+    void *(*acquire_pooled_gm_heap)(size_t size);
+    void *(*acquire_pooled_gm_sm)(size_t size);
     // Single-shot upload of the entire ChipCallable buffer. `callable` is a
     // `const ChipCallable *` (declared void* to avoid pulling task_interface
     // headers into runtime.h). DeviceRunner walks child_offsets_ to compute

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -872,6 +872,11 @@ int DeviceRunner::finalize() {
         pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb, /*user_data=*/nullptr);
     }
 
+    // Release per-Worker pooled GM heap / SM. Must precede mem_alloc_.finalize()
+    // so the pool frees through the still-live allocator, not after it.
+    gm_heap_pool_.release();
+    gm_sm_pool_.release();
+
     // Free all remaining allocations (including handshake buffer and binGmAddr)
     mem_alloc_.finalize();
 

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -39,6 +39,7 @@
 
 #include "callable.h"
 #include "prepare_callable_common.h"
+#include "pto_runtime2/device_pool.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_perf_profiling.h"
@@ -179,8 +180,32 @@ struct AicpuSoInfo {
  */
 class DeviceRunner {
 public:
-    DeviceRunner() = default;
+    DeviceRunner() :
+        gm_heap_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ),
+        gm_sm_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ) {}
     ~DeviceRunner();
+
+    /**
+     * Per-Worker pooled GM heap / shared-memory buffer acquisition.
+     * Grows on demand, never shrinks; backed by `mem_alloc_` so the
+     * underlying allocations are released in `finalize()`.
+     */
+    void *acquire_pooled_gm_heap(size_t size) { return gm_heap_pool_.acquire(size); }
+    void *acquire_pooled_gm_sm(size_t size) { return gm_sm_pool_.acquire(size); }
 
     /**
      * Create a thread bound to this device.
@@ -451,6 +476,12 @@ private:
 
     // Memory management
     MemoryAllocator mem_alloc_;
+
+    // Per-Worker pooled PTO2 GM heap and shared-memory buffers. Constructed
+    // with closures bound to mem_alloc_; released explicitly in finalize()
+    // before mem_alloc_.finalize() so they do not free pointers a second time.
+    pto_runtime2::DevicePool gm_heap_pool_;
+    pto_runtime2::DevicePool gm_sm_pool_;
 
     // Device resources
     rtStream_t stream_aicpu_{nullptr};

--- a/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/onboard/host/pto_runtime_c_api.cpp
@@ -107,6 +107,22 @@ static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     }
 }
 
+static void *acquire_pooled_gm_heap_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_heap(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void *acquire_pooled_gm_sm_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_sm(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 /* ===========================================================================
  * Public C API (resolved by ChipWorker via dlsym)
  * =========================================================================== */
@@ -362,6 +378,8 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
+        r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
+        r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         // Restore kernel addrs + orch symbol names + active_callable_id; the

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -855,6 +855,11 @@ int DeviceRunner::finalize() {
     // Close executor .so files (typically already closed by run(), this is a safety net)
     unload_executor_binaries();
 
+    // Release per-Worker pooled GM heap / SM. Must precede mem_alloc_.finalize()
+    // so the pool frees through the still-live allocator, not after it.
+    gm_heap_pool_.release();
+    gm_sm_pool_.release();
+
     // Free all remaining allocations
     mem_alloc_.finalize();
     clear_cpu_sim_shared_storage();

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -43,6 +43,7 @@
 
 #include "callable.h"
 #include "prepare_callable_common.h"
+#include "pto_runtime2/device_pool.h"
 #include "common/core_type.h"
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
@@ -70,8 +71,32 @@
  */
 class DeviceRunner {
 public:
-    DeviceRunner() = default;
+    DeviceRunner() :
+        gm_heap_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ),
+        gm_sm_pool_(
+            [this](size_t n) {
+                return mem_alloc_.alloc(n);
+            },
+            [this](void *p) {
+                mem_alloc_.free(p);
+            }
+        ) {}
     ~DeviceRunner();
+
+    /**
+     * Per-Worker pooled GM heap / shared-memory buffer acquisition.
+     * Grows on demand, never shrinks; backed by `mem_alloc_` so the
+     * underlying allocations are released in `finalize()`.
+     */
+    void *acquire_pooled_gm_heap(size_t size) { return gm_heap_pool_.acquire(size); }
+    void *acquire_pooled_gm_sm(size_t size) { return gm_sm_pool_.acquire(size); }
 
     /**
      * Create a thread bound to this device.
@@ -250,6 +275,12 @@ private:
 
     // Memory management
     MemoryAllocator mem_alloc_;
+
+    // Per-Worker pooled PTO2 GM heap and shared-memory buffers. Constructed
+    // with closures bound to mem_alloc_; released explicitly in finalize()
+    // before mem_alloc_.finalize() so they do not free pointers a second time.
+    pto_runtime2::DevicePool gm_heap_pool_;
+    pto_runtime2::DevicePool gm_sm_pool_;
 
     // Simulation state (no actual device resources)
     KernelArgs kernel_args_;

--- a/src/a5/platform/sim/host/pto_runtime_c_api.cpp
+++ b/src/a5/platform/sim/host/pto_runtime_c_api.cpp
@@ -102,6 +102,22 @@ static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     }
 }
 
+static void *acquire_pooled_gm_heap_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_heap(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
+static void *acquire_pooled_gm_sm_wrapper(size_t size) {
+    try {
+        return current_runner()->acquire_pooled_gm_sm(size);
+    } catch (...) {
+        return nullptr;
+    }
+}
+
 /* ===========================================================================
  * Public C API (resolved by ChipWorker via dlsym)
  * =========================================================================== */
@@ -289,6 +305,8 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
+        r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
+        r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
         r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -141,6 +141,13 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Acquire a pooled per-Worker device buffer (PTO2 GM heap / shared memory).
+    // The host_build_graph runtime does not currently use these — the field
+    // exists only so the platform layer's pto_runtime_c_api.cpp can populate
+    // the same HostApi struct regardless of which runtime variant it is built
+    // against. Unset for this variant; do not call.
+    void *(*acquire_pooled_gm_heap)(size_t size);
+    void *(*acquire_pooled_gm_sm)(size_t size);
     // Single-shot upload of the entire ChipCallable buffer. `callable` is a
     // `const ChipCallable *` (declared void* to avoid pulling task_interface
     // headers into runtime.h). DeviceRunner walks child_offsets_ to compute

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -271,29 +271,29 @@ extern "C" int bind_prepared_to_runtime_impl(
     uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
     uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
 
-    // Allocate GM heap for orchestrator output buffers (all rings combined)
+    // Acquire pooled GM heap for orchestrator output buffers (all rings combined).
+    // Owned by DeviceRunner across runs; do NOT record in tensor_pairs_ — the
+    // free is deferred to DeviceRunner::finalize().
     uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
     int64_t t_heap_start = _now_ms();
-    void *gm_heap = runtime->host_api.device_malloc(total_heap_size);
+    void *gm_heap = runtime->host_api.acquire_pooled_gm_heap(total_heap_size);
     int64_t t_heap_end = _now_ms();
     if (gm_heap == nullptr) {
-        LOG_ERROR("Failed to allocate GM heap");
+        LOG_ERROR("Failed to acquire pooled GM heap");
         return -1;
     }
-    runtime->tensor_pairs_.push_back({nullptr, gm_heap, total_heap_size});
     runtime->set_gm_heap(gm_heap);
 
-    // Allocate PTO2 shared memory
+    // Acquire pooled PTO2 shared memory (same ownership rule as GM heap).
     int64_t t_sm_start = _now_ms();
     uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
-    void *sm_ptr = runtime->host_api.device_malloc(sm_size);
+    void *sm_ptr = runtime->host_api.acquire_pooled_gm_sm(sm_size);
     int64_t t_sm_end = _now_ms();
     if (sm_ptr == nullptr) {
-        LOG_ERROR("Failed to allocate PTO2 shared memory");
+        LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
         return -1;
     }
     runtime->set_gm_sm_ptr(sm_ptr);
-    runtime->tensor_pairs_.push_back({nullptr, sm_ptr, static_cast<size_t>(sm_size)});
 
     // Set up device orchestration state
     runtime->set_orch_args(device_args);
@@ -302,8 +302,8 @@ extern "C" int bind_prepared_to_runtime_impl(
 
     int64_t t_total_end = _now_ms();
     LOG_INFO_V0("TIMING: args_malloc_copy = %" PRId64 "ms", t_args_end - t_args_start);
-    LOG_INFO_V0("TIMING: gm_heap_alloc(1GB) = %" PRId64 "ms", t_heap_end - t_heap_start);
-    LOG_INFO_V0("TIMING: shared_mem_alloc = %" PRId64 "ms", t_sm_end - t_sm_start);
+    LOG_INFO_V0("TIMING: gm_heap_acquire = %" PRId64 "ms", t_heap_end - t_heap_start);
+    LOG_INFO_V0("TIMING: shared_mem_acquire = %" PRId64 "ms", t_sm_end - t_sm_start);
     LOG_INFO_V0("TIMING: total_init_runtime_impl = %" PRId64 "ms", t_total_end - t_total_start);
 
     return 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -127,6 +127,13 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Acquire a pooled per-Worker device buffer for the PTO2 GM heap / shared
+    // memory. The platform layer keeps the allocation alive across runs and
+    // grows it on demand; the returned pointer must NOT be passed to
+    // device_free or recorded in `tensor_pairs_`, because it is owned by the
+    // DeviceRunner and freed in `DeviceRunner::finalize()`.
+    void *(*acquire_pooled_gm_heap)(size_t size);
+    void *(*acquire_pooled_gm_sm)(size_t size);
     // Single-shot upload of the entire ChipCallable buffer. `callable` is a
     // `const ChipCallable *` (declared void* to avoid pulling task_interface
     // headers into runtime.h). DeviceRunner walks child_offsets_ to compute

--- a/src/common/pto_runtime2/device_pool.h
+++ b/src/common/pto_runtime2/device_pool.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_COMMON_PTO_RUNTIME2_DEVICE_POOL_H_
+#define SRC_COMMON_PTO_RUNTIME2_DEVICE_POOL_H_
+
+#include <cstddef>
+#include <functional>
+
+namespace pto_runtime2 {
+
+/**
+ * Single-slot pooled device buffer. Holds at most one allocation at a time.
+ *
+ * `acquire(size)` returns the current pointer if it is already large enough,
+ * otherwise frees the existing buffer and allocates a fresh, larger one.
+ * Designed for buffers whose lifetime should span many `worker.run()` calls
+ * (e.g. PTO2 GM heap, PTO2 shared memory) — placing them in a DevicePool
+ * lets the owner (per-Worker DeviceRunner) reuse the same device allocation
+ * across runs and free it once at session teardown.
+ *
+ * The constructor takes raw `alloc(size_t) -> void*` / `free(void*)`
+ * callables so unit tests can inject mock allocators without linking against
+ * any real device runtime.
+ */
+class DevicePool {
+public:
+    using AllocFn = std::function<void *(size_t)>;
+    using FreeFn = std::function<void(void *)>;
+
+    DevicePool(AllocFn alloc_fn, FreeFn free_fn) :
+        alloc_(std::move(alloc_fn)),
+        free_(std::move(free_fn)) {}
+
+    ~DevicePool() { release(); }
+
+    DevicePool(const DevicePool &) = delete;
+    DevicePool &operator=(const DevicePool &) = delete;
+
+    void *acquire(size_t need) {
+        if (need == 0) return nullptr;
+        if (ptr_ != nullptr && need <= size_) return ptr_;
+        if (ptr_ != nullptr) free_(ptr_);
+        ptr_ = alloc_(need);
+        size_ = (ptr_ != nullptr) ? need : 0;
+        return ptr_;
+    }
+
+    void release() {
+        if (ptr_ != nullptr) {
+            free_(ptr_);
+            ptr_ = nullptr;
+            size_ = 0;
+        }
+    }
+
+    void *ptr() const { return ptr_; }
+    size_t size() const { return size_; }
+
+private:
+    AllocFn alloc_;
+    FreeFn free_;
+    void *ptr_{nullptr};
+    size_t size_{0};
+};
+
+}  // namespace pto_runtime2
+
+#endif  // SRC_COMMON_PTO_RUNTIME2_DEVICE_POOL_H_

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -266,6 +266,7 @@ set_tests_properties(test_chip_callable_upload_immutable PROPERTIES LABELS "no_h
 # ---------------------------------------------------------------------------
 add_common_utils_test(test_elf_build_id common/test_elf_build_id.cpp)
 add_common_utils_test(test_runtime_orch_so common/test_runtime_orch_so.cpp)
+add_common_utils_test(test_device_pool common/test_device_pool.cpp)
 
 # Per-callable_id orch SO file naming regression (see rtStreamSynchronize
 # 507018 root cause). Compiles the a2a3 onboard `create_orch_so_file`

--- a/tests/ut/cpp/common/test_device_pool.cpp
+++ b/tests/ut/cpp/common/test_device_pool.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+// Unit tests for src/common/pto_runtime2/device_pool.h.
+//
+// DevicePool is a single-slot pooled buffer holder used by DeviceRunner to
+// keep the PTO2 GM heap / shared memory alive across worker.run() dispatches.
+// The pool's contract is:
+//   - acquire(size) returns the existing pointer if it is already large
+//     enough; otherwise frees the old buffer and allocates a fresh one.
+//   - acquire(0) is a no-op that returns nullptr.
+//   - release() frees the buffer and resets state.
+//   - The destructor releases the buffer.
+//
+// These tests exercise the contract with mock alloc/free callables so they
+// do not depend on any real device runtime.
+
+#include <cstddef>
+#include <unordered_set>
+
+#include <gtest/gtest.h>
+
+#include "pto_runtime2/device_pool.h"
+
+using pto_runtime2::DevicePool;
+
+namespace {
+
+// Minimal allocator that hands out fresh host buffers and tracks how many
+// times alloc / free were called. Each returned pointer is unique so tests
+// can assert pointer identity without relying on the system allocator
+// reusing the same address.
+struct MockAllocator {
+    int alloc_count = 0;
+    int free_count = 0;
+    std::unordered_set<void *> live;
+
+    void *alloc(size_t size) {
+        ++alloc_count;
+        void *p = ::operator new(size);
+        live.insert(p);
+        return p;
+    }
+
+    void free(void *p) {
+        ++free_count;
+        EXPECT_EQ(live.count(p), 1u) << "free called on pointer not currently live";
+        live.erase(p);
+        ::operator delete(p);
+    }
+};
+
+DevicePool make_pool(MockAllocator *m) {
+    return DevicePool(
+        [m](size_t n) {
+            return m->alloc(n);
+        },
+        [m](void *p) {
+            m->free(p);
+        }
+    );
+}
+
+TEST(DevicePoolTest, AcquireSameSizeReusesBuffer) {
+    MockAllocator m;
+    DevicePool pool = make_pool(&m);
+
+    void *p1 = pool.acquire(128);
+    ASSERT_NE(p1, nullptr);
+    EXPECT_EQ(m.alloc_count, 1);
+    EXPECT_EQ(m.free_count, 0);
+
+    void *p2 = pool.acquire(128);
+    EXPECT_EQ(p2, p1) << "same-size acquire must reuse existing buffer";
+    EXPECT_EQ(m.alloc_count, 1);
+    EXPECT_EQ(m.free_count, 0);
+}
+
+TEST(DevicePoolTest, AcquireLargerSizeTriggersRealloc) {
+    MockAllocator m;
+    DevicePool pool = make_pool(&m);
+
+    void *p1 = pool.acquire(128);
+    ASSERT_NE(p1, nullptr);
+
+    void *p2 = pool.acquire(256);
+    ASSERT_NE(p2, nullptr);
+    EXPECT_NE(p2, p1) << "grow must allocate a new buffer";
+    EXPECT_EQ(m.alloc_count, 2);
+    EXPECT_EQ(m.free_count, 1);
+    EXPECT_EQ(pool.size(), 256u);
+}
+
+TEST(DevicePoolTest, AcquireSmallerSizeKeepsExistingBuffer) {
+    MockAllocator m;
+    DevicePool pool = make_pool(&m);
+
+    void *p_big = pool.acquire(256);
+    ASSERT_NE(p_big, nullptr);
+    EXPECT_EQ(m.alloc_count, 1);
+
+    void *p_small = pool.acquire(64);
+    EXPECT_EQ(p_small, p_big) << "shrink must not reallocate";
+    EXPECT_EQ(m.alloc_count, 1);
+    EXPECT_EQ(m.free_count, 0);
+    EXPECT_EQ(pool.size(), 256u);
+}
+
+TEST(DevicePoolTest, AcquireZeroReturnsNullAndDoesNotAllocate) {
+    MockAllocator m;
+    DevicePool pool = make_pool(&m);
+
+    void *p = pool.acquire(0);
+    EXPECT_EQ(p, nullptr);
+    EXPECT_EQ(m.alloc_count, 0);
+    EXPECT_EQ(m.free_count, 0);
+}
+
+TEST(DevicePoolTest, ReleaseFreesBufferAndReacquireAllocates) {
+    MockAllocator m;
+    DevicePool pool = make_pool(&m);
+
+    void *p1 = pool.acquire(128);
+    ASSERT_NE(p1, nullptr);
+
+    pool.release();
+    EXPECT_EQ(m.free_count, 1);
+    EXPECT_EQ(pool.ptr(), nullptr);
+    EXPECT_EQ(pool.size(), 0u);
+
+    // release() on an empty pool must be a no-op.
+    pool.release();
+    EXPECT_EQ(m.free_count, 1);
+
+    void *p2 = pool.acquire(64);
+    ASSERT_NE(p2, nullptr);
+    EXPECT_EQ(m.alloc_count, 2);
+}
+
+TEST(DevicePoolTest, DestructorReleasesOutstandingBuffer) {
+    MockAllocator m;
+    {
+        DevicePool pool = make_pool(&m);
+        pool.acquire(128);
+        EXPECT_EQ(m.alloc_count, 1);
+        EXPECT_EQ(m.free_count, 0);
+    }
+    EXPECT_EQ(m.free_count, 1) << "destructor must free the outstanding buffer";
+    EXPECT_TRUE(m.live.empty());
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

`bind_prepared_to_runtime_impl` used to `device_malloc` the PTO2 GM heap (`eff_heap_size × PTO2_MAX_RING_DEPTH`) and the PTO2 shared memory on every dispatch, record them as device-only entries in `tensor_pairs_`, and let `validate_runtime_impl` `device_free` them at the end. With `PTO2_RING_HEAP=8GB` (production default) that was ~32 GB of `aclrtMalloc + aclrtFree` per `worker.run()`, adding ~150 ms of allocator overhead to a kernel that itself runs in ~10 ms.

Reproducer / measurements: see #798.

## Fix

Both buffers are pure scratch — the orchestrator writes them from `heap_top=0` on every run and the kernel never assumes zeroed state — so they can safely live across runs. Move them to `DevicePool` members on `DeviceRunner` (the per-Worker session container) and expose `acquire_pooled_gm_heap` / `acquire_pooled_gm_sm` through `HostApi` so the runtime layer keeps using function pointers and does not include any platform header. `DeviceRunner::finalize` releases the pools before `mem_alloc_.finalize`, so the underlying allocations are freed exactly once.

## Measurements (a2a3 device 9, Qwen3-14B decode reproducer, `user_batch=1`, `num_runs=5`, `child_memory=True`)

`worker.run` time on runs 2-5 (run 1 excluded — it pays the one-time acquire cost, amortized over the Worker lifetime):

| `PTO2_RING_HEAP` | before     | after     |
| ---------------- | ---------: | --------: |
| 128 MB           | ~17 ms     | 13.8 ms   |
| 1 GB             | ~36 ms     | 14.7 ms   |
| 8 GB             | ~175 ms    | 13.5 ms   |

`worker.run` time becomes essentially independent of `PTO2_RING_HEAP`. `final_rms` golden remains bit-exact.

## Scope

Mirrored across the four (a2a3/a5) × (onboard/sim) `DeviceRunner` copies and the four `runtime.h` variants. `host_build_graph` leaves the new `HostApi` fields unset; its `runtime_maker` does not allocate the GM heap.

## Test plan

- [x] `tests/ut/cpp/common/test_device_pool.cpp` — 6 GTest cases cover reuse / grow / shrink / release / destructor with a mock allocator (no hardware)
- [x] `final_rms` on a2a3 hardware — golden bit-exact PASS
- [x] `decode` heap sweep on a2a3 hardware — `worker.run` size-independent (table above)
- [ ] sim platforms — interface mirrored, build verified end-to-end via \`pip install -e .\`; ST suite not exercised here