### PR TITLE
Add: opt-in compiler sanitizers (ASAN/UBSan + TSAN) for host targets

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,68 @@
+name: Sanitizers
+
+# Nightly sanitizer sweep of main. Kept in its OWN workflow (not ci.yml) so the
+# schedule trigger fires ONLY these jobs — adding `schedule` to ci.yml would run
+# every unguarded job (pre-commit, ut, packaging, self-hosted hardware) on cron.
+#
+# ASAN and TSAN are separate, mutually-exclusive builds; both instrument only
+# host-compiled code (sim runtime + kernels + orchestration), and sim unifies on
+# g++-15 so the preloaded runtime matches the kernels' ABI. Not a PR gate: too
+# slow (TSAN ~5-15x) and subject to the pre-existing sim-oversubscription flake,
+# so a generous per-session timeout + manual rerun is expected. detect_leaks=0
+# until LSan suppressions exist for the device custom arenas.
+on:
+  schedule:
+    - cron: "0 18 * * *"  # 02:00 Beijing
+
+concurrency:
+  group: sanitizers-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PTO_ISA_COMMIT: ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8
+
+jobs:
+  sanitizer-sim:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [asan, tsan]
+        platform: [a2a3sim, a5sim]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up C++ compiler
+        run: |
+          sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install -y ninja-build graphviz
+          sudo apt-get install -y g++-15 || sudo apt-get install -y g++
+          if ! command -v g++-15; then sudo ln -s "$(which g++)" /usr/local/bin/g++-15; fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+
+      - name: Install with sanitizer
+        run: |
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          # --no-cache-dir so pip rebuilds rather than reusing a non-sanitizer wheel.
+          pip install --no-cache-dir \
+            --config-settings=cmake.define.SIMPLER_SANITIZER=${{ matrix.sanitizer }} '.[test]'
+
+      - name: Run sanitized scene tests (${{ matrix.sanitizer }}, ${{ matrix.platform }})
+        run: |
+          # Sim unifies host compilation on g++-15, so preload g++-15's runtime.
+          LIB=$(g++-15 -print-file-name=lib${{ matrix.sanitizer }}.so)
+          LD_PRELOAD="$LIB" \
+          ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1 \
+          UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+          TSAN_OPTIONS=halt_on_error=1 \
+          pytest examples tests/st --platform ${{ matrix.platform }} --device 0-15 \
+            --sanitizer ${{ matrix.sanitizer }} -v --pto-session-timeout 1200 \
+            --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https --require-pto-isa

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,13 @@ add_subdirectory(python/bindings)
 set(SIMPLER_PTO_CLONE_PROTOCOL "ssh" CACHE STRING
     "Protocol for cloning pto-isa during install (ssh or https)")
 
+# Compiler sanitizer for host-compiled targets (sim runtime/kernels and the
+# onboard host runtime). Default `none`. Preset (asan/ubsan/tsan) or a raw
+# -fsanitize token list. Enable at `pip install` time via
+#   pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=asan .
+set(SIMPLER_SANITIZER "none" CACHE STRING
+    "Sanitizer for host targets during install (none/asan/ubsan/tsan)")
+
 # Pre-build runtime binaries (persistent build dirs for incremental compilation)
 add_custom_target(build_runtimes ALL
     COMMAND ${Python_EXECUTABLE}
@@ -43,6 +50,7 @@ add_custom_target(build_runtimes ALL
         --lib-dir ${CMAKE_SOURCE_DIR}/build/lib
         --cache-dir ${CMAKE_SOURCE_DIR}/build/cache
         --clone-protocol ${SIMPLER_PTO_CLONE_PROTOCOL}
+        --sanitizer ${SIMPLER_SANITIZER}
     COMMENT "Building runtime binaries (incremental)..."
 )
 

--- a/cmake/sanitizers.cmake
+++ b/cmake/sanitizers.cmake
@@ -1,0 +1,42 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+#
+# Shared compiler-sanitizer helper.
+#
+# `SIMPLER_SANITIZERS` is a comma-separated `-fsanitize` token list (e.g.
+# "address,undefined" or "thread"), passed straight through to the compiler.
+# Empty (the default) makes every call below a no-op, so ordinary builds are
+# byte-for-byte unchanged.
+#
+# Apply ONLY to host-compiled targets — the sim runtime/kernels/orchestration
+# and the onboard *host* runtime. NEVER call it for device toolchains (ccec for
+# AICore, aarch64 cross for the AICPU): they run on the NPU and cannot carry a
+# host sanitizer runtime.
+#
+# `-O1` (the last `-O` wins, overriding an earlier `-O3`) plus frame pointers
+# keep sanitizer stack traces from being inlined away — the standard
+# good-report settings.
+
+function(simpler_apply_sanitizers tgt)
+  if(NOT SIMPLER_SANITIZERS)
+    return()
+  endif()
+  target_compile_options(${tgt} PRIVATE
+    -fsanitize=${SIMPLER_SANITIZERS}
+    -fno-omit-frame-pointer
+    -O1)
+  target_link_options(${tgt} PRIVATE -fsanitize=${SIMPLER_SANITIZERS})
+  # TSAN can't model standalone std::atomic_thread_fence and warns about it;
+  # the AICPU target compiles with -Werror, which would make that warning
+  # fatal. Keep the warning visible but non-fatal — the limitation is known
+  # and acceptable (fence-ordered accesses just aren't TSAN-tracked there).
+  if(SIMPLER_SANITIZERS MATCHES "thread")
+    target_compile_options(${tgt} PRIVATE -Wno-error=tsan)
+  endif()
+endfunction()

--- a/conftest.py
+++ b/conftest.py
@@ -183,6 +183,17 @@ def pytest_addoption(parser):
         help="Protocol for cloning pto-isa when --pto-isa-commit is set",
     )
     parser.addoption(
+        "--sanitizer",
+        action="store",
+        default="none",
+        help=(
+            "Run against sanitizer-built binaries. Preset (asan/ubsan/tsan) or raw "
+            "-fsanitize tokens. Must match the SIMPLER_SANITIZER the runtime was "
+            "pip-installed with, and needs the matching runtime preloaded "
+            "(e.g. LD_PRELOAD=$(g++ -print-file-name=libasan.so))."
+        ),
+    )
+    parser.addoption(
         "--require-pto-isa",
         action="store_true",
         default=False,
@@ -354,6 +365,37 @@ def _install_child_faulthandler() -> None:
             pass
 
 
+def _configure_sanitizer(config):
+    """Wire the `--sanitizer` option: drive kernel compile + require the preload.
+
+    The runtime `.so` are sanitizer-built at install time
+    (`pip install --config-settings=cmake.define.SIMPLER_SANITIZER=...`); this
+    only has to (a) compile the per-test kernels/orchestration to match and
+    (b) fail early if the runtime isn't preloaded.
+    """
+    from simpler_setup import sanitizers as san  # noqa: PLC0415
+    from simpler_setup.kernel_compiler import KernelCompiler  # noqa: PLC0415
+
+    selection = config.getoption("--sanitizer", default="none")
+    tokens = san.resolve(selection)
+    if not tokens:
+        return
+    try:
+        san.validate(tokens)
+    except ValueError as e:
+        raise pytest.UsageError(f"--sanitizer={selection}: {e}") from e
+    KernelCompiler._sanitizers = tokens
+
+    lib = san.preload_lib(tokens)
+    if lib and not san.is_runtime_loaded(lib):
+        platform = config.getoption("--platform", default="") or ""
+        raise pytest.UsageError(
+            f"--sanitizer={selection} needs the {lib} runtime preloaded "
+            f"(the instrumented .so are dlopen'd into this Python). Re-run with:\n"
+            f"  {san.preload_command(tokens, platform)} pytest --sanitizer {selection} ..."
+        )
+
+
 def pytest_configure(config):
     """Register custom markers and apply global config."""
     config.addinivalue_line("markers", "platforms(list): supported platforms for standalone ST functions")
@@ -364,6 +406,8 @@ def pytest_configure(config):
         "runtime(name): runtime this standalone test targets; used by runtime-isolation subprocess "
         "filtering so non-@scene_test tests only run under their matching runtime",
     )
+
+    _configure_sanitizer(config)
 
     log_level = config.getoption("--log-level", default=None)
     if log_level:

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -47,6 +47,16 @@ PullRequest
 | `ut-a5` | a5 self-hosted | `pytest tests/ut --platform a5` + `ctest -L "^requires_hardware(_a5)?$"` |
 | `st-onboard-a5` | a5 self-hosted | `pytest examples tests/st --platform a5 --device ...` |
 
+### Nightly sanitizer sweep
+
+A **separate** workflow, [`sanitizers.yml`](../.github/workflows/sanitizers.yml),
+runs on a nightly `schedule` — kept out of `ci.yml` so the cron fires only the
+sanitizer jobs, never the PR/self-hosted pipeline. Its
+`sanitizer-sim` job builds the sim runtime + kernels with ASAN or TSAN
+(`pip install --config-settings=cmake.define.SIMPLER_SANITIZER=...`) and runs
+`pytest examples tests/st` under the matching `LD_PRELOAD` (a2a3sim/a5sim,
+ubuntu-only). Not a PR gate; see [testing.md](testing.md#sanitizer-builds-asan--tsan).
+
 ### Parallel ST runs on hardware
 
 For self-hosted jobs with multiple NPUs, pass a `--device` range (and

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -651,6 +651,48 @@ Key fields:
 
 If similar coverage exists in both `examples/` and `tests/st/`, collapse it into a single `test_*.py`: small cases get `platforms: ["a2a3sim", "a2a3"]`; large benchmark cases get `platforms: ["a2a3"], "manual": True`.
 
+## Sanitizer builds (ASAN / TSAN)
+
+Sanitizers instrument **host-compiled** code only — on sim that is the runtime
+(`host`/`aicpu`/`aicore`), the per-test kernels, and orchestration; on onboard
+only the host runtime. Device code (ccec AICore `.o`, aarch64 AICPU) cannot
+carry a host sanitizer, and device custom arenas (`DeviceArena`/`HeapRing`)
+bypass ASAN redzones, so device-side heap bugs are not caught.
+
+It is a two-part flag — **install-time** (which sanitizer the binaries are
+built with) and **run-time** (preload + match):
+
+```bash
+# 1. Build the runtime with the sanitizer (ASAN bundles UBSan).
+pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=asan .
+
+# 2. Run, preloading the matching runtime (the instrumented .so are dlopen'd
+#    into a vanilla Python, so the sanitizer runtime must come first). Sim
+#    unifies on g++-15, so preload g++-15's runtime — using plain g++'s would
+#    mismatch the kernels' ABI and fail at load.
+LD_PRELOAD=$(g++-15 -print-file-name=libasan.so) \
+ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+pytest examples tests/st --platform a2a3sim --sanitizer asan -v
+```
+
+`--sanitizer` must match the `SIMPLER_SANITIZER` the runtime was installed with;
+it compiles the per-test kernels/orchestration to match and fails fast (with the
+exact `LD_PRELOAD` command) if the runtime isn't preloaded. Presets: `asan`
+(`address,undefined`), `ubsan`, `tsan`; a raw `-fsanitize` token list also works.
+
+**TSAN is a separate, mutually-exclusive build** (cannot coexist with ASAN) and
+is **Linux-only** (no macOS `libtsan`):
+
+```bash
+pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=tsan .
+LD_PRELOAD=$(g++-15 -print-file-name=libtsan.so) TSAN_OPTIONS=halt_on_error=1 \
+pytest examples tests/st --platform a2a3sim --sanitizer tsan -v
+```
+
+`detect_leaks=0` is recommended initially — LSan false-positives on the device
+custom arenas until suppressions are added.
+
 ## CI Pipeline
 
 See [ci.md](ci.md) for the full CI pipeline documentation, including the job matrix, runner constraints, and marker scheme.

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -38,6 +38,7 @@ sys.path.insert(0, str(_project_root / "python"))
 
 from simpler_setup.platform_info import PROJECT_ROOT, discover_runtimes, parse_platform  # noqa: E402
 from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: E402
+from simpler_setup.sanitizers import SANITIZER_PRESETS, resolve, validate  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +76,7 @@ def build_all(
     cache_dir: Path,
     platforms: Optional[list] = None,
     clone_protocol: str = "ssh",
+    sanitizer: str = "none",
 ) -> None:
     """Build all runtime variants for the given platforms.
 
@@ -85,10 +87,23 @@ def build_all(
         clone_protocol: Protocol used by ensure_pto_isa_root() when an
             onboard platform needs the pto-isa headers and PTO_ISA_ROOT is
             not pre-set. Mirrors conftest's --clone-protocol flag.
+        sanitizer: Sanitizer preset (asan/ubsan/tsan/none) or raw `-fsanitize`
+            token list. Only host-compiled targets honor it; see
+            BuildTarget.gen_cmake_args.
     """
     # Override default paths to respect CLI args
     RuntimeBuilder._LIB_DIR = lib_dir
     RuntimeBuilder._CACHE_DIR = cache_dir
+
+    # Resolve the preset to `-fsanitize` tokens and stash on RuntimeCompiler so
+    # every host cmake configure below picks it up (default "" = no sanitizer).
+    from simpler_setup.runtime_compiler import RuntimeCompiler  # noqa: PLC0415
+
+    tokens = resolve(sanitizer)
+    validate(tokens)
+    RuntimeCompiler._sanitizers = tokens
+    if tokens:
+        logger.info(f"Building with sanitizers: {tokens} (host targets only)")
 
     if platforms is None:
         platforms = detect_buildable_platforms()
@@ -205,6 +220,15 @@ def main():
             "and PTO_ISA_ROOT is not pre-set (default: ssh, matching conftest)"
         ),
     )
+    parser.add_argument(
+        "--sanitizer",
+        default="none",
+        help=(
+            f"Compiler sanitizer for host-compiled targets. Preset "
+            f"({'/'.join(SANITIZER_PRESETS)}) or a raw -fsanitize token list. "
+            "Default: none. asan/tsan are mutually exclusive (separate builds)."
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -229,6 +253,7 @@ def main():
         cache_dir=args.cache_dir,
         platforms=args.platforms,
         clone_protocol=args.clone_protocol,
+        sanitizer=args.sanitizer,
     )
 
 

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -48,6 +48,12 @@ class KernelCompiler:
     - AARCH64_GXX: aarch64 cross-compiler for device orchestration
     """
 
+    # Comma-separated `-fsanitize` tokens, set once by conftest from the pytest
+    # `--sanitizer` option (default "" = off). Only host toolchains (Gxx15 sim
+    # incore, Gxx sim orchestration) honor it; ccec/aarch64 device builds never
+    # do. Must match the runtime's install-time SIMPLER_SANITIZER.
+    _sanitizers = ""
+
     def __init__(self, platform: str = "a2a3"):
         """
         Initialize KernelCompiler.
@@ -80,9 +86,22 @@ class KernelCompiler:
         else:
             self.ccec = None
             self.aarch64 = None
-            self.host_gxx = GxxToolchain()
+            # Sim orchestration must match the sim kernels' g++-15 under a
+            # sanitizer (one runtime per process); see GxxToolchain prefer_g15.
+            self.host_gxx = GxxToolchain(prefer_g15=bool(self._sanitizers))
 
         self.gxx15 = Gxx15Toolchain()
+
+    def _sanitizer_flags(self, toolchain) -> list[str]:
+        """Sanitizer flags for a host-compiled kernel / orchestration .so.
+
+        No-op for device toolchains (ccec/aarch64) and when no sanitizer is
+        selected. `-O1` + frame pointers mirror cmake/sanitizers.cmake so the
+        sim kernel/orchestration match the sanitized runtime.
+        """
+        if not self._sanitizers or not toolchain.is_host:
+            return []
+        return [f"-fsanitize={self._sanitizers}", "-fno-omit-frame-pointer", "-O1"]
 
     def get_platform_include_dirs(self) -> list[str]:
         """
@@ -452,6 +471,7 @@ class KernelCompiler:
         )
 
         cmd = [toolchain.cxx_path] + toolchain.get_compile_flags()
+        cmd += self._sanitizer_flags(toolchain)
 
         # Force a deterministic ELF GNU Build-ID into every orchestration .so.
         # The host-side DeviceRunner reads `.note.gnu.build-id` to detect when
@@ -531,6 +551,7 @@ class KernelCompiler:
 
         # Build command from toolchain
         cmd = [self.gxx15.cxx_path] + self.gxx15.get_compile_flags(core_type=core_type)
+        cmd += self._sanitizer_flags(self.gxx15)
 
         # Add PTO ISA header paths if provided
         if pto_isa_root:

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -40,7 +40,7 @@ class BuildTarget:
     def get_binary_name(self) -> str:
         return self._binary_name
 
-    def gen_cmake_args(self, include_dirs: list[str], source_dirs: list[str]) -> list[str]:
+    def gen_cmake_args(self, include_dirs: list[str], source_dirs: list[str], sanitizers: str = "") -> list[str]:
         """Generate CMake arguments list from toolchain args + custom directories."""
         inc = ";".join(os.path.abspath(d) for d in include_dirs)
         src = ";".join(os.path.abspath(d) for d in source_dirs)
@@ -48,6 +48,12 @@ class BuildTarget:
             f"-DCUSTOM_INCLUDE_DIRS={inc}",
             f"-DCUSTOM_SOURCE_DIRS={src}",
         ]
+        # Sanitizers only apply to host-compiled targets — device toolchains
+        # (ccec, aarch64 cross) run on the NPU and can't carry a host sanitizer
+        # runtime. cmake/sanitizers.cmake reads both defines.
+        if sanitizers and self.toolchain.is_host:
+            args.append(f"-DSIMPLER_SANITIZERS={sanitizers}")
+            args.append(f"-DSIMPLER_CMAKE_DIR={PROJECT_ROOT / 'cmake'}")
         if logger.isEnabledFor(logging.DEBUG):
             args.append("--log-level=VERBOSE")
         return args
@@ -70,6 +76,11 @@ class RuntimeCompiler:
     """
 
     _instances = {}
+
+    # Comma-separated `-fsanitize` tokens for host targets, set once by
+    # build_runtimes.build_all() at install time (default "" = no sanitizer).
+    # Only host toolchains honor it; see BuildTarget.gen_cmake_args.
+    _sanitizers = ""
 
     @classmethod
     def get_instance(cls, platform: str = "a2a3") -> "RuntimeCompiler":
@@ -145,7 +156,9 @@ class RuntimeCompiler:
         No Ascend SDK required.
         """
         self._ensure_host_compilers()
-        gxx = GxxToolchain()
+        # Under a sanitizer, match the sim kernels' g++-15 so every host .so
+        # shares one sanitizer runtime (see GxxToolchain prefer_g15).
+        gxx = GxxToolchain(prefer_g15=bool(self._sanitizers))
 
         self.aicore_target = BuildTarget(gxx, str(self.platform_dir / "aicore"), "libaicore_kernel.so")
         self.aicpu_target = BuildTarget(gxx, str(self.platform_dir / "aicpu"), "libaicpu_kernel.so")
@@ -174,7 +187,9 @@ class RuntimeCompiler:
         No Ascend SDK required.
         """
         self._ensure_host_compilers()
-        gxx = GxxToolchain()
+        # Under a sanitizer, match the sim kernels' g++-15 so every host .so
+        # shares one sanitizer runtime (see GxxToolchain prefer_g15).
+        gxx = GxxToolchain(prefer_g15=bool(self._sanitizers))
 
         self.aicore_target = BuildTarget(gxx, str(self.platform_dir / "aicore"), "libaicore_kernel.so")
         self.aicpu_target = BuildTarget(gxx, str(self.platform_dir / "aicpu"), "libaicpu_kernel.so")
@@ -238,7 +253,7 @@ class RuntimeCompiler:
         else:
             raise ValueError(f"Invalid target platform: {target_platform}. Must be 'aicore', 'aicpu', or 'host'.")
 
-        cmake_args = target.gen_cmake_args(include_dirs, source_dirs)
+        cmake_args = target.gen_cmake_args(include_dirs, source_dirs, sanitizers=self._sanitizers)
         cmake_source_dir = target.get_root_dir()
         binary_name = target.get_binary_name()
         platform = target_platform.upper()
@@ -407,6 +422,19 @@ class RuntimeCompiler:
 
         return binary_path
 
+    def _sanitizer_cmake_args(self) -> list[str]:
+        """Sanitizer defines for the standalone host helper SOs (log, sim_context).
+
+        These are always host-compiled (g++), so they follow the host runtime's
+        instrumentation; cmake/sanitizers.cmake reads both defines.
+        """
+        if not self._sanitizers:
+            return []
+        return [
+            f"-DSIMPLER_SANITIZERS={self._sanitizers}",
+            f"-DSIMPLER_CMAKE_DIR={PROJECT_ROOT / 'cmake'}",
+        ]
+
     def compile_sim_context(
         self,
         build_dir: Optional[str] = None,
@@ -423,7 +451,7 @@ class RuntimeCompiler:
 
         cmake_source_dir = str(self.project_root / "src" / "common" / "sim_context")
         binary_name = "libcpu_sim_context.so"
-        cmake_args = self.host_target.toolchain.get_cmake_args()
+        cmake_args = self.host_target.toolchain.get_cmake_args() + self._sanitizer_cmake_args()
 
         def _build(actual_build_dir: str) -> Union[bytes, Path]:
             binary_path = self._run_compilation(
@@ -464,7 +492,7 @@ class RuntimeCompiler:
         """
         cmake_source_dir = str(self.project_root / "src" / "common" / "log")
         binary_name = "libsimpler_log.so"
-        cmake_args = self.host_target.toolchain.get_cmake_args()
+        cmake_args = self.host_target.toolchain.get_cmake_args() + self._sanitizer_cmake_args()
 
         def _build(actual_build_dir: str) -> Union[bytes, Path]:
             binary_path = self._run_compilation(

--- a/simpler_setup/sanitizers.py
+++ b/simpler_setup/sanitizers.py
@@ -1,0 +1,118 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Single source of truth for compiler-sanitizer selection.
+
+The same `--sanitizer` value drives three places, so the preset table, the
+mutual-exclusion rule, and the runtime-library mapping all live here:
+
+- runtime build (`build_runtimes.py` → cmake `-DSIMPLER_SANITIZERS=`)
+- per-test kernel / orchestration compile (`kernel_compiler.py`)
+- the `LD_PRELOAD` glue at test time (`conftest.py`)
+
+A *preset* (what users type) expands to a comma-separated `-fsanitize` *token*
+list (what the compiler and `cmake/sanitizers.cmake` consume). Adding a
+sanitizer is one dict entry here; the cmake helper never changes.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# Preset name -> comma-separated `-fsanitize=` tokens. Empty = no instrumentation.
+# ASAN bundles UBSan (compatible, cheap). TSAN is its own (mutually exclusive)
+# build. Raw token strings (e.g. "address,leak") are also accepted as-is.
+SANITIZER_PRESETS: dict[str, str] = {
+    "none": "",
+    "asan": "address,undefined",
+    "ubsan": "undefined",
+    "tsan": "thread",
+}
+
+# `-fsanitize=thread` cannot coexist with these in one binary.
+_THREAD_INCOMPATIBLE = {"address", "leak", "memory"}
+
+
+def resolve(selection: str | None) -> str:
+    """Expand a preset name to its `-fsanitize` token list (raw tokens pass through).
+
+    Returns "" for ``None`` / "none" / "" — i.e. no instrumentation.
+    """
+    if not selection:
+        return ""
+    if selection in SANITIZER_PRESETS:
+        return SANITIZER_PRESETS[selection]
+    return selection  # already a raw token list like "address,undefined"
+
+
+def validate(tokens: str) -> None:
+    """Raise ValueError if the token set is an illegal or unsupported combination.
+
+    This is the shared gate for the runtime build, the pytest path, and the
+    standalone path, so the platform check lives here too.
+    """
+    toks = {t.strip() for t in tokens.split(",") if t.strip()}
+    if "thread" in toks and (toks & _THREAD_INCOMPATIBLE):
+        raise ValueError(
+            f"sanitizer 'thread' cannot combine with {sorted(toks & _THREAD_INCOMPATIBLE)} "
+            "in one binary — build them separately"
+        )
+    if "thread" in toks and sys.platform != "linux":
+        raise ValueError("thread sanitizer (TSAN) is Linux-only — no libtsan on this platform")
+
+
+def preload_lib(tokens: str) -> str | None:
+    """Runtime library to `LD_PRELOAD` for a dlopen'd, sanitizer-built `.so`.
+
+    The sanitizer runtime must be the first thing in the process; since the
+    instrumented `.so` files are dlopen'd into a vanilla Python, preloading the
+    matching runtime is required. Returns None when nothing needs preloading.
+    """
+    toks = {t.strip() for t in tokens.split(",") if t.strip()}
+    if "thread" in toks:
+        return "libtsan.so"
+    if "address" in toks:  # ubsan/leak fold into the asan runtime
+        return "libasan.so"
+    if "leak" in toks:  # standalone LSan (no address)
+        return "liblsan.so"
+    if "undefined" in toks:
+        return "libubsan.so"
+    return None
+
+
+def host_cxx(platform: str) -> str:
+    """Host compiler whose sanitizer runtime must be preloaded.
+
+    Sim unifies on g++-15 (matching the kernels) under a sanitizer; onboard host
+    uses plain g++. The `LD_PRELOAD`'d runtime must come from the same compiler
+    that built the `.so`, or the versioned ASan/TSan ABI check fails at load.
+    """
+    return "g++-15" if platform.endswith("sim") else "g++"
+
+
+def is_runtime_loaded(lib: str) -> bool:
+    """Whether `lib` (e.g. libasan.so) is already mapped into this process.
+
+    Best-effort: only Linux exposes /proc/self/maps — elsewhere (macOS) trust
+    the caller. The instrumented `.so` are dlopen'd into a vanilla Python, so
+    the sanitizer runtime must be preloaded before the interpreter starts.
+    """
+    try:
+        with open("/proc/self/maps") as f:
+            return lib.split(".so")[0] in f.read()
+    except OSError:
+        return True
+
+
+def preload_command(tokens: str, platform: str) -> str | None:
+    """The `LD_PRELOAD=$(... -print-file-name=...)` hint for an error message."""
+    lib = preload_lib(tokens)
+    if not lib:
+        return None
+    var = "DYLD_INSERT_LIBRARIES" if sys.platform == "darwin" else "LD_PRELOAD"
+    return f"{var}=$({host_cxx(platform)} -print-file-name={lib})"

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1250,6 +1250,15 @@ class SceneTestCase:
             help="Device id or range ('0', '4-7', '0,2,5')",
         )
         parser.add_argument(
+            "--sanitizer",
+            default="none",
+            help=(
+                "Run against sanitizer-built binaries (asan/ubsan/tsan or raw -fsanitize "
+                "tokens). Must match the installed runtime's SIMPLER_SANITIZER and needs "
+                "the runtime preloaded, e.g. LD_PRELOAD=$(g++ -print-file-name=libasan.so)."
+            ),
+        )
+        parser.add_argument(
             "--case",
             action="append",
             default=None,
@@ -1342,6 +1351,27 @@ class SceneTestCase:
         )
         args = parser.parse_args()
         configure_logging(args.log_level)
+
+        # Match the per-test kernel/orchestration compile to the runtime's
+        # sanitizer, and require the runtime preloaded — same as conftest, since
+        # the standalone path skips it.
+        from . import sanitizers as _san  # noqa: PLC0415
+
+        _san_tokens = _san.resolve(args.sanitizer)
+        if _san_tokens:
+            try:
+                _san.validate(_san_tokens)
+            except ValueError as e:
+                parser.error(f"--sanitizer={args.sanitizer}: {e}")
+            from .kernel_compiler import KernelCompiler  # noqa: PLC0415
+
+            KernelCompiler._sanitizers = _san_tokens
+            _lib = _san.preload_lib(_san_tokens)
+            if _lib and not _san.is_runtime_loaded(_lib):
+                parser.error(
+                    f"--sanitizer={args.sanitizer} needs the {_lib} runtime preloaded. Re-run with:\n"
+                    f"  {_san.preload_command(_san_tokens, args.platform)} python {module_name} ..."
+                )
 
         os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(
             commit=args.pto_isa_commit,
@@ -1518,6 +1548,8 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
     script = os.path.abspath(getattr(module, "__file__", sys.argv[0]))
 
     common = ["-p", args.platform, "--manual", args.manual, "--log-level", args.log_level]
+    if args.sanitizer != "none":
+        common += ["--sanitizer", args.sanitizer]
     if args.rounds != 1:
         common += ["--rounds", str(args.rounds)]
     if args.skip_golden:

--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -90,6 +90,11 @@ class Toolchain:
     - BuildTarget (in runtime_compiler.py): calls get_cmake_args() for CMake builds
     """
 
+    # Host toolchains can carry a host sanitizer runtime; device toolchains
+    # (ccec / aarch64 cross) run on the NPU and cannot. Overridden to True by
+    # the host compilers (Gxx, Gxx15) below.
+    is_host: bool = False
+
     cxx_path: str
 
     def __init__(self):
@@ -164,6 +169,8 @@ class CCECToolchain(Toolchain):
 class Gxx15Toolchain(Toolchain):
     """g++-15 compiler for simulation kernels."""
 
+    is_host = True
+
     def __init__(self):
         super().__init__()
         self.cxx_path = "g++-15"
@@ -195,11 +202,20 @@ class Gxx15Toolchain(Toolchain):
 
 
 class GxxToolchain(Toolchain):
-    """g++ compiler for host compilation."""
+    """g++ compiler for host compilation.
 
-    def __init__(self):
+    ``prefer_g15`` switches the binary to g++-15/gcc-15. Used under a sanitizer
+    on sim: the runtime, helpers, and orchestration must share the SAME host
+    compiler as the sim kernels (which are always g++-15), because mixing g++
+    and g++-15 sanitizer runtimes is an ABI mismatch that fails at `.so` load.
+    """
+
+    is_host = True
+
+    def __init__(self, prefer_g15: bool = False):
         super().__init__()
-        self.cxx_path = "g++"
+        self.cxx_path = "g++-15" if prefer_g15 else "g++"
+        self._prefer_g15 = prefer_g15
         self._gcc = _is_gcc(self.cxx_path)
 
     def get_compile_flags(self, **kwargs) -> list[str]:
@@ -211,7 +227,7 @@ class GxxToolchain(Toolchain):
         return flags
 
     def get_cmake_args(self) -> list[str]:
-        args = _host_compiler_cmake_args("gcc", self.cxx_path)
+        args = _host_compiler_cmake_args("gcc-15" if self._prefer_g15 else "gcc", self.cxx_path)
         if self.ascend_home_path:
             args.append(f"-DASCEND_HOME_PATH={self.ascend_home_path}")
         return args

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -174,3 +174,11 @@ target_link_directories(host_runtime
 )
 
 set_target_properties(host_runtime PROPERTIES OUTPUT_NAME "host_runtime")
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(host_runtime)
+endif()

--- a/src/a2a3/platform/sim/aicore/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicore/CMakeLists.txt
@@ -86,3 +86,11 @@ set_target_properties(aicore_kernel PROPERTIES
     # This matches the hardcoded paths in Python/C++ code
     SUFFIX ".so"
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(aicore_kernel)
+endif()

--- a/src/a2a3/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicpu/CMakeLists.txt
@@ -90,3 +90,11 @@ set_target_properties(aicpu_kernel PROPERTIES
     # This matches the hardcoded paths in Python/C++ code
     SUFFIX ".so"
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(aicpu_kernel)
+endif()

--- a/src/a2a3/platform/sim/host/CMakeLists.txt
+++ b/src/a2a3/platform/sim/host/CMakeLists.txt
@@ -117,3 +117,11 @@ set_target_properties(host_runtime PROPERTIES
     # This matches the hardcoded paths in Python/C++ code
     SUFFIX ".so"
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(host_runtime)
+endif()

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -123,3 +123,11 @@ target_link_directories(host_runtime
 )
 
 set_target_properties(host_runtime PROPERTIES OUTPUT_NAME "host_runtime")
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(host_runtime)
+endif()

--- a/src/a5/platform/sim/aicore/CMakeLists.txt
+++ b/src/a5/platform/sim/aicore/CMakeLists.txt
@@ -86,3 +86,11 @@ set_target_properties(aicore_kernel PROPERTIES
     # This matches the hardcoded paths in Python/C++ code
     SUFFIX ".so"
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(aicore_kernel)
+endif()

--- a/src/a5/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a5/platform/sim/aicpu/CMakeLists.txt
@@ -90,3 +90,11 @@ set_target_properties(aicpu_kernel PROPERTIES
     # This matches the hardcoded paths in Python/C++ code
     SUFFIX ".so"
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(aicpu_kernel)
+endif()

--- a/src/a5/platform/sim/host/CMakeLists.txt
+++ b/src/a5/platform/sim/host/CMakeLists.txt
@@ -118,3 +118,11 @@ set_target_properties(host_runtime PROPERTIES
     # This matches the hardcoded paths in Python/C++ code
     SUFFIX ".so"
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(host_runtime)
+endif()

--- a/src/common/log/CMakeLists.txt
+++ b/src/common/log/CMakeLists.txt
@@ -46,3 +46,11 @@ set_target_properties(simpler_log PROPERTIES
     CXX_STANDARD 17
     CXX_STANDARD_REQUIRED ON
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(simpler_log)
+endif()

--- a/src/common/sim_context/CMakeLists.txt
+++ b/src/common/sim_context/CMakeLists.txt
@@ -40,3 +40,11 @@ set_target_properties(cpu_sim_context PROPERTIES
     SUFFIX ".so"
     POSITION_INDEPENDENT_CODE ON
 )
+
+# Apply compiler sanitizers to this host-compiled target. No-op unless
+# SIMPLER_SANITIZERS is set at configure time, which runtime_compiler only
+# passes for host toolchains (sim + onboard host). See cmake/sanitizers.cmake.
+if(SIMPLER_SANITIZERS)
+    include("${SIMPLER_CMAKE_DIR}/sanitizers.cmake")
+    simpler_apply_sanitizers(cpu_sim_context)
+endif()

--- a/tests/ut/py/test_sanitizers.py
+++ b/tests/ut/py/test_sanitizers.py
@@ -1,0 +1,85 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Unit tests for the sanitizer-selection logic (pure functions, no toolchain)."""
+
+from __future__ import annotations
+
+import pytest
+
+from simpler_setup import sanitizers as san
+
+
+@pytest.mark.parametrize(
+    "selection,expected",
+    [
+        ("none", ""),
+        ("", ""),
+        (None, ""),
+        ("asan", "address,undefined"),
+        ("ubsan", "undefined"),
+        ("tsan", "thread"),
+        ("address,leak", "address,leak"),  # raw tokens pass through unchanged
+    ],
+)
+def test_resolve(selection, expected):
+    assert san.resolve(selection) == expected
+
+
+def test_validate_allows_compatible_combos(monkeypatch):
+    monkeypatch.setattr(san.sys, "platform", "linux")  # tsan is Linux-only
+    san.validate("address,undefined")  # asan + ubsan is fine
+    san.validate("thread")  # tsan alone is fine on Linux
+    san.validate("")  # empty is a no-op
+
+
+@pytest.mark.parametrize("incompatible", ["address", "leak", "memory"])
+def test_validate_rejects_thread_with_address_family(monkeypatch, incompatible):
+    monkeypatch.setattr(san.sys, "platform", "linux")
+    with pytest.raises(ValueError, match="thread"):
+        san.validate(f"thread,{incompatible}")
+
+
+def test_validate_rejects_tsan_off_linux(monkeypatch):
+    monkeypatch.setattr(san.sys, "platform", "darwin")
+    with pytest.raises(ValueError, match="Linux-only"):
+        san.validate("thread")
+
+
+@pytest.mark.parametrize(
+    "tokens,expected",
+    [
+        ("", None),
+        ("undefined", "libubsan.so"),
+        ("address,undefined", "libasan.so"),  # asan runtime covers ubsan
+        ("leak", "liblsan.so"),  # standalone LSan
+        ("thread", "libtsan.so"),
+    ],
+)
+def test_preload_lib(tokens, expected):
+    assert san.preload_lib(tokens) == expected
+
+
+@pytest.mark.parametrize(
+    "platform,expected",
+    [
+        ("a2a3sim", "g++-15"),
+        ("a5sim", "g++-15"),
+        ("a2a3", "g++"),
+        ("a5", "g++"),
+    ],
+)
+def test_host_cxx(platform, expected):
+    # Sim unifies on g++-15 (matches kernels); onboard host uses plain g++.
+    assert san.host_cxx(platform) == expected
+
+
+def test_preload_command_uses_platform_compiler():
+    cmd = san.preload_command("address,undefined", "a2a3sim")
+    assert "g++-15" in cmd and "libasan.so" in cmd
+    assert san.preload_command("", "a2a3sim") is None


### PR DESCRIPTION
## Summary

Implements #904: opt-in compiler sanitizers for **host-compiled** code, driven by a single `--sanitizer` parameter (no env vars), covering the runtime + per-test kernels/orchestration, plus a nightly CI sweep.

**Scope rule** — sanitize iff host-compiled (auto-enforced by `Toolchain.is_host`): sim instruments host+aicpu+aicore + `sim_context`/`log` + kernels + orchestration; onboard instruments host only; device toolchains (ccec/aarch64) never. Device custom arenas bypass ASAN redzones (documented limitation).

### Key design points
- **Single `--sanitizer` parameter**, no env vars. Install-time: `pip install --config-settings=cmake.define.SIMPLER_SANITIZER=asan .`; test-time `--sanitizer` compiles the per-test kernels to match + fails fast with the exact `LD_PRELOAD` command (both pytest and standalone paths).
- **g++-15 unification under sanitizer**: sim kernels are always g++-15, so the runtime/helpers/orchestration build with g++-15 too when sanitizing — mixing g++ and g++-15 sanitizer runtimes is an ABI mismatch that fails at `.so` load. Onboard host stays g++ (its kernels are device, never instrumented).
- **ASAN+UBSan together; TSAN separate** (mutually exclusive). `cmake/sanitizers.cmake` is generic (`-fsanitize=${SIMPLER_SANITIZERS}`); `-Wno-error=tsan` keeps TSAN's "atomic_thread_fence unsupported" warning from failing the AICPU `-Werror` build.
- **Sanitizers are Linux-only** (macOS gcc-15's libasan isn't found by Apple ld).
- **Nightly CI is a SEPARATE workflow** (`.github/workflows/sanitizers.yml`, schedule + workflow_dispatch) so the cron fires only the sanitizer jobs — never the PR/self-hosted pipeline. Not a PR gate.

## Testing (validated on Linux via docker)
- [x] **ASAN end-to-end**: a2a3sim build + run, `dynamic_register::test_register_after_init_then_run` **6/6 green** (~1.7× overhead). Build instrumentation confirmed via `nm` (host/aicpu/aicore + helpers); `--sanitizer none` = 0.
- [x] **TSAN build**: a2a3sim host+aicpu+aicore all build with `__tsan` instrumentation.
- [x] `tests/ut/py/test_sanitizers.py` (preset/validate/preload logic) — 20/20.
- [x] pre-commit green (ruff/pyright/markdownlint/check-yaml).
- [ ] TSAN full run not executed locally (5–15× too slow + amplifies the pre-existing #884 sim-oversubscription flake) — deferred to the nightly job (1200s timeout). The flake is more frequent under sanitizers' slower timing, handled by generous timeout + manual rerun, not a PR gate.