### PR TITLE
fix: serialize drain() teardown against scheduler loop (host UAF)

### DIFF
--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -455,7 +455,19 @@ void Orchestrator::drain() {
     // Every slot is CONSUMED (active_tasks_ == 0 ⇒ allocator last_alive_ ==
     // next_task_id_). Drop all per-slot state so the next Worker.run()
     // starts from task_id = 0 with no accumulated memory.
-    allocator_->reset_to_empty();
+    //
+    // Hold the scheduler's loop mutex across the reset: active_tasks_ can reach
+    // zero while the scheduler thread is still inside on_task_complete (it reads
+    // the slot after the consume that drives the count to 0). Freeing the slots
+    // here without this guard is a heap-use-after-free. The scheduler releases
+    // loop_mu_ only between iterations, and with active_tasks_ == 0 it has no
+    // further slots to touch, so this blocks at most one in-flight iteration.
+    if (sched_loop_mu_ != nullptr) {
+        std::lock_guard<std::mutex> sched_lk(*sched_loop_mu_);
+        allocator_->reset_to_empty();
+    } else {
+        allocator_->reset_to_empty();
+    }
 
     // Rethrow the first dispatch failure seen during this run. Deferred to
     // after allocator reset so the next Worker.run() can proceed cleanly

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -136,6 +136,12 @@ public:
     // task is allowed to finish so ring slots aren't leaked.
     void drain();
 
+    // Wire the Scheduler's loop mutex so drain() can hold it across
+    // reset_to_empty(), preventing the scheduler thread from touching slot
+    // state mid-teardown (heap-use-after-free). Set once by Worker after the
+    // Scheduler is constructed.
+    void set_scheduler_loop_mutex(std::mutex *m) { sched_loop_mu_ = m; }
+
     // Clear any stored dispatch error so the next Worker::run() starts
     // from a clean slate. Called by Worker::run before scope_begin.
     void clear_error();
@@ -170,6 +176,9 @@ private:
     std::atomic<int32_t> active_tasks_{0};
     std::mutex drain_mu_;
     std::condition_variable drain_cv_;
+    // Scheduler's loop mutex (not owned). Held across reset_to_empty() in
+    // drain() so the scheduler can't be mid-on_task_complete during teardown.
+    std::mutex *sched_loop_mu_{nullptr};
 
     // Slot state lives in the Ring; the pointer stays stable for the
     // slot's lifetime. Throws if the id is out of range — callers that

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -82,6 +82,11 @@ void Scheduler::run() {
             });
         }
 
+        // Hold loop_mu_ across the entire slot-touching body so drain()'s
+        // reset_to_empty() cannot free TaskSlotStates while on_task_complete /
+        // dispatch_ready are still reading them (heap-use-after-free).
+        std::lock_guard<std::mutex> loop_lk(loop_mu_);
+
         // Phase 1: drain completions
         while (true) {
             TaskSlot slot;
@@ -112,7 +117,7 @@ void Scheduler::run() {
                     on_task_complete(slot);
                 }
                 dispatch_ready();
-                break;
+                break;  // loop_lk released on scope exit before exiting run()
             }
         }
     }

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -71,8 +71,15 @@ public:
     // Called by WorkerManager (from WorkerThread) after run() completes.
     void worker_done(TaskSlot slot);
 
+    // Mutex held by run() across each loop iteration's slot-touching body
+    // (completion processing + dispatch). Orchestrator::drain() acquires it
+    // before Ring::reset_to_empty() so the ring can't be torn down while the
+    // scheduler thread is mid-on_task_complete (heap-use-after-free).
+    std::mutex &loop_mutex() { return loop_mu_; }
+
 private:
     Config cfg_;
+    std::mutex loop_mu_;
 
     // Shared completion queue (WorkerThread → Scheduler)
     std::queue<TaskSlot> completion_queue_;

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -92,6 +92,9 @@ void Worker::init() {
     };
 
     scheduler_.start(cfg);
+    // Let drain() hold the scheduler's loop mutex across ring teardown so slots
+    // aren't freed while the scheduler thread is mid-on_task_complete.
+    orchestrator_.set_scheduler_loop_mutex(&scheduler_.loop_mutex());
     initialized_ = true;
 }
 


### PR DESCRIPTION
## Summary

Fixes a **heap-use-after-free** in the host hierarchical orchestrator (`src/common/hierarchical/`), the residual sim-oversubscription instability behind `dual_domain_overlap` (intermittent `rc=-6` SIGABRT / `rc=139` SIGSEGV in `st-sim-*`) — and almost certainly the other L3 comm-example flakes (`allreduce_distributed`, `ep_dispatch_combine`, `allgather_distributed`), which all share this orchestrator. Distinct from #898 (device tensormap scheduler) and #893 (init-handshake hang).

## Root cause (ASAN-proven)

```
READ  (scheduler thread): Scheduler::on_task_complete()  scheduler.cpp:157   (producers = s.fanin_producers)
FREED (main thread):      Orchestrator::drain() -> Ring::reset_to_empty()    ring.cpp:210
```

`drain()` waits for `active_tasks_ == 0` then frees all `TaskSlotState`s. But the count reaches 0 *inside* the scheduler thread's `on_task_complete` (`try_consume`→`on_consumed`), which keeps reading the slot afterwards. So `drain()` frees slots the scheduler thread is still touching. Deferring the drain *notify* is insufficient — `active_tasks_` can also reach 0 on the orch/main thread (`scope_end`→`release_ref`), making `drain()`'s predicate true with no notify at all.

## Fix

Add `Scheduler::loop_mutex()`, held by `Scheduler::run()` across each iteration's slot-touching body (completion processing + dispatch). `Orchestrator::drain()` holds it across `reset_to_empty()` (wired from `Worker` via `set_scheduler_loop_mutex`). The ring can't be torn down while the scheduler thread is in its loop body; with `active_tasks_ == 0` the scheduler has no further slots to touch, so `drain()` blocks at most one in-flight iteration. Arch-independent host code → covers a2a3 + a5 and all examples using the hierarchical orchestrator.

## Test plan

- [x] Root-caused with AddressSanitizer (post-mortem core was in stripped host-binding code; rebuilt `_task_interface` with `-fsanitize=address`).
- [x] `dual_domain_overlap` under `--cpus=2` at 4x concurrency: UAF reproduced within ~8-40 runs **before**; **~180 runs with zero ASAN errors after**.
- [ ] CI: `st-sim-a2a3` / `st-sim-a5` under load.
- Onboard unaffected (lifetime/concurrency bug, not platform-specific).

Refs #884.