### PR TITLE
Refactor: separate orch phase-stats and swim-lane gating

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -93,19 +93,30 @@ uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
 uint64_t g_orch_args_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
-#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
+// Cycle accumulation is unconditional under PTO2_ORCH_PROFILING (that's what
+// the flag is for). Swim-lane recording is an opt-in add-on gated at runtime
+// by l2_perf_level so callers can collect totals without paying GM-store cost.
+// When the swim-lane write fires, _t0 is re-sampled from the counter *after*
+// the write so its cost is not attributed to the next phase's accumulator.
+#define CYCLE_COUNT_START()                                                \
+    bool _prof_active = (orch->l2_perf_level >= L2PerfLevel::ORCH_PHASES); \
+    uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc)       \
     do {                           \
         _t1 = get_sys_cnt_aicpu(); \
         acc += (_t1 - _t0);        \
         _t0 = _t1;                 \
     } while (0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                       \
-    do {                                                                                 \
-        _t1 = get_sys_cnt_aicpu();                                                       \
-        acc += (_t1 - _t0);                                                              \
-        l2_perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
-        _t0 = _t1;                                                                       \
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                           \
+    do {                                                                                     \
+        _t1 = get_sys_cnt_aicpu();                                                           \
+        acc += (_t1 - _t0);                                                                  \
+        if (_prof_active) {                                                                  \
+            l2_perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
+            _t0 = get_sys_cnt_aicpu();                                                       \
+        } else {                                                                             \
+            _t0 = _t1;                                                                       \
+        }                                                                                    \
     } while (0)
 #elif PTO2_PROFILING
 #include "aicpu/device_time.h"

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -72,19 +72,30 @@ uint64_t g_orch_fanin_wait_cycle = 0;
 uint64_t g_orch_alloc_atomic_count = 0;
 uint64_t g_orch_args_atomic_count = 0;
 uint64_t g_orch_scope_end_atomic_count = 0;
-#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
+// Cycle accumulation is unconditional under PTO2_ORCH_PROFILING (that's what
+// the flag is for). Swim-lane recording is an opt-in add-on gated at runtime
+// by l2_perf_level so callers can collect totals without paying GM-store cost.
+// When the swim-lane write fires, _t0 is re-sampled from the counter *after*
+// the write so its cost is not attributed to the next phase's accumulator.
+#define CYCLE_COUNT_START()                                                \
+    bool _prof_active = (orch->l2_perf_level >= L2PerfLevel::ORCH_PHASES); \
+    uint64_t _t0 = get_sys_cnt_aicpu(), _t1
 #define CYCLE_COUNT_LAP(acc)       \
     do {                           \
         _t1 = get_sys_cnt_aicpu(); \
         acc += (_t1 - _t0);        \
         _t0 = _t1;                 \
     } while (0)
-#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                       \
-    do {                                                                                 \
-        _t1 = get_sys_cnt_aicpu();                                                       \
-        acc += (_t1 - _t0);                                                              \
-        l2_perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
-        _t0 = _t1;                                                                       \
+#define CYCLE_COUNT_LAP_RECORD(acc, phase_id, tid)                                           \
+    do {                                                                                     \
+        _t1 = get_sys_cnt_aicpu();                                                           \
+        acc += (_t1 - _t0);                                                                  \
+        if (_prof_active) {                                                                  \
+            l2_perf_aicpu_record_orch_phase((phase_id), _t0, _t1, g_orch_submit_idx, (tid)); \
+            _t0 = get_sys_cnt_aicpu();                                                       \
+        } else {                                                                             \
+            _t0 = _t1;                                                                       \
+        }                                                                                    \
     } while (0)
 #elif PTO2_PROFILING
 #include "aicpu/device_time.h"


### PR DESCRIPTION
## Summary

Split the two profiling concerns in the `PTO2_ORCH_PROFILING` branch of
`CYCLE_COUNT_LAP_RECORD` so each is gated independently:

- **Phase-statistics accumulation** (`acc += _t1 - _t0`) — gated only by
  `PTO2_ORCH_PROFILING` at **compile time**, unconditional at runtime.
- **Swim-lane GM writes** — gated only by `orch->l2_perf_level >=
  L2PerfLevel::ORCH_PHASES` at **runtime**, mirroring the
  `PTO2_PROFILING` branch and the matching reads in
  `l2_perf_collector.cpp` / `aicpu_executor.cpp`.

## Why

Previously the `PTO2_ORCH_PROFILING` branch bundled cycle accumulation
and swim-lane writes behind a single compile-time gate, with two
consequences:

1. Callers could not get phase totals without paying GM-store cost on
   every phase boundary.
2. The swim-lane write happened *between* the `_t1` capture and the
   `_t0` reassignment, so its cost leaked into the **next** phase's
   accumulator and distorted the totals the flag exists to measure.

After this change the swim-lane write is followed by a fresh
`get_sys_cnt_aicpu()` for `_t0`, so its GM-store cost is excluded from
the next phase's accumulator.

Mirrored across `a2a3` and `a5` orchestrator implementations.

## Testing

- [ ] Default sim build (compile-time gate stays off — no behavior change)
- [ ] `PTO2_ORCH_PROFILING=1` build on hardware: phase totals stable
      across runs regardless of `--enable-l2-swimlane` level
- [ ] `--enable-l2-swimlane 4` with `PTO2_ORCH_PROFILING=1`: swim-lane
      records present, totals not inflated by GM-store cost