### PR TITLE
Fix: relax spmd_paged_attention tolerance to 1e-2 (#848)

### DIFF
--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -19,10 +19,11 @@ from simpler_setup.goldens.paged_attention import generate_inputs as _pa_generat
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestPagedAttentionUnrollTpushPop(SceneTestCase):
-    # Tolerances relaxed from 2e-3 to absorb hardware numerical drift in the
-    # AIC/AIV cooperative TPUSH/TPOP pipeline; observed max_diff ~4.1e-3.
-    RTOL = 5e-3
-    ATOL = 5e-3
+    # Tolerances relaxed (2e-3 -> 5e-3 in #825, then 5e-3 -> 1e-2 for #848)
+    # to absorb hardware numerical drift in the AIC/AIV cooperative TPUSH/TPOP
+    # pipeline; observed max_diff ~5.5e-3.
+    RTOL = 1e-2
+    ATOL = 1e-2
 
     CALLABLE = {
         "orchestration": {


### PR DESCRIPTION
## Summary

- Bumps `RTOL`/`ATOL` for `TestPagedAttentionUnrollTpushPop` from `5e-3` → `1e-2` to absorb the bf16 / online-softmax drift observed on A2/A3 onboard hardware.
- Second tolerance bump after #825 (which went `2e-3` → `5e-3`). Issue #848 reports `max_diff` of `5.35e-3` and `5.54e-3` — just past the current `5e-3` bound.
- Sized to roughly the same 2-2.5x ratio as the prior bump so a single additional sample of run-to-run drift doesn't immediately re-trip the test.

The underlying numerical-drift source (online-softmax accumulation order under varying AIC/AIV interleave) and the mode-B `aclrtSynchronizeStreamWithTimeout` flake described in #825 remain follow-ups.

Closes #848

## Test plan

- [ ] `st-onboard-a2a3` job passes on this branch
- [ ] `TestPagedAttentionUnrollTpushPop::test_run` passes across several CI reruns

🤖 Generated with [Claude Code](https://claude.com/claude-code)