### PR TITLE
Add: dep_gen overflow chain — capture submits with arbitrary explicit dep count

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -296,11 +296,49 @@ dependencies).
 
 ---
 
-## 7. Architecture Touchpoints
+## 7. Big-Fanin Submits: Overflow Chain
+
+A `DepGenRecord` carries up to **64** explicit_deps inline. Submits with
+more than 64 explicit deps spill into a chain of `DepGenOverflowRecord`
+slots that overlay normal record slots in the buffer.
+
+| Submit `explicit_dep_count` | Chain shape | Per-submit slots used |
+| --------------------------- | ----------- | --------------------- |
+| `0 ≤ dc ≤ 64` | base only — fast path, no chain bookkeeping | 1 |
+| `65 ≤ dc ≤ 390` | base (64 deps) + 1 overflow (up to 326 deps) | 2 |
+| `391 ≤ dc ≤ 716` | base + 2 overflow | 3 |
+| general | base + `⌈(dc − 64) / 326⌉` overflow | `1 + ⌈(dc − 64) / 326⌉` |
+
+**Wire format.** An overflow record reinterprets the same 2624-byte slot
+as `{ task_id (8) + flags (4) + dep_count (2) + _reserved (2) + deps[326] }` —
+no tensor blobs (those live on the base record). Replay distinguishes
+the two views by `flags & DEP_GEN_FLAG_OVERFLOW`. Chain records always
+share the base's `task_id`, and the last one sets
+`DEP_GEN_FLAG_LAST_OVERFLOW` so replay knows the chain is complete
+without peeking ahead.
+
+**Atomicity.** The AICPU writer reserves *all* chain slots up front: if
+the current buffer can't hold the full chain, it switches buffer first.
+`buf->count` is published with a single store at the end, so the host
+either sees the old count (chain invisible) or the new count with the
+full chain committed. Chain records are therefore always contiguous
+within one buffer — replay scans linearly and ties them back to the
+base via `task_id`.
+
+**Truncation tail.** A submit whose chain exceeds the buffer's slot
+budget (`PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32` slots → roughly
+`64 + 31 × 326 = 10170` deps max in the best case) is logged via
+`LOG_ERROR` and truncated to the largest dc that fits. Runtime
+correctness is unaffected — `Arg::set_dependencies` keeps the full dep
+list; only the dep_gen replay graph loses the tail.
+
+---
+
+## 8. Architecture Touchpoints
 
 | Layer | File | Role |
 | ----- | ---- | ---- |
-| Shared-mem layout | `src/a2a3/platform/include/common/dep_gen.h` | `DepGenRecord` (2240 B, cache-line aligned) + SPSC ring + per-thread ready queue |
+| Shared-mem layout | `src/a2a3/platform/include/common/dep_gen.h` | `DepGenRecord` (2624 B base, cache-line aligned, ≤64 inline explicit_deps) + `DepGenOverflowRecord` chain view (≤326 deps per slot) + SPSC ring + per-thread ready queue |
 | AICPU writer | `src/a2a3/platform/{include,src}/aicpu/dep_gen_collector_aicpu.{h,cpp}` | Single-instance write path; weak-fallback exported to host build |
 | Host collector | `src/a2a3/platform/{include/host,src/host}/dep_gen_collector.{h,cpp}` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector |
 | Capture call site | `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. Dep-only tasks land in the record stream with valid tensor/dep info but no kernel_id field (the schema does not carry kernel_id), so replay treats them as ordinary dep nodes — viewers do not currently distinguish dummy from real tasks. |

--- a/simpler_setup/tools/deps_to_graph.py
+++ b/simpler_setup/tools/deps_to_graph.py
@@ -536,6 +536,15 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
     lines = [
         "digraph deps {",
         f"  rankdir={direction};",
+        # `concentrate=true` merges shared edge prefixes through virtual
+        # nodes. Without it, deep DAGs with heavy fan-in (e.g. dep_gen
+        # capture of a >300-wide barrier reached through a tensormap
+        # producer chain) explode the dot position-assignment pass into
+        # ~N²/2 internal virtual nodes and SIGSEGV graphviz. With it,
+        # parallel edges collapse and the layout completes; rank ordering
+        # (the LR DAG shape) is unaffected — only the visual edge routing
+        # is denser.
+        "  concentrate=true;",
         '  node [fontname="Helvetica", fontsize=10];',
         '  edge [color="#888"];',
     ]

--- a/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -73,9 +73,10 @@ void dep_gen_aicpu_set_orch_thread_idx(int thread_idx);
 void dep_gen_aicpu_init();
 
 /**
- * Append one DepGenRecord for a completed submit_task call. Switches buffer
- * via the SPSC free_queue / ready_queue protocol when the current buffer is
- * full. No-op if dep_gen is disabled.
+ * Append a base DepGenRecord (and zero or more DepGenOverflowRecord chain
+ * records) for a completed submit_task call. Switches buffer via the SPSC
+ * free_queue / ready_queue protocol when the current buffer cannot hold the
+ * full chain. No-op if dep_gen is disabled.
  *
  * Tensor handling: for slot i, if tensor_ptrs[i] is non-null, its first
  * DEP_GEN_TENSOR_SIZE bytes are memcpy'd into record.tensors[i]. If null
@@ -83,13 +84,19 @@ void dep_gen_aicpu_init();
  * the runtime), the slot is left zeroed. Replay decides what to do with
  * each slot based on arg_types[i].
  *
+ * Dep handling: the first DEP_GEN_MAX_EXPLICIT_DEPS deps land in the base
+ * record; any excess spills into a chain of DepGenOverflowRecord slots. A
+ * submit whose chain would exceed the buffer's remaining capacity (even
+ * after switch) is truncated to fit; the dropped tail is logged.
+ *
  * @param task_id_raw         PTO2TaskId::raw (the assigned task_id for this submit)
  * @param in_manual_scope     true iff the submit happened inside a manual scope
  * @param tensor_count        Number of slots in tensor_ptrs / arg_types (≤ CORE_MAX_TENSOR_ARGS)
  * @param tensor_ptrs         Per-slot Tensor pointer (nullptr to skip the slot)
  * @param arg_types           Per-slot TensorArgType (interpreted as raw byte)
- * @param explicit_dep_count  Number of explicit_deps (≤ DEP_GEN_MAX_EXPLICIT_DEPS)
- * @param explicit_deps_raw   Per-dep PTO2TaskId::raw
+ * @param explicit_dep_count  Number of explicit_deps — no static cap; truncated only when the
+ *                            chain would not fit in a single DepGenBuffer
+ * @param explicit_deps_raw   Per-dep PTO2TaskId::raw (length = explicit_dep_count)
  */
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,

--- a/src/a2a3/platform/include/common/dep_gen.h
+++ b/src/a2a3/platform/include/common/dep_gen.h
@@ -59,22 +59,32 @@
 constexpr int DEP_GEN_TENSOR_SIZE = 128;
 
 /**
- * Max explicit_dep entries captured per submit by dep_gen replay. This is a
- * diagnostic-side cap only — the runtime's Arg::set_dependencies has no hard
- * limit on dep count. Submits exceeding this cap are logged and truncated by
+ * Max explicit_dep entries captured directly in a base DepGenRecord. Larger
+ * submits spill into a chain of DepGenOverflowRecord entries (same slot size,
+ * reinterpreted via DEP_GEN_FLAG_OVERFLOW) — see dep_gen_records_needed_for().
+ *
+ * This is a diagnostic-side capacity only — the runtime's Arg::set_dependencies
+ * has no hard limit on dep count. Submits whose chain would exceed the host
+ * buffer's record budget are logged and truncated by
  * dep_gen_aicpu_record_submit(); runtime correctness is unaffected.
  */
-constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 16;
+constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 64;
 
 // =============================================================================
 // DepGenRecord — one captured submit_task call
 // =============================================================================
 
 /**
- * Bitmask flags for DepGenRecord.flags.
+ * Bitmask flags for DepGenRecord.flags / DepGenOverflowRecord.flags.
+ *
+ * IN_MANUAL_SCOPE is the only flag the host capture path cares about; the
+ * overflow flags are wire-format markers consumed only by the replay scan.
  */
 enum DepGenRecordFlags : uint32_t {
     DEP_GEN_FLAG_IN_MANUAL_SCOPE = 1u << 0,  // submit happened inside a manual scope
+    DEP_GEN_FLAG_HAS_OVERFLOW = 1u << 1,     // base record: at least one overflow record follows
+    DEP_GEN_FLAG_OVERFLOW = 1u << 2,         // this slot is a DepGenOverflowRecord, not a DepGenRecord
+    DEP_GEN_FLAG_LAST_OVERFLOW = 1u << 3,    // overflow record: end of chain (no further overflow follows)
 };
 
 /**
@@ -84,9 +94,9 @@ enum DepGenRecordFlags : uint32_t {
  *   - task_id, flags, counts, explicit_deps, arg_types in the first cache lines
  *   - tensors[] (16 × 128 B opaque blobs) at the tail; covers ~64% of the entry
  *
- * Total size: 8 + 4 + 4 + 16*8 + 16 + 32 (pad) + 16*128 = 2240 bytes.
- * Aligned to 64 B → 2240 B (already a multiple of 64). The 32-byte _pad0
- * pushes the tensors[] array to offset 192 = 3 * 64 so each 128-byte tensor
+ * Total size: 8 + 4 + 4 + 64*8 + 16 + 32 (pad) + 16*128 = 2624 bytes.
+ * Aligned to 64 B → 2624 B (already a multiple of 64). The 32-byte _pad0
+ * pushes the tensors[] array to offset 576 = 9 * 64 so each 128-byte tensor
  * blob covers exactly two cache lines instead of straddling three.
  */
 struct DepGenRecord {
@@ -96,12 +106,72 @@ struct DepGenRecord {
     uint16_t explicit_dep_count;                                 // number of valid explicit_dep slots
     uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];           // PTO2TaskId::raw, length = explicit_dep_count
     uint8_t arg_types[CORE_MAX_TENSOR_ARGS];                     // TensorArgType, length = tensor_count
-    uint8_t _pad0[32];                                           // align tensors[] to 64 B (offset 192)
+    uint8_t _pad0[32];                                           // align tensors[] to 64 B (offset 576)
     uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
 } __attribute__((aligned(64)));
 
+static_assert(sizeof(DepGenRecord) == 2624, "DepGenRecord size changed — update header comment + docs/dfx/dep_gen.md");
 static_assert(sizeof(DepGenRecord) % 64 == 0, "DepGenRecord must be cache-line aligned");
 static_assert(offsetof(DepGenRecord, tensors) % 64 == 0, "DepGenRecord::tensors[] must start on a cache-line boundary");
+static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors offset changed — update header comment");
+
+// =============================================================================
+// DepGenOverflowRecord — chain extension for submits with >DEP_GEN_MAX_EXPLICIT_DEPS deps
+// =============================================================================
+
+/**
+ * Number of deps carried by a single overflow record. Sized so a
+ * DepGenOverflowRecord exactly overlays a DepGenRecord slot in the buffer.
+ *
+ * Layout: 16-byte header (task_id + flags + dep_count + _reserved) + deps[].
+ * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 326 entries.
+ */
+constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 326;
+
+/**
+ * Reinterpret-view of a DepGenRecord slot when flags & DEP_GEN_FLAG_OVERFLOW.
+ *
+ * A submit with explicit_dep_count > DEP_GEN_MAX_EXPLICIT_DEPS is encoded as:
+ *   - One base DepGenRecord (carries first DEP_GEN_MAX_EXPLICIT_DEPS deps +
+ *     tensor info; flags |= HAS_OVERFLOW).
+ *   - One or more DepGenOverflowRecord (each carries up to
+ *     DEP_GEN_OVERFLOW_DEPS_PER_RECORD additional deps).
+ *   - The last overflow record carries flags |= LAST_OVERFLOW so replay knows
+ *     the chain is complete without peeking at the next slot.
+ *
+ * Chain records are guaranteed contiguous within the same DepGenBuffer:
+ * dep_gen_aicpu_record_submit() switches buffer up front if the full chain
+ * would not fit. Replay reads them by linear scan; same task_id ties them
+ * back to the preceding base.
+ */
+struct DepGenOverflowRecord {
+    uint64_t task_id;    // mirrors base record's task_id for chain join
+    uint32_t flags;      // DEP_GEN_FLAG_OVERFLOW [| DEP_GEN_FLAG_LAST_OVERFLOW]
+    uint16_t dep_count;  // number of valid entries in deps[]
+    uint16_t _reserved;
+    uint64_t deps[DEP_GEN_OVERFLOW_DEPS_PER_RECORD];  // PTO2TaskId::raw, length = dep_count
+} __attribute__((aligned(64)));
+
+static_assert(
+    sizeof(DepGenOverflowRecord) == sizeof(DepGenRecord), "DepGenOverflowRecord must overlay DepGenRecord exactly"
+);
+static_assert(
+    alignof(DepGenOverflowRecord) == alignof(DepGenRecord), "DepGenOverflowRecord alignment must match DepGenRecord"
+);
+
+/**
+ * Number of buffer slots (1 base + N overflow records) needed to capture a
+ * submit with `dc` explicit deps. Used by the writer to reserve the whole
+ * chain before writing any of it.
+ */
+inline int dep_gen_records_needed_for(int dc) {
+    if (dc <= DEP_GEN_MAX_EXPLICIT_DEPS) return 1;
+    // Use int64_t for the ceil-div so a pathologically large dc (close to
+    // INT_MAX, e.g. via a corrupted explicit_dep_count) cannot overflow
+    // `spill + DEP_GEN_OVERFLOW_DEPS_PER_RECORD - 1`.
+    int64_t spill = static_cast<int64_t>(dc) - DEP_GEN_MAX_EXPLICIT_DEPS;
+    return static_cast<int>(1 + (spill + DEP_GEN_OVERFLOW_DEPS_PER_RECORD - 1) / DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+}
 
 // =============================================================================
 // DepGenBuffer — fixed-capacity record container
@@ -153,18 +223,29 @@ static_assert(sizeof(DepGenFreeQueue) == 128, "DepGenFreeQueue must be 128 bytes
  * Per-instance state for dep_gen.
  *
  * Writers:
- *   free_queue.tail:        Host writes (pushes new/recycled buffers)
- *   free_queue.head:        Device writes (pops buffers)
- *   current_buf_ptr:        Device writes (after pop), Host reads
- *   current_buf_seq:        Device writes (monotonic counter)
- *   dropped_record_count:   Device writes — submits dropped because free_queue
- *                           was empty / ready_queue was full / no active buf
- *   total_record_count:     Device writes — monotonic count of every submit
- *                           the orchestrator attempted to record (success +
- *                           dropped)
+ *   free_queue.tail:               Host writes (pushes new/recycled buffers)
+ *   free_queue.head:               Device writes (pops buffers)
+ *   current_buf_ptr:               Device writes (after pop), Host reads
+ *   current_buf_seq:               Device writes (monotonic counter)
+ *   dropped_record_count:          Device writes — submits dropped because
+ *                                  free_queue was empty / ready_queue was full
+ *                                  / no active buf
+ *   total_record_count:            Device writes — monotonic count of every
+ *                                  submit the orchestrator attempted to record
+ *                                  (success + dropped). One increment per
+ *                                  submit_task regardless of chain length.
+ *   total_overflow_record_count:   Device writes — monotonic count of extra
+ *                                  DepGenOverflowRecord slots committed for
+ *                                  chained submits. Lets the host reconcile
+ *                                  physical records collected against logical
+ *                                  submits attempted (see formula below).
  *
- * Host reads dropped / total at finalize to cross-check:
- *   collected_on_host + sum(dropped) == sum(total)
+ * Host reconciliation invariant at finalize:
+ *   collected_on_host + sum(dropped) == sum(total) + sum(total_overflow)
+ *
+ * — `collected` counts physical buffer slots (base + every overflow), while
+ * `total` counts submits attempted. Without `total_overflow` the equation
+ * over-counts every chain on the LHS, which is why this counter is split out.
  */
 struct DepGenBufferState {
     DepGenFreeQueue free_queue;
@@ -172,7 +253,8 @@ struct DepGenBufferState {
     volatile uint32_t current_buf_seq;
     volatile uint32_t dropped_record_count;
     volatile uint32_t total_record_count;
-    uint32_t _pad[11];
+    volatile uint32_t total_overflow_record_count;
+    uint32_t _pad[10];
 } __attribute__((aligned(64)));
 
 static_assert(sizeof(DepGenBufferState) == 192, "DepGenBufferState must be 192 bytes");

--- a/src/a2a3/platform/src/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/a2a3/platform/src/aicpu/dep_gen_collector_aicpu.cpp
@@ -171,6 +171,11 @@ void dep_gen_aicpu_record_submit(
     // Account every attempted record so total == collected + dropped on host.
     s_dep_gen_state->total_record_count += 1;
 
+    int dc = explicit_dep_count;
+    if (dc < 0) dc = 0;
+    if (dc > 0 && explicit_deps_raw == nullptr) dc = 0;
+    int needed = dep_gen_records_needed_for(dc);
+
     rmb();
     uint64_t cur_ptr = s_dep_gen_state->current_buf_ptr;
     if (cur_ptr == 0) {
@@ -180,7 +185,21 @@ void dep_gen_aicpu_record_submit(
     }
     DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(cur_ptr);
 
-    if (buf->count >= static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
+    // Snapshot the count from volatile shared memory into a local so capacity
+    // math, base-record idx, and the final publish all use the same value.
+    // Single-writer ownership means a re-read would return the same value
+    // today, but a local snapshot makes the invariant explicit and is also
+    // a guardrail if a future device-side actor ever races count.
+    uint32_t local_count = buf->count;
+
+    // Reserve the whole chain up front. If it won't fit in the current
+    // buffer, switch first (skipping the switch when the current buffer is
+    // already empty — switching would just enqueue a zero-record buffer and
+    // pop a fresh one we'd truncate into anyway). Then, regardless of whether
+    // we switched, if the chain still won't fit (chain larger than the
+    // buffer), cap dc to what the buffer can hold and log truncation.
+    if (local_count > 0 &&
+        local_count + static_cast<uint32_t>(needed) > static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
         dep_gen_switch_buffer();
         rmb();
         cur_ptr = s_dep_gen_state->current_buf_ptr;
@@ -190,15 +209,30 @@ void dep_gen_aicpu_record_submit(
             return;
         }
         buf = reinterpret_cast<DepGenBuffer *>(cur_ptr);
+        local_count = buf->count;  // refresh after switch — new buffer starts at 0
     }
 
-    uint32_t idx = buf->count;
-    DepGenRecord *rec = &buf->records[idx];
-
-    rec->task_id = task_id_raw;
-    // Cast the enum to uint32_t before the ternary so Linux GCC's -Wextra
-    // does not warn about "enumerated and non-enumerated type in conditional".
-    rec->flags = in_manual_scope ? static_cast<uint32_t>(DEP_GEN_FLAG_IN_MANUAL_SCOPE) : 0u;
+    const int capacity = PLATFORM_DEP_GEN_RECORDS_PER_BUFFER - static_cast<int>(local_count);
+    if (capacity <= 0) {
+        // local_count is bounded by the previous writer's publish step, so
+        // this is only reachable if shared memory was corrupted out from
+        // under us. Drop the record and bail rather than write past the end
+        // of buf->records[].
+        LOG_ERROR("dep_gen: invalid capacity %d (local_count=%u), dropping record", capacity, local_count);
+        s_dep_gen_state->dropped_record_count += 1;
+        wmb();
+        return;
+    }
+    if (needed > capacity) {
+        // Compute the largest dc that fits in `capacity` slots.
+        int dc_fit = DEP_GEN_MAX_EXPLICIT_DEPS + (capacity - 1) * DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
+        LOG_ERROR(
+            "dep_gen: chain (%d records for %d deps) exceeds buffer capacity (%d slots), truncating to %d deps", needed,
+            dc, capacity, dc_fit
+        );
+        dc = dc_fit;
+        needed = dep_gen_records_needed_for(dc);
+    }
 
     int tc = tensor_count;
     if (tc < 0) {
@@ -209,22 +243,27 @@ void dep_gen_aicpu_record_submit(
         LOG_ERROR("dep_gen: tensor_count %d > CORE_MAX_TENSOR_ARGS (%d), truncating", tc, CORE_MAX_TENSOR_ARGS);
         tc = CORE_MAX_TENSOR_ARGS;
     }
+
+    // ---- Write base record ----
+    uint32_t idx = local_count;
+    DepGenRecord *rec = &buf->records[idx];
+
+    rec->task_id = task_id_raw;
+    // Cast the enum to uint32_t before the ternary so Linux GCC's -Wextra
+    // does not warn about "enumerated and non-enumerated type in conditional".
+    uint32_t base_flags = in_manual_scope ? static_cast<uint32_t>(DEP_GEN_FLAG_IN_MANUAL_SCOPE) : 0u;
+    if (needed > 1) {
+        base_flags |= static_cast<uint32_t>(DEP_GEN_FLAG_HAS_OVERFLOW);
+    }
+    rec->flags = base_flags;
     rec->tensor_count = static_cast<uint16_t>(tc);
 
-    int dc = explicit_dep_count;
-    if (dc < 0) {
-        dc = 0;
-    } else if (dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
-        LOG_ERROR(
-            "dep_gen: explicit_dep_count %d > DEP_GEN_MAX_EXPLICIT_DEPS (%d), truncating", dc, DEP_GEN_MAX_EXPLICIT_DEPS
-        );
-        dc = DEP_GEN_MAX_EXPLICIT_DEPS;
-    }
-    rec->explicit_dep_count = static_cast<uint16_t>(dc);
+    int base_dc = (dc < DEP_GEN_MAX_EXPLICIT_DEPS) ? dc : DEP_GEN_MAX_EXPLICIT_DEPS;
+    rec->explicit_dep_count = static_cast<uint16_t>(base_dc);
 
-    // explicit_deps (tail of the entry, packed; replay reads only the first dc entries)
-    if (dc > 0 && explicit_deps_raw != nullptr) {
-        memcpy(rec->explicit_deps, explicit_deps_raw, static_cast<size_t>(dc) * sizeof(uint64_t));
+    // explicit_deps (tail of the entry, packed; replay reads only the first base_dc entries)
+    if (base_dc > 0) {
+        memcpy(rec->explicit_deps, explicit_deps_raw, static_cast<size_t>(base_dc) * sizeof(uint64_t));
     }
 
     // arg_types
@@ -247,7 +286,39 @@ void dep_gen_aicpu_record_submit(
         }
     }
 
-    buf->count = idx + 1;
+    // ---- Write overflow chain ----
+    // Charge each overflow slot to total_overflow_record_count so the host's
+    // reconciliation equation (`collected + dropped == total + total_overflow`)
+    // accounts for chain expansion. total_record_count stays "one per submit"
+    // — see DepGenBufferState doc.
+    if (needed > 1) {
+        s_dep_gen_state->total_overflow_record_count += static_cast<uint32_t>(needed - 1);
+    }
+    int written = base_dc;
+    for (int slot = 1; slot < needed; slot++) {
+        auto *over = reinterpret_cast<DepGenOverflowRecord *>(&buf->records[idx + static_cast<uint32_t>(slot)]);
+        over->task_id = task_id_raw;
+        const int chunk =
+            ((dc - written) < DEP_GEN_OVERFLOW_DEPS_PER_RECORD) ? (dc - written) : DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
+        const bool is_last = (slot == needed - 1);
+        uint32_t over_flags = static_cast<uint32_t>(DEP_GEN_FLAG_OVERFLOW);
+        if (is_last) {
+            over_flags |= static_cast<uint32_t>(DEP_GEN_FLAG_LAST_OVERFLOW);
+        }
+        over->flags = over_flags;
+        over->dep_count = static_cast<uint16_t>(chunk);
+        over->_reserved = 0;
+        if (chunk > 0) {
+            memcpy(over->deps, explicit_deps_raw + written, static_cast<size_t>(chunk) * sizeof(uint64_t));
+        }
+        written += chunk;
+    }
+
+    // Publish all reserved slots atomically — host either sees the old count
+    // (chain invisible) or the new count with the full chain committed. The
+    // single trailing wmb() flushes both the record payloads and the count
+    // store, matching the pre-chain contract.
+    buf->count = idx + static_cast<uint32_t>(needed);
     wmb();
 }
 

--- a/src/a2a3/platform/src/host/dep_gen_collector.cpp
+++ b/src/a2a3/platform/src/host/dep_gen_collector.cpp
@@ -177,6 +177,7 @@ bool DepGenCollector::reconcile_counters() {
 
     uint64_t total_device = state->total_record_count;
     uint64_t dropped_device = state->dropped_record_count;
+    uint64_t overflow_device = state->total_overflow_record_count;
 
     if (dropped_device > 0) {
         LOG_WARN(
@@ -187,20 +188,23 @@ bool DepGenCollector::reconcile_counters() {
         );
         clean = false;
     }
-    if (total_collected_ + dropped_device != total_device) {
+    // collected counts physical buffer slots; total_device counts submits; the
+    // chain expands submits into multiple slots, so the overflow counter
+    // bridges the two.
+    if (total_collected_ + dropped_device != total_device + overflow_device) {
         LOG_WARN(
-            "dep_gen reconcile: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu, "
-            "silent_loss=%ld)",
+            "dep_gen reconcile: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu + "
+            "overflow=%lu, silent_loss=%ld)",
             static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
-            static_cast<unsigned long>(total_device),
-            static_cast<long>(total_device) - static_cast<long>(total_collected_ + dropped_device)
+            static_cast<unsigned long>(total_device), static_cast<unsigned long>(overflow_device),
+            static_cast<long>(total_device + overflow_device) - static_cast<long>(total_collected_ + dropped_device)
         );
         clean = false;
     } else {
         LOG_INFO_V0(
-            "dep_gen reconcile: counts match (collected=%lu, dropped=%lu, device_total=%lu)",
+            "dep_gen reconcile: counts match (collected=%lu, dropped=%lu, device_total=%lu, overflow=%lu)",
             static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
-            static_cast<unsigned long>(total_device)
+            static_cast<unsigned long>(total_device), static_cast<unsigned long>(overflow_device)
         );
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -98,6 +98,10 @@ int32_t count_outputs(const DepGenRecord *records, size_t n) {
     int32_t total = 0;
     for (size_t i = 0; i < n; i++) {
         const DepGenRecord &r = records[i];
+        // Overflow chain slots are reinterpret_cast views with no tensor data;
+        // their `tensor_count` bytes are actually the overflow `dep_count` field,
+        // which would mislead the loop below if read as a tensor count.
+        if (r.flags & DEP_GEN_FLAG_OVERFLOW) continue;
         for (uint16_t j = 0; j < r.tensor_count; j++) {
             auto t = static_cast<TensorArgType>(r.arg_types[j]);
             if (t == TensorArgType::INOUT || t == TensorArgType::OUTPUT_EXISTING) {
@@ -509,8 +513,18 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
     std::unordered_set<uint64_t> oracle_preds;
     std::unordered_set<uint64_t> annot_preds;
 
+    // Scratch buffer for assembling full dep lists across overflow chains.
+    // Declared outside the loop so it can be reused (clear() keeps capacity).
+    std::vector<uint64_t> full_deps_buf;
+
     for (size_t rec_i = 0; rec_i < num_records; rec_i++) {
         const DepGenRecord &rec = records[rec_i];
+
+        // Overflow chain records are consumed by the preceding base; skip
+        // them in the main scan so we don't double-process or read the
+        // overflow's reinterpreted bytes as tensor/dep info.
+        if (rec.flags & DEP_GEN_FLAG_OVERFLOW) continue;
+
         PTO2TaskId task_id{rec.task_id};
         bool in_manual_scope = (rec.flags & DEP_GEN_FLAG_IN_MANUAL_SCOPE) != 0;
 
@@ -526,9 +540,81 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
             atype_buf[i] = static_cast<TensorArgType>(rec.arg_types[i]);
         }
 
-        int32_t dc = static_cast<int32_t>(rec.explicit_dep_count);
-        if (dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
-            dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+        // Assemble the full dep list. Fast path: ≤ DEP_GEN_MAX_EXPLICIT_DEPS,
+        // no chain, point straight at rec.explicit_deps. Slow path: gather
+        // base + chain into full_deps_buf and point at the buffer.
+        //
+        // `explicit_dep_count` / `over->dep_count` originate from device
+        // shared memory and are bounded by the writer to the array sizes, but
+        // we clamp on read too so a corrupted record never drives an OOB read
+        // off the end of rec.explicit_deps[64] / over->deps[326].
+        const uint64_t *deps_data;
+        int32_t dc;
+        if (rec.flags & DEP_GEN_FLAG_HAS_OVERFLOW) {
+            full_deps_buf.clear();
+            uint16_t base_dc = rec.explicit_dep_count;
+            if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
+                LOG_ERROR(
+                    "dep_gen replay: clamping base explicit_dep_count %u > %d at rec_idx=%zu (task_id=%" PRIu64 ")",
+                    base_dc, DEP_GEN_MAX_EXPLICIT_DEPS, rec_i, rec.task_id
+                );
+                base_dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+            }
+            full_deps_buf.reserve(static_cast<size_t>(base_dc) + DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+            full_deps_buf.insert(full_deps_buf.end(), rec.explicit_deps, rec.explicit_deps + base_dc);
+            bool chain_complete = false;
+            for (size_t j = rec_i + 1; j < num_records; j++) {
+                const DepGenRecord &maybe = records[j];
+                if (!(maybe.flags & DEP_GEN_FLAG_OVERFLOW)) {
+                    LOG_ERROR(
+                        "dep_gen replay: unterminated overflow chain at rec_idx=%zu (task_id=%" PRIu64 ")", rec_i,
+                        rec.task_id
+                    );
+                    break;
+                }
+                if (maybe.task_id != rec.task_id) {
+                    LOG_ERROR(
+                        "dep_gen replay: orphan overflow at rec_idx=%zu (expected task_id=%" PRIu64 ", found %" PRIu64
+                        ")",
+                        j, rec.task_id, maybe.task_id
+                    );
+                    break;
+                }
+                const auto *over = reinterpret_cast<const DepGenOverflowRecord *>(&maybe);
+                uint16_t over_dc = over->dep_count;
+                if (over_dc > DEP_GEN_OVERFLOW_DEPS_PER_RECORD) {
+                    LOG_ERROR(
+                        "dep_gen replay: clamping overflow dep_count %u > %d at rec_idx=%zu (task_id=%" PRIu64 ")",
+                        over_dc, DEP_GEN_OVERFLOW_DEPS_PER_RECORD, j, rec.task_id
+                    );
+                    over_dc = DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
+                }
+                full_deps_buf.insert(full_deps_buf.end(), over->deps, over->deps + over_dc);
+                if (over->flags & DEP_GEN_FLAG_LAST_OVERFLOW) {
+                    chain_complete = true;
+                    break;
+                }
+            }
+            if (!chain_complete) {
+                LOG_ERROR(
+                    "dep_gen replay: chain for task_id=%" PRIu64 " missing LAST_OVERFLOW marker — "
+                    "using partial dep list (%zu deps)",
+                    rec.task_id, full_deps_buf.size()
+                );
+            }
+            deps_data = full_deps_buf.data();
+            dc = static_cast<int32_t>(full_deps_buf.size());
+        } else {
+            deps_data = rec.explicit_deps;
+            uint16_t base_dc = rec.explicit_dep_count;
+            if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
+                LOG_ERROR(
+                    "dep_gen replay: clamping no-chain explicit_dep_count %u > %d at rec_idx=%zu (task_id=%" PRIu64 ")",
+                    base_dc, DEP_GEN_MAX_EXPLICIT_DEPS, rec_i, rec.task_id
+                );
+                base_dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+            }
+            dc = static_cast<int32_t>(base_dc);
         }
 
         DepInputs inputs;
@@ -536,7 +622,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         inputs.tensors = tref_buf;
         inputs.arg_types = atype_buf;
         inputs.explicit_dep_count = dc;
-        inputs.explicit_deps = reinterpret_cast<const PTO2TaskId *>(rec.explicit_deps);
+        inputs.explicit_deps = reinterpret_cast<const PTO2TaskId *>(deps_data);
 
         // Register tasks[] entry (with per-arg slot info) and any unseen
         // tensors[] entries up-front. Tensors are registered from the
@@ -576,9 +662,11 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         // ============ STEP 1 — explicit_deps (call-site emit) ============
         // Same loop on both passes; they MUST produce identical sets here
         // because they read the same record. Annot records explicit edges
-        // with consumer_arg_idx = -1 (not tied to any tensor arg).
+        // with consumer_arg_idx = -1 (not tied to any tensor arg). Reads
+        // from deps_data (base record's explicit_deps[] on fast path, the
+        // gathered base+chain buffer on overflow path).
         for (int32_t i = 0; i < dc; i++) {
-            uint64_t pred_raw = rec.explicit_deps[i];
+            uint64_t pred_raw = deps_data[i];
             if (oracle_preds.insert(pred_raw).second) {
                 // First time this pred is seen at runtime call site.
             }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Many-to-one barrier via explicit set_dependencies — exercises the dep_gen
+ * overflow chain wire format.
+ *
+ * Submits N producers each writing X[0] = 42.0, then a dummy_T whose only
+ * dependency surface is set_dependencies({all N producer ids}, N), then a
+ * consumer that explicit-depends on the barrier and copies X[0] -> Y[0].
+ *
+ * Picking N > DEP_GEN_MAX_EXPLICIT_DEPS (=64) forces the dep_gen capture to
+ * spill into one or more DepGenOverflowRecord slots; picking N to span the
+ * 64 + k*326 boundaries exercises both single- and multi-overflow chains.
+ *
+ * Args layout: [X, Y, scalar(N)]
+ *   - X: every producer writes it (tensormap auto-deps the chain so the
+ *        SENTINEL is preserved); consumer reads it.
+ *   - Y: consumer writes it; host checks Y[0] == SENTINEL.
+ *
+ * Scalar: N (1 .. MAX_PRODUCERS).
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+
+// Stack room for producer_ids[]. 500 covers everything we expect to test;
+// PTO2_DEP_LIST_POOL_SIZE (16384) is the real ceiling on a per-ring basis.
+static constexpr int32_t MAX_PRODUCERS = 500;
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,  // X, Y, scalar(N)
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
+
+    uint64_t n_raw = orch_args.scalar(0);
+    int32_t n = static_cast<int32_t>(n_raw);
+    if (n < 1 || n > MAX_PRODUCERS) {
+        rt_report_fatal(PTO2_ERROR_INVALID_ARGS, "chain_barrier_orch: invalid n=%d", n);
+        return;
+    }
+
+    PTO2TaskId producer_ids[MAX_PRODUCERS];
+
+    // N producers each INOUT X. tensormap auto-deps them in a chain, so X[0]
+    // stays at SENTINEL through all of them — the host only checks the final
+    // value, which proves the barrier waited for every producer to finish.
+    for (int32_t i = 0; i < n; i++) {
+        Arg args;
+        args.add_inout(ext_X);
+        producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+    }
+
+    // Dummy barrier with explicit deps on ALL N producers. dc=n > 64 forces
+    // the dep_gen writer to emit base + overflow chain.
+    PTO2TaskId barrier_id;
+    {
+        Arg args;
+        args.set_dependencies(producer_ids, n);
+        barrier_id = rt_submit_dummy_task(args).task_id();
+    }
+
+    // Consumer: explicit dep on barrier only, reads X, writes Y.
+    {
+        Arg args;
+        PTO2TaskId consumer_deps[] = {barrier_id};
+        args.set_dependencies(consumer_deps, 1);
+        args.add_input(ext_X);
+        args.add_inout(ext_Y);
+        rt_submit_aic_task(FUNC_COPY_FIRST, args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""dep_gen overflow chain regression — submits with >64 explicit deps.
+
+A submit with explicit_dep_count > DEP_GEN_MAX_EXPLICIT_DEPS (=64) spills the
+extra deps into one or more DepGenOverflowRecord slots that overlay the same
+buffer ring. Before the chain wire format, dep_gen would silently truncate
+the tail in deps.json; this test verifies every explicit dep edge survives
+the round-trip writer → host collector → replay → deps.json.
+
+Test shape (chain_barrier_orch.cpp): N producers each INOUT X, then a dummy
+barrier `set_dependencies({all N producer ids})`, then a consumer
+`set_dependencies({barrier_id})` reading X and writing Y. With N spanning
+the {64, 65, 390, 391} boundaries we exercise:
+
+  - n=64: base only (no chain) — sanity baseline
+  - n=65: base + 1 overflow record (1 dep in overflow)
+  - n=200: base + 1 overflow (136 deps in overflow)
+  - n=391: base + 2 overflow (326 + 1 deps across two overflows)
+
+Validation: the barrier task in deps.json must have exactly N predecessors,
+all of which are the producer ids. The consumer must have one explicit
+predecessor — the barrier.
+"""
+
+import json
+import sys
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+# Path is relative to this file's directory (the SceneTestCase build helper
+# resolves CALLABLE sources from there). dummy_task already ships the two
+# kernels we need (write_const + copy_first), so we reuse those instead of
+# duplicating the source.
+DUMMY_KERNELS = "../../dummy_task/kernels"
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestDepGenChain(SceneTestCase):
+    """dep_gen overflow chain: many-to-one barrier with >64 explicit deps."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/chain_barrier_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],  # X, Y; N goes as scalar
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": f"{DUMMY_KERNELS}/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": f"{DUMMY_KERNELS}/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+            },
+        ],
+    }
+
+    # Sentinel must match kernel_write_const (writes 42.0f).
+    SENTINEL = 42.0
+    INIT_VAL = -1.0
+
+    CASES = [
+        {
+            "name": "n_64_no_chain",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 64},
+        },
+        {
+            "name": "n_65_single_overflow",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 65},
+        },
+        {
+            "name": "n_200_single_overflow",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 200},
+        },
+        {
+            "name": "n_391_two_overflow",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 391},
+        },
+    ]
+
+    def generate_args(self, params):
+        # Single-element tensors are enough — kernel_write_const writes index 0
+        # and kernel_copy_first reads index 0.
+        x = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
+        y = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
+        return TaskArgsBuilder(
+            Tensor("x", x),
+            Tensor("y", y),
+            Scalar("n", int(params["n"])),
+        )
+
+    def compute_golden(self, args, params):
+        # Producers each write SENTINEL to X[0]; consumer copies X[0] -> Y[0].
+        # If the barrier didn't actually wait for all producers, the consumer
+        # could race ahead and copy INIT_VAL instead — making the host check
+        # a defacto sanity gate even before we look at deps.json.
+        args.x[0] = self.SENTINEL
+        args.y[0] = self.SENTINEL
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        if not self._effective_enable_dep_gen(request):
+            return
+        for case in self.CASES:
+            if st_platform in case.get("platforms", []):
+                self._post_validate(case)
+
+    def _post_validate(self, case):
+        """Verify every explicit dep edge survived the writer → replay round-trip.
+
+        With dep_gen on, deps.json must contain N edges from the producers to
+        the barrier task (one per `set_dependencies` entry the orchestration
+        emitted), plus the consumer's one explicit edge back from the barrier.
+        Pre-chain code would truncate the producer→barrier edge set to 16/64.
+        """
+        case_name = case["name"]
+        n = int(case["params"]["n"])
+        safe_label = _sanitize_for_filename(f"TestDepGenChain_{case_name}")
+        outputs = _outputs_dir()
+        matches = sorted(outputs.glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        assert matches, f"no output dir for case {case_name!r} — scene didn't run on this platform?"
+        out_dir = matches[-1]
+        deps_path = out_dir / "deps.json"
+        # _post_validate is only invoked when dep_gen was effectively enabled;
+        # absence of deps.json means the host runner declined to emit it (most
+        # likely reconcile_counters failed). Surface that as a hard failure
+        # rather than silently passing — the whole point of this test is to
+        # catch chain-side reconciliation regressions.
+        assert deps_path.exists(), (
+            f"dep_gen was enabled but {deps_path} is missing. Likely cause: "
+            f"reconcile_counters() detected a count mismatch and suppressed deps.json emission. "
+            f"Check the run log for 'dep_gen reconcile' warnings."
+        )
+
+        with deps_path.open() as f:
+            deps = json.load(f)
+        assert deps.get("version") == 3, f"deps.json version {deps.get('version')} != 3"
+
+        raw_edges = deps.get("edges", [])
+        # Project annotated edges → (pred, succ) — we only care about graph
+        # structure here; the annot-vs-oracle agreement gate already ran
+        # inside the replay before deps.json was written.
+        edges = set()
+        explicit_edges = set()
+        for e in raw_edges:
+            if not isinstance(e, dict):
+                continue
+            pred, succ = e.get("pred"), e.get("succ")
+            if pred is None or succ is None:
+                continue
+            pair = (int(pred), int(succ))
+            edges.add(pair)
+            if e.get("source") == "explicit":
+                explicit_edges.add(pair)
+
+        # Identify the barrier task: it's the task with exactly n explicit-source
+        # incoming edges. (Producers have 0; consumer has 1 — the one to barrier.)
+        explicit_by_succ = {}
+        for pred, succ in explicit_edges:
+            explicit_by_succ.setdefault(succ, set()).add(pred)
+        barrier_candidates = [tid for tid, preds in explicit_by_succ.items() if len(preds) == n]
+        assert len(barrier_candidates) == 1, (
+            f"expected exactly one task with {n} explicit predecessors "
+            f"(the barrier), got {len(barrier_candidates)}: "
+            f"{[(tid, len(preds)) for tid, preds in explicit_by_succ.items()]}"
+        )
+        barrier_id = barrier_candidates[0]
+        barrier_preds = explicit_by_succ[barrier_id]
+
+        # All N producer→barrier edges must be present. This is the chain
+        # round-trip assertion: pre-chain code drops anything past index 63.
+        assert len(barrier_preds) == n, f"barrier has {len(barrier_preds)} preds, expected {n}"
+
+        # Consumer must explicit-depend on the barrier — exactly one outgoing
+        # explicit edge from the barrier.
+        outgoing_explicit_from_barrier = {succ for pred, succ in explicit_edges if pred == barrier_id}
+        assert len(outgoing_explicit_from_barrier) == 1, (
+            f"barrier {barrier_id} has {len(outgoing_explicit_from_barrier)} outgoing explicit edges, "
+            f"expected 1 (the consumer)"
+        )
+
+
+if __name__ == "__main__":
+    # Standalone entry: auto-add the swimlane flag so fanout ⊆ deps gate runs
+    # alongside the chain assertions, matching test_dep_gen.py's convention.
+    if "--enable-dep-gen" in sys.argv and "--enable-l2-swimlane" not in sys.argv:
+        sys.argv.append("--enable-l2-swimlane")
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## Summary

`DepGenRecord::explicit_deps[]` held at most 16 entries, so submits with >16 explicit deps were silently truncated in `deps.json` — leaving big-fanin barriers (many-to-one barriers built with `Arg::set_dependencies`) underspecified in the captured graph. Runtime correctness was always fine; this was a diagnostic blind spot, but a load-bearing one for swimlane viewers.

This PR:
- **Bumps the inline base capacity from 16 → 64.** Covers all realistic fan-in at +17% buffer footprint (record 2240 → 2624 B, `tensors[]` offset 192 → 576). Added exact-size + exact-offset `static_assert` guards so future layout drift fails at compile time.
- **Adds a wire-format overflow chain** for submits past 64. `DepGenOverflowRecord` reinterprets a buffer slot (same size + alignment) as `{ task_id, flags, dep_count, deps[326] }`, distinguished by `DEP_GEN_FLAG_OVERFLOW`. Base records set `HAS_OVERFLOW`; the final overflow sets `LAST_OVERFLOW`. Chain slots share the base task_id and are contiguous within one `DepGenBuffer` — writer reserves the full chain up front (switching buffer if needed) and publishes via one `buf->count` store, so the host sees either old count (chain invisible) or new count with everything committed.
- **Replay reads the chain back** by skipping `OVERFLOW` slots in the main scan and assembling base + chain into a single `deps_data` buffer before driving `compute_task_fanin` and the annot mirror. `count_outputs()` also skips overflow slots so their reinterpreted bytes don't get misread as `tensor_count`/`arg_types`.
- **Fast path unchanged**: dc ≤ 64 still writes exactly one record with no chain bookkeeping; replay points straight at `rec.explicit_deps`.

Chain that won't fit even in a fresh buffer is truncated to the largest dc that fits, logged via `LOG_ERROR`. Theoretical max per submit ≈ 64 + 31 × 326 = 10170 deps.

## Reconciliation fix (caught by the new test)

`reconcile_counters()` checked `collected + dropped == total_record_count`, but `total_collected_` counts physical buffer slots while `total_record_count` increments once per `submit_task`. Every chained submit over-counted the LHS and tripped the mismatch warning, and the host runner gates `deps.json` emission on a clean reconcile — so the chain feature silently produced no output for any submit with >64 deps before this fix.

Added `DepGenBufferState::total_overflow_record_count` (sized into the existing `_pad[]` so the 192-byte struct invariant holds). New reconciliation invariant:

```
collected + dropped == total_record_count + total_overflow_record_count
```

## Test plan

- [x] Local `pip install -e .` builds clean on a2a3sim (`darwin-arm64`).
- [x] All `static_assert`s in `dep_gen.h` hold (DepGenRecord: 2624 B, tensors offset: 576; DepGenOverflowRecord size + alignment match base).
- [x] New `tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py` passes on a2a3sim for n ∈ {64, 65, 200, 391}: barrier task has exactly N explicit predecessors in `deps.json` for every case.
- [x] No reconcile warnings emitted for any chain case (verified in run log).
- [ ] CI a2a3 onboard run (please trigger).

## Cross-referenced changes

- `src/a2a3/platform/include/common/dep_gen.h` — capacity bump, chain wire format, helpers, `total_overflow_record_count`.
- `src/a2a3/platform/{include,src}/aicpu/dep_gen_collector_aicpu.{h,cpp}` — writer rewrite to emit chain.
- `src/a2a3/platform/src/host/dep_gen_collector.cpp` — reconciliation invariant.
- `src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp` — chain join in replay scan + `count_outputs()` skip.
- `docs/dfx/dep_gen.md` — new §7 documenting chain shape, atomicity, truncation tail.
- `tests/st/.../dfx/dep_gen/` — new test + reusable orchestration kernel.