### PR TITLE
fix: join dump-collector writer thread on aborted runs to stop host hang

### DIFF
--- a/src/a2a3/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a2a3/platform/src/host/tensor_dump_collector.cpp
@@ -568,6 +568,29 @@ int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const Du
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
     stop();
 
+    // ProfilerBase::stop() only joins the mgmt + poll threads. The writer
+    // thread is otherwise torn down solely by export_dump_files(), so any path
+    // that skips export — e.g. run() bailing on a device error before its
+    // collector-teardown block — would leak it: left blocked on write_cv_ with
+    // writer_done_ == false while writer_thread_ stays joinable, which trips
+    // std::terminate when the collector is destroyed or re-run. finalize() is
+    // reached via run()'s perf_cleanup guard on every exit path, so join the
+    // writer here too. Idempotent: export_dump_files() clears writer_started_
+    // on the success path, making this a no-op.
+    if (writer_started_ && writer_thread_.joinable()) {
+        writer_done_.store(true);
+        write_cv_.notify_one();
+        writer_thread_.join();
+    }
+
+    // The writer thread opens bin_file_ in start_writer_thread_once() and it is
+    // otherwise closed only by export_dump_files(). Close it here too so an
+    // export-skipping path does not leave it open — a stale-open stream makes
+    // the next run's bin_file_.open() set failbit. Guarded for idempotency.
+    if (bin_file_.is_open()) {
+        bin_file_.close();
+    }
+
     // DumpMetaBuffers appear in multiple lists (per-thread free_queues,
     // recycled pool); dedup so each dev_ptr funnels through the shared
     // ProfilerBase RAII helper exactly once.

--- a/src/a5/platform/src/host/tensor_dump_collector.cpp
+++ b/src/a5/platform/src/host/tensor_dump_collector.cpp
@@ -615,6 +615,29 @@ int TensorDumpCollector::finalize(DumpUnregisterCallback unregister_cb, const Du
     // Stop mgmt + collector threads if the caller didn't already (idempotent).
     stop();
 
+    // ProfilerBase::stop() only joins the mgmt + poll threads. The writer
+    // thread is otherwise torn down solely by export_dump_files(), so any path
+    // that skips export — e.g. run() bailing on a device error before its
+    // collector-teardown block — would leak it: left blocked on write_cv_ with
+    // writer_done_ == false while writer_thread_ stays joinable, which trips
+    // std::terminate when the collector is destroyed or re-run. finalize() is
+    // reached via run()'s perf_cleanup guard on every exit path, so join the
+    // writer here too. Idempotent: export_dump_files() clears writer_started_
+    // on the success path, making this a no-op.
+    if (writer_started_ && writer_thread_.joinable()) {
+        writer_done_.store(true);
+        write_cv_.notify_one();
+        writer_thread_.join();
+    }
+
+    // The writer thread opens bin_file_ in start_writer_thread_once() and it is
+    // otherwise closed only by export_dump_files(). Close it here too so an
+    // export-skipping path does not leave it open — a stale-open stream makes
+    // the next run's bin_file_.open() set failbit. Guarded for idempotency.
+    if (bin_file_.is_open()) {
+        bin_file_.close();
+    }
+
     auto release_dev = [&](void *p) {
         release_one_buffer(p, unregister_cb, free_cb);
     };


### PR DESCRIPTION
## Problem

Fixes #919.

With `--dump-tensor` enabled, a run that ends abnormally (times out or the runtime reports a fatal status) does not fail cleanly on the host — the process hangs and is only terminated by the external watchdog (e.g. the 300s task-queue limit). The same failing run without `--dump-tensor` exits promptly, so the hang is purely host-side and specific to the dump path.

## Root cause

`TensorDumpCollector`'s writer thread is only signalled (`writer_done_`) and joined inside `export_dump_files()`, which runs only on the success path. On an abnormal run, `DeviceRunner::run()` returns early and skips the collector-teardown block. The cleanup path still reaches `TensorDumpCollector::finalize()`, but `finalize()` and the base-class `stop()` only join the mgmt + poll threads — never the writer thread. The writer thread is left blocked on its condition variable while `writer_thread_` stays joinable, wedging teardown.

## Fix

Join the writer thread in `finalize()`, right after `stop()`. `finalize()` is reached via `run()`'s `perf_cleanup` guard on **every** exit path (including early error returns), so the writer is always reclaimed. The join is idempotent: `export_dump_files()` clears `writer_started_` on the success path, making the new block a no-op there.

Applied symmetrically to a2a3 and a5.

## Test

- No existing cpput harness for `TensorDumpCollector`; the reproducer is an end-to-end hardware run with `--dump-tensor` that ends abnormally.
- Verified the change is a no-op on the success path (writer already torn down by `export_dump_files()`).