### PR TITLE
Fix: raise CPU-sim scheduler idle cap via platform-defined constant

### DIFF
--- a/src/a2a3/platform/onboard/aicpu/spin_hint.h
+++ b/src/a2a3/platform/onboard/aicpu/spin_hint.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file spin_hint.h
  * @brief Platform-specific spin-wait hint for AICPU (real hardware)
@@ -9,6 +19,14 @@
 #ifndef PLATFORM_A2A3_AICPU_SPIN_HINT_H_
 #define PLATFORM_A2A3_AICPU_SPIN_HINT_H_
 
+#include <cstdint>
+
 #define SPIN_WAIT_HINT() ((void)0)
+
+// Consecutive idle scheduler iterations (no task progress) before the dispatch
+// loop aborts with PTO2_ERROR_SCHEDULER_TIMEOUT. On real hardware each idle
+// iteration is a cheap no-op spin, so this bounds a genuine deadlock. The
+// runtime consumes it as MAX_IDLE_ITERATIONS (see scheduler_types.h).
+constexpr int32_t PLATFORM_MAX_IDLE_ITERATIONS = 800000;
 
 #endif  // PLATFORM_A2A3_AICPU_SPIN_HINT_H_

--- a/src/a2a3/platform/sim/aicpu/spin_hint.h
+++ b/src/a2a3/platform/sim/aicpu/spin_hint.h
@@ -19,13 +19,17 @@
  * complete — especially on resource-constrained CI runners (e.g., 2 cores
  * running 13+ threads).
  *
- * The CPU hint (pause/yield) reduces pipeline waste, and sched_yield() lets the
- * OS scheduler give time slices to threads doing real work.
+ * Two mitigations live here. The CPU hint (pause/yield) plus sched_yield() let
+ * the OS scheduler give time slices to threads doing real work, and
+ * PLATFORM_MAX_IDLE_ITERATIONS below raises the idle cap well above the onboard
+ * value so a slow CPU-sim task (e.g. matmul-heavy kernels) making real progress
+ * is not mistaken for a deadlock.
  */
 
 #ifndef PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
 #define PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
 
+#include <cstdint>
 #include <sched.h>
 
 #if defined(__aarch64__)
@@ -43,5 +47,14 @@
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
+
+// Consecutive idle scheduler iterations (no task progress) before the dispatch
+// loop aborts with PTO2_ERROR_SCHEDULER_TIMEOUT. CPU sim accumulates idle
+// iterations far faster than real kernel progress, so the cap is raised well
+// above the onboard value to avoid false timeouts on slow (e.g. matmul-heavy)
+// kernels. Set to 10x the onboard cap as a conservative bump; raise further if
+// a slow kernel still false-times-out. The runtime consumes it as
+// MAX_IDLE_ITERATIONS (see scheduler_types.h).
+constexpr int32_t PLATFORM_MAX_IDLE_ITERATIONS = 8000000;
 
 #endif  // PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -17,6 +17,7 @@
 #include "common/core_type.h"
 #include "common/platform_config.h"
 #include "pto_runtime2_types.h"
+#include "spin_hint.h"
 
 // =============================================================================
 // Profiling macros (compile-time gated)
@@ -43,9 +44,9 @@
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 400000;        // LOG_INFO_V9 every N idle iters to debug hang
-constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
+constexpr int32_t MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS;  // platform-defined cap (sim vs onboard)
+constexpr int32_t STALL_LOG_INTERVAL = MAX_IDLE_ITERATIONS / 2;  // derived: ~one stall diagnostic halfway to timeout
+constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;             // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
 constexpr int32_t STALL_DUMP_CORE_MAX = 8;

--- a/src/a5/platform/onboard/aicpu/spin_hint.h
+++ b/src/a5/platform/onboard/aicpu/spin_hint.h
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
 /**
  * @file spin_hint.h
  * @brief Platform-specific spin-wait hint for AICPU (real hardware)
@@ -9,6 +19,14 @@
 #ifndef PLATFORM_A2A3_AICPU_SPIN_HINT_H_
 #define PLATFORM_A2A3_AICPU_SPIN_HINT_H_
 
+#include <cstdint>
+
 #define SPIN_WAIT_HINT() ((void)0)
+
+// Consecutive idle scheduler iterations (no task progress) before the dispatch
+// loop aborts with PTO2_ERROR_SCHEDULER_TIMEOUT. On real hardware each idle
+// iteration is a cheap no-op spin, so this bounds a genuine deadlock. The
+// runtime consumes it as MAX_IDLE_ITERATIONS (see scheduler_types.h).
+constexpr int32_t PLATFORM_MAX_IDLE_ITERATIONS = 800000;
 
 #endif  // PLATFORM_A2A3_AICPU_SPIN_HINT_H_

--- a/src/a5/platform/sim/aicpu/spin_hint.h
+++ b/src/a5/platform/sim/aicpu/spin_hint.h
@@ -19,13 +19,17 @@
  * complete — especially on resource-constrained CI runners (e.g., 2 cores
  * running 13+ threads).
  *
- * The CPU hint (pause/yield) reduces pipeline waste, and sched_yield() lets the
- * OS scheduler give time slices to threads doing real work.
+ * Two mitigations live here. The CPU hint (pause/yield) plus sched_yield() let
+ * the OS scheduler give time slices to threads doing real work, and
+ * PLATFORM_MAX_IDLE_ITERATIONS below raises the idle cap well above the onboard
+ * value so a slow CPU-sim task (e.g. matmul-heavy kernels) making real progress
+ * is not mistaken for a deadlock.
  */
 
 #ifndef PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
 #define PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
 
+#include <cstdint>
 #include <sched.h>
 
 #if defined(__aarch64__)
@@ -43,5 +47,14 @@
 #else
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
+
+// Consecutive idle scheduler iterations (no task progress) before the dispatch
+// loop aborts with PTO2_ERROR_SCHEDULER_TIMEOUT. CPU sim accumulates idle
+// iterations far faster than real kernel progress, so the cap is raised well
+// above the onboard value to avoid false timeouts on slow (e.g. matmul-heavy)
+// kernels. Set to 10x the onboard cap as a conservative bump; raise further if
+// a slow kernel still false-times-out. The runtime consumes it as
+// MAX_IDLE_ITERATIONS (see scheduler_types.h).
+constexpr int32_t PLATFORM_MAX_IDLE_ITERATIONS = 8000000;
 
 #endif  // PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -18,6 +18,7 @@
 #include "common/platform_config.h"
 #include "pto2_dispatch_payload.h"
 #include "pto_runtime2_types.h"
+#include "spin_hint.h"
 
 // =============================================================================
 // Profiling macros (compile-time gated)
@@ -44,9 +45,9 @@
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = 800000;       // ~20s idle then scheduler gives up (avoid long hang)
-constexpr int32_t STALL_LOG_INTERVAL = 400000;        // LOG_INFO_V9 every N idle iters to debug hang
-constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
+constexpr int32_t MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS;  // platform-defined cap (sim vs onboard)
+constexpr int32_t STALL_LOG_INTERVAL = MAX_IDLE_ITERATIONS / 2;  // derived: ~one stall diagnostic halfway to timeout
+constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;             // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
 constexpr int32_t STALL_DUMP_CORE_MAX = 8;


### PR DESCRIPTION
## Summary

`MAX_IDLE_ITERATIONS` was a single runtime constant (800000) shared by sim and
onboard. On CPU sim, idle scheduler iterations accumulate far faster than real
kernel progress, so matmul-heavy kernels (e.g. `compressor_ratio4`) hit the cap
and fail with `PTO2_ERROR_SCHEDULER_TIMEOUT` (`run_prepared failed with code
-100`) while the kernel is still making forward progress.

This moves the cap to a **platform-defined** `PLATFORM_MAX_IDLE_ITERATIONS` in
each backend's `spin_hint.h` (the existing per-backend AICPU header), so the
runtime consumes a single symbol while sim and onboard supply their own values:

- **onboard**: `800000` (unchanged hardware behavior)
- **sim**: `8000000` (10× the onboard cap — a conservative bump, see caveat below)

## Changes

- `PLATFORM_MAX_IDLE_ITERATIONS` added to all four `spin_hint.h` (a5/a2a3 ×
  sim/onboard). The sim variant's doc comment already described this exact
  `MAX_IDLE_ITERATIONS` interaction, so the cap is co-located there.
- `scheduler_types.h` aliases `MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS`,
  mirroring the existing `MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS` pattern.
  The runtime stays platform-agnostic — no sim/onboard `#ifdef` in runtime code.
- `STALL_LOG_INTERVAL` is now derived as `MAX_IDLE_ITERATIONS / 2` instead of a
  fixed `400000`, so the stall-diagnostic log fires ~once halfway to timeout on
  every platform (the larger sim cap would otherwise spam stall warnings).
  Preserves prior onboard behavior exactly (`800000 / 2 == 400000`).
- The onboard `spin_hint.h` headers gain the standard license block required by
  the pre-commit header check.
- Applied to both `a5` and `a2a3` trees.

## Design note

The runtime consumes one platform-provided symbol; the sim/onboard split lives
entirely in the platform layer (same precedent as `SPIN_WAIT_HINT()` and
`PLATFORM_MAX_AICPU_THREADS`). A wall-clock timeout via `get_sys_cnt_aicpu()`
was considered but rejected to keep the idle hot path a plain integer compare
(lower per-iteration overhead, no clock noise).

## Scope / caveats

- **The sim value (`8000000`) is not empirically calibrated.** The repro kernel
  `compressor_ratio4.py` lives in the PTO/pypto repo, not here, so it could not
  be reproduced or measured in this repo. `8000000` is a 10× bump over the
  onboard cap; for reference, the sibling `host_build_graph` runtime already
  runs CPU sim with a `50000000` idle cap. The value should be **validated
  against `compressor_ratio4` in the PTO env** and raised if a slow kernel still
  false-times-out (a one-line change).
- The PTO-ISA `TMatmulNzZn` optimizations suggested in the issue are in the
  PTO-ISA repo and **out of scope** for this change.

## Testing

- [x] a2a3sim + a5sim runtimes build clean (all targets)
- [x] `tensormap_and_ringbuffer` sim st test passes on both archs (`dummy_task`)
- [ ] Hardware tests (unchanged onboard value; not run here)
- [ ] `compressor_ratio4` on a2a3sim in PTO env (requires PTO_ISA_ROOT)

Fixes #840