### PR TITLE
Polish: pop-delta uint32 debug_assert + drop misleading batch=64 line

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -35,7 +35,6 @@ Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_
 
 ```text
 Thread 3: Calling aicpu_orchestration_entry from SO
-aicpu_orchestration_entry ">>>>>> batch = 64"
 Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
 Thread 3: === Orchestrator Profiling: 16704 tasks, total=14601.580us ===
 Thread 3:   sync_tensormap : 286.300us (2.0%)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,6 +12,8 @@
 
 #include <cinttypes>
 
+#include "common.h"  // debug_assert
+
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
@@ -589,6 +591,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 // pop_hit / pop_miss stay intact for the cold-path log.
                 uint64_t pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
                 uint64_t pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
+                // AicpuPhaseRecord's extras are uint32 — a delta that overflows means
+                // an emit was missed for ~4 billion pops, which is well outside any
+                // realistic dispatch cadence and silently truncates without this guard.
+                debug_assert(pop_hit_delta < (1ULL << 32));
+                debug_assert(pop_miss_delta < (1ULL << 32));
                 l2_perf_aicpu_record_phase(
                     thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, l2_perf.sched_loop_count,
                     l2_perf.phase_dispatch_count, static_cast<uint32_t>(pop_hit_delta),
@@ -673,6 +680,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     if (l2_perf_level_ >= L2PerfLevel::SCHED_PHASES) {
         uint64_t final_pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
         uint64_t final_pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
+        debug_assert(final_pop_hit_delta < (1ULL << 32));
+        debug_assert(final_pop_miss_delta < (1ULL << 32));
         if (final_pop_hit_delta != 0 || final_pop_miss_delta != 0) {
             uint64_t t_now = get_sys_cnt_aicpu();
             l2_perf_aicpu_record_phase(

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md
@@ -35,7 +35,6 @@ Thread 3 loads the orchestration `.so` via `dlopen`, calls `aicpu_orchestration_
 
 ```text
 Thread 3: Calling aicpu_orchestration_entry from SO
-aicpu_orchestration_entry ">>>>>> batch = 64"
 Thread 3: aicpu_orchestration_entry returned, cost 20943.940us
 Thread 3: === Orchestrator Profiling: 16704 tasks, total=14601.580us ===
 Thread 3:   sync_tensormap : 286.300us (2.0%)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -12,6 +12,7 @@
 
 #include <cinttypes>
 
+#include "common.h"  // debug_assert
 #include "common/unified_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/platform_regs.h"
@@ -591,6 +592,11 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                 // pop_hit / pop_miss stay intact for the cold-path log.
                 uint64_t pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
                 uint64_t pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
+                // AicpuPhaseRecord's extras are uint32 — a delta that overflows means
+                // an emit was missed for ~4 billion pops, which is well outside any
+                // realistic dispatch cadence and silently truncates without this guard.
+                debug_assert(pop_hit_delta < (1ULL << 32));
+                debug_assert(pop_miss_delta < (1ULL << 32));
                 l2_perf_aicpu_record_phase(
                     thread_idx, AicpuPhaseId::SCHED_DISPATCH, _t0_phase, _t1, l2_perf.sched_loop_count,
                     l2_perf.phase_dispatch_count, static_cast<uint32_t>(pop_hit_delta),
@@ -673,6 +679,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     if (l2_perf.l2_perf_enabled) {
         uint64_t final_pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit;
         uint64_t final_pop_miss_delta = l2_perf.pop_miss - l2_perf.pop_miss_at_last_emit;
+        debug_assert(final_pop_hit_delta < (1ULL << 32));
+        debug_assert(final_pop_miss_delta < (1ULL << 32));
         if (final_pop_hit_delta != 0 || final_pop_miss_delta != 0) {
             uint64_t t_now = get_sys_cnt_aicpu();
             l2_perf_aicpu_record_phase(


### PR DESCRIPTION
## Summary

Two small follow-ups left over from earlier swimlane work
(#769 + #775 + #804). Net: 4 files, +17 / −2.

### 1. \`debug_assert\` on pop-delta uint32 truncation

The dispatch emit and final-drain emit both compute
\`pop_hit_delta = l2_perf.pop_hit - l2_perf.pop_hit_at_last_emit\`
(uint64) and then \`static_cast<uint32_t>\` it into the
\`AicpuPhaseRecord::extras\` field. In a realistic dispatch cadence
the delta is bounded by the per-emit task count, so 2^32 is
unreachable — but a future regression that stops resetting
\`pop_hit_at_last_emit\`, removes the final-drain emit and lets the
next run inherit a stale snapshot, or any other source of an
unbounded delta would silently truncate today. The guard fires in
debug + sim CI well before that hits hardware.

Gated on \`NDEBUG\` (the existing \`debug_assert\` macro from
\`runtime/common.h\`) so release builds pay zero.

The \`AicpuPhaseRecord\` 40-byte size invariant itself was already
covered by a \`static_assert\` in \`common/l2_perf_profiling.h\` —
this commit just adds the complementary delta-fits-in-extras check.

### 2. Drop misleading \`batch=64\` line from device_log_profiling.md

The example block in
\`src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/docs/device_log_profiling.md\`
showed an interleaved line:

\`\`\`text
aicpu_orchestration_entry ">>>>>> batch = 64"
\`\`\`

which is actually a user-side \`LOG_INFO_V9\` inside
\`paged_attention_orch.cpp\`, not a runtime-schema field. Including it
in a doc that describes the profiling contract was inviting readers
to take it for one. Removed the line; nothing else needed.

## Test plan

- [x] Local rebuild for both arches
- [x] dfx smoke (\`l2_swimlane × 2, pmu, dep_gen, tensor_dump\`) on a2a3sim
- [x] \`pytest tests/st/a2a3/tensormap_and_ringbuffer --platform a2a3sim --device 0-1 -k 'not L3'\` → 25 passed
- [x] \`pytest tests/st/a5/tensormap_and_ringbuffer --platform a5sim --device 0-1 -k 'not L3'\` → 16 passed