### PR TITLE
Refactor: rename sche_cpu_num to aicpu_thread_num for honest semantics

### DIFF
--- a/src/a2a3/platform/include/aicpu/platform_aicpu_affinity.h
+++ b/src/a2a3/platform/include/aicpu/platform_aicpu_affinity.h
@@ -1,8 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #pragma once
 #include <cstdint>
 
 // Returns true if this thread should call aicpu_execute().
 // Returns false if this thread should exit (dropped).
-// logical_count: desired active threads (from runtime.sche_cpu_num)
+// logical_count: desired active threads (from runtime.aicpu_thread_num)
 // total_launched: actual threads launched (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched);

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -123,7 +123,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_dep_gen_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DEP_GEN));
 
     // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+    if (!platform_aicpu_affinity_gate(runtime->aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
         LOG_INFO_V0("Thread dropped by cluster affinity");
         return 0;
     }

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -601,7 +601,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     runtime.worker_count = num_aicore;
     worker_count_ = num_aicore;  // Store for print_handshake_results in destructor
-    runtime.sche_cpu_num = launch_aicpu_num;
+    runtime.aicpu_thread_num = launch_aicpu_num;
 
     // Scope guards for register-address cleanup on all exit paths. Declared
     // before the allocs so that an alloc-failure early-return still triggers
@@ -1374,7 +1374,7 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.sche_cpu_num;
+    int num_dump_threads = runtime.aicpu_thread_num;
 
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -419,7 +419,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // Initialize handshake buffers
     runtime.worker_count = num_aicore;
     worker_count_ = num_aicore;
-    runtime.sche_cpu_num = launch_aicpu_num;
+    runtime.aicpu_thread_num = launch_aicpu_num;
 
     // Calculate number of AIC cores
     int num_aic = block_dim;
@@ -1174,7 +1174,7 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.sche_cpu_num;
+    int num_dump_threads = runtime.aicpu_thread_num;
 
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -52,7 +52,7 @@ struct AicpuExecutor {
     std::atomic<bool> init_failed_{false};
     std::atomic<bool> finished_{false};
 
-    int thread_num_{0};
+    int aicpu_thread_num_{0};
     int cores_total_num_{0};
     int thread_cores_num_[MAX_AICPU_THREADS]{};  // Total cores (AIC+AIV) assigned to each thread
     int aic_per_thread_{0};                      // Max AIC cores per thread (ceil), used as local queue cap
@@ -309,11 +309,11 @@ int AicpuExecutor::init(Runtime *runtime) {
     }
 
     // Read execution parameters from runtime
-    thread_num_ = runtime->sche_cpu_num;
+    aicpu_thread_num_ = runtime->aicpu_thread_num;
 
     // Simplified defensive check
-    if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid thread_num: %d (valid range: 1-%d)", thread_num_, MAX_AICPU_THREADS);
+    if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
+        LOG_ERROR("Invalid aicpu_thread_num: %d (valid range: 1-%d)", aicpu_thread_num_, MAX_AICPU_THREADS);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -335,7 +335,7 @@ int AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    LOG_INFO_V0("Config: threads=%d, cores=%d", thread_num_, cores_total_num_);
+    LOG_INFO_V0("Config: threads=%d, cores=%d", aicpu_thread_num_, cores_total_num_);
 
     for (int i = 0; i < cores_total_num_; i++) {
         pending_task_ids_[i] = AICPU_TASK_INVALID;
@@ -355,7 +355,7 @@ int AicpuExecutor::init(Runtime *runtime) {
     }
 #if PTO2_PROFILING
     if (is_dump_tensor_enabled()) {
-        dump_tensor_init(thread_num_);
+        dump_tensor_init(aicpu_thread_num_);
     }
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
@@ -485,27 +485,27 @@ int AicpuExecutor::handshake_all_cores(Runtime *runtime) {
 
 // Assign discovered cores to threads using round-robin
 void AicpuExecutor::assign_cores_to_threads() {
-    // Round-robin: AIC core i → thread (i % thread_num_), AIV core i → thread (i % thread_num_).
+    // Round-robin: AIC core i → thread (i % aicpu_thread_num_), AIV core i → thread (i % aicpu_thread_num_).
     // AIC and AIV are assigned independently; no cluster pairing is required.
     // aic_per_thread_ / aiv_per_thread_ store the ceiling value and serve as local queue caps.
-    aic_per_thread_ = (aic_count_ + thread_num_ - 1) / thread_num_;
-    aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
+    aic_per_thread_ = (aic_count_ + aicpu_thread_num_ - 1) / aicpu_thread_num_;
+    aiv_per_thread_ = (aiv_count_ + aicpu_thread_num_ - 1) / aicpu_thread_num_;
 
     LOG_INFO_V0(
         "Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)", aic_count_,
-        aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_
+        aiv_count_, aicpu_thread_num_, aic_per_thread_, aiv_per_thread_
     );
 
-    for (int t = 0; t < thread_num_; t++) {
+    for (int t = 0; t < aicpu_thread_num_; t++) {
         int core_idx = 0;
 
-        // Assign AIC cores: cores at indices t, t+thread_num_, t+2*thread_num_, ...
-        for (int i = t; i < aic_count_; i += thread_num_) {
+        // Assign AIC cores: cores at indices t, t+aicpu_thread_num_, t+2*aicpu_thread_num_, ...
+        for (int i = t; i < aic_count_; i += aicpu_thread_num_) {
             core_assignments_[t][core_idx++] = aic_cores_[i].worker_id;
         }
 
         // Assign AIV cores after AIC cores
-        for (int i = t; i < aiv_count_; i += thread_num_) {
+        for (int i = t; i < aiv_count_; i += aicpu_thread_num_) {
             core_assignments_[t][core_idx++] = aiv_cores_[i].worker_id;
         }
 
@@ -518,14 +518,14 @@ void AicpuExecutor::assign_cores_to_threads() {
             log_buffer + offset, sizeof(log_buffer) - offset, "Thread %d: assigned %d cores - AIC[", t, core_idx
         );
 
-        for (int k = 0, i = t; i < aic_count_; i += thread_num_, k++) {
+        for (int k = 0, i = t; i < aic_count_; i += aicpu_thread_num_, k++) {
             if (k > 0) offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, ",");
             offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, "%d", aic_cores_[i].worker_id);
         }
 
         offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, "] AIV[");
 
-        for (int k = 0, i = t; i < aiv_count_; i += thread_num_, k++) {
+        for (int k = 0, i = t; i < aiv_count_; i += aicpu_thread_num_, k++) {
             if (k > 0) offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, ",");
             offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, "%d", aiv_cores_[i].worker_id);
         }
@@ -588,7 +588,7 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
             shared_count++;
         }
 
-        next_thread_idx = (thread_idx + 1) % thread_num_;
+        next_thread_idx = (thread_idx + 1) % aicpu_thread_num_;
     };
 
     int task_count = runtime->get_task_count();
@@ -622,7 +622,7 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
         initial_aiv_count - aiv_shared_count, aiv_shared_count
     );
 
-    for (int t = 0; t < thread_num_; t++) {
+    for (int t = 0; t < aicpu_thread_num_; t++) {
         int aic_size =
             (cur_ready_queue_aic_tail_[t] - cur_ready_queue_aic_head_[t] + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
         int aiv_size =
@@ -1147,7 +1147,7 @@ int AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO_V0("Thread %d: Completed", thread_idx);
 
     int prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
-    if (prev_finished + 1 == thread_num_) {
+    if (prev_finished + 1 == aicpu_thread_num_) {
         finished_.store(true, std::memory_order_release);
         LOG_INFO_V0("Thread %d: Last thread, marking executor finished", thread_idx);
     }
@@ -1205,7 +1205,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
-    thread_num_ = 0;
+    aicpu_thread_num_ = 0;
     aic_per_thread_ = 0;
     aiv_per_thread_ = 0;
     memset(core_assignments_, 0, sizeof(core_assignments_));

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -44,7 +44,7 @@ Runtime::Runtime() {
     next_task_id = 0;
     initial_ready_count = 0;
     worker_count = 0;
-    sche_cpu_num = 1;
+    aicpu_thread_num = 1;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;
     tensor_allocation_storage_ = nullptr;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -208,8 +208,10 @@ public:
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
-    // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    // Total AICPU threads launched on this run. host_build_graph has no
+    // orchestrator/scheduler split — every thread dispatches tasks in
+    // round-robin across the assigned cores. See AicpuExecutor::init.
+    int aicpu_thread_num;
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -119,7 +119,7 @@ struct AicpuExecutor {
     std::atomic<bool> init_failed_{false};
     std::atomic<bool> finished_{false};
 
-    int32_t thread_num_{0};
+    int32_t aicpu_thread_num_{0};
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
@@ -179,19 +179,21 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    // Read execution parameters from runtime
-    thread_num_ = runtime->sche_cpu_num;
-    sched_thread_num_ = thread_num_ - 1;
+    // Read execution parameters from runtime. The 0 → 1 fixup runs before the
+    // sched_thread_num_ derivation so a zero input doesn't leave the scheduler
+    // count at -1.
+    aicpu_thread_num_ = runtime->aicpu_thread_num;
+    if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
+    sched_thread_num_ = aicpu_thread_num_ - 1;
     orch_to_sched_ = runtime->orch_to_sched;
-    if (thread_num_ == 0) thread_num_ = 1;
 
-    if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid thread_num: %d", thread_num_);
+    if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
+        LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
 
-    if (sched_ctx_.init(runtime, thread_num_, sched_thread_num_, orch_to_sched_, get_platform_regs()) != 0) {
+    if (sched_ctx_.init(runtime, aicpu_thread_num_, sched_thread_num_, orch_to_sched_, get_platform_regs()) != 0) {
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -674,7 +676,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
-    if (prev_finished + 1 == thread_num_) {
+    if (prev_finished + 1 == aicpu_thread_num_) {
         finished_.store(true, std::memory_order_release);
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
@@ -709,7 +711,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     finished_count_.store(0, std::memory_order_release);
     runtime_init_ready_.store(false, std::memory_order_release);
 
-    thread_num_ = 0;
+    aicpu_thread_num_ = 0;
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -544,7 +544,7 @@ Public surface (called from `AicpuExecutor::init/run/deinit`):
 
 | Method | Phase | Purpose |
 | ------ | ----- | ------- |
-| `init(runtime, thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
+| `init(runtime, aicpu_thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
 | `bind_runtime(rt)` | device-orch only | Wire `sched_` to `rt->scheduler` once the orchestrator thread creates `rt` |
 | `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
 | `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled |

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -15,7 +15,7 @@
  * protocol. Task graph construction is handled by PTO2Runtime; this class
  * only handles:
  * - Handshake buffers for AICPU-AICore communication
- * - Execution parameters (block_dim, sche_cpu_num)
+ * - Execution parameters (block_dim, aicpu_thread_num)
  * - Tensor pair management for host-device memory tracking
  * - Device orchestration state (gm_sm_ptr_, orch_args_)
  * - Function address mapping (func_id_to_addr_)
@@ -176,8 +176,14 @@ public:
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
-    // Execution parameters for AICPU scheduling
-    int sche_cpu_num;        // Number of AICPU threads for scheduling
+    // Execution parameters for AICPU scheduling.
+    //
+    // aicpu_thread_num is the *total* AICPU thread count launched on this run
+    // (= orch + schedulers). AicpuExecutor splits this into one orchestrator
+    // thread (highest idx, runs aicpu_orchestration_entry) and the remaining
+    // aicpu_thread_num-1 scheduler threads that dispatch tasks to AICore.
+    // The orch thread also dispatches when env PTO2_ORCH_TO_SCHED is set.
+    int aicpu_thread_num;
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -202,7 +202,7 @@ void format_core_status(
 }  // namespace
 
 int32_t SchedulerContext::find_core_owner_thread(int32_t core_id) const {
-    for (int32_t t = 0; t < thread_num_; t++) {
+    for (int32_t t = 0; t < aicpu_thread_num_; t++) {
         const int32_t *ids = core_trackers_[t].core_ids();
         int32_t n = core_trackers_[t].core_num();
         for (int32_t i = 0; i < n; i++) {
@@ -298,7 +298,7 @@ void SchedulerContext::log_stall_diagnostics(
     // CLUSTER lines: one per cluster this thread owns.
     // cluster_id = local_cluster_idx * active_sched_threads_ + thread_idx, matching the
     // round-robin assignment in assign_cores_to_threads / reassign_cores_for_all_threads.
-    int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : thread_num_;
+    int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
         int32_t aic_id = tracker.get_aic_core_id(offset);
@@ -638,7 +638,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 bool SchedulerContext::assign_cores_to_threads() {
     // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
     // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
-    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
+    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
     int32_t cluster_count = aic_count_;
 
     // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
@@ -683,14 +683,16 @@ bool SchedulerContext::assign_cores_to_threads() {
         LOG_INFO_V0("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
-    for (int32_t t = 0; t < thread_num_; t++) {
+    for (int32_t t = 0; t < aicpu_thread_num_; t++) {
         LOG_INFO_V0(
             "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count()
         );
     }
 
-    LOG_INFO_V0("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
+    LOG_INFO_V0(
+        "Config: threads=%d, cores=%d, cores_per_thread=%d", aicpu_thread_num_, cores_total_num_, thread_cores_num
+    );
     return true;
 }
 
@@ -699,12 +701,12 @@ bool SchedulerContext::assign_cores_to_threads() {
 // =============================================================================
 void SchedulerContext::reassign_cores_for_all_threads() {
     LOG_INFO_V0(
-        "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_
+        "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", aicpu_thread_num_, aic_count_, aiv_count_
     );
 
     // Collect running worker_ids from all current trackers
     bool running_cores[RUNTIME_MAX_WORKER] = {};
-    for (int32_t i = 0; i < thread_num_; i++) {
+    for (int32_t i = 0; i < aicpu_thread_num_; i++) {
         auto all_running = core_trackers_[i].get_all_running_cores();
         int32_t bp;
         while ((bp = all_running.pop_first()) >= 0) {
@@ -716,18 +718,18 @@ void SchedulerContext::reassign_cores_for_all_threads() {
     int32_t cluster_count = aic_count_;
     int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
     for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % thread_num_]++;
+        clusters_per_thread[ci % aicpu_thread_num_]++;
     }
 
     // Re-init all trackers and reset core counts
-    for (int32_t i = 0; i < thread_num_; i++) {
+    for (int32_t i = 0; i < aicpu_thread_num_; i++) {
         core_trackers_[i].init(clusters_per_thread[i]);
     }
 
     // Assign clusters round-robin and restore running state
     int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
     for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % thread_num_;
+        int32_t t = ci % aicpu_thread_num_;
 
         int32_t aic_wid = aic_worker_ids_[ci];
         int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
@@ -753,7 +755,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 
     // Log final distribution
     LOG_INFO_V0("Core reassignment complete:");
-    for (int32_t t = 0; t < thread_num_; t++) {
+    for (int32_t t = 0; t < aicpu_thread_num_; t++) {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
         LOG_INFO_V0(
@@ -761,7 +763,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
             core_trackers_[t].get_cluster_count(), aic_running, aiv_running
         );
     }
-    active_sched_threads_ = thread_num_;
+    active_sched_threads_ = aicpu_thread_num_;
 }
 
 // =============================================================================
@@ -792,7 +794,7 @@ void SchedulerContext::emergency_shutdown(Runtime *runtime) {
 // Lifecycle: init / deinit
 // =============================================================================
 int32_t SchedulerContext::init(
-    Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base
+    Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base
 ) {
     always_assert(runtime != nullptr);
 
@@ -800,7 +802,7 @@ int32_t SchedulerContext::init(
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
 
     // Wire thread/transition configuration that handshake/assign need to read.
-    thread_num_ = thread_num;
+    aicpu_thread_num_ = aicpu_thread_num;
     sched_thread_num_ = sched_thread_num;
     orch_to_sched_ = orch_to_sched;
     regs_ = regs_base;
@@ -905,7 +907,7 @@ void SchedulerContext::deinit() {
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
-    thread_num_ = 0;
+    aicpu_thread_num_ = 0;
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
     active_sched_threads_ = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -61,7 +61,7 @@ public:
     // - Captures AICore-register base (consumed by handshake_all_cores())
     // Returns 0 on success, negative on failure (handshake / assignment error).
     int32_t
-    init(Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base);
+    init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base);
 
     // Reset all SchedulerContext-owned state to its post-construction defaults.
     // Called by AicpuExecutor::deinit() during per-run teardown.
@@ -159,7 +159,7 @@ private:
     int32_t active_sched_threads_{0};
     int32_t sched_thread_num_{0};
     bool orch_to_sched_{false};
-    int32_t thread_num_{0};
+    int32_t aicpu_thread_num_{0};
     int32_t cores_total_num_{0};
 
     // Cluster-ordered worker_id lists, populated by handshake_all_cores().

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -357,7 +357,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
 #if PTO2_PROFILING
         if (is_dump_tensor_enabled()) {
-            dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
+            dump_tensor_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
         }
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -32,7 +32,7 @@ Runtime::Runtime() {
     // Initialize handshake buffers
     memset(workers, 0, sizeof(workers));
     worker_count = 0;
-    sche_cpu_num = 1;
+    aicpu_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
     task_window_size = 0;
     heap_size = 0;

--- a/src/a5/platform/include/aicpu/platform_aicpu_affinity.h
+++ b/src/a5/platform/include/aicpu/platform_aicpu_affinity.h
@@ -1,8 +1,19 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
 #pragma once
 #include <cstdint>
 
 // Returns true if this thread should call aicpu_execute().
 // Returns false if this thread should exit (dropped).
-// logical_count: desired active threads (from runtime.sche_cpu_num)
+// logical_count: desired active threads (from runtime.aicpu_thread_num)
 // total_launched: actual threads launched (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched);

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -116,7 +116,7 @@ extern "C" __attribute__((visibility("default"))) int DynTileFwkBackendKernelSer
     set_pmu_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_PMU));
 
     // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->sche_cpu_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
+    if (!platform_aicpu_affinity_gate(runtime->aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
         LOG_INFO_V0("Thread dropped by cluster affinity");
         return 0;
     }

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -479,7 +479,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     runtime.worker_count = num_aicore;
     worker_count_ = num_aicore;  // Store for print_handshake_results in destructor
-    runtime.sche_cpu_num = launch_aicpu_num;
+    runtime.aicpu_thread_num = launch_aicpu_num;
 
     // Get AICore register addresses for register-based task dispatch
     rc = init_aicore_register_addresses(&kernel_args_.args.regs, static_cast<uint64_t>(device_id_), mem_alloc_);
@@ -1181,7 +1181,7 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.sche_cpu_num;
+    int num_dump_threads = runtime.aicpu_thread_num;
 
     int rc = dump_collector_.initialize(
         num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -385,7 +385,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // Initialize handshake buffers
     runtime.worker_count = num_aicore;
     worker_count_ = num_aicore;
-    runtime.sche_cpu_num = launch_aicpu_num;
+    runtime.aicpu_thread_num = launch_aicpu_num;
 
     // Calculate number of AIC cores
     int num_aic = block_dim;
@@ -1079,7 +1079,7 @@ int DeviceRunner::init_l2_perf(int num_aicore, int device_id) {
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.sche_cpu_num;
+    int num_dump_threads = runtime.aicpu_thread_num;
 
     int rc = dump_collector_.initialize(
         num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -49,7 +49,7 @@ struct AicpuExecutor {
     std::atomic<bool> init_failed_{false};
     std::atomic<bool> finished_{false};
 
-    int thread_num_{0};
+    int aicpu_thread_num_{0};
     int cores_total_num_{0};
     int thread_cores_num_[MAX_AICPU_THREADS]{};  // Total cores (AIC+AIV) assigned to each thread
     int aic_per_thread_{0};                      // Max AIC cores per thread (ceil), used as local queue cap
@@ -312,12 +312,12 @@ int AicpuExecutor::init(Runtime *runtime) {
     }
 
     // Read execution parameters from runtime
-    thread_num_ = runtime->sche_cpu_num;
+    aicpu_thread_num_ = runtime->aicpu_thread_num;
     runtime_ = runtime;
 
     // Simplified defensive check
-    if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid thread_num: %d (valid range: 1-%d)", thread_num_, MAX_AICPU_THREADS);
+    if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
+        LOG_ERROR("Invalid aicpu_thread_num: %d (valid range: 1-%d)", aicpu_thread_num_, MAX_AICPU_THREADS);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -335,7 +335,7 @@ int AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    LOG_INFO_V0("Config: threads=%d, cores=%d", thread_num_, cores_total_num_);
+    LOG_INFO_V0("Config: threads=%d, cores=%d", aicpu_thread_num_, cores_total_num_);
 
     for (int i = 0; i < cores_total_num_; i++) {
         pending_task_ids_[i] = AICPU_TASK_INVALID;
@@ -358,7 +358,7 @@ int AicpuExecutor::init(Runtime *runtime) {
     }
 #if PTO2_PROFILING
     if (is_dump_tensor_enabled()) {
-        dump_tensor_init(thread_num_);
+        dump_tensor_init(aicpu_thread_num_);
     }
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
@@ -487,27 +487,27 @@ int AicpuExecutor::handshake_all_cores(Runtime *runtime) {
 
 // Assign discovered cores to threads using round-robin
 void AicpuExecutor::assign_cores_to_threads() {
-    // Round-robin: AIC core i → thread (i % thread_num_), AIV core i → thread (i % thread_num_).
+    // Round-robin: AIC core i → thread (i % aicpu_thread_num_), AIV core i → thread (i % aicpu_thread_num_).
     // AIC and AIV are assigned independently; no cluster pairing is required.
     // aic_per_thread_ / aiv_per_thread_ store the ceiling value and serve as local queue caps.
-    aic_per_thread_ = (aic_count_ + thread_num_ - 1) / thread_num_;
-    aiv_per_thread_ = (aiv_count_ + thread_num_ - 1) / thread_num_;
+    aic_per_thread_ = (aic_count_ + aicpu_thread_num_ - 1) / aicpu_thread_num_;
+    aiv_per_thread_ = (aiv_count_ + aicpu_thread_num_ - 1) / aicpu_thread_num_;
 
     LOG_INFO_V0(
         "Core Assignment: %d AIC cores, %d AIV cores across %d threads (max %d AIC/thread, %d AIV/thread)", aic_count_,
-        aiv_count_, thread_num_, aic_per_thread_, aiv_per_thread_
+        aiv_count_, aicpu_thread_num_, aic_per_thread_, aiv_per_thread_
     );
 
-    for (int t = 0; t < thread_num_; t++) {
+    for (int t = 0; t < aicpu_thread_num_; t++) {
         int core_idx = 0;
 
-        // Assign AIC cores: cores at indices t, t+thread_num_, t+2*thread_num_, ...
-        for (int i = t; i < aic_count_; i += thread_num_) {
+        // Assign AIC cores: cores at indices t, t+aicpu_thread_num_, t+2*aicpu_thread_num_, ...
+        for (int i = t; i < aic_count_; i += aicpu_thread_num_) {
             core_assignments_[t][core_idx++] = aic_cores_[i].worker_id;
         }
 
         // Assign AIV cores after AIC cores
-        for (int i = t; i < aiv_count_; i += thread_num_) {
+        for (int i = t; i < aiv_count_; i += aicpu_thread_num_) {
             core_assignments_[t][core_idx++] = aiv_cores_[i].worker_id;
         }
 
@@ -520,14 +520,14 @@ void AicpuExecutor::assign_cores_to_threads() {
             log_buffer + offset, sizeof(log_buffer) - offset, "Thread %d: assigned %d cores - AIC[", t, core_idx
         );
 
-        for (int k = 0, i = t; i < aic_count_; i += thread_num_, k++) {
+        for (int k = 0, i = t; i < aic_count_; i += aicpu_thread_num_, k++) {
             if (k > 0) offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, ",");
             offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, "%d", aic_cores_[i].worker_id);
         }
 
         offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, "] AIV[");
 
-        for (int k = 0, i = t; i < aiv_count_; i += thread_num_, k++) {
+        for (int k = 0, i = t; i < aiv_count_; i += aicpu_thread_num_, k++) {
             if (k > 0) offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, ",");
             offset += snprintf(log_buffer + offset, sizeof(log_buffer) - offset, "%d", aiv_cores_[i].worker_id);
         }
@@ -590,7 +590,7 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
             shared_count++;
         }
 
-        next_thread_idx = (thread_idx + 1) % thread_num_;
+        next_thread_idx = (thread_idx + 1) % aicpu_thread_num_;
     };
 
     int task_count = runtime->get_task_count();
@@ -624,7 +624,7 @@ void AicpuExecutor::classify_and_distribute_initial_tasks(Runtime *runtime) {
         initial_aiv_count - aiv_shared_count, aiv_shared_count
     );
 
-    for (int t = 0; t < thread_num_; t++) {
+    for (int t = 0; t < aicpu_thread_num_; t++) {
         int aic_size =
             (cur_ready_queue_aic_tail_[t] - cur_ready_queue_aic_head_[t] + MAX_CORES_PER_THREAD) % MAX_CORES_PER_THREAD;
         int aiv_size =
@@ -1114,7 +1114,7 @@ int AicpuExecutor::run(Runtime *runtime) {
     LOG_INFO_V0("Thread %d: Completed", thread_idx);
 
     int prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
-    if (prev_finished + 1 == thread_num_) {
+    if (prev_finished + 1 == aicpu_thread_num_) {
         finished_.store(true, std::memory_order_release);
         LOG_INFO_V0("Thread %d: Last thread, marking executor finished", thread_idx);
     }
@@ -1172,7 +1172,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
-    thread_num_ = 0;
+    aicpu_thread_num_ = 0;
     aic_per_thread_ = 0;
     aiv_per_thread_ = 0;
     memset(core_assignments_, 0, sizeof(core_assignments_));

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -44,7 +44,7 @@ Runtime::Runtime() {
     next_task_id = 0;
     initial_ready_count = 0;
     worker_count = 0;
-    sche_cpu_num = 1;
+    aicpu_thread_num = 1;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;
     tensor_allocation_storage_ = nullptr;

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -214,8 +214,10 @@ public:
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
-    // Execution parameters for AICPU scheduling
-    int sche_cpu_num;  // Number of AICPU threads for scheduling
+    // Total AICPU threads launched on this run. host_build_graph has no
+    // orchestrator/scheduler split — every thread dispatches tasks in
+    // round-robin across the assigned cores. See AicpuExecutor::init.
+    int aicpu_thread_num;
 
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -118,7 +118,7 @@ struct AicpuExecutor {
     std::atomic<bool> init_failed_{false};
     std::atomic<bool> finished_{false};
 
-    int32_t thread_num_{0};
+    int32_t aicpu_thread_num_{0};
 
     // ===== Task queue state (managed by scheduler ready queues) =====
 
@@ -178,19 +178,21 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
         return -1;
     }
 
-    // Read execution parameters from runtime
-    thread_num_ = runtime->sche_cpu_num;
-    sched_thread_num_ = thread_num_ - 1;
+    // Read execution parameters from runtime. The 0 → 1 fixup runs before the
+    // sched_thread_num_ derivation so a zero input doesn't leave the scheduler
+    // count at -1.
+    aicpu_thread_num_ = runtime->aicpu_thread_num;
+    if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
+    sched_thread_num_ = aicpu_thread_num_ - 1;
     orch_to_sched_ = runtime->orch_to_sched;
-    if (thread_num_ == 0) thread_num_ = 1;
 
-    if (thread_num_ < 1 || thread_num_ > MAX_AICPU_THREADS) {
-        LOG_ERROR("Invalid thread_num: %d", thread_num_);
+    if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
+        LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
 
-    if (sched_ctx_.init(runtime, thread_num_, sched_thread_num_, orch_to_sched_, get_platform_regs()) != 0) {
+    if (sched_ctx_.init(runtime, aicpu_thread_num_, sched_thread_num_, orch_to_sched_, get_platform_regs()) != 0) {
         init_failed_.store(true, std::memory_order_release);
         return -1;
     }
@@ -659,7 +661,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
     // Check if this is the last thread to finish
     int32_t prev_finished = finished_count_.fetch_add(1, std::memory_order_acq_rel);
-    if (prev_finished + 1 == thread_num_) {
+    if (prev_finished + 1 == aicpu_thread_num_) {
         finished_.store(true, std::memory_order_release);
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
@@ -694,7 +696,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     finished_count_.store(0, std::memory_order_release);
     runtime_init_ready_.store(false, std::memory_order_release);
 
-    thread_num_ = 0;
+    aicpu_thread_num_ = 0;
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -544,7 +544,7 @@ Public surface (called from `AicpuExecutor::init/run/deinit`):
 
 | Method | Phase | Purpose |
 | ------ | ----- | ------- |
-| `init(runtime, thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
+| `init(runtime, aicpu_thread_num, sched_thread_num, orch_to_sched, regs_base)` | once per run | Handshake + assign cores, reset counters, latch `regs_base`, bind `func_id_to_addr_` |
 | `bind_runtime(rt)` | device-orch only | Wire `sched_` to `rt->scheduler` once the orchestrator thread creates `rt` |
 | `resolve_and_dispatch(runtime, thread_idx)` | per scheduler thread | Main dispatch loop |
 | `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores |

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -15,7 +15,7 @@
  * protocol. Task graph construction is handled by PTO2Runtime; this class
  * only handles:
  * - Handshake buffers for AICPU-AICore communication
- * - Execution parameters (block_dim, sche_cpu_num)
+ * - Execution parameters (block_dim, aicpu_thread_num)
  * - Tensor pair management for host-device memory tracking
  * - Device orchestration state (gm_sm_ptr_, orch_args_)
  * - Function address mapping (func_id_to_addr_)
@@ -183,8 +183,14 @@ public:
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
-    // Execution parameters for AICPU scheduling
-    int sche_cpu_num;        // Number of AICPU threads for scheduling
+    // Execution parameters for AICPU scheduling.
+    //
+    // aicpu_thread_num is the *total* AICPU thread count launched on this run
+    // (= orch + schedulers). AicpuExecutor splits this into one orchestrator
+    // thread (highest idx, runs aicpu_orchestration_entry) and the remaining
+    // aicpu_thread_num-1 scheduler threads that dispatch tasks to AICore.
+    // The orch thread also dispatches when env PTO2_ORCH_TO_SCHED is set.
+    int aicpu_thread_num;
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
     // Ring buffer size overrides (0 = use compile-time defaults)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -202,7 +202,7 @@ void format_core_status(
 }  // namespace
 
 int32_t SchedulerContext::find_core_owner_thread(int32_t core_id) const {
-    for (int32_t t = 0; t < thread_num_; t++) {
+    for (int32_t t = 0; t < aicpu_thread_num_; t++) {
         const int32_t *ids = core_trackers_[t].core_ids();
         int32_t n = core_trackers_[t].core_num();
         for (int32_t i = 0; i < n; i++) {
@@ -298,7 +298,7 @@ void SchedulerContext::log_stall_diagnostics(
     // CLUSTER lines: one per cluster this thread owns.
     // cluster_id = local_cluster_idx * active_sched_threads_ + thread_idx, matching the
     // round-robin assignment in assign_cores_to_threads / reassign_cores_for_all_threads.
-    int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : thread_num_;
+    int32_t ast = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
     for (int32_t cli = 0; cli < tracker.get_cluster_count() && cli < STALL_DUMP_CORE_MAX; cli++) {
         int32_t offset = cli * 3;
         int32_t aic_id = tracker.get_aic_core_id(offset);
@@ -638,7 +638,7 @@ int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
 bool SchedulerContext::assign_cores_to_threads() {
     // Cluster-aligned round-robin assignment: cluster ci -> sched thread ci % active_sched_threads_.
     // Each cluster = 1 AIC + 2 adjacent AIV; the triple is always kept together.
-    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : thread_num_;
+    active_sched_threads_ = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
     int32_t cluster_count = aic_count_;
 
     // Max clusters any single sched thread can hold: ceil(cluster_count / active_sched_threads_).
@@ -683,14 +683,16 @@ bool SchedulerContext::assign_cores_to_threads() {
         LOG_INFO_V0("Thread %d: cluster %d (AIC=%d, AIV0=%d, AIV1=%d)", t, ci, aic_wid, aiv0_wid, aiv1_wid);
     }
 
-    for (int32_t t = 0; t < thread_num_; t++) {
+    for (int32_t t = 0; t < aicpu_thread_num_; t++) {
         LOG_INFO_V0(
             "Thread %d: total %d cores (%d clusters)", t, core_trackers_[t].core_num(),
             core_trackers_[t].get_cluster_count()
         );
     }
 
-    LOG_INFO_V0("Config: threads=%d, cores=%d, cores_per_thread=%d", thread_num_, cores_total_num_, thread_cores_num);
+    LOG_INFO_V0(
+        "Config: threads=%d, cores=%d, cores_per_thread=%d", aicpu_thread_num_, cores_total_num_, thread_cores_num
+    );
     return true;
 }
 
@@ -699,12 +701,12 @@ bool SchedulerContext::assign_cores_to_threads() {
 // =============================================================================
 void SchedulerContext::reassign_cores_for_all_threads() {
     LOG_INFO_V0(
-        "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", thread_num_, aic_count_, aiv_count_
+        "Reassigning cores (cluster-aligned) for %d threads: %d AIC, %d AIV", aicpu_thread_num_, aic_count_, aiv_count_
     );
 
     // Collect running worker_ids from all current trackers
     bool running_cores[RUNTIME_MAX_WORKER] = {};
-    for (int32_t i = 0; i < thread_num_; i++) {
+    for (int32_t i = 0; i < aicpu_thread_num_; i++) {
         auto all_running = core_trackers_[i].get_all_running_cores();
         int32_t bp;
         while ((bp = all_running.pop_first()) >= 0) {
@@ -716,18 +718,18 @@ void SchedulerContext::reassign_cores_for_all_threads() {
     int32_t cluster_count = aic_count_;
     int32_t clusters_per_thread[MAX_AICPU_THREADS] = {};
     for (int32_t ci = 0; ci < cluster_count; ci++) {
-        clusters_per_thread[ci % thread_num_]++;
+        clusters_per_thread[ci % aicpu_thread_num_]++;
     }
 
     // Re-init all trackers and reset core counts
-    for (int32_t i = 0; i < thread_num_; i++) {
+    for (int32_t i = 0; i < aicpu_thread_num_; i++) {
         core_trackers_[i].init(clusters_per_thread[i]);
     }
 
     // Assign clusters round-robin and restore running state
     int32_t cluster_idx_per_thread[MAX_AICPU_THREADS] = {};
     for (int32_t ci = 0; ci < cluster_count; ci++) {
-        int32_t t = ci % thread_num_;
+        int32_t t = ci % aicpu_thread_num_;
 
         int32_t aic_wid = aic_worker_ids_[ci];
         int32_t aiv0_wid = aiv_worker_ids_[2 * ci];
@@ -753,7 +755,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 
     // Log final distribution
     LOG_INFO_V0("Core reassignment complete:");
-    for (int32_t t = 0; t < thread_num_; t++) {
+    for (int32_t t = 0; t < aicpu_thread_num_; t++) {
         int32_t aic_running = core_trackers_[t].get_running_count<CoreType::AIC>();
         int32_t aiv_running = core_trackers_[t].get_running_count<CoreType::AIV>();
         LOG_INFO_V0(
@@ -761,7 +763,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
             core_trackers_[t].get_cluster_count(), aic_running, aiv_running
         );
     }
-    active_sched_threads_ = thread_num_;
+    active_sched_threads_ = aicpu_thread_num_;
 }
 
 // =============================================================================
@@ -792,7 +794,7 @@ void SchedulerContext::emergency_shutdown(Runtime *runtime) {
 // Lifecycle: init / deinit
 // =============================================================================
 int32_t SchedulerContext::init(
-    Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base
+    Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base
 ) {
     always_assert(runtime != nullptr);
 
@@ -800,7 +802,7 @@ int32_t SchedulerContext::init(
     memset(core_exec_states_, 0, sizeof(core_exec_states_));
 
     // Wire thread/transition configuration that handshake/assign need to read.
-    thread_num_ = thread_num;
+    aicpu_thread_num_ = aicpu_thread_num;
     sched_thread_num_ = sched_thread_num;
     orch_to_sched_ = orch_to_sched;
     regs_ = regs_base;
@@ -891,7 +893,7 @@ void SchedulerContext::deinit() {
     aic_count_ = 0;
     aiv_count_ = 0;
     cores_total_num_ = 0;
-    thread_num_ = 0;
+    aicpu_thread_num_ = 0;
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
     active_sched_threads_ = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -59,7 +59,7 @@ public:
     // - Captures AICore-register base (consumed by handshake_all_cores())
     // Returns 0 on success, negative on failure (handshake / assignment error).
     int32_t
-    init(Runtime *runtime, int32_t thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base);
+    init(Runtime *runtime, int32_t aicpu_thread_num, int32_t sched_thread_num, bool orch_to_sched, uint64_t regs_base);
 
     // Reset all SchedulerContext-owned state to its post-construction defaults.
     // Called by AicpuExecutor::deinit() during per-run teardown.
@@ -154,7 +154,7 @@ private:
     int32_t active_sched_threads_{0};
     int32_t sched_thread_num_{0};
     bool orch_to_sched_{false};
-    int32_t thread_num_{0};
+    int32_t aicpu_thread_num_{0};
     int32_t cores_total_num_{0};
 
     // Cluster-ordered worker_id lists, populated by handshake_all_cores().

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -369,7 +369,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 #endif
 #if PTO2_PROFILING
         if (is_dump_tensor_enabled()) {
-            dump_tensor_init(orch_to_sched_ ? thread_num_ : sched_thread_num_);
+            dump_tensor_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
         }
         if (is_pmu_enabled()) {
             pmu_aicpu_init(physical_core_ids_, cores_total_num_);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -32,7 +32,7 @@ Runtime::Runtime() {
     // Initialize handshake buffers
     memset(workers, 0, sizeof(workers));
     worker_count = 0;
-    sche_cpu_num = 1;
+    aicpu_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
     task_window_size = 0;
     heap_size = 0;


### PR DESCRIPTION
## Summary
Pure rename, no behavior change. \`Runtime::sche_cpu_num\` was a legacy misnomer — the name implied "scheduler thread count" but the value was always the **total** AICPU thread count (orch + schedulers). The orch/sched split lived in \`AicpuExecutor::init\` as \`sched_thread_num_ = thread_num_ - 1\`, with the \`-1\` carving out the orchestrator thread. The runtime field name lied; the local \`-1\` did the bookkeeping the rename never did.

## Renames
- \`Runtime::sche_cpu_num\` → \`Runtime::aicpu_thread_num\` (matches the user-facing \`CallConfig::aicpu_thread_num\` field — same name end-to-end)
- \`AicpuExecutor::thread_num_\` → \`AicpuExecutor::aicpu_thread_num_\`
- \`SchedulerContext::thread_num_\` → \`SchedulerContext::aicpu_thread_num_\` (and the \`init()\` parameter)
- \`LOG_ERROR("Invalid thread_num:")\` → \`("Invalid aicpu_thread_num:")\`
- Field doc-comment expanded to describe the orch/sched split (trb) or the no-split round-robin (hbg)

\`sched_thread_num_\` (the member holding \`aicpu_thread_num_ - 1\`) **keeps its name** — it accurately means "scheduler subset," and renaming it would only confuse the contrast with the new total field.

## Drive-by
Two \`platform_aicpu_affinity.h\` files were missing the standard copyright header — surfaced by \`check-headers\` because the comment inside them was touched. Added the standard header to both (pre-existing omission, but no-skip rule applies).

## Why
After [PR #850](https://github.com/hw-native-sys/simpler/pull/850), the user-facing field is \`CallConfig::aicpu_thread_num\` (clear: total) but it landed in \`Runtime::sche_cpu_num\` (confusing: implies scheduler-only). Reading \`aicpu_executor.cpp:182-183\` you have to figure out from context that \`sche_cpu_num\` means "total" — only the \`-1\` on the next line tells you. After this rename the same lines read:
\`\`\`cpp
aicpu_thread_num_ = runtime->aicpu_thread_num;
sched_thread_num_ = aicpu_thread_num_ - 1;  // -1 because the last thread is the orchestrator
\`\`\`
Self-documenting.

## Blast radius
28 files, 164/+122/− across \`a5\` + \`a2a3\` × \`tensormap_and_ringbuffer\` + \`host_build_graph\`. ChipWorker dlsym ABI is unchanged (the field rename is internal to the host/runtime contract; no exported symbol changed).

## Test plan
- [x] Local sim build (\`pip install --no-build-isolation -e .\`) clean
- [x] \`tests/ut/py/test_chip_worker.py\` passes (14 tests)
- [x] \`tests/st/a5/.../spmd_basic\` passes on sim (covers both Case1 with explicit block_dim and Case2_AutoBlockDim via the new path)
- [x] All pre-commit hooks (clang-format, clang-tidy, cpplint, pyright, etc.) clean
- [ ] Onboard CI (st-onboard-a5 + st-onboard-a2a3) — needs CI run