### PR TITLE
Fix: relax bootstrap-error test regex to accept any chip's failure

### DIFF
--- a/tests/ut/py/test_worker/test_worker_distributed_sim.py
+++ b/tests/ut/py/test_worker/test_worker_distributed_sim.py
@@ -219,7 +219,12 @@ class TestWorkerBootstrapErrorPath:
             num_sub_workers=0,
             comm_plan=_make_bad_store_plan(nranks),
         )
-        with pytest.raises(RuntimeError, match="chip 0 bootstrap failed"):
+        # The regex matches any chip index — with nranks=2 either child may
+        # report the ValueError first depending on OS fork / scheduling order
+        # (observed flaky on macOS GitHub runners). The contract asserted here
+        # is "some chip's bootstrap failed and the parent surfaces it"; which
+        # chip wins the race is not part of that contract.
+        with pytest.raises(RuntimeError, match=r"chip \d+ bootstrap failed"):
             worker.init()
 
         # init() abort path must return the Worker to an uninitialised state.


### PR DESCRIPTION
## Summary

`TestWorkerBootstrapErrorPath.test_bootstrap_value_error_fails_init_and_cleans_up` hardcoded `match="chip 0 bootstrap failed"`, but with `nranks=2` the OS fork / scheduling order decides which child reports the `ValueError` first. On macOS GitHub runners this is observed flaky — chip 1 often schedules first and surfaces the error, breaking the regex even though the assertion the test cares about (some chip failed, parent raised `RuntimeError`, no `/dev/shm` leaks) still holds.

Example failure on a recent run:

\`\`\`
AssertionError: Regex pattern did not match.
  Expected: "chip 0 bootstrap failed"
  Actual:   "chip 1 bootstrap failed: ValueError: ChipBufferSpec(...) requires matching HostBufferStaging..."
\`\`\`

## Fix

Match \`chip \\d+\` instead so the test asserts the contract (the parent surfaces the child's bootstrap failure) and not the fork order.

## Test plan

- [x] `pytest tests/ut/py/test_worker/test_worker_distributed_sim.py::TestWorkerBootstrapErrorPath::test_bootstrap_value_error_fails_init_and_cleans_up` — locally (would still pass on either chip-order)
- [x] `ruff` / `pyright` (pre-commit hooks pass)

CI will exercise both chip-order outcomes naturally across runners.