### PR TITLE
Add: dep_gen capture+replay support on a5

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -74,10 +74,10 @@ is `--enable-dep-gen`:
 
 ```bash
 # Standalone
-python test_my_case.py --platform a2a3 --enable-dep-gen --enable-l2-swimlane
+python test_my_case.py --platform <a2a3|a5> --enable-dep-gen --enable-l2-swimlane
 
 # Pytest
-pytest tests/st/... --platform a2a3 --enable-dep-gen --enable-l2-swimlane
+pytest tests/st/... --platform <a2a3|a5> --enable-dep-gen --enable-l2-swimlane
 ```
 
 The `--enable-l2-swimlane` flag is independent but recommended in pair
@@ -301,10 +301,11 @@ underlying task-pair count.
 | `task.fanout[]` (L2SwimlaneAicpuTaskRecord) | Successors known at producer-retire time | **Yes** — sealed when producer retires |
 | `deps.json` (this feature) | Every consumer → producer reachable via tensormap / explicit_deps | No — replay sees every submit |
 
-`tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py`
-enforces `fanout ⊆ deps` as a validation gate: any edge in fanout that
-is missing from deps is a replay-side regression and fails the test.
-Cases where `deps - fanout ≠ ∅` are the dep_gen sweet spot — those are
+`tests/st/{a2a3,a5}/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py`
+enforces the 6-edge expectation against the `vector_example`
+orchestration as a validation gate: any edge missing from `deps.json`
+is a replay-side regression and fails the test. Cases where
+`deps - fanout ≠ ∅` are the dep_gen sweet spot — those are
 exactly the race-window edges fanout dropped. The
 `swimlane_converter.py` uses `deps.json` (when present) as the source
 of flow events in the Perfetto trace, and flags any edge whose
@@ -356,13 +357,13 @@ list; only the dep_gen replay graph loses the tail.
 
 | Layer | File | Role |
 | ----- | ---- | ---- |
-| Shared-mem layout | `src/a2a3/platform/include/common/dep_gen.h` | `DepGenRecord` (2624 B base, cache-line aligned, ≤64 inline explicit_deps) + `DepGenOverflowRecord` chain view (≤326 deps per slot) + SPSC ring + per-thread ready queue |
-| AICPU writer | `src/a2a3/platform/{include,src}/aicpu/dep_gen_collector_aicpu.{h,cpp}` | Single-instance write path; weak-fallback exported to host build |
-| Host collector | `src/a2a3/platform/{include/host,src/host}/dep_gen_collector.{h,cpp}` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector |
-| Capture call site | `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. Dep-only tasks land in the record stream with valid tensor/dep info but no kernel_id field (the schema does not carry kernel_id), so replay treats them as ordinary dep nodes — viewers do not currently distinguish dummy from real tasks. |
-| Replay | `src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.{h,cpp}` | Pure CPU; runs dual-pass differential replay — `compute_task_fanin` (oracle) + inlined STEP A/B mirror (annotated) against two `PTO2TensorMap` instances. Emits `deps.json` when both passes agree per record. |
-| Device-runner hookup | `src/a2a3/platform/{onboard,sim}/host/device_runner.cpp` | post-`reconcile_counters` calls `dep_gen_replay_emit_deps_json(records.data(), records.size(), deps_path, nullptr)` |
+| Shared-mem layout | `src/{a2a3,a5}/platform/include/common/dep_gen.h` | `DepGenRecord` (2624 B base, cache-line aligned, ≤64 inline explicit_deps) + `DepGenOverflowRecord` chain view (≤326 deps per slot) + SPSC ring + per-thread ready queue. Byte-identical layout across platforms. |
+| AICPU writer | `src/{a2a3,a5}/platform/{include,shared}/aicpu/dep_gen_collector_aicpu.{h,cpp}` | Single-instance write path; weak-fallback exported to host build. a5 reuses the a2a3 source verbatim — the writer accesses its own device-side view of shared memory, independent of how host↔device transport is implemented. |
+| Host collector | `src/{a2a3,a5}/platform/{include/host,shared/host}/dep_gen_collector.{h,cpp}` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector. On a5 (no SVM) it uses the base `alloc_paired_buffer`, which malloc's a host shadow + `copy_to_device`'s it and registers it via `add_malloc_shadow` so teardown can free it; `reconcile_counters` explicitly `copy_from_device`'s the BufferState before reading, and `finalize` lets `BufferPoolManager::clear_mappings()` release all shadows as the single source of truth. |
+| Capture call site | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. Dep-only tasks land in the record stream with valid tensor/dep info but no kernel_id field (the schema does not carry kernel_id), so replay treats them as ordinary dep nodes — viewers do not currently distinguish dummy from real tasks. |
+| Replay | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.{h,cpp}` | Pure CPU; runs dual-pass differential replay — `compute_task_fanin` (oracle) + inlined STEP A/B mirror (annotated) against two `PTO2TensorMap` instances. Emits `deps.json` when both passes agree per record. Platform-agnostic — a5 reuses the a2a3 source verbatim. |
+| Device-runner hookup | `src/{a2a3,a5}/platform/{onboard,sim}/host/device_runner.cpp` | post-`reconcile_counters` calls `dep_gen_replay_emit_deps_json(records.data(), records.size(), deps_path)` |
 | Viewer | `simpler_setup/tools/deps_to_graph.py` | `deps.json` → pan/zoom HTML |
-| Test | `tests/st/a2a3/tensormap_and_ringbuffer/dep_gen_capture/test_dep_gen_capture.py` | Smoke test + `fanout ⊆ deps` validation gate |
+| Test | `tests/st/{a2a3,a5}/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py` + `test_dep_gen_chain.py` | Smoke test + 6-edge validation against `vector_example` orchestration (both platforms share byte-identical orchestration code). |
 
-Currently a2a3 only; an a5 port is planned.
+Supported on both a2a3 and a5. The a5 host collector differs from a2a3 only in its host↔device transport path (a5 has no SVM, so all transfers go through `profiling_copy_to_device` / `profiling_copy_from_device` instead of relying on `halHostRegister`'s shared mapping); the AICPU writer, shared-memory ABI, runtime call site, and replay are platform-agnostic.

--- a/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector_aicpu.h
+ * @brief AICPU-side dep_gen (SubmitTrace) capture interface
+ *
+ * Lifecycle (called from aicpu_executor.cpp + pto_orchestrator.cpp):
+ *   dep_gen_aicpu_set_orch_thread_idx() — record which AICPU thread runs the
+ *                                         orchestrator (used to select the
+ *                                         per-thread ready_queue on flush).
+ *   dep_gen_aicpu_init()                — pop the initial DepGenBuffer from
+ *                                         the (single) instance's free_queue.
+ *   [submit_task loop]
+ *     dep_gen_aicpu_record_submit()     — append one DepGenRecord; rotate
+ *                                         buffer when full.
+ *   dep_gen_aicpu_flush()               — push current buffer (if non-empty)
+ *                                         to ready_queue.
+ *   dep_gen_aicpu_finalize()            — clear bookkeeping.
+ *
+ * All-primitive interface (no runtime types in platform header):
+ *   - task_id passed as raw uint64 (PTO2TaskId::raw)
+ *   - tensor data passed via opaque void* pointers (memcpy'd into the
+ *     DEP_GEN_TENSOR_SIZE-byte slot; static_asserted against sizeof(Tensor)
+ *     in the .cpp)
+ *   - explicit_deps passed as uint64*
+ *
+ * No-op when dep_gen is disabled (is_dep_gen_enabled() returns false).
+ */
+
+#ifndef PLATFORM_AICPU_DEP_GEN_COLLECTOR_AICPU_H_
+#define PLATFORM_AICPU_DEP_GEN_COLLECTOR_AICPU_H_
+
+#include <cstdint>
+
+#include "common/dep_gen.h"
+
+extern "C" void set_platform_dep_gen_base(uint64_t dep_gen_data_base);
+extern "C" uint64_t get_platform_dep_gen_base();
+extern "C" void set_dep_gen_enabled(bool enable);
+extern "C" bool is_dep_gen_enabled();
+
+/**
+ * Register the AICPU thread index that hosts the orchestrator. Used to select
+ * the per-thread ready_queue when buffers fill or on flush. Must be called by
+ * aicpu_executor.cpp before any dep_gen_aicpu_record_submit() can fire.
+ *
+ * Mirrors l2_perf_aicpu_set_orch_thread_idx().
+ */
+void dep_gen_aicpu_set_orch_thread_idx(int thread_idx);
+
+/**
+ * Initialize dep_gen capture: pop the initial DepGenBuffer from the (single)
+ * orchestrator instance's free_queue and stash it as the current buffer.
+ *
+ * Pre-conditions:
+ *   - Host has set the data base via set_platform_dep_gen_base()
+ *   - dep_gen is enabled via set_dep_gen_enabled(true)
+ *   - dep_gen_aicpu_set_orch_thread_idx() has been called
+ *
+ * If the free_queue is empty at init (host bug), the function leaves the
+ * current buffer as null and subsequent record_submit calls will bump
+ * dropped_record_count.
+ */
+void dep_gen_aicpu_init();
+
+/**
+ * Append a base DepGenRecord (and zero or more DepGenOverflowRecord chain
+ * records) for a completed submit_task call. Switches buffer via the SPSC
+ * free_queue / ready_queue protocol when the current buffer cannot hold the
+ * full chain. No-op if dep_gen is disabled.
+ *
+ * Tensor handling: for slot i, if tensor_ptrs[i] is non-null, its first
+ * DEP_GEN_TENSOR_SIZE bytes are memcpy'd into record.tensors[i]. If null
+ * (e.g. arg_types[i] == OUTPUT, where the Tensor is materialized later by
+ * the runtime), the slot is left zeroed. Replay decides what to do with
+ * each slot based on arg_types[i].
+ *
+ * Dep handling: the first DEP_GEN_MAX_EXPLICIT_DEPS deps land in the base
+ * record; any excess spills into a chain of DepGenOverflowRecord slots. A
+ * submit whose chain would exceed the buffer's remaining capacity (even
+ * after switch) is truncated to fit; the dropped tail is logged.
+ *
+ * @param task_id_raw         PTO2TaskId::raw (the assigned task_id for this submit)
+ * @param in_manual_scope     true iff the submit happened inside a manual scope
+ * @param tensor_count        Number of slots in tensor_ptrs / arg_types (≤ CORE_MAX_TENSOR_ARGS)
+ * @param tensor_ptrs         Per-slot Tensor pointer (nullptr to skip the slot)
+ * @param arg_types           Per-slot TensorArgType (interpreted as raw byte)
+ * @param explicit_dep_count  Number of explicit_deps — no static cap; truncated only when the
+ *                            chain would not fit in a single DepGenBuffer
+ * @param explicit_deps_raw   Per-dep PTO2TaskId::raw (length = explicit_dep_count)
+ */
+void dep_gen_aicpu_record_submit(
+    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw
+);
+
+/**
+ * Push the current (partially-filled) DepGenBuffer to the orchestrator
+ * thread's ready_queue so the host can pick it up. Called once at end of
+ * run, after the orchestrator's last submit.
+ */
+void dep_gen_aicpu_flush();
+
+/**
+ * Clear file-local bookkeeping (current_buf cache, etc.). Called at shutdown.
+ */
+void dep_gen_aicpu_finalize();
+
+#endif  // PLATFORM_AICPU_DEP_GEN_COLLECTOR_AICPU_H_

--- a/src/a5/platform/include/common/dep_gen.h
+++ b/src/a5/platform/include/common/dep_gen.h
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen.h
+ * @brief dep_gen (SubmitTrace) shared-memory data structures
+ *
+ * Captures the inputs to every Orchestrator::submit_task call into a streaming
+ * ring of DepGenRecord. The host side replays these records offline to
+ * reconstruct the full task dependency graph (deps.json). deps.json is the
+ * sole source of truth for fanout edges; the L2 swimlane hot path no longer
+ * carries fanout to keep AICPU off the per-task GM-store critical path.
+ *
+ * Streaming buffer design mirrors PMU / L2Perf / TensorDump (single source of
+ * algorithmic truth in src/common/platform/include/host/profiler_base.h):
+ *
+ *   DepGenFreeQueue    — SPSC: Host pushes free DepGenBuffers, AICPU pops them.
+ *   DepGenBufferState  — Per-instance state: free_queue + current buffer ptr.
+ *   DepGenDataHeader   — Fixed shared-mem header: per-thread ready queues.
+ *   DepGenBuffer       — Fixed-capacity record buffer.
+ *
+ * Single-instance: the orchestrator is one AICPU thread, so the BufferState
+ * array has length 1. Kept array-shaped (vs scalar) for symmetry with PMU /
+ * L2Perf and to match ProfilerBase<DepGenModule>::for_each_instance.
+ *
+ * Tensor data is captured as opaque 128-byte blobs (`DEP_GEN_TENSOR_SIZE`)
+ * matching the runtime Tensor struct size. The AICPU writer
+ * (dep_gen_collector_aicpu.cpp) static_asserts sizeof(Tensor) == 128 against
+ * the runtime headers it imports; the platform shared-memory header stays
+ * runtime-agnostic.
+ */
+
+#ifndef SRC_A5_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_
+#define SRC_A5_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "arg_direction.h"  // CORE_MAX_TENSOR_ARGS
+#include "common/platform_config.h"
+
+// =============================================================================
+// dep_gen-local capacity constants
+// =============================================================================
+
+/**
+ * Bytes per captured Tensor slot — matches runtime sizeof(Tensor). Verified
+ * in dep_gen_collector_aicpu.cpp via static_assert against the runtime header.
+ * Two cache lines: cache line 1 (lookup hot path) + cache line 2 (offsets).
+ */
+constexpr int DEP_GEN_TENSOR_SIZE = 128;
+
+/**
+ * Max explicit_dep entries captured directly in a base DepGenRecord. Larger
+ * submits spill into a chain of DepGenOverflowRecord entries (same slot size,
+ * reinterpreted via DEP_GEN_FLAG_OVERFLOW) — see dep_gen_records_needed_for().
+ *
+ * This is a diagnostic-side capacity only — the runtime's Arg::set_dependencies
+ * has no hard limit on dep count. Submits whose chain would exceed the host
+ * buffer's record budget are logged and truncated by
+ * dep_gen_aicpu_record_submit(); runtime correctness is unaffected.
+ */
+constexpr int DEP_GEN_MAX_EXPLICIT_DEPS = 64;
+
+// =============================================================================
+// DepGenRecord — one captured submit_task call
+// =============================================================================
+
+/**
+ * Bitmask flags for DepGenRecord.flags / DepGenOverflowRecord.flags.
+ *
+ * IN_MANUAL_SCOPE is the only flag the host capture path cares about; the
+ * overflow flags are wire-format markers consumed only by the replay scan.
+ */
+enum DepGenRecordFlags : uint32_t {
+    DEP_GEN_FLAG_IN_MANUAL_SCOPE = 1u << 0,  // submit happened inside a manual scope
+    DEP_GEN_FLAG_HAS_OVERFLOW = 1u << 1,     // base record: at least one overflow record follows
+    DEP_GEN_FLAG_OVERFLOW = 1u << 2,         // this slot is a DepGenOverflowRecord, not a DepGenRecord
+    DEP_GEN_FLAG_LAST_OVERFLOW = 1u << 3,    // overflow record: end of chain (no further overflow follows)
+};
+
+/**
+ * Per-submit_task capture. Replay reads these to reconstruct the dep graph.
+ *
+ * Layout:
+ *   - task_id, flags, counts, explicit_deps, arg_types in the first cache lines
+ *   - tensors[] (16 × 128 B opaque blobs) at the tail; covers ~64% of the entry
+ *
+ * Total size: 8 + 4 + 4 + 64*8 + 16 + 32 (pad) + 16*128 = 2624 bytes.
+ * Aligned to 64 B → 2624 B (already a multiple of 64). The 32-byte _pad0
+ * pushes the tensors[] array to offset 576 = 9 * 64 so each 128-byte tensor
+ * blob covers exactly two cache lines instead of straddling three.
+ */
+struct DepGenRecord {
+    uint64_t task_id;                                            // PTO2 encoding (ring_id << 32) | local_id
+    uint32_t flags;                                              // DepGenRecordFlags bitmask
+    uint16_t tensor_count;                                       // number of valid Tensor slots
+    uint16_t explicit_dep_count;                                 // number of valid explicit_dep slots
+    uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];           // PTO2TaskId::raw, length = explicit_dep_count
+    uint8_t arg_types[CORE_MAX_TENSOR_ARGS];                     // TensorArgType, length = tensor_count
+    uint8_t _pad0[32];                                           // align tensors[] to 64 B (offset 576)
+    uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DepGenRecord) == 2624, "DepGenRecord size changed — update header comment + docs/dfx/dep_gen.md");
+static_assert(sizeof(DepGenRecord) % 64 == 0, "DepGenRecord must be cache-line aligned");
+static_assert(offsetof(DepGenRecord, tensors) % 64 == 0, "DepGenRecord::tensors[] must start on a cache-line boundary");
+static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors offset changed — update header comment");
+
+// =============================================================================
+// DepGenOverflowRecord — chain extension for submits with >DEP_GEN_MAX_EXPLICIT_DEPS deps
+// =============================================================================
+
+/**
+ * Number of deps carried by a single overflow record. Sized so a
+ * DepGenOverflowRecord exactly overlays a DepGenRecord slot in the buffer.
+ *
+ * Layout: 16-byte header (task_id + flags + dep_count + _reserved) + deps[].
+ * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 326 entries.
+ */
+constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 326;
+
+/**
+ * Reinterpret-view of a DepGenRecord slot when flags & DEP_GEN_FLAG_OVERFLOW.
+ *
+ * A submit with explicit_dep_count > DEP_GEN_MAX_EXPLICIT_DEPS is encoded as:
+ *   - One base DepGenRecord (carries first DEP_GEN_MAX_EXPLICIT_DEPS deps +
+ *     tensor info; flags |= HAS_OVERFLOW).
+ *   - One or more DepGenOverflowRecord (each carries up to
+ *     DEP_GEN_OVERFLOW_DEPS_PER_RECORD additional deps).
+ *   - The last overflow record carries flags |= LAST_OVERFLOW so replay knows
+ *     the chain is complete without peeking at the next slot.
+ *
+ * Chain records are guaranteed contiguous within the same DepGenBuffer:
+ * dep_gen_aicpu_record_submit() switches buffer up front if the full chain
+ * would not fit. Replay reads them by linear scan; same task_id ties them
+ * back to the preceding base.
+ */
+struct DepGenOverflowRecord {
+    uint64_t task_id;    // mirrors base record's task_id for chain join
+    uint32_t flags;      // DEP_GEN_FLAG_OVERFLOW [| DEP_GEN_FLAG_LAST_OVERFLOW]
+    uint16_t dep_count;  // number of valid entries in deps[]
+    uint16_t _reserved;
+    uint64_t deps[DEP_GEN_OVERFLOW_DEPS_PER_RECORD];  // PTO2TaskId::raw, length = dep_count
+} __attribute__((aligned(64)));
+
+static_assert(
+    sizeof(DepGenOverflowRecord) == sizeof(DepGenRecord), "DepGenOverflowRecord must overlay DepGenRecord exactly"
+);
+static_assert(
+    alignof(DepGenOverflowRecord) == alignof(DepGenRecord), "DepGenOverflowRecord alignment must match DepGenRecord"
+);
+
+/**
+ * Number of buffer slots (1 base + N overflow records) needed to capture a
+ * submit with `dc` explicit deps. Used by the writer to reserve the whole
+ * chain before writing any of it.
+ */
+inline int dep_gen_records_needed_for(int dc) {
+    if (dc <= DEP_GEN_MAX_EXPLICIT_DEPS) return 1;
+    // Use int64_t for the ceil-div so a pathologically large dc (close to
+    // INT_MAX, e.g. via a corrupted explicit_dep_count) cannot overflow
+    // `spill + DEP_GEN_OVERFLOW_DEPS_PER_RECORD - 1`.
+    int64_t spill = static_cast<int64_t>(dc) - DEP_GEN_MAX_EXPLICIT_DEPS;
+    return static_cast<int>(1 + (spill + DEP_GEN_OVERFLOW_DEPS_PER_RECORD - 1) / DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+}
+
+// =============================================================================
+// DepGenBuffer — fixed-capacity record container
+// =============================================================================
+
+/**
+ * Fixed-capacity DepGenRecord buffer.
+ * Allocated by Host, pushed into the orchestrator instance's free_queue.
+ *
+ * AICPU writer is the orchestrator thread (single producer); it commits
+ * directly into records[count] without a dual_issue staging slot (PMU's
+ * staging slots exist because AICore reads MMIO and writes them, not us).
+ */
+struct DepGenBuffer {
+    // Header (first 64 bytes) — host copies this alone first to learn count.
+    volatile uint32_t count;  // Number of valid records committed
+    uint32_t _pad0[15];       // Pad count to 64 B; isolates count's cache line.
+
+    // Records (flexible-size, up to PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)
+    DepGenRecord records[PLATFORM_DEP_GEN_RECORDS_PER_BUFFER];
+} __attribute__((aligned(64)));
+
+static_assert(offsetof(DepGenBuffer, records) == 64, "DepGenBuffer header must be exactly 64 bytes");
+
+// =============================================================================
+// SPSC free queue
+// =============================================================================
+
+/**
+ * SPSC lock-free queue for free DepGenBuffer management.
+ *
+ * Producer: Host (DepGenCollector mgmt thread) pushes recycled/new buffers.
+ * Consumer: Device (AICPU orchestrator thread) pops buffers when switching.
+ */
+struct DepGenFreeQueue {
+    volatile uint64_t buffer_ptrs[PLATFORM_DEP_GEN_SLOT_COUNT];
+    volatile uint32_t head;  // Consumer read position (Device increments)
+    volatile uint32_t tail;  // Producer write position (Host increments)
+    uint32_t _pad[22];       // Pad to 128 B
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DepGenFreeQueue) == 128, "DepGenFreeQueue must be 128 bytes");
+
+// =============================================================================
+// Per-instance buffer state
+// =============================================================================
+
+/**
+ * Per-instance state for dep_gen.
+ *
+ * Writers:
+ *   free_queue.tail:               Host writes (pushes new/recycled buffers)
+ *   free_queue.head:               Device writes (pops buffers)
+ *   current_buf_ptr:               Device writes (after pop), Host reads
+ *   current_buf_seq:               Device writes (monotonic counter)
+ *   dropped_record_count:          Device writes — submits dropped because
+ *                                  free_queue was empty / ready_queue was full
+ *                                  / no active buf
+ *   total_record_count:            Device writes — monotonic count of every
+ *                                  submit the orchestrator attempted to record
+ *                                  (success + dropped). One increment per
+ *                                  submit_task regardless of chain length.
+ *   total_overflow_record_count:   Device writes — monotonic count of extra
+ *                                  DepGenOverflowRecord slots committed for
+ *                                  chained submits. Lets the host reconcile
+ *                                  physical records collected against logical
+ *                                  submits attempted (see formula below).
+ *
+ * Host reconciliation invariant at finalize:
+ *   collected_on_host + sum(dropped) == sum(total) + sum(total_overflow)
+ *
+ * — `collected` counts physical buffer slots (base + every overflow), while
+ * `total` counts submits attempted. Without `total_overflow` the equation
+ * over-counts every chain on the LHS, which is why this counter is split out.
+ */
+struct DepGenBufferState {
+    DepGenFreeQueue free_queue;
+    volatile uint64_t current_buf_ptr;
+    volatile uint32_t current_buf_seq;
+    volatile uint32_t dropped_record_count;
+    volatile uint32_t total_record_count;
+    volatile uint32_t total_overflow_record_count;
+    uint32_t _pad[10];
+} __attribute__((aligned(64)));
+
+static_assert(sizeof(DepGenBufferState) == 192, "DepGenBufferState must be 192 bytes");
+
+// =============================================================================
+// Ready queue entry
+// =============================================================================
+
+/**
+ * Ready queue entry — when a DepGenBuffer fills, AICPU pushes one of these
+ * onto the per-thread ready queue for host pickup.
+ */
+struct DepGenReadyQueueEntry {
+    uint32_t instance_index;  // Always 0 for dep_gen (single instance)
+    uint32_t _pad0;
+    uint64_t buffer_ptr;  // Device pointer to the full DepGenBuffer
+    uint32_t buffer_seq;
+    uint32_t _pad1;
+} __attribute__((aligned(32)));
+
+static_assert(sizeof(DepGenReadyQueueEntry) == 32, "DepGenReadyQueueEntry must be 32 bytes");
+
+// =============================================================================
+// Top-level shared-memory header
+// =============================================================================
+
+/**
+ * dep_gen data fixed header. Located at the start of dep_gen shared memory.
+ *
+ * Per-thread ready queues (one per AICPU scheduling thread):
+ *   Producer: AICPU thread (adds full DepGenBuffers)
+ *   Consumer: Host DepGenCollector mgmt thread
+ *
+ * Even though dep_gen is single-instance, ready queues are per-thread to
+ * match the ProfilerBase contract (which polls header->queues[q] for q in
+ * [0, num_threads)). The orchestrator currently writes into queue[0].
+ */
+struct DepGenDataHeader {
+    DepGenReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_DEP_GEN_READYQUEUE_SIZE];
+    volatile uint32_t queue_heads[PLATFORM_MAX_AICPU_THREADS];  // Host reads (consumer)
+    volatile uint32_t queue_tails[PLATFORM_MAX_AICPU_THREADS];  // AICPU writes (producer)
+    uint32_t num_instances;                                     // Always 1 for now
+    uint32_t _pad[3];
+} __attribute__((aligned(64)));
+
+// =============================================================================
+// Memory layout helpers
+// =============================================================================
+
+/**
+ * Total bytes for the dep_gen shared-mem region (header + buffer states).
+ * Actual DepGenBuffers are dynamically allocated and tracked by the host.
+ */
+inline size_t calc_dep_gen_shm_size(int num_instances) {
+    return sizeof(DepGenDataHeader) + static_cast<size_t>(num_instances) * sizeof(DepGenBufferState);
+}
+
+inline DepGenDataHeader *get_dep_gen_header(void *base_ptr) { return reinterpret_cast<DepGenDataHeader *>(base_ptr); }
+
+inline DepGenBufferState *get_dep_gen_buffer_state(void *base_ptr, int instance_index) {
+    return reinterpret_cast<DepGenBufferState *>(reinterpret_cast<char *>(base_ptr) + sizeof(DepGenDataHeader)) +
+           instance_index;
+}
+
+#endif  // SRC_A5_PLATFORM_INCLUDE_COMMON_DEP_GEN_H_

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -59,6 +59,8 @@ extern "C" {
  * - device_args: Written by host, read by AICPU (contains aicpu_so_bin/aicpu_so_len)
  * - runtime_args: Written by host, read by AICPU (task runtime, includes
  *   handshake buffers)
+ * - dep_gen_data_base: Written by host platform, read by AICPU platform layer;
+ *   zero when dep_gen capture is unused
  *
  * Note: AICore kernels receive Runtime* directly, not KernelArgs
  *       - AICPU: accesses runtime_args->workers directly
@@ -73,7 +75,8 @@ struct KernelArgs {
     uint64_t l2_swimlane_data_base{
         0
     };  // L2 swimlane shared memory base address; use explicit flags to detect enablement
-    uint64_t pmu_data_base{0};  // PMU buffer base address (device memory); 0 = PMU disabled
+    uint64_t pmu_data_base{0};      // PMU buffer base address (device memory); 0 = PMU disabled
+    uint64_t dep_gen_data_base{0};  // dep_gen shared memory base address; use explicit flags to detect enablement
     // Profiling per-core address arrays (moved out of Handshake). Each *_addrs
     // field is a device pointer to uint64_t[num_aicore]. AICore KERNEL_ENTRY
     // indexes by block_idx and forwards into per-core platform state.

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -169,6 +169,7 @@ inline double cycles_to_us(uint64_t cycles) {
 #define PROFILING_FLAG_DUMP_TENSOR (1u << 0)
 #define PROFILING_FLAG_L2_SWIMLANE (1u << 1)
 #define PROFILING_FLAG_PMU (1u << 2)
+#define PROFILING_FLAG_DEP_GEN (1u << 3)
 #define PROFILING_FLAG_SCOPE_STATS (1u << 4)
 #define GET_PROFILING_FLAG(flags, bit) ((((uint32_t)(flags)) & ((uint32_t)(bit))) != 0u)
 #define SET_PROFILING_FLAG(flags, bit) ((flags) |= (uint32_t)(bit))
@@ -272,6 +273,39 @@ constexpr int PLATFORM_PMU_READYQUEUE_SIZE = PLATFORM_MAX_CORES * PLATFORM_PMU_B
  * Idle timeout duration for PMU collection (seconds).
  */
 constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
+
+// =============================================================================
+// dep_gen (SubmitTrace) Configuration
+// =============================================================================
+
+/**
+ * Number of DepGenRecord entries per DepGenBuffer.
+ * Each DepGenRecord is ~2.3 KB (16 Tensor blobs + small header), so a buffer
+ * is ~74 KB. Mirrors a2a3 sizing — same orchestrator submit cadence.
+ */
+constexpr int PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32;
+
+/**
+ * SPSC free_queue slot count for dep_gen buffers (Host→Device hand-off depth).
+ */
+constexpr int PLATFORM_DEP_GEN_SLOT_COUNT = 4;
+
+/**
+ * Pre-allocated DepGenBuffer count per orchestrator instance.
+ */
+constexpr int PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE = 4;
+
+/**
+ * Ready queue capacity for dep_gen (per AICPU thread). dep_gen is single-
+ * instance (orchestrator thread), but the queue array is per-thread to match
+ * the ProfilerBase contract.
+ */
+constexpr int PLATFORM_DEP_GEN_READYQUEUE_SIZE = PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE * 2;
+
+/**
+ * Idle timeout duration for dep_gen collection (seconds).
+ */
+constexpr int PLATFORM_DEP_GEN_TIMEOUT_SECONDS = 30;
 
 // =============================================================================
 // scope_stats Configuration

--- a/src/a5/platform/include/host/dep_gen_collector.h
+++ b/src/a5/platform/include/host/dep_gen_collector.h
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector.h
+ * @brief Host-side dep_gen (SubmitTrace) buffer allocation, streaming
+ *        collection, and raw binary export.
+ *
+ * Architecture:
+ * - BufferPoolManager<DepGenModule>: shared mgmt-thread infrastructure that
+ *   polls the per-thread ready queue, drains the done_queue, and replenishes
+ *   the (single instance's) free_queue from a unified recycled pool.
+ * - DepGenCollector: collector thread pops full DepGenBuffers from the manager
+ *   and appends their DepGenRecords to a binary file (submit_trace.bin).
+ *
+ * Lifecycle:
+ *   init()                       — Allocate header + 1 BufferState + N DepGenBuffers
+ *                                  (pre-fills free_queue; surplus → recycled pool).
+ *                                  Calls set_memory_context() on the base.
+ *   start(tf)                    — Inherited: launches mgmt + poll threads.
+ *   [device execution]
+ *   stop()                       — Inherited: drain queues, join threads.
+ *   reconcile_counters()         — Sanity-check current_buf_ptr is cleared by
+ *                                  AICPU flush, run collected+dropped==total
+ *                                  cross-check. If dropped_record_count > 0,
+ *                                  the host caller skips deps.json emission
+ *                                  (incomplete graph; user gets a warning).
+ *   finalize()                   — Free all device memory, unregister.
+ *
+ * Output format (submit_trace.bin): a fixed-size header followed by a
+ * contiguous stream of DepGenRecord values. Replay (future PR) reads this
+ * back. Layout intentionally trivial (no varint / framing) so the
+ * `sizeof(DepGenRecord)` ABI in `common/dep_gen.h` is the only contract.
+ */
+
+#ifndef SRC_A5_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_
+#define SRC_A5_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#include "common/dep_gen.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+#include "host/profiler_base.h"
+
+// ---------------------------------------------------------------------------
+// dep_gen Module (drives BufferPoolManager<DepGenModule>)
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal hand-off struct delivered from the mgmt thread to the collector.
+ * thread_index identifies the AICPU thread queue the entry was popped from
+ * (always equal to the orchestrator thread index, since dep_gen is single-
+ * instance — exposed for symmetry with PmuReadyBufferInfo).
+ */
+struct DepGenReadyBufferInfo {
+    uint32_t instance_index;  // Always 0 (single instance)
+    uint32_t thread_index;    // AICPU thread queue index this entry came from
+    void *dev_buffer_ptr;
+    void *host_buffer_ptr;
+    uint32_t buffer_seq;
+};
+
+struct DepGenModule {
+    using DataHeader = DepGenDataHeader;
+    using ReadyEntry = DepGenReadyQueueEntry;
+    using ReadyBufferInfo = ::DepGenReadyBufferInfo;
+    using FreeQueue = DepGenFreeQueue;
+
+    static constexpr int kBufferKinds = 1;
+    static constexpr uint32_t kReadyQueueSize = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
+    static constexpr uint32_t kSlotCount = PLATFORM_DEP_GEN_SLOT_COUNT;
+    static constexpr const char *kSubsystemName = "DepGenModule";
+
+    /**
+     * Buffers grown by proactive_replenish are batch-allocated up to the
+     * per-instance ceiling minus the slot count.
+     */
+    static constexpr int batch_size(int /*kind*/) {
+        constexpr int kBatch = PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE - PLATFORM_DEP_GEN_SLOT_COUNT;
+        return kBatch < 1 ? 1 : kBatch;
+    }
+
+    static DataHeader *header_from_shm(void *shm) { return get_dep_gen_header(shm); }
+
+    /**
+     * `count` is intentionally NOT reset here — AICPU is the sole writer and
+     * resets it itself on flush/drop/pop.
+     */
+    static std::optional<profiling_common::EntrySite<DepGenModule>>
+    resolve_entry(void *shm, DataHeader * /*header*/, int q, const ReadyEntry &entry) {
+        DepGenBufferState *state = get_dep_gen_buffer_state(shm, static_cast<int>(entry.instance_index));
+        profiling_common::EntrySite<DepGenModule> site;
+        site.kind = 0;
+        site.free_queue = &state->free_queue;
+        site.buffer_size = sizeof(DepGenBuffer);
+        site.info.instance_index = entry.instance_index;
+        site.info.thread_index = static_cast<uint32_t>(q);
+        site.info.dev_buffer_ptr = reinterpret_cast<void *>(entry.buffer_ptr);
+        site.info.host_buffer_ptr = nullptr;  // filled by ProfilerAlgorithms
+        site.info.buffer_seq = entry.buffer_seq;
+        return site;
+    }
+
+    template <typename Cb>
+    static void for_each_instance(void *shm, DataHeader *header, Cb &&cb) {
+        const int n = static_cast<int>(header->num_instances);
+        for (int i = 0; i < n; i++) {
+            DepGenBufferState *state = get_dep_gen_buffer_state(shm, i);
+            cb(/*kind=*/0, &state->free_queue, sizeof(DepGenBuffer));
+        }
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Memory callbacks — thin aliases for the canonical profiling_common shapes.
+// alloc / free are std::function so callers bind their MemoryAllocator via
+// lambda capture; register / unregister stay as plain function pointers
+// because they wrap stateless HAL globals (halHost*).
+// ---------------------------------------------------------------------------
+
+using DepGenAllocCallback = profiling_common::ProfAllocCallback;
+using DepGenRegisterCallback = profiling_common::ProfRegisterCallback;
+using DepGenUnregisterCallback = profiling_common::ProfUnregisterCallback;
+using DepGenFreeCallback = profiling_common::ProfFreeCallback;
+
+// ---------------------------------------------------------------------------
+// DepGenCollector
+// ---------------------------------------------------------------------------
+
+class DepGenCollector : public profiling_common::ProfilerBase<DepGenCollector, DepGenModule> {
+public:
+    DepGenCollector() = default;
+    ~DepGenCollector();
+
+    DepGenCollector(const DepGenCollector &) = delete;
+    DepGenCollector &operator=(const DepGenCollector &) = delete;
+
+    static constexpr int kIdleTimeoutSec = PLATFORM_DEP_GEN_TIMEOUT_SECONDS;
+    static constexpr const char *kSubsystemName = "DepGen";
+
+    /**
+     * Allocate dep_gen shared memory and pre-populate the free_queue.
+     *
+     * Allocates a DepGenDataHeader + 1 DepGenBufferState, plus
+     * PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE DepGenBuffers. The first
+     * PLATFORM_DEP_GEN_SLOT_COUNT buffers go directly into the free_queue;
+     * the surplus go into BufferPoolManager's shared recycled pool.
+     *
+     * @param num_threads     Number of AICPU scheduling threads (so the
+     *                        DataHeader sizes its per-thread ready queues)
+     * @param alloc_cb        Memory allocation callback
+     * @param register_cb     halHostRegister callback (nullptr on a5)
+     * @param free_cb         Memory free callback
+     * @param device_id       Device ID
+     * @return 0 on success, non-zero on failure
+     */
+    int init(
+        int num_threads, const DepGenAllocCallback &alloc_cb, DepGenRegisterCallback register_cb,
+        const DepGenFreeCallback &free_cb, int device_id
+    );
+
+    /**
+     * Device pointer to the DepGenDataHeader. Set kernel_args.dep_gen_data_base
+     * to this after init() so AICPU can find the shared memory via
+     * set_platform_dep_gen_base().
+     */
+    void *get_dep_gen_shm_device_ptr() const { return shm_dev_; }
+
+    /**
+     * Per-buffer callback invoked by ProfilerBase's poll loop. Appends the
+     * buffer's DepGenRecord entries to the in-memory ``records_`` vector
+     * (no disk I/O — the host replay consumes that vector directly via
+     * ``records()`` once the device run completes).
+     */
+    void on_buffer_collected(const DepGenReadyBufferInfo &info);
+
+    /**
+     * After stop(): cross-check collected + dropped == total. If dropped > 0,
+     * the host caller skips deps.json emission so users get an incomplete-
+     * graph warning rather than partial data they might mistake for complete.
+     *
+     * @return true iff the run captured a complete trace (no drops, no leftovers).
+     */
+    bool reconcile_counters();
+
+    /**
+     * Free all device memory and release the in-memory record buffer. Idempotent.
+     */
+    void finalize(DepGenUnregisterCallback unregister_cb, const DepGenFreeCallback &free_cb);
+
+    /**
+     * @return true if init() succeeded and finalize() has not run.
+     */
+    bool is_initialized() const { return initialized_; }
+
+    /**
+     * Total DepGenRecords drained from the device-side ring buffer so far.
+     */
+    uint64_t total_collected() const { return total_collected_; }
+
+    /**
+     * In-memory record buffer (host replay's input). Valid between init()
+     * and finalize(); pointer/size stay stable after stop() returns, which
+     * is when the caller hands them to ``dep_gen_replay_emit_deps_json``.
+     */
+    const std::vector<DepGenRecord> &records() const { return records_; }
+
+private:
+    bool initialized_ = false;
+    int num_threads_ = 0;
+
+    // Shared memory region (DepGenDataHeader + DepGenBufferState[1]).
+    // shm_host_ / device_id_ live on ProfilerBase (set via set_memory_context
+    // in init()).
+    void *shm_dev_ = nullptr;
+    size_t shm_size_ = 0;
+
+    // In-memory record buffer — drained from the device ring on
+    // on_buffer_collected() and consumed by the host replay directly (no
+    // disk hop). Mutex serializes the mgmt thread's appends against the
+    // (rare) reader on the same collector instance.
+    std::vector<DepGenRecord> records_;
+    std::mutex records_mutex_;
+
+    // Running total of records appended. Equal to ``records_.size()`` after
+    // every append; kept separately for the reconcile_counters cross-check
+    // even when records_ may be inspected concurrently.
+    uint64_t total_collected_ = 0;
+
+    DepGenDataHeader *dep_gen_header() const { return get_dep_gen_header(shm_host_); }
+    DepGenBufferState *dep_gen_state(int idx = 0) const { return get_dep_gen_buffer_state(shm_host_, idx); }
+
+    void append_buffer_records(const void *buf_host_ptr);
+};
+
+/**
+ * Build the ``deps.json`` output path under the caller-provided per-task
+ * directory. Filename is fixed (no timestamp) — the directory is the
+ * per-task uniqueness boundary, mirroring make_pmu_csv_path().
+ */
+inline std::string make_deps_json_path(const std::string &output_dir) {
+    std::filesystem::path dir(output_dir);
+    std::error_code ec;
+    std::filesystem::create_directories(dir, ec);
+    if (ec) {
+        LOG_WARN("Failed to create dep_gen output directory %s: %s", output_dir.c_str(), ec.message().c_str());
+    }
+    return (dir / "deps.json").string();
+}
+
+#endif  // SRC_A5_PLATFORM_INCLUDE_HOST_DEP_GEN_COLLECTOR_H_

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -13,6 +13,7 @@
 #include "common/unified_log.h"
 #include "common/kernel_args.h"
 #include "common/platform_config.h"
+#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
@@ -109,6 +110,8 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     set_l2_swimlane_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);
     set_pmu_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_PMU));
+    set_platform_dep_gen_base(k_args->dep_gen_data_base);
+    set_dep_gen_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DEP_GEN));
     set_scope_stats_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_SCOPE_STATS));
     set_platform_scope_stats_base(k_args->scope_stats_data_base);
 

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -44,6 +44,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/host_regs.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/l2_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/dep_gen_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/scope_stats_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/tensor_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/comm_hccl.cpp"

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -38,6 +38,22 @@
 #include "host/host_regs.h"  // Register address retrieval
 #include "host/raii_scope_guard.h"
 
+// dep_gen_replay_emit_deps_json: strong symbol provided by
+// runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp when that runtime is
+// linked into host_runtime.so. host_build_graph has no replay implementation
+// today, so its host_runtime.so falls through to this weak stub. visibility=
+// hidden keeps the stub off the global dynamic symbol table so it can't
+// accidentally shadow the strong symbol via RTLD_GLOBAL.
+// LOG_DEBUG (not WARN): runtimes that don't link dep_gen never enable it in
+// practice, so this path is unreachable for end users — the symbol exists
+// purely to keep the .so loadable.
+extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_deps_json(
+    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/
+) {
+    LOG_DEBUG("dep_gen replay not implemented for this runtime — deps.json skipped");
+    return -1;
+}
+
 // =============================================================================
 // DeviceRunner Implementation
 // =============================================================================
@@ -151,6 +167,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (enable_dump_tensor_) SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR);
     if (enable_l2_swimlane_) SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE);
     if (enable_pmu_) SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
+    if (enable_dep_gen_) SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DEP_GEN);
     if (enable_scope_stats_) SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_SCOPE_STATS);
     kernel_args_.args.enable_profiling_flag = enable_profiling_flag;
 
@@ -195,6 +212,14 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
     }
 
+    if (enable_dep_gen_) {
+        rc = init_dep_gen(launch_aicpu_num, device_id_);
+        if (rc != 0) {
+            LOG_ERROR("init_dep_gen failed: %d", rc);
+            return rc;
+        }
+    }
+
     if (enable_scope_stats_) {
         rc = init_scope_stats(launch_aicpu_num, device_id_);
         if (rc != 0) {
@@ -220,6 +245,13 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (rc != 0) return rc;
 
     start_shared_collectors_for_run();
+    // a5-specific dep_gen collector — share the same thread_factory shape as base.
+    if (enable_dep_gen_) {
+        auto thread_factory = [this](std::function<void()> fn) {
+            return create_thread(std::move(fn));
+        };
+        dep_gen_collector_.start(thread_factory);
+    }
 
     LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::InitName);
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::InitName, 1);
@@ -256,6 +288,19 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     teardown_shared_collectors_after_run();
 
+    // a5-specific dep_gen teardown: stop + reconcile + replay emit.
+    if (enable_dep_gen_) {
+        dep_gen_collector_.stop();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const auto &records = dep_gen_collector_.records();
+            const std::string deps = make_deps_json_path(output_prefix_);
+            int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+            if (replay_rc != 0) {
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
+            }
+        }
+    }
+
     // Print handshake results (reads from device memory, must be before free)
     print_handshake_results();
 
@@ -290,6 +335,9 @@ int DeviceRunner::finalize() {
     }
     if (pmu_collector_.is_initialized()) {
         pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
+    }
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
     if (scope_stats_collector_.is_initialized()) {
         scope_stats_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
@@ -344,6 +392,9 @@ void DeviceRunner::finalize_collectors() {
     if (pmu_collector_.is_initialized()) {
         pmu_collector_.stop();
     }
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.stop();
+    }
 }
 
 int DeviceRunner::init_l2_swimlane(int num_aicore, int device_id) {
@@ -397,5 +448,17 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
     }
     kernel_args_.args.scope_stats_data_base =
         reinterpret_cast<uint64_t>(scope_stats_collector_.get_scope_stats_shm_device_ptr());
+    return 0;
+}
+
+int DeviceRunner::init_dep_gen(int num_threads, int device_id) {
+    // a5: register_cb=nullptr, so the collector mallocs a host shadow per
+    // device buffer + rtMemcpy's the zeroed shadow to device. No
+    // halHostRegister on a5 (matches PMU / L2 swimlane / dump collectors).
+    int rc = dep_gen_collector_.init(num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, device_id);
+    if (rc != 0) {
+        return rc;
+    }
+    kernel_args_.args.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
 }

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -50,6 +50,7 @@
 #include "host/memory_allocator.h"
 #include "host/l2_swimlane_collector.h"
 #include "host/pmu_collector.h"
+#include "host/dep_gen_collector.h"
 #include "host/scope_stats_collector.h"
 #include "host/tensor_dump_collector.h"
 #include "aicpu_loader/host/load_aicpu_op.h"
@@ -112,6 +113,12 @@ public:
     // `set_pmu_enabled`, `set_scope_stats_enabled`, `set_output_prefix`,
     // `output_prefix()`, and `launch_aicpu_kernel` live on
     // `DeviceRunnerBase`.
+
+    /**
+     * a5 `dep_gen` enablement setter, overriding the base no-op. Captures
+     * orchestrator submit_task inputs for offline replay into deps.json.
+     */
+    void set_dep_gen_enabled(bool enable) override { enable_dep_gen_ = enable; }
 
     /**
      * Cleanup all resources
@@ -180,6 +187,10 @@ private:
     // Shared collectors (`l2_swimlane_collector_`, `dump_collector_`,
     // `pmu_collector_`, `scope_stats_collector_`) live on `DeviceRunnerBase`.
 
+    // dep_gen collector — captures orchestrator submit_task inputs for
+    // offline replay. a5-specific (the base keeps dep_gen as a virtual hook).
+    DepGenCollector dep_gen_collector_;
+
     // `query_max_block_dim`, `validate_block_dim`, `ensure_binaries_loaded`,
     // `configure_aicore_op_timeout`, and `prepare_orch_so` are inherited
     // (protected) from `DeviceRunnerBase`.
@@ -223,9 +234,21 @@ private:
     // Shared enable flags (`enable_l2_swimlane_`, `enable_dump_tensor_`,
     // `enable_pmu_`, `enable_scope_stats_`, `l2_swimlane_level_`,
     // `pmu_event_type_`, `output_prefix_`) live on `DeviceRunnerBase`.
+    //
+    // dep_gen enablement is a5-specific (a2a3 carries its own copy).
+    bool enable_dep_gen_{false};
 
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
     int init_scope_stats(int num_threads, int device_id);
+
+    /**
+     * Initialize dep_gen capture shared memory.
+     *
+     * Allocates a DepGenDataHeader + 1 DepGenBufferState + N DepGenBuffers,
+     * stores the device pointer to the data header into
+     * kernel_args.dep_gen_data_base.
+     */
+    int init_dep_gen(int num_threads, int device_id);
 
     // Per-run collector teardown: stops mgmt + poll threads on every collector
     // whose init succeeded, in the only safe order (stop() joins mgmt before

--- a/src/a5/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/a5/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector_aicpu.cpp
+ * @brief AICPU-side dep_gen capture implementation
+ *
+ * Single-instance: dep_gen captures the orchestrator's submit_task stream,
+ * so there is one BufferState and one current_buf — no per-core arrays.
+ *
+ * Buffer switching (SPSC):
+ *   - Host pushes free DepGenBuffers via free_queue.
+ *   - AICPU pops when current buffer fills; pushes full buffer to per-thread
+ *     ready_queue (indexed by orch_thread_idx).
+ *   - On free_queue empty or ready_queue full: overwrite current buffer
+ *     (record dropped_record_count, keep AICPU alive). Host reads dropped
+ *     at finalize to decide whether to emit deps.json.
+ */
+
+#include "aicpu/dep_gen_collector_aicpu.h"
+
+#include <cstring>
+
+#include "common/memory_barrier.h"
+#include "common/platform_config.h"
+#include "common/unified_log.h"
+
+static uint64_t g_platform_dep_gen_base = 0;
+static bool g_enable_dep_gen = false;
+
+// File-local cached state for the single dep_gen instance (the orchestrator).
+static DepGenDataHeader *s_dep_gen_header = nullptr;
+static DepGenBufferState *s_dep_gen_state = nullptr;
+static int s_orch_thread_idx = -1;  // set via dep_gen_aicpu_set_orch_thread_idx
+
+extern "C" void set_platform_dep_gen_base(uint64_t dep_gen_data_base) { g_platform_dep_gen_base = dep_gen_data_base; }
+
+extern "C" uint64_t get_platform_dep_gen_base() { return g_platform_dep_gen_base; }
+
+extern "C" void set_dep_gen_enabled(bool enable) { g_enable_dep_gen = enable; }
+
+extern "C" bool is_dep_gen_enabled() { return g_enable_dep_gen; }
+
+void dep_gen_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
+
+// ---------------------------------------------------------------------------
+// Internal: enqueue full buffer to per-thread ready_queue
+// ---------------------------------------------------------------------------
+
+static int enqueue_dep_gen_ready_buffer(uint64_t buffer_ptr, uint32_t buffer_seq) {
+    if (s_orch_thread_idx < 0 || s_orch_thread_idx >= PLATFORM_MAX_AICPU_THREADS) {
+        return -1;
+    }
+    int q = s_orch_thread_idx;
+    uint32_t capacity = PLATFORM_DEP_GEN_READYQUEUE_SIZE;
+    uint32_t current_tail = s_dep_gen_header->queue_tails[q];
+    uint32_t current_head = s_dep_gen_header->queue_heads[q];
+
+    uint32_t next_tail = (current_tail + 1) % capacity;
+    if (next_tail == current_head) {
+        return -1;  // Queue full
+    }
+
+    s_dep_gen_header->queues[q][current_tail].instance_index = 0;
+    s_dep_gen_header->queues[q][current_tail].buffer_ptr = buffer_ptr;
+    s_dep_gen_header->queues[q][current_tail].buffer_seq = buffer_seq;
+    s_dep_gen_header->queue_tails[q] = next_tail;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: switch the current buffer
+// ---------------------------------------------------------------------------
+
+static void dep_gen_switch_buffer() {
+    if (s_dep_gen_state == nullptr) {
+        return;
+    }
+    DepGenBuffer *full_buf = reinterpret_cast<DepGenBuffer *>(s_dep_gen_state->current_buf_ptr);
+    if (full_buf == nullptr) {
+        return;
+    }
+
+    // Check free_queue before committing the full buffer
+    rmb();
+    uint32_t head = s_dep_gen_state->free_queue.head;
+    uint32_t tail = s_dep_gen_state->free_queue.tail;
+
+    if (head == tail) {
+        // No replacement buffer available — overwrite current buffer to keep
+        // the orch loop alive; account every record we drop.
+        LOG_WARN("dep_gen: no free buffer, overwriting current (dropped %u records)", full_buf->count);
+        s_dep_gen_state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    uint32_t seq = s_dep_gen_state->current_buf_seq;
+    int rc = enqueue_dep_gen_ready_buffer(s_dep_gen_state->current_buf_ptr, seq);
+    if (rc != 0) {
+        LOG_ERROR("dep_gen: failed to enqueue full buffer (ready_queue full), %u records dropped", full_buf->count);
+        s_dep_gen_state->dropped_record_count += full_buf->count;
+        full_buf->count = 0;
+        wmb();
+        return;
+    }
+
+    // Pop next buffer from free_queue
+    uint64_t new_buf_ptr = s_dep_gen_state->free_queue.buffer_ptrs[head % PLATFORM_DEP_GEN_SLOT_COUNT];
+    rmb();
+    s_dep_gen_state->free_queue.head = head + 1;
+    s_dep_gen_state->current_buf_ptr = new_buf_ptr;
+    s_dep_gen_state->current_buf_seq = seq + 1;
+    wmb();
+
+    DepGenBuffer *new_buf = reinterpret_cast<DepGenBuffer *>(new_buf_ptr);
+    new_buf->count = 0;
+}
+
+// ---------------------------------------------------------------------------
+// Public interface
+// ---------------------------------------------------------------------------
+
+void dep_gen_aicpu_init() {
+    void *base = reinterpret_cast<void *>(get_platform_dep_gen_base());
+    if (base == nullptr) {
+        LOG_ERROR("dep_gen_aicpu_init: dep_gen_data_base is NULL");
+        return;
+    }
+    s_dep_gen_header = get_dep_gen_header(base);
+    s_dep_gen_state = get_dep_gen_buffer_state(base, /*instance_index=*/0);
+
+    rmb();
+    uint32_t head = s_dep_gen_state->free_queue.head;
+    uint32_t tail = s_dep_gen_state->free_queue.tail;
+
+    if (head != tail) {
+        uint64_t buf_ptr = s_dep_gen_state->free_queue.buffer_ptrs[head % PLATFORM_DEP_GEN_SLOT_COUNT];
+        rmb();
+        s_dep_gen_state->free_queue.head = head + 1;
+        s_dep_gen_state->current_buf_ptr = buf_ptr;
+        s_dep_gen_state->current_buf_seq = 0;
+        wmb();
+        DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(buf_ptr);
+        buf->count = 0;
+        LOG_INFO_V0("dep_gen: popped initial buffer addr=0x%lx", buf_ptr);
+    } else {
+        LOG_ERROR("dep_gen: free_queue empty during init");
+        s_dep_gen_state->current_buf_ptr = 0;
+    }
+    wmb();
+}
+
+void dep_gen_aicpu_record_submit(
+    uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw
+) {
+    if (!g_enable_dep_gen || s_dep_gen_state == nullptr) {
+        return;
+    }
+
+    // Account every attempted record so total == collected + dropped on host.
+    s_dep_gen_state->total_record_count += 1;
+
+    int dc = explicit_dep_count;
+    if (dc < 0) dc = 0;
+    if (dc > 0 && explicit_deps_raw == nullptr) dc = 0;
+    int needed = dep_gen_records_needed_for(dc);
+
+    rmb();
+    uint64_t cur_ptr = s_dep_gen_state->current_buf_ptr;
+    if (cur_ptr == 0) {
+        s_dep_gen_state->dropped_record_count += 1;
+        wmb();
+        return;
+    }
+    DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(cur_ptr);
+
+    // Snapshot the count from volatile shared memory into a local so capacity
+    // math, base-record idx, and the final publish all use the same value.
+    // Single-writer ownership means a re-read would return the same value
+    // today, but a local snapshot makes the invariant explicit and is also
+    // a guardrail if a future device-side actor ever races count.
+    uint32_t local_count = buf->count;
+
+    // Reserve the whole chain up front. If it won't fit in the current
+    // buffer, switch first (skipping the switch when the current buffer is
+    // already empty — switching would just enqueue a zero-record buffer and
+    // pop a fresh one we'd truncate into anyway). Then, regardless of whether
+    // we switched, if the chain still won't fit (chain larger than the
+    // buffer), cap dc to what the buffer can hold and log truncation.
+    if (local_count > 0 &&
+        local_count + static_cast<uint32_t>(needed) > static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
+        dep_gen_switch_buffer();
+        rmb();
+        cur_ptr = s_dep_gen_state->current_buf_ptr;
+        if (cur_ptr == 0) {
+            s_dep_gen_state->dropped_record_count += 1;
+            wmb();
+            return;
+        }
+        buf = reinterpret_cast<DepGenBuffer *>(cur_ptr);
+        local_count = buf->count;  // refresh after switch — new buffer starts at 0
+    }
+
+    const int capacity = PLATFORM_DEP_GEN_RECORDS_PER_BUFFER - static_cast<int>(local_count);
+    if (capacity <= 0) {
+        // local_count is bounded by the previous writer's publish step, so
+        // this is only reachable if shared memory was corrupted out from
+        // under us. Drop the record and bail rather than write past the end
+        // of buf->records[].
+        LOG_ERROR("dep_gen: invalid capacity %d (local_count=%u), dropping record", capacity, local_count);
+        s_dep_gen_state->dropped_record_count += 1;
+        wmb();
+        return;
+    }
+    if (needed > capacity) {
+        // Compute the largest dc that fits in `capacity` slots.
+        int dc_fit = DEP_GEN_MAX_EXPLICIT_DEPS + (capacity - 1) * DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
+        LOG_ERROR(
+            "dep_gen: chain (%d records for %d deps) exceeds buffer capacity (%d slots), truncating to %d deps", needed,
+            dc, capacity, dc_fit
+        );
+        dc = dc_fit;
+        needed = dep_gen_records_needed_for(dc);
+    }
+
+    int tc = tensor_count;
+    if (tc < 0) {
+        tc = 0;
+    } else if (tc > CORE_MAX_TENSOR_ARGS) {
+        // The runtime's Arg also caps at CORE_MAX_TENSOR_ARGS, so this should
+        // never trip; clamp defensively to keep the writer crash-free.
+        LOG_ERROR("dep_gen: tensor_count %d > CORE_MAX_TENSOR_ARGS (%d), truncating", tc, CORE_MAX_TENSOR_ARGS);
+        tc = CORE_MAX_TENSOR_ARGS;
+    }
+
+    // ---- Write base record ----
+    uint32_t idx = local_count;
+    DepGenRecord *rec = &buf->records[idx];
+
+    rec->task_id = task_id_raw;
+    // Cast the enum to uint32_t before the ternary so Linux GCC's -Wextra
+    // does not warn about "enumerated and non-enumerated type in conditional".
+    uint32_t base_flags = in_manual_scope ? static_cast<uint32_t>(DEP_GEN_FLAG_IN_MANUAL_SCOPE) : 0u;
+    if (needed > 1) {
+        base_flags |= static_cast<uint32_t>(DEP_GEN_FLAG_HAS_OVERFLOW);
+    }
+    rec->flags = base_flags;
+    rec->tensor_count = static_cast<uint16_t>(tc);
+
+    int base_dc = (dc < DEP_GEN_MAX_EXPLICIT_DEPS) ? dc : DEP_GEN_MAX_EXPLICIT_DEPS;
+    rec->explicit_dep_count = static_cast<uint16_t>(base_dc);
+
+    // explicit_deps (tail of the entry, packed; replay reads only the first base_dc entries)
+    if (base_dc > 0) {
+        memcpy(rec->explicit_deps, explicit_deps_raw, static_cast<size_t>(base_dc) * sizeof(uint64_t));
+    }
+
+    // arg_types
+    if (tc > 0 && arg_types != nullptr) {
+        memcpy(rec->arg_types, arg_types, static_cast<size_t>(tc));
+    }
+
+    // tensors[]: per-slot 128-byte blob (or zero if pointer is null — OUTPUT slot)
+    if (tc > 0) {
+        if (tensor_ptrs == nullptr) {
+            memset(rec->tensors, 0, static_cast<size_t>(tc) * DEP_GEN_TENSOR_SIZE);
+        } else {
+            for (int i = 0; i < tc; i++) {
+                if (tensor_ptrs[i] == nullptr) {
+                    memset(rec->tensors[i], 0, DEP_GEN_TENSOR_SIZE);
+                } else {
+                    memcpy(rec->tensors[i], tensor_ptrs[i], DEP_GEN_TENSOR_SIZE);
+                }
+            }
+        }
+    }
+
+    // ---- Write overflow chain ----
+    // Charge each overflow slot to total_overflow_record_count so the host's
+    // reconciliation equation (`collected + dropped == total + total_overflow`)
+    // accounts for chain expansion. total_record_count stays "one per submit"
+    // — see DepGenBufferState doc.
+    if (needed > 1) {
+        s_dep_gen_state->total_overflow_record_count += static_cast<uint32_t>(needed - 1);
+    }
+    int written = base_dc;
+    for (int slot = 1; slot < needed; slot++) {
+        auto *over = reinterpret_cast<DepGenOverflowRecord *>(&buf->records[idx + static_cast<uint32_t>(slot)]);
+        over->task_id = task_id_raw;
+        const int chunk =
+            ((dc - written) < DEP_GEN_OVERFLOW_DEPS_PER_RECORD) ? (dc - written) : DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
+        const bool is_last = (slot == needed - 1);
+        uint32_t over_flags = static_cast<uint32_t>(DEP_GEN_FLAG_OVERFLOW);
+        if (is_last) {
+            over_flags |= static_cast<uint32_t>(DEP_GEN_FLAG_LAST_OVERFLOW);
+        }
+        over->flags = over_flags;
+        over->dep_count = static_cast<uint16_t>(chunk);
+        over->_reserved = 0;
+        if (chunk > 0) {
+            memcpy(over->deps, explicit_deps_raw + written, static_cast<size_t>(chunk) * sizeof(uint64_t));
+        }
+        written += chunk;
+    }
+
+    // Publish all reserved slots atomically — host either sees the old count
+    // (chain invisible) or the new count with the full chain committed. The
+    // single trailing wmb() flushes both the record payloads and the count
+    // store, matching the pre-chain contract.
+    buf->count = idx + static_cast<uint32_t>(needed);
+    wmb();
+}
+
+void dep_gen_aicpu_flush() {
+    if (s_dep_gen_header == nullptr || s_dep_gen_state == nullptr) {
+        return;
+    }
+
+    rmb();
+    uint64_t buf_ptr = s_dep_gen_state->current_buf_ptr;
+    if (buf_ptr == 0) {
+        return;
+    }
+    DepGenBuffer *buf = reinterpret_cast<DepGenBuffer *>(buf_ptr);
+    if (buf->count == 0) {
+        return;
+    }
+
+    uint32_t seq = s_dep_gen_state->current_buf_seq;
+    int rc = enqueue_dep_gen_ready_buffer(buf_ptr, seq);
+    if (rc == 0) {
+        LOG_INFO_V0("dep_gen: flushed buffer with %u records", buf->count);
+        s_dep_gen_state->current_buf_ptr = 0;
+        wmb();
+    } else {
+        LOG_ERROR("dep_gen: flush failed (ready_queue full), %u records dropped", buf->count);
+        s_dep_gen_state->dropped_record_count += buf->count;
+        buf->count = 0;
+        s_dep_gen_state->current_buf_ptr = 0;
+        wmb();
+    }
+}
+
+void dep_gen_aicpu_finalize() {
+    // No HW state to restore (unlike PMU). Reset file-local cache for cleanliness
+    // — the next init re-resolves these from the (potentially new) base anyway.
+    s_dep_gen_header = nullptr;
+    s_dep_gen_state = nullptr;
+    s_orch_thread_idx = -1;
+}

--- a/src/a5/platform/shared/host/dep_gen_collector.cpp
+++ b/src/a5/platform/shared/host/dep_gen_collector.cpp
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_collector.cpp
+ * @brief Host-side dep_gen collector. The mgmt-thread + buffer-pool machinery
+ *        lives in profiling_common::BufferPoolManager parameterized by
+ *        DepGenModule (host/dep_gen_collector.h); this file owns the
+ *        per-buffer on_buffer_collected callback (in-memory append) and the
+ *        device-side cross-check. Records stay in ``records_`` and are
+ *        consumed directly by the host replay — no on-disk submit_trace.bin
+ *        intermediary.
+ *
+ * a5 specifics: device↔host transfers go through profiling_copy.h. Each
+ * DepGenBuffer's contents are pulled from device on demand inside
+ * ProfilerAlgorithms::process_entry, so on_buffer_collected can read
+ * `count` and `records[]` directly off the host shadow.
+ */
+
+#include "host/dep_gen_collector.h"
+
+#include <cassert>
+#include <cstring>
+
+#include "common/memory_barrier.h"
+#include "common/unified_log.h"
+#include "host/profiling_copy.h"
+
+DepGenCollector::~DepGenCollector() { stop(); }
+
+// ---------------------------------------------------------------------------
+// init
+// ---------------------------------------------------------------------------
+
+int DepGenCollector::init(
+    int num_threads, const DepGenAllocCallback &alloc_cb, DepGenRegisterCallback register_cb,
+    const DepGenFreeCallback &free_cb, int device_id
+) {
+    if (initialized_) {
+        LOG_ERROR("DepGenCollector already initialized");
+        return -1;
+    }
+    if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
+        LOG_ERROR("DepGenCollector::init: invalid arguments");
+        return -1;
+    }
+
+    num_threads_ = num_threads;
+    total_collected_ = 0;
+    records_.clear();
+
+    // Stash callbacks on the base up-front so alloc_paired_buffer sees
+    // consistent values during init. shm_host_ stays nullptr until the shm
+    // allocation succeeds — start(tf) gates on shm_host_.
+    set_memory_context(
+        alloc_cb, register_cb, free_cb, profiling_copy_to_device_for_ops, profiling_copy_from_device_for_ops,
+        /*shm_dev=*/nullptr, /*shm_host=*/nullptr, /*shm_size=*/0, device_id
+    );
+
+    // RAII rollback: any early return after this point releases the shm
+    // region + every DepGenBuffer (device pointer + malloc'd host shadow)
+    // tracked by the manager. `guard.commit()` runs on the success path
+    // before the trailing return 0.
+    profiling_common::InitRollbackGuard<decltype(manager_)> guard(manager_, free_cb);
+
+    // ---- Allocate shared header + buffer-state region ----
+    // dep_gen is single-instance: just one DepGenBufferState after the header.
+    const int num_instances = 1;
+    size_t shm_size = calc_dep_gen_shm_size(num_instances);
+    void *shm_host_local = nullptr;
+    void *shm_dev_local = alloc_paired_buffer(shm_size, &shm_host_local);
+    if (shm_dev_local == nullptr) {
+        LOG_ERROR("DepGenCollector: failed to allocate dep_gen shared memory (%zu bytes)", shm_size);
+        return -1;
+    }
+
+    std::memset(shm_host_local, 0, shm_size);
+    DepGenDataHeader *hdr = get_dep_gen_header(shm_host_local);
+    hdr->num_instances = static_cast<uint32_t>(num_instances);
+
+    // ---- Allocate DepGenBuffers, populate free_queue + recycled pool ----
+    const size_t buf_size = sizeof(DepGenBuffer);
+    DepGenBufferState *state = get_dep_gen_buffer_state(shm_host_local, 0);
+
+    for (int b = 0; b < PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE; b++) {
+        void *host_ptr = nullptr;
+        void *dev_ptr = alloc_paired_buffer(buf_size, &host_ptr);
+        if (dev_ptr == nullptr) {
+            LOG_ERROR("DepGenCollector: failed to allocate DepGenBuffer b=%d", b);
+            return -1;
+        }
+
+        if (b < PLATFORM_DEP_GEN_SLOT_COUNT) {
+            // First N buffers go directly into the (single) instance's free_queue.
+            // All writes hit the host shadow here; the whole shm region gets
+            // pushed to device once below — no wmb needed.
+            uint32_t tail = state->free_queue.tail;
+            assert(tail - state->free_queue.head < PLATFORM_DEP_GEN_SLOT_COUNT && "free_queue overflow on init");
+            state->free_queue.buffer_ptrs[tail % PLATFORM_DEP_GEN_SLOT_COUNT] = reinterpret_cast<uint64_t>(dev_ptr);
+            state->free_queue.tail = tail + 1;
+        } else {
+            manager_.push_recycled(0, dev_ptr);
+        }
+    }
+
+    // Push the entire initialized shm region (header + BufferState +
+    // free_queue contents) to device.
+    profiling_copy_to_device(shm_dev_local, shm_host_local, shm_size);
+
+    shm_dev_ = shm_dev_local;
+    shm_size_ = shm_size;
+    initialized_ = true;
+
+    // Re-set_memory_context now that the shm region is ready. start(tf) gates
+    // on shm_host_ being non-null, so this is the moment the collector
+    // becomes startable.
+    set_memory_context(
+        alloc_cb, register_cb, free_cb, profiling_copy_to_device_for_ops, profiling_copy_from_device_for_ops,
+        shm_dev_local, shm_host_local, shm_size, device_id
+    );
+
+    LOG_INFO_V0(
+        "DepGen collector initialized: %d threads, SHM=0x%lx (records held in memory until replay)", num_threads,
+        reinterpret_cast<unsigned long>(shm_dev_)
+    );
+    guard.commit();
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Record accumulation (in-memory — no disk hop)
+// ---------------------------------------------------------------------------
+
+void DepGenCollector::append_buffer_records(const void *buf_host_ptr) {
+    const DepGenBuffer *buf = reinterpret_cast<const DepGenBuffer *>(buf_host_ptr);
+    uint32_t n = buf->count;
+    if (n > static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER)) {
+        n = static_cast<uint32_t>(PLATFORM_DEP_GEN_RECORDS_PER_BUFFER);
+    }
+    if (n == 0) return;
+
+    std::scoped_lock lock(records_mutex_);
+    records_.insert(records_.end(), buf->records, buf->records + n);
+    total_collected_ += n;
+}
+
+// ---------------------------------------------------------------------------
+// ProfilerBase callback
+// ---------------------------------------------------------------------------
+
+void DepGenCollector::on_buffer_collected(const DepGenReadyBufferInfo &info) {
+    append_buffer_records(info.host_buffer_ptr);
+}
+
+// ---------------------------------------------------------------------------
+// reconcile_counters
+// ---------------------------------------------------------------------------
+
+bool DepGenCollector::reconcile_counters() {
+    if (shm_host_ == nullptr) return false;
+
+    // mgmt thread is stopped by the caller; pull the latest BufferState
+    // (current_buf_ptr, total/dropped counters) from device so the
+    // cross-check sees post-stop() values.
+    if (manager_.shared_mem_dev() != nullptr && shm_size_ > 0) {
+        profiling_copy_from_device(shm_host_, manager_.shared_mem_dev(), shm_size_);
+    }
+
+    bool clean = true;
+
+    DepGenBufferState *state = dep_gen_state(0);
+    uint64_t buf_dev = state->current_buf_ptr;
+    if (buf_dev != 0) {
+        void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_dev));
+        if (host_ptr != nullptr) {
+            profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_dev), sizeof(DepGenBuffer));
+            uint32_t count = reinterpret_cast<const DepGenBuffer *>(host_ptr)->count;
+            if (count != 0) {
+                LOG_ERROR(
+                    "dep_gen reconcile: un-flushed buffer (current_buf_ptr=0x%lx, count=%u) — device flush failed",
+                    static_cast<unsigned long>(buf_dev), count
+                );
+                clean = false;
+            }
+        }
+    }
+
+    uint64_t total_device = state->total_record_count;
+    uint64_t dropped_device = state->dropped_record_count;
+    uint64_t overflow_device = state->total_overflow_record_count;
+
+    if (dropped_device > 0) {
+        LOG_WARN(
+            "dep_gen reconcile: %lu records dropped on device side (free_queue empty or ready_queue full). "
+            "Increase PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE / PLATFORM_DEP_GEN_READYQUEUE_SIZE if frequent. "
+            "deps.json will NOT be emitted for this run (incomplete graph).",
+            static_cast<unsigned long>(dropped_device)
+        );
+        clean = false;
+    }
+    // collected counts physical buffer slots; total_device counts submits; the
+    // chain expands submits into multiple slots, so the overflow counter
+    // bridges the two.
+    if (total_collected_ + dropped_device != total_device + overflow_device) {
+        LOG_WARN(
+            "dep_gen reconcile: record count mismatch (collected=%lu + dropped=%lu != device_total=%lu + "
+            "overflow=%lu, silent_loss=%ld)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device), static_cast<unsigned long>(overflow_device),
+            static_cast<long>(total_device + overflow_device) - static_cast<long>(total_collected_ + dropped_device)
+        );
+        clean = false;
+    } else {
+        LOG_INFO_V0(
+            "dep_gen reconcile: counts match (collected=%lu, dropped=%lu, device_total=%lu, overflow=%lu)",
+            static_cast<unsigned long>(total_collected_), static_cast<unsigned long>(dropped_device),
+            static_cast<unsigned long>(total_device), static_cast<unsigned long>(overflow_device)
+        );
+    }
+
+    return clean;
+}
+
+// ---------------------------------------------------------------------------
+// finalize
+// ---------------------------------------------------------------------------
+
+void DepGenCollector::finalize(DepGenUnregisterCallback unregister_cb, const DepGenFreeCallback &free_cb) {
+    if (!initialized_) return;
+
+    stop();
+
+    {
+        std::scoped_lock lock(records_mutex_);
+        records_.clear();
+        records_.shrink_to_fit();
+    }
+
+    auto release_dev = [&](void *p) {
+        release_one_buffer(p, unregister_cb, free_cb);
+    };
+
+    // Free buffers still parked in the free_queue / current_buf_ptr.
+    // Release the device pointer only — the paired host shadow stays in
+    // dev_to_host_ and is freed by clear_mappings() below.
+    if (shm_host_ != nullptr) {
+        DepGenBufferState *state = dep_gen_state(0);
+
+        release_dev(reinterpret_cast<void *>(state->current_buf_ptr));
+        state->current_buf_ptr = 0;
+
+        uint32_t head = state->free_queue.head;
+        uint32_t tail = state->free_queue.tail;
+        uint32_t queued = tail - head;
+        if (queued > PLATFORM_DEP_GEN_SLOT_COUNT) queued = PLATFORM_DEP_GEN_SLOT_COUNT;
+        for (uint32_t i = 0; i < queued; i++) {
+            uint32_t slot = (head + i) % PLATFORM_DEP_GEN_SLOT_COUNT;
+            release_dev(reinterpret_cast<void *>(state->free_queue.buffer_ptrs[slot]));
+            state->free_queue.buffer_ptrs[slot] = 0;
+        }
+        state->free_queue.head = tail;
+    }
+
+    // Release framework-owned buffers (recycled pool, ready_queue,
+    // done_queue). release_owned_buffers also frees their host shadows.
+    manager_.release_owned_buffers([&](void *p) {
+        release_dev(p);
+    });
+
+    // Free shared header region (device only — shadow stays in
+    // dev_to_host_ until clear_mappings).
+    if (shm_dev_ != nullptr) {
+        release_dev(shm_dev_);
+        shm_dev_ = nullptr;
+    }
+
+    // Free remaining host shadows (per-state buffers + shm region).
+    manager_.clear_mappings();
+
+    initialized_ = false;
+    shm_size_ = 0;
+    total_collected_ = 0;
+    clear_memory_context();
+    LOG_INFO_V0("DepGen collector finalized");
+}

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -47,6 +47,7 @@ list(APPEND HOST_RUNTIME_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/platform_compile_info.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/l2_swimlane_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/pmu_collector.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../shared/host/dep_gen_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/scope_stats_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/shared/host/tensor_dump_collector.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../common/platform/sim/aicpu/platform_aicpu_affinity.cpp"

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -39,6 +39,22 @@
 #include "host/raii_scope_guard.h"
 #include "runtime.h"
 
+// dep_gen_replay_emit_deps_json: strong symbol provided by
+// runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp when that runtime is
+// linked into host_runtime.so. host_build_graph has no replay implementation
+// today, so its host_runtime.so falls through to this weak stub. visibility=
+// hidden keeps the stub off the global dynamic symbol table so it can't
+// accidentally shadow the strong symbol via RTLD_GLOBAL.
+// LOG_DEBUG (not WARN): runtimes that don't link dep_gen never enable it in
+// practice, so this path is unreachable for end users — the symbol exists
+// purely to keep the .so loadable.
+extern "C" __attribute__((weak, visibility("hidden"))) int dep_gen_replay_emit_deps_json(
+    const struct DepGenRecord * /*records*/, size_t /*num_records*/, const char * /*deps_json_path*/
+) {
+    LOG_DEBUG("dep_gen replay not implemented for this runtime — deps.json skipped");
+    return -1;
+}
+
 // a5 sim: malloc / free wrappers shared by the four profiling subsystems'
 // init_* methods. Plain function pointers convert implicitly into the
 // framework's std::function alloc / free shapes. Kept on the subclass (not
@@ -88,6 +104,9 @@ int DeviceRunner::ensure_binaries_loaded() {
         if (!load_sym("set_l2_swimlane_enabled", reinterpret_cast<void **>(&set_l2_swimlane_enabled_func_))) return -1;
         if (!load_sym("set_platform_pmu_base", reinterpret_cast<void **>(&set_platform_pmu_base_func_))) return -1;
         if (!load_sym("set_pmu_enabled", reinterpret_cast<void **>(&set_pmu_enabled_func_))) return -1;
+        if (!load_sym("set_platform_dep_gen_base", reinterpret_cast<void **>(&set_platform_dep_gen_base_func_)))
+            return -1;
+        if (!load_sym("set_dep_gen_enabled", reinterpret_cast<void **>(&set_dep_gen_enabled_func_))) return -1;
         if (!load_sym("set_scope_stats_enabled", reinterpret_cast<void **>(&set_scope_stats_enabled_func_))) return -1;
         if (!load_sym("set_platform_scope_stats_base", reinterpret_cast<void **>(&set_platform_scope_stats_base_func_)))
             return -1;
@@ -201,6 +220,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (enable_pmu_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_PMU);
     }
+    if (enable_dep_gen_) {
+        SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_DEP_GEN);
+    }
     if (enable_scope_stats_) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_SCOPE_STATS);
     }
@@ -254,6 +276,14 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
             LOG_ERROR("PMU init failed: %d, disabling PMU for this run", rc);
             kernel_args_.pmu_data_base = 0;
             enable_pmu_ = false;
+        }
+    }
+
+    if (enable_dep_gen_) {
+        rc = init_dep_gen(launch_aicpu_num, device_id_);
+        if (rc != 0) {
+            LOG_ERROR("init_dep_gen failed: %d", rc);
+            return rc;
         }
     }
 
@@ -312,6 +342,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
         set_platform_dump_base_func_ == nullptr || set_dump_tensor_enabled_func_ == nullptr ||
         set_platform_pmu_base_func_ == nullptr || set_pmu_enabled_func_ == nullptr ||
+        set_platform_dep_gen_base_func_ == nullptr || set_dep_gen_enabled_func_ == nullptr ||
         set_scope_stats_enabled_func_ == nullptr || set_platform_scope_stats_base_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
@@ -324,6 +355,8 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     set_l2_swimlane_enabled_func_(enable_l2_swimlane_);
     set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
     set_pmu_enabled_func_(enable_pmu_);
+    set_platform_dep_gen_base_func_(kernel_args_.dep_gen_data_base);
+    set_dep_gen_enabled_func_(enable_dep_gen_);
     set_scope_stats_enabled_func_(enable_scope_stats_);
     set_platform_scope_stats_base_func_(kernel_args_.scope_stats_data_base);
 
@@ -339,6 +372,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
     if (enable_pmu_) {
         pmu_collector_.start(thread_factory);
+    }
+    if (enable_dep_gen_) {
+        dep_gen_collector_.start(thread_factory);
     }
     if (enable_scope_stats_) {
         scope_stats_collector_.start(thread_factory);
@@ -427,6 +463,18 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         pmu_collector_.reconcile_counters();
     }
 
+    if (enable_dep_gen_) {
+        dep_gen_collector_.stop();
+        if (dep_gen_collector_.reconcile_counters()) {
+            const auto &records = dep_gen_collector_.records();
+            const std::string deps = make_deps_json_path(output_prefix_);
+            int replay_rc = dep_gen_replay_emit_deps_json(records.data(), records.size(), deps.c_str());
+            if (replay_rc != 0) {
+                LOG_ERROR("dep_gen replay failed (%d) — deps.json not produced", replay_rc);
+            }
+        }
+    }
+
     if (enable_scope_stats_) {
         scope_stats_collector_.stop();
         scope_stats_collector_.reconcile_counters();
@@ -460,6 +508,8 @@ void DeviceRunner::unload_executor_binaries() {
         set_l2_swimlane_enabled_func_ = nullptr;
         set_platform_pmu_base_func_ = nullptr;
         set_pmu_enabled_func_ = nullptr;
+        set_platform_dep_gen_base_func_ = nullptr;
+        set_dep_gen_enabled_func_ = nullptr;
         set_scope_stats_enabled_func_ = nullptr;
         set_platform_scope_stats_base_func_ = nullptr;
         aicpu_so_loaded_ = false;
@@ -494,6 +544,9 @@ int DeviceRunner::finalize() {
     }
     if (pmu_collector_.is_initialized()) {
         pmu_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
+    }
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
     }
     if (scope_stats_collector_.is_initialized()) {
         scope_stats_collector_.finalize(/*unregister_cb=*/nullptr, prof_free_cb);
@@ -539,6 +592,9 @@ void DeviceRunner::stop_collectors() {
     }
     if (pmu_collector_.is_initialized()) {
         pmu_collector_.stop();
+    }
+    if (dep_gen_collector_.is_initialized()) {
+        dep_gen_collector_.stop();
     }
 }
 
@@ -596,5 +652,17 @@ int DeviceRunner::init_scope_stats(int num_threads) {
     }
     kernel_args_.scope_stats_data_base =
         reinterpret_cast<uint64_t>(scope_stats_collector_.get_scope_stats_shm_device_ptr());
+    return 0;
+}
+
+int DeviceRunner::init_dep_gen(int num_threads, int /*device_id*/) {
+    // a5 sim: register_cb=nullptr; sim's profiling_copy_* are plain memcpys, so
+    // the dev/host shadow path collapses to one allocation pair.
+    int rc =
+        dep_gen_collector_.init(num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*device_id=*/-1);
+    if (rc != 0) {
+        return rc;
+    }
+    kernel_args_.dep_gen_data_base = reinterpret_cast<uint64_t>(dep_gen_collector_.get_dep_gen_shm_device_ptr());
     return 0;
 }

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -25,6 +25,7 @@
 
 #include "common/core_type.h"
 #include "device_runner_base.h"
+#include "host/dep_gen_collector.h"
 
 class DeviceRunner : public SimDeviceRunnerBase {
 public:
@@ -33,8 +34,9 @@ public:
 
     int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) override;
     int finalize() override;
-    // a5 has no dep_gen; SimDeviceRunnerBase's default no-op set_dep_gen_enabled
-    // applies (the c_api unconditionally calls it).
+    // a5 dep_gen enablement setter, overriding the base no-op (the c_api
+    // unconditionally calls it).
+    void set_dep_gen_enabled(bool enable) override { enable_dep_gen_ = enable; }
 
 private:
     int ensure_binaries_loaded() override;
@@ -44,6 +46,7 @@ private:
     int init_tensor_dump(Runtime &runtime, int device_id);
     int init_pmu(int num_cores, int num_threads, const std::string &csv_path, PmuEventType event_type, int device_id);
     int init_scope_stats(int num_threads);
+    int init_dep_gen(int num_threads, int device_id);
 
     // Per-run collector teardown: stops mgmt + poll threads on every collector
     // whose init succeeded. Idempotent. a5 stops only (does not finalize); the
@@ -61,8 +64,14 @@ private:
     void (*set_platform_l2_swimlane_base_func_)(uint64_t){nullptr};
     void (*set_l2_swimlane_enabled_func_)(bool){nullptr};
     void (*set_pmu_enabled_func_)(bool){nullptr};
+    void (*set_platform_dep_gen_base_func_)(uint64_t){nullptr};
+    void (*set_dep_gen_enabled_func_)(bool){nullptr};
     void (*set_scope_stats_enabled_func_)(bool){nullptr};
     void (*set_platform_scope_stats_base_func_)(uint64_t){nullptr};
+
+    // dep_gen collector — captures orchestrator submit_task inputs for offline replay.
+    DepGenCollector dep_gen_collector_;
+    bool enable_dep_gen_{false};
 };
 
 #endif  // SRC_A5_PLATFORM_SIM_HOST_DEVICE_RUNNER_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -35,6 +35,7 @@
 #include "pto_shared_memory.h"
 
 // Performance profiling headers
+#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/scope_stats_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
@@ -559,6 +560,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             scope_stats_aicpu_set_orch_thread_idx(thread_idx);
 #endif
 
+            // dep_gen plugs into the orchestrator thread (single-instance subsystem):
+            // set the per-thread queue index and pop the initial buffer before any
+            // submit_task can fire inside orch_func_.
+            if (is_dep_gen_enabled()) {
+                dep_gen_aicpu_set_orch_thread_idx(thread_idx);
+                dep_gen_aicpu_init();
+            }
+
 #if PTO2_PROFILING
             orch_cycle_start = get_sys_cnt_aicpu();
 #endif
@@ -569,6 +578,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             rt_scope_begin(rt);
             (*p_func)(*orch_args_cached_);
             rt_scope_end(rt);
+
+            // Flush the (potentially partially-filled) DepGenBuffer so the host
+            // collector can pick it up before this orchestrator thread joins.
+            if (is_dep_gen_enabled()) {
+                dep_gen_aicpu_flush();
+            }
 #if PTO2_PROFILING
             // Push the partially-filled scope_stats buffer so the host gets the
             // final scope_end records. Idempotent / no-op when disabled.
@@ -762,6 +777,9 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
+
+    // Clear dep_gen file-local bookkeeping. No-op when dep_gen is disabled.
+    dep_gen_aicpu_finalize();
 
     LOG_INFO_V0("DeInit: Runtime execution state reset");
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -405,10 +405,10 @@ add_definitions(-DPTO2_ORCH_PROFILING=1)
 
 ### Code Locations
 
-- Macro definitions: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`
-- Scheduler profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp` and `scheduler_cold_path.cpp`
-- Orchestrator profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`
-- TensorMap profiling: `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
+- Macro definitions: `src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`
+- Scheduler profiling: `src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp` and `scheduler_cold_path.cpp`
+- Orchestrator profiling: `src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`
+- TensorMap profiling: `src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_tensormap.h`
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -1,0 +1,776 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_replay.cpp
+ * @brief Replay in-memory DepGenRecord stream → deps.json (strided tensor
+ *        representation, tensor-annotated) via a host-resident PTO2TensorMap,
+ *        with a differential check against the runtime template `compute_task_fanin`.
+ *
+ * Two passes run per record against two parallel PTO2TensorMap instances that
+ * evolve in lockstep:
+ *
+ *   ORACLE pass (read-only contract):
+ *     Drives `compute_task_fanin` (the same template the device orchestrator
+ *     uses in pto_orchestrator.cpp:submit_task) against `tm_oracle`. Emits
+ *     only PTO2TaskId values — the canonical set of producer IDs the runtime
+ *     would have wired. We never widen this template's emit signature: this
+ *     pass IS the contract, and any future change to `compute_task_fanin`
+ *     automatically refreshes the oracle.
+ *
+ *   ANNOT pass (this file's feature):
+ *     Inlines the same STEP A (creator retention) + STEP B (tensormap lookup)
+ *     against `tm_annot`, but the callback fires with the full
+ *     `PTO2TensorMapEntry&` + the consumer Tensor* + the arg index, so the
+ *     replay can record per-edge tensor metadata (producer/consumer
+ *     shape/offset, dtype, version).
+ *
+ * After both passes finish per record, we compare the producer-ID set the
+ * oracle emitted to the producer-ID set the annot pass emitted. They MUST
+ * match. If they diverge, deps.json is not written and the function returns
+ * non-zero — this is the "no shotgun modifications" guarantee: anyone who
+ * changes `compute_task_fanin` will trip this gate immediately and know to
+ * mirror the change in the annot pass.
+ *
+ * STEP 1 (explicit_deps) is emitted at the call site (per pto_dep_compute.h's
+ * "kept at call site" note); both passes run the same explicit-deps loop, so
+ * the comparison covers it too.
+ *
+ * STEP 4 (`register_task_outputs`) runs on BOTH tensor maps after both passes
+ * complete, keeping `tm_oracle` and `tm_annot` bit-equivalent for the next
+ * record's INOUT+COVERED `remove_entry` mutations.
+ *
+ * Pool sizing: replay never advances last_task_alive, so each tensor map's
+ * entry pool must accommodate every output write across the whole trace. We
+ * scan the record buffer once to count INOUT + OUTPUT_EXISTING slots and size
+ * the pool accordingly. Both maps get the same size.
+ */
+
+#include "dep_gen_replay.h"
+
+#include <cinttypes>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "common/dep_gen.h"
+#include "common/unified_log.h"
+#include "data_type.h"
+#include "pto_dep_compute.h"
+#include "pto_task_id.h"
+#include "pto_tensormap.h"
+#include "tensor.h"
+#include "tensor_arg.h"
+
+namespace {
+
+int32_t ceil_pow2(int32_t v) {
+    if (v <= 1) return 1;
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    return v + 1;
+}
+
+// Count INOUT + OUTPUT_EXISTING slots across the record buffer —
+// register_task_outputs only inserts those, and skips entries with manual_dep
+// set. Counting both without inspecting manual_dep is a conservative upper
+// bound (manual_dep is rare; the small over-allocation pays for itself in
+// avoided pool exhaustion).
+int32_t count_outputs(const DepGenRecord *records, size_t n) {
+    int32_t total = 0;
+    for (size_t i = 0; i < n; i++) {
+        const DepGenRecord &r = records[i];
+        // Overflow chain slots are reinterpret_cast views with no tensor data;
+        // their `tensor_count` bytes are actually the overflow `dep_count` field,
+        // which would mislead the loop below if read as a tensor count.
+        if (r.flags & DEP_GEN_FLAG_OVERFLOW) continue;
+        for (uint16_t j = 0; j < r.tensor_count; j++) {
+            auto t = static_cast<TensorArgType>(r.arg_types[j]);
+            if (t == TensorArgType::INOUT || t == TensorArgType::OUTPUT_EXISTING) {
+                total++;
+            }
+        }
+    }
+    return total;
+}
+
+// ---------------------------------------------------------------------------
+// JSON output accumulators (in-memory tables that get serialized at the end)
+// ---------------------------------------------------------------------------
+
+// Edge categories — matches the three places a runtime fanin edge is born.
+enum class EdgeSource { EXPLICIT, CREATOR, TENSORMAP };
+
+const char *edge_source_str(EdgeSource s) {
+    switch (s) {
+    case EdgeSource::EXPLICIT:
+        return "explicit";
+    case EdgeSource::CREATOR:
+        return "creator";
+    case EdgeSource::TENSORMAP:
+        return "tensormap";
+    }
+    return "unknown";
+}
+
+const char *overlap_status_str(OverlapStatus s) {
+    switch (s) {
+    case OverlapStatus::COVERED:
+        return "covered";
+    case OverlapStatus::OTHER:
+        return "other";
+    case OverlapStatus::NO_OVERLAP:
+        return "no_overlap";
+    }
+    return "unknown";
+}
+
+// One annotated edge. consumer_* always populated. producer_* populated for
+// TENSORMAP source only — the explicit/creator emit paths don't have a
+// matched tensormap entry to copy from.
+//
+// Slice description follows the strided Tensor model: (start_offset, strides[])
+// in element units. Byte offset of element coords[] is
+//   (start_offset + Σ coords[i] · strides[i]) · dtype_bytes
+struct EdgeAnnot {
+    uint64_t pred;
+    uint64_t succ;
+    int32_t consumer_arg_idx;  // -1 for EXPLICIT (not tied to a tensor arg)
+    EdgeSource source;
+    OverlapStatus overlap;  // only meaningful for TENSORMAP
+    uint64_t tensor_id;     // 0 for EXPLICIT
+    // Consumer side (the Tensor the submitting task is reading).
+    uint8_t consumer_dtype;
+    uint32_t consumer_ndims;
+    uint32_t consumer_shape[RUNTIME_MAX_TENSOR_DIMS];
+    uint64_t consumer_start_offset;  // 1D element offset
+    uint32_t consumer_strides[RUNTIME_MAX_TENSOR_DIMS];
+    // Producer side (the slice the producer wrote, from the tensormap entry).
+    // Only populated when source == TENSORMAP.
+    uint32_t producer_ndims;
+    uint32_t producer_shape[RUNTIME_MAX_TENSOR_DIMS];
+    uint64_t producer_start_offset;
+    uint32_t producer_strides[RUNTIME_MAX_TENSOR_DIMS];
+};
+
+// One entry in the tensors[] table: the underlying storage, keyed by
+// (buffer_addr, version). buffer_numel is the storage element count;
+// per-edge fields describe the slice (start_offset + stride).
+struct TensorTableEntry {
+    uint64_t tensor_id;
+    uint64_t buffer_addr;
+    uint64_t buffer_numel;  // storage size in elements (= buffer.size / dtype_bytes)
+    int32_t version;
+    uint8_t dtype;
+};
+
+// One arg slot of a task, captured for the `tasks[].args[]` block so
+// downstream viewers can render per-task input / output compartments without
+// having to scan every edge. `has_tensor_info` is false only for OUTPUT slots:
+// the runtime hasn't materialized a Tensor yet at submit_task time, so the
+// captured blob is zeroed.
+struct TaskArgEntry {
+    int32_t idx;
+    TensorArgType arg_type;
+    bool has_tensor_info;
+    uint64_t tensor_id;
+    uint8_t dtype;
+    uint32_t ndims;
+    uint32_t shape[RUNTIME_MAX_TENSOR_DIMS];
+    uint64_t start_offset;  // 1D element offset
+    uint32_t strides[RUNTIME_MAX_TENSOR_DIMS];
+};
+
+struct TaskTableEntry {
+    uint64_t task_id;
+    bool in_manual_scope;
+    std::vector<TaskArgEntry> args;
+};
+
+const char *arg_type_str(TensorArgType t) {
+    switch (t) {
+    case TensorArgType::INPUT:
+        return "INPUT";
+    case TensorArgType::OUTPUT:
+        return "OUTPUT";
+    case TensorArgType::INOUT:
+        return "INOUT";
+    case TensorArgType::OUTPUT_EXISTING:
+        return "OUTPUT_EXISTING";
+    }
+    return "UNKNOWN";
+}
+
+// FNV-1a 64-bit hash of (buffer_addr, version) — stable tensor identity
+// across runs (no time-dependent inputs).
+uint64_t make_tensor_id(uint64_t buffer_addr, int32_t version) {
+    constexpr uint64_t FNV_OFFSET = 0xcbf29ce484222325ULL;
+    constexpr uint64_t FNV_PRIME = 0x100000001b3ULL;
+    uint64_t h = FNV_OFFSET;
+    const uint8_t *p;
+    p = reinterpret_cast<const uint8_t *>(&buffer_addr);
+    for (size_t i = 0; i < sizeof(buffer_addr); i++) {
+        h ^= p[i];
+        h *= FNV_PRIME;
+    }
+    uint32_t v = static_cast<uint32_t>(version);
+    p = reinterpret_cast<const uint8_t *>(&v);
+    for (size_t i = 0; i < sizeof(v); i++) {
+        h ^= p[i];
+        h *= FNV_PRIME;
+    }
+    return h;
+}
+
+// Register a tensor in the tensors[] table on first sight of (addr,
+// version). buffer_numel describes the underlying storage size in elements;
+// per-edge fields describe the slice via (start_offset, strides[]). Subsequent
+// sightings of the same (addr, version) are no-ops.
+uint64_t register_tensor(
+    std::unordered_map<uint64_t, size_t> &index_by_id, std::vector<TensorTableEntry> &table, const Tensor &t
+) {
+    uint64_t id = make_tensor_id(t.buffer.addr, t.version);
+    auto it = index_by_id.find(id);
+    if (it != index_by_id.end()) {
+        return id;
+    }
+    TensorTableEntry e;
+    e.tensor_id = id;
+    e.buffer_addr = t.buffer.addr;
+    e.version = t.version;
+    e.dtype = static_cast<uint8_t>(t.dtype);
+    const uint64_t elem_size = get_element_size(t.dtype);
+    e.buffer_numel = (elem_size == 0) ? 0 : (t.buffer.size / elem_size);
+    index_by_id[id] = table.size();
+    table.push_back(e);
+    return id;
+}
+
+// Copy a Tensor's slice description (shape + start_offset + stride) into an
+// EdgeAnnot's consumer_* fields.
+void fill_consumer(EdgeAnnot &e, const Tensor &t) {
+    e.consumer_dtype = static_cast<uint8_t>(t.dtype);
+    e.consumer_ndims = t.ndims;
+    e.consumer_start_offset = t.start_offset;
+    for (uint32_t i = 0; i < t.ndims && i < RUNTIME_MAX_TENSOR_DIMS; i++) {
+        e.consumer_shape[i] = t.shapes[i];
+        e.consumer_strides[i] = t.strides[i];
+    }
+}
+
+// Copy a PTO2TensorMapEntry's slice description into an EdgeAnnot's producer_*
+// fields. Only called from the TENSORMAP emit path.
+void fill_producer(EdgeAnnot &e, const PTO2TensorMapEntry &entry) {
+    e.producer_ndims = entry.ndims;
+    e.producer_start_offset = entry.start_offset;
+    for (uint32_t i = 0; i < entry.ndims && i < RUNTIME_MAX_TENSOR_DIMS; i++) {
+        e.producer_shape[i] = entry.shapes[i];
+        e.producer_strides[i] = entry.strides[i];
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON writer
+// ---------------------------------------------------------------------------
+
+void write_uint_array(std::ofstream &out, const uint32_t *data, uint32_t n) {
+    out << '[';
+    for (uint32_t i = 0; i < n; i++) {
+        if (i > 0) out << ',';
+        out << data[i];
+    }
+    out << ']';
+}
+
+bool write_deps_json(
+    const char *path, const std::vector<TaskTableEntry> &tasks, const std::vector<TensorTableEntry> &tensors,
+    const std::vector<EdgeAnnot> &edges
+) {
+    std::ofstream out(path, std::ios::out | std::ios::trunc);
+    if (!out) {
+        LOG_ERROR("dep_gen replay: failed to open '%s' for write", path);
+        return false;
+    }
+    // Strided tensor representation. tensors[].buffer_numel is the underlying
+    // storage element count; tasks[].args[] and edges[] carry per-slice
+    // geometry as (start_offset uint64, strides[] uint32 — runtime invariant
+    // forbids zero / negative strides, see runtime/tensor.h).
+    out << "{\"tasks\":[";
+    for (size_t i = 0; i < tasks.size(); i++) {
+        if (i > 0) out << ',';
+        const auto &t = tasks[i];
+        // uint64 fields are quoted as strings — task_id/tensor_id/buffer_addr/
+        // pred/succ can exceed Number.MAX_SAFE_INTEGER (2^53-1), silently
+        // losing precision in JS-based JSON parsers. Python consumers already
+        // pass these through int(...) and don't care which form they receive.
+        out << "{\"task_id\":\"" << t.task_id << '"';
+        out << ",\"scope\":\"" << (t.in_manual_scope ? "manual" : "auto") << '"';
+        out << ",\"args\":[";
+        for (size_t a = 0; a < t.args.size(); a++) {
+            if (a > 0) out << ',';
+            const auto &arg = t.args[a];
+            out << "{\"idx\":" << arg.idx;
+            out << ",\"type\":\"" << arg_type_str(arg.arg_type) << '"';
+            if (arg.has_tensor_info) {
+                out << ",\"tensor_id\":\"" << arg.tensor_id << '"';
+                out << ",\"dtype\":\"" << get_dtype_name(static_cast<DataType>(arg.dtype)) << '"';
+                out << ",\"shape\":";
+                write_uint_array(out, arg.shape, arg.ndims);
+                out << ",\"start_offset\":\"" << arg.start_offset << '"';
+                out << ",\"strides\":";
+                write_uint_array(out, arg.strides, arg.ndims);
+            }
+            out << '}';
+        }
+        out << "]}";
+    }
+    out << ']';
+
+    out << ",\"tensors\":[";
+    for (size_t i = 0; i < tensors.size(); i++) {
+        if (i > 0) out << ',';
+        const auto &t = tensors[i];
+        out << "{\"tensor_id\":\"" << t.tensor_id << '"';
+        out << ",\"buffer_addr\":\"" << t.buffer_addr << '"';
+        out << ",\"version\":" << t.version;
+        out << ",\"dtype\":\"" << get_dtype_name(static_cast<DataType>(t.dtype)) << '"';
+        out << ",\"buffer_numel\":\"" << t.buffer_numel << '"';
+        out << '}';
+    }
+    out << ']';
+
+    out << ",\"edges\":[";
+    for (size_t i = 0; i < edges.size(); i++) {
+        if (i > 0) out << ',';
+        const auto &e = edges[i];
+        out << "{\"pred\":\"" << e.pred << "\",\"succ\":\"" << e.succ << '"';
+        out << ",\"arg\":" << e.consumer_arg_idx;
+        out << ",\"source\":\"" << edge_source_str(e.source) << '"';
+        if (e.source == EdgeSource::TENSORMAP) {
+            out << ",\"overlap\":\"" << overlap_status_str(e.overlap) << '"';
+        }
+        if (e.source != EdgeSource::EXPLICIT) {
+            out << ",\"tensor_id\":\"" << e.tensor_id << '"';
+            out << ",\"consumer_dtype\":\"" << get_dtype_name(static_cast<DataType>(e.consumer_dtype)) << '"';
+            out << ",\"consumer_shape\":";
+            write_uint_array(out, e.consumer_shape, e.consumer_ndims);
+            out << ",\"consumer_start_offset\":\"" << e.consumer_start_offset << '"';
+            out << ",\"consumer_strides\":";
+            write_uint_array(out, e.consumer_strides, e.consumer_ndims);
+        }
+        if (e.source == EdgeSource::TENSORMAP) {
+            out << ",\"producer_shape\":";
+            write_uint_array(out, e.producer_shape, e.producer_ndims);
+            out << ",\"producer_start_offset\":\"" << e.producer_start_offset << '"';
+            out << ",\"producer_strides\":";
+            write_uint_array(out, e.producer_strides, e.producer_ndims);
+        }
+        out << '}';
+    }
+    out << "]}\n";
+    return static_cast<bool>(out);
+}
+
+// ---------------------------------------------------------------------------
+// Annot pass — mirrors compute_task_fanin step-by-step against tm_annot.
+// Must stay bit-equivalent to pto_dep_compute.h::compute_task_fanin in terms
+// of which producer IDs are emitted (the differential check enforces this).
+// ---------------------------------------------------------------------------
+
+template <typename EmitTM, typename EmitCreator>
+void annot_pass(
+    const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_manual_scope, EmitCreator emit_creator,
+    EmitTM emit_tensormap
+) {
+    if (in_manual_scope) {
+        return;
+    }
+    for (int32_t i = 0; i < inputs.tensor_count; i++) {
+        TensorArgType ptype = inputs.arg_types[i];
+        if (ptype == TensorArgType::OUTPUT) {
+            continue;
+        }
+        const Tensor *tensor = inputs.tensors[i].ptr;
+
+        // STEP A: creator retention.
+        PTO2TaskId owner = tensor->owner_task_id;
+        if (owner.is_valid()) {
+            emit_creator(owner, i, *tensor);
+        }
+
+        // STEP B: tensormap lookup (only INPUT/INOUT, skip manual_dep).
+        if (ptype != TensorArgType::INPUT && ptype != TensorArgType::INOUT) {
+            continue;
+        }
+        if (tensor->manual_dep) {
+            continue;
+        }
+
+        tensor_map.lookup(*tensor, [&](PTO2TensorMapEntry &entry, OverlapStatus overlap_status) -> bool {
+            emit_tensormap(entry.producer_task_id, i, *tensor, entry, overlap_status);
+            if (ptype == TensorArgType::INOUT && overlap_status == OverlapStatus::COVERED) {
+                tensor_map.remove_entry(entry);
+            }
+            return true;
+        });
+    }
+}
+
+}  // namespace
+
+extern "C" int
+dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, const char *deps_json_path) {
+    if (deps_json_path == nullptr) {
+        LOG_ERROR("dep_gen replay: null deps_json_path");
+        return -1;
+    }
+    if (num_records > 0 && records == nullptr) {
+        LOG_ERROR("dep_gen replay: num_records=%zu but records pointer is null", num_records);
+        return -1;
+    }
+    LOG_INFO_V0("dep_gen replay: processing %zu in-memory records (dual-pass)", num_records);
+
+    // Per-ring task window sizes — tensormap masks slot indices and requires
+    // each to be a power of two. Auto-size from the records themselves so each
+    // ring's window comfortably covers its observed max local_id (no slot
+    // aliasing during INOUT+COVERED remove_from_task). Same sizes feed both
+    // maps so they stay in lockstep.
+    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint32_t max_local[PTO2_MAX_RING_DEPTH] = {0};
+    for (size_t i = 0; i < num_records; i++) {
+        PTO2TaskId tid{records[i].task_id};
+        uint8_t ring = tid.ring();
+        uint32_t local = tid.local();
+        if (ring < PTO2_MAX_RING_DEPTH && local > max_local[ring]) {
+            max_local[ring] = local;
+        }
+    }
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        int32_t need = static_cast<int32_t>(max_local[r] + 1);
+        task_window_sizes[r] = ceil_pow2(need < 16 ? 16 : need);
+    }
+
+    int32_t output_count = count_outputs(records, num_records);
+    int32_t pool_size = output_count + (output_count / 10) + 64;
+    if (pool_size < PTO2_TENSORMAP_POOL_SIZE) {
+        pool_size = PTO2_TENSORMAP_POOL_SIZE;
+    }
+
+    PTO2TensorMap tm_oracle;
+    PTO2TensorMap tm_annot;
+    std::memset(&tm_oracle, 0, sizeof(tm_oracle));
+    std::memset(&tm_annot, 0, sizeof(tm_annot));
+
+    // Libc-backed arena (default ctor) that owns both replay tensormaps'
+    // storage. Released by the arena destructor when this function returns.
+    DeviceArena replay_arena;
+
+    auto oracle_layout =
+        PTO2TensorMap::reserve_layout(replay_arena, PTO2_TENSORMAP_NUM_BUCKETS, pool_size, task_window_sizes);
+    auto annot_layout =
+        PTO2TensorMap::reserve_layout(replay_arena, PTO2_TENSORMAP_NUM_BUCKETS, pool_size, task_window_sizes);
+    if (replay_arena.commit() == nullptr || !tm_oracle.init_data_from_layout(oracle_layout, replay_arena) ||
+        !tm_annot.init_data_from_layout(annot_layout, replay_arena)) {
+        LOG_ERROR("dep_gen replay: tensormap.init failed (buckets=%d, pool=%d)", PTO2_TENSORMAP_NUM_BUCKETS, pool_size);
+        return -3;
+    }
+    // Replay tensormaps live entirely on host; only arena-internal pointer
+    // fields need wiring (no parent-orch back-reference exists anymore).
+    tm_oracle.wire_arena_pointers(oracle_layout, replay_arena);
+    tm_annot.wire_arena_pointers(annot_layout, replay_arena);
+
+    // JSON output accumulators.
+    std::vector<TaskTableEntry> task_table;
+    std::vector<TensorTableEntry> tensor_table;
+    std::unordered_map<uint64_t, size_t> tensor_index;  // tensor_id → table idx
+    std::vector<EdgeAnnot> annot_edges;
+    annot_edges.reserve(num_records * 2);
+
+    TensorRef tref_buf[CORE_MAX_TENSOR_ARGS];
+    TensorArgType atype_buf[CORE_MAX_TENSOR_ARGS];
+
+    // Per-record dedup of producer IDs — must match runtime's
+    // PTO2FaninBuilder::append_fanin_or_fail semantics, which collapses STEP 1
+    // (explicit_deps) + STEP A (creator retention) + STEP B (tensormap lookup)
+    // into a single per-task fanin list. Both oracle and annot use this same
+    // semantics so the divergence check is meaningful.
+    std::unordered_set<uint64_t> oracle_preds;
+    std::unordered_set<uint64_t> annot_preds;
+
+    // Scratch buffer for assembling full dep lists across overflow chains.
+    // Declared outside the loop so it can be reused (clear() keeps capacity).
+    std::vector<uint64_t> full_deps_buf;
+
+    for (size_t rec_i = 0; rec_i < num_records; rec_i++) {
+        const DepGenRecord &rec = records[rec_i];
+
+        // Overflow chain records are consumed by the preceding base; skip
+        // them in the main scan so we don't double-process or read the
+        // overflow's reinterpreted bytes as tensor/dep info.
+        if (rec.flags & DEP_GEN_FLAG_OVERFLOW) continue;
+
+        PTO2TaskId task_id{rec.task_id};
+        bool in_manual_scope = (rec.flags & DEP_GEN_FLAG_IN_MANUAL_SCOPE) != 0;
+
+        oracle_preds.clear();
+        annot_preds.clear();
+
+        int32_t tc = static_cast<int32_t>(rec.tensor_count);
+        if (tc > CORE_MAX_TENSOR_ARGS) {
+            tc = CORE_MAX_TENSOR_ARGS;
+        }
+        for (int32_t i = 0; i < tc; i++) {
+            tref_buf[i].ptr = reinterpret_cast<const Tensor *>(&rec.tensors[i][0]);
+            atype_buf[i] = static_cast<TensorArgType>(rec.arg_types[i]);
+        }
+
+        // Assemble the full dep list. Fast path: ≤ DEP_GEN_MAX_EXPLICIT_DEPS,
+        // no chain, point straight at rec.explicit_deps. Slow path: gather
+        // base + chain into full_deps_buf and point at the buffer.
+        //
+        // `explicit_dep_count` / `over->dep_count` originate from device
+        // shared memory and are bounded by the writer to the array sizes, but
+        // we clamp on read too so a corrupted record never drives an OOB read
+        // off the end of rec.explicit_deps[64] / over->deps[326].
+        const uint64_t *deps_data;
+        int32_t dc;
+        if (rec.flags & DEP_GEN_FLAG_HAS_OVERFLOW) {
+            full_deps_buf.clear();
+            uint16_t base_dc = rec.explicit_dep_count;
+            if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
+                LOG_ERROR(
+                    "dep_gen replay: clamping base explicit_dep_count %u > %d at rec_idx=%zu (task_id=%" PRIu64 ")",
+                    base_dc, DEP_GEN_MAX_EXPLICIT_DEPS, rec_i, rec.task_id
+                );
+                base_dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+            }
+            full_deps_buf.reserve(static_cast<size_t>(base_dc) + DEP_GEN_OVERFLOW_DEPS_PER_RECORD);
+            full_deps_buf.insert(full_deps_buf.end(), rec.explicit_deps, rec.explicit_deps + base_dc);
+            bool chain_complete = false;
+            for (size_t j = rec_i + 1; j < num_records; j++) {
+                const DepGenRecord &maybe = records[j];
+                if (!(maybe.flags & DEP_GEN_FLAG_OVERFLOW)) {
+                    LOG_ERROR(
+                        "dep_gen replay: unterminated overflow chain at rec_idx=%zu (task_id=%" PRIu64 ")", rec_i,
+                        rec.task_id
+                    );
+                    break;
+                }
+                if (maybe.task_id != rec.task_id) {
+                    LOG_ERROR(
+                        "dep_gen replay: orphan overflow at rec_idx=%zu (expected task_id=%" PRIu64 ", found %" PRIu64
+                        ")",
+                        j, rec.task_id, maybe.task_id
+                    );
+                    break;
+                }
+                const auto *over = reinterpret_cast<const DepGenOverflowRecord *>(&maybe);
+                uint16_t over_dc = over->dep_count;
+                if (over_dc > DEP_GEN_OVERFLOW_DEPS_PER_RECORD) {
+                    LOG_ERROR(
+                        "dep_gen replay: clamping overflow dep_count %u > %d at rec_idx=%zu (task_id=%" PRIu64 ")",
+                        over_dc, DEP_GEN_OVERFLOW_DEPS_PER_RECORD, j, rec.task_id
+                    );
+                    over_dc = DEP_GEN_OVERFLOW_DEPS_PER_RECORD;
+                }
+                full_deps_buf.insert(full_deps_buf.end(), over->deps, over->deps + over_dc);
+                if (over->flags & DEP_GEN_FLAG_LAST_OVERFLOW) {
+                    chain_complete = true;
+                    break;
+                }
+            }
+            if (!chain_complete) {
+                LOG_ERROR(
+                    "dep_gen replay: chain for task_id=%" PRIu64 " missing LAST_OVERFLOW marker — "
+                    "using partial dep list (%zu deps)",
+                    rec.task_id, full_deps_buf.size()
+                );
+            }
+            deps_data = full_deps_buf.data();
+            dc = static_cast<int32_t>(full_deps_buf.size());
+        } else {
+            deps_data = rec.explicit_deps;
+            uint16_t base_dc = rec.explicit_dep_count;
+            if (base_dc > DEP_GEN_MAX_EXPLICIT_DEPS) {
+                LOG_ERROR(
+                    "dep_gen replay: clamping no-chain explicit_dep_count %u > %d at rec_idx=%zu (task_id=%" PRIu64 ")",
+                    base_dc, DEP_GEN_MAX_EXPLICIT_DEPS, rec_i, rec.task_id
+                );
+                base_dc = DEP_GEN_MAX_EXPLICIT_DEPS;
+            }
+            dc = static_cast<int32_t>(base_dc);
+        }
+
+        DepInputs inputs;
+        inputs.tensor_count = tc;
+        inputs.tensors = tref_buf;
+        inputs.arg_types = atype_buf;
+        inputs.explicit_dep_count = dc;
+        inputs.explicit_deps = reinterpret_cast<const PTO2TaskId *>(deps_data);
+
+        // Register tasks[] entry (with per-arg slot info) and any unseen
+        // tensors[] entries up-front. Tensors are registered from the
+        // consumer-side blob so raw_shapes / dtype are populated (the
+        // producer-side PTO2TensorMapEntry drops raw_shapes to fit in two
+        // cache lines).
+        TaskTableEntry task_entry;
+        task_entry.task_id = rec.task_id;
+        task_entry.in_manual_scope = in_manual_scope;
+        task_entry.args.reserve(tc);
+        for (int32_t i = 0; i < tc; i++) {
+            TaskArgEntry slot{};
+            slot.idx = i;
+            slot.arg_type = atype_buf[i];
+            if (atype_buf[i] == TensorArgType::OUTPUT) {
+                // OUTPUT blob is zero at submit time (writer has no Tensor
+                // yet); leave has_tensor_info=false. Viewers render this as
+                // a placeholder "alloc" output slot.
+                slot.has_tensor_info = false;
+            } else {
+                const Tensor &t = *tref_buf[i].ptr;
+                register_tensor(tensor_index, tensor_table, t);
+                slot.has_tensor_info = true;
+                slot.tensor_id = make_tensor_id(t.buffer.addr, t.version);
+                slot.dtype = static_cast<uint8_t>(t.dtype);
+                slot.ndims = t.ndims;
+                slot.start_offset = t.start_offset;
+                for (uint32_t d = 0; d < t.ndims && d < RUNTIME_MAX_TENSOR_DIMS; d++) {
+                    slot.shape[d] = t.shapes[d];
+                    slot.strides[d] = t.strides[d];
+                }
+            }
+            task_entry.args.push_back(slot);
+        }
+        task_table.push_back(std::move(task_entry));
+
+        // ============ STEP 1 — explicit_deps (call-site emit) ============
+        // Same loop on both passes; they MUST produce identical sets here
+        // because they read the same record. Annot records explicit edges
+        // with consumer_arg_idx = -1 (not tied to any tensor arg). Reads
+        // from deps_data (base record's explicit_deps[] on fast path, the
+        // gathered base+chain buffer on overflow path).
+        for (int32_t i = 0; i < dc; i++) {
+            uint64_t pred_raw = deps_data[i];
+            if (oracle_preds.insert(pred_raw).second) {
+                // First time this pred is seen at runtime call site.
+            }
+            if (annot_preds.insert(pred_raw).second) {
+                EdgeAnnot e{};
+                e.pred = pred_raw;
+                e.succ = rec.task_id;
+                e.consumer_arg_idx = -1;
+                e.source = EdgeSource::EXPLICIT;
+                annot_edges.push_back(e);
+            }
+        }
+
+        // ============ ORACLE pass — drive compute_task_fanin ============
+        bool ok = compute_task_fanin(inputs, tm_oracle, in_manual_scope, [&](PTO2TaskId producer) -> bool {
+            oracle_preds.insert(producer.raw);
+            return true;
+        });
+        if (!ok) {
+            LOG_ERROR("dep_gen replay: compute_task_fanin returned fatal at task_id=%" PRIu64, rec.task_id);
+            tm_oracle.destroy();
+            tm_annot.destroy();
+            return -4;
+        }
+
+        // ============ ANNOT pass — inline mirror, full entry capture ============
+        annot_pass(
+            inputs, tm_annot, in_manual_scope,
+            // emit_creator(producer, arg_idx, consumer_tensor)
+            [&](PTO2TaskId producer, int32_t arg_idx, const Tensor &consumer) {
+                if (!annot_preds.insert(producer.raw).second) {
+                    return;  // already covered by an earlier emit on this record
+                }
+                EdgeAnnot e{};
+                e.pred = producer.raw;
+                e.succ = rec.task_id;
+                e.consumer_arg_idx = arg_idx;
+                e.source = EdgeSource::CREATOR;
+                e.tensor_id = make_tensor_id(consumer.buffer.addr, consumer.version);
+                fill_consumer(e, consumer);
+                annot_edges.push_back(e);
+            },
+            // emit_tensormap(producer, arg_idx, consumer_tensor, entry, status)
+            [&](PTO2TaskId producer, int32_t arg_idx, const Tensor &consumer, const PTO2TensorMapEntry &entry,
+                OverlapStatus status) {
+                // Per-(succ, arg_idx, producer_buffer_addr, producer_version)
+                // dedup gives us "the same producer slice fired twice for the
+                // same consumer arg" collapse — but two distinct slices from
+                // the same producer (different version), or two different
+                // producers, both yield their own edges. The producer-id-set
+                // comparison below uses annot_preds, which dedups by pred
+                // only, matching runtime PTO2FaninBuilder semantics.
+                annot_preds.insert(producer.raw);
+                EdgeAnnot e{};
+                e.pred = producer.raw;
+                e.succ = rec.task_id;
+                e.consumer_arg_idx = arg_idx;
+                e.source = EdgeSource::TENSORMAP;
+                e.overlap = status;
+                e.tensor_id = make_tensor_id(entry.buffer_addr, entry.version);
+                fill_consumer(e, consumer);
+                fill_producer(e, entry);
+                annot_edges.push_back(e);
+            }
+        );
+
+        // ============ Differential check ============
+        if (oracle_preds != annot_preds) {
+            LOG_ERROR(
+                "dep_gen replay: DIVERGENCE at task_id=%" PRIu64 " (rec_idx=%zu): oracle has %zu preds, annot has %zu",
+                rec.task_id, rec_i, oracle_preds.size(), annot_preds.size()
+            );
+            // Log the symmetric difference for debugging.
+            for (uint64_t p : oracle_preds) {
+                if (annot_preds.find(p) == annot_preds.end()) {
+                    LOG_ERROR("  only-in-oracle pred: %" PRIu64, p);
+                }
+            }
+            for (uint64_t p : annot_preds) {
+                if (oracle_preds.find(p) == oracle_preds.end()) {
+                    LOG_ERROR("  only-in-annot  pred: %" PRIu64, p);
+                }
+            }
+            tm_oracle.destroy();
+            tm_annot.destroy();
+            return -6;
+        }
+
+        // ============ STEP 4 — publish outputs on BOTH maps ============
+        register_task_outputs(inputs, task_id, tm_oracle, in_manual_scope);
+        register_task_outputs(inputs, task_id, tm_annot, in_manual_scope);
+    }
+
+    tm_oracle.destroy();
+    tm_annot.destroy();
+
+    if (!write_deps_json(deps_json_path, task_table, tensor_table, annot_edges)) {
+        return -5;
+    }
+    LOG_INFO_V0(
+        "dep_gen replay: wrote deps.json to %s (tasks=%zu, tensors=%zu, edges=%zu)", deps_json_path, task_table.size(),
+        tensor_table.size(), annot_edges.size()
+    );
+    return 0;
+}

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * @file dep_gen_replay.h
+ * @brief Host-side replay of in-memory DepGenRecord stream → deps.json.
+ *
+ * Takes the records the host collector drained from the device ring buffer
+ * (``DepGenCollector::records()``) and runs them back through a host-resident
+ * PTO2TensorMap using the same ``compute_task_fanin`` / ``register_task_outputs``
+ * primitives the device orchestrator uses, emitting the full
+ * predecessor → successor edge list to deps.json.
+ *
+ * The records buffer is passed in directly — there is no intermediate
+ * ``submit_trace.bin`` on disk. The host already has the records once the
+ * device run completes, so going through the filesystem would just be
+ * extra I/O and an extra file in the output directory.
+ *
+ * deps.json is the sole source of truth for fanout: the L2 swimlane hot
+ * path no longer records ``L2PerfRecord::fanout[]`` (taking the per-task
+ * 1 KB GM store off the scheduler critical path). Replay sees every
+ * submit and reconstructs the complete dependency graph.
+ *
+ * Output format (deps.json, strided tensor representation):
+ *
+ *   {"tasks":   [{"task_id":<u64>, "scope":"auto|manual",
+ *                 "args":[{"idx":<i32>, "type":"<arg_type>",
+ *                          "tensor_id":<u64>, "dtype":"...", "shape":[...],
+ *                          "start_offset":<u64>, "strides":[...]}, ...]}, ...],
+ *    "tensors": [{"tensor_id":<u64>, "buffer_addr":<u64>, "version":<i32>,
+ *                 "dtype":"FLOAT32", "buffer_numel":<u64>}, ...],
+ *    "edges":   [{"pred":<u64>, "succ":<u64>, "arg":<i32>,
+ *                 "source":"explicit|creator|tensormap",
+ *                 "overlap":"covered|other" (tensormap only),
+ *                 "tensor_id":<u64> (non-explicit),
+ *                 "consumer_dtype":"...", "consumer_shape":[...],
+ *                 "consumer_start_offset":<u64>, "consumer_strides":[...],
+ *                 "producer_shape":[...] (tensormap),
+ *                 "producer_start_offset":<u64> (tensormap),
+ *                 "producer_strides":[...] (tensormap)},
+ *                ...]}
+ *
+ *   - All task ids are ``PTO2TaskId::raw`` values (``(ring_id << 32) | local_id``).
+ *   - ``tensor_id`` is a stable FNV-1a hash of ``(buffer_addr, version)``.
+ *   - ``buffer_numel`` is the underlying storage element count; tensor shapes
+ *     are carried per-arg / per-edge alongside ``start_offset`` + ``strides``.
+ *   - Distinct producers / arg indices / sources keep their own edges; per-record
+ *     deduplication of producer ids mirrors the runtime
+ *     ``PTO2FaninBuilder::append_fanin_or_fail`` semantics so the set of
+ *     ``(pred, succ)`` pairs is identical to what the runtime would have
+ *     recorded.
+ *
+ * Self-checking: the replay runs two parallel tensormap instances per record —
+ * an "oracle" map driven by the canonical ``compute_task_fanin`` template, and
+ * an "annotated" map driven by an inlined mirror that captures the per-edge
+ * tensor metadata. If the producer-id set on the two passes ever diverges,
+ * deps.json is NOT written and the function returns a non-zero error code.
+ * This is the guarantee against silent shotgun modifications: anyone who
+ * changes ``compute_task_fanin`` semantics has to mirror the change here too
+ * or the gate fires immediately.
+ *
+ * The replay is single-threaded and pure CPU: no device handle is required.
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_HOST_DEP_GEN_REPLAY_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_HOST_DEP_GEN_REPLAY_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+// Opaque forward decl — the canonical layout lives in common/dep_gen.h, but
+// replay's API only needs to take a pointer + count. Callers who construct
+// the buffer must include common/dep_gen.h themselves.
+struct DepGenRecord;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Replay an in-memory DepGenRecord stream and write deps.json.
+ *
+ * Per-ring task window sizes are auto-derived from the trace itself so each
+ * ring's window covers its observed max local_id without slot aliasing.
+ *
+ * @param records            Pointer to a contiguous DepGenRecord array
+ *                           (typically ``DepGenCollector::records().data()``).
+ * @param num_records        Number of records in the array.
+ * @param deps_json_path     Output path; truncated if it exists.
+ * @return 0 on success; negative on error (see source for codes).
+ */
+int dep_gen_replay_emit_deps_json(const struct DepGenRecord *records, size_t num_records, const char *deps_json_path);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_HOST_DEP_GEN_REPLAY_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -26,6 +26,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "aicpu/dep_gen_collector_aicpu.h"
+#include "common/dep_gen.h"
 #include "common/unified_log.h"
 #include "pto_dep_compute.h"
 #include "pto_runtime2_types.h"
@@ -36,6 +38,25 @@
 
 extern "C" void set_dump_tensor_selective_mode(bool enable);
 extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
+
+// Verify the captured Tensor blob size in DepGenRecord matches the runtime
+// Tensor layout. The platform header defines DEP_GEN_TENSOR_SIZE without
+// including runtime/tensor.h, so this check lives at the orch callsite.
+static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot size out of sync with sizeof(Tensor)");
+// DEP_GEN_MAX_EXPLICIT_DEPS is a diagnostic-side capture cap only; the runtime
+// imposes no hard cap on explicit dep count. If a submit exceeds this cap,
+// dep_gen_aicpu_record_submit() logs and truncates — runtime correctness is
+// unaffected, only the captured replay record is truncated.
+
+// Weak fallbacks: dep_gen_collector_aicpu.cpp provides the strong symbols in
+// AICPU builds. Host builds (host_build_graph runtime, future dep_gen replay)
+// link these no-op stubs so the runtime translation unit is self-contained.
+// Visibility is hidden so the HOST .so doesn't export them into the global
+// dynamic symbol table where they'd shadow the AICPU .so's strong symbols
+// (same pattern as get_sys_cnt_aicpu / l2_perf_aicpu_record_orch_phase below).
+extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
+__attribute__((weak, visibility("hidden"))) void
+dep_gen_aicpu_record_submit(uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *) {}
 
 #if PTO2_PROFILING
 #include "aicpu/scope_stats_collector_aicpu.h"
@@ -501,6 +522,38 @@ static TaskOutputTensors submit_task_common(
     PTO2TaskDescriptor &task = *prepared.task;
     PTO2TaskPayload &payload = *prepared.payload;
     result.set_task_id(task_id);
+
+    // dep_gen capture point: snapshot the orch submit_task inputs while the
+    // tensormap is still in its pre-lookup state for this task. Replay reads
+    // these records offline to reconstruct the complete dep graph — the sole
+    // source of truth for fanout now that the swimlane hot path no longer
+    // records it.
+    if (is_dep_gen_enabled()) {
+        const void *tensor_ptrs[MAX_TENSOR_ARGS];
+        // TensorArgType is `enum class : int32_t` (4 bytes); the on-disk record
+        // packs arg_types as uint8_t[16] (5-value enum fits in a byte). Narrow
+        // each tag here rather than letting the AICPU writer reinterpret a
+        // 4×-wider array as bytes — that path silently lost two of every three
+        // tags on little-endian and synthesized phantom self-edges in replay.
+        uint8_t arg_types_u8[MAX_TENSOR_ARGS];
+        // Clamp to MAX_TENSOR_ARGS even though the Arg builder caps adds at
+        // MAX_TENSOR_ARGS: defensive against any future builder bypass /
+        // shared-memory bit-flip that could otherwise overrun the two
+        // MAX_TENSOR_ARGS-sized stack buffers above.
+        const int tc_raw = args.tensor_count();
+        const int tc = tc_raw > MAX_TENSOR_ARGS ? MAX_TENSOR_ARGS : tc_raw;
+        for (int i = 0; i < tc; i++) {
+            // OUTPUT slots carry create_info (not yet a Tensor); skip them —
+            // they have no producer to look up and replay's per-tensor loop
+            // also skips OUTPUT.
+            tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : args.tensor(i).ptr;
+            arg_types_u8[i] = static_cast<uint8_t>(args.tag(i));
+        }
+        dep_gen_aicpu_record_submit(
+            task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
+            static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data())
+        );
+    }
 
     PTO2FaninBuilder fanin_builder(orch->rings[ring_id].fanin_pool);
 

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -389,8 +389,8 @@ int run_prepared(
         runner->set_l2_swimlane_enabled(enable_l2_swimlane);
         runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
         runner->set_pmu_enabled(enable_pmu);
-        // Virtual: a2a3 wires through to its enable_dep_gen_; a5 is a no-op
-        // (dep_gen isn't implemented on a5 today).
+        // Virtual: a2a3 and a5 wire through to their enable_dep_gen_; an arch
+        // without dep_gen falls through to the base no-op.
         runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_scope_stats_enabled(enable_scope_stats != 0);
         runner->set_output_prefix(output_prefix);

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -311,8 +311,8 @@ public:
     // The shared `pto_runtime_c_api` glue (`src/common/platform/onboard/host/
     // c_api_shared.cpp`) works through `DeviceRunnerBase *` and dispatches
     // through these virtuals. Each arch's `DeviceRunner` overrides
-    // `run` and `finalize`; a2a3 also overrides `set_dep_gen_enabled`
-    // (a5 keeps the default no-op since dep_gen is a2a3-only today).
+    // `run` and `finalize`; a2a3 and a5 both override `set_dep_gen_enabled`
+    // (an arch without dep_gen keeps the base no-op default).
 
     /**
      * Execute a Runtime. Each arch implements its own `run()` — the bodies
@@ -332,9 +332,9 @@ public:
     virtual int finalize() = 0;
 
     /**
-     * a2a3-only diagnostics setter. The shared c_api `run_prepared`
-     * calls this unconditionally; on a5 it's a no-op default (dep_gen
-     * is not implemented there yet).
+     * dep_gen enablement setter. The shared c_api `run_prepared` calls this
+     * unconditionally; a2a3 and a5 override it to capture submit_task inputs.
+     * The base default is a no-op for any arch that does not implement dep_gen.
      */
     virtual void set_dep_gen_enabled(bool /*enable*/) {}
 
@@ -746,8 +746,8 @@ protected:
     // Shared diagnostics collectors. Each subclass initializes its own
     // (a2a3 wraps `halHostRegister`/`Unregister` callbacks, a5 uses
     // direct `rtMalloc`/`rtFree`), but the storage and lifetime live
-    // on the base. `DepGenCollector` is a2a3-only and stays on the
-    // a2a3 subclass.
+    // on the base. `DepGenCollector` is not shared — each arch that
+    // implements dep_gen (a2a3, a5) keeps it on its own subclass.
     L2SwimlaneCollector l2_swimlane_collector_;
     TensorDumpCollector dump_collector_;
     PmuCollector pmu_collector_;

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -65,7 +65,7 @@ public:
     // --- Pure / no-op virtuals dispatched from the shared c_api glue ----
     virtual int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) = 0;
     virtual int finalize() = 0;
-    // a2a3 overrides (dep_gen on a2a3 only); a5 leaves the default no-op.
+    // a2a3 and a5 both override; an arch without dep_gen leaves the no-op.
     virtual void set_dep_gen_enabled(bool /*enable*/) {}
 
     // --- Shared methods --------------------------------------------------

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Many-to-one barrier via explicit set_dependencies — exercises the dep_gen
+ * overflow chain wire format.
+ *
+ * Submits N producers each writing X[0] = 42.0, then a dummy_T whose only
+ * dependency surface is set_dependencies({all N producer ids}, N), then a
+ * consumer that explicit-depends on the barrier and copies X[0] -> Y[0].
+ *
+ * Picking N > DEP_GEN_MAX_EXPLICIT_DEPS (=64) forces the dep_gen capture to
+ * spill into one or more DepGenOverflowRecord slots; picking N to span the
+ * 64 + k*326 boundaries exercises both single- and multi-overflow chains.
+ *
+ * Args layout: [X, Y, scalar(N)]
+ *   - X: every producer writes it (tensormap auto-deps the chain so the
+ *        SENTINEL is preserved); consumer reads it.
+ *   - Y: consumer writes it; host checks Y[0] == SENTINEL.
+ *
+ * Scalar: N (1 .. MAX_PRODUCERS).
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_WRITE_CONST 0
+#define FUNC_COPY_FIRST 1
+
+// Stack room for producer_ids[]. 500 covers everything we expect to test;
+// PTO2_DEP_LIST_POOL_SIZE (16384) is the real ceiling on a per-ring basis.
+static constexpr int32_t MAX_PRODUCERS = 500;
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,  // X, Y, scalar(N)
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
+    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
+
+    uint64_t n_raw = orch_args.scalar(0);
+    int32_t n = static_cast<int32_t>(n_raw);
+    if (n < 1 || n > MAX_PRODUCERS) {
+        rt_report_fatal(PTO2_ERROR_INVALID_ARGS, "chain_barrier_orch: invalid n=%d", n);
+        return;
+    }
+
+    PTO2TaskId producer_ids[MAX_PRODUCERS];
+
+    // N producers each INOUT X. tensormap auto-deps them in a chain, so X[0]
+    // stays at SENTINEL through all of them — the host only checks the final
+    // value, which proves the barrier waited for every producer to finish.
+    for (int32_t i = 0; i < n; i++) {
+        Arg args;
+        args.add_inout(ext_X);
+        producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+    }
+
+    // Dummy barrier with explicit deps on ALL N producers. dc=n > 64 forces
+    // the dep_gen writer to emit base + overflow chain.
+    PTO2TaskId barrier_id;
+    {
+        Arg args;
+        args.set_dependencies(producer_ids, n);
+        barrier_id = rt_submit_dummy_task(args).task_id();
+    }
+
+    // Consumer: explicit dep on barrier only, reads X, writes Y.
+    {
+        Arg args;
+        PTO2TaskId consumer_deps[] = {barrier_id};
+        args.set_dependencies(consumer_deps, 1);
+        args.add_input(ext_X);
+        args.add_inout(ext_Y);
+        rt_submit_aic_task(FUNC_COPY_FIRST, args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -10,7 +10,7 @@
 """dep_gen capture + replay sim test.
 
 Re-runs the ``vector_example`` orchestration with ``--enable-dep-gen``.
-Verifies the end-to-end dep_gen pipeline on a2a3sim:
+Verifies the end-to-end dep_gen pipeline on a5sim:
 
   ``<output_prefix>/deps.json`` is produced by the host replay
   (PTO2TensorMap replay → JSON edge list), and contains exactly the
@@ -20,7 +20,7 @@ Verifies the end-to-end dep_gen pipeline on a2a3sim:
   implicitly: if it broke, deps.json would be empty or wrong.
 
 deps.json is now the sole source of truth for fanout edges — the device
-hot path no longer records L2SwimlaneAicpuTaskRecord::fanout[], so there is no
+hot path no longer records L2PerfRecord::fanout[], so there is no
 "fanout ⊆ deps" cross-check to run. swimlane_converter.py joins
 deps.json into the Perfetto trace at post-process time.
 
@@ -40,7 +40,7 @@ from simpler.task_interface import ArgDirection as D
 from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
 from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
 
-KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels"
+KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
 
 
 def _task_id(ring: int, local: int) -> int:
@@ -86,7 +86,7 @@ class TestDepGen(SceneTestCase):
     CASES = [
         {
             "name": "default",
-            "platforms": ["a2a3sim", "a2a3"],
+            "platforms": ["a5sim", "a5"],
             "config": {"aicpu_thread_num": 4, "block_dim": 3},
             "params": {},
         },

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""dep_gen overflow chain regression — submits with >64 explicit deps.
+
+A submit with explicit_dep_count > DEP_GEN_MAX_EXPLICIT_DEPS (=64) spills the
+extra deps into one or more DepGenOverflowRecord slots that overlay the same
+buffer ring. Before the chain wire format, dep_gen would silently truncate
+the tail in deps.json; this test verifies every explicit dep edge survives
+the round-trip writer → host collector → replay → deps.json.
+
+Test shape (chain_barrier_orch.cpp): N producers each INOUT X, then a dummy
+barrier `set_dependencies({all N producer ids})`, then a consumer
+`set_dependencies({barrier_id})` reading X and writing Y. With N spanning
+the {64, 65, 390, 391} boundaries we exercise:
+
+  - n=64: base only (no chain) — sanity baseline
+  - n=65: base + 1 overflow record (1 dep in overflow)
+  - n=200: base + 1 overflow (136 deps in overflow)
+  - n=391: base + 2 overflow (326 + 1 deps across two overflows)
+
+Validation: the barrier task in deps.json must have exactly N predecessors,
+all of which are the producer ids. The consumer must have one explicit
+predecessor — the barrier.
+"""
+
+import json
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+# Path is relative to this file's directory (the SceneTestCase build helper
+# resolves CALLABLE sources from there). dummy_task already ships the two
+# kernels we need (write_const + copy_first), so we reuse those instead of
+# duplicating the source.
+DUMMY_KERNELS = "../../dummy_task/kernels"
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestDepGenChain(SceneTestCase):
+    """dep_gen overflow chain: many-to-one barrier with >64 explicit deps."""
+
+    RTOL = 0
+    ATOL = 0
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/chain_barrier_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],  # X, Y; N goes as scalar
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": f"{DUMMY_KERNELS}/aic/kernel_write_const.cpp",
+                "core_type": "aic",
+            },
+            {
+                "func_id": 1,
+                "name": "COPY_FIRST",
+                "source": f"{DUMMY_KERNELS}/aic/kernel_copy_first.cpp",
+                "core_type": "aic",
+            },
+        ],
+    }
+
+    # Sentinel must match kernel_write_const (writes 42.0f).
+    SENTINEL = 42.0
+    INIT_VAL = -1.0
+
+    CASES = [
+        {
+            "name": "n_64_no_chain",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 64},
+        },
+        {
+            "name": "n_65_single_overflow",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 65},
+        },
+        {
+            "name": "n_200_single_overflow",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 200},
+        },
+        {
+            "name": "n_391_two_overflow",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 2, "block_dim": 1},
+            "params": {"n": 391},
+        },
+    ]
+
+    def generate_args(self, params):
+        # Single-element tensors are enough — kernel_write_const writes index 0
+        # and kernel_copy_first reads index 0.
+        x = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
+        y = torch.full((16,), self.INIT_VAL, dtype=torch.float32)
+        return TaskArgsBuilder(
+            Tensor("x", x),
+            Tensor("y", y),
+            Scalar("n", int(params["n"])),
+        )
+
+    def compute_golden(self, args, params):
+        # Producers each write SENTINEL to X[0]; consumer copies X[0] -> Y[0].
+        # If the barrier didn't actually wait for all producers, the consumer
+        # could race ahead and copy INIT_VAL instead — making the host check
+        # a defacto sanity gate even before we look at deps.json.
+        args.x[0] = self.SENTINEL
+        args.y[0] = self.SENTINEL
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        if not self._effective_enable_dep_gen(request):
+            return
+        for case in self.CASES:
+            if st_platform in case.get("platforms", []):
+                self._post_validate(case)
+
+    def _post_validate(self, case):
+        """Verify every explicit dep edge survived the writer → replay round-trip.
+
+        With dep_gen on, deps.json must contain N edges from the producers to
+        the barrier task (one per `set_dependencies` entry the orchestration
+        emitted), plus the consumer's one explicit edge back from the barrier.
+        Pre-chain code would truncate the producer→barrier edge set to 16/64.
+        """
+        case_name = case["name"]
+        n = int(case["params"]["n"])
+        safe_label = _sanitize_for_filename(f"TestDepGenChain_{case_name}")
+        outputs = _outputs_dir()
+        matches = sorted(outputs.glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        assert matches, f"no output dir for case {case_name!r} — scene didn't run on this platform?"
+        out_dir = matches[-1]
+        deps_path = out_dir / "deps.json"
+        # _post_validate is only invoked when dep_gen was effectively enabled;
+        # absence of deps.json means the host runner declined to emit it (most
+        # likely reconcile_counters failed). Surface that as a hard failure
+        # rather than silently passing — the whole point of this test is to
+        # catch chain-side reconciliation regressions.
+        assert deps_path.exists(), (
+            f"dep_gen was enabled but {deps_path} is missing. Likely cause: "
+            f"reconcile_counters() detected a count mismatch and suppressed deps.json emission. "
+            f"Check the run log for 'dep_gen reconcile' warnings."
+        )
+
+        with deps_path.open() as f:
+            deps = json.load(f)
+
+        raw_edges = deps.get("edges", [])
+        # Project annotated edges → (pred, succ) — we only care about graph
+        # structure here; the annot-vs-oracle agreement gate already ran
+        # inside the replay before deps.json was written.
+        edges = set()
+        explicit_edges = set()
+        for e in raw_edges:
+            if not isinstance(e, dict):
+                continue
+            pred, succ = e.get("pred"), e.get("succ")
+            if pred is None or succ is None:
+                continue
+            pair = (int(pred), int(succ))
+            edges.add(pair)
+            if e.get("source") == "explicit":
+                explicit_edges.add(pair)
+
+        # Identify the barrier task: it's the task with exactly n explicit-source
+        # incoming edges. (Producers have 0; consumer has 1 — the one to barrier.)
+        explicit_by_succ = {}
+        for pred, succ in explicit_edges:
+            explicit_by_succ.setdefault(succ, set()).add(pred)
+        barrier_candidates = [tid for tid, preds in explicit_by_succ.items() if len(preds) == n]
+        assert len(barrier_candidates) == 1, (
+            f"expected exactly one task with {n} explicit predecessors "
+            f"(the barrier), got {len(barrier_candidates)}: "
+            f"{[(tid, len(preds)) for tid, preds in explicit_by_succ.items()]}"
+        )
+        barrier_id = barrier_candidates[0]
+        barrier_preds = explicit_by_succ[barrier_id]
+
+        # All N producer→barrier edges must be present. This is the chain
+        # round-trip assertion: pre-chain code drops anything past index 63.
+        assert len(barrier_preds) == n, f"barrier has {len(barrier_preds)} preds, expected {n}"
+
+        # Consumer must explicit-depend on the barrier — exactly one outgoing
+        # explicit edge from the barrier.
+        outgoing_explicit_from_barrier = {succ for pred, succ in explicit_edges if pred == barrier_id}
+        assert len(outgoing_explicit_from_barrier) == 1, (
+            f"barrier {barrier_id} has {len(outgoing_explicit_from_barrier)} outgoing explicit edges, "
+            f"expected 1 (the consumer)"
+        )
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
Add: dep_gen capture+replay support on a5

Port the dep_gen (SubmitTrace) feature from a2a3 to a5 so the
tensormap_and_ringbuffer runtime on a5 can produce deps.json and feed
flow events into swimlane_converter.py. Without this, --enable-dep-gen
was a no-op on a5 and merged_swimlane_*.json had no dependency arrows.

Reused from a2a3 (code-identical; the .cpp files are byte-for-byte
copies, the headers differ only in include-guard names and
L2Swimlane->L2Perf / a2a3->a5 comment refs):
  - Shared-memory ABI: common/dep_gen.h (DepGenRecord 2624 B, overflow
    chain, SPSC free_queue, per-thread ready_queue) — layout byte-identical
  - AICPU writer: aicpu/dep_gen_collector_aicpu.{h,cpp} (.cpp identical)
  - Runtime replay: runtime/tensormap_and_ringbuffer/host/dep_gen_replay
    (.cpp identical)
  - Orchestrator capture point + aicpu_executor lifecycle hooks
  - 5 platform_config constants + PROFILING_FLAG_DEP_GEN bit

Specialized for a5 (no SVM, see profiling_common diff vs a2a3):
  - dep_gen_collector.cpp uses alloc_single_buffer (malloc shadow +
    profiling_copy_to_device) instead of identity-mapping when
    register_cb is null — matches a5's PMU/L2Perf/Dump collectors.
  - Two-phase set_memory_context: callbacks first, then shm pointers
    once the region is committed, so start(tf) gates correctly.
  - reconcile_counters explicitly copy_from_device's the BufferState +
    current_buf before reading (mgmt thread is stopped by then).
  - finalize lets BufferPoolManager::clear_mappings() be the single
    source of truth for host-shadow lifetime — no per-collector dedup.

Sim path: dlsym set_platform_dep_gen_base / set_dep_gen_enabled out of
the AICPU .so and forward kernel_args.dep_gen_data_base + enable flag
at boot, mirroring the existing pmu / dump / l2_perf setters.

Onboard kernel.cpp adds two lines to forward dep_gen_data_base +
PROFILING_FLAG_DEP_GEN into the AICPU writer's globals, mirroring the
existing PMU / L2 / Dump setters.

c_api: a5's DeviceRunner now overrides set_dep_gen_enabled() (was the
base no-op), so run_prepared's already-present enable_dep_gen call is
honored on a5 instead of being silently dropped. The shared
c_api_shared.cpp / device_runner_base.h changes are comment-only —
refreshing stale "a2a3-only" notes to reflect both arches now wire it.

Tests:
  - tests/st/a5/.../dfx/dep_gen/test_dep_gen.py: 6-edge validation
    against vector_example orchestration (byte-identical to a2a3 — same
    expected edge set).
  - tests/st/a5/.../dfx/dep_gen/test_dep_gen_chain.py
    (+ kernels/orchestration/chain_barrier_orch.cpp): overflow chain
    regression for >64 explicit deps.
  - tests/st/a2a3/.../dfx/dep_gen/test_dep_gen.py: harden the existing
    a2a3 gate — a missing deps.json under --enable-dep-gen now fails
    loudly (assert) instead of silently skipping, so a
    capture->reconcile->replay regression can no longer pass green
    ([[[#742](https://github.com/hw-native-sys/simpler/issues/742)](https://github.com/hw-native-sys/simpler/issues/742)](https://github.com/hw-native-sys/simpler/issues/742)).

Docs:
  - docs/dfx/dep_gen.md: §8 Architecture Touchpoints now lists both
    platforms; "Currently a2a3 only" line removed.
  - src/a5/runtime/.../docs/profiling_levels.md: Code Locations point