### PR TITLE
Add: SIMPLER_CHIP_TIMING instrumentation to surface PTO2_RING_HEAP validate cost

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -321,6 +321,13 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
     the first H2D upload); TASK_READY also lazy-prepares as a safety net.
     """
     prepared: set[int] = set()
+
+    # SIMPLER_CHIP_TIMING: opt-in env-gated Python-side timing of each
+    # chip task. When off, the boolean read once at loop start keeps the
+    # hot path one comparison cheaper than always sampling.
+    _chip_timing = os.environ.get("SIMPLER_CHIP_TIMING", "") == "1"
+    _task_seq = 0
+
     while True:
         state = _mailbox_load_i32(state_addr)
         if state == _TASK_READY:
@@ -329,6 +336,8 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
 
             code = 0
             msg = ""
+            if _chip_timing:
+                _t0 = time.perf_counter()
             try:
                 _ensure_prepared(cw, registry, prepared, cid, lazy=True, device_id=device_id)
                 # Hand the mailbox bytes straight to C++ (zero-copy zero-decode):
@@ -341,6 +350,9 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
                 code = 1
                 msg = _format_exc(f"chip_process dev={device_id}", e)
 
+            if _chip_timing:
+                _t_hook_start = time.perf_counter()
+
             # On a successful kernel run, give the caller a chance to do
             # post-run work (e.g. store_to_host D2H staging) before the
             # parent sees TASK_DONE. The kernel's failure path skips the
@@ -348,6 +360,17 @@ def _run_chip_main_loop(  # noqa: PLR0912 -- TASK_READY + 6 control sub-commands
             # staging garbage would mask the real error in post-mortems.
             if code == 0 and on_task_done_success is not None:
                 code, msg = on_task_done_success()
+
+            if _chip_timing:
+                _t_hook_end = time.perf_counter()
+                sys.stderr.write(
+                    f"[chip_timing dev={device_id}] task={_task_seq}"
+                    f"  run_from_blob={(_t_hook_start - _t0) * 1000:.2f}ms"
+                    f"  task_done_hook={(_t_hook_end - _t_hook_start) * 1000:.2f}ms"
+                    f"  total={(_t_hook_end - _t0) * 1000:.2f}ms\n"
+                )
+                sys.stderr.flush()
+                _task_seq += 1
 
             _write_error(buf, code, msg)
             _mailbox_store_i32(state_addr, _TASK_DONE)

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -22,6 +22,9 @@
 #include <dlfcn.h>
 
 #include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -499,6 +502,17 @@ int DeviceRunner::validate_block_dim(rtStream_t stream, int block_dim) {
 }
 
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
+    using Clock = std::chrono::steady_clock;
+    static const bool chip_timing = (std::getenv("SIMPLER_CHIP_TIMING") != nullptr &&
+                                     std::string(std::getenv("SIMPLER_CHIP_TIMING")) == "1");
+    static int run_seq = 0;
+    const int cur_seq = run_seq++;
+    auto ms = [](Clock::time_point a, Clock::time_point b) -> double {
+        return std::chrono::duration<double, std::milli>(b - a).count();
+    };
+
+    auto t_run_start = Clock::now();
+
     // Validate launch_aicpu_num
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);
@@ -506,7 +520,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     // Ensure device is initialized (lazy initialization)
+    auto t_ensure_dev_start = Clock::now();
     int rc = ensure_device_initialized();
+    auto t_ensure_dev_end = Clock::now();
     if (rc != 0) {
         LOG_ERROR("ensure_device_initialized failed: %d", rc);
         return rc;
@@ -548,6 +564,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     });
 
     // Get AICore register addresses for register-based task dispatch
+    auto t_regs_start = Clock::now();
     rc = init_aicore_register_addresses(
         &kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_, AicoreRegKind::Ctrl
     );
@@ -566,6 +583,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
             return rc;
         }
     }
+    auto t_regs_end = Clock::now();
 
     // Calculate number of AIC cores (1/3 of total)
     int num_aic = block_dim;  // Round up for 1/3
@@ -657,13 +675,16 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     LOG_INFO_V0("=== Initialize runtime args ===");
     // Resolve the orchestration SO into a device-resident buffer and refresh
     // runtime metadata before the Runtime struct is uploaded to device.
+    auto t_orch_so_start = Clock::now();
     rc = prepare_orch_so(runtime);
+    auto t_orch_so_end = Clock::now();
     if (rc != 0) {
         LOG_ERROR("prepare_orch_so failed: %d", rc);
         return rc;
     }
 
     // Initialize runtime args
+    auto t_init_args_start = Clock::now();
     rc = kernel_args_.init_runtime_args(runtime, mem_alloc_);
     if (rc != 0) {
         LOG_ERROR("init_runtime_args failed: %d", rc);
@@ -689,6 +710,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         LOG_ERROR("init_device_kernel_args failed: %d", rc);
         return rc;
     }
+    auto t_init_args_end = Clock::now();
 
     // Start collector mgmt + poll threads now, just before kernels launch.
     // Starting earlier wastes CPU on empty queues and risks tripping
@@ -711,7 +733,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     LOG_INFO_V0("=== launch_aicpu_kernel DynTileFwkKernelServerInit ===");
     // Launch AICPU init kernel
+    auto t_launch_aicpu_init_start = Clock::now();
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServerInit", 1);
+    auto t_launch_aicpu_init_end = Clock::now();
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (init) failed: %d", rc);
         return rc;
@@ -719,9 +743,11 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     LOG_INFO_V0("=== launch_aicpu_kernel DynTileFwkKernelServer ===");
     // Launch AICPU main kernel (over-launch for affinity gate)
+    auto t_launch_aicpu_main_start = Clock::now();
     rc = launch_aicpu_kernel(
         stream_aicpu_, &kernel_args_.args, "DynTileFwkKernelServer", PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
     );
+    auto t_launch_aicpu_main_end = Clock::now();
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         return rc;
@@ -729,14 +755,18 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     LOG_INFO_V0("=== launch_aicore_kernel ===");
     // Launch AICore kernel (pass device copy of KernelArgs)
+    auto t_launch_aicore_start = Clock::now();
     rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
+    auto t_launch_aicore_end = Clock::now();
     if (rc != 0) {
         LOG_ERROR("launch_aicore_kernel failed: %d", rc);
         return rc;
     }
 
     LOG_INFO_V0("=== aclrtSynchronizeStreamWithTimeout stream_aicpu_ ===");
+    auto t_sync_aicpu_start = Clock::now();
     rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    auto t_sync_aicpu_end = Clock::now();
     if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
         LOG_ERROR(
             "Stream sync timeout: stream=AICPU timeout_ms=%d device_id=%d block_dim=%d",
@@ -750,7 +780,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     LOG_INFO_V0("=== aclrtSynchronizeStreamWithTimeout stream_aicore_ ===");
+    auto t_sync_aicore_start = Clock::now();
     rc = aclrtSynchronizeStreamWithTimeout(stream_aicore_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    auto t_sync_aicore_end = Clock::now();
     if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
         LOG_ERROR(
             "Stream sync timeout: stream=AICore timeout_ms=%d device_id=%d block_dim=%d",
@@ -761,6 +793,35 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (rc != 0) {
         LOG_ERROR("aclrtSynchronizeStreamWithTimeout (AICore) failed: %d", rc);
         return rc;
+    }
+
+    if (chip_timing) {
+        auto t_run_end = Clock::now();
+        fprintf(
+            stderr,
+            "[runner_timing dev=%d] run=%d"
+            "  ensure_dev=%.2fms"
+            "  regs=%.2fms"
+            "  orch_so=%.2fms"
+            "  init_args=%.2fms"
+            "  launch_aicpu_init=%.2fms"
+            "  launch_aicpu_main=%.2fms"
+            "  launch_aicore=%.2fms"
+            "  sync_aicpu=%.2fms"
+            "  sync_aicore=%.2fms"
+            "  total=%.2fms\n",
+            device_id_, cur_seq,
+            ms(t_ensure_dev_start, t_ensure_dev_end),
+            ms(t_regs_start, t_regs_end),
+            ms(t_orch_so_start, t_orch_so_end),
+            ms(t_init_args_start, t_init_args_end),
+            ms(t_launch_aicpu_init_start, t_launch_aicpu_init_end),
+            ms(t_launch_aicpu_main_start, t_launch_aicpu_main_end),
+            ms(t_launch_aicore_start, t_launch_aicore_end),
+            ms(t_sync_aicpu_start, t_sync_aicpu_end),
+            ms(t_sync_aicore_start, t_sync_aicore_end),
+            ms(t_run_start, t_run_end)
+        );
     }
 
     // Tear down collectors. stop() joins mgmt then collector in the only safe

--- a/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
+++ b/src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp
@@ -23,7 +23,10 @@
 
 #include <pthread.h>
 
+#include <chrono>
+#include <cstdio>
 #include <cstdlib>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -308,6 +311,22 @@ int run_prepared(
         return -1;
     }
 
+    // SIMPLER_CHIP_TIMING: opt-in env-gated per-stage instrumentation. When
+    // off, the static once-read keeps the hot path one comparison cheaper than
+    // the boolean default. Splits run_prepared into the five phases whose
+    // wall-clock relationship surfaces the PTO2_RING_HEAP validate-cost
+    // pattern (heap alloc lives in bind_runtime_impl; matching free in
+    // validate). See examples/.../qwen3_14b_decode for a reproducer.
+    using Clock = std::chrono::steady_clock;
+    static const bool chip_timing = (std::getenv("SIMPLER_CHIP_TIMING") != nullptr &&
+                                     std::string(std::getenv("SIMPLER_CHIP_TIMING")) == "1");
+    static int run_seq = 0;
+    const int cur_seq = run_seq++;
+    auto ms = [](Clock::time_point a, Clock::time_point b) -> double {
+        return std::chrono::duration<double, std::milli>(b - a).count();
+    };
+    auto t_total_start = Clock::now();
+
     pthread_once(&g_runner_key_once, create_runner_key);
     pthread_setspecific(g_runner_key, ctx);
     auto tsd_guard = RAIIScopeGuard([]() {
@@ -315,7 +334,9 @@ int run_prepared(
     });
 
     try {
+        auto t_prepare_start = Clock::now();
         int rc = runner->prepare_run_context(runner->device_id());
+        auto t_prepare_end = Clock::now();
         if (rc != 0) return rc;
         auto run_context_guard = RAIIScopeGuard([runner]() {
             runner->release_run_context();
@@ -334,17 +355,26 @@ int run_prepared(
         // is the cached ChipCallable signature_[]; it's plumbed end-to-end for
         // per-tensor direction decisions in runtime_maker but is currently
         // unconsumed on both runtimes — see bind_prepared_to_runtime_impl.
+        auto t_bind_callable_start = Clock::now();
         auto bind_result = runner->bind_prepared_callable_to_runtime(*r, callable_id);
+        auto t_bind_callable_end = Clock::now();
         if (bind_result.rc != 0) {
             r->~Runtime();
             return bind_result.rc;
         }
 
-        // Per-run binding (tensor args, GM heap, SM alloc)
+        // Per-run binding (tensor args, GM heap, SM alloc) — the
+        // device_malloc(total_heap_size) for the orchestrator GM heap and
+        // device_malloc(sm_size) for PTO2 shared memory both live here, so
+        // bind_runtime_impl is the timing phase that scales with
+        // PTO2_RING_HEAP. validate_runtime_impl matches it with the
+        // device_free calls.
+        auto t_bind_runtime_start = Clock::now();
         rc = bind_prepared_to_runtime_impl(
             r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
             bind_result.signature, bind_result.sig_count
         );
+        auto t_bind_runtime_end = Clock::now();
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
             validate_runtime_impl(r);
@@ -358,15 +388,41 @@ int run_prepared(
         runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_output_prefix(output_prefix);
 
+        auto t_runner_run_start = Clock::now();
         rc = runner->run(*r, block_dim, aicpu_thread_num);
+        auto t_runner_run_end = Clock::now();
         if (rc != 0) {
             validate_runtime_impl(r);
             r->~Runtime();
             return rc;
         }
 
+        auto t_validate_start = Clock::now();
         rc = validate_runtime_impl(r);
+        auto t_validate_end = Clock::now();
         r->~Runtime();
+
+        if (chip_timing) {
+            auto t_total_end = Clock::now();
+            fprintf(
+                stderr,
+                "[c_api_timing dev=%d] run=%d"
+                "  prepare_ctx=%.2fms"
+                "  bind_callable=%.2fms"
+                "  bind_runtime=%.2fms"
+                "  runner_run=%.2fms"
+                "  validate=%.2fms"
+                "  total=%.2fms\n",
+                runner->device_id(), cur_seq,
+                ms(t_prepare_start, t_prepare_end),
+                ms(t_bind_callable_start, t_bind_callable_end),
+                ms(t_bind_runtime_start, t_bind_runtime_end),
+                ms(t_runner_run_start, t_runner_run_end),
+                ms(t_validate_start, t_validate_end),
+                ms(t_total_start, t_total_end)
+            );
+        }
+
         return rc;
     } catch (...) {
         return -1;


### PR DESCRIPTION
## Summary

Adds env-gated (`SIMPLER_CHIP_TIMING=1`) per-stage timing instrumentation in three places along the chip dispatch path, plumbed end-to-end:

| File | Probe | Stages exposed |
|------|-------|----------------|
| [`src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp`](src/a2a3/platform/onboard/host/pto_runtime_c_api.cpp) | `[c_api_timing]` | `prepare_ctx`, `bind_callable`, **`bind_runtime`**, `runner_run`, **`validate`**, `total` |
| [`src/a2a3/platform/onboard/host/device_runner.cpp`](src/a2a3/platform/onboard/host/device_runner.cpp) | `[runner_timing]` | `ensure_dev`, `regs`, `orch_so`, `init_args`, `launch_aicpu_init`, `launch_aicpu_main`, `launch_aicore`, `sync_aicpu`, `sync_aicore`, `total` |
| [`python/simpler/worker.py`](python/simpler/worker.py) | `[chip_timing]` | `run_from_blob`, `task_done_hook`, `total` (per-task in the L3 child mailbox loop) |

When the env var is unset, the static once-read keeps the hot path one comparison cheaper than the boolean default and emits nothing — no measurable overhead, no behavioural change.

## What this surfaces

`validate_runtime_impl` time scales **linearly with `PTO2_RING_HEAP`** even when no user tensors are D2H-copied. A Qwen3-14B decode dispatch at `user_batch=1` with `child_memory=True` on every task arg (`copyback_pairs=0`, `total_copyback_bytes=0`) on **a2a3 real hardware**:

| `PTO2_RING_HEAP` | `validate` avg | ms / GB |
|------------------|---------------:|--------:|
| default (small)  |    ~5 ms       | —       |
| 128 MB           |  3.46 ms       | 27.7    |
| 512 MB           | 10.33 ms       | 20.7    |
| 1 GB             | 20.23 ms       | 20.2    |
| 2 GB             | 39.62 ms       | 19.8    |
| 4 GB             | 78.45 ms       | 19.6    |
| 8 GB             |  ~150 ms       | 18.8    |

`PTO2_RING_HEAP=8GB` is the value production inference uses (e.g. `pypto-lib/run.sh`). Every `worker.run()` pays ~150 ms of `device_malloc(8GB) + device_free(8GB)` overhead even when the kernel itself ran in 8-13 ms.

## Where the overhead comes from

In [`src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp`](src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp):

- `bind_prepared_to_runtime_impl` calls `device_malloc(total_heap_size)` for the GM heap and `device_malloc(sm_size)` for PTO2 shared memory **on every per-run binding** and records them via `record_tensor_pair(nullptr, dev_ptr, size)` — these are the `device_only_pairs` visible in instrumented output.
- `validate_runtime_impl` `device_free`s every recorded `dev_ptr` at the end of each run, so the next `worker.run()` re-allocates from scratch.

The heap content is read-only orchestrator scratch — no need to recycle the device buffer per dispatch. Pooling it across runs of the same Worker session (allocate-on-first-run, free-on-Worker-close) eliminates the overhead. **That fix lives in a separate runtime PR; this PR only adds the instrumentation that makes the cost visible.**

The split between `bind_runtime` and `validate` is what makes the root-cause attribution unambiguous: `bind_runtime` is where the `device_malloc(8GB)` happens, `validate` is where the matching `device_free` happens.

## How to reproduce

The Qwen3-14B 1-layer decode example in [#798](https://github.com/hw-native-sys/simpler/pull/798) is a convenient driver at production shape (`HIDDEN=5120`, `NUM_HEADS=40`, paged KV-cache):

```bash
pip install --no-build-isolation -e .

for HEAP_MB in 128 512 1024 2048 4096 8192; do
    SIMPLER_CHIP_TIMING=1 PTO2_RING_HEAP=$((HEAP_MB * 1024 * 1024)) \
        pytest examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/ -v -s \
            --platform a2a3 --rounds 5 2>&1 | grep c_api_timing
done
```

Each run prints `[c_api_timing dev=N] ... bind_runtime=X.XXms ... validate=Y.YYms ...` with `bind_runtime` and `validate` both proportional to the heap size.

## Test plan

- [x] Smoke-tested on a2a3 with `vector_example` (lightweight 1-kernel test):
  ```
  [runner_timing dev=0] run=0  ensure_dev=0.90ms  regs=0.24ms  orch_so=0.00ms
                                init_args=0.04ms  launch_aicpu_init=0.17ms
                                launch_aicpu_main=0.02ms  launch_aicore=0.38ms
                                sync_aicpu=46.23ms  sync_aicore=0.11ms
                                total=48.14ms
  [c_api_timing  dev=0] run=0  prepare_ctx=0.78ms  bind_callable=0.00ms
                                bind_runtime=1.16ms  runner_run=48.43ms
                                validate=5.85ms  total=56.22ms
  ```
- [x] When `SIMPLER_CHIP_TIMING` is unset, no stderr lines printed; existing tests unaffected (passes that produced no output before still produce no output).

## Scope / non-goals

- This PR only adds the instrumentation. The `PTO2_RING_HEAP` pooling fix that drops the per-run heap alloc/free is a separate runtime PR.
- `[chip_timing]` (Python-side) is wired only into the L3 child mailbox loop (`_run_chip_main_loop`). L2 dispatch goes through C++ directly and is fully covered by `[c_api_timing]` + `[runner_timing]`.
- a5 platform doesn't get the corresponding probes in this PR — the validate-cost finding was on a2a3 hardware; if a5 needs the same view, an analogous patch to `src/a5/platform/onboard/host/` can be added in follow-up.