### PR TITLE
Refactor: remove --build flag; load runtime binaries from build/lib only

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -47,4 +47,4 @@ my_example/
 
 Run via pytest: `pytest examples tests/st --platform <platform>`, or standalone: `python <example_or_test>/test_*.py -p <platform>`.
 
-Add `--build` to recompile runtime from source (incremental). Without it, pre-built binaries from `build/lib/` are used. See [docs/developer-guide.md](../../docs/developer-guide.md#build-workflow) for the full rebuild decision table.
+Tests load pre-built runtime binaries from `build/lib/`. After changing runtime/platform C++, re-run `pip install --no-build-isolation -e .` to rebuild them (incremental via the cmake cache; there is no rebuild-on-import — `editable.rebuild = false`) before re-running. See [docs/developer-guide.md](../../docs/developer-guide.md#when-to-rebuild) for the full rebuild decision table.

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -21,11 +21,11 @@ Before running tests, determine whether runtime binaries need recompilation:
 
 | What changed | Rebuild needed? | How |
 | ------------ | --------------- | --- |
-| Runtime/platform C++ (`src/{arch}/runtime/`, `src/{arch}/platform/`) | Yes | Pass `--build` to the pytest or `python test_*.py` invocation |
+| Runtime/platform C++ (`src/{arch}/runtime/`, `src/{arch}/platform/`) | Yes | Re-run `pip install --no-build-isolation -e .` (incremental via `build/cache/`) |
 | Nanobind bindings (`python/bindings/`) | Yes | Re-run `pip install -e .` |
 | Python-only code, examples, kernels | No | Just re-run the test |
 
-In CI, `pip install .` pre-builds all runtimes, so `--build` is never needed on CI runners.
+In CI, `pip install .` pre-builds all runtimes before tests run.
 
 ```bash
 # Python unit tests (no hardware)
@@ -57,9 +57,9 @@ pytest examples tests/st --platform a2a3sim --runtime host_build_graph \
 pytest examples/a2a3/host_build_graph/vector_example --platform a2a3sim \
     --clone-protocol https --pto-isa-commit <commit>
 
-# Single example (standalone, recompile runtime from source after changing runtime C++)
+# Single example (standalone; re-run `pip install --no-build-isolation -e .` first if runtime C++ changed)
 python examples/a2a3/host_build_graph/vector_example/test_vector_example.py \
-    -p a2a3sim --build --clone-protocol https --pto-isa-commit <commit>
+    -p a2a3sim --clone-protocol https --pto-isa-commit <commit>
 ```
 
 ## Pre-Commit Testing Strategy
@@ -94,12 +94,12 @@ Run `git diff --name-only` (or `git diff --cached --name-only` for staged change
 | ------------- | ----- | --------------- |
 | `src/{arch}/platform/*` | Full (all runtimes) | `pytest examples tests/st --platform <platform>` |
 | `src/{arch}/runtime/<rt>/*` | Single runtime | `pytest examples tests/st --platform <platform> --runtime <rt>` |
-| `examples/{arch}/<rt>/<ex>/*` | Single example | `python <ex>/test_*.py -p <platform> --build` (or `pytest <ex> --platform <platform> --build`) |
+| `examples/{arch}/<rt>/<ex>/*` | Single example | `python <ex>/test_*.py -p <platform>` (or `pytest <ex> --platform <platform>`) |
 | `tests/ut/*` (Python) | Python UT only | `pytest tests/ut` (add `--platform <platform>` on a device runner) |
 | `tests/ut/cpp/*` | C++ UT only | `cmake -B tests/ut/cpp/build -S tests/ut/cpp && cmake --build tests/ut/cpp/build && ctest --test-dir tests/ut/cpp/build -LE requires_hardware` |
 | Mixed (spans multiple categories) | Escalate to the **widest** matching scope | — |
 
-> **Note on `--build`**: When changed paths include `src/{arch}/runtime/` or `src/{arch}/platform/`, pass `--build` so the runtime C++ is recompiled incrementally. Pytest batch runs accept `--build` at the CLI (applies to the whole session).
+> **Note on runtime C++ changes**: When changed paths include `src/{arch}/runtime/` or `src/{arch}/platform/`, re-run `pip install --no-build-isolation -e .` before testing to rebuild the runtime binaries in `build/lib/` (incremental via `build/cache/`). There is no rebuild-on-import — `editable.rebuild = false`.
 
 ### Step 3 — Parallel Strategy
 
@@ -133,7 +133,7 @@ git diff --name-only
        │    ├─ runtime    → single runtime (--runtime ...)
        │    └─ example    → single example (standalone test_*.py or pytest <ex>)
        │
-       ├─ Runtime C++ changed (src/{arch}/)? ──→ add --build
+       ├─ Runtime C++ changed (src/{arch}/)? ──→ pip install --no-build-isolation -e . first
        │
        └─ npu-smi found?
             ├─ Yes → sim + hardware (idle devs, max 4)

--- a/conftest.py
+++ b/conftest.py
@@ -169,7 +169,6 @@ def pytest_addoption(parser):
         default=False,
         help="Enable per-scope peak collection and emit <output_prefix>/scope_stats.jsonl (per-scope ring-fill peaks).",
     )
-    parser.addoption("--build", action="store_true", default=False, help="Compile runtime from source")
     parser.addoption(
         "--pto-isa-commit",
         action="store",
@@ -966,7 +965,6 @@ def st_worker(request, st_platform, device_pool, _l2_worker_pool):
 
     level = cls._st_level
     runtime = cls._st_runtime
-    build = request.config.getoption("--build", default=False)
 
     if level == 2:
         # L2 share: reuse any Worker already created for this runtime in the
@@ -990,7 +988,7 @@ def st_worker(request, st_platform, device_pool, _l2_worker_pool):
         key = (runtime, dev_id)
         from simpler.worker import Worker  # noqa: PLC0415
 
-        w = Worker(level=2, device_id=dev_id, platform=st_platform, runtime=runtime, build=build)
+        w = Worker(level=2, device_id=dev_id, platform=st_platform, runtime=runtime)
         w._st_device_id = dev_id
         w.init()
         _l2_worker_pool[key] = w
@@ -1014,7 +1012,6 @@ def st_worker(request, st_platform, device_pool, _l2_worker_pool):
             num_sub_workers=max_subs,
             platform=st_platform,
             runtime=runtime,
-            build=build,
         )
         w._st_device_id = ids[0]  # expose primary device to test_run for profiling snapshots
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -168,38 +168,26 @@ pip install --no-build-isolation -e .
 
 This builds the nanobind `_task_interface` extension **and** pre-builds all runtime binaries for available toolchains into `build/lib/`. Sim platforms (a2a3sim, a5sim) are built when `gcc`/`g++` are available; onboard platforms (a2a3, a5) are built when `ccec` and the cross-compiler under `ASCEND_HOME_PATH` are available. Since a2a3 and a5 share the same compilation — differing only at runtime — both architectures are always built together when their toolchain is present.
 
-### Editable rebuild on import
+### No rebuild on import
 
-`pyproject.toml` enables `editable.rebuild = true`. Every fresh Python process that imports `simpler_setup` or `_task_interface` triggers `cmake --build` on the top-level CMake tree before the import returns. This auto-rebuilds the nanobind module when `python/bindings/` C++ changes — no manual `pip install -e .` needed. Also re-invokes `build_runtimes.py` (an `ALL` target), so the per-runtime cmake caches under `build/cache/` get checked too. Costs:
-
-- Nothing changed: a few hundred ms per inner cmake check (10-30+ inner cmakes total depending on installed toolchains)
-- Real C++ change: full incremental rebuild blocks the import until done
-
-If startup latency becomes painful, run `unset SKBUILD_EDITABLE_REBUILD` before pytest, or run `pip install --no-build-isolation -e .` once and revert. CI should never use editable installs.
+`pyproject.toml` sets `editable.rebuild = false`, so importing the package does **not** trigger a `cmake --build`. (Enabling it breaks under build isolation: the cmake path baked into `build.ninja` points into pip's deleted ephemeral env, so the next import fails with `cmake: No such file or directory` — see [Python packaging](python-packaging.md).) Therefore **any** C++ change — nanobind bindings or runtime/platform sources — only takes effect after re-running `pip install --no-build-isolation -e .`. The rebuild is incremental via the persistent cmake caches under `build/cache/` (~1-2s for a one-file change). CI should never use editable installs.
 
 ### When to rebuild
 
 | What changed | Action |
 | ------------ | ------ |
 | First time / clean checkout | `pip install --no-build-isolation -e .` |
-| Runtime C++ source (`src/{arch}/runtime/`, `src/{arch}/platform/`) | Pass `--build` to a standalone `python test_*.py` invocation (incremental, ~1-2s); editable rebuild does **not** cover this (runtime cmake is decoupled from the top-level cmake target). For pytest batch runs, pass `--build` at the pytest CLI. |
-| Nanobind bindings (`python/bindings/`) | Auto-rebuilt on next import (`editable.rebuild = true`) |
+| Runtime C++ source (`src/{arch}/runtime/`, `src/{arch}/platform/`) | Re-run `pip install --no-build-isolation -e .` (or `.` for a non-editable install). Incremental via the cmake caches under `build/cache/` (~1-2s). |
+| Nanobind bindings (`python/bindings/`) | Re-run `pip install --no-build-isolation -e .` (no rebuild-on-import; `editable.rebuild = false`) |
 | Python-only code (`python/*.py`, `simpler_setup/*.py`) | No rebuild needed (editable install) |
 | Examples / kernels (`examples/{arch}/`, `tests/st/`) | No rebuild needed, just re-run |
 
-### The `--build` flag
+### Runtime binary lookup
 
-By default, scene tests load pre-built runtime binaries from `build/lib/`. When runtime C++ source has changed, pass `--build` to recompile incrementally:
-
-```bash
-# Standalone: single test file
-python examples/a2a3/host_build_graph/vector_example/test_vector_example.py --build -p a2a3sim
-
-# Pytest: applies to every test in the session
-pytest examples tests/st --platform a2a3sim --build
-```
-
-This uses the persistent cmake cache in `build/cache/`, recompiling only what changed. In CI, `pip install .` pre-builds all runtimes before pytest runs, so examples use pre-built binaries.
+Scene tests load pre-built runtime binaries from `build/lib/`. These are produced
+by `build_runtimes.py` during `pip install`, using the persistent cmake cache in
+`build/cache/` to recompile only what changed. If the binaries are missing, the
+runtime loader raises with a hint to run `pip install --no-build-isolation .`.
 
 ### Disk layout
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -37,9 +37,6 @@ pytest examples tests/st --platform a2a3 --device 4-7  # hardware with device po
 # Single scene test (standalone)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim
 
-# Standalone with build-from-source
-python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py -p a2a3sim --build
-
 # Benchmark mode (100 rounds, skip golden comparison)
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
     -p a2a3 -d 0 --rounds 100 --skip-golden
@@ -81,7 +78,6 @@ pytest --platform a2a3sim                                        # default: 1 ro
 pytest --platform a2a3 --rounds 100 --skip-golden                # benchmark mode
 pytest --platform a2a3 --enable-l2-swimlane                             # L2 swimlane (first round)
 pytest --platform a2a3 --enable-pmu                              # PMU CSV
-pytest --platform a2a3sim --build                                # compile runtime from source
 pytest --platform a2a3sim --log-level debug                        # verbose C++ logging
 ```
 
@@ -93,7 +89,6 @@ python test_xxx.py -p a2a3 -d 0 --rounds 100 --skip-golden       # benchmark mod
 python test_xxx.py -p a2a3 --enable-l2-swimlane                         # L2 swimlane (first round)
 python test_xxx.py -p a2a3 --dump-tensor                         # dump per-task tensor I/O
 python test_xxx.py -p a2a3 --enable-pmu 4                        # PMU CSV (MEMORY)
-python test_xxx.py -p a2a3sim --build                            # compile runtime from source
 python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ logging
 ```
 
@@ -112,7 +107,6 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--enable-l2-swimlane [PERF_LEVEL]` | | `0` | Enable L2 swimlane collection on first round only. The flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md#31-enable-l2-swimlane) for the level table. Each test case gets its own `outputs/<case>_<ts>/` directory under which `l2_perf_records.json` lands; parallel runs never collide. |
 | `--dump-tensor` | | false | Dump per-task tensor I/O during runtime execution |
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
-| `--build` | | false | Compile runtime from source (not pre-built) |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
 | `--log-level LEVEL` | | `v5` | Simpler logger threshold. Accepts `debug` / `V0..V9` / `info` / `warn` / `error` / `null` (case-insensitive). pytest's own CLI validator does `int(getattr(logging, level.upper(), level))`, so the V tiers and `NUL`/`NULL` are exposed as attributes on the `logging` module via `setattr` (registration in `conftest.py` runs before pytest's option machinery). `logging.addLevelName` is also called so `%(levelname)s` formatters print `V3` instead of `Level 18`, but it is not what makes the CLI parser accept the value. The "simpler" Python logger is the single source of truth; the value is snapshotted into the platform SO at `Worker.init()` time (not per `Worker.run()`) and pushed to host `HostLogger`, runner state, and (onboard) CANN `dlog_setlevel`. AICPU receives it via `KernelArgs.log_info_v`. Changing the Python logger level after `Worker.init()` does not retroactively affect that worker. See [Log levels](#log-levels). |
 
@@ -217,7 +211,7 @@ Worked examples:
 | `--rounds` | both | **(none)** | pytest-xdist already uses `-n` for worker count. Standalone originally had `-n` for `--rounds`, creating a letter-level collision whenever a user switched between pytest (`-n 8` = 8 workers) and standalone (`-n 8` = 8 rounds). Removed in [#574](https://github.com/hw-native-sys/simpler/pull/574); do not reintroduce. |
 | `--max-parallel` | both | **(none)** | `-j` would be the natural make-style short, but pytest reserves all lowercase single letters (`parser.addoption` rejects lowercase shorts). Standalone mirrors this to keep both CLIs identical — no short in either, always spell out `--max-parallel`. |
 | `--runtime` / `--level` | both | **(none)** | Internal child-mode markers; users rarely type them. No short keeps them distinctive. |
-| `--build`, `--skip-golden`, `--enable-l2-swimlane`, `--dump-tensor`, `--enable-pmu`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
+| `--skip-golden`, `--enable-l2-swimlane`, `--dump-tensor`, `--enable-pmu`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
 
 Practical guidance when adding a new CLI option:
 

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -94,7 +94,6 @@ def run(
     platform: str = "a2a3",
     device_ids: list[int] | None = None,
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     if device_ids is None:
         device_ids = [0, 1]
@@ -116,7 +115,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
     try:
@@ -170,10 +168,9 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", default="a2a3")
     parser.add_argument("-d", "--device", default="0-1")
-    parser.add_argument("--build", action="store_true")
     parser.add_argument("--pto-isa-commit", default=None)
     args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -95,7 +95,6 @@ def run(
     platform: str = "a2a3sim",
     device_ids: list[int] | None = None,
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     if device_ids is None:
         device_ids = [0, 1]
@@ -117,7 +116,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
     try:
@@ -182,10 +180,9 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", default="a2a3sim")
     parser.add_argument("-d", "--device", default="0-1")
-    parser.add_argument("--build", action="store_true")
     parser.add_argument("--pto-isa-commit", default=None)
     args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -103,7 +103,6 @@ def run(
     platform: str = "a2a3",
     device_ids: list[int] | None = None,
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     if device_ids is None:
         device_ids = [0, 1]
@@ -133,7 +132,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
     try:
@@ -202,10 +200,9 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", default="a2a3")
     parser.add_argument("-d", "--device", default="0-1")
-    parser.add_argument("--build", action="store_true")
     parser.add_argument("--pto-isa-commit", default=None)
     args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/test_async_notify_demo.py
@@ -164,7 +164,6 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", default="a5")
     parser.add_argument("-d", "--device", default="0-1")
-    parser.add_argument("--build", action="store_true")
     parser.add_argument("--pto-isa-commit", default=None)
     args = parser.parse_args()
     return run(args.platform, parse_device_range(args.device), args.pto_isa_commit)

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/test_deferred_notify_demo.py
@@ -95,7 +95,6 @@ def run(
     platform: str = "a5sim",
     device_ids: list[int] | None = None,
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     if device_ids is None:
         device_ids = [0, 1]
@@ -117,7 +116,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
     try:
@@ -182,10 +180,9 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", default="a5sim")
     parser.add_argument("-d", "--device", default="0-1")
-    parser.add_argument("--build", action="store_true")
     parser.add_argument("--pto-isa-commit", default=None)
     args = parser.parse_args()
-    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit, build=args.build)
+    return run(args.platform, parse_device_range(args.device), args.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/allgather_distributed/main.py
+++ b/examples/workers/l3/allgather_distributed/main.py
@@ -116,7 +116,6 @@ def run(
     device_ids: list[int],
     platform: str = "a2a3",
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     """Core logic — callable from both CLI and pytest."""
     nranks = len(device_ids)
@@ -139,7 +138,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -205,15 +203,10 @@ def main() -> int:
     parser.add_argument(
         "-d", "--device", default="0-1", help="Device range, e.g. '0-1' or '0-3'. 2 to 16 chips required."
     )
-    parser.add_argument(
-        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
-    )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
 
-    return run(
-        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
-    )
+    return run(parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/allreduce_distributed/main.py
+++ b/examples/workers/l3/allreduce_distributed/main.py
@@ -133,7 +133,6 @@ def run(
     device_ids: list[int],
     platform: str = "a2a3",
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     """Core logic — callable from both CLI and pytest."""
     nranks = len(device_ids)
@@ -163,7 +162,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -235,15 +233,10 @@ def main() -> int:
     parser.add_argument(
         "-d", "--device", default="0-1", help="Device range, e.g. '0-1' or '0-3'. 2 to 16 chips required."
     )
-    parser.add_argument(
-        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
-    )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
 
-    return run(
-        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
-    )
+    return run(parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/ep_dispatch_combine/main.py
+++ b/examples/workers/l3/ep_dispatch_combine/main.py
@@ -419,7 +419,6 @@ def run(
     device_ids: list[int],
     platform: str = "a2a3",
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     """Core logic — callable from CLI and pytest."""
     nranks = len(device_ids)
@@ -487,7 +486,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -573,15 +571,10 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
     parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
-    parser.add_argument(
-        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
-    )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
 
-    return run(
-        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
-    )
+    return run(parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/ffn_tp_parallel/main.py
+++ b/examples/workers/l3/ffn_tp_parallel/main.py
@@ -161,7 +161,6 @@ def run(
     device_ids: list[int],
     platform: str = "a2a3",
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     nranks = len(device_ids)
     # scratch = mailbox(nranks * M*N floats) + signal tail (nranks int32).
@@ -188,7 +187,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     ffn_cid = worker.register(ffn_local_cc)
     allreduce_cid = worker.register(allreduce_cc)
@@ -277,15 +275,10 @@ def main() -> int:
 
     parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
     parser.add_argument("-d", "--device", default="0-1", help="Device range, e.g. '0-1'. Two chips required.")
-    parser.add_argument(
-        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
-    )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
 
-    return run(
-        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
-    )
+    return run(parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/examples/workers/l3/reduce_scatter_distributed/main.py
+++ b/examples/workers/l3/reduce_scatter_distributed/main.py
@@ -120,7 +120,6 @@ def run(
     device_ids: list[int],
     platform: str = "a2a3",
     pto_isa_commit: str | None = None,
-    build: bool = False,
 ) -> int:
     """Core logic — callable from both CLI and pytest."""
     nranks = len(device_ids)
@@ -145,7 +144,6 @@ def run(
         runtime="tensormap_and_ringbuffer",
         device_ids=device_ids,
         num_sub_workers=0,
-        build=build,
     )
     chip_cid = worker.register(chip_callable)
 
@@ -218,15 +216,10 @@ def main() -> int:
     parser.add_argument(
         "-d", "--device", default="0-1", help="Device range, e.g. '0-1' or '0-3'. 2 to 16 chips required."
     )
-    parser.add_argument(
-        "--build", action="store_true", help="Rebuild runtime from source instead of using cached libs."
-    )
     parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
     cli = parser.parse_args()
 
-    return run(
-        parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit, build=cli.build
-    )
+    return run(parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit)
 
 
 if __name__ == "__main__":

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -1253,7 +1253,7 @@ class Worker:
         device_id = self._config.get("device_id", 0)
 
         builder = RuntimeBuilder(platform)
-        binaries = builder.get_binaries(runtime, build=self._config.get("build", False))
+        binaries = builder.get_binaries(runtime)
 
         self._chip_worker = ChipWorker()
         self._chip_worker.init(device_id, binaries)
@@ -1286,7 +1286,7 @@ class Worker:
             platform = self._config["platform"]
             runtime = self._config["runtime"]
             builder = RuntimeBuilder(platform)
-            binaries = builder.get_binaries(runtime, build=self._config.get("build", False))
+            binaries = builder.get_binaries(runtime)
 
             # Stash the full RuntimeBinaries so forked chip children can
             # construct a ChipWorker with one call (`cw.init(device_id, bins)`)

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -183,7 +183,7 @@ class RuntimeBuilder:
                 f"Pre-built runtime binaries not found for '{name}' "
                 f"(platform={self.platform}):\n"
                 + "\n".join(f"  {m}" for m in missing)
-                + "\nRun 'pip install .' or pass --build to compile them."
+                + "\nRun 'pip install --no-build-isolation .' to compile them."
             )
 
         # Validate sim_context SO exists for sim platforms
@@ -191,7 +191,7 @@ class RuntimeBuilder:
         if sim_context_path is not None and not sim_context_path.is_file():
             raise FileNotFoundError(
                 f"Pre-built libcpu_sim_context.so not found at {sim_context_path}.\n"
-                "Run 'pip install .' or pass --build to compile it."
+                "Run 'pip install --no-build-isolation .' to compile it."
             )
 
         # Validate libsimpler_log.so exists (built once per arch/variant).
@@ -199,7 +199,7 @@ class RuntimeBuilder:
         if not simpler_log_path.is_file():
             raise FileNotFoundError(
                 f"Pre-built libsimpler_log.so not found at {simpler_log_path}.\n"
-                "Run 'pip install .' or pass --build to compile it."
+                "Run 'pip install --no-build-isolation .' to compile it."
             )
 
         # Resolve and validate libsimpler_aicpu_dispatcher.so for onboard
@@ -210,7 +210,7 @@ class RuntimeBuilder:
         if dispatcher_path is not None and not dispatcher_path.is_file():
             raise FileNotFoundError(
                 f"Pre-built libsimpler_aicpu_dispatcher.so not found at {dispatcher_path}.\n"
-                "Run 'pip install .' or pass --build to compile it."
+                "Run 'pip install --no-build-isolation .' to compile it."
             )
 
         return RuntimeBinaries(
@@ -361,7 +361,7 @@ class RuntimeBuilder:
         if not build:
             raise FileNotFoundError(
                 f"Pre-built libsimpler_log.so not found at {so_path}.\n"
-                "Run 'pip install .' or pass --build to compile it."
+                "Run 'pip install --no-build-isolation .' to compile it."
             )
 
         cache_dir = self._CACHE_DIR
@@ -388,7 +388,7 @@ class RuntimeBuilder:
         if not build:
             raise FileNotFoundError(
                 f"Pre-built libcpu_sim_context.so not found at {so_path}.\n"
-                "Run 'pip install .' or pass --build to compile it."
+                "Run 'pip install --no-build-isolation .' to compile it."
             )
 
         cache_dir = self._CACHE_DIR

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -846,7 +846,7 @@ class SceneTestCase:
     # ------------------------------------------------------------------
 
     @classmethod
-    def _create_worker(cls, platform, device_id=0, build=False):
+    def _create_worker(cls, platform, device_id=0):
         """Create the L2 Worker for the standalone path.
 
         Mirrors the ``st_worker`` pytest fixture, which yields a ``Worker``
@@ -856,7 +856,7 @@ class SceneTestCase:
         """
         from simpler.worker import Worker  # noqa: PLC0415
 
-        w = Worker(level=2, device_id=device_id, platform=platform, runtime=cls._st_runtime, build=build)
+        w = Worker(level=2, device_id=device_id, platform=platform, runtime=cls._st_runtime)
         w.init()
         return w
 
@@ -1296,7 +1296,6 @@ class SceneTestCase:
             help="Enable per-scope peak collection and emit <output_prefix>/scope_stats/scope_stats.jsonl "
             "(per-scope ring-fill peaks).",
         )
-        parser.add_argument("--build", action="store_true", help="Compile runtime from source")
         parser.add_argument(
             "--runtime",
             default=None,
@@ -1531,8 +1530,6 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
         common.append("--enable-dep-gen")
     if args.enable_scope_stats:
         common.append("--enable-scope-stats")
-    if args.build:
-        common.append("--build")
 
     # ----- L3 phase: one subprocess per class (not per case).
     # The child's _create_standalone_worker allocates max(cls.CASES.device_count)
@@ -1712,9 +1709,8 @@ def _create_standalone_worker(group, level, args, selected_by_cls):
     callables nor pre-registered chip callables, so both dicts are empty.
     """
     first_cls = group[0]
-    build = getattr(args, "build", False)
     if level == 2:
-        return first_cls._create_worker(args.platform, args.device, build=build), {}, {}
+        return first_cls._create_worker(args.platform, args.device), {}, {}
 
     from simpler.worker import Worker  # noqa: PLC0415
 
@@ -1739,7 +1735,6 @@ def _create_standalone_worker(group, level, args, selected_by_cls):
         num_sub_workers=max_subs,
         platform=args.platform,
         runtime=first_cls._st_runtime,
-        build=build,
     )
     # Register sub callables per-class to avoid name collisions
     per_class_sub_ids: dict[type, dict] = {}

--- a/tests/st/a2a3/host_build_graph/prepared_callable/conftest.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/conftest.py
@@ -36,7 +36,6 @@ def st_worker(request, st_platform, device_pool):
         pytest.skip("isolated st_worker requires a SceneTestCase subclass")
 
     runtime = cls._st_runtime
-    build = request.config.getoption("--build", default=False)
 
     ids = device_pool.allocate(1)
     if not ids:
@@ -50,7 +49,6 @@ def st_worker(request, st_platform, device_pool):
             device_id=dev_id,
             platform=st_platform,
             runtime=runtime,
-            build=build,
         )
         w.init()
         try:

--- a/tests/st/a2a3/host_build_graph/vector_example/README.md
+++ b/tests/st/a2a3/host_build_graph/vector_example/README.md
@@ -27,8 +27,8 @@ python tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py -p a
 pytest tests/st/a2a3/host_build_graph/vector_example --platform a2a3sim
 ```
 
-`--log-level debug` enables verbose compile / runtime logs. `--build`
-recompiles runtime C++ before running.
+`--log-level debug` enables verbose compile / runtime logs. After changing
+runtime C++, re-run `pip install --no-build-isolation -e .` to refresh the pre-built binaries.
 
 ## Layout
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/conftest.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/conftest.py
@@ -36,7 +36,6 @@ def st_worker(request, st_platform, device_pool):
         pytest.skip("isolated st_worker requires a SceneTestCase subclass")
 
     runtime = cls._st_runtime
-    build = request.config.getoption("--build", default=False)
 
     ids = device_pool.allocate(1)
     if not ids:
@@ -50,7 +49,6 @@ def st_worker(request, st_platform, device_pool):
             device_id=dev_id,
             platform=st_platform,
             runtime=runtime,
-            build=build,
         )
         w.init()
         try:

--- a/tests/st/a5/host_build_graph/prepared_callable/conftest.py
+++ b/tests/st/a5/host_build_graph/prepared_callable/conftest.py
@@ -36,7 +36,6 @@ def st_worker(request, st_platform, device_pool):
         pytest.skip("isolated st_worker requires a SceneTestCase subclass")
 
     runtime = cls._st_runtime
-    build = request.config.getoption("--build", default=False)
 
     ids = device_pool.allocate(1)
     if not ids:
@@ -50,7 +49,6 @@ def st_worker(request, st_platform, device_pool):
             device_id=dev_id,
             platform=st_platform,
             runtime=runtime,
-            build=build,
         )
         w.init()
         try:

--- a/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/conftest.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/conftest.py
@@ -36,7 +36,6 @@ def st_worker(request, st_platform, device_pool):
         pytest.skip("isolated st_worker requires a SceneTestCase subclass")
 
     runtime = cls._st_runtime
-    build = request.config.getoption("--build", default=False)
 
     ids = device_pool.allocate(1)
     if not ids:
@@ -50,7 +49,6 @@ def st_worker(request, st_platform, device_pool):
             device_id=dev_id,
             platform=st_platform,
             runtime=runtime,
-            build=build,
         )
         w.init()
         try:

--- a/tests/ut/py/test_worker/test_dynamic_alloc_hw.py
+++ b/tests/ut/py/test_worker/test_dynamic_alloc_hw.py
@@ -31,8 +31,6 @@ the C ABI.
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 
@@ -50,8 +48,7 @@ def test_two_rank_allocate_release_round_trip(st_device_ids):
 
     from simpler_setup.runtime_builder import RuntimeBuilder
 
-    build = bool(os.environ.get("PTO_UT_BUILD"))
-    _ = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer", build=build)
+    _ = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer")
     assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
     device_ids = [int(d) for d in st_device_ids[:2]]
     nranks = len(device_ids)

--- a/tests/ut/py/test_worker/test_dynamic_alloc_sim.py
+++ b/tests/ut/py/test_worker/test_dynamic_alloc_sim.py
@@ -30,8 +30,6 @@ The flow under test:
 
 from __future__ import annotations
 
-import os
-
 import pytest
 
 
@@ -39,9 +37,8 @@ def _sim_binaries():
     """Resolve pre-built a2a3sim runtime binaries, or skip if unavailable."""
     from simpler_setup.runtime_builder import RuntimeBuilder
 
-    build = bool(os.environ.get("PTO_UT_BUILD"))
     try:
-        bins = RuntimeBuilder(platform="a2a3sim").get_binaries("tensormap_and_ringbuffer", build=build)
+        bins = RuntimeBuilder(platform="a2a3sim").get_binaries("tensormap_and_ringbuffer")
     except FileNotFoundError as e:
         pytest.skip(f"a2a3sim runtime binaries unavailable: {e}")
     return bins

--- a/tests/ut/py/test_worker/test_platform_comm.py
+++ b/tests/ut/py/test_worker/test_platform_comm.py
@@ -172,8 +172,7 @@ def test_two_rank_comm_lifecycle(st_device_ids):
     """End-to-end 2-rank hardware smoke test for ChipWorker.comm_* wrappers."""
     from simpler_setup.runtime_builder import RuntimeBuilder
 
-    build = bool(os.environ.get("PTO_UT_BUILD"))
-    bins = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer", build=build)
+    bins = RuntimeBuilder(platform="a2a3").get_binaries("tensormap_and_ringbuffer")
     assert len(st_device_ids) >= 2, "device_count(2) fixture must yield >= 2 ids"
     nranks = 2
     rootinfo_path = f"/tmp/pto_comm_py_ut_rootinfo_{os.getpid()}.bin"


### PR DESCRIPTION
## Summary

Removes the `--build` developer flag (and the undocumented `PTO_UT_BUILD`
env var) that let a test recompile runtime C++ on demand. Tests now load
runtime binaries **only** from `build/lib/`, which is the normal workflow:
edit C++ → `pip install .` (or editable rebuild-on-import) → run.

The compile machinery itself is **unchanged** — `RuntimeBuilder.get_binaries(build=True)`
stays (it's what `build_runtimes.py` uses during `pip install`), as does
`test_runtime_builder.py` which tests it directly.

### What changed
- `conftest.py` / `scene_test.py`: drop the `--build` pytest/standalone option and the `build=` plumbing into `Worker(...)`
- `worker.py`: `get_binaries()` loads pre-built binaries
- 4 st `prepared_callable` conftests + 10 example scripts: drop `--build`
- 3 worker UTs: drop the `PTO_UT_BUILD` env-var escape hatch
- `runtime_builder.py`: error hints now say "Run 'pip install .'" (dropped "or pass --build")
- docs/skills (`developer-guide`, `testing`, `architecture`, testing skill, example README): replace `--build` guidance with `pip install -e .`

### Behavior change
After editing runtime/platform C++, re-run `pip install --no-build-isolation -e .`
(editable rebuild-on-import refreshes `build/lib/` incrementally) before re-running
tests. Previously `--build` recompiled on demand at test time.

Clears the way for the opt-in sanitizer build flag (#904), which is a
clean install-time CMake define rather than another per-test rebuild flag.

## Testing
- [x] `py_compile` + `ruff` + `markdownlint` + `pyright` clean (pre-commit green)
- [ ] Simulation tests pass (CI)
- [ ] Hardware tests pass (CI)