### PR TITLE
Update: auto-resolve CallConfig.block_dim to max stream capacity

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -140,7 +140,8 @@ worker = ChipWorker()
 worker.init(device_id=0, bins=bins)   # bins = RuntimeBuilder(platform).get_binaries(...)
 
 config = CallConfig()
-config.block_dim = 24
+# config.block_dim defaults to 0 = auto (DeviceRunner resolves to the max
+# the AICore stream allows). Set explicitly to pin a smaller value.
 config.aicpu_thread_num = 3
 config.enable_pmu = 0
 worker.run(callable, args, config)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -167,8 +167,10 @@ worker.init(device_id=0, bins=binaries)
 # Register the ChipCallable to obtain a callable_id
 cid = worker.register(chip_callable)
 
-# Execute the registered callable on device
-worker.run(cid, orch_args, block_dim=24)
+# Execute the registered callable on device. Omitting block_dim uses the
+# default 0 = auto, which DeviceRunner resolves to the max the AICore
+# stream allows. Pass block_dim=<n> to pin a smaller value.
+worker.run(cid, orch_args)
 
 # Cleanup
 worker.finalize()

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -169,7 +169,7 @@ View does **not** own memory. Valid for the duration of a single
 
 ```cpp
 struct CallConfig {
-    int32_t block_dim = 1;
+    int32_t block_dim = 0;  // 0 = auto (DeviceRunner resolves to stream max at run() time)
     int32_t aicpu_thread_num = 3;
     bool    enable_l2_swimlane = false;
     bool    enable_dump_tensor = false;

--- a/python/simpler/task_interface.py
+++ b/python/simpler/task_interface.py
@@ -292,7 +292,7 @@ class ChipWorker:
         worker = ChipWorker()
         worker.init(device_id=0, bins=bins)
         worker.prepare_callable(callable_id=0, callable=chip_callable)
-        worker.run(callable_id=0, args=orch_args, config=CallConfig(block_dim=24))
+        worker.run(callable_id=0, args=orch_args, config=CallConfig())  # block_dim defaults to 0 = auto
         worker.unregister_callable(callable_id=0)
         worker.finalize()
     """
@@ -384,7 +384,11 @@ class ChipWorker:
             callable_id: Stable id passed to a prior ``prepare_callable``.
             args: ChipStorageTaskArgs for this invocation.
             config: Optional CallConfig. If None, a default is created.
-            **kwargs: Overrides applied to config (e.g. block_dim=24).
+            **kwargs: Overrides applied to config (e.g. ``block_dim=8`` to
+                pin a smaller value than the default). Omit ``block_dim`` (or
+                set it to 0) to have DeviceRunner auto-resolve it to the max
+                the AICore stream allows (``aclrtGetStreamResLimit`` on
+                onboard, ``PLATFORM_MAX_BLOCKDIM`` on sim).
 
         Returns a :class:`RunTiming` with host + device wall.
         """

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -857,7 +857,11 @@ class SceneTestCase:
         from simpler.task_interface import CallConfig  # noqa: PLC0415
 
         config = CallConfig()
-        config.block_dim = config_dict.get("block_dim", 1)
+        # Default to 0 (CallConfig "auto" sentinel) when a case omits
+        # block_dim — DeviceRunner resolves it to the stream's max capacity
+        # at run() time. Cases that need a specific value still set it
+        # explicitly in their config dict.
+        config.block_dim = config_dict.get("block_dim", 0)
         config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 3)
         config.enable_l2_swimlane = enable_l2_swimlane
         config.enable_dump_tensor = enable_dump_tensor

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -503,35 +503,45 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
+int DeviceRunner::query_max_block_dim(rtStream_t stream, uint32_t *out_cube, uint32_t *out_vector) {
+    uint32_t cube_limit = 0, vector_limit = 0;
+    bool got_limits = (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_CUBE_CORE, &cube_limit) == ACL_ERROR_NONE) &&
+                      (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_VECTOR_CORE, &vector_limit) == ACL_ERROR_NONE) &&
+                      cube_limit > 0 && vector_limit > 0;
+    if (out_cube != nullptr) *out_cube = got_limits ? cube_limit : 0;
+    if (out_vector != nullptr) *out_vector = got_limits ? vector_limit : 0;
+    if (got_limits) {
+        // Cap by PLATFORM_MAX_BLOCKDIM as well: runtime handshake/scheduler
+        // arrays are statically sized to RUNTIME_MAX_WORKER (= PLATFORM_MAX_BLOCKDIM
+        // * PLATFORM_CORES_PER_BLOCKDIM), so even if ACL reports more cores
+        // than the platform cap we must not exceed it.
+        int from_stream = static_cast<int>(
+            std::min(cube_limit / PLATFORM_AIC_CORES_PER_BLOCKDIM, vector_limit / PLATFORM_AIV_CORES_PER_BLOCKDIM)
+        );
+        return std::min(from_stream, PLATFORM_MAX_BLOCKDIM);
+    }
+    return PLATFORM_MAX_BLOCKDIM;
+}
+
 int DeviceRunner::validate_block_dim(rtStream_t stream, int block_dim) {
     if (block_dim < 1) {
         LOG_ERROR("block_dim (%d) must be >= 1", block_dim);
         return -1;
     }
-
     uint32_t cube_limit = 0, vector_limit = 0;
-    bool got_limits = (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_CUBE_CORE, &cube_limit) == ACL_ERROR_NONE) &&
-                      (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_VECTOR_CORE, &vector_limit) == ACL_ERROR_NONE) &&
-                      cube_limit > 0 && vector_limit > 0;
-
-    if (got_limits) {
-        int max_bd = static_cast<int>(
-            std::min(cube_limit / PLATFORM_AIC_CORES_PER_BLOCKDIM, vector_limit / PLATFORM_AIV_CORES_PER_BLOCKDIM)
-        );
-        if (block_dim > max_bd) {
+    int max_bd = query_max_block_dim(stream, &cube_limit, &vector_limit);
+    if (block_dim > max_bd) {
+        if (cube_limit > 0 && vector_limit > 0) {
             LOG_ERROR(
                 "block_dim (%d) exceeds available cores (max_block_dim=%d, cube=%u, vector=%u)", block_dim, max_bd,
                 cube_limit, vector_limit
             );
-            return -1;
+        } else {
+            LOG_ERROR(
+                "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
+                block_dim, PLATFORM_MAX_BLOCKDIM
+            );
         }
-    } else if (block_dim > PLATFORM_MAX_BLOCKDIM) {
-        // aclrtGetStreamResLimit unavailable (or reported no cores) — fall back
-        // to the static platform capacity so block_dim stays bounded.
-        LOG_ERROR(
-            "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
-            block_dim, PLATFORM_MAX_BLOCKDIM
-        );
         return -1;
     }
     return 0;
@@ -564,10 +574,21 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
-    // Validate block_dim against stream resource limits
-    rc = validate_block_dim(stream_aicore_, block_dim);
-    if (rc != 0) {
-        return rc;
+    // Auto sentinel (block_dim == 0) is resolved directly from
+    // query_max_block_dim; explicit values still go through validate. The
+    // auto branch skips validate so we don't pay the ACL syscalls twice.
+    if (block_dim == 0) {
+        block_dim = query_max_block_dim(stream_aicore_);
+        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
+        if (block_dim < 1) {
+            LOG_ERROR("block_dim auto-resolved to invalid value %d", block_dim);
+            return -1;
+        }
+    } else {
+        rc = validate_block_dim(stream_aicore_, block_dim);
+        if (rc != 0) {
+            return rc;
+        }
     }
     block_dim_ = block_dim;
 

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -691,10 +691,25 @@ private:
     int ensure_device_initialized();
 
     /**
+     * Query the maximum block_dim the stream can host.
+     *
+     * Uses aclrtGetStreamResLimit(CUBE_CORE / VECTOR_CORE) and returns
+     * min(cube / AIC_PER_BLOCKDIM, vector / AIV_PER_BLOCKDIM). Falls back to
+     * the static PLATFORM_MAX_BLOCKDIM cap when the query is unavailable or
+     * reports no cores. Used both to validate explicit block_dim values and
+     * to resolve the CallConfig "auto" sentinel (block_dim == 0).
+     *
+     * If non-null, `out_cube` / `out_vector` receive the raw ACL limits when
+     * the query succeeded, or 0 when it failed. Callers use this to
+     * distinguish the ACL-unavailable fallback path from the success path in
+     * error logs.
+     */
+    int query_max_block_dim(rtStream_t stream, uint32_t *out_cube = nullptr, uint32_t *out_vector = nullptr);
+
+    /**
      * Validate block_dim against the stream's CUBE/VECTOR core limits
-     * (aclrtGetStreamResLimit). When that query is unavailable or reports no
-     * cores, falls back to the static PLATFORM_MAX_BLOCKDIM cap.
-     * Returns 0 if block_dim fits, -1 otherwise (or if block_dim < 1).
+     * (via query_max_block_dim). Returns 0 if block_dim fits, -1 otherwise
+     * (or if block_dim < 1).
      */
     int validate_block_dim(rtStream_t stream, int block_dim);
 

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -376,6 +376,13 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // DeviceRunner::validate_block_dim). The scheduler assigns cores to
     // threads cluster-aligned round-robin, so block_dim need not be evenly
     // divisible by the scheduler thread count.
+    //
+    // block_dim == 0 is the CallConfig "auto" sentinel — resolve to the
+    // static max since sim has no per-stream resource query.
+    if (block_dim == 0) {
+        block_dim = PLATFORM_MAX_BLOCKDIM;
+        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
+    }
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
         LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -384,35 +384,45 @@ int DeviceRunner::copy_from_device(void *host_ptr, const void *dev_ptr, size_t b
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
+int DeviceRunner::query_max_block_dim(rtStream_t stream, uint32_t *out_cube, uint32_t *out_vector) {
+    uint32_t cube_limit = 0, vector_limit = 0;
+    bool got_limits = (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_CUBE_CORE, &cube_limit) == ACL_ERROR_NONE) &&
+                      (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_VECTOR_CORE, &vector_limit) == ACL_ERROR_NONE) &&
+                      cube_limit > 0 && vector_limit > 0;
+    if (out_cube != nullptr) *out_cube = got_limits ? cube_limit : 0;
+    if (out_vector != nullptr) *out_vector = got_limits ? vector_limit : 0;
+    if (got_limits) {
+        // Cap by PLATFORM_MAX_BLOCKDIM as well: runtime handshake/scheduler
+        // arrays are statically sized to RUNTIME_MAX_WORKER (= PLATFORM_MAX_BLOCKDIM
+        // * PLATFORM_CORES_PER_BLOCKDIM), so even if ACL reports more cores
+        // than the platform cap we must not exceed it.
+        int from_stream = static_cast<int>(
+            std::min(cube_limit / PLATFORM_AIC_CORES_PER_BLOCKDIM, vector_limit / PLATFORM_AIV_CORES_PER_BLOCKDIM)
+        );
+        return std::min(from_stream, PLATFORM_MAX_BLOCKDIM);
+    }
+    return PLATFORM_MAX_BLOCKDIM;
+}
+
 int DeviceRunner::validate_block_dim(rtStream_t stream, int block_dim) {
     if (block_dim < 1) {
         LOG_ERROR("block_dim (%d) must be >= 1", block_dim);
         return -1;
     }
-
     uint32_t cube_limit = 0, vector_limit = 0;
-    bool got_limits = (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_CUBE_CORE, &cube_limit) == ACL_ERROR_NONE) &&
-                      (aclrtGetStreamResLimit(stream, ACL_RT_DEV_RES_VECTOR_CORE, &vector_limit) == ACL_ERROR_NONE) &&
-                      cube_limit > 0 && vector_limit > 0;
-
-    if (got_limits) {
-        int max_bd = static_cast<int>(
-            std::min(cube_limit / PLATFORM_AIC_CORES_PER_BLOCKDIM, vector_limit / PLATFORM_AIV_CORES_PER_BLOCKDIM)
-        );
-        if (block_dim > max_bd) {
+    int max_bd = query_max_block_dim(stream, &cube_limit, &vector_limit);
+    if (block_dim > max_bd) {
+        if (cube_limit > 0 && vector_limit > 0) {
             LOG_ERROR(
                 "block_dim (%d) exceeds available cores (max_block_dim=%d, cube=%u, vector=%u)", block_dim, max_bd,
                 cube_limit, vector_limit
             );
-            return -1;
+        } else {
+            LOG_ERROR(
+                "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
+                block_dim, PLATFORM_MAX_BLOCKDIM
+            );
         }
-    } else if (block_dim > PLATFORM_MAX_BLOCKDIM) {
-        // aclrtGetStreamResLimit unavailable (or reported no cores) — fall back
-        // to the static platform capacity so block_dim stays bounded.
-        LOG_ERROR(
-            "aclrtGetStreamResLimit unavailable; block_dim (%d) exceeds static cap PLATFORM_MAX_BLOCKDIM (%d)",
-            block_dim, PLATFORM_MAX_BLOCKDIM
-        );
         return -1;
     }
     return 0;
@@ -442,10 +452,21 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
-    // Validate block_dim against stream resource limits
-    rc = validate_block_dim(stream_aicore_, block_dim);
-    if (rc != 0) {
-        return rc;
+    // Auto sentinel (block_dim == 0) is resolved directly from
+    // query_max_block_dim; explicit values still go through validate. The
+    // auto branch skips validate so we don't pay the ACL syscalls twice.
+    if (block_dim == 0) {
+        block_dim = query_max_block_dim(stream_aicore_);
+        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
+        if (block_dim < 1) {
+            LOG_ERROR("block_dim auto-resolved to invalid value %d", block_dim);
+            return -1;
+        }
+    } else {
+        rc = validate_block_dim(stream_aicore_, block_dim);
+        if (rc != 0) {
+            return rc;
+        }
     }
     block_dim_ = block_dim;
 

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -580,10 +580,25 @@ private:
     int ensure_device_initialized();
 
     /**
+     * Query the maximum block_dim the stream can host.
+     *
+     * Uses aclrtGetStreamResLimit(CUBE_CORE / VECTOR_CORE) and returns
+     * min(cube / AIC_PER_BLOCKDIM, vector / AIV_PER_BLOCKDIM). Falls back to
+     * the static PLATFORM_MAX_BLOCKDIM cap when the query is unavailable or
+     * reports no cores. Used both to validate explicit block_dim values and
+     * to resolve the CallConfig "auto" sentinel (block_dim == 0).
+     *
+     * If non-null, `out_cube` / `out_vector` receive the raw ACL limits when
+     * the query succeeded, or 0 when it failed. Callers use this to
+     * distinguish the ACL-unavailable fallback path from the success path in
+     * error logs.
+     */
+    int query_max_block_dim(rtStream_t stream, uint32_t *out_cube = nullptr, uint32_t *out_vector = nullptr);
+
+    /**
      * Validate block_dim against the stream's CUBE/VECTOR core limits
-     * (aclrtGetStreamResLimit). When that query is unavailable or reports no
-     * cores, falls back to the static PLATFORM_MAX_BLOCKDIM cap.
-     * Returns 0 if block_dim fits, -1 otherwise (or if block_dim < 1).
+     * (via query_max_block_dim). Returns 0 if block_dim fits, -1 otherwise
+     * (or if block_dim < 1).
      */
     int validate_block_dim(rtStream_t stream, int block_dim);
 

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -345,6 +345,13 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // DeviceRunner::validate_block_dim). The scheduler assigns cores to
     // threads cluster-aligned round-robin, so block_dim need not be evenly
     // divisible by the scheduler thread count.
+    //
+    // block_dim == 0 is the CallConfig "auto" sentinel — resolve to the
+    // static max since sim has no per-stream resource query.
+    if (block_dim == 0) {
+        block_dim = PLATFORM_MAX_BLOCKDIM;
+        LOG_INFO_V0("block_dim auto-resolved to %d", block_dim);
+    }
     if (block_dim < 1 || block_dim > PLATFORM_MAX_BLOCKDIM) {
         LOG_ERROR("block_dim (%d) must be in range [1, %d]", block_dim, PLATFORM_MAX_BLOCKDIM);
         return -1;

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -15,6 +15,12 @@
  * sub-features under the profiling umbrella: `enable_l2_swimlane` (swimlane),
  * `enable_dump_tensor`, `enable_pmu`, and `enable_dep_gen`.
  *
+ * `block_dim == 0` is a sentinel for "auto" — DeviceRunner resolves it at
+ * run() time to the max block_dim the AICore stream allows
+ * (aclrtGetStreamResLimit on onboard; PLATFORM_MAX_BLOCKDIM on sim).
+ * Any positive value is taken as an explicit cap and validated against
+ * the same stream-resource limits.
+ *
  * Lives here (rather than chip_worker.h) so distributed task slot state
  * can store it directly without pulling in the full ChipWorker header
  * (which depends on types.h).
@@ -40,7 +46,7 @@
 
 #pragma pack(push, 1)
 struct CallConfig {
-    int32_t block_dim = 24;
+    int32_t block_dim = 0;  // 0 = auto; resolved by DeviceRunner at run() time
     int32_t aicpu_thread_num = 3;
     int32_t enable_l2_swimlane = 0;
     int32_t enable_dump_tensor = 0;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -53,6 +53,17 @@ class TestSpmdBasic(SceneTestCase):
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {},
         },
+        {
+            # Exercises the CallConfig block_dim=0 "auto" path: scene_test
+            # omits block_dim, so DeviceRunner resolves it to the stream's
+            # max (PLATFORM_MAX_BLOCKDIM on sim, aclrtGetStreamResLimit on
+            # onboard). The SPMD task itself is block_num=1, so the golden
+            # is identical to Case1 regardless of how many workers exist.
+            "name": "Case2_AutoBlockDim",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
     ]
 
     def generate_args(self, params):

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -53,6 +53,17 @@ class TestSpmdBasic(SceneTestCase):
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {},
         },
+        {
+            # Exercises the CallConfig block_dim=0 "auto" path: scene_test
+            # omits block_dim, so DeviceRunner resolves it to the stream's
+            # max (PLATFORM_MAX_BLOCKDIM on sim, aclrtGetStreamResLimit on
+            # onboard). The SPMD task itself is block_num=1, so the golden
+            # is identical to Case1 regardless of how many workers exist.
+            "name": "Case2_AutoBlockDim",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4},
+            "params": {},
+        },
     ]
 
     def generate_args(self, params):

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -19,7 +19,9 @@ from _task_interface import CallConfig, _ChipWorker  # pyright: ignore[reportMis
 class TestCallConfig:
     def test_defaults(self):
         config = CallConfig()
-        assert config.block_dim == 24
+        # 0 is the "auto" sentinel — DeviceRunner resolves it at run() time
+        # to the max the AICore stream allows.
+        assert config.block_dim == 0
         assert config.aicpu_thread_num == 3
         assert config.enable_l2_swimlane == 0
         assert config.enable_dump_tensor is False
@@ -63,7 +65,7 @@ class TestCallConfig:
     def test_repr(self):
         config = CallConfig()
         r = repr(config)
-        assert "block_dim=24" in r
+        assert "block_dim=0" in r
         assert "enable_l2_swimlane=0" in r
 
 


### PR DESCRIPTION
## Summary
- `CallConfig::block_dim` default flips from `24` to `0` (sentinel for "auto"); `DeviceRunner::run` resolves `0` at launch time to the max the AICore stream can host.
- Onboard runners query `aclrtGetStreamResLimit(CUBE_CORE / VECTOR_CORE)` and pick `min(cube/AIC_per_bd, vector/AIV_per_bd)`, falling back to `PLATFORM_MAX_BLOCKDIM` if the ACL call fails. Sim runners short-circuit to `PLATFORM_MAX_BLOCKDIM` since there is no per-stream resource query.
- `scene_test.py`'s implicit `block_dim` fallback (`1`) is dropped in favour of `0` so cases that omit `block_dim` exercise the new auto path.

## Behavior change
- Any caller constructing `CallConfig()` without setting `block_dim` previously got `24`. They now get the stream's max — `36` on a full-die a5 stream, `24` on a2a3, possibly smaller on resource-limited streams.
- `validate_block_dim` now applies the `PLATFORM_MAX_BLOCKDIM` clamp on both the ACL-success path and the ACL-fallback path (previously only the fallback was clamped). This is a defensive narrowing — the runtime handshake/scheduler arrays are statically sized to `RUNTIME_MAX_WORKER = PLATFORM_MAX_BLOCKDIM * PLATFORM_CORES_PER_BLOCKDIM`, so accepting an ACL-reported value larger than the platform cap would over-run those static arrays. No observed-hardware impact today, but explicit values above the platform cap now error early instead of corrupting later.

## Why
Most callers want "use everything the stream allows" and were hand-picking `24` arbitrarily. Centralizing the policy in `DeviceRunner` removes the magic number from user code and adapts automatically when stream capacity is constrained (CPU partitioning, model-shared streams, etc.).

## Test plan
- [x] Local sim build (`pip install --no-build-isolation -e .`) passes
- [x] `tests/ut/py/test_chip_worker.py::TestCallConfig` updated for new default; pre-commit hooks (clang-tidy / cpplint / pyright) clean
- [x] `spmd_basic` ST gains a `Case2_AutoBlockDim` on both a5 and a2a3 that omits `block_dim`, so onboard CI exercises `query_max_block_dim` end-to-end
- [x] `simpler_setup/scene_test.py` fallback flipped from `1` to `0` so future cases that omit `block_dim` also exercise the auto path