### PR TITLE
Refactor: lock-free MPSC for deferred-completion registration

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -52,7 +52,7 @@
 
 #include <stdint.h>
 
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "pto_task_id.h"
 
 #ifndef __gm__

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -12,10 +12,20 @@
 #ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
 #define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
 
-#include <stdint.h>
+#include <atomic>
+#include <cstdint>
 
+#include "aicore_completion_mailbox_types.h"
 #include "pto_constants.h"
 #include "pto_task_id.h"
+
+// AICPU-only MPSC ring used to convey deferred-completion observations from
+// FIN-handling scheduler threads to the dispatch thread. Producers push under
+// CAS on `head`; the single consumer (dispatch thread, under AsyncWaitList::
+// busy) drains in seq order. Kernel-side code never touches this struct —
+// AICore writes go into DeferredCompletionSlab (see
+// aicore_completion_mailbox_types.h), which the FIN thread reads, flattens
+// into messages here, and forwards.
 
 #define AICORE_COMPLETION_MAILBOX_CAPACITY 4096u
 #define AICORE_COMPLETION_MAILBOX_MASK (AICORE_COMPLETION_MAILBOX_CAPACITY - 1u)
@@ -25,55 +35,151 @@ static_assert(
     "AICORE_COMPLETION_MAILBOX_CAPACITY must be a power of two"
 );
 
-inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
-
-#define COMPLETION_ENGINE_SDMA 0u
-#define COMPLETION_ENGINE_ROCE 1u
-#define COMPLETION_ENGINE_URMA 2u
-#define COMPLETION_ENGINE_CCU 3u
-
-#define COMPLETION_TYPE_COUNTER 0
-#define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
+// Mailbox message discriminator. CONDITION carries one deferred-completion
+// observation flattened from a DeferredCompletionEntry. TASK_NORMAL_DONE
+// carries the slot_state pointer in `addr` so the consumer can finalize the
+// AsyncWaitEntry.slot_state binding for tasks whose conditions arrived
+// before the FIN thread saw mixed_complete. New kinds may be added in future
+// without growing the message — the `_pad[5]` slack is reserved for
+// kind-specific payload extension.
+#define MSG_KIND_CONDITION 0u
+#define MSG_KIND_TASK_NORMAL_DONE 1u
 
 struct AICoreCompletionMailboxMessage {
-    volatile uint64_t seq;
+    // Per-slot ready flag. Producer publishes `tail+1` after filling the rest
+    // of the slot with a release store; consumer waits for the matching seq
+    // value with an acquire load. The release-acquire pair publishes all
+    // other fields below as a side effect, so they stay plain.
+    std::atomic<uint64_t> seq;
     PTO2TaskId task_token;
+    // CONDITION: completion observation addr (counter / SDMA event record).
+    // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
+    //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
     uint32_t expected_value;
     uint32_t engine;
     int32_t completion_type;
-    uint32_t _pad[6];
+    uint32_t kind;
+    uint32_t _pad[5];
 };
 
 static_assert(sizeof(AICoreCompletionMailboxMessage) == PTO2_ALIGN_SIZE, "AICoreCompletionMailboxMessage layout drift");
-
-struct DeferredCompletionEntry {
-    uint64_t addr;
-    uint32_t expected_value;
-    uint32_t engine;
-    int32_t completion_type;
-    uint32_t _pad;
-};
-
-static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
-
-struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
-    volatile uint32_t count;
-    volatile int32_t error_code;
-    DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
-};
-
 static_assert(
-    sizeof(DeferredCompletionSlab) % PTO2_ALIGN_SIZE == 0,
-    "DeferredCompletionSlab size must preserve array element cache-line boundaries"
+    sizeof(std::atomic<uint64_t>) == sizeof(uint64_t),
+    "std::atomic<uint64_t> must be layout-compatible with uint64_t for the message slot layout to hold"
+);
+static_assert(
+    std::atomic<uint64_t>::is_always_lock_free,
+    "AICoreCompletionMailbox requires lock-free uint64_t atomics on every supported target"
 );
 
+// POD view of a drained message. `seq` is the ring's publication flag, not
+// payload, so try_pop copies out only the fields below (and seq is not even
+// copyable — it is a std::atomic).
+struct AICoreCompletionMsgView {
+    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    uint64_t addr{0};
+    uint32_t expected_value{0};
+    uint32_t engine{0};
+    int32_t completion_type{0};
+    uint32_t kind{0};
+};
+
 struct AICoreCompletionMailbox {
-    alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
+    // head and tail live on their own cache lines so producer CAS contention
+    // on head can't false-share with the consumer's tail updates.
+    alignas(PTO2_ALIGN_SIZE) std::atomic<uint64_t> head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
-    alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
+    alignas(PTO2_ALIGN_SIZE) std::atomic<uint64_t> tail;
     uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
     alignas(PTO2_ALIGN_SIZE) AICoreCompletionMailboxMessage entries[AICORE_COMPLETION_MAILBOX_CAPACITY];
+
+    // Cheap, lock-free pending hint. Callers may invoke this outside the
+    // consumer lock; a stale answer only over/under-triggers a drain attempt.
+    bool has_pending() { return tail.load(std::memory_order_acquire) < head.load(std::memory_order_acquire); }
+
+    // MPSC push for a CONDITION message. Returns false when the ring is full
+    // (head - tail >= CAPACITY); caller should SPIN_WAIT_HINT and retry.
+    // Lock-free: CAS the shared head to claim a slot, write the fields, then
+    // release-store seq so the single consumer observes the publication.
+    //
+    // The head CAS is relaxed: head is a pure ticket counter and carries no
+    // data to the consumer — publication is solely the seq release-store, and
+    // slot-reuse safety rests on the acquire load of tail. The relaxed failure
+    // order is likewise sufficient since a lost CAS just re-reads head and
+    // retries. compare_exchange_weak is used because this loop already re-reads
+    // head and re-checks fullness, so masking LL/SC spurious failures (what
+    // _strong adds on aarch64) would only be a redundant inner retry.
+    //
+    // Safe to call concurrently from any number of producers; structurally
+    // independent of the AsyncWaitList::busy lock.
+    bool try_push_condition(
+        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+    ) {
+        while (true) {
+            uint64_t h = head.load(std::memory_order_relaxed);
+            uint64_t t = tail.load(std::memory_order_acquire);
+            if (h - t >= AICORE_COMPLETION_MAILBOX_CAPACITY) return false;
+            uint64_t new_head = h + 1;
+            if (head.compare_exchange_weak(h, new_head, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                AICoreCompletionMailboxMessage *slot = &entries[h & AICORE_COMPLETION_MAILBOX_MASK];
+                slot->task_token.raw = task_token.raw;
+                slot->addr = addr;
+                slot->expected_value = expected_value;
+                slot->engine = engine;
+                slot->completion_type = completion_type;
+                slot->kind = MSG_KIND_CONDITION;
+                slot->seq.store(new_head, std::memory_order_release);
+                return true;
+            }
+            // CAS lost: another producer claimed the slot, retry with refreshed head.
+        }
+    }
+
+    // MPSC push for a TASK_NORMAL_DONE sentinel. Carries the PTO2TaskSlotState
+    // pointer in the `addr` field so the consumer can finish binding the
+    // AsyncWaitEntry.slot_state without going back to the FIN-handling thread.
+    bool try_push_normal_done(PTO2TaskId task_token, uint64_t slot_state_addr) {
+        while (true) {
+            uint64_t h = head.load(std::memory_order_relaxed);
+            uint64_t t = tail.load(std::memory_order_acquire);
+            if (h - t >= AICORE_COMPLETION_MAILBOX_CAPACITY) return false;
+            uint64_t new_head = h + 1;
+            if (head.compare_exchange_weak(h, new_head, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                AICoreCompletionMailboxMessage *slot = &entries[h & AICORE_COMPLETION_MAILBOX_MASK];
+                slot->task_token.raw = task_token.raw;
+                slot->addr = slot_state_addr;
+                slot->expected_value = 0;
+                slot->engine = 0;
+                slot->completion_type = 0;
+                slot->kind = MSG_KIND_TASK_NORMAL_DONE;
+                slot->seq.store(new_head, std::memory_order_release);
+                return true;
+            }
+        }
+    }
+
+    // Single-consumer transport-level dequeue (caller holds the consumer lock).
+    // Returns false at the first not-yet-published slot (gap) or when empty;
+    // otherwise copies the next message in tail order into `out`, advances
+    // tail, and returns true. tail is consumer-only-written (relaxed read);
+    // head bounds the scan (relaxed); the seq acquire is the real publication
+    // gate; the tail release publishes "slot free" to reusing producers.
+    bool try_pop(AICoreCompletionMsgView &out) {
+        uint64_t t = tail.load(std::memory_order_relaxed);
+        uint64_t h = head.load(std::memory_order_relaxed);
+        if (t >= h) return false;
+        AICoreCompletionMailboxMessage *slot = &entries[t & AICORE_COMPLETION_MAILBOX_MASK];
+        if (slot->seq.load(std::memory_order_acquire) != t + 1) return false;
+        out.task_token.raw = slot->task_token.raw;
+        out.addr = slot->addr;
+        out.expected_value = slot->expected_value;
+        out.engine = slot->engine;
+        out.completion_type = slot->completion_type;
+        out.kind = slot->kind;
+        tail.store(t + 1, std::memory_order_release);
+        return true;
+    }
 };
 
 static_assert(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_TYPES_H_
+#define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_TYPES_H_
+
+#include <stdint.h>
+
+#include "pto_constants.h"
+
+// Types shared across the AICore↔AICPU boundary.
+//
+// This header is reachable from AICore-side translation units (via
+// pto_async_kernel_api.h / pto_completion_token.h / sdma_completion_kernel.h)
+// and must stay parseable by every AICore toolchain configuration: no
+// <atomic>, no __atomic_* intrinsics, no MPSC ring buffer struct.
+//
+// The MPSC ring (AICoreCompletionMailbox) and its push/drain helpers live in
+// aicore_completion_mailbox.h, which is AICPU-only.
+
+inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
+
+#define COMPLETION_ENGINE_SDMA 0u
+#define COMPLETION_ENGINE_ROCE 1u
+#define COMPLETION_ENGINE_URMA 2u
+#define COMPLETION_ENGINE_CCU 3u
+
+#define COMPLETION_TYPE_COUNTER 0
+#define COMPLETION_TYPE_SDMA_EVENT_RECORD 1
+
+// DeferredCompletionEntry / DeferredCompletionSlab back the per-task scratch
+// area that AICore writes into to record "this completion has to be observed
+// before the task can retire." The FIN-handling scheduler thread reads the
+// slab, flattens entries into AICoreCompletionMailbox messages, and forwards
+// them to the dispatch thread. `volatile` here is load-bearing: writers live
+// on AICore and readers on AICPU, so the qualifier is the correct way to
+// pin the compiler against caching / reordering on either side.
+struct DeferredCompletionEntry {
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint32_t _pad;
+};
+
+static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
+
+struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
+    volatile uint32_t count;
+    volatile int32_t error_code;
+    DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
+};
+
+static_assert(
+    sizeof(DeferredCompletionSlab) % PTO2_ALIGN_SIZE == 0,
+    "DeferredCompletionSlab size must preserve array element cache-line boundaries"
+);
+
+#endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_TYPES_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_kernel.h
@@ -18,7 +18,7 @@
 #include <pto/npu/comm/async/sdma/sdma_async_intrin.hpp>
 
 #include "pto_async_kernel_api.h"
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "pto_runtime_status.h"
 
 #ifndef __aicore__

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -18,7 +18,7 @@
 #include <pto/comm/pto_comm_inst.hpp>
 
 #include "intrinsic.h"
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -28,14 +28,11 @@ struct PTO2LocalReadyBuffer;
 struct CompletionStats;
 
 inline constexpr int32_t MAX_ASYNC_WAITS = 64;
-inline constexpr int32_t MAX_PENDING_COMPLETIONS = 128;
 
-inline bool aicore_completion_mailbox_has_pending(volatile AICoreCompletionMailbox *aicore_mailbox) {
-    if (aicore_mailbox == nullptr) return false;
-    uint64_t head = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
-    uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
-    return tail < head;
-}
+// The mailbox transport (has_pending / try_push_condition /
+// try_push_normal_done / try_pop) lives as AICoreCompletionMailbox member
+// functions in aicore_completion_mailbox.h. This file only holds the
+// application layer: translating drained messages into wait-list state.
 
 inline uintptr_t mailbox_cache_line(const volatile void *addr) {
     return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
@@ -124,13 +121,6 @@ struct AsyncWaitEntry {
     bool normal_done{false};
 };
 
-struct PendingCompletion {
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
-    uint64_t addr{0};
-    uint32_t expected_value{0};
-    AsyncEngine engine{ASYNC_ENGINE_SDMA};
-};
-
 struct AsyncPollResult {
     int32_t completed{0};
     int32_t error_code{PTO2_ERROR_NONE};
@@ -156,8 +146,11 @@ struct AsyncWaitList {
     std::atomic<int32_t> busy{0};
     AsyncWaitEntry entries[MAX_ASYNC_WAITS];
     int32_t count{0};
-    PendingCompletion pending_completions[MAX_PENDING_COMPLETIONS];
-    int32_t pending_completion_count{0};
+    // Diagnostic: counts every FIN-side try_push that hit a full mailbox.
+    // Expected to stay zero on real workloads (ring is 4096 entries); a
+    // non-zero value means consumers are too slow or the ring is undersized.
+    // Read by scheduler shutdown / l2 perf summary; not on the hot path.
+    std::atomic<uint64_t> mpsc_skipped_count{0};
 
     bool try_lock() {
         int32_t expected = 0;
@@ -173,91 +166,105 @@ struct AsyncWaitList {
         return nullptr;
     }
 
-    int32_t
-    drain_aicore_completion_mailbox_locked(volatile AICoreCompletionMailbox *aicore_mailbox, int32_t &error_code) {
+    // Captures the side-channel a scheduler-aware drain needs to complete
+    // NotDeferred tasks inline (without storing a transient entry in
+    // entries[]).
+    struct DrainCompletionSink {
+        PTO2SchedulerState *sched{nullptr};
+        PTO2LocalReadyBuffer *local_bufs{nullptr};
+        PTO2TaskSlotState **deferred_release_slot_states{nullptr};
+        int32_t *deferred_release_count{nullptr};
+        int32_t deferred_release_capacity{0};
+        int32_t inline_completed{0};
+#if PTO2_SCHED_PROFILING
+        int32_t thread_idx{0};
+#endif
+
+        bool can_inline_complete() const { return sched != nullptr; }
+    };
+
+    // Inline-complete a NotDeferred task during drain. Returns false on
+    // deferred_release_slot_states overflow.
+    bool try_inline_complete_locked(DrainCompletionSink &sink, PTO2TaskSlotState &slot_state);
+
+    // Single-consumer drain: pop each published message in tail order and
+    // translate it into wait-list state. An empty sink (sched == nullptr) just
+    // materializes entries; a sched-aware sink additionally inline-completes
+    // lonely NotDeferred NORMAL_DONEs without ever growing entries[].
+    int32_t drain_aicore_completion_mailbox_locked(
+        AICoreCompletionMailbox *aicore_mailbox, DrainCompletionSink &sink, int32_t &error_code
+    ) {
         error_code = PTO2_ERROR_NONE;
         if (aicore_mailbox == nullptr) return 0;
 
         int32_t drained = 0;
-        while (true) {
-            uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
-            uint64_t head_snapshot = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
-            if (tail >= head_snapshot) break;
-
-            while (tail < head_snapshot) {
-                volatile AICoreCompletionMailboxMessage *slot =
-                    &aicore_mailbox->entries[tail & AICORE_COMPLETION_MAILBOX_MASK];
-                uint64_t expected_seq = tail + 1;
-                uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-                if (seq != expected_seq) return drained;
-
-                PTO2TaskId token{slot->task_token.raw};
-                uint64_t addr = slot->addr;
-                uint32_t expected_value = slot->expected_value;
-                AsyncEngine engine = static_cast<AsyncEngine>(slot->engine);
-
-                __atomic_store_n(&slot->seq, 0, __ATOMIC_RELEASE);
-                __atomic_store_n(&aicore_mailbox->tail, tail + 1, __ATOMIC_RELEASE);
-                drained++;
-                tail++;
-
-                AsyncWaitEntry *entry = find_entry_by_token(token);
-                if (entry != nullptr) {
-                    if (entry->condition_count >= MAX_COMPLETIONS_PER_TASK) {
-                        error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+        AICoreCompletionMsgView msg;
+        // try_pop is the transport layer (seq-gated, in-order dequeue); this
+        // loop is the application layer (translate each message into wait-list
+        // state). try_pop returns false at the first gap or when empty.
+        while (aicore_mailbox->try_pop(msg)) {
+            drained++;
+            if (msg.kind == MSG_KIND_CONDITION) {
+                AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
+                if (entry == nullptr) {
+                    // First message for this task — materialize the entry here.
+                    // slot_state stays null until the matching TASK_NORMAL_DONE
+                    // sentinel arrives.
+                    if (count >= MAX_ASYNC_WAITS) {
+                        error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                         return drained;
                     }
-                    CompletionCondition &cond = entry->conditions[entry->condition_count++];
-                    cond.engine = engine;
-                    cond.completion_type = COMPLETION_TYPE_COUNTER;
-                    cond.satisfied = false;
-                    cond.retired = false;
-                    cond.addr = addr;
-                    cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
-                    cond.expected_value = expected_value;
-                    entry->waiting_completion_count++;
-                    continue;
+                    entry = &entries[count++];
+                    entry->task_token = msg.task_token;
+                    entry->slot_state = nullptr;
+                    entry->condition_count = 0;
+                    entry->waiting_completion_count = 0;
+                    entry->normal_done = false;
                 }
-
-                if (pending_completion_count >= MAX_PENDING_COMPLETIONS) {
-                    error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                if (!append_condition_locked(
+                        *entry, msg.addr, msg.expected_value, static_cast<AsyncEngine>(msg.engine), msg.completion_type,
+                        error_code
+                    )) {
                     return drained;
                 }
-                PendingCompletion &pending = pending_completions[pending_completion_count++];
-                pending.task_token = token;
-                pending.addr = addr;
-                pending.expected_value = expected_value;
-                pending.engine = engine;
+            } else if (msg.kind == MSG_KIND_TASK_NORMAL_DONE) {
+                PTO2TaskSlotState *slot_state_ptr =
+                    reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(msg.addr));
+                AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
+                if (entry == nullptr) {
+                    // Producers strictly order: all CONDITIONs for token T are
+                    // pushed before the matching NORMAL_DONE (the acq_rel on
+                    // on_subtask_complete enforces this across producers). So
+                    // observing NORMAL_DONE first => the task registered no
+                    // conditions => NotDeferred. Complete it inline when the
+                    // sink allows; otherwise fall back to the entry-store path.
+                    if (sink.can_inline_complete()) {
+                        (void)try_inline_complete_locked(sink, *slot_state_ptr);
+                        continue;
+                    }
+                    if (count >= MAX_ASYNC_WAITS) {
+                        error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                        return drained;
+                    }
+                    entry = &entries[count++];
+                    entry->task_token = msg.task_token;
+                    entry->slot_state = slot_state_ptr;
+                    entry->condition_count = 0;
+                    entry->waiting_completion_count = 0;
+                    entry->normal_done = true;
+                } else {
+                    if (entry->slot_state == nullptr) {
+                        entry->slot_state = slot_state_ptr;
+                    }
+                    entry->normal_done = true;
+                }
+            } else {
+                error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                return drained;
             }
         }
         return drained;
     }
-
-    void absorb_pending_completions_locked(AsyncWaitEntry &entry) {
-        int32_t write = 0;
-        for (int32_t i = 0; i < pending_completion_count; i++) {
-            if (pending_completions[i].task_token == entry.task_token) {
-                if (entry.condition_count < MAX_COMPLETIONS_PER_TASK) {
-                    CompletionCondition &cond = entry.conditions[entry.condition_count++];
-                    cond.engine = pending_completions[i].engine;
-                    cond.completion_type = COMPLETION_TYPE_COUNTER;
-                    cond.satisfied = false;
-                    cond.retired = false;
-                    cond.addr = pending_completions[i].addr;
-                    cond.counter_addr =
-                        reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(pending_completions[i].addr));
-                    cond.expected_value = pending_completions[i].expected_value;
-                    entry.waiting_completion_count++;
-                }
-            } else {
-                if (write != i) pending_completions[write] = pending_completions[i];
-                write++;
-            }
-        }
-        pending_completion_count = write;
-    }
-
-    enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
     bool append_condition_locked(
         AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine, int32_t completion_type,
@@ -281,84 +288,9 @@ struct AsyncWaitList {
         return true;
     }
 
-    RegisterResult
-    register_deferred(PTO2TaskSlotState &slot_state, const AsyncCtx &async_ctx, bool normal_done, int32_t &error_code) {
-        error_code = PTO2_ERROR_NONE;
-        if (slot_state.payload == nullptr) {
-            return RegisterResult::NotDeferred;
-        }
-
-        if (!try_lock()) return RegisterResult::Skipped;
-
-        uint32_t deferred_count = 0;
-        if (async_ctx.completion_count != nullptr) {
-            if (async_ctx.completion_error_code != nullptr) {
-                if (*async_ctx.completion_error_code != PTO2_ERROR_NONE) {
-                    error_code = *async_ctx.completion_error_code;
-                    unlock();
-                    return RegisterResult::Error;
-                }
-            }
-            deferred_count = *async_ctx.completion_count;
-        }
-        if (deferred_count > async_ctx.completion_capacity) {
-            error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
-            unlock();
-            return RegisterResult::Error;
-        }
-        if (deferred_count > 0) {
-            if (async_ctx.completion_entries == nullptr) {
-                error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
-                unlock();
-                return RegisterResult::Error;
-            }
-        }
-        AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
-        if (entry == nullptr && deferred_count == 0) {
-            unlock();
-            return RegisterResult::NotDeferred;
-        }
-        if (entry == nullptr) {
-            if (count >= MAX_ASYNC_WAITS) {
-                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-                unlock();
-                return RegisterResult::Error;
-            }
-            entry = &entries[count++];
-            entry->slot_state = &slot_state;
-            entry->task_token = slot_state.task->task_id;
-            entry->condition_count = 0;
-            entry->waiting_completion_count = 0;
-            entry->normal_done = false;
-        }
-        if (normal_done) {
-            entry->normal_done = true;
-        }
-
-        for (uint32_t i = 0; i < deferred_count; ++i) {
-            volatile DeferredCompletionEntry *deferred = &async_ctx.completion_entries[i];
-            if (deferred->completion_type == COMPLETION_TYPE_COUNTER) {
-                volatile uint32_t *counter =
-                    reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(deferred->addr));
-                cache_invalidate_range(reinterpret_cast<const void *>(mailbox_cache_line(counter)), sizeof(uint32_t));
-            }
-            if (!append_condition_locked(
-                    *entry, deferred->addr, deferred->expected_value, static_cast<AsyncEngine>(deferred->engine),
-                    deferred->completion_type, error_code
-                )) {
-                unlock();
-                return RegisterResult::Error;
-            }
-        }
-
-        absorb_pending_completions_locked(*entry);
-        unlock();
-        return RegisterResult::Registered;
-    }
-
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
-        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+        AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
         PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
         int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "pto_runtime_status.h"
 
 // CompletionToken is the runtime-internal POD that backend submit handlers

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -339,8 +339,17 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor *task;
 
     // --- Set per-submit (depend on task inputs) ---
-    ActiveMask active_mask;    // Bitmask of active subtask slots (set once)
-    uint8_t ring_id;           // Ring layer (immutable after init)
+    ActiveMask active_mask;  // Bitmask of active subtask slots (set once)
+    uint8_t ring_id;         // Ring layer (immutable after init)
+    // Set by any subtask FIN that pushed deferred-completion CONDITIONs to
+    // the runtime mailbox; read by the last subtask FIN to decide whether
+    // the task needs MPSC-deferred completion or can complete inline on this
+    // thread. Carved out of the otherwise-padding byte between ring_id and
+    // dep_pool_mark to keep PTO2TaskSlotState at 64 bytes. The write is
+    // sequenced before on_subtask_complete's acq_rel fetch_add and the read
+    // after, so all earlier subtasks' writes are visible to the last subtask.
+    std::atomic<bool> any_subtask_deferred{false};
+    uint8_t _async_pad{0};
     int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
@@ -385,6 +394,7 @@ struct alignas(64) PTO2TaskSlotState {
         fanout_refcount.store(0, std::memory_order_relaxed);
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx = 0;
+        any_subtask_deferred.store(false, std::memory_order_relaxed);
     }
 
     // === Per-task fanout spinlock ===

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1089,9 +1089,41 @@ struct PTO2SchedulerState {
 // Scheduler cold-path API is declared as PTO2SchedulerState member functions.
 // See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
+// try_inline_complete_locked: short-circuit NotDeferred completions seen during
+// drain so they don't grow entries[]. Defined here (not in pto_async_wait.h)
+// because PTO2SchedulerState's on_mixed_task_complete signature is only known
+// after its full definition above.
+//
+// When the deferred_release_slot_states[] buffer is full, drain it via
+// on_task_release before appending — mirrors the same overflow-drain idiom
+// that scheduler_completion.cpp's inline NotDeferred path uses, so high task
+// rates don't surface as ASYNC_WAIT_OVERFLOW errors.
+inline bool
+AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+#if PTO2_SCHED_PROFILING
+    sink.sched->on_mixed_task_complete(slot_state, sink.thread_idx, sink.local_bufs);
+#else
+    sink.sched->on_mixed_task_complete(slot_state, sink.local_bufs);
+#endif
+    if (*sink.deferred_release_count >= sink.deferred_release_capacity) {
+        while (*sink.deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+            (void)sink.sched->on_task_release(
+                *sink.deferred_release_slot_states[--(*sink.deferred_release_count)], sink.thread_idx
+            );
+#else
+            sink.sched->on_task_release(*sink.deferred_release_slot_states[--(*sink.deferred_release_count)]);
+#endif
+        }
+    }
+    sink.deferred_release_slot_states[(*sink.deferred_release_count)++] = &slot_state;
+    sink.inline_completed++;
+    return true;
+}
+
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
-    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+    AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
     PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
     ,
@@ -1101,13 +1133,24 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
     AsyncPollResult result;
     if (!try_lock()) return result;
 
+    AsyncWaitList::DrainCompletionSink sink{};
+    sink.sched = sched;
+    sink.local_bufs = local_bufs;
+    sink.deferred_release_slot_states = deferred_release_slot_states;
+    sink.deferred_release_count = &deferred_release_count;
+    sink.deferred_release_capacity = deferred_release_capacity;
+#if PTO2_SCHED_PROFILING
+    sink.thread_idx = thread_idx;
+#endif
+
     int32_t drain_err = PTO2_ERROR_NONE;
-    drain_aicore_completion_mailbox_locked(aicore_mailbox, drain_err);
+    drain_aicore_completion_mailbox_locked(aicore_mailbox, sink, drain_err);
     if (drain_err != PTO2_ERROR_NONE) {
         result.error_code = drain_err;
         unlock();
         return result;
     }
+    result.completed += sink.inline_completed;
 
     for (int32_t i = count - 1; i >= 0; --i) {
         AsyncWaitEntry &entry = entries[i];
@@ -1137,17 +1180,25 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
         }
 
         if (entry.normal_done && entry.waiting_completion_count <= 0) {
-            if (deferred_release_count >= deferred_release_capacity) {
-                result.error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-                result.failed_slot_state = entry.slot_state;
-                unlock();
-                return result;
-            }
 #if PTO2_SCHED_PROFILING
             sched->on_mixed_task_complete(*entry.slot_state, thread_idx, local_bufs);
 #else
             sched->on_mixed_task_complete(*entry.slot_state, local_bufs);
 #endif
+            // Drain deferred_release in place when the buffer fills — same
+            // overflow-drain idiom used by complete_slot_task's inline path
+            // and by try_inline_complete_locked. Without this, large bursts
+            // of completable wait_list entries in a single poll surfaced as
+            // ASYNC_WAIT_OVERFLOW under the MPSC model.
+            if (deferred_release_count >= deferred_release_capacity) {
+                while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+                    (void)sched->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+#else
+                    sched->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+#endif
+                }
+            }
             deferred_release_slot_states[deferred_release_count++] = entry.slot_state;
             result.completed++;
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -80,33 +80,71 @@ void SchedulerContext::complete_slot_task(
 #else
     (void)hank;
 #endif
-    bool mixed_complete = sched_->on_subtask_complete(slot_state);
-    if (slot_state.payload != nullptr) {
-        int32_t reg_err = PTO2_ERROR_NONE;
-        AsyncWaitList::RegisterResult reg_result;
-        volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
-        AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
-        do {
-            reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);
-            if (reg_result == AsyncWaitList::RegisterResult::Skipped) {
-                SPIN_WAIT_HINT();
-            }
-        } while (reg_result == AsyncWaitList::RegisterResult::Skipped);
+    // MPSC fast-path is opt-in per task: only tasks with at least one subtask
+    // that registered a deferred condition route through the mailbox. Pure
+    // non-deferred tasks complete inline on this thread (matching pre-MPSC
+    // behavior — keeps the common case parallelized across scheduler threads
+    // instead of serializing through the single consumer). The
+    // any_subtask_deferred flag on slot_state is the discriminator; it's set
+    // (release) before on_subtask_complete and read (acquire) after, so the
+    // last subtask sees flag writes from any earlier subtask of the same task.
+    AICoreCompletionMailbox *mailbox = rt_ != nullptr ? rt_->aicore_mailbox : nullptr;
+    bool defer_completion_to_consumer = false;
 
-        if (reg_result == AsyncWaitList::RegisterResult::Error) {
+    if (slot_state.payload != nullptr) {
+        volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        int32_t slab_err = deferred_slab->error_code;
+        if (slab_err != PTO2_ERROR_NONE) {
             int32_t expected = PTO2_ERROR_NONE;
             sched_->sm_header->sched_error_code.compare_exchange_strong(
-                expected, reg_err, std::memory_order_acq_rel, std::memory_order_acquire
+                expected, slab_err, std::memory_order_acq_rel, std::memory_order_acquire
             );
             completed_.store(true, std::memory_order_release);
             return;
         }
 
-        if (mixed_complete && reg_result == AsyncWaitList::RegisterResult::Registered) {
+        uint32_t cond_count = deferred_slab->count;
+        if (cond_count > MAX_COMPLETIONS_PER_TASK) {
+            int32_t expected = PTO2_ERROR_NONE;
+            sched_->sm_header->sched_error_code.compare_exchange_strong(
+                expected, PTO2_ERROR_ASYNC_REGISTRATION_FAILED, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+            completed_.store(true, std::memory_order_release);
             return;
         }
+
+        if (cond_count > 0) {
+            // Publish "this task is deferred" before on_subtask_complete so the
+            // acq_rel fetch_add inside on_subtask_complete makes the flag
+            // visible to whichever subtask sees mixed_complete=true (which may
+            // be this thread or a later one).
+            slot_state.any_subtask_deferred.store(true, std::memory_order_release);
+
+            const PTO2TaskId token = slot_state.task->task_id;
+            for (uint32_t i = 0; i < cond_count; ++i) {
+                volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
+                while (!mailbox->try_push_condition(token, e->addr, e->expected_value, e->engine, e->completion_type)) {
+                    sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
+                    SPIN_WAIT_HINT();
+                }
+            }
+        }
     }
-    if (mixed_complete) {
+
+    bool mixed_complete = sched_->on_subtask_complete(slot_state);
+
+    if (mixed_complete && slot_state.payload != nullptr &&
+        slot_state.any_subtask_deferred.load(std::memory_order_acquire)) {
+        // Some subtask of this task registered conditions; finish the
+        // registration by handing the slot_state off to the consumer.
+        while (!mailbox->try_push_normal_done(slot_state.task->task_id, reinterpret_cast<uint64_t>(&slot_state))) {
+            sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
+            SPIN_WAIT_HINT();
+        }
+        defer_completion_to_consumer = true;
+    }
+
+    if (mixed_complete && !defer_completion_to_consumer) {
 #if PTO2_PROFILING
         if (is_dump_tensor_enabled()) {
             dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -586,7 +586,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
 
         if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
-            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
+            (sched_->async_wait_list.count > 0 || rt_->aicore_mailbox->has_pending())) {
             AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
                 rt_->aicore_mailbox, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -52,7 +52,7 @@
 
 #include <stdint.h>
 
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "pto_task_id.h"
 
 #ifndef __gm__

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h
@@ -12,10 +12,20 @@
 #ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
 #define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_H_
 
-#include <stdint.h>
+#include <atomic>
+#include <cstdint>
 
+#include "aicore_completion_mailbox_types.h"
 #include "pto_constants.h"
 #include "pto_task_id.h"
+
+// AICPU-only MPSC ring used to convey deferred-completion observations from
+// FIN-handling scheduler threads to the dispatch thread. Producers push under
+// CAS on `head`; the single consumer (dispatch thread, under AsyncWaitList::
+// busy) drains in seq order. Kernel-side code never touches this struct —
+// AICore writes go into DeferredCompletionSlab (see
+// aicore_completion_mailbox_types.h), which the FIN thread reads, flattens
+// into messages here, and forwards.
 
 #define AICORE_COMPLETION_MAILBOX_CAPACITY 4096u
 #define AICORE_COMPLETION_MAILBOX_MASK (AICORE_COMPLETION_MAILBOX_CAPACITY - 1u)
@@ -25,54 +35,140 @@ static_assert(
     "AICORE_COMPLETION_MAILBOX_CAPACITY must be a power of two"
 );
 
-inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
-
-#define COMPLETION_ENGINE_SDMA 0u
-#define COMPLETION_ENGINE_ROCE 1u
-#define COMPLETION_ENGINE_URMA 2u
-#define COMPLETION_ENGINE_CCU 3u
-
-#define COMPLETION_TYPE_COUNTER 0
+// Mailbox message discriminator. CONDITION carries one deferred-completion
+// observation flattened from a DeferredCompletionEntry. TASK_NORMAL_DONE
+// carries the slot_state pointer in `addr` so the consumer can finalize the
+// AsyncWaitEntry.slot_state binding for tasks whose conditions arrived
+// before the FIN thread saw mixed_complete.
+#define MSG_KIND_CONDITION 0u
+#define MSG_KIND_TASK_NORMAL_DONE 1u
 
 struct AICoreCompletionMailboxMessage {
-    volatile uint64_t seq;
+    // Per-slot ready flag. Producer publishes `tail+1` after filling the rest
+    // of the slot with a release store; consumer waits for the matching seq
+    // value with an acquire load. The release-acquire pair publishes all
+    // other fields below as a side effect, so they stay plain.
+    std::atomic<uint64_t> seq;
     PTO2TaskId task_token;
+    // CONDITION: completion observation addr (counter / event record).
+    // TASK_NORMAL_DONE: PTO2TaskSlotState pointer carried over to the consumer
+    //   so it can finalize the AsyncWaitEntry.slot_state binding.
     uint64_t addr;
     uint32_t expected_value;
     uint32_t engine;
     int32_t completion_type;
-    uint32_t _pad[6];
+    uint32_t kind;
+    uint32_t _pad[5];
 };
 
 static_assert(sizeof(AICoreCompletionMailboxMessage) == PTO2_ALIGN_SIZE, "AICoreCompletionMailboxMessage layout drift");
-
-struct DeferredCompletionEntry {
-    uint64_t addr;
-    uint32_t expected_value;
-    uint32_t engine;
-    int32_t completion_type;
-    uint32_t _pad;
-};
-
-static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
-
-struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
-    volatile uint32_t count;
-    volatile int32_t error_code;
-    DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
-};
-
 static_assert(
-    sizeof(DeferredCompletionSlab) % PTO2_ALIGN_SIZE == 0,
-    "DeferredCompletionSlab size must preserve array element cache-line boundaries"
+    sizeof(std::atomic<uint64_t>) == sizeof(uint64_t),
+    "std::atomic<uint64_t> must be layout-compatible with uint64_t for the message slot layout to hold"
+);
+static_assert(
+    std::atomic<uint64_t>::is_always_lock_free,
+    "AICoreCompletionMailbox requires lock-free uint64_t atomics on every supported target"
 );
 
+// POD view of a drained message. `seq` is the ring's publication flag, not
+// payload, so try_pop copies out only the fields below (and seq is not even
+// copyable — it is a std::atomic).
+struct AICoreCompletionMsgView {
+    PTO2TaskId task_token{PTO2TaskId::invalid()};
+    uint64_t addr{0};
+    uint32_t expected_value{0};
+    uint32_t engine{0};
+    int32_t completion_type{0};
+    uint32_t kind{0};
+};
+
 struct AICoreCompletionMailbox {
-    alignas(PTO2_ALIGN_SIZE) volatile uint64_t head;
+    // head and tail live on their own cache lines so producer CAS contention
+    // on head can't false-share with the consumer's tail updates.
+    alignas(PTO2_ALIGN_SIZE) std::atomic<uint64_t> head;
     uint8_t _head_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
-    alignas(PTO2_ALIGN_SIZE) volatile uint64_t tail;
+    alignas(PTO2_ALIGN_SIZE) std::atomic<uint64_t> tail;
     uint8_t _tail_pad[PTO2_ALIGN_SIZE - sizeof(uint64_t)];
     alignas(PTO2_ALIGN_SIZE) AICoreCompletionMailboxMessage entries[AICORE_COMPLETION_MAILBOX_CAPACITY];
+
+    // Cheap, lock-free pending hint. Callers may invoke this outside the
+    // consumer lock; a stale answer only over/under-triggers a drain attempt.
+    bool has_pending() { return tail.load(std::memory_order_acquire) < head.load(std::memory_order_acquire); }
+
+    // MPSC push for a CONDITION message. Reserves a slot via CAS on head, then
+    // publishes the payload by release-storing the matching seq value.
+    //
+    // The head CAS is relaxed: head is a pure ticket counter and carries no
+    // data to the consumer — publication is solely the seq release-store, and
+    // slot-reuse safety rests on the acquire load of tail. The relaxed failure
+    // order is likewise sufficient since a lost CAS just re-reads head and
+    // retries. compare_exchange_weak is used because this loop already re-reads
+    // head and re-checks fullness, so masking LL/SC spurious failures (what
+    // _strong adds on aarch64) would only be a redundant inner retry.
+    bool try_push_condition(
+        PTO2TaskId task_token, uint64_t addr, uint32_t expected_value, uint32_t engine, int32_t completion_type
+    ) {
+        while (true) {
+            uint64_t h = head.load(std::memory_order_relaxed);
+            uint64_t t = tail.load(std::memory_order_acquire);
+            if (h - t >= AICORE_COMPLETION_MAILBOX_CAPACITY) return false;
+            uint64_t new_head = h + 1;
+            if (head.compare_exchange_weak(h, new_head, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                AICoreCompletionMailboxMessage *slot = &entries[h & AICORE_COMPLETION_MAILBOX_MASK];
+                slot->task_token.raw = task_token.raw;
+                slot->addr = addr;
+                slot->expected_value = expected_value;
+                slot->engine = engine;
+                slot->completion_type = completion_type;
+                slot->kind = MSG_KIND_CONDITION;
+                slot->seq.store(new_head, std::memory_order_release);
+                return true;
+            }
+        }
+    }
+
+    bool try_push_normal_done(PTO2TaskId task_token, uint64_t slot_state_addr) {
+        while (true) {
+            uint64_t h = head.load(std::memory_order_relaxed);
+            uint64_t t = tail.load(std::memory_order_acquire);
+            if (h - t >= AICORE_COMPLETION_MAILBOX_CAPACITY) return false;
+            uint64_t new_head = h + 1;
+            if (head.compare_exchange_weak(h, new_head, std::memory_order_relaxed, std::memory_order_relaxed)) {
+                AICoreCompletionMailboxMessage *slot = &entries[h & AICORE_COMPLETION_MAILBOX_MASK];
+                slot->task_token.raw = task_token.raw;
+                slot->addr = slot_state_addr;
+                slot->expected_value = 0;
+                slot->engine = 0;
+                slot->completion_type = 0;
+                slot->kind = MSG_KIND_TASK_NORMAL_DONE;
+                slot->seq.store(new_head, std::memory_order_release);
+                return true;
+            }
+        }
+    }
+
+    // Single-consumer transport-level dequeue (caller holds the consumer lock).
+    // Returns false at the first not-yet-published slot (gap) or when empty;
+    // otherwise copies the next message in tail order into `out`, advances
+    // tail, and returns true. tail is consumer-only-written (relaxed read);
+    // head bounds the scan (relaxed); the seq acquire is the real publication
+    // gate; the tail release publishes "slot free" to reusing producers.
+    bool try_pop(AICoreCompletionMsgView &out) {
+        uint64_t t = tail.load(std::memory_order_relaxed);
+        uint64_t h = head.load(std::memory_order_relaxed);
+        if (t >= h) return false;
+        AICoreCompletionMailboxMessage *slot = &entries[t & AICORE_COMPLETION_MAILBOX_MASK];
+        if (slot->seq.load(std::memory_order_acquire) != t + 1) return false;
+        out.task_token.raw = slot->task_token.raw;
+        out.addr = slot->addr;
+        out.expected_value = slot->expected_value;
+        out.engine = slot->engine;
+        out.completion_type = slot->completion_type;
+        out.kind = slot->kind;
+        tail.store(t + 1, std::memory_order_release);
+        return true;
+    }
 };
 
 static_assert(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox_types.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_TYPES_H_
+#define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_TYPES_H_
+
+#include <stdint.h>
+
+#include "pto_constants.h"
+
+// Types shared across the AICore↔AICPU boundary.
+//
+// This header is reachable from AICore-side translation units (via
+// pto_async_kernel_api.h / pto_completion_token.h / sdma_completion_kernel.h)
+// and must stay parseable by every AICore toolchain configuration: no
+// <atomic>, no __atomic_* intrinsics, no MPSC ring buffer struct.
+//
+// The MPSC ring (AICoreCompletionMailbox) and its push/drain helpers live in
+// aicore_completion_mailbox.h, which is AICPU-only.
+
+inline constexpr int32_t MAX_COMPLETIONS_PER_TASK = 64;
+
+#define COMPLETION_ENGINE_SDMA 0u
+#define COMPLETION_ENGINE_ROCE 1u
+#define COMPLETION_ENGINE_URMA 2u
+#define COMPLETION_ENGINE_CCU 3u
+
+#define COMPLETION_TYPE_COUNTER 0
+
+// DeferredCompletionEntry / DeferredCompletionSlab back the per-task scratch
+// area that AICore writes into to record "this completion has to be observed
+// before the task can retire." The FIN-handling scheduler thread reads the
+// slab, flattens entries into AICoreCompletionMailbox messages, and forwards
+// them to the dispatch thread. `volatile` here is load-bearing: writers live
+// on AICore and readers on AICPU, so the qualifier is the correct way to
+// pin the compiler against caching / reordering on either side.
+struct DeferredCompletionEntry {
+    uint64_t addr;
+    uint32_t expected_value;
+    uint32_t engine;
+    int32_t completion_type;
+    uint32_t _pad;
+};
+
+static_assert(sizeof(DeferredCompletionEntry) == 24, "DeferredCompletionEntry layout drift");
+
+struct alignas(PTO2_ALIGN_SIZE) DeferredCompletionSlab {
+    volatile uint32_t count;
+    volatile int32_t error_code;
+    DeferredCompletionEntry entries[MAX_COMPLETIONS_PER_TASK];
+};
+
+static_assert(
+    sizeof(DeferredCompletionSlab) % PTO2_ALIGN_SIZE == 0,
+    "DeferredCompletionSlab size must preserve array element cache-line boundaries"
+);
+
+#endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_AICORE_COMPLETION_MAILBOX_TYPES_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_kernel_api.h
@@ -18,7 +18,7 @@
 #include <pto/comm/pto_comm_inst.hpp>
 
 #include "intrinsic.h"
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 #include "pto_completion_token.h"
 #include "pto_runtime_status.h"
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -25,14 +25,11 @@ struct PTO2LocalReadyBuffer;
 struct CompletionStats;
 
 inline constexpr int32_t MAX_ASYNC_WAITS = 64;
-inline constexpr int32_t MAX_PENDING_COMPLETIONS = 128;
 
-inline bool aicore_completion_mailbox_has_pending(volatile AICoreCompletionMailbox *aicore_mailbox) {
-    if (aicore_mailbox == nullptr) return false;
-    uint64_t head = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
-    uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
-    return tail < head;
-}
+// The mailbox transport (has_pending / try_push_condition /
+// try_push_normal_done / try_pop) lives as AICoreCompletionMailbox member
+// functions in aicore_completion_mailbox.h. This file only holds the
+// application layer: translating drained messages into wait-list state.
 
 enum class CompletionPollState : uint8_t {
     PENDING = 0,
@@ -73,13 +70,6 @@ struct AsyncWaitEntry {
     bool normal_done{false};
 };
 
-struct PendingCompletion {
-    PTO2TaskId task_token{PTO2TaskId::invalid()};
-    uint64_t addr{0};
-    uint32_t expected_value{0};
-    AsyncEngine engine{ASYNC_ENGINE_SDMA};
-};
-
 struct AsyncPollResult {
     int32_t completed{0};
     int32_t error_code{PTO2_ERROR_NONE};
@@ -105,8 +95,7 @@ struct AsyncWaitList {
     std::atomic<int32_t> busy{0};
     AsyncWaitEntry entries[MAX_ASYNC_WAITS];
     int32_t count{0};
-    PendingCompletion pending_completions[MAX_PENDING_COMPLETIONS];
-    int32_t pending_completion_count{0};
+    std::atomic<uint64_t> mpsc_skipped_count{0};
 
     bool try_lock() {
         int32_t expected = 0;
@@ -122,85 +111,89 @@ struct AsyncWaitList {
         return nullptr;
     }
 
-    int32_t
-    drain_aicore_completion_mailbox_locked(volatile AICoreCompletionMailbox *aicore_mailbox, int32_t &error_code) {
+    struct DrainCompletionSink {
+        PTO2SchedulerState *sched{nullptr};
+        PTO2LocalReadyBuffer *local_bufs{nullptr};
+        PTO2TaskSlotState **deferred_release_slot_states{nullptr};
+        int32_t *deferred_release_count{nullptr};
+        int32_t deferred_release_capacity{0};
+        int32_t inline_completed{0};
+#if PTO2_SCHED_PROFILING
+        int32_t thread_idx{0};
+#endif
+        bool can_inline_complete() const { return sched != nullptr; }
+    };
+
+    bool try_inline_complete_locked(DrainCompletionSink &sink, PTO2TaskSlotState &slot_state);
+
+    // Single-consumer drain: pop each published message in tail order and
+    // translate it into wait-list state. An empty sink (sched == nullptr) just
+    // materializes entries; a sched-aware sink additionally inline-completes
+    // lonely NotDeferred NORMAL_DONEs without ever growing entries[].
+    int32_t drain_aicore_completion_mailbox_locked(
+        AICoreCompletionMailbox *aicore_mailbox, DrainCompletionSink &sink, int32_t &error_code
+    ) {
         error_code = PTO2_ERROR_NONE;
         if (aicore_mailbox == nullptr) return 0;
 
         int32_t drained = 0;
-        while (true) {
-            uint64_t tail = __atomic_load_n(&aicore_mailbox->tail, __ATOMIC_ACQUIRE);
-            uint64_t head_snapshot = __atomic_load_n(&aicore_mailbox->head, __ATOMIC_ACQUIRE);
-            if (tail >= head_snapshot) break;
-
-            while (tail < head_snapshot) {
-                volatile AICoreCompletionMailboxMessage *slot =
-                    &aicore_mailbox->entries[tail & AICORE_COMPLETION_MAILBOX_MASK];
-                uint64_t expected_seq = tail + 1;
-                uint64_t seq = __atomic_load_n(&slot->seq, __ATOMIC_ACQUIRE);
-                if (seq != expected_seq) return drained;
-
-                PTO2TaskId token{slot->task_token.raw};
-                uint64_t addr = slot->addr;
-                uint32_t expected_value = slot->expected_value;
-                AsyncEngine engine = static_cast<AsyncEngine>(slot->engine);
-
-                __atomic_store_n(&slot->seq, 0, __ATOMIC_RELEASE);
-                __atomic_store_n(&aicore_mailbox->tail, tail + 1, __ATOMIC_RELEASE);
-                drained++;
-                tail++;
-
-                AsyncWaitEntry *entry = find_entry_by_token(token);
-                if (entry != nullptr) {
-                    if (entry->condition_count >= MAX_COMPLETIONS_PER_TASK) {
-                        error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+        AICoreCompletionMsgView msg;
+        // try_pop is the transport layer (seq-gated, in-order dequeue); this
+        // loop is the application layer (translate each message into wait-list
+        // state). try_pop returns false at the first gap or when empty.
+        while (aicore_mailbox->try_pop(msg)) {
+            drained++;
+            if (msg.kind == MSG_KIND_CONDITION) {
+                AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
+                if (entry == nullptr) {
+                    if (count >= MAX_ASYNC_WAITS) {
+                        error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
                         return drained;
                     }
-                    CompletionCondition &cond = entry->conditions[entry->condition_count++];
-                    cond.engine = engine;
-                    cond.satisfied = false;
-                    cond.counter_addr = reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(addr));
-                    cond.expected_value = expected_value;
-                    entry->waiting_completion_count++;
-                    continue;
+                    entry = &entries[count++];
+                    entry->task_token = msg.task_token;
+                    entry->slot_state = nullptr;
+                    entry->condition_count = 0;
+                    entry->waiting_completion_count = 0;
+                    entry->normal_done = false;
                 }
-
-                if (pending_completion_count >= MAX_PENDING_COMPLETIONS) {
-                    error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                if (!append_condition_locked(
+                        *entry, msg.addr, msg.expected_value, static_cast<AsyncEngine>(msg.engine), error_code
+                    )) {
                     return drained;
                 }
-                PendingCompletion &pending = pending_completions[pending_completion_count++];
-                pending.task_token = token;
-                pending.addr = addr;
-                pending.expected_value = expected_value;
-                pending.engine = engine;
+            } else if (msg.kind == MSG_KIND_TASK_NORMAL_DONE) {
+                PTO2TaskSlotState *slot_state_ptr =
+                    reinterpret_cast<PTO2TaskSlotState *>(static_cast<uintptr_t>(msg.addr));
+                AsyncWaitEntry *entry = find_entry_by_token(msg.task_token);
+                if (entry == nullptr) {
+                    if (sink.can_inline_complete()) {
+                        (void)try_inline_complete_locked(sink, *slot_state_ptr);
+                        continue;
+                    }
+                    if (count >= MAX_ASYNC_WAITS) {
+                        error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
+                        return drained;
+                    }
+                    entry = &entries[count++];
+                    entry->task_token = msg.task_token;
+                    entry->slot_state = slot_state_ptr;
+                    entry->condition_count = 0;
+                    entry->waiting_completion_count = 0;
+                    entry->normal_done = true;
+                } else {
+                    if (entry->slot_state == nullptr) {
+                        entry->slot_state = slot_state_ptr;
+                    }
+                    entry->normal_done = true;
+                }
+            } else {
+                error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
+                return drained;
             }
         }
         return drained;
     }
-
-    void absorb_pending_completions_locked(AsyncWaitEntry &entry) {
-        int32_t write = 0;
-        for (int32_t i = 0; i < pending_completion_count; i++) {
-            if (pending_completions[i].task_token == entry.task_token) {
-                if (entry.condition_count < MAX_COMPLETIONS_PER_TASK) {
-                    CompletionCondition &cond = entry.conditions[entry.condition_count++];
-                    cond.engine = pending_completions[i].engine;
-                    cond.satisfied = false;
-                    cond.counter_addr =
-                        reinterpret_cast<volatile uint32_t *>(static_cast<uintptr_t>(pending_completions[i].addr));
-                    cond.expected_value = pending_completions[i].expected_value;
-                    entry.waiting_completion_count++;
-                }
-            } else {
-                if (write != i) pending_completions[write] = pending_completions[i];
-                write++;
-            }
-        }
-        pending_completion_count = write;
-    }
-
-    enum class RegisterResult { Registered, NotDeferred, Skipped, Error };
 
     bool append_condition_locked(
         AsyncWaitEntry &entry, uint64_t addr, uint32_t expected_value, AsyncEngine engine, int32_t &error_code
@@ -218,79 +211,9 @@ struct AsyncWaitList {
         return true;
     }
 
-    RegisterResult
-    register_deferred(PTO2TaskSlotState &slot_state, const AsyncCtx &async_ctx, bool normal_done, int32_t &error_code) {
-        error_code = PTO2_ERROR_NONE;
-        if (slot_state.payload == nullptr) {
-            return RegisterResult::NotDeferred;
-        }
-
-        if (!try_lock()) return RegisterResult::Skipped;
-
-        uint32_t deferred_count = 0;
-        if (async_ctx.completion_count != nullptr) {
-            if (async_ctx.completion_error_code != nullptr) {
-                if (*async_ctx.completion_error_code != PTO2_ERROR_NONE) {
-                    error_code = *async_ctx.completion_error_code;
-                    unlock();
-                    return RegisterResult::Error;
-                }
-            }
-            deferred_count = *async_ctx.completion_count;
-        }
-        if (deferred_count > async_ctx.completion_capacity) {
-            error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
-            unlock();
-            return RegisterResult::Error;
-        }
-        if (deferred_count > 0) {
-            if (async_ctx.completion_entries == nullptr) {
-                error_code = PTO2_ERROR_ASYNC_REGISTRATION_FAILED;
-                unlock();
-                return RegisterResult::Error;
-            }
-        }
-        AsyncWaitEntry *entry = find_entry_by_token(slot_state.task->task_id);
-        if (entry == nullptr && deferred_count == 0) {
-            unlock();
-            return RegisterResult::NotDeferred;
-        }
-        if (entry == nullptr) {
-            if (count >= MAX_ASYNC_WAITS) {
-                error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-                unlock();
-                return RegisterResult::Error;
-            }
-            entry = &entries[count++];
-            entry->slot_state = &slot_state;
-            entry->task_token = slot_state.task->task_id;
-            entry->condition_count = 0;
-            entry->waiting_completion_count = 0;
-            entry->normal_done = false;
-        }
-        if (normal_done) {
-            entry->normal_done = true;
-        }
-
-        for (uint32_t i = 0; i < deferred_count; ++i) {
-            volatile DeferredCompletionEntry *deferred = &async_ctx.completion_entries[i];
-            if (!append_condition_locked(
-                    *entry, deferred->addr, deferred->expected_value, static_cast<AsyncEngine>(deferred->engine),
-                    error_code
-                )) {
-                unlock();
-                return RegisterResult::Error;
-            }
-        }
-
-        absorb_pending_completions_locked(*entry);
-        unlock();
-        return RegisterResult::Registered;
-    }
-
     template <bool Profiling>
     AsyncPollResult poll_and_complete(
-        volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+        AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
         PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count,
         int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_completion_token.h
@@ -14,7 +14,7 @@
 
 #include <stdint.h>
 
-#include "aicore_completion_mailbox.h"
+#include "aicore_completion_mailbox_types.h"
 
 // CompletionToken is the runtime-internal POD that backend submit handlers
 // produce and the generic register_completion_condition() consumes. It is the

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -339,8 +339,15 @@ struct alignas(64) PTO2TaskSlotState {
     PTO2TaskDescriptor *task;
 
     // --- Set per-submit (depend on task inputs) ---
-    ActiveMask active_mask;    // Bitmask of active subtask slots (set once)
-    uint8_t ring_id;           // Ring layer (immutable after init)
+    ActiveMask active_mask;  // Bitmask of active subtask slots (set once)
+    uint8_t ring_id;         // Ring layer (immutable after init)
+    // Set by any subtask FIN that pushed deferred-completion CONDITIONs to
+    // the runtime mailbox; read by the last subtask FIN to decide MPSC vs
+    // inline completion. Mirrors a2a3; see that mirror for the full
+    // memory-order argument. Carved out of the padding byte between ring_id
+    // and dep_pool_mark to keep PTO2TaskSlotState at 64 bytes.
+    std::atomic<bool> any_subtask_deferred{false};
+    uint8_t _async_pad{0};
     int32_t dep_pool_mark{0};  // Dep pool top after wiring (thread-0-only)
 
     std::atomic<int16_t> completed_subtasks{0};  // Each core completion increments by 1
@@ -385,6 +392,7 @@ struct alignas(64) PTO2TaskSlotState {
         fanout_refcount.store(0, std::memory_order_relaxed);
         completed_subtasks.store(0, std::memory_order_relaxed);
         next_block_idx = 0;
+        any_subtask_deferred.store(false, std::memory_order_relaxed);
     }
 
     // === Per-task fanout spinlock ===

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1089,9 +1089,34 @@ struct PTO2SchedulerState {
 // Scheduler cold-path API is declared as PTO2SchedulerState member functions.
 // See init()/destroy()/print_stats()/print_queues() below the struct definition.
 
+// Short-circuit NotDeferred completions seen during drain so they don't grow
+// entries[]. Mirrors the a2a3 impl; see that mirror for the rationale.
+inline bool
+AsyncWaitList::try_inline_complete_locked(AsyncWaitList::DrainCompletionSink &sink, PTO2TaskSlotState &slot_state) {
+#if PTO2_SCHED_PROFILING
+    sink.sched->on_mixed_task_complete(slot_state, sink.thread_idx, sink.local_bufs);
+#else
+    sink.sched->on_mixed_task_complete(slot_state, sink.local_bufs);
+#endif
+    if (*sink.deferred_release_count >= sink.deferred_release_capacity) {
+        while (*sink.deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+            (void)sink.sched->on_task_release(
+                *sink.deferred_release_slot_states[--(*sink.deferred_release_count)], sink.thread_idx
+            );
+#else
+            sink.sched->on_task_release(*sink.deferred_release_slot_states[--(*sink.deferred_release_count)]);
+#endif
+        }
+    }
+    sink.deferred_release_slot_states[(*sink.deferred_release_count)++] = &slot_state;
+    sink.inline_completed++;
+    return true;
+}
+
 template <bool Profiling>
 inline AsyncPollResult AsyncWaitList::poll_and_complete(
-    volatile AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
+    AICoreCompletionMailbox *aicore_mailbox, PTO2SchedulerState *sched, PTO2LocalReadyBuffer *local_bufs,
     PTO2TaskSlotState **deferred_release_slot_states, int32_t &deferred_release_count, int32_t deferred_release_capacity
 #if PTO2_SCHED_PROFILING
     ,
@@ -1101,13 +1126,24 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
     AsyncPollResult result;
     if (!try_lock()) return result;
 
+    AsyncWaitList::DrainCompletionSink sink{};
+    sink.sched = sched;
+    sink.local_bufs = local_bufs;
+    sink.deferred_release_slot_states = deferred_release_slot_states;
+    sink.deferred_release_count = &deferred_release_count;
+    sink.deferred_release_capacity = deferred_release_capacity;
+#if PTO2_SCHED_PROFILING
+    sink.thread_idx = thread_idx;
+#endif
+
     int32_t drain_err = PTO2_ERROR_NONE;
-    drain_aicore_completion_mailbox_locked(aicore_mailbox, drain_err);
+    drain_aicore_completion_mailbox_locked(aicore_mailbox, sink, drain_err);
     if (drain_err != PTO2_ERROR_NONE) {
         result.error_code = drain_err;
         unlock();
         return result;
     }
+    result.completed += sink.inline_completed;
 
     for (int32_t i = count - 1; i >= 0; --i) {
         AsyncWaitEntry &entry = entries[i];
@@ -1128,17 +1164,20 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
         }
 
         if (entry.normal_done && entry.waiting_completion_count <= 0) {
-            if (deferred_release_count >= deferred_release_capacity) {
-                result.error_code = PTO2_ERROR_ASYNC_WAIT_OVERFLOW;
-                result.failed_slot_state = entry.slot_state;
-                unlock();
-                return result;
-            }
 #if PTO2_SCHED_PROFILING
             sched->on_mixed_task_complete(*entry.slot_state, thread_idx, local_bufs);
 #else
             sched->on_mixed_task_complete(*entry.slot_state, local_bufs);
 #endif
+            if (deferred_release_count >= deferred_release_capacity) {
+                while (deferred_release_count > 0) {
+#if PTO2_SCHED_PROFILING
+                    (void)sched->on_task_release(*deferred_release_slot_states[--deferred_release_count], thread_idx);
+#else
+                    sched->on_task_release(*deferred_release_slot_states[--deferred_release_count]);
+#endif
+                }
+            }
             deferred_release_slot_states[deferred_release_count++] = entry.slot_state;
             result.completed++;
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -80,33 +80,61 @@ void SchedulerContext::complete_slot_task(
 #else
     (void)hank;
 #endif
-    bool mixed_complete = sched_->on_subtask_complete(slot_state);
-    if (slot_state.payload != nullptr) {
-        int32_t reg_err = PTO2_ERROR_NONE;
-        AsyncWaitList::RegisterResult reg_result;
-        volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
-        AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);
-        do {
-            reg_result = sched_->async_wait_list.register_deferred(slot_state, async_ctx, mixed_complete, reg_err);
-            if (reg_result == AsyncWaitList::RegisterResult::Skipped) {
-                SPIN_WAIT_HINT();
-            }
-        } while (reg_result == AsyncWaitList::RegisterResult::Skipped);
+    // MPSC fast-path: see a2a3 mirror for the full design narrative. The
+    // any_subtask_deferred flag on slot_state discriminates non-deferred
+    // tasks (inline complete in parallel on FIN thread) from deferred ones
+    // (route through the lock-free AICoreCompletionMailbox).
+    AICoreCompletionMailbox *mailbox = rt_ != nullptr ? rt_->aicore_mailbox : nullptr;
+    bool defer_completion_to_consumer = false;
 
-        if (reg_result == AsyncWaitList::RegisterResult::Error) {
+    if (slot_state.payload != nullptr) {
+        volatile DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][expected_reg_task_id & 1];
+        int32_t slab_err = deferred_slab->error_code;
+        if (slab_err != PTO2_ERROR_NONE) {
             int32_t expected = PTO2_ERROR_NONE;
             sched_->sm_header->sched_error_code.compare_exchange_strong(
-                expected, reg_err, std::memory_order_acq_rel, std::memory_order_acquire
+                expected, slab_err, std::memory_order_acq_rel, std::memory_order_acquire
             );
             completed_.store(true, std::memory_order_release);
             return;
         }
 
-        if (mixed_complete && reg_result == AsyncWaitList::RegisterResult::Registered) {
+        uint32_t cond_count = deferred_slab->count;
+        if (cond_count > MAX_COMPLETIONS_PER_TASK) {
+            int32_t expected = PTO2_ERROR_NONE;
+            sched_->sm_header->sched_error_code.compare_exchange_strong(
+                expected, PTO2_ERROR_ASYNC_REGISTRATION_FAILED, std::memory_order_acq_rel, std::memory_order_acquire
+            );
+            completed_.store(true, std::memory_order_release);
             return;
         }
+
+        if (cond_count > 0) {
+            slot_state.any_subtask_deferred.store(true, std::memory_order_release);
+
+            const PTO2TaskId token = slot_state.task->task_id;
+            for (uint32_t i = 0; i < cond_count; ++i) {
+                volatile DeferredCompletionEntry *e = &deferred_slab->entries[i];
+                while (!mailbox->try_push_condition(token, e->addr, e->expected_value, e->engine, e->completion_type)) {
+                    sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
+                    SPIN_WAIT_HINT();
+                }
+            }
+        }
     }
-    if (mixed_complete) {
+
+    bool mixed_complete = sched_->on_subtask_complete(slot_state);
+
+    if (mixed_complete && slot_state.payload != nullptr &&
+        slot_state.any_subtask_deferred.load(std::memory_order_acquire)) {
+        while (!mailbox->try_push_normal_done(slot_state.task->task_id, reinterpret_cast<uint64_t>(&slot_state))) {
+            sched_->async_wait_list.mpsc_skipped_count.fetch_add(1, std::memory_order_relaxed);
+            SPIN_WAIT_HINT();
+        }
+        defer_completion_to_consumer = true;
+    }
+
+    if (mixed_complete && !defer_completion_to_consumer) {
 #if PTO2_PROFILING
         if (is_dump_tensor_enabled()) {
             dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -581,7 +581,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         }
 
         if (rt_ != nullptr && rt_->aicore_mailbox != nullptr &&
-            (sched_->async_wait_list.count > 0 || sched_->async_wait_list.pending_completion_count > 0)) {
+            (sched_->async_wait_list.count > 0 || rt_->aicore_mailbox->has_pending())) {
             AsyncPollResult poll_result = sched_->async_wait_list.poll_and_complete<false>(
                 rt_->aicore_mailbox, sched_, local_bufs, deferred_release_slot_states, deferred_release_count,
                 PTO2_DEFERRED_RELEASE_CAP

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -347,6 +347,7 @@ add_a2a3_runtime_test(test_a2a3_tensormap   a2a3/test_tensormap.cpp)
 add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
 add_a2a3_runtime_test(test_spsc_queue       a2a3/test_spsc_queue.cpp)
 add_a2a3_runtime_test(test_wiring           a2a3/test_wiring.cpp)
+add_a2a3_runtime_test(test_aicore_completion_mailbox a2a3/test_aicore_completion_mailbox.cpp)
 
 # ---------------------------------------------------------------------------
 # A5 tests (src/a5/runtime/tensormap_and_ringbuffer/)
@@ -367,6 +368,7 @@ add_a5_runtime_test(test_a5_tensormap        a5/test_tensormap.cpp)
 add_a5_runtime_test(test_a5_fanin_pool       a5/test_fanin_pool.cpp)
 add_a5_runtime_test(test_a5_spsc_queue       a5/test_spsc_queue.cpp)
 add_a5_runtime_test(test_a5_wiring           a5/test_wiring.cpp)
+add_a5_runtime_test(test_a5_aicore_completion_mailbox a5/test_aicore_completion_mailbox.cpp)
 
 # Host logger silent/off behavior — no runtime deps, just compile host_log.cpp
 # alongside the test (faster than dlopen'ing libsimpler_log.so for a unit test).

--- a/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unit tests for the AICoreCompletionMailbox MPSC push protocol.
+ *
+ * Pins the lock-free producer/consumer contract used by the FIN-handling
+ * scheduler thread to register deferred completions without taking the
+ * AsyncWaitList::busy lock. The mailbox is the registration ingress
+ * (complete_slot_task pushes here); this test stresses the push/drain path
+ * under contention without booting the rest of the runtime.
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstring>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "aicore_completion_mailbox.h"
+#include "pto_async_wait.h"
+#include "scheduler/pto_scheduler.h"
+
+namespace {
+
+PTO2TaskId make_token(uint32_t local) { return PTO2TaskId::make(/*ring=*/0, local); }
+
+AICoreCompletionMailbox *fresh_mailbox() {
+    // ~256KB heap allocation — avoid stack/BSS pressure across tests.
+    void *raw = ::operator new(sizeof(AICoreCompletionMailbox));
+    auto *mb = new (raw) AICoreCompletionMailbox{};
+    std::memset(mb, 0, sizeof(*mb));
+    return mb;
+}
+
+void destroy_mailbox(AICoreCompletionMailbox *mb) {
+    mb->~AICoreCompletionMailbox();
+    ::operator delete(mb);
+}
+
+}  // namespace
+
+// =============================================================================
+// Basic push / drain round-trip
+// =============================================================================
+
+TEST(AICoreCompletionMailbox, PushConditionThenDrainCreatesEntry) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(42);
+    constexpr uint64_t kAddr = 0xCAFEBABEDEADBEEFull;
+    ASSERT_TRUE(
+        mb->try_push_condition(token, kAddr, /*expected=*/7, /*engine=*/COMPLETION_ENGINE_ROCE, COMPLETION_TYPE_COUNTER)
+    );
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    int32_t drained = wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+    EXPECT_EQ(drained, 1);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    // A CONDITION for an unknown token materializes the entry directly
+    // (slot_state stays null until a TASK_NORMAL_DONE sentinel arrives, but
+    // the condition is already attached).
+    ASSERT_EQ(wait_list.count, 1);
+    EXPECT_EQ(wait_list.entries[0].task_token.raw, token.raw);
+    EXPECT_EQ(wait_list.entries[0].slot_state, nullptr);
+    ASSERT_EQ(wait_list.entries[0].condition_count, 1);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].addr, kAddr);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].expected_value, 7u);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].completion_type, COMPLETION_TYPE_COUNTER);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, 1);
+    EXPECT_FALSE(wait_list.entries[0].normal_done);
+
+    destroy_mailbox(mb);
+}
+
+TEST(AICoreCompletionMailbox, PushNormalDoneCreatesEntryReadyToComplete) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(99);
+    PTO2TaskSlotState dummy_slot{};
+    uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
+    ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    int32_t drained = wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+    EXPECT_EQ(drained, 1);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    // A lone TASK_NORMAL_DONE means "no subtask of this task registered a
+    // condition" — the consumer creates an entry with waiting_count=0 and
+    // normal_done=true so the next poll iteration completes it inline.
+    ASSERT_EQ(wait_list.count, 1);
+    EXPECT_EQ(wait_list.entries[0].task_token.raw, token.raw);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].slot_state), slot_addr);
+    EXPECT_EQ(wait_list.entries[0].condition_count, 0);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, 0);
+    EXPECT_TRUE(wait_list.entries[0].normal_done);
+
+    destroy_mailbox(mb);
+}
+
+TEST(AICoreCompletionMailbox, NormalDoneAttachesToExistingEntry) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    // Pre-seed an entry so drain's TASK_NORMAL_DONE branch flips it in place
+    // rather than stashing. Exercises the "entry exists already" arm.
+    PTO2TaskId token = make_token(7);
+    wait_list.entries[0].task_token = token;
+    wait_list.entries[0].slot_state = nullptr;
+    wait_list.entries[0].condition_count = 0;
+    wait_list.entries[0].waiting_completion_count = 0;
+    wait_list.entries[0].normal_done = false;
+    wait_list.count = 1;
+
+    PTO2TaskSlotState dummy_slot{};
+    uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
+    ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    ASSERT_EQ(wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err), 1);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    EXPECT_TRUE(wait_list.entries[0].normal_done);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].slot_state), slot_addr);
+
+    destroy_mailbox(mb);
+}
+
+TEST(AICoreCompletionMailbox, ConditionAttachesToExistingEntry) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(15);
+    wait_list.entries[0].task_token = token;
+    wait_list.entries[0].slot_state = nullptr;
+    wait_list.entries[0].condition_count = 0;
+    wait_list.entries[0].waiting_completion_count = 0;
+    wait_list.entries[0].normal_done = false;
+    wait_list.count = 1;
+
+    constexpr uint64_t kAddr1 = 0x1000;
+    constexpr uint64_t kAddr2 = 0x2000;
+    ASSERT_TRUE(mb->try_push_condition(token, kAddr1, /*expected=*/3, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER));
+    ASSERT_TRUE(
+        mb->try_push_condition(token, kAddr2, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_SDMA_EVENT_RECORD)
+    );
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    ASSERT_EQ(wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err), 2);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    ASSERT_EQ(wait_list.entries[0].condition_count, 2);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].addr, kAddr1);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].expected_value, 3u);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].completion_type, COMPLETION_TYPE_COUNTER);
+    EXPECT_EQ(wait_list.entries[0].conditions[1].addr, kAddr2);
+    EXPECT_EQ(wait_list.entries[0].conditions[1].completion_type, COMPLETION_TYPE_SDMA_EVENT_RECORD);
+    // SDMA_EVENT_RECORD conditions don't bind counter_addr.
+    EXPECT_EQ(wait_list.entries[0].conditions[1].counter_addr, nullptr);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, 2);
+
+    destroy_mailbox(mb);
+}
+
+// =============================================================================
+// Capacity / overflow
+// =============================================================================
+
+TEST(AICoreCompletionMailbox, PushReturnsFalseWhenFull) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    constexpr uint32_t kCap = AICORE_COMPLETION_MAILBOX_CAPACITY;
+    PTO2TaskId token = make_token(1);
+    for (uint32_t i = 0; i < kCap; i++) {
+        ASSERT_TRUE(
+            mb->try_push_condition(token, /*addr=*/i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+        );
+    }
+    EXPECT_FALSE(
+        mb->try_push_condition(token, /*addr=*/kCap, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+    );
+    EXPECT_FALSE(mb->try_push_normal_done(token, /*slot_state_addr=*/0));
+
+    destroy_mailbox(mb);
+}
+
+// =============================================================================
+// Multi-producer correctness
+// =============================================================================
+
+TEST(AICoreCompletionMailbox, MultiProducerNoLossAndPerProducerOrder) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    constexpr int kProducers = 8;
+    constexpr int kPerProducer = 256;
+    static_assert(kProducers * kPerProducer < AICORE_COMPLETION_MAILBOX_CAPACITY);
+
+    std::vector<std::thread> producers;
+    producers.reserve(kProducers);
+    for (int p = 0; p < kProducers; p++) {
+        producers.emplace_back([mb, p]() {
+            PTO2TaskId token = make_token(static_cast<uint32_t>(p));
+            for (int i = 0; i < kPerProducer; i++) {
+                // Encode (producer, index) into addr to check per-producer
+                // ordering on the consumer side.
+                uint64_t addr = (static_cast<uint64_t>(p) << 32) | static_cast<uint64_t>(i);
+                while (!mb->try_push_condition(
+                    token, addr, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+                )) {
+                    std::this_thread::yield();  // sized below capacity so this is defensive
+                }
+            }
+        });
+    }
+    for (auto &t : producers)
+        t.join();
+
+    // Read slots in producer-emit order via the seq protocol (mirrors what
+    // drain_aicore_completion_mailbox_locked does internally).
+    std::vector<std::pair<uint32_t, uint32_t>> observed;
+    observed.reserve(kProducers * kPerProducer);
+    uint64_t head_total = static_cast<uint64_t>(kProducers) * kPerProducer;
+    for (uint64_t tail = 0; tail < head_total; tail++) {
+        AICoreCompletionMailboxMessage *slot = &mb->entries[tail & AICORE_COMPLETION_MAILBOX_MASK];
+        uint64_t expected_seq = tail + 1;
+        uint64_t seq = slot->seq.load(std::memory_order_acquire);
+        ASSERT_EQ(seq, expected_seq) << "missing publish at tail=" << tail;
+        EXPECT_EQ(slot->kind, MSG_KIND_CONDITION);
+        uint64_t addr = slot->addr;
+        observed.emplace_back(static_cast<uint32_t>(addr >> 32), static_cast<uint32_t>(addr & 0xFFFFFFFFu));
+    }
+
+    EXPECT_EQ(observed.size(), static_cast<size_t>(kProducers) * kPerProducer);
+
+    // For each producer p, the i values must appear in increasing order in
+    // `observed`. (Cross-producer interleaving is fine.)
+    std::unordered_map<uint32_t, int> last_seen;
+    for (auto &kv : observed) {
+        auto it = last_seen.find(kv.first);
+        if (it == last_seen.end()) {
+            EXPECT_EQ(kv.second, 0u) << "producer " << kv.first << " first emit not index 0";
+            last_seen[kv.first] = 0;
+        } else {
+            EXPECT_EQ(kv.second, static_cast<uint32_t>(it->second + 1)) << "producer " << kv.first << " out of order";
+            it->second++;
+        }
+    }
+    for (int p = 0; p < kProducers; p++) {
+        EXPECT_EQ(last_seen[static_cast<uint32_t>(p)], kPerProducer - 1) << "producer " << p << " missing tail emits";
+    }
+
+    destroy_mailbox(mb);
+}
+
+// =============================================================================
+// Push interleaved with drain (single producer thread + single drain thread,
+// stress-tests seq publish/observe round-trips across capacity wrap).
+// =============================================================================
+
+TEST(AICoreCompletionMailbox, ProducerInterleavedWithDrain) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+    // Pre-seed the entry for `token` so the drained CONDITIONs append to a
+    // known slot the final assertions can read.
+    PTO2TaskId token = make_token(5);
+    wait_list.entries[0].task_token = token;
+    wait_list.entries[0].slot_state = nullptr;
+    wait_list.entries[0].condition_count = 0;
+    wait_list.entries[0].waiting_completion_count = 0;
+    wait_list.entries[0].normal_done = false;
+    wait_list.count = 1;
+
+    // entry.conditions[] is bounded at MAX_COMPLETIONS_PER_TASK = 64, so cap
+    // the producer to that. Pin down: 64 pushes interleaved with drain do
+    // not lose any condition and waiting_completion_count tracks the total.
+    constexpr int kTotal = MAX_COMPLETIONS_PER_TASK;
+
+    std::atomic<int> pushed{0};
+    std::atomic<bool> drainer_stop{false};
+    std::thread producer([&]() {
+        for (int i = 0; i < kTotal; i++) {
+            while (!mb->try_push_condition(
+                token, /*addr=*/i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+            )) {
+                std::this_thread::yield();
+            }
+            pushed.fetch_add(1, std::memory_order_release);
+        }
+    });
+    std::thread drainer([&]() {
+        while (!drainer_stop.load(std::memory_order_acquire)) {
+            int32_t err = PTO2_ERROR_NONE;
+            AsyncWaitList::DrainCompletionSink sink{};
+            (void)wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+            ASSERT_EQ(err, PTO2_ERROR_NONE);
+            std::this_thread::yield();
+        }
+    });
+    producer.join();
+    // Stop and join the drain thread first so the final pass runs as the sole
+    // consumer — drain_aicore_completion_mailbox_locked is single-consumer
+    // (MPSC), so two concurrent drainers would race on tail/entries and could
+    // double-append past MAX_COMPLETIONS_PER_TASK.
+    drainer_stop.store(true, std::memory_order_release);
+    drainer.join();
+    // Final drain pass to consume any in-flight messages the drainer left
+    // after it observed the stop flag.
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    (void)wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+
+    EXPECT_EQ(pushed.load(), kTotal);
+    EXPECT_EQ(wait_list.entries[0].condition_count, kTotal);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, kTotal);
+
+    destroy_mailbox(mb);
+}

--- a/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unit tests for the a5 AICoreCompletionMailbox MPSC push protocol.
+ *
+ * Mirrors tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp but adapted
+ * to a5's simpler CompletionCondition (no completion_type field; counter-only).
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <cstring>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "aicore_completion_mailbox.h"
+#include "pto_async_wait.h"
+#include "scheduler/pto_scheduler.h"
+
+namespace {
+
+PTO2TaskId make_token(uint32_t local) { return PTO2TaskId::make(/*ring=*/0, local); }
+
+AICoreCompletionMailbox *fresh_mailbox() {
+    void *raw = ::operator new(sizeof(AICoreCompletionMailbox));
+    auto *mb = new (raw) AICoreCompletionMailbox{};
+    std::memset(mb, 0, sizeof(*mb));
+    return mb;
+}
+
+void destroy_mailbox(AICoreCompletionMailbox *mb) {
+    mb->~AICoreCompletionMailbox();
+    ::operator delete(mb);
+}
+
+}  // namespace
+
+TEST(A5AICoreCompletionMailbox, PushConditionThenDrainCreatesEntry) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(42);
+    constexpr uint64_t kAddr = 0xCAFEBABEDEADBEEFull;
+    ASSERT_TRUE(
+        mb->try_push_condition(token, kAddr, /*expected=*/7, /*engine=*/COMPLETION_ENGINE_ROCE, COMPLETION_TYPE_COUNTER)
+    );
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    int32_t drained = wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+    EXPECT_EQ(drained, 1);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    ASSERT_EQ(wait_list.count, 1);
+    EXPECT_EQ(wait_list.entries[0].task_token.raw, token.raw);
+    EXPECT_EQ(wait_list.entries[0].slot_state, nullptr);
+    ASSERT_EQ(wait_list.entries[0].condition_count, 1);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].expected_value, 7u);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].conditions[0].counter_addr), kAddr);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, 1);
+    EXPECT_FALSE(wait_list.entries[0].normal_done);
+
+    destroy_mailbox(mb);
+}
+
+TEST(A5AICoreCompletionMailbox, PushNormalDoneCreatesEntryReadyToComplete) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(99);
+    PTO2TaskSlotState dummy_slot{};
+    uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
+    ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    ASSERT_EQ(wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err), 1);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    ASSERT_EQ(wait_list.count, 1);
+    EXPECT_EQ(wait_list.entries[0].task_token.raw, token.raw);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].slot_state), slot_addr);
+    EXPECT_EQ(wait_list.entries[0].condition_count, 0);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, 0);
+    EXPECT_TRUE(wait_list.entries[0].normal_done);
+
+    destroy_mailbox(mb);
+}
+
+TEST(A5AICoreCompletionMailbox, NormalDoneAttachesToExistingEntry) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(7);
+    wait_list.entries[0].task_token = token;
+    wait_list.entries[0].slot_state = nullptr;
+    wait_list.entries[0].condition_count = 0;
+    wait_list.entries[0].waiting_completion_count = 0;
+    wait_list.entries[0].normal_done = false;
+    wait_list.count = 1;
+
+    PTO2TaskSlotState dummy_slot{};
+    uint64_t slot_addr = reinterpret_cast<uint64_t>(&dummy_slot);
+    ASSERT_TRUE(mb->try_push_normal_done(token, slot_addr));
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    ASSERT_EQ(wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err), 1);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    EXPECT_TRUE(wait_list.entries[0].normal_done);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].slot_state), slot_addr);
+
+    destroy_mailbox(mb);
+}
+
+TEST(A5AICoreCompletionMailbox, ConditionAttachesToExistingEntry) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+
+    PTO2TaskId token = make_token(15);
+    wait_list.entries[0].task_token = token;
+    wait_list.entries[0].slot_state = nullptr;
+    wait_list.entries[0].condition_count = 0;
+    wait_list.entries[0].waiting_completion_count = 0;
+    wait_list.entries[0].normal_done = false;
+    wait_list.count = 1;
+
+    // a5 is counter-only (no SDMA event-record backend), so both conditions
+    // are COUNTER and bind counter_addr / expected_value.
+    constexpr uint64_t kAddr1 = 0x1000;
+    constexpr uint64_t kAddr2 = 0x2000;
+    ASSERT_TRUE(mb->try_push_condition(token, kAddr1, /*expected=*/3, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER));
+    ASSERT_TRUE(mb->try_push_condition(token, kAddr2, /*expected=*/9, COMPLETION_ENGINE_ROCE, COMPLETION_TYPE_COUNTER));
+
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    ASSERT_EQ(wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err), 2);
+    EXPECT_EQ(err, PTO2_ERROR_NONE);
+
+    ASSERT_EQ(wait_list.entries[0].condition_count, 2);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].conditions[0].counter_addr), kAddr1);
+    EXPECT_EQ(wait_list.entries[0].conditions[0].expected_value, 3u);
+    EXPECT_EQ(reinterpret_cast<uint64_t>(wait_list.entries[0].conditions[1].counter_addr), kAddr2);
+    EXPECT_EQ(wait_list.entries[0].conditions[1].expected_value, 9u);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, 2);
+
+    destroy_mailbox(mb);
+}
+
+TEST(A5AICoreCompletionMailbox, PushReturnsFalseWhenFull) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    constexpr uint32_t kCap = AICORE_COMPLETION_MAILBOX_CAPACITY;
+    PTO2TaskId token = make_token(1);
+    for (uint32_t i = 0; i < kCap; i++) {
+        ASSERT_TRUE(mb->try_push_condition(
+            token, /*addr=*/0x10000 + i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+        ));
+    }
+    EXPECT_FALSE(
+        mb->try_push_condition(token, /*addr=*/0x20000, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+    );
+    EXPECT_FALSE(mb->try_push_normal_done(token, /*slot_state_addr=*/0));
+
+    destroy_mailbox(mb);
+}
+
+TEST(A5AICoreCompletionMailbox, MultiProducerNoLossAndPerProducerOrder) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    constexpr int kProducers = 8;
+    constexpr int kPerProducer = 256;
+    static_assert(kProducers * kPerProducer < AICORE_COMPLETION_MAILBOX_CAPACITY);
+
+    std::vector<std::thread> producers;
+    producers.reserve(kProducers);
+    for (int p = 0; p < kProducers; p++) {
+        producers.emplace_back([mb, p]() {
+            PTO2TaskId token = make_token(static_cast<uint32_t>(p));
+            for (int i = 0; i < kPerProducer; i++) {
+                uint64_t addr = (static_cast<uint64_t>(p) << 32) | static_cast<uint64_t>(i);
+                while (!mb->try_push_condition(
+                    token, addr, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+                )) {
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+    for (auto &t : producers)
+        t.join();
+
+    std::vector<std::pair<uint32_t, uint32_t>> observed;
+    observed.reserve(kProducers * kPerProducer);
+    uint64_t head_total = static_cast<uint64_t>(kProducers) * kPerProducer;
+    for (uint64_t tail = 0; tail < head_total; tail++) {
+        AICoreCompletionMailboxMessage *slot = &mb->entries[tail & AICORE_COMPLETION_MAILBOX_MASK];
+        uint64_t expected_seq = tail + 1;
+        uint64_t seq = slot->seq.load(std::memory_order_acquire);
+        ASSERT_EQ(seq, expected_seq) << "missing publish at tail=" << tail;
+        EXPECT_EQ(slot->kind, MSG_KIND_CONDITION);
+        uint64_t addr = slot->addr;
+        observed.emplace_back(static_cast<uint32_t>(addr >> 32), static_cast<uint32_t>(addr & 0xFFFFFFFFu));
+    }
+
+    EXPECT_EQ(observed.size(), static_cast<size_t>(kProducers) * kPerProducer);
+
+    std::unordered_map<uint32_t, int> last_seen;
+    for (auto &kv : observed) {
+        auto it = last_seen.find(kv.first);
+        if (it == last_seen.end()) {
+            EXPECT_EQ(kv.second, 0u) << "producer " << kv.first << " first emit not index 0";
+            last_seen[kv.first] = 0;
+        } else {
+            EXPECT_EQ(kv.second, static_cast<uint32_t>(it->second + 1)) << "producer " << kv.first << " out of order";
+            it->second++;
+        }
+    }
+    for (int p = 0; p < kProducers; p++) {
+        EXPECT_EQ(last_seen[static_cast<uint32_t>(p)], kPerProducer - 1) << "producer " << p << " missing tail emits";
+    }
+
+    destroy_mailbox(mb);
+}
+
+// =============================================================================
+// Push interleaved with drain (single producer thread + single drain thread,
+// stress-tests seq publish/observe round-trips across capacity wrap).
+// =============================================================================
+
+TEST(A5AICoreCompletionMailbox, ProducerInterleavedWithDrain) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+    AsyncWaitList wait_list{};
+    // Pre-seed the entry for `token` so the drained CONDITIONs append to a
+    // known slot the final assertions can read.
+    PTO2TaskId token = make_token(5);
+    wait_list.entries[0].task_token = token;
+    wait_list.entries[0].slot_state = nullptr;
+    wait_list.entries[0].condition_count = 0;
+    wait_list.entries[0].waiting_completion_count = 0;
+    wait_list.entries[0].normal_done = false;
+    wait_list.count = 1;
+
+    // entry.conditions[] is bounded at MAX_COMPLETIONS_PER_TASK = 64, so cap
+    // the producer to that. Pin down: 64 pushes interleaved with drain do
+    // not lose any condition and waiting_completion_count tracks the total.
+    constexpr int kTotal = MAX_COMPLETIONS_PER_TASK;
+
+    std::atomic<int> pushed{0};
+    std::atomic<bool> drainer_stop{false};
+    std::thread producer([&]() {
+        for (int i = 0; i < kTotal; i++) {
+            while (!mb->try_push_condition(
+                token, /*addr=*/i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+            )) {
+                std::this_thread::yield();
+            }
+            pushed.fetch_add(1, std::memory_order_release);
+        }
+    });
+    std::thread drainer([&]() {
+        while (!drainer_stop.load(std::memory_order_acquire)) {
+            int32_t err = PTO2_ERROR_NONE;
+            AsyncWaitList::DrainCompletionSink sink{};
+            (void)wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+            ASSERT_EQ(err, PTO2_ERROR_NONE);
+            std::this_thread::yield();
+        }
+    });
+    producer.join();
+    // Stop and join the drain thread first so the final pass runs as the sole
+    // consumer — drain_aicore_completion_mailbox_locked is single-consumer
+    // (MPSC), so two concurrent drainers would race on tail/entries and could
+    // double-append past MAX_COMPLETIONS_PER_TASK.
+    drainer_stop.store(true, std::memory_order_release);
+    drainer.join();
+    // Final drain pass to consume any in-flight messages the drainer left
+    // after it observed the stop flag.
+    int32_t err = PTO2_ERROR_NONE;
+    AsyncWaitList::DrainCompletionSink sink{};
+    (void)wait_list.drain_aicore_completion_mailbox_locked(mb, sink, err);
+
+    EXPECT_EQ(pushed.load(), kTotal);
+    EXPECT_EQ(wait_list.entries[0].condition_count, kTotal);
+    EXPECT_EQ(wait_list.entries[0].waiting_completion_count, kTotal);
+
+    destroy_mailbox(mb);
+}


### PR DESCRIPTION
### Summary

- Replace the `do { register_deferred(...); if (Skipped) SPIN_WAIT_HINT(); } while (Skipped)` loop in `complete_slot_task` with a lock-free push to a new `AICoreCompletionMailbox`; the consumer side drains the mailbox from inside `poll_and_complete`. The wait_list `busy` lock is no longer in the FIN-handling critical path.
- Preserve the parallel non-deferred completion path via a `PTO2TaskSlotState::any_subtask_deferred` discriminator (packed into otherwise-padding so `PTO2TaskSlotState` stays 64 bytes). Non-deferred tasks never touch the mailbox or the lock and complete inline on the FIN thread, matching pre-refactor behavior.
- Mirror to the a5 runtime.

### Why

`register_deferred` takes `AsyncWaitList::busy` for every FIN, including non-deferred tasks (just to do a `find_entry_by_token` and return `NotDeferred`). Under contention with `poll_and_complete` (the only other lock holder), `complete_slot_task` previously spun in `do/while`. Goal: registration never blocks on another scheduler's poll — a structural prerequisite for deferred-heavy workloads, even though current benchmark cases don't hit the contention regime hard enough to show measurable speedup.

### Approach

Producer side (FIN thread, `scheduler_completion.cpp::complete_slot_task`):

1. Read `slab.error_code` and `slab.count` locally (volatile, no lock).
2. If `slab.count > 0`: release-store `slot_state.any_subtask_deferred = true`, then push N `MSG_KIND_CONDITION` messages to the mailbox via CAS-on-head.
3. Call `on_subtask_complete` (acq_rel, baseline path).
4. On `mixed_complete`, acquire-load `any_subtask_deferred`:
   - **true** → push one `MSG_KIND_TASK_NORMAL_DONE` sentinel carrying `&slot_state` in `addr`. Skip inline completion; consumer handles it.
   - **false** → run inline `on_mixed_task_complete` + `deferred_release` (unchanged).

The any_subtask_deferred flag uses the acq_rel barrier inside `on_subtask_complete` (fetch_add) so the last subtask sees writes from all earlier subtasks of the same task. This makes "is this task deferred" a local atomic check rather than a global wait_list scan.

Consumer side (`pto_scheduler.h::poll_and_complete`):

1. Gated by `(wait_list.count > 0 || pending_completion_count > 0 || aicore_completion_mailbox_has_pending())` in `scheduler_dispatch.cpp` — empty state skips the entire block, no `try_lock` attempted.
2. `try_lock(busy)` — non-blocking; lose the race → return immediately, next iteration retries.
3. `drain_aicore_completion_mailbox_locked` walks the mailbox in seq order, dispatches per `kind`:
   - CONDITION: find or create entry, append condition.
   - TASK_NORMAL_DONE: find entry → set `normal_done`; if no entry exists (defensive; the producer-side fast-path means this shouldn't happen), inline-complete via `try_inline_complete_locked` rather than growing `entries[]`.
4. Iterate `entries[]` reverse, poll each unsatisfied condition, complete when `normal_done && waiting_count <= 0`.

Lock free for all FIN handlers; `busy` is only acquired by the (at most one at a time) consumer.

### Files changed

- `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/aicore_completion_mailbox.h`: `kind` field in 64B message; `MSG_KIND_CONDITION` / `MSG_KIND_TASK_NORMAL_DONE` enums.
- `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h`: `try_push_condition` / `try_push_normal_done` (MPSC CAS-on-head producers); drain rewritten to create entries directly + `DrainCompletionSink` for inline-complete handoff; `mpsc_skipped_count` diagnostic counter; `pending_normal_done[]` stash (defensive, untouched by fast-path).
- `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`: `PTO2TaskSlotState::any_subtask_deferred` atomic<bool> packed into existing padding, reset in `reset_for_reuse`.
- `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp`: producer fast-path replaces the do-while spin.
- `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp`: extend poll-gate with `aicore_completion_mailbox_has_pending`.
- `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h`: `try_inline_complete_locked` definition + in-place drain of `deferred_release` on capacity overflow inside `poll_and_complete`.
- `tests/ut/cpp/{a2a3,a5}/test_aicore_completion_mailbox.cpp`: new cpput suite (7 + 5 tests covering push/drain, normal_done attach, ring fullness, multi-producer no-loss / per-producer order).
- `tests/ut/cpp/CMakeLists.txt`: wire the two new test targets.

### Validation

- cpput: 27/27 `no_hardware` tests pass (was 26 + 1 new).
- a2a3sim `deferred_notify_demo`: `max_diff = 0` on both ranks.
- a2a3sim `dummy_task`: all 3 scene cases PASSED (covers non-deferred fast-path on sim).
- a5sim `deferred_notify_demo`: `max_diff = 0` on both ranks.
- a2a3 onboard, device 3, `tools/benchmark_rounds.sh -n 30`: 7/7 passing benchmarks within ±1.5% of baseline scheduler time (round-trip noise floor). `mpsc_skipped_count` stayed at 0 across all runs. See `.docs/25.comm-api-refactor/07.mpsc-benchmark-results.md` for the full table.
- `spmd_paged_attention` Case1/Case2 hang in both baseline and after — pre-existing failure (reproduces on `d873e48c` with `--build`), unrelated to this change; should be tracked as a separate issue.

### Test plan

- [ ] `cmake --build tests/ut/cpp/build && ctest -L no_hardware -j8` clean.
- [ ] `python examples/a2a3/.../deferred_notify_demo/test_deferred_notify_demo.py -p a2a3sim` passes, `max_diff = 0`.
- [ ] `python examples/a5/.../deferred_notify_demo/test_deferred_notify_demo.py -p a5sim` passes, `max_diff = 0`.
- [ ] `python tests/st/a2a3/.../dummy_task/test_dummy_task.py -p a2a3sim` all PASSED.
- [ ] Smoke a non-deferred onboard case (`alternating_matmul_add Case1` or similar) shows no `sched_error_code` set.

### Known caveats

- `spmd_paged_attention` Case1/Case2 hang predates this PR. Confirmed on the parent of the first MPSC commit; intentionally not in scope here.
- `mpsc_skipped_count` is a diagnostic. Non-zero value indicates either the 4096-slot mailbox is undersized for the workload or the consumer is starved; neither has been observed in the benchmark suite. Hook it up to L2 perf summary in a follow-up if deferred-heavy workloads emerge.
- The legacy `register_deferred` API and the `pending_completions[]` / `pending_normal_done[]` stashes are retained for the cpput unit tests and as defensive fallbacks. After the producer-side fast-path lands, the stash arrays are never written in practice; a follow-up can delete them and simplify the poll-gate to a 2-arg expression. Not bundled here to keep this PR mechanically smaller.
