### PR TITLE
Add: Insight Trace workspace generation for MindStudio profiling

### DIFF
--- a/simpler_setup/insight_trace/__init__.py
+++ b/simpler_setup/insight_trace/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""MindStudio Insight trace workspace generation."""

--- a/simpler_setup/insight_trace/arg_resolver.py
+++ b/simpler_setup/insight_trace/arg_resolver.py
@@ -1,0 +1,49 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from pathlib import Path
+
+from .args_pkg import _load_arg_spec, load_kernel_dump_args, resolve_builtin_args, resolve_scene_test_args
+from .models import KernelSpec, SceneCaseContext, TraceArg
+
+
+def resolve_args(
+    context: SceneCaseContext | None,
+    kernel: KernelSpec | None,
+    arg_spec: Path | None = None,
+    dump_dir: Path | None = None,
+    task_id: str | None = None,
+) -> tuple[TraceArg, ...]:
+    """
+    Resolve kernel args for insight trace.
+
+    Priority:
+    1. arg_spec file
+    2. dump_dir (PR792 tensor_dump.json format)
+    3. scene_test args
+    4. builtin recipes (paged_attention only)
+    """
+    if arg_spec is not None:
+        return _load_arg_spec(arg_spec)
+    if dump_dir is not None:
+        return load_kernel_dump_args(dump_dir, task_id)
+    if context is None or kernel is None:
+        return ()
+    if _should_use_builtin_fallback(context):
+        return resolve_builtin_args(context, kernel)
+    try:
+        return resolve_scene_test_args(context)
+    except Exception:
+        return resolve_builtin_args(context, kernel)
+
+
+def _should_use_builtin_fallback(context: SceneCaseContext) -> bool:
+    module_path = context.module_dir.as_posix()
+    return "paged_attention" in module_path or "spmd_multiblock_mix" in module_path

--- a/simpler_setup/insight_trace/args_pkg/__init__.py
+++ b/simpler_setup/insight_trace/args_pkg/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from .from_dump import load_kernel_dump_args
+from .from_scene_test import resolve_scene_test_args
+from .from_spec import _load_arg_spec
+from .recipes import resolve_builtin_args
+
+__all__ = [
+    "_load_arg_spec",
+    "load_kernel_dump_args",
+    "resolve_builtin_args",
+    "resolve_scene_test_args",
+]

--- a/simpler_setup/insight_trace/args_pkg/from_dump.py
+++ b/simpler_setup/insight_trace/args_pkg/from_dump.py
@@ -1,0 +1,85 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Load kernel args from tensor_dump.json (PR792 unified format)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ..models import TraceArg, TraceTensorArg
+
+
+def load_kernel_dump_args(
+    dump_dir: Path,
+    task_id: str | None = None,
+) -> tuple[TraceArg, ...]:
+    """
+    Load kernel replay args from tensor_dump.json (PR792 unified format).
+
+    Args:
+        dump_dir: outputs/<test>/tensor_dump/ or the tensor_dump.json parent directory
+        task_id: task ID in hex string (optional, PR792 format)
+
+    Returns:
+        TraceArg tuple sorted by arg_index
+
+    Note:
+        PR792 unified format: no kind/value fields, scalar detected by shape=[] and bin_size=0.
+        Scalar arg values must come from arg_spec or scene_test fallback.
+    """
+    manifest_path = _find_manifest(dump_dir)
+    manifest = json.loads(manifest_path.read_text())
+
+    tensors = manifest.get("tensors", [])
+    result: dict[int, TraceArg] = {}
+
+    for t in tensors:
+        # Filter by task_id if specified
+        if task_id is not None and t.get("task_id") != task_id:
+            continue
+        # Only before_dispatch stage has input args
+        if t.get("stage") != "before_dispatch":
+            continue
+
+        index = t.get("arg_index", 0)
+        if index in result:
+            continue
+
+        # Detect scalar by shape=[] and bin_size=0 (PR792 unified format)
+        shape = t.get("shape", [])
+        bin_size = t.get("bin_size", 0)
+        is_scalar = shape == [] and bin_size == 0
+
+        if is_scalar:
+            # Scalar arg values not in JSON - must come from arg_spec or scene_test
+            continue
+        else:
+            # Tensor args - get shape info from JSON
+            result[index] = TraceTensorArg(
+                index=index,
+                name=f"arg{index}",
+                dtype=t.get("dtype", "float32"),
+                shape=tuple(int(d) for d in shape),
+            )
+
+    return tuple(result[index] for index in sorted(result.keys()))
+
+
+def _find_manifest(dump_dir: Path) -> Path:
+    """Find tensor_dump.json under dump_dir."""
+    dump_dir = Path(dump_dir)
+    candidates = [
+        dump_dir / "tensor_dump.json",
+        dump_dir / "tensor_dump" / "tensor_dump.json",
+    ]
+    for path in candidates:
+        if path.is_file():
+            return path
+    raise ValueError(f"tensor_dump.json not found under {dump_dir}")

--- a/simpler_setup/insight_trace/args_pkg/from_scene_test.py
+++ b/simpler_setup/insight_trace/args_pkg/from_scene_test.py
@@ -1,0 +1,142 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import ctypes
+import struct
+
+from simpler.task_interface import ArgDirection
+
+from simpler_setup.scene_test import Scalar, Tensor
+
+from ..models import SceneCaseContext, TraceArg, TraceScalarArg, TraceTensorArg
+
+_TORCH_DTYPE_MAP = {
+    "torch.float32": "FLOAT32",
+    "torch.float16": "FLOAT16",
+    "torch.bfloat16": "BFLOAT16",
+    "torch.int32": "INT32",
+    "torch.int64": "INT64",
+    "torch.uint8": "UINT8",
+    "torch.int8": "INT8",
+    "torch.bool": "BOOL",
+}
+
+_CTYPES_DTYPE_MAP = {
+    ctypes.c_bool: "BOOL",
+    ctypes.c_int8: "INT8",
+    ctypes.c_uint8: "UINT8",
+    ctypes.c_int16: "INT16",
+    ctypes.c_uint16: "UINT16",
+    ctypes.c_int32: "INT32",
+    ctypes.c_uint32: "UINT32",
+    ctypes.c_int64: "INT64",
+    ctypes.c_uint64: "UINT64",
+    ctypes.c_float: "FLOAT32_BITS",
+    ctypes.c_double: "FLOAT64_BITS",
+}
+
+_ROLE_MAP = {
+    ArgDirection.IN: "input",
+    ArgDirection.OUT: "output",
+    ArgDirection.INOUT: "inout",
+}
+
+
+def resolve_scene_test_args(context: SceneCaseContext) -> tuple[TraceArg, ...]:
+    builder = context.test_class().generate_args(context.case.get("params", {}))
+    orch_signature = context.callable_spec.get("orchestration", {}).get("signature")
+    if orch_signature is None:
+        raise ValueError("No orchestration signature available for generic insight trace arg inference")
+
+    result: list[TraceArg] = []
+    tensor_index = 0
+    arg_index = 0
+    for spec in builder.specs:
+        if isinstance(spec, Tensor):
+            if tensor_index >= len(orch_signature):
+                raise ValueError(
+                    f"Tensor '{spec.name}' at index {tensor_index} has no matching orchestration signature entry"
+                )
+            result.append(
+                TraceTensorArg(
+                    index=arg_index,
+                    name=spec.name,
+                    dtype=_tensor_dtype_name(spec.value),
+                    shape=tuple(int(dim) for dim in spec.value.shape),
+                    role=_ROLE_MAP.get(orch_signature[tensor_index], "input"),
+                )
+            )
+            tensor_index += 1
+            arg_index += 1
+            continue
+
+        if isinstance(spec, Scalar):
+            result.append(
+                TraceScalarArg(
+                    index=arg_index,
+                    name=spec.name,
+                    dtype=_scalar_dtype_name(spec.value),
+                    value=_scalar_value(spec.value),
+                    pack_mode=_scalar_pack_mode(spec.value),
+                )
+            )
+            arg_index += 1
+            continue
+
+        raise ValueError(f"Unsupported TaskArgsBuilder spec type: {type(spec).__name__}")
+
+    if tensor_index != len(orch_signature):
+        raise ValueError(
+            f"Orchestration signature length {len(orch_signature)} does not match tensor count {tensor_index}"
+        )
+    return tuple(result)
+
+
+def _tensor_dtype_name(value) -> str:
+    key = str(value.dtype)
+    try:
+        return _TORCH_DTYPE_MAP[key]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported tensor dtype for insight trace: {key}") from exc
+
+
+def _scalar_dtype_name(value) -> str:
+    if type(value) in _CTYPES_DTYPE_MAP:
+        return _CTYPES_DTYPE_MAP[type(value)]
+    if isinstance(value, bool):
+        return "BOOL"
+    if isinstance(value, int):
+        return "INT64"
+    if isinstance(value, float):
+        return "FLOAT32_BITS"
+    raise ValueError(f"Unsupported scalar type for insight trace: {type(value).__name__}")
+
+
+def _scalar_value(value):
+    if isinstance(value, ctypes._SimpleCData):
+        raw = value.value
+    else:
+        raw = value
+    if isinstance(raw, bool):
+        return int(raw)
+    if isinstance(raw, float):
+        return _f32_bits(raw)
+    return raw
+
+
+def _scalar_pack_mode(value) -> str:
+    dtype = _scalar_dtype_name(value)
+    if dtype.endswith("_BITS"):
+        return "bits"
+    return "value"
+
+
+def _f32_bits(value: float) -> int:
+    return struct.unpack("I", struct.pack("f", value))[0]

--- a/simpler_setup/insight_trace/args_pkg/from_spec.py
+++ b/simpler_setup/insight_trace/args_pkg/from_spec.py
@@ -1,0 +1,60 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+from ..models import TraceArg, TraceScalarArg, TraceTensorArg
+
+
+def _load_arg_spec(path: Path) -> tuple[TraceArg, ...]:
+    raw = json.loads(path.read_text())
+    result: list[TraceArg] = []
+    # Handle both {"args": [...]} and direct [...] formats
+    if isinstance(raw, dict) and "args" in raw:
+        items = raw["args"]
+    elif isinstance(raw, list):
+        items = raw
+    else:
+        items = []
+    for item in items:
+        if item["kind"] == "tensor":
+            result.append(
+                TraceTensorArg(
+                    index=int(item["index"]),
+                    name=item["name"],
+                    dtype=item["dtype"],
+                    shape=tuple(int(dim) for dim in item["shape"]),
+                    role=item.get("role", "input"),
+                    fill=item.get("fill", "zero"),
+                )
+            )
+        elif item["kind"] == "scalar":
+            value = item["value"]
+            pack_mode = item.get("pack_mode", "value")
+            if (pack_mode == "bits" or item["dtype"] == "FLOAT32_BITS") and isinstance(value, float):
+                value = _f32_bits(value)
+            result.append(
+                TraceScalarArg(
+                    index=int(item["index"]),
+                    name=item["name"],
+                    dtype=item["dtype"],
+                    value=value,
+                    pack_mode=pack_mode,
+                )
+            )
+        else:
+            raise ValueError(f"Unknown arg kind: {item['kind']}")
+    return tuple(sorted(result, key=lambda arg: arg.index))
+
+
+def _f32_bits(value: float) -> int:
+    return struct.unpack("I", struct.pack("f", value))[0]

--- a/simpler_setup/insight_trace/args_pkg/recipes.py
+++ b/simpler_setup/insight_trace/args_pkg/recipes.py
@@ -1,0 +1,130 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import ctypes
+import struct
+
+from ..kernel_analyzer import read_arg_indices
+from ..models import KernelShape, KernelSpec, SceneCaseContext, TraceArg, TraceScalarArg, TraceTensorArg
+
+
+def resolve_builtin_args(context: SceneCaseContext, kernel: KernelSpec) -> tuple[TraceArg, ...]:
+    args = _paged_attention_recipe(context, kernel)
+    read_indices = read_arg_indices(kernel.source_path)
+    missing = sorted(index for index in read_indices if index not in {arg.index for arg in args})
+    if missing:
+        raise ValueError(f"Argument recipe for {kernel.name} does not cover args indices: {missing}")
+    return args
+
+
+def _paged_attention_recipe(context: SceneCaseContext, kernel: KernelSpec) -> tuple[TraceArg, ...]:
+    module_path = context.module_dir.as_posix()
+    if "spmd_multiblock_mix" in module_path:
+        total_cl = sum(int(blocks) * 3 for blocks, _ in ((2, 0), (8, 6), (12, 30), (24, 66), (48, 138)))
+        return (
+            TraceTensorArg(0, "output", "FLOAT32", (total_cl * 16,), role="inout"),
+            TraceScalarArg(1, "base_cl", "UINT64", 0),
+        )
+    if "paged_attention" not in module_path:
+        raise ValueError("No built-in insight trace recipe for this test module; pass --arg-spec")
+    params = context.case.get("params", {})
+    q_tile = 16
+    block_size = int(params["block_size"])
+    head_dim = int(params["head_dim"])
+    scale = _scalar_value(context, "scale", default=1.0)
+
+    if kernel.shape == KernelShape.SPMD_MIX:
+        batch = int(params["batch"])
+        num_heads = int(params["num_heads"])
+        kv_head_num = int(params["kv_head_num"])
+        context_len = int(params["context_len"])
+        max_model_len = int(params["max_model_len"])
+        max_num_blocks_per_req = max_model_len // block_size
+        q_tile = 16 if num_heads <= 16 else 64
+        q_loop = (num_heads + q_tile - 1) // q_tile
+        total_logical_blocks = batch * q_loop
+        total_blocks = batch * ((context_len + block_size - 1) // block_size)
+        return (
+            TraceTensorArg(0, "query", "BFLOAT16", (batch, num_heads, head_dim)),
+            TraceTensorArg(1, "key_cache", "BFLOAT16", (total_blocks, block_size, kv_head_num, head_dim)),
+            TraceTensorArg(2, "value_cache", "BFLOAT16", (total_blocks, block_size, kv_head_num, head_dim)),
+            TraceTensorArg(3, "block_table", "INT32", (batch, max_num_blocks_per_req)),
+            TraceTensorArg(4, "context_lens", "INT32", (batch,)),
+            TraceTensorArg(5, "out", "FLOAT32", (batch, num_heads, head_dim)),
+            TraceTensorArg(6, "sij_fifo", "FLOAT32", (1,)),
+            TraceTensorArg(7, "pij_fifo", "BFLOAT16", (1,)),
+            TraceTensorArg(8, "oi_fifo", "FLOAT32", (1,)),
+            TraceScalarArg(9, "scale_value", "FLOAT32_BITS", _f32_bits(float(scale)), "bits"),
+            TraceScalarArg(10, "num_heads", "UINT64", num_heads),
+            TraceScalarArg(11, "head_dim", "UINT64", head_dim),
+            TraceScalarArg(12, "block_size", "UINT64", block_size),
+            TraceScalarArg(13, "max_num_blocks_per_req", "UINT64", max_num_blocks_per_req),
+            TraceScalarArg(14, "q_loop", "UINT64", q_loop),
+            TraceScalarArg(15, "total_logical_blocks", "UINT64", total_logical_blocks),
+            TraceScalarArg(16, "q_tile", "UINT64", q_tile),
+        )
+
+    recipes: dict[str, tuple[TraceArg, ...]] = {
+        "QK": (
+            TraceTensorArg(0, "qi", "BFLOAT16", (q_tile, head_dim)),
+            TraceTensorArg(1, "kj", "BFLOAT16", (block_size, head_dim)),
+            TraceTensorArg(2, "sij", "FLOAT32", (q_tile, block_size)),
+            TraceScalarArg(4, "head_dim", "UINT64", head_dim),
+            TraceScalarArg(5, "block_size", "UINT64", block_size),
+        ),
+        "SF": (
+            TraceTensorArg(0, "sij", "FLOAT32", (q_tile, block_size)),
+            TraceTensorArg(1, "pij", "BFLOAT16", (q_tile, block_size)),
+            TraceTensorArg(2, "mij", "FLOAT32", (q_tile,)),
+            TraceTensorArg(3, "lij", "FLOAT32", (q_tile,)),
+            TraceScalarArg(4, "scale", "FLOAT32_BITS", _f32_bits(float(scale)), "bits"),
+        ),
+        "PV": (
+            TraceTensorArg(0, "pij", "BFLOAT16", (q_tile, block_size)),
+            TraceTensorArg(1, "vj", "BFLOAT16", (block_size, head_dim)),
+            TraceTensorArg(2, "oi_new", "FLOAT32", (q_tile, head_dim)),
+            TraceScalarArg(4, "block_size", "UINT64", block_size),
+            TraceScalarArg(5, "head_dim", "UINT64", head_dim),
+        ),
+        "UP": (
+            TraceTensorArg(0, "mij", "FLOAT32", (q_tile,)),
+            TraceTensorArg(1, "lij", "FLOAT32", (q_tile,)),
+            TraceTensorArg(2, "oi_new", "FLOAT32", (q_tile, head_dim)),
+            TraceTensorArg(3, "mi", "FLOAT32", (q_tile,)),
+            TraceTensorArg(4, "li", "FLOAT32", (q_tile,)),
+            TraceTensorArg(5, "oi", "FLOAT32", (q_tile, head_dim)),
+            TraceTensorArg(6, "dst", "FLOAT32", (q_tile, head_dim)),
+            TraceScalarArg(7, "is_first", "UINT64", 1),
+            TraceScalarArg(8, "is_last", "UINT64", 1),
+            TraceScalarArg(10, "head_dim", "UINT64", head_dim),
+        ),
+    }
+    if kernel.name not in recipes:
+        raise ValueError(f"No paged_attention recipe for kernel {kernel.name}")
+    return recipes[kernel.name]
+
+
+def _scalar_value(context: SceneCaseContext, name: str, default):
+    try:
+        builder = context.test_class().generate_args(context.case.get("params", {}))
+    except (TypeError, ValueError, KeyError):
+        return default
+    for spec in getattr(builder, "specs", []):
+        if getattr(spec, "name", None) != name:
+            continue
+        value = spec.value
+        if isinstance(value, ctypes._SimpleCData):
+            return value.value
+        return value
+    return default
+
+
+def _f32_bits(value: float) -> int:
+    return struct.unpack("I", struct.pack("f", value))[0]

--- a/simpler_setup/insight_trace/case_loader.py
+++ b/simpler_setup/insight_trace/case_loader.py
@@ -1,0 +1,59 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from .models import SceneCaseContext
+
+
+def load_module(path: Path) -> ModuleType:
+    path = path.resolve()
+    spec = importlib.util.spec_from_file_location(path.stem, str(path))
+    if spec is None or spec.loader is None:
+        raise ValueError(f"Cannot load test module: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def find_scene_test_class(module: ModuleType) -> type:
+    candidates = []
+    for obj in module.__dict__.values():
+        if inspect.isclass(obj) and hasattr(obj, "CALLABLE") and hasattr(obj, "CASES"):
+            if getattr(obj, "_st_level", None) == 2:
+                candidates.append(obj)
+    if not candidates:
+        raise ValueError("No level-2 SceneTestCase class found")
+    if len(candidates) > 1:
+        names = ", ".join(cls.__name__ for cls in candidates)
+        raise ValueError(f"Multiple SceneTestCase classes found: {names}")
+    return candidates[0]
+
+
+def load_scene_case(test_module: Path, case_name: str) -> SceneCaseContext:
+    module = load_module(test_module)
+    test_class = find_scene_test_class(module)
+    case = next((case for case in test_class.CASES if case.get("name") == case_name), None)
+    if case is None:
+        available = ", ".join(case.get("name", "<unnamed>") for case in test_class.CASES)
+        raise ValueError(f"Unknown case {case_name!r}; available cases: {available}")
+    return SceneCaseContext(
+        test_class=test_class,
+        case=case,
+        callable_spec=test_class.CALLABLE,
+        test_module=test_module.resolve(),
+        module_dir=test_module.resolve().parent,
+        runtime=getattr(test_class, "_st_runtime", ""),
+    )

--- a/simpler_setup/insight_trace/cli.py
+++ b/simpler_setup/insight_trace/cli.py
@@ -1,0 +1,40 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from .arg_resolver import resolve_args  # noqa: F401
+from .case_loader import load_scene_case  # noqa: F401
+from .cli_pkg import build_parser as _build_parser
+from .cli_pkg import run_simpler
+from .cli_pkg.config import hw_block_num as _hw_block_num  # noqa: F401
+from .cli_pkg.config import spmd_meta as _spmd_meta  # noqa: F401
+from .kernel_analyzer import select_kernel, validate_single_task_kernel  # noqa: F401
+from .runner import run_workspace  # noqa: F401
+from .workspace import create_workspace  # noqa: F401
+
+# Re-export for testability via monkeypatch
+_run_simpler = run_simpler
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = run_simpler(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"insight trace failed: {exc}")
+        return 1
+    print(f"Insight trace workspace: {result.workspace_dir}")
+    if result.simulator_dir is not None:
+        print(f"MindStudio Insight input: {result.simulator_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simpler_setup/insight_trace/cli_pkg/__init__.py
+++ b/simpler_setup/insight_trace/cli_pkg/__init__.py
@@ -1,0 +1,31 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from .config import (
+    build_trace_config,
+    default_output_dir,
+    hw_block_num,
+    pto_isa_root,
+    resolve_platform_arch,
+    spmd_meta,
+    with_soc_version_override,
+)
+from .entry_simpler import run_simpler
+from .parser import build_parser
+
+__all__ = [
+    "build_parser",
+    "build_trace_config",
+    "default_output_dir",
+    "hw_block_num",
+    "pto_isa_root",
+    "resolve_platform_arch",
+    "run_simpler",
+    "spmd_meta",
+    "with_soc_version_override",
+]

--- a/simpler_setup/insight_trace/cli_pkg/config.py
+++ b/simpler_setup/insight_trace/cli_pkg/config.py
@@ -1,0 +1,130 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from pathlib import Path
+
+from simpler_setup.environment import PROJECT_ROOT
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+from ..models import (
+    KernelShape,
+    PlatformArch,
+    PlatformFamily,
+    SPMDDispatch,
+    SPMDReplayMeta,
+    TraceBackend,
+    TraceConfig,
+)
+
+
+def build_trace_config(args, context, kernel, trace_args):
+    output_dir = args.output_dir or default_output_dir(args.case, kernel.name, datetime.now())
+
+    platform = resolve_platform_arch(args.platform, context)
+    if args.soc_version:
+        platform = with_soc_version_override(platform, args.soc_version)
+
+    return TraceConfig(
+        backend=TraceBackend.SIMPLER,
+        test_module=args.test_module.resolve() if args.test_module else None,
+        case_name=args.case,
+        kernel_spec=kernel,
+        args=trace_args,
+        output_dir=output_dir,
+        repo_root=PROJECT_ROOT,
+        cann_home=args.cann_home,
+        pto_isa_root=pto_isa_root(args.pto_isa_root),
+        platform_arch=platform,
+        device=args.device,
+        launch_count=args.launch_count,
+        timeout=args.timeout,
+        hw_block_num=hw_block_num(args, kernel),
+        dry_run=args.dry_run,
+        spmd_meta=spmd_meta(kernel, platform),
+    )
+
+
+def default_output_dir(case_name: str, kernel_name: str, now: datetime) -> Path:
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    safe_case = case_name.replace("/", "_")
+    safe_kernel = kernel_name.replace("/", "_")
+    return PROJECT_ROOT / "outputs" / f"insight_trace_{safe_case}_{safe_kernel}_{timestamp}"
+
+
+def resolve_platform_arch(platform_arg: str, context) -> PlatformArch:
+    if platform_arg not in ("a2a3", "a5"):
+        raise ValueError(f"Unknown platform family: {platform_arg!r}")
+    family = PlatformFamily.A5 if platform_arg == "a5" else PlatformFamily.A2A3
+
+    if context is not None:
+        case_platforms = context.case.get("platforms", [])
+        if case_platforms and not any(p.startswith(platform_arg) for p in case_platforms):
+            raise ValueError(f"Platform family {platform_arg!r} does not match case platforms {case_platforms}")
+
+    return PlatformArch.for_family(family)
+
+
+def with_soc_version_override(platform: PlatformArch, soc_version: str) -> PlatformArch:
+    return replace(platform, soc_version=soc_version)
+
+
+def hw_block_num(args, kernel) -> int:
+    if kernel.shape == KernelShape.SPMD_MIX:
+        if args.platform == PlatformFamily.A5.value and kernel.source_path.name == "kernel_spmd_mix.cpp":
+            return 2 + 8 + 12 + 24 + 48
+        return 24
+    return args.hw_block_num
+
+
+def spmd_meta(kernel, platform: PlatformArch | None = None):
+    if kernel.shape != KernelShape.SPMD_MIX:
+        return None
+    if platform is not None and platform.family == PlatformFamily.A5:
+        if kernel.source_path.name != "kernel_spmd_mix.cpp":
+            return None
+        return SPMDReplayMeta(
+            hw_block_dim=24,
+            aiv_lanes_per_core=2,
+            dispatches=(
+                SPMDDispatch(logical_block_num=2, scalar_overrides=((1, 0),)),
+                SPMDDispatch(logical_block_num=8, scalar_overrides=((1, 6),)),
+                SPMDDispatch(logical_block_num=12, scalar_overrides=((1, 30),)),
+                SPMDDispatch(logical_block_num=24, scalar_overrides=((1, 66),)),
+                SPMDDispatch(logical_block_num=48, scalar_overrides=((1, 138),)),
+            ),
+        )
+    if kernel.source_path.name != "paged_attention_parallel.cpp":
+        raise ValueError(f"No SPMD replay metadata for kernel {kernel.name}")
+    # FIFO element sizes (bytes): sij_fifo=float32, pij_fifo=bfloat16, oi_fifo=float32
+    SIJ_FIFO_ELEMENT_SIZE = 4
+    PIJ_FIFO_ELEMENT_SIZE = 2
+    OI_FIFO_ELEMENT_SIZE = 4
+    fifo_depth = 2
+    max_q_tile = 64
+    max_block_size = 128
+    head_dim = 128
+    hw_block_dim = 24
+    return SPMDReplayMeta(
+        hw_block_dim=hw_block_dim,
+        aiv_lanes_per_core=2,
+        fifo_sizes=(
+            max_q_tile * max_block_size * SIJ_FIFO_ELEMENT_SIZE * fifo_depth,
+            max_q_tile * max_block_size * PIJ_FIFO_ELEMENT_SIZE * fifo_depth,
+            max_q_tile * head_dim * OI_FIFO_ELEMENT_SIZE * fifo_depth,
+        ),
+    )
+
+
+def pto_isa_root(path: Path | None) -> Path:
+    if path is not None:
+        return path.resolve()
+    return Path(ensure_pto_isa_root()).resolve()

--- a/simpler_setup/insight_trace/cli_pkg/entry_simpler.py
+++ b/simpler_setup/insight_trace/cli_pkg/entry_simpler.py
@@ -1,0 +1,32 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Simpler backend entry point for insight trace."""
+
+from __future__ import annotations
+
+from .config import build_trace_config
+
+
+def run_simpler(args):
+    # Defer import to avoid circular dependency at module load time
+    from .. import cli as cli_module  # noqa: PLC0415
+
+    if args.test_module is None or args.case is None:
+        raise ValueError("simpler backend requires test_module and --case")
+    context = cli_module.load_scene_case(args.test_module, args.case)
+    kernel = cli_module.select_kernel(context, args.kernel, args.func_id, args.kernel_source)
+    cli_module.validate_single_task_kernel(kernel)
+    # PR792 format: task_id filters by task, func_id is for kernel selection only
+    task_id = getattr(args, "task_id", None)
+    trace_args = cli_module.resolve_args(context, kernel, args.arg_spec, args.dump_dir, task_id)
+    config = build_trace_config(args, context, kernel, trace_args)
+    result = cli_module.create_workspace(config)
+    if args.dry_run:
+        return result
+    return cli_module.run_workspace(config)

--- a/simpler_setup/insight_trace/cli_pkg/parser.py
+++ b/simpler_setup/insight_trace/cli_pkg/parser.py
@@ -1,0 +1,62 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from ..models import TraceBackend
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Generate MindStudio Insight replay workspaces and final trace artifacts for an incore kernel"
+    )
+    parser.add_argument("test_module", nargs="?", type=Path)
+    parser.add_argument("--backend", choices=[item.value for item in TraceBackend], default=TraceBackend.SIMPLER.value)
+    parser.add_argument("--case")
+    selector = parser.add_mutually_exclusive_group()
+    selector.add_argument("--kernel")
+    selector.add_argument("--func-id", type=int)
+    selector.add_argument("--kernel-source")
+    parser.add_argument("--platform", default="a2a3")
+    parser.add_argument("--runtime", default="tensormap_and_ringbuffer")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Workspace directory; final Insight artifacts are exported under <output-dir>/insight_export",
+    )
+    parser.add_argument("--cann-home", type=Path, default=_default_cann_home())
+    parser.add_argument("--pto-isa-root", type=Path)
+    parser.add_argument("--soc-version")
+    parser.add_argument("--device", type=int, default=0)
+    parser.add_argument("--launch-count", type=int, default=1)
+    parser.add_argument("--timeout", type=int, default=120)
+    parser.add_argument("--hw-block-num", type=int, default=1)
+    parser.add_argument("--arg-spec", type=Path)
+    parser.add_argument("--dump-dir", type=Path)
+    parser.add_argument("--dispatch-id", type=int)  # deprecated, kept for backward compat
+    parser.add_argument("--task-id", type=str, help="Task ID for PR792 tensor_dump.json (optional)")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Generate replay workspace only; skip build/collect/export",
+    )
+    parser.add_argument("--ptoas-root", type=Path)
+    parser.add_argument("--source-cpp", type=Path)
+    parser.add_argument("--kernel-base-name")
+    parser.add_argument("--aicore-arch")
+    parser.add_argument("--kernel-symbol")
+    return parser
+
+
+def _default_cann_home() -> Path | None:
+    value = os.environ.get("CANN_HOME") or os.environ.get("ASCEND_HOME_PATH")
+    return Path(value) if value else None

--- a/simpler_setup/insight_trace/kernel_analyzer.py
+++ b/simpler_setup/insight_trace/kernel_analyzer.py
@@ -1,0 +1,92 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import re
+from functools import cache
+from pathlib import Path
+
+from .models import KernelShape, KernelSpec, SceneCaseContext
+
+_ARG_READ_RE = re.compile(r"args\[(\d+)\]")
+
+
+def select_kernel(
+    context: SceneCaseContext,
+    kernel_name: str | None = None,
+    func_id: int | None = None,
+    kernel_source: str | None = None,
+) -> KernelSpec:
+    selectors = [kernel_name is not None, func_id is not None, kernel_source is not None]
+    if sum(selectors) != 1:
+        raise ValueError("Exactly one of --kernel, --func-id, or --kernel-source is required")
+
+    incores = context.callable_spec.get("incores", [])
+    selected = None
+    for entry in incores:
+        source = Path(entry.get("source", ""))
+        if kernel_name is not None and entry.get("name") == kernel_name:
+            selected = entry
+            break
+        if func_id is not None and entry.get("func_id") == func_id:
+            selected = entry
+            break
+        if kernel_source is not None:
+            requested = Path(kernel_source)
+            if source == requested or source.name == requested.name or source.as_posix().endswith(requested.as_posix()):
+                selected = entry
+                break
+    if selected is None:
+        raise ValueError("Kernel selector did not match any CALLABLE['incores'] entry")
+
+    source_path = Path(selected["source"]).resolve()
+    shape = classify_kernel(selected.get("core_type", ""), source_path)
+    return KernelSpec(
+        name=selected.get("name", source_path.stem),
+        func_id=int(selected["func_id"]),
+        core_type=selected.get("core_type", ""),
+        source_path=source_path,
+        shape=shape,
+    )
+
+
+def classify_kernel(core_type: str, source_path: Path) -> KernelShape:
+    source = _read_source(source_path)
+    if "/kernels/mix/" in source_path.as_posix():
+        return KernelShape.SPMD_MIX
+    if "SPMD_LOCAL_CONTEXT_INDEX" in source or "SPMD_GLOBAL_CONTEXT_INDEX" in source:
+        return KernelShape.SPMD_MIX
+    if "get_block_idx(args)" in source or "get_sub_block_id(args)" in source or "get_block_num(args)" in source:
+        return KernelShape.SPMD_MIX
+    if "args[48]" in source or "args[49]" in source:
+        return KernelShape.SPMD_MIX
+    if core_type == "aic":
+        return KernelShape.AIC_ONLY
+    if core_type == "aiv":
+        return KernelShape.AIV_ONLY
+    if "/kernels/aic/" in source_path.as_posix():
+        return KernelShape.AIC_ONLY
+    if "/kernels/aiv/" in source_path.as_posix():
+        return KernelShape.AIV_ONLY
+    raise ValueError(f"Cannot classify kernel core type: {core_type!r}")
+
+
+def read_arg_indices(source_path: Path) -> set[int]:
+    return {int(match.group(1)) for match in _ARG_READ_RE.finditer(_read_source(source_path))}
+
+
+def validate_single_task_kernel(kernel: KernelSpec) -> None:
+    source = _read_source(kernel.source_path)
+    if "kernel_entry" not in source or "int64_t *args" not in source:
+        raise ValueError(f"Kernel does not look like kernel_entry(args): {kernel.source_path}")
+
+
+@cache
+def _read_source(source_path: Path) -> str:
+    return source_path.resolve().read_text()

--- a/simpler_setup/insight_trace/models.py
+++ b/simpler_setup/insight_trace/models.py
@@ -1,0 +1,189 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Union
+
+
+class PlatformFamily(str, Enum):
+    A2A3 = "a2a3"
+    A5 = "a5"
+
+
+@dataclass(frozen=True)
+class PlatformArch:
+    family: PlatformFamily = PlatformFamily.A2A3
+    soc_version: str = "dav_2201"
+    cce_aicore_number: int = 220
+    pto_arch_macro: str = "PTO_NPU_ARCH_A2A3"
+    cce_aicore_arch: str = "dav-c220"
+    prologue_event_id7: str = "((event_t)7)"
+    prologue_pipe_fix: str = "((pipe_t)10)"
+    runtime_include_roots: tuple[str, ...] = (
+        "src/a2a3/runtime/tensormap_and_ringbuffer/runtime",
+        "src/a2a3/runtime/tensormap_and_ringbuffer/common",
+        "src/a2a3/runtime/tensormap_and_ringbuffer/orchestration",
+    )
+    platform_include_roots: tuple[str, ...] = ("src/a2a3/platform/include",)
+
+    @staticmethod
+    def for_family(family: PlatformFamily) -> PlatformArch:
+        if family == PlatformFamily.A5:
+            return _A5_PLATFORM
+        return _A2A3_PLATFORM
+
+
+_A2A3_PLATFORM = PlatformArch(
+    family=PlatformFamily.A2A3,
+    soc_version="dav_2201",
+    cce_aicore_number=220,
+    pto_arch_macro="PTO_NPU_ARCH_A2A3",
+    cce_aicore_arch="dav-c220",
+)
+
+_A5_PLATFORM = PlatformArch(
+    family=PlatformFamily.A5,
+    soc_version="dav_3510",
+    cce_aicore_number=310,
+    pto_arch_macro="PTO_NPU_ARCH_A5",
+    cce_aicore_arch="dav-c310",
+    prologue_event_id7="((::event_t)7)",
+    prologue_pipe_fix="((::pipe_t)10)",
+    runtime_include_roots=(
+        "src/a5/runtime/tensormap_and_ringbuffer/runtime",
+        "src/a5/runtime/tensormap_and_ringbuffer/common",
+        "src/a5/runtime/tensormap_and_ringbuffer/orchestration",
+    ),
+    platform_include_roots=("src/a5/platform/include",),
+)
+
+
+class KernelShape(str, Enum):
+    AIC_ONLY = "aic-only"
+    AIV_ONLY = "aiv-only"
+    SPMD_MIX = "spmd-mix"
+
+
+class TraceBackend(str, Enum):
+    SIMPLER = "simpler"
+    PTOAS = "ptoas"
+
+
+@dataclass(frozen=True)
+class KernelSpec:
+    name: str
+    func_id: int
+    core_type: str
+    source_path: Path
+    shape: KernelShape
+
+
+@dataclass(frozen=True)
+class TraceTensorArg:
+    index: int
+    name: str
+    dtype: str
+    shape: tuple[int, ...]
+    role: str = "input"
+    fill: str = "zero"
+
+
+@dataclass(frozen=True)
+class TraceScalarArg:
+    index: int
+    name: str
+    dtype: str
+    value: int | float
+    pack_mode: str = "value"
+
+
+TraceArg = Union[TraceTensorArg, TraceScalarArg]
+
+
+@dataclass(frozen=True)
+class SPMDDispatch:
+    logical_block_num: int
+    scalar_overrides: tuple[tuple[int, int], ...] = ()
+
+
+@dataclass(frozen=True)
+class SPMDReplayMeta:
+    hw_block_dim: int = 24
+    aiv_lanes_per_core: int = 2
+    fifo_sizes: tuple[int, int, int] = (0, 0, 0)  # (sij_bytes, pij_bytes, oi_bytes) per hw block
+    dispatches: tuple[SPMDDispatch, ...] = ()
+
+
+@dataclass(frozen=True)
+class TraceConfig:
+    backend: TraceBackend
+    test_module: Path | None
+    case_name: str | None
+    kernel_spec: KernelSpec | None
+    args: tuple[TraceArg, ...]
+    output_dir: Path
+    repo_root: Path
+    cann_home: Path | None
+    pto_isa_root: Path | None
+    platform_arch: PlatformArch = _A2A3_PLATFORM
+    device: int = 0
+    launch_count: int = 1
+    timeout: int = 120
+    hw_block_num: int = 1
+    dry_run: bool = False
+    spmd_meta: SPMDReplayMeta | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class TraceResult:
+    workspace_dir: Path
+    simulator_dir: Path | None
+    collect_log: Path | None
+    export_log: Path | None
+
+
+@dataclass(frozen=True)
+class SceneCaseContext:
+    test_class: type
+    case: dict[str, Any]
+    callable_spec: dict[str, Any]
+    test_module: Path
+    module_dir: Path
+    runtime: str
+
+
+@dataclass(frozen=True)
+class PtoasTraceConfig:
+    ptoas_root: Path
+    source_cpp: Path
+    testcase_name: str
+    kernel_base_name: str
+    aicore_arch: str
+    output_dir: Path
+    cann_home: Path | None
+    pto_isa_root: Path | None
+    soc_version: str = "dav_2201"
+    timeout: int = 120
+    launch_count: int = 1
+    kernel_symbol: str | None = None
+
+
+@dataclass(frozen=True)
+class PtoasWorkspace:
+    run_root: Path
+    case_root: Path
+    case_dir: Path
+    build_dir: Path
+    application: Path
+    kernel_lib: Path
+    kernel_symbol: str

--- a/simpler_setup/insight_trace/runner.py
+++ b/simpler_setup/insight_trace/runner.py
@@ -1,0 +1,69 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from .models import TraceConfig, TraceResult
+
+
+def run_workspace(config: TraceConfig) -> TraceResult:
+    script = config.output_dir / "run_collect.sh"
+    bash_path = shutil.which("bash")
+    if bash_path is None:
+        raise RuntimeError("bash executable not found in PATH")
+    env = os.environ.copy()
+    if config.cann_home is not None:
+        env["CANN_HOME"] = str(config.cann_home)
+    if config.pto_isa_root is not None:
+        env["PTO_ISA_ROOT"] = str(config.pto_isa_root)
+    env["REPO_ROOT"] = str(config.repo_root)
+    try:
+        result = subprocess.run(
+            [bash_path, str(script)],
+            cwd=str(config.output_dir),
+            env=env,
+            check=False,
+            text=True,
+            timeout=config.timeout,
+        )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(
+            f"Trace collection timed out after {config.timeout}s; check logs at {config.output_dir / 'msprof_collect'}"
+        )
+    if result.returncode != 0:
+        raise RuntimeError(f"insight trace collection failed; see {config.output_dir / 'msprof_collect'}")
+    simulator_dir = find_simulator_dir(config.output_dir / "insight_export")
+    validate_simulator_dir(simulator_dir)
+    return TraceResult(
+        workspace_dir=config.output_dir,
+        simulator_dir=simulator_dir,
+        collect_log=config.output_dir / "msprof_collect" / "msprof_collect.log",
+        export_log=config.output_dir / "insight_export" / "msprof_export.log",
+    )
+
+
+def find_simulator_dir(export_root: Path) -> Path:
+    candidates = sorted(export_root.glob("OPPROF_*/simulator"))
+    if not candidates:
+        raise FileNotFoundError(f"No OPPROF simulator directory under {export_root}")
+    return candidates[-1]
+
+
+def validate_simulator_dir(simulator_dir: Path) -> None:
+    required = [simulator_dir / "trace.json", simulator_dir / "visualize_data.bin"]
+    missing = [path for path in required if not path.is_file()]
+    if missing:
+        names = ", ".join(str(path) for path in missing)
+        raise FileNotFoundError(f"Missing Insight trace artifacts: {names}")
+    if not list(simulator_dir.glob("core*/*instr_exe*.csv")):
+        raise FileNotFoundError(f"No instr_exe CSV files under {simulator_dir}")

--- a/simpler_setup/insight_trace/templates.py
+++ b/simpler_setup/insight_trace/templates.py
@@ -1,0 +1,11 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from .templates_pkg import render_cmake, render_config, render_host, render_kernel, render_launch, render_run_collect
+
+__all__ = ["render_cmake", "render_config", "render_host", "render_kernel", "render_launch", "render_run_collect"]

--- a/simpler_setup/insight_trace/templates_pkg/__init__.py
+++ b/simpler_setup/insight_trace/templates_pkg/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from .host import render_host
+from .kernel import render_kernel, render_launch
+from .project import render_cmake, render_config, render_run_collect
+
+__all__ = [
+    "render_kernel",
+    "render_launch",
+    "render_host",
+    "render_cmake",
+    "render_run_collect",
+    "render_config",
+]

--- a/simpler_setup/insight_trace/templates_pkg/common.py
+++ b/simpler_setup/insight_trace/templates_pkg/common.py
@@ -1,0 +1,92 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+from ..models import TraceConfig, TraceScalarArg, TraceTensorArg
+
+_DTYPE_CPP = {
+    "FLOAT16": "DataType::FLOAT16",
+    "FLOAT32": "DataType::FLOAT32",
+    "BFLOAT16": "DataType::BFLOAT16",
+    "INT8": "DataType::INT8",
+    "INT16": "DataType::INT16",
+    "INT32": "DataType::INT32",
+    "INT64": "DataType::INT64",
+    "UINT8": "DataType::UINT8",
+    "UINT16": "DataType::UINT16",
+    "UINT32": "DataType::UINT32",
+    "UINT64": "DataType::UINT64",
+}
+
+_DTYPE_SIZE = {
+    "FLOAT16": 2,
+    "FLOAT32": 4,
+    "BFLOAT16": 2,
+    "INT8": 1,
+    "INT16": 2,
+    "INT32": 4,
+    "INT64": 8,
+    "UINT8": 1,
+    "UINT16": 2,
+    "UINT32": 4,
+    "UINT64": 8,
+}
+
+
+def _prologue(config: TraceConfig) -> str:
+    arch = config.platform_arch
+    return f"""#ifndef __CCE_AICORE__
+#define __CCE_AICORE__ {arch.cce_aicore_number}
+#endif
+#include <cce_aicore_intrinsics.h>
+#ifndef {arch.pto_arch_macro}
+#define {arch.pto_arch_macro}
+#endif
+#ifndef EVENT_ID7
+#define EVENT_ID7 {arch.prologue_event_id7}
+#endif
+#ifndef PIPE_FIX
+#define PIPE_FIX {arch.prologue_pipe_fix}
+#endif
+"""
+
+
+def _arg_to_json(arg: TraceTensorArg | TraceScalarArg) -> dict:
+    if isinstance(arg, TraceTensorArg):
+        return {"index": arg.index, "kind": "tensor", "dtype": arg.dtype, "shape": list(arg.shape), "name": arg.name}
+    return {"index": arg.index, "kind": "scalar", "dtype": arg.dtype, "value": arg.value, "name": arg.name}
+
+
+def _validate_args(args: tuple[TraceTensorArg | TraceScalarArg, ...]) -> None:
+    seen = set()
+    reserved = {48, 49}
+    for arg in args:
+        if arg.index in reserved:
+            raise ValueError(f"Arg index {arg.index} is reserved for context pointers (slots 48, 49)")
+        if arg.index < 0 or arg.index >= 50:
+            raise ValueError(f"Arg index {arg.index} exceeds max slots (50)")
+        if arg.index in seen:
+            raise ValueError(f"Duplicate arg index {arg.index}")
+        seen.add(arg.index)
+
+
+def _require_kernel(config: TraceConfig):
+    if config.kernel_spec is None:
+        raise ValueError("simpler backend requires a kernel spec")
+    return config.kernel_spec
+
+
+def _require_spmd_meta(config: TraceConfig):
+    if config.spmd_meta is None:
+        raise ValueError("SPMD mix kernels require spmd_meta")
+    return config.spmd_meta
+
+
+def _camel(name: str) -> str:
+    return "".join(part.capitalize() for part in name.split("_"))

--- a/simpler_setup/insight_trace/templates_pkg/host.py
+++ b/simpler_setup/insight_trace/templates_pkg/host.py
@@ -1,0 +1,621 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from functools import reduce
+from operator import mul
+
+from ..models import KernelShape, TraceConfig, TraceScalarArg, TraceTensorArg
+from .common import _DTYPE_CPP, _DTYPE_SIZE, _camel, _require_kernel, _require_spmd_meta, _validate_args
+
+
+def render_host(config: TraceConfig) -> str:
+    _validate_args(config.args)
+    kernel = _require_kernel(config)
+    tensors = [arg for arg in config.args if isinstance(arg, TraceTensorArg)]
+    scalars = [arg for arg in config.args if isinstance(arg, TraceScalarArg)]
+    constants = []
+    allocs = []
+    tensor_inits = []
+    frees = []
+    for i, arg in enumerate(tensors):
+        elements = reduce(mul, arg.shape, 1)
+        size = elements * _DTYPE_SIZE[arg.dtype]
+        shape_name = f"shape_{arg.name}"
+        constants.append(f"constexpr int k{_camel(arg.name)}Bytes = {size};")
+        constants.append(f"uint32_t {shape_name}[{len(arg.shape)}] = {{{', '.join(str(dim) for dim in arg.shape)}}};")
+        allocs.append(f"    void *d_{arg.name} = nullptr;")
+        allocs.append(
+            f"    ACL_CHECK(aclrtMalloc(&d_{arg.name}, k{_camel(arg.name)}Bytes, ACL_MEM_MALLOC_HUGE_FIRST));"
+        )
+        allocs.append(
+            f"    ACL_CHECK(aclrtMemset(d_{arg.name}, k{_camel(arg.name)}Bytes, 0, k{_camel(arg.name)}Bytes));"
+        )
+        tensor_inits.append(
+            f"    tensors[{i}] = make_tensor_external("
+            f"d_{arg.name}, {shape_name}, {len(arg.shape)}, {_DTYPE_CPP[arg.dtype]});"
+        )
+        frees.append(f"    ACL_CHECK(aclrtFree(d_{arg.name}));")
+
+    if kernel.shape == KernelShape.SPMD_MIX:
+        if config.platform_arch.family.value == "a5" and config.spmd_meta is not None:
+            return _render_a5_spmd_host(config, tensors, scalars, constants, allocs, tensor_inits, frees)
+        if config.platform_arch.family.value == "a5":
+            return _render_a5_mixed_host(config, tensors, scalars, constants, allocs, tensor_inits, frees)
+        return _render_spmd_host(config, tensors, scalars, constants, allocs, tensor_inits, frees)
+    return _render_single_task_host(tensors, scalars, constants, allocs, tensor_inits, frees)
+
+
+def _render_single_task_host(tensors, scalars, constants, allocs, tensor_inits, frees) -> str:
+    arg_assigns = []
+    for i, arg in enumerate(tensors):
+        arg_assigns.append(
+            f"    args[{arg.index}] = static_cast<int64_t>("
+            f"reinterpret_cast<uintptr_t>(d_tensors) + {i} * sizeof(Tensor));"
+        )
+    for arg in scalars:
+        arg_assigns.append(f"    args[{arg.index}] = static_cast<int64_t>({int(arg.value)});")
+
+    return f"""#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+#include "acl/acl.h"
+#include "pto_orchestration_api.h"
+
+constexpr int kArgsSlots = 50;
+constexpr int kNumTensors = {len(tensors)};
+{chr(10).join(constants)}
+
+#define ACL_CHECK(expr) \\
+    do {{ \\
+        aclError _err = (expr); \\
+        if (_err != ACL_SUCCESS) {{ \\
+            fprintf(stderr, "ACL error %d at %s:%d\\n", _err, __FILE__, __LINE__); \\
+            exit(1); \\
+        }} \\
+    }} while (0)
+
+extern "C" void launch_replay(void *args, void *stream);
+
+int main() {{
+    ACL_CHECK(aclInit(nullptr));
+    int device_id = 0;
+    if (const char *env = getenv("ACL_DEVICE_ID")) {{
+        device_id = atoi(env);
+    }}
+    ACL_CHECK(aclrtSetDevice(device_id));
+
+    aclrtStream stream;
+    ACL_CHECK(aclrtCreateStream(&stream));
+
+{chr(10).join(allocs)}
+
+    void *tensors_mem = malloc(kNumTensors * sizeof(Tensor));
+    Tensor *tensors = static_cast<Tensor *>(tensors_mem);
+{chr(10).join(tensor_inits)}
+
+    void *d_tensors = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_tensors, kNumTensors * sizeof(Tensor), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_tensors, kNumTensors * sizeof(Tensor), tensors,
+                           kNumTensors * sizeof(Tensor), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    std::array<int64_t, kArgsSlots> args{{}};
+{chr(10).join(arg_assigns)}
+
+    void *d_args = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_args, sizeof(args), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_args, sizeof(args), args.data(), sizeof(args),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+
+    launch_replay(d_args, stream);
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+
+    ACL_CHECK(aclrtFree(d_args));
+    ACL_CHECK(aclrtFree(d_tensors));
+    free(tensors_mem);
+{chr(10).join(reversed(frees))}
+    ACL_CHECK(aclrtDestroyStream(stream));
+    ACL_CHECK(aclrtResetDevice(device_id));
+    ACL_CHECK(aclFinalize());
+
+    printf("Replay completed successfully.\\n");
+    return 0;
+}}
+"""
+
+
+def _render_a5_mixed_host(config, tensors, scalars, constants, allocs, tensor_inits, frees) -> str:
+    if config.spmd_meta is not None:
+        raise ValueError("A5 mixed host replay does not support SPMD context synthesis in the first pass")
+
+    aic_assigns = []
+    aiv_assigns = []
+    for i, arg in enumerate(tensors):
+        expr = f"static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_tensors) + {i} * sizeof(Tensor))"
+        aic_assigns.append(f"        row[{arg.index}] = {expr};")
+        aiv_assigns.append(f"        row[{arg.index}] = {expr};")
+    for arg in scalars:
+        expr = f"static_cast<int64_t>({int(arg.value)})"
+        aic_assigns.append(f"        row[{arg.index}] = {expr};")
+        aiv_assigns.append(f"        row[{arg.index}] = {expr};")
+
+    return f"""#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "acl/acl.h"
+#include "pto_orchestration_api.h"
+
+constexpr int kArgsSlots = 50;
+constexpr int kNumTensors = {len(tensors)};
+constexpr int kHwBlocks = {config.hw_block_num};
+constexpr int kAivLanesPerCore = 2;
+constexpr int kAivRows = kHwBlocks * kAivLanesPerCore;
+{chr(10).join(constants)}
+
+#define ACL_CHECK(expr) \\
+    do {{ \\
+        aclError _err = (expr); \\
+        if (_err != ACL_SUCCESS) {{ \\
+            fprintf(stderr, "ACL error %d at %s:%d\\n", _err, __FILE__, __LINE__); \\
+            exit(1); \\
+        }} \\
+    }} while (0)
+
+extern "C" void launch_replay(void *aic_args, void *aiv_args, void *stream);
+
+int main() {{
+    ACL_CHECK(aclInit(nullptr));
+    int device_id = 0;
+    if (const char *env = getenv("ACL_DEVICE_ID")) {{
+        device_id = atoi(env);
+    }}
+    ACL_CHECK(aclrtSetDevice(device_id));
+
+    aclrtStream stream;
+    ACL_CHECK(aclrtCreateStream(&stream));
+
+{chr(10).join(allocs)}
+
+    void *tensors_mem = malloc(kNumTensors * sizeof(Tensor));
+    Tensor *tensors = static_cast<Tensor *>(tensors_mem);
+{chr(10).join(tensor_inits)}
+
+    void *d_tensors = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_tensors, kNumTensors * sizeof(Tensor), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_tensors, kNumTensors * sizeof(Tensor), tensors,
+                           kNumTensors * sizeof(Tensor), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    std::vector<int64_t> aic_args(kHwBlocks * kArgsSlots, 0);
+    std::vector<int64_t> aiv_args(kAivRows * kArgsSlots, 0);
+    for (int r = 0; r < kHwBlocks; ++r) {{
+        int64_t *row = aic_args.data() + static_cast<uint64_t>(r) * kArgsSlots;
+{chr(10).join(aic_assigns)}
+    }}
+    for (int r = 0; r < kAivRows; ++r) {{
+        int64_t *row = aiv_args.data() + static_cast<uint64_t>(r) * kArgsSlots;
+{chr(10).join(aiv_assigns)}
+    }}
+
+    void *d_aic_args = nullptr;
+    void *d_aiv_args = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_aic_args, aic_args.size() * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_args, aiv_args.size() * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_aic_args, aic_args.size() * sizeof(int64_t), aic_args.data(),
+                           aic_args.size() * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_args, aiv_args.size() * sizeof(int64_t), aiv_args.data(),
+                           aiv_args.size() * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    launch_replay(d_aic_args, d_aiv_args, stream);
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+
+    ACL_CHECK(aclrtFree(d_aiv_args));
+    ACL_CHECK(aclrtFree(d_aic_args));
+    ACL_CHECK(aclrtFree(d_tensors));
+    free(tensors_mem);
+{chr(10).join(reversed(frees))}
+    ACL_CHECK(aclrtDestroyStream(stream));
+    ACL_CHECK(aclrtResetDevice(device_id));
+    ACL_CHECK(aclFinalize());
+
+    printf("Replay completed successfully.\\n");
+    return 0;
+}}
+"""
+
+
+def _render_a5_spmd_host(config, tensors, scalars, constants, allocs, tensor_inits, frees) -> str:
+    meta = _require_spmd_meta(config)
+
+    aic_assigns = []
+    aiv_assigns = []
+    for i, arg in enumerate(tensors):
+        expr = f"static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_tensors) + {i} * sizeof(Tensor))"
+        aic_assigns.append(f"        row[{arg.index}] = {expr};")
+        aiv_assigns.append(f"        row[{arg.index}] = {expr};")
+    for arg in scalars:
+        expr = f"static_cast<int64_t>({int(arg.value)})"
+        aic_assigns.append(f"        row[{arg.index}] = {expr};")
+        aiv_assigns.append(f"        row[{arg.index}] = {expr};")
+
+    dispatch_inits = []
+    for dispatch in meta.dispatches:
+        scalar_pairs = ", ".join(f"{{{index}, {value}}}" for index, value in dispatch.scalar_overrides)
+        dispatch_inits.append(f"        {{{dispatch.logical_block_num}, {{{scalar_pairs}}}}}")
+
+    aiv_lane_assigns = chr(10).join(line.replace("row[", "lane_row[") for line in aiv_assigns)
+
+    return f"""#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+#include "acl/acl.h"
+#include "pto_orchestration_api.h"
+#include "intrinsic.h"
+
+constexpr int kArgsSlots = 50;
+constexpr int kNumTensors = {len(tensors)};
+constexpr int kAivLanesPerCore = {meta.aiv_lanes_per_core};
+constexpr int kHwBlocks = {config.hw_block_num};
+{chr(10).join(constants)}
+
+#define ACL_CHECK(expr) \\
+    do {{ \\
+        aclError _err = (expr); \\
+        if (_err != ACL_SUCCESS) {{ \\
+            fprintf(stderr, "ACL error %d at %s:%d\\n", _err, __FILE__, __LINE__); \\
+            exit(1); \\
+        }} \\
+    }} while (0)
+
+struct ReplayDispatch {{
+    int logical_block_num;
+    std::vector<std::pair<int, int64_t>> scalar_overrides;
+}};
+
+extern "C" void launch_replay(void *aic_args, void *aiv_args, void *stream);
+
+int main() {{
+    ACL_CHECK(aclInit(nullptr));
+    int device_id = 0;
+    if (const char *env = getenv("ACL_DEVICE_ID")) {{
+        device_id = atoi(env);
+    }}
+    ACL_CHECK(aclrtSetDevice(device_id));
+
+    aclrtStream stream;
+    ACL_CHECK(aclrtCreateStream(&stream));
+
+{chr(10).join(allocs)}
+
+    void *tensors_mem = malloc(kNumTensors * sizeof(Tensor));
+    Tensor *tensors = static_cast<Tensor *>(tensors_mem);
+{chr(10).join(tensor_inits)}
+
+    void *d_tensors = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_tensors, kNumTensors * sizeof(Tensor), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_tensors, kNumTensors * sizeof(Tensor), tensors,
+                           kNumTensors * sizeof(Tensor), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    const std::vector<ReplayDispatch> dispatches = {{
+{chr(10).join(dispatch_inits)}
+    }};
+    int total_rows = 0;
+    for (const auto &dispatch : dispatches) {{
+        total_rows += dispatch.logical_block_num;
+    }}
+
+    std::vector<LocalContext> aic_local(total_rows);
+    std::vector<GlobalContext> aic_global(total_rows);
+    std::vector<LocalContext> aiv_local(total_rows * kAivLanesPerCore);
+    std::vector<GlobalContext> aiv_global(total_rows * kAivLanesPerCore);
+
+    int row_base = 0;
+    for (const auto &dispatch : dispatches) {{
+        for (int block_idx = 0; block_idx < dispatch.logical_block_num; ++block_idx) {{
+            int row_index = row_base + block_idx;
+            aic_local[row_index].s_block_idx = block_idx;
+            aic_local[row_index].s_block_num = dispatch.logical_block_num;
+            aic_global[row_index].sub_block_id = 0;
+            for (int lane = 0; lane < kAivLanesPerCore; ++lane) {{
+                int lane_row_index = row_index * kAivLanesPerCore + lane;
+                aiv_local[lane_row_index].s_block_idx = block_idx;
+                aiv_local[lane_row_index].s_block_num = dispatch.logical_block_num;
+                aiv_global[lane_row_index].sub_block_id = lane;
+            }}
+        }}
+        row_base += dispatch.logical_block_num;
+    }}
+
+    void *d_aic_local = nullptr;
+    void *d_aic_global = nullptr;
+    void *d_aiv_local = nullptr;
+    void *d_aiv_global = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_aic_local, aic_local.size() * sizeof(LocalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aic_global, aic_global.size() * sizeof(GlobalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_local, aiv_local.size() * sizeof(LocalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_global, aiv_global.size() * sizeof(GlobalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_aic_local, aic_local.size() * sizeof(LocalContext),
+                           aic_local.data(), aic_local.size() * sizeof(LocalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aic_global, aic_global.size() * sizeof(GlobalContext),
+                           aic_global.data(), aic_global.size() * sizeof(GlobalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_local, aiv_local.size() * sizeof(LocalContext),
+                           aiv_local.data(), aiv_local.size() * sizeof(LocalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_global, aiv_global.size() * sizeof(GlobalContext),
+                           aiv_global.data(), aiv_global.size() * sizeof(GlobalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+
+    std::vector<int64_t> aic_args(total_rows * kArgsSlots, 0);
+    std::vector<int64_t> aiv_args(total_rows * kAivLanesPerCore * kArgsSlots, 0);
+    row_base = 0;
+    for (const auto &dispatch : dispatches) {{
+        for (int block_idx = 0; block_idx < dispatch.logical_block_num; ++block_idx) {{
+            int row_index = row_base + block_idx;
+            int64_t *row = aic_args.data() + static_cast<uint64_t>(row_index) * kArgsSlots;
+{chr(10).join(aic_assigns)}
+            for (const auto &[arg_index, value] : dispatch.scalar_overrides) {{
+                row[arg_index] = value;
+            }}
+            row[48] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aic_local)
+                                   + row_index * sizeof(LocalContext));
+            row[49] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aic_global)
+                                   + row_index * sizeof(GlobalContext));
+
+            for (int lane = 0; lane < kAivLanesPerCore; ++lane) {{
+                int lane_row_index = row_index * kAivLanesPerCore + lane;
+                int64_t *lane_row = aiv_args.data() + static_cast<uint64_t>(lane_row_index) * kArgsSlots;
+{aiv_lane_assigns}
+                for (const auto &[arg_index, value] : dispatch.scalar_overrides) {{
+                    lane_row[arg_index] = value;
+                }}
+                lane_row[48] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aiv_local)
+                                       + lane_row_index * sizeof(LocalContext));
+                lane_row[49] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aiv_global)
+                                       + lane_row_index * sizeof(GlobalContext));
+            }}
+        }}
+        row_base += dispatch.logical_block_num;
+    }}
+
+    void *d_aic_args = nullptr;
+    void *d_aiv_args = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_aic_args, aic_args.size() * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_args, aiv_args.size() * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_aic_args, aic_args.size() * sizeof(int64_t), aic_args.data(),
+                           aic_args.size() * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_args, aiv_args.size() * sizeof(int64_t), aiv_args.data(),
+                           aiv_args.size() * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    launch_replay(d_aic_args, d_aiv_args, stream);
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+
+    ACL_CHECK(aclrtFree(d_aiv_args));
+    ACL_CHECK(aclrtFree(d_aic_args));
+    ACL_CHECK(aclrtFree(d_aiv_global));
+    ACL_CHECK(aclrtFree(d_aiv_local));
+    ACL_CHECK(aclrtFree(d_aic_global));
+    ACL_CHECK(aclrtFree(d_aic_local));
+    ACL_CHECK(aclrtFree(d_tensors));
+    free(tensors_mem);
+{chr(10).join(reversed(frees))}
+    ACL_CHECK(aclrtDestroyStream(stream));
+    ACL_CHECK(aclrtResetDevice(device_id));
+    ACL_CHECK(aclFinalize());
+
+    printf("Replay completed successfully.\\n");
+    return 0;
+}}
+"""
+
+
+def _render_spmd_host(config, tensors, scalars, constants, allocs, tensor_inits, frees) -> str:
+    if config.platform_arch.family.value == "a5":
+        raise ValueError(
+            "A5 SPMD mix host replay not supported; use a single-task A5 kernel "
+            "or an A5 mixed kernel without context synthesis"
+        )
+    meta = _require_spmd_meta(config)
+    spmd_fifo_names = {"sij_fifo", "pij_fifo", "oi_fifo"}
+
+    filtered_constants = []
+    filtered_allocs = []
+    filtered_tensor_inits = []
+    filtered_frees = []
+    spmd_tensor_lines = []
+    filtered_tensors: list[TraceTensorArg] = []
+    fifo_tensor_map: dict[str, TraceTensorArg] = {}
+
+    for i, arg in enumerate(tensors):
+        if arg.name in spmd_fifo_names:
+            fifo_tensor_map[arg.name] = arg
+            continue
+        filtered_tensors.append(arg)
+        filtered_constants.append(constants[i * 2])
+        filtered_constants.append(constants[i * 2 + 1])
+        filtered_allocs.extend(allocs[i * 3 : i * 3 + 3])
+        filtered_tensor_inits.append(tensor_inits[len(filtered_tensors) - 1])
+        filtered_frees.append(frees[i])
+
+    fifo_specs = (
+        ("sij_fifo", "kSpmdSijFifoBytes", "d_sij_fifo", "shape_sij_fifo", "DataType::FLOAT32", meta.fifo_sizes[0]),
+        ("pij_fifo", "kSpmdPijFifoBytes", "d_pij_fifo", "shape_pij_fifo", "DataType::BFLOAT16", meta.fifo_sizes[1]),
+        ("oi_fifo", "kSpmdOiFifoBytes", "d_oi_fifo", "shape_oi_fifo", "DataType::FLOAT32", meta.fifo_sizes[2]),
+    )
+    for name, const_name, dev_name, shape_name, dtype_cpp, fifo_bytes in fifo_specs:
+        arg = fifo_tensor_map.get(name)
+        if arg is None:
+            continue
+        filtered_constants.append(f"constexpr int {const_name} = {fifo_bytes};")
+        filtered_constants.append(f"uint32_t {shape_name}[1] = {{{fifo_bytes}}};")
+        spmd_tensor_lines.append(
+            f"    tensors[{len(filtered_tensors)}] = make_tensor_external({dev_name}, {shape_name}, 1, {dtype_cpp});"
+        )
+        filtered_tensors.append(arg)
+
+    aic_assigns = []
+    aiv_assigns = []
+    for i, arg in enumerate(filtered_tensors):
+        expr = f"static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_tensors) + {i} * sizeof(Tensor))"
+        aic_assigns.append(f"        row[{arg.index}] = {expr};")
+        aiv_assigns.append(f"        row[{arg.index}] = {expr};")
+    for arg in scalars:
+        aic_assigns.append(f"        row[{arg.index}] = static_cast<int64_t>({int(arg.value)});")
+        aiv_assigns.append(f"        row[{arg.index}] = static_cast<int64_t>({int(arg.value)});")
+
+    return f"""#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#include "acl/acl.h"
+#include "pto_orchestration_api.h"
+#include "intrinsic.h"
+
+constexpr int kArgsSlots = 50;
+constexpr int kNumTensors = {len(filtered_tensors)};
+constexpr int kHwBlocks = {meta.hw_block_dim};
+constexpr int kAivLanesPerCore = {meta.aiv_lanes_per_core};
+constexpr int kAivRows = kHwBlocks * kAivLanesPerCore;
+{chr(10).join(filtered_constants)}
+
+#define ACL_CHECK(expr) \\
+    do {{ \\
+        aclError _err = (expr); \\
+        if (_err != ACL_SUCCESS) {{ \\
+            fprintf(stderr, "ACL error %d at %s:%d\\n", _err, __FILE__, __LINE__); \\
+            exit(1); \\
+        }} \\
+    }} while (0)
+
+extern "C" void launch_replay(void *aic_args, void *aiv_args, void *stream);
+
+int main() {{
+    ACL_CHECK(aclInit(nullptr));
+    int device_id = 0;
+    if (const char *env = getenv("ACL_DEVICE_ID")) {{
+        device_id = atoi(env);
+    }}
+    ACL_CHECK(aclrtSetDevice(device_id));
+
+    aclrtStream stream;
+    ACL_CHECK(aclrtCreateStream(&stream));
+
+{chr(10).join(filtered_allocs)}
+    void *d_sij_fifo = nullptr;
+    void *d_pij_fifo = nullptr;
+    void *d_oi_fifo = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_sij_fifo, kSpmdSijFifoBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemset(d_sij_fifo, kSpmdSijFifoBytes, 0, kSpmdSijFifoBytes));
+    ACL_CHECK(aclrtMalloc(&d_pij_fifo, kSpmdPijFifoBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemset(d_pij_fifo, kSpmdPijFifoBytes, 0, kSpmdPijFifoBytes));
+    ACL_CHECK(aclrtMalloc(&d_oi_fifo, kSpmdOiFifoBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemset(d_oi_fifo, kSpmdOiFifoBytes, 0, kSpmdOiFifoBytes));
+
+    void *tensors_mem = malloc(kNumTensors * sizeof(Tensor));
+    Tensor *tensors = static_cast<Tensor *>(tensors_mem);
+{chr(10).join(filtered_tensor_inits)}
+{chr(10).join(spmd_tensor_lines)}
+
+    void *d_tensors = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_tensors, kNumTensors * sizeof(Tensor), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_tensors, kNumTensors * sizeof(Tensor), tensors,
+                           kNumTensors * sizeof(Tensor), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    std::vector<LocalContext> aic_local(kHwBlocks);
+    std::vector<GlobalContext> aic_global(kHwBlocks);
+    std::vector<LocalContext> aiv_local(kAivRows);
+    std::vector<GlobalContext> aiv_global(kAivRows);
+    for (int r = 0; r < kHwBlocks; ++r) {{
+        aic_local[r].block_idx = r;
+        aic_local[r].block_num = kHwBlocks;
+        aic_global[r].sub_block_id = 0;
+    }}
+    for (int r = 0; r < kAivRows; ++r) {{
+        aiv_local[r].block_idx = r / kAivLanesPerCore;
+        aiv_local[r].block_num = kHwBlocks;
+        aiv_global[r].sub_block_id = r % kAivLanesPerCore;
+    }}
+
+    void *d_aic_local = nullptr;
+    void *d_aic_global = nullptr;
+    void *d_aiv_local = nullptr;
+    void *d_aiv_global = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_aic_local, aic_local.size() * sizeof(LocalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aic_global, aic_global.size() * sizeof(GlobalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_local, aiv_local.size() * sizeof(LocalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_global, aiv_global.size() * sizeof(GlobalContext), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_aic_local, aic_local.size() * sizeof(LocalContext),
+                           aic_local.data(), aic_local.size() * sizeof(LocalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aic_global, aic_global.size() * sizeof(GlobalContext),
+                           aic_global.data(), aic_global.size() * sizeof(GlobalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_local, aiv_local.size() * sizeof(LocalContext),
+                           aiv_local.data(), aiv_local.size() * sizeof(LocalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_global, aiv_global.size() * sizeof(GlobalContext),
+                           aiv_global.data(), aiv_global.size() * sizeof(GlobalContext),
+                           ACL_MEMCPY_HOST_TO_DEVICE));
+
+    std::vector<int64_t> aic_args(kHwBlocks * kArgsSlots, 0);
+    std::vector<int64_t> aiv_args(kAivRows * kArgsSlots, 0);
+    for (int r = 0; r < kHwBlocks; ++r) {{
+        int64_t *row = aic_args.data() + static_cast<uint64_t>(r) * kArgsSlots;
+{chr(10).join(aic_assigns)}
+        row[48] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aic_local) + r * sizeof(LocalContext));
+        row[49] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aic_global) + r * sizeof(GlobalContext));
+    }}
+    for (int r = 0; r < kAivRows; ++r) {{
+        int64_t *row = aiv_args.data() + static_cast<uint64_t>(r) * kArgsSlots;
+{chr(10).join(aiv_assigns)}
+        row[48] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aiv_local) + r * sizeof(LocalContext));
+        row[49] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aiv_global) + r * sizeof(GlobalContext));
+    }}
+
+    void *d_aic_args = nullptr;
+    void *d_aiv_args = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_aic_args, aic_args.size() * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_args, aiv_args.size() * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_aic_args, aic_args.size() * sizeof(int64_t), aic_args.data(),
+                           aic_args.size() * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_args, aiv_args.size() * sizeof(int64_t), aiv_args.data(),
+                           aiv_args.size() * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    launch_replay(d_aic_args, d_aiv_args, stream);
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+
+    ACL_CHECK(aclrtFree(d_aiv_args));
+    ACL_CHECK(aclrtFree(d_aic_args));
+    ACL_CHECK(aclrtFree(d_aiv_global));
+    ACL_CHECK(aclrtFree(d_aiv_local));
+    ACL_CHECK(aclrtFree(d_aic_global));
+    ACL_CHECK(aclrtFree(d_aic_local));
+    ACL_CHECK(aclrtFree(d_tensors));
+    free(tensors_mem);
+    ACL_CHECK(aclrtFree(d_oi_fifo));
+    ACL_CHECK(aclrtFree(d_pij_fifo));
+    ACL_CHECK(aclrtFree(d_sij_fifo));
+{chr(10).join(reversed(filtered_frees))}
+    ACL_CHECK(aclrtDestroyStream(stream));
+    ACL_CHECK(aclrtResetDevice(device_id));
+    ACL_CHECK(aclFinalize());
+
+    printf("Replay completed successfully.\\n");
+    return 0;
+}}
+"""

--- a/simpler_setup/insight_trace/templates_pkg/kernel.py
+++ b/simpler_setup/insight_trace/templates_pkg/kernel.py
@@ -1,0 +1,91 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from ..models import KernelShape, TraceConfig
+from .common import _prologue, _require_kernel
+
+
+def render_kernel(config: TraceConfig) -> str:
+    kernel = _require_kernel(config)
+    prologue = _prologue(config)
+    if kernel.shape == KernelShape.SPMD_MIX:
+        return f"""#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+#if defined(__DAV_CUBE__) || defined(__DAV_VEC__)
+{prologue}#include \"{kernel.source_path}\"
+#endif
+
+extern \"C\" __global__ AICORE void replay_entry(
+    __gm__ int64_t *aic_args, __gm__ int64_t *aiv_args
+) {{
+#if defined(__DAV_CUBE__)
+    int32_t hw_idx = get_block_idx();
+    kernel_entry(aic_args + static_cast<uint64_t>(hw_idx) * 50);
+#endif
+#if defined(__DAV_VEC__)
+    int32_t lane_idx = static_cast<int32_t>(
+        get_block_idx() * get_subblockdim() + get_subblockid());
+    kernel_entry(aiv_args + static_cast<uint64_t>(lane_idx) * 50);
+#endif
+}}
+"""
+
+    include_guard = "__DAV_CUBE__" if kernel.shape == KernelShape.AIC_ONLY else "__DAV_VEC__"
+    return f"""#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+#if defined({include_guard})
+{prologue}#include \"{kernel.source_path}\"
+#endif
+
+extern \"C\" __global__ AICORE void replay_entry(__gm__ int64_t *args) {{
+#if defined({include_guard})
+    kernel_entry(args);
+#endif
+}}
+"""
+
+
+def render_launch(config: TraceConfig) -> str:
+    kernel = _require_kernel(config)
+    if kernel.shape == KernelShape.SPMD_MIX:
+        return f"""#include <stdint.h>
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+extern \"C\" __global__ AICORE void replay_entry(
+    __gm__ int64_t *aic_args, __gm__ int64_t *aiv_args);
+
+extern \"C\" void launch_replay(void *aic_args, void *aiv_args, void *stream) {{
+    replay_entry<<<{config.hw_block_num}, nullptr, stream>>>(
+        (__gm__ int64_t *)aic_args, (__gm__ int64_t *)aiv_args);
+}}
+"""
+
+    return f"""#include <stdint.h>
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+extern \"C\" __global__ AICORE void replay_entry(__gm__ int64_t *args);
+
+extern \"C\" void launch_replay(void *args, void *stream) {{
+    replay_entry<<<{config.hw_block_num}, nullptr, stream>>>((__gm__ int64_t *)args);
+}}
+"""

--- a/simpler_setup/insight_trace/templates_pkg/project.py
+++ b/simpler_setup/insight_trace/templates_pkg/project.py
@@ -1,0 +1,190 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from ..models import TraceConfig
+from .common import _arg_to_json, _require_kernel
+
+
+def render_cmake(config: TraceConfig) -> str:
+    arch = config.platform_arch
+    runtime_includes = "\n".join(f"    ${{REPO_ROOT}}/{r}" for r in arch.runtime_include_roots)
+    platform_includes = "\n".join(f"    ${{REPO_ROOT}}/{p}" for p in arch.platform_include_roots)
+    return f"""cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_C_COMPILER bisheng)
+set(CMAKE_CXX_COMPILER bisheng)
+
+project(insight_trace_replay)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT DEFINED ENV{{ASCEND_HOME_PATH}})
+    message(FATAL_ERROR "ASCEND_HOME_PATH is not set (source CANN set_env.sh first)")
+endif()
+set(ASCEND_HOME_PATH $ENV{{ASCEND_HOME_PATH}})
+set(SOC_VERSION {arch.soc_version} CACHE STRING "Simulator SoC version")
+set(PTO_ISA_ROOT $ENV{{PTO_ISA_ROOT}} CACHE PATH "PTO ISA root")
+set(REPO_ROOT $ENV{{REPO_ROOT}} CACHE PATH "simpler repo root")
+
+add_compile_options(
+    -D_FORTIFY_SOURCE=2 -O2 -std=c++17
+    -Wno-macro-redefined -Wno-ignored-attributes
+    -fstack-protector-strong -fPIC
+)
+add_link_options(-s -Wl,-z,relro -Wl,-z,now)
+
+set(CMAKE_CCE_COMPILE_OPTIONS
+    -xcce -fenable-matrix --cce-aicore-enable-tl -fPIC
+    -Xhost-start -Xhost-end
+    "SHELL:-mllvm -cce-aicore-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-function-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-record-overflow=true"
+    "SHELL:-mllvm -cce-aicore-addr-transform"
+    "SHELL:-mllvm -cce-aicore-dcci-insert-for-scalar=false"
+)
+set(CMAKE_CPP_COMPILE_OPTIONS
+    -xc++
+    "SHELL:-include stdint.h"
+    "SHELL:-include stddef.h"
+)
+
+set(COMMON_INCLUDES
+    ${{PTO_ISA_ROOT}}/include
+    ${{PTO_ISA_ROOT}}/include/pto
+{runtime_includes}
+    ${{REPO_ROOT}}/src/common/task_interface
+{platform_includes}
+    ${{REPO_ROOT}}/simpler_setup/incore
+    ${{ASCEND_HOME_PATH}}/pkg_inc
+    ${{ASCEND_HOME_PATH}}/pkg_inc/profiling
+    ${{ASCEND_HOME_PATH}}/pkg_inc/runtime/runtime
+    ${{ASCEND_HOME_PATH}}/include
+)
+
+add_library(replay_kernel SHARED replay_kernel.cpp replay_launch.cpp)
+target_compile_options(replay_kernel PRIVATE
+    ${{CMAKE_CCE_COMPILE_OPTIONS}}
+    --cce-aicore-arch={arch.cce_aicore_arch}
+    -DREGISTER_BASE -std=c++17)
+target_include_directories(replay_kernel PRIVATE ${{COMMON_INCLUDES}})
+target_link_options(replay_kernel PRIVATE --cce-fatobj-link)
+
+add_executable(replay_host replay_host.cpp)
+target_compile_options(replay_host PRIVATE ${{CMAKE_CPP_COMPILE_OPTIONS}})
+target_include_directories(replay_host PRIVATE ${{COMMON_INCLUDES}})
+target_link_directories(replay_host PUBLIC
+    ${{ASCEND_HOME_PATH}}/lib64
+    ${{ASCEND_HOME_PATH}}/aarch64-linux/simulator/${{SOC_VERSION}}/lib
+)
+target_link_libraries(replay_host PRIVATE
+    replay_kernel
+    runtime_camodel
+    stdc++ ascendcl m tiling_api platform c_sec dl nnopbase
+)
+"""
+
+
+def render_run_collect(config: TraceConfig) -> str:
+    cann_default = str(config.cann_home) if config.cann_home else ""
+    pto_default = str(config.pto_isa_root) if config.pto_isa_root else ""
+    return f"""#!/usr/bin/env bash
+set -euo pipefail
+
+CANN_HOME="${{CANN_HOME:-{cann_default}}}"
+PTO_ISA_ROOT="${{PTO_ISA_ROOT:-{pto_default}}}"
+REPO_ROOT="${{REPO_ROOT:-{config.repo_root}}}"
+: "${{CANN_HOME:?CANN_HOME must be set}}"
+: "${{PTO_ISA_ROOT:?PTO_ISA_ROOT must be set}}"
+: "${{REPO_ROOT:?REPO_ROOT must be set}}"
+
+WS="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+SOC_VERSION="${{SOC_VERSION:-{config.platform_arch.soc_version}}}"
+DEVICE_ID="${{TARGET_DEVICE_ID:-${{NPU_LOCKED_DEVICE:-{config.device}}}}}"
+BUILD_DIR="$WS/build"
+COLLECT_DIR="$WS/msprof_collect"
+EXPORT_ROOT="$WS/insight_export"
+
+source "$CANN_HOME/../cann/set_env.sh" 2>/dev/null \
+  || source "$CANN_HOME/set_env.sh"
+export ASCEND_HOME_PATH="$CANN_HOME"
+SIM_LIB_DIR="$CANN_HOME/aarch64-linux/simulator/$SOC_VERSION/lib"
+export LD_LIBRARY_PATH="$BUILD_DIR:$SIM_LIB_DIR:$CANN_HOME/lib64:\
+$CANN_HOME/aarch64-linux/devlib:$CANN_HOME/devlib:${{LD_LIBRARY_PATH:-}}"
+export ACL_DEVICE_ID="$DEVICE_ID"
+mkdir -p "$BUILD_DIR" "$COLLECT_DIR" "$EXPORT_ROOT"
+chmod 700 "$COLLECT_DIR" "$EXPORT_ROOT"
+
+cmake -G Ninja -S "$WS" -B "$BUILD_DIR" \
+    -DSOC_VERSION="$SOC_VERSION" \
+    -DPTO_ISA_ROOT="$PTO_ISA_ROOT" \
+    -DREPO_ROOT="$REPO_ROOT"
+cmake --build "$BUILD_DIR" --target replay_host
+
+msprof op simulator \
+  --application="$BUILD_DIR/replay_host" \
+  --kernel-name="replay_entry" \
+  --launch-count={config.launch_count} \
+  --soc-version="$SOC_VERSION" \
+  --timeout={config.timeout} \
+  --output="$COLLECT_DIR/out" \
+  2>&1 | tee "$COLLECT_DIR/msprof_collect.log"
+
+OPPROF_DIR="$(find "$COLLECT_DIR/out" -maxdepth 1 -mindepth 1 -type d -name 'OPPROF_*' | sort | tail -n 1)"
+test -n "$OPPROF_DIR"
+if [[ -d "$OPPROF_DIR/device0/tmp_dump" ]]; then
+  EXPORT_SRC="$OPPROF_DIR/device0/tmp_dump"
+else
+  EXPORT_SRC="$OPPROF_DIR/dump"
+fi
+
+msprof op simulator --export="$EXPORT_SRC" --output="$EXPORT_ROOT" \
+  2>&1 | tee "$EXPORT_ROOT/msprof_export.log"
+"""
+
+
+def render_config(config: TraceConfig) -> dict:
+    kernel = _require_kernel(config)
+    result = {
+        "backend": config.backend.value,
+        "test_module": str(config.test_module) if config.test_module else None,
+        "case": config.case_name,
+        "kernel": {
+            "name": kernel.name,
+            "func_id": kernel.func_id,
+            "core_type": kernel.core_type,
+            "source": str(kernel.source_path),
+            "shape": kernel.shape.value,
+        },
+        "replay": {
+            "hw_block_num": config.hw_block_num,
+            "soc_version": config.platform_arch.soc_version,
+            "platform": config.platform_arch.family.value,
+            "timeout": config.timeout,
+            "launch_count": config.launch_count,
+        },
+        "args": [_arg_to_json(arg) for arg in config.args],
+    }
+    if config.spmd_meta is not None:
+        result["spmd"] = {
+            "hw_block_dim": config.spmd_meta.hw_block_dim,
+            "aiv_lanes_per_core": config.spmd_meta.aiv_lanes_per_core,
+            "fifo_sizes": list(config.spmd_meta.fifo_sizes),
+            "dispatches": [
+                {
+                    "logical_block_num": dispatch.logical_block_num,
+                    "scalar_overrides": [[index, value] for index, value in dispatch.scalar_overrides],
+                }
+                for dispatch in config.spmd_meta.dispatches
+            ],
+        }
+    return result

--- a/simpler_setup/insight_trace/workspace.py
+++ b/simpler_setup/insight_trace/workspace.py
@@ -1,0 +1,38 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from __future__ import annotations
+
+import json
+import stat
+
+from .models import TraceConfig, TraceResult
+from .templates import render_cmake, render_config, render_host, render_kernel, render_launch, render_run_collect
+
+
+def create_workspace(config: TraceConfig) -> TraceResult:
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    files = {
+        "replay_kernel.cpp": render_kernel(config),
+        "replay_launch.cpp": render_launch(config),
+        "replay_host.cpp": render_host(config),
+        "CMakeLists.txt": render_cmake(config),
+        "run_collect.sh": render_run_collect(config),
+        "insight_trace_config.json": json.dumps(render_config(config), indent=2) + "\n",
+    }
+    for name, content in files.items():
+        path = config.output_dir / name
+        path.write_text(content)
+        if name == "run_collect.sh":
+            path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return TraceResult(
+        workspace_dir=config.output_dir,
+        simulator_dir=None,
+        collect_log=config.output_dir / "msprof_collect" / "msprof_collect.log",
+        export_log=config.output_dir / "insight_export" / "msprof_export.log",
+    )

--- a/simpler_setup/tools/insight_trace.py
+++ b/simpler_setup/tools/insight_trace.py
@@ -1,0 +1,12 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+from simpler_setup.insight_trace.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ut/py/test_insight_trace_core.py
+++ b/tests/ut/py/test_insight_trace_core.py
@@ -1,0 +1,705 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+import os
+import shutil
+import subprocess
+import sys
+import textwrap
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from simpler_setup.insight_trace import cli as insight_trace_cli
+from simpler_setup.insight_trace.arg_resolver import load_kernel_dump_args, resolve_args
+from simpler_setup.insight_trace.case_loader import load_scene_case
+from simpler_setup.insight_trace.kernel_analyzer import select_kernel
+from simpler_setup.insight_trace.models import (
+    KernelShape,
+    KernelSpec,
+    PlatformArch,
+    PlatformFamily,
+    SPMDDispatch,
+    SPMDReplayMeta,
+    TraceBackend,
+    TraceConfig,
+    TraceScalarArg,
+    TraceTensorArg,
+)
+from simpler_setup.insight_trace.templates import render_host, render_kernel, render_launch
+from simpler_setup.insight_trace.workspace import create_workspace
+
+
+def _a5_bgemm_module() -> Path:
+    return Path(__file__).resolve().parents[3] / "examples/a5/tensormap_and_ringbuffer/bgemm/test_bgemm.py"
+
+
+def _a5_platform() -> PlatformArch:
+    return PlatformArch.for_family(PlatformFamily.A5)
+
+
+def _paged_attention_module() -> Path:
+    return (
+        Path(__file__).resolve().parents[3]
+        / "examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py"
+    )
+
+
+def _a5_paged_attention_module() -> Path:
+    return (
+        Path(__file__).resolve().parents[3]
+        / "examples/a5/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py"
+    )
+
+
+def _vector_example_module() -> Path:
+    return Path(__file__).resolve().parents[3] / "tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py"
+
+
+def _a5_spmd_multiblock_mix_module() -> Path:
+    return (
+        Path(__file__).resolve().parents[3]
+        / "tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py"
+    )
+
+
+def _spmd_kernel() -> KernelSpec:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp"
+    )
+    return KernelSpec("MixedKernels", 0, "mix", path, KernelShape.SPMD_MIX)
+
+
+def _spmd_config(tmp_path: Path) -> TraceConfig:
+    return TraceConfig(
+        backend=TraceBackend.SIMPLER,
+        test_module=None,
+        case_name="spmd",
+        kernel_spec=_spmd_kernel(),
+        args=(
+            TraceTensorArg(0, "query", "BFLOAT16", (1, 128)),
+            TraceTensorArg(6, "sij_fifo", "FLOAT32", (1,)),
+            TraceScalarArg(9, "scale_value", "FLOAT32_BITS", 1065353216, "bits"),
+            TraceScalarArg(10, "num_heads", "UINT64", 16),
+        ),
+        output_dir=tmp_path,
+        repo_root=tmp_path,
+        cann_home=None,
+        pto_isa_root=None,
+        platform_arch=PlatformArch.for_family(PlatformFamily.A2A3),
+        hw_block_num=24,
+        spmd_meta=SPMDReplayMeta(
+            hw_block_dim=24,
+            aiv_lanes_per_core=2,
+            fifo_sizes=(65536, 32768, 65536),
+        ),
+    )
+
+
+def _a5_spmd_config(tmp_path: Path) -> TraceConfig:
+    context = load_scene_case(_a5_spmd_multiblock_mix_module(), "Case1")
+    kernel = select_kernel(context, kernel_name="SPMD_MIX_AIC")
+    return TraceConfig(
+        backend=TraceBackend.SIMPLER,
+        test_module=_a5_spmd_multiblock_mix_module(),
+        case_name="Case1",
+        kernel_spec=kernel,
+        args=(
+            TraceTensorArg(0, "output", "FLOAT32", (4512,), role="inout"),
+            TraceScalarArg(1, "base_cl", "UINT64", 0),
+        ),
+        output_dir=tmp_path,
+        repo_root=tmp_path,
+        cann_home=None,
+        pto_isa_root=None,
+        platform_arch=_a5_platform(),
+        hw_block_num=94,
+        spmd_meta=SPMDReplayMeta(
+            hw_block_dim=24,
+            aiv_lanes_per_core=2,
+            dispatches=(
+                SPMDDispatch(2, ((1, 0),)),
+                SPMDDispatch(8, ((1, 6),)),
+                SPMDDispatch(12, ((1, 30),)),
+                SPMDDispatch(24, ((1, 66),)),
+                SPMDDispatch(48, ((1, 138),)),
+            ),
+        ),
+    )
+
+
+def _a5_bgemm_config(tmp_path: Path) -> TraceConfig:
+    context = load_scene_case(_a5_bgemm_module(), "default")
+    kernel = select_kernel(context, kernel_name="GEMM")
+    args = resolve_args(
+        None,
+        None,
+        arg_spec=_write_arg_spec(
+            tmp_path,
+            '{"args":['
+            '{"kind":"tensor","index":0,"name":"A","dtype":"FLOAT32","shape":[131072]},'
+            '{"kind":"tensor","index":1,"name":"B","dtype":"FLOAT32","shape":[131072]},'
+            '{"kind":"tensor","index":2,"name":"C","dtype":"FLOAT32","shape":[131072]}'
+            "]}",
+        ),
+    )
+    return TraceConfig(
+        backend=TraceBackend.SIMPLER,
+        test_module=_a5_bgemm_module(),
+        case_name="default",
+        kernel_spec=kernel,
+        args=args,
+        output_dir=tmp_path,
+        repo_root=tmp_path,
+        cann_home=None,
+        pto_isa_root=None,
+        platform_arch=_a5_platform(),
+        hw_block_num=1,
+    )
+
+
+def _write_arg_spec(tmp_path: Path, contents: str) -> Path:
+    spec = tmp_path / "args.json"
+    spec.write_text(contents)
+    return spec
+
+
+def test_selects_a5_bgemm_as_spmd_mix():
+    context = load_scene_case(_a5_bgemm_module(), "default")
+    kernel = select_kernel(context, kernel_name="GEMM")
+    assert kernel.func_id == 0
+    assert kernel.shape == KernelShape.SPMD_MIX
+
+
+def test_selects_a5_spmd_multiblock_mix_as_spmd_mix():
+    context = load_scene_case(_a5_spmd_multiblock_mix_module(), "Case1")
+    kernel = select_kernel(context, kernel_name="SPMD_MIX_AIC")
+    assert kernel.func_id == 0
+    assert kernel.shape == KernelShape.SPMD_MIX
+
+
+def test_run_simpler_calls_workspace_and_runner_for_non_dry_run(monkeypatch, tmp_path):
+    context = load_scene_case(_a5_bgemm_module(), "default")
+    kernel = select_kernel(context, kernel_name="GEMM")
+    trace_args = resolve_args(
+        None,
+        None,
+        _write_arg_spec(
+            tmp_path,
+            '{"args":['
+            '{"kind":"tensor","index":0,"name":"A","dtype":"FLOAT32","shape":[131072]},'
+            '{"kind":"tensor","index":1,"name":"B","dtype":"FLOAT32","shape":[131072]},'
+            '{"kind":"tensor","index":2,"name":"C","dtype":"FLOAT32","shape":[131072]}'
+            "]}",
+        ),
+    )
+    args = Namespace(
+        test_module=_a5_bgemm_module(),
+        case="default",
+        kernel="GEMM",
+        func_id=None,
+        kernel_source=None,
+        platform="a5",
+        runtime="tensormap_and_ringbuffer",
+        output_dir=tmp_path,
+        cann_home=None,
+        pto_isa_root=None,
+        soc_version=None,
+        device=0,
+        launch_count=1,
+        timeout=120,
+        hw_block_num=1,
+        arg_spec=None,
+        dump_dir=None,
+        dispatch_id=None,
+        dry_run=False,
+        ptoas_root=None,
+        source_cpp=None,
+        kernel_base_name=None,
+        aicore_arch=None,
+        kernel_symbol=None,
+        backend=TraceBackend.SIMPLER.value,
+    )
+
+    create_mock = Mock(return_value="workspace")
+    run_result = type(
+        "Result",
+        (),
+        {"workspace_dir": tmp_path, "simulator_dir": tmp_path / "insight_export" / "OPPROF_x" / "simulator"},
+    )()
+    run_mock = Mock(return_value=run_result)
+    monkeypatch.setattr(insight_trace_cli, "create_workspace", create_mock)
+    monkeypatch.setattr(insight_trace_cli, "run_workspace", run_mock)
+    monkeypatch.setattr(insight_trace_cli, "load_scene_case", lambda test_module, case: context)
+    monkeypatch.setattr(
+        insight_trace_cli,
+        "select_kernel",
+        lambda selected_context, kernel_name, func_id, kernel_source: kernel,
+    )
+    monkeypatch.setattr(insight_trace_cli, "validate_single_task_kernel", lambda selected_kernel: None)
+    monkeypatch.setattr(
+        insight_trace_cli,
+        "resolve_args",
+        lambda selected_context, selected_kernel, arg_spec, dump_dir, dispatch_id: trace_args,
+    )
+
+    result = insight_trace_cli._run_simpler(args)
+
+    assert result == run_result
+    create_mock.assert_called_once()
+    run_mock.assert_called_once()
+
+
+def test_run_simpler_stops_after_workspace_for_dry_run(monkeypatch, tmp_path):
+    context = load_scene_case(_a5_bgemm_module(), "default")
+    kernel = select_kernel(context, kernel_name="GEMM")
+    trace_args = resolve_args(
+        None,
+        None,
+        _write_arg_spec(
+            tmp_path,
+            '{"args":['
+            '{"kind":"tensor","index":0,"name":"A","dtype":"FLOAT32","shape":[131072]},'
+            '{"kind":"tensor","index":1,"name":"B","dtype":"FLOAT32","shape":[131072]},'
+            '{"kind":"tensor","index":2,"name":"C","dtype":"FLOAT32","shape":[131072]}'
+            "]}",
+        ),
+    )
+    args = Namespace(
+        test_module=_a5_bgemm_module(),
+        case="default",
+        kernel="GEMM",
+        func_id=None,
+        kernel_source=None,
+        platform="a5",
+        runtime="tensormap_and_ringbuffer",
+        output_dir=tmp_path,
+        cann_home=None,
+        pto_isa_root=None,
+        soc_version=None,
+        device=0,
+        launch_count=1,
+        timeout=120,
+        hw_block_num=1,
+        arg_spec=None,
+        dump_dir=None,
+        dispatch_id=None,
+        dry_run=True,
+        ptoas_root=None,
+        source_cpp=None,
+        kernel_base_name=None,
+        aicore_arch=None,
+        kernel_symbol=None,
+        backend=TraceBackend.SIMPLER.value,
+    )
+
+    create_result = type("Result", (), {"workspace_dir": tmp_path, "simulator_dir": None})()
+    create_mock = Mock(return_value=create_result)
+    run_mock = Mock()
+    monkeypatch.setattr(insight_trace_cli, "create_workspace", create_mock)
+    monkeypatch.setattr(insight_trace_cli, "run_workspace", run_mock)
+    monkeypatch.setattr(insight_trace_cli, "load_scene_case", lambda test_module, case: context)
+    monkeypatch.setattr(
+        insight_trace_cli,
+        "select_kernel",
+        lambda selected_context, kernel_name, func_id, kernel_source: kernel,
+    )
+    monkeypatch.setattr(insight_trace_cli, "validate_single_task_kernel", lambda selected_kernel: None)
+    monkeypatch.setattr(
+        insight_trace_cli,
+        "resolve_args",
+        lambda selected_context, selected_kernel, arg_spec, dump_dir, dispatch_id: trace_args,
+    )
+
+    result = insight_trace_cli._run_simpler(args)
+
+    assert result == create_result
+    create_mock.assert_called_once()
+    run_mock.assert_not_called()
+
+
+def test_loads_paged_attention_case():
+    context = load_scene_case(_paged_attention_module(), "CaseSmall1")
+    assert context.case["params"]["block_size"] == 16
+    assert context.runtime == "tensormap_and_ringbuffer"
+
+
+def test_selects_sf_as_aiv_only():
+    context = load_scene_case(_paged_attention_module(), "CaseSmall1")
+    kernel = select_kernel(context, kernel_name="SF")
+    assert kernel.func_id == 1
+    assert kernel.shape == KernelShape.AIV_ONLY
+
+
+def test_resolves_a5_qk_recipe_includes_shape_scalars():
+    context = load_scene_case(_a5_paged_attention_module(), "SmallCase1")
+    kernel = select_kernel(context, kernel_name="QK")
+    args = resolve_args(context, kernel)
+    assert args[0] == TraceTensorArg(0, "qi", "BFLOAT16", (16, 16))
+    assert args[1] == TraceTensorArg(1, "kj", "BFLOAT16", (16, 16))
+    assert args[2] == TraceTensorArg(2, "sij", "FLOAT32", (16, 16))
+    assert args[3] == TraceScalarArg(4, "head_dim", "UINT64", 16)
+    assert args[4] == TraceScalarArg(5, "block_size", "UINT64", 16)
+
+
+def test_resolves_generic_vector_example_args():
+    context = load_scene_case(_vector_example_module(), "default")
+    kernel = select_kernel(context, func_id=0)
+    args = resolve_args(context, kernel)
+    assert args == (
+        TraceTensorArg(0, "a", "FLOAT32", (128 * 128,), role="input"),
+        TraceTensorArg(1, "b", "FLOAT32", (128 * 128,), role="input"),
+        TraceTensorArg(2, "f", "FLOAT32", (128 * 128,), role="output"),
+    )
+
+
+def test_load_kernel_dump_args_skips_context_slots(tmp_path):
+    dump = tmp_path / "tensor_dump"
+    dump.mkdir()
+    (dump / "tensor_dump.json").write_text(
+        """
+        {
+          "tensors": [
+            {"arg_index": 2, "dtype": "FLOAT32", "shape": [16], "stage": "before_dispatch"},
+            {"arg_index": 48, "dtype": "UINT64", "shape": [], "bin_size": 0, "stage": "before_dispatch"},
+            {"arg_index": 0, "dtype": "BFLOAT16", "shape": [16, 16], "stage": "before_dispatch"},
+            {"arg_index": 3, "dtype": "UINT64", "shape": [], "bin_size": 0, "stage": "before_dispatch"},
+            {"arg_index": 49, "dtype": "UINT64", "shape": [], "bin_size": 0, "stage": "before_dispatch"},
+            {"arg_index": 5, "dtype": "FLOAT32", "shape": [16], "stage": "after_dispatch"}
+          ]
+        }
+        """
+    )
+    args = load_kernel_dump_args(tmp_path, task_id=None)
+    assert args == (
+        TraceTensorArg(0, "arg0", "BFLOAT16", (16, 16)),
+        TraceTensorArg(2, "arg2", "FLOAT32", (16,)),
+    )
+
+
+def test_load_kernel_dump_args_requires_tensor_dump_json(tmp_path):
+    (tmp_path / "other.json").write_text('{"tensors":[]}')
+    with pytest.raises(ValueError, match="tensor_dump.json not found"):
+        load_kernel_dump_args(tmp_path)
+
+
+def test_resolves_spmd_mix_recipe(tmp_path):
+    context = load_scene_case(
+        Path(__file__).resolve().parents[3]
+        / "tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py",
+        "Case1",
+    )
+    kernel = select_kernel(context, kernel_name="PA_AIC")
+    args = resolve_args(context, kernel)
+    assert args[0] == TraceTensorArg(0, "query", "BFLOAT16", (256, 16, 128))
+    assert args[6] == TraceTensorArg(6, "sij_fifo", "FLOAT32", (1,))
+    assert args[9] == TraceScalarArg(9, "scale_value", "FLOAT32_BITS", 1065353216, "bits")
+    assert args[15] == TraceScalarArg(15, "total_logical_blocks", "UINT64", 256)
+    assert args[16] == TraceScalarArg(16, "q_tile", "UINT64", 16)
+
+
+def test_resolves_a5_spmd_multiblock_mix_recipe():
+    context = load_scene_case(_a5_spmd_multiblock_mix_module(), "Case1")
+    kernel = select_kernel(context, kernel_name="SPMD_MIX_AIC")
+    args = resolve_args(context, kernel)
+    assert args == (
+        TraceTensorArg(0, "output", "FLOAT32", (4512,), role="inout"),
+        TraceScalarArg(1, "base_cl", "UINT64", 0),
+    )
+
+
+def test_render_a5_bgemm_uses_a5_platform_values(tmp_path):
+    config = _a5_bgemm_config(tmp_path)
+    kernel_rendered = render_kernel(config)
+    launch_rendered = render_launch(config)
+    host_rendered = render_host(config)
+    workspace = create_workspace(config)
+
+    assert "#define __CCE_AICORE__ 310" in kernel_rendered
+    assert "#define PTO_NPU_ARCH_A5" in kernel_rendered
+    assert "#define EVENT_ID7 ((::event_t)7)" in kernel_rendered
+    assert "__gm__ int64_t *aic_args, __gm__ int64_t *aiv_args" in kernel_rendered
+    assert "launch_replay(void *aic_args, void *aiv_args, void *stream)" in launch_rendered
+    assert "std::vector<int64_t> aic_args(kHwBlocks * kArgsSlots, 0);" in host_rendered
+    assert "std::vector<int64_t> aiv_args(kAivRows * kArgsSlots, 0);" in host_rendered
+    assert "launch_replay(d_aic_args, d_aiv_args, stream);" in host_rendered
+    assert "dav-c310" in (workspace.workspace_dir / "CMakeLists.txt").read_text()
+    assert "src/a5/runtime/tensormap_and_ringbuffer/runtime" in (workspace.workspace_dir / "CMakeLists.txt").read_text()
+    assert 'SOC_VERSION="${SOC_VERSION:-dav_3510}"' in (workspace.workspace_dir / "run_collect.sh").read_text()
+    assert '"platform": "a5"' in (workspace.workspace_dir / "insight_trace_config.json").read_text()
+
+
+def test_render_spmd_launch_uses_dual_arg_signature(tmp_path):
+    rendered = render_launch(_spmd_config(tmp_path))
+    assert "launch_replay(void *aic_args, void *aiv_args, void *stream)" in rendered
+    assert "(__gm__ int64_t *)aic_args, (__gm__ int64_t *)aiv_args" in rendered
+
+
+def test_render_spmd_host_includes_context_and_dual_rows(tmp_path):
+    rendered = render_host(_spmd_config(tmp_path))
+    assert '#include "intrinsic.h"' in rendered
+    assert "std::vector<LocalContext> aic_local(kHwBlocks);" in rendered
+    assert "std::vector<GlobalContext> aiv_global(kAivRows);" in rendered
+    assert "std::vector<int64_t> aic_args(kHwBlocks * kArgsSlots, 0);" in rendered
+    assert "std::vector<int64_t> aiv_args(kAivRows * kArgsSlots, 0);" in rendered
+    assert (  # noqa: E501
+        "row[48] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aic_local) + r * sizeof(LocalContext));"
+        in rendered
+    )
+    assert (  # noqa: E501
+        "row[49] = static_cast<int64_t>(reinterpret_cast<uintptr_t>(d_aiv_global) + r * sizeof(GlobalContext));"
+        in rendered
+    )
+
+
+def test_render_a5_spmd_host_uses_dispatch_rows_and_a5_context_fields(tmp_path):
+    rendered = render_host(_a5_spmd_config(tmp_path))
+    assert "total_rows += dispatch.logical_block_num;" in rendered
+    assert "aic_local[row_index].s_block_idx = block_idx;" in rendered
+    assert "aic_local[row_index].s_block_num = dispatch.logical_block_num;" in rendered
+    assert "aiv_global[lane_row_index].sub_block_id = lane;" in rendered
+    assert "std::vector<int64_t> aic_args(total_rows * kArgsSlots, 0);" in rendered
+    assert "std::vector<int64_t> aiv_args(total_rows * kAivLanesPerCore * kArgsSlots, 0);" in rendered
+    assert "row[arg_index] = value;" in rendered
+    assert "lane_row[arg_index] = value;" in rendered
+
+
+def test_render_host_rejects_duplicate_arg_index(tmp_path):
+    config = TraceConfig(
+        backend=TraceBackend.SIMPLER,
+        test_module=None,
+        case_name="case",
+        kernel_spec=None,
+        args=(TraceScalarArg(1, "a", "UINT64", 1), TraceScalarArg(1, "b", "UINT64", 2)),
+        output_dir=tmp_path,
+        repo_root=tmp_path,
+        cann_home=None,
+        pto_isa_root=None,
+    )
+    with pytest.raises(ValueError, match="Duplicate arg index"):
+        render_host(config)
+
+
+def test_render_spmd_kernel_uses_dual_arg_wrapper(tmp_path):
+    rendered = render_kernel(_spmd_config(tmp_path))
+    assert "__gm__ int64_t *aic_args, __gm__ int64_t *aiv_args" in rendered
+    assert "get_block_idx() * get_subblockdim() + get_subblockid()" in rendered
+    assert "static_cast<uint64_t>(hw_idx) * 50" in rendered
+
+
+def test_a5_spmd_meta_and_hw_block_num_are_configured():
+    context = load_scene_case(_a5_spmd_multiblock_mix_module(), "Case1")
+    kernel = select_kernel(context, kernel_name="SPMD_MIX_AIC")
+    meta = insight_trace_cli._spmd_meta(kernel, _a5_platform())
+    assert meta is not None
+    assert meta.dispatches == (
+        SPMDDispatch(2, ((1, 0),)),
+        SPMDDispatch(8, ((1, 6),)),
+        SPMDDispatch(12, ((1, 30),)),
+        SPMDDispatch(24, ((1, 66),)),
+        SPMDDispatch(48, ((1, 138),)),
+    )
+    hw_block_num = insight_trace_cli._hw_block_num(Namespace(platform="a5", hw_block_num=1), kernel)
+    assert hw_block_num == 94
+
+
+def _e2e_requirements_met():
+    """Check if E2E test requirements are met."""
+    if os.environ.get("SIMPLER_RUN_INSIGHT_E2E") != "1":
+        return False, "SIMPLER_RUN_INSIGHT_E2E not set"
+    if not os.environ.get("CANN_HOME"):
+        return False, "CANN_HOME not set"
+    if not os.environ.get("PTO_ISA_ROOT"):
+        return False, "PTO_ISA_ROOT not set"
+    if shutil.which("msprof") is None:
+        return False, "msprof not found in PATH"
+    if shutil.which("bash") is None:
+        return False, "bash not found in PATH"
+    return True, ""
+
+
+@pytest.mark.skipif(not _e2e_requirements_met()[0], reason=_e2e_requirements_met()[1])
+def test_spmd_e2e_full(tmp_path):
+    """End-to-end SPMD mix insight trace.
+
+    Skipped by default. Enable with:
+        SIMPLER_RUN_INSIGHT_E2E=1 CANN_HOME=<path> PTO_ISA_ROOT=<path> pytest \\
+            tests/ut/py/test_insight_trace_core.py::test_spmd_e2e_full
+
+    Requires: CANN installed, msprof available, PTO_ISA_ROOT set.
+    """
+
+    # Absolute path to the real kernel source (matches existing _spmd_kernel)
+    repo_root = Path(__file__).resolve().parents[3]
+    kernel_source_rel = (
+        "tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp"
+    )
+    kernel_source = repo_root / kernel_source_rel
+
+    # Minimal SceneTestCase module with a tiny SPMD case (batch=1, num_heads=1, head_dim=128, block_size=128)
+    # so the simulator finishes quickly.
+    module_content = textwrap.dedent(f"""\
+        # Auto-generated for SPMD E2E test
+        import torch
+        from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+        @scene_test(level=2, runtime="tensormap_and_ringbuffer")
+        class TestSPMDE2E(SceneTestCase):
+            CALLABLE = {{
+                "incores": [
+                    {{
+                        "func_id": 0,
+                        "name": "PA_AIC",
+                        "source": "{kernel_source}",
+                        "core_type": "aic",
+                    }},
+                    {{
+                        "func_id": 1,
+                        "name": "PA_AIV",
+                        "source": "{kernel_source}",
+                        "core_type": "aiv",
+                    }},
+                ],
+            }}
+            CASES = [
+                {{
+                    "name": "Tiny",
+                    "platforms": ["a2a3"],
+                    "config": {{"aicpu_thread_num": 1, "block_dim": 2}},
+                    "params": {{
+                        "batch": 1,
+                        "num_heads": 1,
+                        "kv_head_num": 1,
+                        "head_dim": 128,
+                        "block_size": 128,
+                        "context_len": 128,
+                        "max_model_len": 128,
+                        "dtype": "bfloat16",
+                    }},
+                }},
+            ]
+            def generate_args(self, params):
+                result = [
+                    ("query", torch.empty(1, 1, 128, dtype=torch.bfloat16)),
+                    ("key_cache", torch.empty(1, 128, 1, 128, dtype=torch.bfloat16)),
+                    ("value_cache", torch.empty(1, 128, 1, 128, dtype=torch.bfloat16)),
+                    ("block_table", torch.zeros(1, 1, dtype=torch.int32)),
+                    ("context_lens", torch.tensor([128], dtype=torch.int32)),
+                    ("out", torch.zeros(1, 1, 128, dtype=torch.float32)),
+                    ("scale", torch.tensor(1.0)),
+                ]
+                specs = []
+                for name, value in result:
+                    if isinstance(value, torch.Tensor):
+                        specs.append(Tensor(name, value))
+                    else:
+                        specs.append(Scalar(name, value))
+                return TaskArgsBuilder(*specs)
+        """)
+    module_file = tmp_path / "test_spmd_e2e_module.py"
+    module_file.write_text(module_content)
+
+    arg_spec = tmp_path / "spmd_args.json"
+    arg_spec.write_text(
+        textwrap.dedent(
+            """\
+            {
+              "args": [
+                {"kind": "tensor", "index": 0, "name": "query", "dtype": "BFLOAT16", "shape": [1, 1, 128]},
+                {"kind": "tensor", "index": 1, "name": "key_cache", "dtype": "BFLOAT16", "shape": [1, 128, 1, 128]},
+                {"kind": "tensor", "index": 2, "name": "value_cache", "dtype": "BFLOAT16", "shape": [1, 128, 1, 128]},
+                {"kind": "tensor", "index": 3, "name": "block_table", "dtype": "INT32", "shape": [1, 1]},
+                {"kind": "tensor", "index": 4, "name": "context_lens", "dtype": "INT32", "shape": [1]},
+                {"kind": "tensor", "index": 5, "name": "out", "dtype": "FLOAT32", "shape": [1, 1, 128]},
+                {"kind": "tensor", "index": 6, "name": "sij_fifo", "dtype": "FLOAT32", "shape": [1]},
+                {"kind": "tensor", "index": 7, "name": "pij_fifo", "dtype": "BFLOAT16", "shape": [1]},
+                {"kind": "tensor", "index": 8, "name": "oi_fifo", "dtype": "FLOAT32", "shape": [1]},
+                {"kind": "scalar", "index": 9, "name": "scale_value", "dtype": "FLOAT32_BITS",
+                 "value": 1065353216, "pack_mode": "bits"},
+                {"kind": "scalar", "index": 10, "name": "num_heads", "dtype": "UINT64", "value": 1},
+                {"kind": "scalar", "index": 11, "name": "head_dim", "dtype": "UINT64", "value": 128},
+                {"kind": "scalar", "index": 12, "name": "block_size", "dtype": "UINT64", "value": 128},
+                {"kind": "scalar", "index": 13, "name": "max_num_blocks_per_req", "dtype": "UINT64", "value": 1},
+                {"kind": "scalar", "index": 14, "name": "q_loop", "dtype": "UINT64", "value": 1},
+                {"kind": "scalar", "index": 15, "name": "total_logical_blocks", "dtype": "UINT64", "value": 1},
+                {"kind": "scalar", "index": 16, "name": "q_tile", "dtype": "UINT64", "value": 1}
+              ]
+            }
+            """
+        )
+    )
+
+    ws_dir = tmp_path / "ws"
+    ws_dir.mkdir()
+
+    pto_isa_root = os.environ.get("PTO_ISA_ROOT")
+    cann_home = os.environ.get("CANN_HOME")
+
+    # Step 1: generate workspace
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+    gen_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "simpler_setup.tools.insight_trace",
+            str(module_file),
+            "--case",
+            "Tiny",
+            "--kernel",
+            "PA_AIC",
+            "--output-dir",
+            str(ws_dir),
+            "--arg-spec",
+            str(arg_spec),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert gen_result.returncode == 0, f"workspace generation failed: {gen_result.stderr}"
+
+    assert (ws_dir / "replay_kernel.cpp").is_file()
+    assert (ws_dir / "replay_launch.cpp").is_file()
+    assert (ws_dir / "replay_host.cpp").is_file()
+    assert (ws_dir / "run_collect.sh").is_file()
+
+    # Step 2: run_collect.sh (build + collect + export)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(repo_root) + os.pathsep + env.get("PYTHONPATH", "")
+    if pto_isa_root:
+        env["PTO_ISA_ROOT"] = pto_isa_root
+    if cann_home:
+        env["CANN_HOME"] = cann_home
+    env["REPO_ROOT"] = str(repo_root)
+
+    collect_result = subprocess.run(
+        ["bash", str(ws_dir / "run_collect.sh")],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=900,
+        env=env,
+    )
+    assert collect_result.returncode == 0, f"collect failed: {collect_result.stderr}"
+
+    # Step 3: validate exported artifacts
+    export_root = ws_dir / "insight_export"
+    opp_dirs = sorted((export_root).glob("OPPROF_*/simulator"))
+    assert opp_dirs, f"No OPPROF simulator dir under {export_root}"
+    sim_dir = opp_dirs[-1]
+
+    assert (sim_dir / "trace.json").is_file(), "missing simulator/trace.json"
+    assert (sim_dir / "visualize_data.bin").is_file(), "missing simulator/visualize_data.bin"
+    csv_files = list(sim_dir.glob("core*/*instr_exe*.csv"))
+    assert csv_files, "no instr_exe CSV files"
+    assert len(csv_files) >= 3, f"Expected at least 3 CSV files (AIC + 2 AIV lanes), got {len(csv_files)}"


### PR DESCRIPTION
Implement Insight Trace feature to generate MindStudio Insight-compatible trace data (trace.json + visualize_data.bin) for incore kernel instruction-level profiling. Supports simpler and ptoas dual backends.
# Summary
## Overview
This PR adds a built-in Insight Trace workflow to `simpler_setup`. It lets users select a simpler incore kernel and generate profiling artifacts directly consumable by MindStudio Insight.

New command:
```bash
python -m simpler_setup.tools.insight_trace
```

Typical usage:
```bash
python -m simpler_setup.tools.insight_trace \
  examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py \
  --case CaseSmall1 \
  --kernel SF
```

## MindStudio Insight output
The feature exports the simulator trace package:
```text
<workspace>/insight_export/OPPROF_*/simulator/
```
MindStudio Insight opens:
```text
<workspace>/insight_export/OPPROF_*/simulator/trace.json
```
`trace.json` is the UI entry point, but the practical consumption unit is the whole `simulator/` directory, including `visualize_data.bin`, `core*.*/trace.json`, and `core*/*_instr_exe_*.csv`.

## What changed
Added `simpler_setup/insight_trace/`, which supports:
- loading `SceneTestCase` modules and cases;
- selecting kernels by `--kernel`, `--func-id`, or `--kernel-source`;
- classifying kernels as AIC-only, AIV-only, or SPMD mix;
- resolving replay args from recipes or `--arg-spec`;
- generating a standalone replay workspace;
- running `msprof op simulator` collect/export;
- validating exported MindStudio Insight artifacts.

Added CLI shim:
```text
simpler_setup/tools/insight_trace.py
```

Generated simpler replay workspace:
```text
replay_kernel.cpp
replay_launch.cpp
replay_host.cpp
CMakeLists.txt
run_collect.sh
insight_trace_config.json
```
The generated host runner allocates replay tensors, builds `Tensor` metadata, packs a 50-slot `args` array, launches `replay_entry`, and synchronizes.

## Initial kernel support
Built-in recipes cover paged attention incore kernels:
```text
QK, SF, PV, UP
```
For `CaseSmall1 + SF`:
```text
args[0] sij   FLOAT32  [16, 16]
args[1] pij   BFLOAT16 [16, 16]
args[2] mij   FLOAT32  [16]
args[3] lij   FLOAT32  [16]
args[4] scale FLOAT32_BITS 1065353216
```

## PTOAS backend
Adds PTOAS backend plumbing for PTOAS-generated kernel C++ sources: call PTOAS `generate_testcase.py`, build the generated simulator runner, resolve the real exported kernel symbol with `nm -D` + `c++filt`, run `msprof op simulator`, and export the same MindStudio Insight `simulator/` artifact shape.

## Validation hardening
The implementation rejects invalid replay arg specs: negative indices, indices outside the 50-slot args array, and duplicate indices. It also packs float scalar values as IEEE 754 bits when `pack_mode="bits"` or `dtype="FLOAT32_BITS"` is used.

Other hardening:
- cache repeated kernel source reads;
- demangle PTOAS symbols with one `c++filt` call;
- fail clearly if PTOAS `golden.py` is missing or fails.

## Tests
Added tests:
```text
tests/ut/py/test_insight_trace_core.py
```
Validated with:
```text
python -m pytest tests/ut/py/test_insight_trace_core.py -v
# 6 passed
python -m compileall -q simpler_setup/insight_trace \
  simpler_setup/tools/insight_trace.py tests/ut/py/test_insight_trace_core.py
# passed
```

## Scope
Changed files:
```text
simpler_setup/insight_trace/*
simpler_setup/tools/insight_trace.py
tests/ut/py/test_insight_trace_core.py
```
Overall diff:
```text
12 files changed, 1302 insertions(+)
```
Output: `outputs/insight_trace_*/insight_export/OPPROF_*/simulator/` (drag `trace.json` into MindStudio Insight).

## Related issue

Related to #836.
