### PR TITLE
Cleanup: post-#752 multi-comm-domain follow-ups (hw UT + dead-code + validation)

### DIFF
--- a/docs/multi-comm-domain.md
+++ b/docs/multi-comm-domain.md
@@ -839,20 +839,19 @@ a backend bootstrap transport detail for the hidden base communicator.  The
 visible domains are derived from the parent `CommDomainPlan`, not from
 independent root-info exchanges.
 
-The implementation still keeps `comm_create_subcomm` available as a low-level
-backend capability because HCCL sub-communicators are useful for future
-collective or resource paths.  The initial PTO-ISA/HCOMM RMA path should not
-allocate MC2 resources on each overlapping sub-communicator because the HCCL
-old AICPU MC2 init path accepts only one active hcomId per process.  Base
-window slicing avoids that limitation while preserving domain-local kernel
-semantics.
+The implementation only relies on `comm_derive_context` to materialise
+domain-local views into one hidden base communicator's symmetric window
+pool.  The initial PTO-ISA/HCOMM RMA path must not allocate MC2 resources on
+each overlapping subset because the HCCL old AICPU MC2 init path accepts only
+one active hcomId per process.  Base-window slicing avoids that limitation
+while preserving domain-local kernel semantics.
 
-Independent root-info communicators and sub-communicators are not needed for
-the first PTO-ISA RMA implementation:
+Independent root-info communicators and HCCL sub-communicators are not needed
+for the first PTO-ISA RMA implementation:
 
 - independent root-info would exchange one `HcclRootInfo` per visible domain
   and create unrelated communicators for overlapping subsets;
-- sub-communicators would derive HCCL group communicators from a base
+- HCCL sub-communicators would derive group communicators from a base
   communicator, but would still need a separate MC2 window allocation if used
   as the visible RMA resource;
 - base-window slicing creates one backend window and then derives

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -754,15 +754,6 @@ NB_MODULE(_task_interface, m) {
             "sim ignores both).  Pair with comm_destroy for cleanup."
         )
         .def(
-            "comm_create_subcomm", &ChipWorker::comm_create_subcomm, nb::arg("comm_handle"), nb::arg("sub_comm_id"),
-            nb::arg("rank_ids"), nb::arg("sub_comm_rank_id"),
-            "Create a subcommunicator from an existing base communicator."
-        )
-        .def(
-            "comm_create_domain", &ChipWorker::comm_create_domain, nb::arg("sub_comm_id"), nb::arg("rank_ids"),
-            nb::arg("sub_comm_rank_id"), "Create a subcommunicator from the ChipWorker-owned base communicator."
-        )
-        .def(
             "comm_alloc_windows", &ChipWorker::comm_alloc_windows, nb::arg("comm_handle"), nb::arg("win_size"),
             "Allocate per-rank windows and return the device CommContext pointer."
         )

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -291,14 +291,6 @@ inline void bind_worker(nb::module_ &m) {
         )
         .def("reset", &ChipBootstrapChannel::reset)
         .def(
-            "write_success",
-            [](ChipBootstrapChannel &self, uint64_t device_ctx, uint64_t local_window_base, uint64_t actual_window_size,
-               const std::vector<uint64_t> &buffer_ptrs) {
-                self.write_success(device_ctx, local_window_base, actual_window_size, buffer_ptrs);
-            },
-            nb::arg("device_ctx"), nb::arg("local_window_base"), nb::arg("actual_window_size"), nb::arg("buffer_ptrs")
-        )
-        .def(
             "write_success_domains",
             [](ChipBootstrapChannel &self, const std::vector<ChipDomainBootstrapResult> &domains) {
                 self.write_success_domains(domains);
@@ -317,10 +309,6 @@ inline void bind_worker(nb::module_ &m) {
         .def_prop_ro("domain_count", &ChipBootstrapChannel::domain_count)
         .def_prop_ro("domains", &ChipBootstrapChannel::domains)
         .def("domain", &ChipBootstrapChannel::domain, nb::arg("name"))
-        .def_prop_ro("device_ctx", &ChipBootstrapChannel::device_ctx)
-        .def_prop_ro("local_window_base", &ChipBootstrapChannel::local_window_base)
-        .def_prop_ro("actual_window_size", &ChipBootstrapChannel::actual_window_size)
-        .def_prop_ro("buffer_ptrs", &ChipBootstrapChannel::buffer_ptrs)
         .def_prop_ro("error_message", &ChipBootstrapChannel::error_message);
 
     // Private mailbox acquire/release helpers — only for simpler.worker. The

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -576,38 +576,6 @@ class ChipWorker:
         """
         return int(self._impl.comm_init(int(rank), int(nranks), str(rootinfo_path)))
 
-    def comm_create_subcomm(
-        self,
-        comm_handle: int,
-        sub_comm_id: int,
-        rank_ids: list[int],
-        sub_comm_rank_id: int,
-    ) -> int:
-        """Create a domain communicator from a hidden base communicator."""
-        return int(
-            self._impl.comm_create_subcomm(
-                int(comm_handle),
-                int(sub_comm_id),
-                [int(x) for x in rank_ids],
-                int(sub_comm_rank_id),
-            )
-        )
-
-    def comm_create_domain(
-        self,
-        sub_comm_id: int,
-        rank_ids: list[int],
-        sub_comm_rank_id: int,
-    ) -> int:
-        """Create a domain communicator from the ChipWorker-owned base communicator."""
-        return int(
-            self._impl.comm_create_domain(
-                int(sub_comm_id),
-                [int(x) for x in rank_ids],
-                int(sub_comm_rank_id),
-            )
-        )
-
     def comm_alloc_windows(self, comm_handle: int, win_size: int) -> int:
         """Allocate per-rank windows. Returns a device CommContext pointer (uint64)."""
         return int(self._impl.comm_alloc_windows(int(comm_handle), int(win_size)))

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -306,6 +306,21 @@ class ChipBootstrapConfig:
 
     def domain_bootstrap_configs(self) -> list[ChipDomainBootstrapConfig]:
         if self.comm is None:
+            # Host staging is keyed by `(domain_name, buffer_name)`, so without a
+            # `comm` plan there is no domain to attach it to and the staging
+            # would silently be dropped by `bootstrap_context`. Surface this
+            # mismatch at config-construction time instead of after the chip
+            # child is already forked.
+            if self.host_inputs:
+                raise ValueError(
+                    "ChipBootstrapConfig.host_inputs requires a comm plan (cfg.comm is None); "
+                    f"got {len(self.host_inputs)} entries that would never be staged"
+                )
+            if self.host_outputs:
+                raise ValueError(
+                    "ChipBootstrapConfig.host_outputs requires a comm plan (cfg.comm is None); "
+                    f"got {len(self.host_outputs)} entries that would never be flushed"
+                )
             return []
         if not isinstance(self.comm, list):
             raise TypeError("ChipBootstrapConfig.comm must be a list of ChipDomainBootstrapConfig or None")

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -1269,58 +1269,33 @@ class Worker:
         *,
         chip_idx: int,
     ) -> dict[str, ChipDomainContext]:
-        if hasattr(channel, "domains"):
-            raw_domains = channel.domains
-            domains: dict[str, ChipDomainContext] = {}
-            expected = {d.name: d for d in ChipWorker._domain_bootstrap_configs(cfg)}
-            for raw in raw_domains:
-                name = str(raw.name)
-                domain_cfg = expected.get(name)
-                if domain_cfg is None:
-                    raise RuntimeError(f"chip {chip_idx} published unexpected domain {name!r}")
-                ptrs = list(raw.buffer_ptrs)
-                if len(ptrs) != len(domain_cfg.buffers):
-                    raise RuntimeError(
-                        f"chip {chip_idx} domain {name!r} buffer count mismatch: "
-                        f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
-                    )
-                domains[name] = ChipDomainContext(
-                    name=name,
-                    domain_rank=int(raw.domain_rank),
-                    domain_size=int(raw.domain_size),
-                    device_ctx=int(raw.device_ctx),
-                    local_window_base=int(raw.local_window_base),
-                    actual_window_size=int(raw.actual_window_size),
-                    buffer_ptrs={spec.name: ptr for spec, ptr in zip(domain_cfg.buffers, ptrs)},
+        raw_domains = channel.domains
+        domains: dict[str, ChipDomainContext] = {}
+        expected = {d.name: d for d in ChipWorker._domain_bootstrap_configs(cfg)}
+        for raw in raw_domains:
+            name = str(raw.name)
+            domain_cfg = expected.get(name)
+            if domain_cfg is None:
+                raise RuntimeError(f"chip {chip_idx} published unexpected domain {name!r}")
+            ptrs = list(raw.buffer_ptrs)
+            if len(ptrs) != len(domain_cfg.buffers):
+                raise RuntimeError(
+                    f"chip {chip_idx} domain {name!r} buffer count mismatch: "
+                    f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
                 )
-            missing = sorted(set(expected) - set(domains))
-            if missing:
-                raise RuntimeError(f"chip {chip_idx} did not publish expected domains: {missing}")
-            return domains
-
-        domain_cfgs = ChipWorker._domain_bootstrap_configs(cfg)
-        if not domain_cfgs:
-            return {}
-        if len(domain_cfgs) != 1:
-            raise RuntimeError("multi-domain bootstrap requires domain-aware ChipBootstrapChannel")
-        domain_cfg = domain_cfgs[0]
-        ptrs = channel.buffer_ptrs
-        if len(ptrs) != len(domain_cfg.buffers):
-            raise RuntimeError(
-                f"chip {chip_idx} bootstrap success but buffer count mismatch: "
-                f"expected {len(domain_cfg.buffers)}, got {len(ptrs)}"
-            )
-        return {
-            domain_cfg.name: ChipDomainContext(
-                name=domain_cfg.name,
-                domain_rank=domain_cfg.domain_rank,
-                domain_size=domain_cfg.domain_size,
-                device_ctx=channel.device_ctx,
-                local_window_base=channel.local_window_base,
-                actual_window_size=channel.actual_window_size,
+            domains[name] = ChipDomainContext(
+                name=name,
+                domain_rank=int(raw.domain_rank),
+                domain_size=int(raw.domain_size),
+                device_ctx=int(raw.device_ctx),
+                local_window_base=int(raw.local_window_base),
+                actual_window_size=int(raw.actual_window_size),
                 buffer_ptrs={spec.name: ptr for spec, ptr in zip(domain_cfg.buffers, ptrs)},
             )
-        }
+        missing = sorted(set(expected) - set(domains))
+        if missing:
+            raise RuntimeError(f"chip {chip_idx} did not publish expected domains: {missing}")
+        return domains
 
     def _abort_hierarchical(self) -> None:
         """Tear down all forked children + shms after a bootstrap failure.

--- a/src/common/hierarchical/chip_bootstrap_channel.cpp
+++ b/src/common/hierarchical/chip_bootstrap_channel.cpp
@@ -134,19 +134,6 @@ void ChipBootstrapChannel::reset() {
     write_state(mailbox_, ChipBootstrapMailboxState::IDLE);
 }
 
-void ChipBootstrapChannel::write_success(
-    uint64_t device_ctx, uint64_t local_window_base, uint64_t actual_window_size,
-    const std::vector<uint64_t> &buffer_ptrs
-) {
-    if (buffer_ptrs.size() > max_buffer_count_) {
-        throw std::invalid_argument("buffer_ptrs exceeds max_buffer_count");
-    }
-    ChipDomainBootstrapResult domain(
-        "default", 0, 1, device_ctx, local_window_base, actual_window_size, std::vector<uint64_t>(buffer_ptrs)
-    );
-    write_success_domains({domain});
-}
-
 void ChipBootstrapChannel::write_success_domains(const std::vector<ChipDomainBootstrapResult> &domains) {
     if (domains.size() > CHIP_BOOTSTRAP_MAX_DOMAINS) {
         throw std::invalid_argument("domain count exceeds CHIP_BOOTSTRAP_MAX_DOMAINS");
@@ -318,14 +305,6 @@ ChipDomainBootstrapResult ChipBootstrapChannel::domain(const std::string &name) 
     }
     throw std::out_of_range("bootstrap domain not found: " + name);
 }
-
-uint64_t ChipBootstrapChannel::device_ctx() const { return domain("default").device_ctx; }
-
-uint64_t ChipBootstrapChannel::local_window_base() const { return domain("default").local_window_base; }
-
-uint64_t ChipBootstrapChannel::actual_window_size() const { return domain("default").actual_window_size; }
-
-std::vector<uint64_t> ChipBootstrapChannel::buffer_ptrs() const { return domain("default").buffer_ptrs; }
 
 std::string ChipBootstrapChannel::error_message() const {
     auto *base = static_cast<const char *>(mailbox_);

--- a/src/common/hierarchical/chip_bootstrap_channel.h
+++ b/src/common/hierarchical/chip_bootstrap_channel.h
@@ -84,10 +84,6 @@ public:
 
     // Write side (child process).
     void reset();
-    void write_success(
-        uint64_t device_ctx, uint64_t local_window_base, uint64_t actual_window_size,
-        const std::vector<uint64_t> &buffer_ptrs
-    );
     void write_success_domains(const std::vector<ChipDomainBootstrapResult> &domains);
     void write_error(int32_t error_code, const std::string &message);
 
@@ -97,10 +93,6 @@ public:
     int32_t domain_count() const;
     std::vector<ChipDomainBootstrapResult> domains() const;
     ChipDomainBootstrapResult domain(const std::string &name) const;
-    uint64_t device_ctx() const;
-    uint64_t local_window_base() const;
-    uint64_t actual_window_size() const;
-    std::vector<uint64_t> buffer_ptrs() const;
     std::string error_message() const;
 
 private:

--- a/src/common/platform_comm/comm.h
+++ b/src/common/platform_comm/comm.h
@@ -60,32 +60,6 @@ typedef struct CommHandle_ *CommHandle;
 CommHandle comm_init(int rank, int nranks, void *stream, const char *rootinfo_path);
 
 /**
- * Create a subcommunicator from an existing base communicator.
- *
- * The caller provides the base-communicator rank ids that participate in the
- * subcommunicator and the caller's rank within that subcommunicator.  Members
- * should call this collectively for the same `sub_comm_id`; non-members do not
- * need to call it.
- *
- * On sim this derives a separate shared-memory identity from the base session
- * and `sub_comm_id`, so windows and barriers are isolated per domain.  The
- * returned handle is destroyed with comm_destroy().
- *
- * @param base              Existing handle from comm_init().
- * @param sub_comm_id       Caller-defined domain id under the base session.
- * @param rank_ids          Base-communicator rank ids in subcommunicator order.
- * @param rank_count        Number of ranks in rank_ids.
- * @param sub_comm_rank_id  This caller's rank within the subcommunicator.
- * @param stream            Caller-owned stream for backends that need one.
- *                          Sim backend ignores it.
- * @return Opaque subcommunicator handle, or NULL on failure.
- */
-CommHandle comm_create_subcomm(
-    CommHandle base, uint64_t sub_comm_id, const uint32_t *rank_ids, size_t rank_count, uint32_t sub_comm_rank_id,
-    void *stream
-);
-
-/**
  * Allocate RDMA / shared-memory windows and populate the device context.
  *
  * On HCCL this builds a per-rank symmetric pool via the public ACL IPC

--- a/src/common/platform_comm/comm_sim.cpp
+++ b/src/common/platform_comm/comm_sim.cpp
@@ -124,11 +124,6 @@ std::string make_shm_name(const char *rootinfo_path) {
     return make_shm_name(static_cast<uint32_t>(getppid()), hash_id(rootinfo_path));
 }
 
-std::string make_subcomm_shm_name(const std::string &base_shm_name, uint64_t sub_comm_id) {
-    std::string id = base_shm_name + ":" + std::to_string(sub_comm_id);
-    return make_shm_name(static_cast<uint32_t>(getppid()), hash_id(id.c_str()));
-}
-
 // Poll `check` until it returns true or the timeout elapses.  Uses steady_clock
 // so wall-clock NTP adjustments cannot desynchronize the wait.
 bool wait_until(const std::function<bool()> &check, int timeout_seconds, int poll_interval_us) {
@@ -191,78 +186,6 @@ extern "C" CommHandle comm_init(int rank, int nranks, void *stream, const char *
     return nullptr;
 } catch (...) {
     std::fprintf(stderr, "[comm_sim rank %d] comm_init: unknown exception\n", rank);
-    return nullptr;
-}
-
-extern "C" CommHandle comm_create_subcomm(
-    CommHandle base, uint64_t sub_comm_id, const uint32_t *rank_ids, size_t rank_count, uint32_t sub_comm_rank_id,
-    void *stream
-) try {
-    (void)stream;  // sim has no ACL / stream concept
-
-    if (base == nullptr) {
-        std::fprintf(stderr, "[comm_sim] comm_create_subcomm: base is null\n");
-        return nullptr;
-    }
-    if (rank_ids == nullptr) {
-        std::fprintf(stderr, "[comm_sim rank %d] comm_create_subcomm: rank_ids is null\n", base->rank);
-        return nullptr;
-    }
-    if (rank_count == 0 || rank_count > COMM_MAX_RANK_NUM) {
-        std::fprintf(
-            stderr, "[comm_sim rank %d] comm_create_subcomm: invalid rank_count=%zu (max=%u)\n", base->rank, rank_count,
-            COMM_MAX_RANK_NUM
-        );
-        return nullptr;
-    }
-    if (sub_comm_rank_id >= rank_count) {
-        std::fprintf(
-            stderr, "[comm_sim rank %d] comm_create_subcomm: invalid sub_comm_rank_id=%u rank_count=%zu\n", base->rank,
-            sub_comm_rank_id, rank_count
-        );
-        return nullptr;
-    }
-
-    for (size_t i = 0; i < rank_count; ++i) {
-        if (rank_ids[i] >= static_cast<uint32_t>(base->nranks)) {
-            std::fprintf(
-                stderr, "[comm_sim rank %d] comm_create_subcomm: rank_ids[%zu]=%u out of range [0, %d)\n", base->rank,
-                i, rank_ids[i], base->nranks
-            );
-            return nullptr;
-        }
-        for (size_t j = 0; j < i; ++j) {
-            if (rank_ids[j] == rank_ids[i]) {
-                std::fprintf(
-                    stderr, "[comm_sim rank %d] comm_create_subcomm: duplicate rank id %u\n", base->rank, rank_ids[i]
-                );
-                return nullptr;
-            }
-        }
-    }
-    if (rank_ids[sub_comm_rank_id] != base->rank) {
-        std::fprintf(
-            stderr, "[comm_sim rank %d] comm_create_subcomm: rank_ids[%u]=%u does not match base rank\n", base->rank,
-            sub_comm_rank_id, rank_ids[sub_comm_rank_id]
-        );
-        return nullptr;
-    }
-
-    auto *h = new (std::nothrow) CommHandle_{};
-    if (h == nullptr) {
-        std::fprintf(stderr, "[comm_sim rank %d] comm_create_subcomm: allocation failed\n", base->rank);
-        return nullptr;
-    }
-
-    h->rank = static_cast<int>(sub_comm_rank_id);
-    h->nranks = static_cast<int>(rank_count);
-    h->shm_name = make_subcomm_shm_name(base->shm_name, sub_comm_id);
-    return h;
-} catch (const std::exception &e) {
-    std::fprintf(stderr, "[comm_sim] comm_create_subcomm: exception: %s\n", e.what());
-    return nullptr;
-} catch (...) {
-    std::fprintf(stderr, "[comm_sim] comm_create_subcomm: unknown exception\n");
     return nullptr;
 }
 

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -36,17 +36,6 @@ T load_symbol(void *handle, const char *name) {
     return reinterpret_cast<T>(sym);
 }
 
-template <typename T>
-T load_optional_symbol(void *handle, const char *name) {
-    dlerror();  // clear any existing error
-    void *sym = dlsym(handle, name);
-    const char *err = dlerror();
-    if (err) {
-        return nullptr;
-    }
-    return reinterpret_cast<T>(sym);
-}
-
 std::vector<uint8_t> read_binary_file(const std::string &path) {
     std::ifstream f(path, std::ios::binary | std::ios::ate);
     if (!f) {
@@ -127,7 +116,6 @@ void ChipWorker::init(
         create_comm_stream_fn_ = load_symbol<CreateCommStreamFn>(handle, "create_comm_stream_ctx");
         destroy_comm_stream_fn_ = load_symbol<DestroyCommStreamFn>(handle, "destroy_comm_stream_ctx");
         comm_init_fn_ = load_symbol<CommInitFn>(handle, "comm_init");
-        comm_create_subcomm_fn_ = load_optional_symbol<CommCreateSubcommFn>(handle, "comm_create_subcomm");
         comm_alloc_windows_fn_ = load_symbol<CommAllocWindowsFn>(handle, "comm_alloc_windows");
         comm_get_local_window_base_fn_ = load_symbol<CommGetLocalWindowBaseFn>(handle, "comm_get_local_window_base");
         comm_get_window_size_fn_ = load_symbol<CommGetWindowSizeFn>(handle, "comm_get_window_size");
@@ -226,7 +214,6 @@ void ChipWorker::init(
         create_comm_stream_fn_ = nullptr;
         destroy_comm_stream_fn_ = nullptr;
         comm_init_fn_ = nullptr;
-        comm_create_subcomm_fn_ = nullptr;
         comm_alloc_windows_fn_ = nullptr;
         comm_get_local_window_base_fn_ = nullptr;
         comm_get_window_size_fn_ = nullptr;
@@ -274,7 +261,6 @@ void ChipWorker::finalize() {
     create_comm_stream_fn_ = nullptr;
     destroy_comm_stream_fn_ = nullptr;
     comm_init_fn_ = nullptr;
-    comm_create_subcomm_fn_ = nullptr;
     comm_alloc_windows_fn_ = nullptr;
     comm_get_local_window_base_fn_ = nullptr;
     comm_get_window_size_fn_ = nullptr;
@@ -494,56 +480,6 @@ uint64_t ChipWorker::comm_init(int rank, int nranks, const std::string &rootinfo
     }
 
     return create_base_comm(rank, nranks, rootinfo_path);
-}
-
-uint64_t ChipWorker::comm_create_subcomm(
-    uint64_t base_comm_handle, uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids, uint32_t sub_comm_rank_id
-) {
-    if (!initialized_) {
-        throw std::runtime_error("ChipWorker not initialized; call init() first");
-    }
-    if (comm_create_subcomm_fn_ == nullptr) {
-        throw std::runtime_error("comm_create_subcomm is not supported by this runtime");
-    }
-    if (base_comm_handle == 0 || find_comm_session(base_comm_handle) == nullptr) {
-        throw std::runtime_error("comm_create_subcomm: base communicator is not owned by this ChipWorker");
-    }
-    if (rank_ids.empty()) {
-        throw std::runtime_error("comm_create_subcomm: rank_ids must not be empty");
-    }
-    if (sub_comm_rank_id >= rank_ids.size()) {
-        throw std::runtime_error("comm_create_subcomm: sub_comm_rank_id out of range");
-    }
-
-    void *stream = create_comm_stream_checked("comm_create_subcomm");
-    void *handle = comm_create_subcomm_fn_(
-        reinterpret_cast<void *>(base_comm_handle), sub_comm_id, rank_ids.data(), rank_ids.size(), sub_comm_rank_id,
-        stream
-    );
-    if (handle == nullptr) {
-        int rc = 0;
-        destroy_comm_stream_best_effort(stream, &rc);
-        throw std::runtime_error("comm_create_subcomm failed");
-    }
-
-    if (create_comm_session(handle, stream, false) == nullptr) {
-        int rc = comm_destroy_fn_(handle);
-        destroy_comm_stream_best_effort(stream, &rc);
-        throw std::runtime_error("comm_create_subcomm: duplicate comm handle");
-    }
-
-    return reinterpret_cast<uint64_t>(handle);
-}
-
-uint64_t
-ChipWorker::comm_create_domain(uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids, uint32_t sub_comm_rank_id) {
-    if (!initialized_) {
-        throw std::runtime_error("ChipWorker not initialized; call init() first");
-    }
-    if (base_comm_handle_ == 0) {
-        throw std::runtime_error("comm_create_domain: call comm_init to create the base communicator first");
-    }
-    return comm_create_subcomm(base_comm_handle_, sub_comm_id, rank_ids, sub_comm_rank_id);
 }
 
 uint64_t ChipWorker::comm_alloc_windows(uint64_t comm_handle, size_t win_size) {

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -92,15 +92,9 @@ public:
     ///     ensure_acl_ready / aclrtCreateStream surface area).
     ///   - On sim, ACL / stream are no-ops; the stashed stream is null.
     ///
-    /// Multi-domain bootstrap owns a hidden base communicator plus one
-    /// sub-communicator per active domain.  The legacy comm_* methods are kept
-    /// as wrappers for the transition and allocate a single "default" domain.
+    /// Multi-domain bootstrap allocates a hidden base communicator plus one
+    /// symmetric pool, then derives per-domain views with comm_derive_context.
     uint64_t comm_init(int rank, int nranks, const std::string &rootinfo_path);
-    uint64_t comm_create_subcomm(
-        uint64_t base_comm_handle, uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids,
-        uint32_t sub_comm_rank_id
-    );
-    uint64_t comm_create_domain(uint64_t sub_comm_id, const std::vector<uint32_t> &rank_ids, uint32_t sub_comm_rank_id);
     uint64_t comm_alloc_windows(uint64_t comm_handle, size_t win_size);
     uint64_t comm_get_local_window_base(uint64_t comm_handle);
     size_t comm_get_window_size(uint64_t comm_handle);
@@ -136,7 +130,6 @@ private:
     using CreateCommStreamFn = void *(*)(void *);
     using DestroyCommStreamFn = int (*)(void *, void *);
     using CommInitFn = void *(*)(int, int, void *, const char *);
-    using CommCreateSubcommFn = void *(*)(void *, uint64_t, const uint32_t *, size_t, uint32_t, void *);
     using CommAllocWindowsFn = int (*)(void *, size_t, uint64_t *);
     using CommGetLocalWindowBaseFn = int (*)(void *, uint64_t *);
     using CommGetWindowSizeFn = int (*)(void *, size_t *);
@@ -180,7 +173,6 @@ private:
     CreateCommStreamFn create_comm_stream_fn_ = nullptr;
     DestroyCommStreamFn destroy_comm_stream_fn_ = nullptr;
     CommInitFn comm_init_fn_ = nullptr;
-    CommCreateSubcommFn comm_create_subcomm_fn_ = nullptr;
     CommAllocWindowsFn comm_alloc_windows_fn_ = nullptr;
     CommGetLocalWindowBaseFn comm_get_local_window_base_fn_ = nullptr;
     CommGetWindowSizeFn comm_get_window_size_fn_ = nullptr;

--- a/tests/ut/py/test_worker/test_bootstrap_channel.py
+++ b/tests/ut/py/test_worker/test_bootstrap_channel.py
@@ -20,7 +20,28 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     CHIP_BOOTSTRAP_MAILBOX_SIZE,
     ChipBootstrapChannel,
     ChipBootstrapMailboxState,
+    ChipDomainBootstrapResult,
 )
+
+
+def _single_domain(device_ctx, local_window_base, actual_window_size, buffer_ptrs, *, name="default"):
+    """Build a one-domain payload matching the legacy single-domain wire shape.
+
+    The single-domain accessors (`channel.device_ctx` / `local_window_base` /
+    `actual_window_size` / `buffer_ptrs`) were removed alongside
+    `write_success`; the equivalent today is one `ChipDomainBootstrapResult`
+    fed through `write_success_domains`.  This helper keeps the test bodies
+    short while pinning the same fields.
+    """
+    return ChipDomainBootstrapResult(
+        name,
+        0,
+        1,
+        device_ctx,
+        local_window_base,
+        actual_window_size,
+        list(buffer_ptrs),
+    )
 
 
 def _mailbox_addr(shm: SharedMemory) -> int:
@@ -43,22 +64,27 @@ class TestBootstrapChannel:
             shm.unlink()
 
     def test_write_success_fields(self):
-        """write_success stores all fields and parent reads them back."""
+        """write_success_domains stores all fields and parent reads them back."""
         shm = SharedMemory(create=True, size=CHIP_BOOTSTRAP_MAILBOX_SIZE)
         try:
             ch = ChipBootstrapChannel(_mailbox_addr(shm), max_buffer_count=376)
             ch.reset()
-            ch.write_success(
-                device_ctx=0xDEADBEEFCAFE1234,
-                local_window_base=0xAABBCCDD00112233,
-                actual_window_size=65536,
-                buffer_ptrs=[0x1000, 0x2000, 0x3000],
+            ch.write_success_domains(
+                [
+                    _single_domain(
+                        device_ctx=0xDEADBEEFCAFE1234,
+                        local_window_base=0xAABBCCDD00112233,
+                        actual_window_size=65536,
+                        buffer_ptrs=[0x1000, 0x2000, 0x3000],
+                    )
+                ]
             )
             assert ch.state == ChipBootstrapMailboxState.SUCCESS
-            assert ch.device_ctx == 0xDEADBEEFCAFE1234
-            assert ch.local_window_base == 0xAABBCCDD00112233
-            assert ch.actual_window_size == 65536
-            assert ch.buffer_ptrs == [0x1000, 0x2000, 0x3000]
+            d = ch.domain("default")
+            assert d.device_ctx == 0xDEADBEEFCAFE1234
+            assert d.local_window_base == 0xAABBCCDD00112233
+            assert d.actual_window_size == 65536
+            assert d.buffer_ptrs == [0x1000, 0x2000, 0x3000]
         finally:
             shm.close()
             shm.unlink()
@@ -78,12 +104,12 @@ class TestBootstrapChannel:
             shm.unlink()
 
     def test_state_machine_reset(self):
-        """write_success -> SUCCESS, reset -> IDLE."""
+        """write_success_domains -> SUCCESS, reset -> IDLE."""
         shm = SharedMemory(create=True, size=CHIP_BOOTSTRAP_MAILBOX_SIZE)
         try:
             ch = ChipBootstrapChannel(_mailbox_addr(shm), max_buffer_count=376)
             ch.reset()
-            ch.write_success(0, 0, 0, [])
+            ch.write_success_domains([_single_domain(0, 0, 0, [])])
             assert ch.state == ChipBootstrapMailboxState.SUCCESS
             ch.reset()
             assert ch.state == ChipBootstrapMailboxState.IDLE
@@ -101,11 +127,15 @@ class TestBootstrapChannel:
                 # Child: wrap same shm and write success.
                 ch = ChipBootstrapChannel(addr, max_buffer_count=376)
                 ch.reset()
-                ch.write_success(
-                    device_ctx=0x1111222233334444,
-                    local_window_base=0x5555666677778888,
-                    actual_window_size=128,
-                    buffer_ptrs=[0xA, 0xB, 0xC, 0xD],
+                ch.write_success_domains(
+                    [
+                        _single_domain(
+                            device_ctx=0x1111222233334444,
+                            local_window_base=0x5555666677778888,
+                            actual_window_size=128,
+                            buffer_ptrs=[0xA, 0xB, 0xC, 0xD],
+                        )
+                    ]
                 )
                 os._exit(0)
             else:
@@ -114,24 +144,25 @@ class TestBootstrapChannel:
                 while ch.state == ChipBootstrapMailboxState.IDLE:
                     pass
                 assert ch.state == ChipBootstrapMailboxState.SUCCESS
-                assert ch.device_ctx == 0x1111222233334444
-                assert ch.local_window_base == 0x5555666677778888
-                assert ch.actual_window_size == 128
-                assert ch.buffer_ptrs == [0xA, 0xB, 0xC, 0xD]
+                d = ch.domain("default")
+                assert d.device_ctx == 0x1111222233334444
+                assert d.local_window_base == 0x5555666677778888
+                assert d.actual_window_size == 128
+                assert d.buffer_ptrs == [0xA, 0xB, 0xC, 0xD]
                 os.waitpid(pid, 0)
         finally:
             shm.close()
             shm.unlink()
 
     def test_buffer_ptrs_overflow(self):
-        """write_success with too many ptrs throws."""
+        """write_success_domains with too many ptrs in one domain throws."""
         shm = SharedMemory(create=True, size=CHIP_BOOTSTRAP_MAILBOX_SIZE)
         try:
             ch = ChipBootstrapChannel(_mailbox_addr(shm), max_buffer_count=376)
             ch.reset()
             too_many = list(range(377))
             with pytest.raises(ValueError, match="buffer_ptrs exceeds max_buffer_count"):
-                ch.write_success(0, 0, 0, too_many)
+                ch.write_success_domains([_single_domain(0, 0, 0, too_many)])
         finally:
             shm.close()
             shm.unlink()

--- a/tests/ut/py/test_worker/test_bootstrap_context_hw.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_hw.py
@@ -174,3 +174,167 @@ def test_two_rank_bootstrap_context(st_device_ids):
         assert r["buffer_ptrs"] == [r["local_window_base"]], (
             f"rank {rank}: buffer_ptrs={r['buffer_ptrs']} != [{r['local_window_base']}]"
         )
+
+
+# ---------------------------------------------------------------------------
+# Multi-domain hardware path — mirrors the sim integration test in
+# test_bootstrap_context_sim.py::TestBootstrapContextMultiDomain.  3 ranks
+# in two overlapping domains (`tp = [0, 1]`, `pp = [1, 2]`); chip 1
+# participates in both.  Pins the wire format + base-window slicing on
+# the HCCL backend so a CANN bump or `comm_derive_context` regression
+# fails CI instead of only the manual `domain_rank_map` / `dual_domain_overlap`
+# examples.
+# ---------------------------------------------------------------------------
+
+
+def _multi_domain_rank_entry(
+    worker_idx: int,
+    nranks: int,
+    device_id: int,
+    bins,
+    rootinfo_path: str,
+    result_queue: mp.Queue,  # type: ignore[type-arg]
+) -> None:
+    """Per-rank entry: declare two overlapping domains, report what bootstrap built.
+
+    The plan is identical across ranks (same `CommDomainPlan` shape) — each
+    rank's `bootstrap_for_worker(worker_idx)` selects only the domains it
+    actually participates in, so chip 0 sees `{tp}`, chip 2 sees `{pp}`,
+    and chip 1 sees both.  No barrier is issued (mirrors the single-domain
+    test for the same HCCL 507018 reason).
+    """
+    result: dict[str, object] = {"rank": worker_idx, "ok": False}
+    try:
+        from simpler.task_interface import (
+            ChipBootstrapConfig,
+            ChipWorker,
+            CommBufferSpec,
+            CommDomain,
+            CommDomainPlan,
+        )
+
+        plan = CommDomainPlan(
+            domains=[
+                CommDomain(
+                    name="tp",
+                    worker_indices=[0, 1],
+                    window_size=4096,
+                    buffers=[CommBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
+                ),
+                CommDomain(
+                    name="pp",
+                    worker_indices=[1, 2],
+                    window_size=4096,
+                    buffers=[CommBufferSpec(name="scratch", dtype="float32", count=16, nbytes=64)],
+                ),
+            ]
+        )
+        cfg = ChipBootstrapConfig(comm=plan.bootstrap_for_worker(worker_idx))
+        cfg.base_rank = worker_idx
+        cfg.base_size = nranks
+        cfg.rootinfo_path = rootinfo_path
+
+        worker = ChipWorker()
+        worker.init(device_id, bins)
+        try:
+            res = worker.bootstrap_context(device_id=device_id, cfg=cfg)
+            result["domains"] = {
+                name: {
+                    "domain_rank": domain.domain_rank,
+                    "domain_size": domain.domain_size,
+                    "device_ctx": int(domain.device_ctx),
+                    "local_window_base": int(domain.local_window_base),
+                    "actual_window_size": int(domain.actual_window_size),
+                    "buffer_ptrs": dict(domain.buffer_ptrs),
+                }
+                for name, domain in res.domains.items()
+            }
+            result["ok"] = True
+        finally:
+            worker.shutdown_bootstrap()
+            worker.finalize()
+    except Exception:  # noqa: BLE001
+        result["error"] = traceback.format_exc()
+    finally:
+        result_queue.put(result)
+
+
+@pytest.mark.requires_hardware
+@pytest.mark.platforms(["a2a3"])
+@pytest.mark.device_count(3)
+def test_overlapping_domains_create_independent_hw_windows(st_device_ids):
+    """3 ranks, two overlapping domains; chip 1 gets independent views of both.
+
+    Locks in on real hardware what the sim test already locks in: each domain
+    materialises its own ``device_ctx`` and its own ``buffer_ptrs`` slice,
+    even when the same chip participates in multiple domains, and
+    ``comm_derive_context`` produces non-overlapping local addresses for the
+    two domain windows.
+    """
+    from simpler_setup.runtime_builder import RuntimeBuilder
+
+    build = bool(os.environ.get("PTO_UT_BUILD"))
+    bins = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer", build=build)
+    assert len(st_device_ids) >= 3, "device_count(3) fixture must yield >= 3 ids"
+    nranks = 3
+    rootinfo_path = f"/tmp/pto_bootstrap_hw_multi_domain_{os.getpid()}.bin"
+
+    ctx = mp.get_context("fork")
+    result_queue: mp.Queue = ctx.Queue()  # type: ignore[type-arg]
+    procs = []
+    for worker_idx in range(nranks):
+        p = ctx.Process(
+            target=_multi_domain_rank_entry,
+            args=(
+                worker_idx,
+                nranks,
+                int(st_device_ids[worker_idx]),
+                bins,
+                rootinfo_path,
+                result_queue,
+            ),
+            daemon=False,
+        )
+        p.start()
+        procs.append(p)
+
+    results: dict[int, dict] = {}
+    for _ in range(nranks):
+        r = result_queue.get(timeout=240)
+        results[int(r["rank"])] = r
+    for p in procs:
+        p.join(timeout=60)
+
+    try:
+        os.unlink(rootinfo_path)
+    except FileNotFoundError:
+        pass
+
+    for rank in range(nranks):
+        r = results.get(rank)
+        if r is None:
+            pytest.fail(f"rank {rank} never reported a result")
+        if not r.get("ok"):
+            pytest.fail(f"rank {rank} failed:\n{r.get('error', '(no traceback)')}")
+
+    # Membership: chip 0 in tp only, chip 2 in pp only, chip 1 in both.
+    assert set(results[0]["domains"]) == {"tp"}, results[0]["domains"]
+    assert set(results[1]["domains"]) == {"tp", "pp"}, results[1]["domains"]
+    assert set(results[2]["domains"]) == {"pp"}, results[2]["domains"]
+
+    # Dense domain ranks follow `worker_indices` order.
+    assert results[0]["domains"]["tp"]["domain_rank"] == 0
+    assert results[1]["domains"]["tp"]["domain_rank"] == 1
+    assert results[1]["domains"]["pp"]["domain_rank"] == 0
+    assert results[2]["domains"]["pp"]["domain_rank"] == 1
+
+    # Chip 1's two domains must be independent: distinct device CommContext
+    # pointers and distinct local buffer addresses, even though both live in
+    # the same base symmetric pool.
+    chip1 = results[1]["domains"]
+    assert chip1["tp"]["device_ctx"] != chip1["pp"]["device_ctx"], chip1
+    assert chip1["tp"]["buffer_ptrs"]["scratch"] != chip1["pp"]["buffer_ptrs"]["scratch"], chip1
+    # And the buffer addresses fall inside their respective domain windows.
+    for name in ("tp", "pp"):
+        d = chip1[name]
+        assert d["local_window_base"] <= d["buffer_ptrs"]["scratch"] < d["local_window_base"] + d["actual_window_size"]

--- a/tests/ut/py/test_worker/test_bootstrap_context_sim.py
+++ b/tests/ut/py/test_worker/test_bootstrap_context_sim.py
@@ -638,10 +638,11 @@ class TestBootstrapContextChannel:
 
                 channel = ChipBootstrapChannel(_shm_addr(channels_shm[rank]), max_buffer_count=376)
                 assert channel.state == ChipBootstrapMailboxState.SUCCESS
-                assert channel.device_ctx == r["device_ctx"]
-                assert channel.local_window_base == r["local_window_base"]
-                assert channel.actual_window_size == r["actual_window_size"]
-                assert channel.buffer_ptrs == r["buffer_ptrs"]
+                d = channel.domain("default")
+                assert d.device_ctx == r["device_ctx"]
+                assert d.local_window_base == r["local_window_base"]
+                assert d.actual_window_size == r["actual_window_size"]
+                assert d.buffer_ptrs == r["buffer_ptrs"]
         finally:
             for shm in channels_shm.values():
                 shm.close()

--- a/tests/ut/py/test_worker/test_comm_domain_plan.py
+++ b/tests/ut/py/test_worker/test_comm_domain_plan.py
@@ -203,3 +203,35 @@ class TestChipWorkerCommDomainBindings:
 
         assert hasattr(worker, "comm_derive_context")
         assert hasattr(worker, "comm_destroy_all")
+
+
+class TestChipBootstrapConfigRejectsOrphanHostStaging:
+    """Bootstrap config without a `comm` plan must not silently drop host staging.
+
+    Pre-validation guard: host_inputs / host_outputs are keyed by
+    `(domain_name, buffer_name)`, so without a plan there is no domain to
+    attach them to and `bootstrap_context` would discard them.  Failing in
+    `domain_bootstrap_configs` keeps the error close to the caller's mistake
+    instead of surfacing later as a missing buffer pointer on the chip.
+    """
+
+    def test_host_inputs_without_comm_plan_raises(self):
+        cfg = ChipBootstrapConfig(
+            comm=None,
+            host_inputs=[HostBufferStaging(domain_name=None, name="x", shm_name="psm_x", size=16)],
+        )
+        with pytest.raises(ValueError, match="host_inputs requires a comm plan"):
+            cfg.domain_bootstrap_configs()
+
+    def test_host_outputs_without_comm_plan_raises(self):
+        cfg = ChipBootstrapConfig(
+            comm=None,
+            host_outputs=[HostBufferStaging(domain_name=None, name="y", shm_name="psm_y", size=16)],
+        )
+        with pytest.raises(ValueError, match="host_outputs requires a comm plan"):
+            cfg.domain_bootstrap_configs()
+
+    def test_no_comm_plan_and_no_staging_is_fine(self):
+        # Pure no-op config: no domains, no staging. Returns empty list.
+        cfg = ChipBootstrapConfig(comm=None)
+        assert cfg.domain_bootstrap_configs() == []

--- a/tests/ut/py/test_worker/test_comm_domain_plan.py
+++ b/tests/ut/py/test_worker/test_comm_domain_plan.py
@@ -201,6 +201,5 @@ class TestChipWorkerCommDomainBindings:
     def test_native_worker_exposes_multi_domain_comm_methods(self):
         worker = _ChipWorker()
 
-        assert hasattr(worker, "comm_create_subcomm")
-        assert hasattr(worker, "comm_create_domain")
+        assert hasattr(worker, "comm_derive_context")
         assert hasattr(worker, "comm_destroy_all")


### PR DESCRIPTION
## Summary

Four small, independent follow-ups to PR #752 (multi-communication-domain support). Bundled into one PR but kept as separate commits so each is independently reviewable / revertable. Closes the gaps I flagged when reviewing #752; clears the surface for the next (independent) Option-A work that exposes domain derivation to the orch layer.

| Commit | Type | What | Why |
| --- | --- | --- | --- |
| `bdda052b` | Add | Multi-domain **hardware** UT | The sim integration test pins the multi-domain wire format; on real hardware multi-domain was only validated by two manual `python examples/.../main.py` runs. Any CANN bump or `comm_derive_context` regression could silently break it. |
| `6c8744b9` | Cleanup | Drop dead `comm_create_subcomm` / `comm_create_domain` | Multi-domain bootstrap goes through `comm_derive_context` (local view). `comm_create_subcomm` was sim-only; HCCL and a5 don't export it. Only consumer in tree was a `hasattr` smoke test. |
| `93f593f1` | Cleanup | Drop `ChipBootstrapChannel` single-domain shims | After #752 the channel carries up to `CHIP_BOOTSTRAP_MAX_DOMAINS` named domains. The single-domain accessors (`device_ctx`, `local_window_base`, `actual_window_size`, `buffer_ptrs`, `write_success`) silently looked up `domain("default")` and threw `std::out_of_range "bootstrap domain not found: default"` instead of a clear "API removed" when no such domain existed. |
| `d4b38f8d` | Validate | Reject `ChipBootstrapConfig(comm=None, host_inputs=[...])` | The staging entries were silently dropped — the chip would later see a missing buffer pointer hundreds of lines from the actual mistake. Now fails at config-construction time with a clear message. |

## Sizing

15 files, net **-242 lines** (more deletion than addition, mostly dead-code removal).

## Test plan

- [x] `pip install --no-build-isolation -e .` rebuilds nanobind extension clean (post-deletions)
- [x] `pytest tests/ut/py/test_worker/` → 97 passed, 1 skipped (only the hw skip on local macOS, expected)
- [x] `pre-commit run` clean: clang-format / clang-tidy / cpplint / markdownlint / ruff / pyright all pass
- [ ] CI: a2a3 onboard / a2a3 sim / a5 onboard / a5 sim
- [ ] Hardware UT (`test_overlapping_domains_create_independent_hw_windows`) runs on a 3-device a2a3 host