### PR TITLE
Fix: mirror AICore op-execution timeout chain to a5 onboard

### DIFF
--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -59,6 +59,21 @@ constexpr int PLATFORM_MAX_AICPU_THREADS = 7;
  */
 constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 7;
 
+/**
+ * AICore op execution timeout (microseconds).
+ * Passed to aclrtSetOpExecuteTimeOutV2 so that STARS actively monitors
+ * AICore task execution and kills ops that exceed this threshold.
+ */
+constexpr uint64_t PLATFORM_OP_EXECUTE_TIMEOUT_US = 1000000;  // 1s
+
+/**
+ * Host-side stream synchronization timeout (milliseconds).
+ * Passed to aclrtSynchronizeStreamWithTimeout to detect stream sync hangs.
+ * Must be longer than PLATFORM_OP_EXECUTE_TIMEOUT_US to allow STARS
+ * enough time to kill the timed-out op and propagate the notification.
+ */
+constexpr int PLATFORM_STREAM_SYNC_TIMEOUT_MS = 2000;  // 2s (> op timeout 1s)
+
 // =============================================================================
 // Derived Platform Limits
 // =============================================================================

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -231,8 +231,27 @@ int DeviceRunner::attach_current_thread(int device_id) {
         return rc;
     }
 
+    if (device_id_ == -1) {
+        configure_aicore_op_timeout();
+    }
+
     device_id_ = device_id;
     return 0;
+}
+
+void DeviceRunner::configure_aicore_op_timeout() {
+    uint64_t actual_timeout = 0;
+    int rc = aclrtSetOpExecuteTimeOutV2(PLATFORM_OP_EXECUTE_TIMEOUT_US, &actual_timeout);
+    if (rc != 0) {
+        LOG_ERROR(
+            "aclrtSetOpExecuteTimeOutV2(%llu us) failed: %d", (unsigned long long)PLATFORM_OP_EXECUTE_TIMEOUT_US, rc
+        );
+    } else {
+        LOG_INFO_V0(
+            "aclrtSetOpExecuteTimeOutV2: requested=%llu us, actual=%llu us",
+            (unsigned long long)PLATFORM_OP_EXECUTE_TIMEOUT_US, (unsigned long long)actual_timeout
+        );
+    }
 }
 
 int DeviceRunner::prepare_run_context(int device_id) {
@@ -545,17 +564,31 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return rc;
     }
 
-    LOG_INFO_V0("=== rtStreamSynchronize stream_aicpu_ ===");
-    rc = rtStreamSynchronize(stream_aicpu_);
+    LOG_INFO_V0("=== aclrtSynchronizeStreamWithTimeout stream_aicpu_ ===");
+    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
+        LOG_ERROR(
+            "Stream sync timeout: stream=AICPU timeout_ms=%d device_id=%d block_dim=%d",
+            PLATFORM_STREAM_SYNC_TIMEOUT_MS, device_id_, block_dim_
+        );
+        return rc;
+    }
     if (rc != 0) {
-        LOG_ERROR("rtStreamSynchronize (AICPU) failed: %d", rc);
+        LOG_ERROR("aclrtSynchronizeStreamWithTimeout (AICPU) failed: %d", rc);
         return rc;
     }
 
-    LOG_INFO_V0("=== rtStreamSynchronize stream_aicore_ ===");
-    rc = rtStreamSynchronize(stream_aicore_);
+    LOG_INFO_V0("=== aclrtSynchronizeStreamWithTimeout stream_aicore_ ===");
+    rc = aclrtSynchronizeStreamWithTimeout(stream_aicore_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
+        LOG_ERROR(
+            "Stream sync timeout: stream=AICore timeout_ms=%d device_id=%d block_dim=%d",
+            PLATFORM_STREAM_SYNC_TIMEOUT_MS, device_id_, block_dim_
+        );
+        return rc;
+    }
     if (rc != 0) {
-        LOG_ERROR("rtStreamSynchronize (AICore) failed: %d", rc);
+        LOG_ERROR("aclrtSynchronizeStreamWithTimeout (AICore) failed: %d", rc);
         return rc;
     }
 

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -552,6 +552,16 @@ private:
     int prepare_orch_so(Runtime &runtime);
 
     /**
+     * Configure STARS op execution timeout (once per DeviceRunner lifetime).
+     *
+     * Called on first device attach to set the hardware-level AICore op
+     * execution timeout via aclrtSetOpExecuteTimeOutV2.  The actual
+     * timeout may differ from the requested value due to hardware timer
+     * granularity.
+     */
+    void configure_aicore_op_timeout();
+
+    /**
      * Initialize performance profiling device buffers
      *
      * Allocates L2PerfSetupHeader and per-core/per-thread buffers on device;

--- a/tests/st/aicore_op_timeout/test_aicore_op_timeout.py
+++ b/tests/st/aicore_op_timeout/test_aicore_op_timeout.py
@@ -12,10 +12,9 @@
 Hardware-only: dispatches an AIC kernel that spins forever. The 3-layer
 timeout chain (STARS op watchdog ~1 s, AICPU deinit ~1 s, host stream sync
 2 s/stream) must reap the hang and surface a ``RuntimeError`` in
-single-digit seconds rather than deadlocking. There is no a2a3sim case
+single-digit seconds rather than deadlocking. Sim variants are excluded
 because the simulator has no STARS watchdog — a ``while(true)`` kernel
-would wedge the sim. a5 has no equivalent timeout mechanism yet; mirror
-this test there once it does.
+would wedge the sim.
 """
 
 import os
@@ -57,7 +56,7 @@ def _build_chip_callable(platform: str) -> ChipCallable:
     )
 
 
-@pytest.mark.platforms(["a2a3"])
+@pytest.mark.platforms(["a2a3", "a5"])
 @pytest.mark.device_count(1)
 @pytest.mark.runtime(RUNTIME)
 @pytest.mark.timeout(60)


### PR DESCRIPTION
PR #718 added a 3-layer timeout chain (STARS op watchdog, AICPU deinit watchdog, host aclrtSynchronizeStreamWithTimeout) on a2a3 but only Layer 2 was carried over to a5. With L1 and L3 missing, a stuck AICore op on a5 would still wedge the host indefinitely. This ports the remaining two layers verbatim and extends the matching ST to cover a5.

- src/a5/platform/include/common/platform_config.h: add PLATFORM_OP_EXECUTE_TIMEOUT_US (1s) and PLATFORM_STREAM_SYNC_TIMEOUT_MS (2s); values match a2a3 so behaviour is identical across platforms
- src/a5/platform/onboard/host/device_runner: add configure_aicore_op_timeout() invoked once on first attach_current_thread; replace rtStreamSynchronize with aclrtSynchronizeStreamWithTimeout on both AICPU and AICore streams, surfacing ACL_ERROR_RT_STREAM_SYNC_TIMEOUT to the caller
- tests/st/aicore_op_timeout/test_aicore_op_timeout.py: expand @pytest.mark.platforms to ["a2a3", "a5"] and refresh the module docstring (drop the "a5 has no equivalent timeout mechanism yet" note)

Verified on a5 silicon: ST passes with elapsed ~9.5s, matching a2a3's ~8.8s within driver noise; 507046 (ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) fires as expected and the host recovers without deadlocking.