### PR TITLE
Add scheduler stall snapshot before emergency shutdown

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -327,8 +327,30 @@ void SchedulerContext::log_stall_diagnostics(
     }
 }
 
+void SchedulerContext::log_shutdown_stall_snapshot(
+    int32_t trigger_thread_idx, int32_t trigger_idle_iterations, int32_t trigger_last_progress_count
+) {
+    LOG_WARN(
+        "[SHUTDOWN_SNAPSHOT trigger_thread=%d reason=scheduler_timeout idle_iterations=%d] "
+        "dumping all scheduler threads before emergency shutdown",
+        trigger_thread_idx, trigger_idle_iterations
+    );
+    int32_t thread_count = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
+    if (thread_count < 0 || thread_count > MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "[SHUTDOWN_SNAPSHOT trigger_thread=%d] invalid thread_count=%d, clamping to [0,%d]", trigger_thread_idx,
+            thread_count, MAX_AICPU_THREADS
+        );
+        thread_count = thread_count < 0 ? 0 : MAX_AICPU_THREADS;
+    }
+    for (int32_t t = 0; t < thread_count; t++) {
+        log_stall_diagnostics(t, total_tasks_, trigger_idle_iterations, trigger_last_progress_count);
+    }
+}
+
 int32_t SchedulerContext::handle_timeout_exit(
-    int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
+    int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations,
+    int32_t last_progress_count
 #if PTO2_PROFILING
     ,
     uint64_t sched_start_ts
@@ -340,6 +362,7 @@ int32_t SchedulerContext::handle_timeout_exit(
     );
     latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+        log_shutdown_stall_snapshot(thread_idx, idle_iterations, last_progress_count);
         emergency_shutdown(runtime);
     }
 #if PTO2_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -330,13 +330,18 @@ private:
     __attribute__((noinline, cold)) void
     log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
 
+    __attribute__((noinline, cold)) void log_shutdown_stall_snapshot(
+        int32_t trigger_thread_idx, int32_t trigger_idle_iterations, int32_t trigger_last_progress_count
+    );
+
     // Reverse lookup: given a global core_id, find which scheduler thread's
     // tracker owns it. Returns -1 if not found. Linear scan — only used on
     // the cold diagnostic path.
     int32_t find_core_owner_thread(int32_t core_id) const;
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
-        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
+        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations,
+        int32_t last_progress_count
 #if PTO2_PROFILING
         ,
         uint64_t sched_start_ts

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -757,7 +757,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
             if (idle_iterations >= MAX_IDLE_ITERATIONS) {
                 return handle_timeout_exit(
-                    thread_idx, header, runtime, idle_iterations
+                    thread_idx, header, runtime, idle_iterations, last_progress_count
 #if PTO2_PROFILING
                     ,
                     l2_perf.sched_start_ts

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -45,8 +45,9 @@
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS;  // platform-defined cap (sim vs onboard)
-constexpr int32_t STALL_LOG_INTERVAL = MAX_IDLE_ITERATIONS / 2;  // derived: ~one stall diagnostic halfway to timeout
-constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;             // Check orchestrator error every N idle iters
+constexpr int32_t STALL_LOG_INTERVAL =
+    MAX_IDLE_ITERATIONS * 6 / 10;                     // derived: ~one stall diagnostic halfway to timeout
+constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
 constexpr int32_t STALL_DUMP_CORE_MAX = 8;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -327,8 +327,30 @@ void SchedulerContext::log_stall_diagnostics(
     }
 }
 
+void SchedulerContext::log_shutdown_stall_snapshot(
+    int32_t trigger_thread_idx, int32_t trigger_idle_iterations, int32_t trigger_last_progress_count
+) {
+    LOG_WARN(
+        "[SHUTDOWN_SNAPSHOT trigger_thread=%d reason=scheduler_timeout idle_iterations=%d] "
+        "dumping all scheduler threads before emergency shutdown",
+        trigger_thread_idx, trigger_idle_iterations
+    );
+    int32_t thread_count = active_sched_threads_ > 0 ? active_sched_threads_ : aicpu_thread_num_;
+    if (thread_count < 0 || thread_count > MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "[SHUTDOWN_SNAPSHOT trigger_thread=%d] invalid thread_count=%d, clamping to [0,%d]", trigger_thread_idx,
+            thread_count, MAX_AICPU_THREADS
+        );
+        thread_count = thread_count < 0 ? 0 : MAX_AICPU_THREADS;
+    }
+    for (int32_t t = 0; t < thread_count; t++) {
+        log_stall_diagnostics(t, total_tasks_, trigger_idle_iterations, trigger_last_progress_count);
+    }
+}
+
 int32_t SchedulerContext::handle_timeout_exit(
-    int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
+    int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations,
+    int32_t last_progress_count
 #if PTO2_PROFILING
     ,
     uint64_t sched_start_ts
@@ -340,6 +362,7 @@ int32_t SchedulerContext::handle_timeout_exit(
     );
     latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
+        log_shutdown_stall_snapshot(thread_idx, idle_iterations, last_progress_count);
         emergency_shutdown(runtime);
     }
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -334,13 +334,18 @@ private:
     __attribute__((noinline, cold)) void
     log_stall_diagnostics(int32_t thread_idx, int32_t task_count, int32_t idle_iterations, int32_t last_progress_count);
 
+    __attribute__((noinline, cold)) void log_shutdown_stall_snapshot(
+        int32_t trigger_thread_idx, int32_t trigger_idle_iterations, int32_t trigger_last_progress_count
+    );
+
     // Reverse lookup: given a global core_id, find which scheduler thread's
     // tracker owns it. Returns -1 if not found. Linear scan — only used on
     // the cold diagnostic path.
     int32_t find_core_owner_thread(int32_t core_id) const;
 
     __attribute__((noinline, cold)) int32_t handle_timeout_exit(
-        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations
+        int32_t thread_idx, PTO2SharedMemoryHeader *header, Runtime *runtime, int32_t idle_iterations,
+        int32_t last_progress_count
 #if PTO2_PROFILING
         ,
         uint64_t sched_start_ts

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -753,7 +753,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
             }
             if (idle_iterations >= MAX_IDLE_ITERATIONS) {
                 return handle_timeout_exit(
-                    thread_idx, header, runtime, idle_iterations
+                    thread_idx, header, runtime, idle_iterations, last_progress_count
 #if PTO2_PROFILING
                     ,
                     l2_perf.sched_start_ts

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -46,8 +46,9 @@
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
 constexpr int32_t MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS;  // platform-defined cap (sim vs onboard)
-constexpr int32_t STALL_LOG_INTERVAL = MAX_IDLE_ITERATIONS / 2;  // derived: ~one stall diagnostic halfway to timeout
-constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;             // Check orchestrator error every N idle iters
+constexpr int32_t STALL_LOG_INTERVAL =
+    MAX_IDLE_ITERATIONS * 6 / 10;                     // derived: ~one stall diagnostic halfway to timeout
+constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 constexpr int32_t STALL_DUMP_READY_MAX = 8;
 constexpr int32_t STALL_DUMP_WAIT_MAX = 4;
 constexpr int32_t STALL_DUMP_CORE_MAX = 8;


### PR DESCRIPTION
## Summary
- Add a cold-path shutdown snapshot wrapper for a2a3 and a5 schedulers
- Reuse existing stall diagnostics to dump all active scheduler threads
- Pass last progress count through timeout handling for summary logs
- Clamp snapshot thread count before indexing scheduler trackers

## Testing
- CI

Fixes #868