### PR TITLE
docs: docstrings for deinit-timeout hooks + fix sim vCPU count in ci.md

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -75,17 +75,23 @@ profiling-vs-parallelism trade-off.
 
 ### Sim jobs on CPU-constrained runners
 
-Sim jobs (`st-sim-a2a3`, `st-sim-a5`) run on `ubuntu-latest`, which typically
-has 2 vCPUs. `--device 0-15` is still the right choice for the **pool size**
-(some L3 cases need several virtual ids), but the default `--max-parallel auto`
-caps the in-flight subprocess count to `min(nproc, len(--device))` — on a
-2-core runner that becomes `2`, avoiding CPU thrashing:
+Sim jobs (`st-sim-a2a3`, `st-sim-a5`) run on `ubuntu-latest`, whose standard
+GitHub-hosted runner currently has **4 vCPUs**. `--device 0-15` is still the
+right choice for the **pool size** (some L3 cases need several virtual ids), but
+the default `--max-parallel auto` caps the in-flight subprocess count to
+`min(nproc, len(--device))` — on a 4-core runner that becomes `4`. Note
+`os.cpu_count()` reports the host's logical CPUs and ignores any cgroup CPU
+quota, so this is the true core count, not a container limit.
 
 ```bash
-# Sim: --max-parallel auto resolves to 2 on ubuntu-latest
+# Sim: --max-parallel auto resolves to 4 on a standard ubuntu-latest runner
 pytest examples tests/st --platform a2a3sim --device 0-15
 
-# Or pin explicitly if your runner has a different CPU count
+# Throttle further on a CPU-starved runner: 4 concurrent cases (each forking
+# several chip subprocesses with many threads) can oversubscribe 4 cores and
+# trigger the sim handshake/deinit failures in
+# troubleshooting/sim-oversubscription-hang.md. --max-parallel 2 trades
+# throughput for stability.
 pytest examples tests/st --platform a2a3sim --device 0-15 --max-parallel 2
 ```
 

--- a/src/a2a3/platform/onboard/aicpu/inner_platform_regs.cpp
+++ b/src/a2a3/platform/onboard/aicpu/inner_platform_regs.cpp
@@ -23,7 +23,14 @@
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
 
-// 1 s budget on real hardware — non-response that long means the op was
-// STARS-killed or the core is wedged; aclrtResetDevice will clean up.
-// See declaration in platform_regs.h for the design rationale.
+/**
+ * @brief Deinit ACK-wait budget on real hardware: 1 s.
+ *
+ * On silicon a non-response this long means the op was STARS-killed or the
+ * core is wedged; aclrtResetDevice will clean up. The tight budget preserves
+ * hardware hang detection. See the declaration in platform_regs.h for the
+ * full rationale.
+ *
+ * @return Timeout in profiling system-counter ticks.
+ */
 uint64_t inner_get_deinit_timeout_ticks() { return PLATFORM_PROF_SYS_CNT_FREQ; }

--- a/src/a2a3/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a2a3/platform/sim/aicpu/inner_platform_regs.cpp
@@ -22,7 +22,14 @@
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
 
-// 10 s budget on sim — AICore is a host CPU thread and "no response" can
-// just mean the OS scheduler hasn't given it a slice on a CPU-starved CI
-// runner. See declaration in platform_regs.h for the design rationale.
+/**
+ * @brief Deinit ACK-wait budget on sim: 10 s.
+ *
+ * On sim "AICore" is a host CPU thread, so a missing exit ACK usually just
+ * means the OS scheduler hasn't given that thread a slice on a CPU-starved CI
+ * runner — not a wedged op. The wide budget tolerates that jitter. See the
+ * declaration in platform_regs.h for the full rationale.
+ *
+ * @return Timeout in profiling system-counter ticks.
+ */
 uint64_t inner_get_deinit_timeout_ticks() { return 10 * PLATFORM_PROF_SYS_CNT_FREQ; }

--- a/src/a5/platform/onboard/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/onboard/aicpu/inner_platform_regs.cpp
@@ -37,7 +37,14 @@ void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
     *get_reg_ptr(reg_base_addr, reg) = static_cast<uint32_t>(value);
 }
 
-// 1 s budget on real hardware — non-response that long means the op was
-// STARS-killed or the core is wedged; aclrtResetDevice will clean up.
-// See declaration in platform_regs.h for the design rationale.
+/**
+ * @brief Deinit ACK-wait budget on real hardware: 1 s.
+ *
+ * On silicon a non-response this long means the op was STARS-killed or the
+ * core is wedged; aclrtResetDevice will clean up. The tight budget preserves
+ * hardware hang detection. See the declaration in platform_regs.h for the
+ * full rationale.
+ *
+ * @return Timeout in profiling system-counter ticks.
+ */
 uint64_t inner_get_deinit_timeout_ticks() { return PLATFORM_PROF_SYS_CNT_FREQ; }

--- a/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
@@ -34,7 +34,14 @@ void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
     *get_reg_ptr(reg_base_addr, reg) = static_cast<uint32_t>(value);
 }
 
-// 10 s budget on sim — AICore is a host CPU thread and "no response" can
-// just mean the OS scheduler hasn't given it a slice on a CPU-starved CI
-// runner. See declaration in platform_regs.h for the design rationale.
+/**
+ * @brief Deinit ACK-wait budget on sim: 10 s.
+ *
+ * On sim "AICore" is a host CPU thread, so a missing exit ACK usually just
+ * means the OS scheduler hasn't given that thread a slice on a CPU-starved CI
+ * runner — not a wedged op. The wide budget tolerates that jitter. See the
+ * declaration in platform_regs.h for the full rationale.
+ *
+ * @return Timeout in profiling system-counter ticks.
+ */
 uint64_t inner_get_deinit_timeout_ticks() { return 10 * PLATFORM_PROF_SYS_CNT_FREQ; }


### PR DESCRIPTION
## Summary

Follow-up to #893 (now merged). Two doc-only fixes:

- **Docstring coverage** — CodeRabbit flagged #893 at 50% docstring coverage (< 80%). The four `inner_get_deinit_timeout_ticks()` definitions (a5/a2a3 × sim/onboard) carried plain `//` comments, which the coverage tool doesn't count. Converted them to `/** */` blocks with `@return`, preserving the sim-10s / onboard-1s rationale.
- **`ci.md` vCPU count** — the "Sim jobs on CPU-constrained runners" section claimed `ubuntu-latest` has 2 vCPUs and that `--max-parallel auto` resolves to `2`. Standard GitHub-hosted runners currently have **4 vCPUs**, so it resolves to `4` (= `min(nproc, len(--device))`). Corrected the number, noted `os.cpu_count()` ignores cgroup quotas, and documented that 4 concurrent cases can oversubscribe the runner (the #884 / `sim-oversubscription-hang` failure mode) with `--max-parallel 2` as the throttle.

Comment/doc-only — no functional or ABI change; onboard 1s budget and sim 10s budget are unchanged.

## Testing
- [x] pre-commit (clang-format / clang-tidy / cpplint / markdownlint) pass
- [x] No code path changed (doc comments + markdown only)

Refs #893, #884.