### PR TITLE
Fix: disambiguate paged attention event casts

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
@@ -104,7 +104,7 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        wait_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));
         TLOAD(aMatTile[cur], pijGlobal);
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
@@ -112,22 +112,22 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
-        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
+        set_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));  // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/aic/aic_pv_matmul.cpp
@@ -105,7 +105,7 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        wait_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));
         TLOAD(aMatTile[cur], pijGlobal);
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
@@ -113,22 +113,22 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
-        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
+        set_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));  // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -106,7 +106,7 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        wait_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));
         TLOAD(aMatTile[cur], pijGlobal);
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
@@ -114,22 +114,22 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
-        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
+        set_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));  // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/aic/aic_pv_matmul.cpp
@@ -113,7 +113,7 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        wait_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));
         TLOAD(aMatTile[cur], pijGlobal);
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
@@ -121,22 +121,22 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
-        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
+        set_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));  // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/aic/aic_pv_matmul.cpp
@@ -105,7 +105,7 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 1: TLOAD (MTE2: GM → L1[cur])
         // Wait for MTE1 to release L1[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);
+        wait_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));
         TLOAD(aMatTile[cur], pijGlobal);
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: A in L1 ready
         TLOAD(bMatTile[cur], vjGlobal);
@@ -113,22 +113,22 @@ static __aicore__ void pv_matmul_n_impl(
 
         // Stage 2: TMOV (MTE1: L1[cur] → L0[cur])
         // Wait for M-pipe to release L0[cur] (reverse dep from previous iteration)
-        wait_flag(PIPE_M, PIPE_MTE1, (event_t)cur);
+        wait_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);  // forward: wait A loaded
         TMOV(aTile[cur], aMatTile[cur]);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID1);  // forward: wait B loaded
         TMOV(bTile[cur], bMatTile[cur]);
-        set_flag(PIPE_MTE1, PIPE_MTE2, (event_t)cur);  // reverse: release L1[cur]
+        set_flag(PIPE_MTE1, PIPE_MTE2, static_cast<::event_t>(cur));  // reverse: release L1[cur]
 
         // Stage 3: TMATMUL (M-pipe: L0A[cur] × L0B[cur] → L0C)
-        set_flag(PIPE_MTE1, PIPE_M, (event_t)cur);  // forward: L0[cur] ready
-        wait_flag(PIPE_MTE1, PIPE_M, (event_t)cur);
+        set_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));  // forward: L0[cur] ready
+        wait_flag(PIPE_MTE1, PIPE_M, static_cast<::event_t>(cur));
         if (i == 0) {
             TMATMUL(cTile, aTile[cur], bTile[cur]);
         } else {
             TMATMUL_ACC(cTile, cTile, aTile[cur], bTile[cur]);
         }
-        set_flag(PIPE_M, PIPE_MTE1, (event_t)cur);  // reverse: release L0[cur]
+        set_flag(PIPE_M, PIPE_MTE1, static_cast<::event_t>(cur));  // reverse: release L0[cur]
     }
 
     // Drain outstanding reverse-dependency flags


### PR DESCRIPTION
## Summary

Fix A5 onboard compilation failures in paged-attention AIC kernels by replacing
ambiguous C-style event_t casts with explicit global event_t casts.

A5's onboard toolchain sees both CANN's global event_t and PTO-ISA's
pto::event_t, so a C-style event_t cast can fail name lookup with:

```text
reference to 'event_t' is ambiguous
```

## Scope

- Update paged-attention AIC kernels in A5 and matching A2/A3 example/ST files.
- Keep the cast target explicitly global so it selects the CANN intrinsic event type.
- No Python callable or golden tolerance changes are included.

## Validation

- `rg "\(event_t\)" examples tests src python` has no remaining matches.
- `clang-format --dry-run --Werror` passed on all touched files.
- `git diff --cached --check` passed before commit.

This was exposed by `st-onboard-a5` in PR #839, specifically:

```text
examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/test_paged_attention_unroll.py::TestPagedAttentionUnrollManualScope::test_run
```
