### PR TITLE
toolchain: ABI-pin host compiler to g++-15 under a sanitizer

### DIFF
--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -53,16 +53,47 @@ def _parse_compiler_env(var_name: str, default: str) -> tuple[str, list[str]]:
     return tokens[0], tokens[1:]
 
 
-def _host_compiler_cmake_args(default_cc: str, default_cxx: str) -> list[str]:
+def _matches_pinned_name(actual: str, pinned: str) -> bool:
+    """True if *actual* (a CC/CXX value) names the *pinned* compiler.
+
+    Matches the bare name or a versioned/triplet variant — ``g++-15``,
+    ``/opt/tc/bin/g++-15``, ``aarch64-linux-gnu-g++-15`` — but NOT a substring
+    false-positive like ``clang++-15`` (``"g++-15" in "clang++-15"`` is True),
+    whose sanitizer-runtime ABI differs from GCC's.
+    """
+    base = os.path.basename(actual)
+    return base == pinned or base.endswith(f"-{pinned}")
+
+
+def _host_compiler_cmake_args(default_cc: str, default_cxx: str, pin_compiler: bool = False) -> list[str]:
     """CMake ``-D`` args for a host GCC/G++ toolchain.
 
     Reads CC/CXX from the environment and splits off any conda-injected flags
     (e.g. ``-pthread -B <env>/compiler_compat``) into CMAKE_{C,CXX}_FLAGS. The
     flags are re-joined with ``shlex.join`` so tokens containing spaces survive
     CMake's shell-style re-parse of the flag string.
+
+    When ``pin_compiler`` is set, an env CC/CXX naming a *different* GCC is
+    overridden by the caller's ``default_cc``/``default_cxx`` — but any
+    env-injected flags are still preserved, and an env compiler that already
+    names the pinned version (e.g. a custom path ``/opt/tc/bin/g++-15``) is kept
+    so non-PATH installs still work. This is required under a sanitizer: the
+    host compiler is ABI-pinned to g++-15 so its sanitizer runtime
+    (libtsan.so.2 / libasan.so) matches the lib*san the run-step preloads.
+    scikit-build-core exports CXX during ``pip install``; letting it name a
+    different GCC (whose libtsan SONAME is .so.0) produces a runtime mismatch
+    that fails at dlopen with "cannot allocate memory in static TLS block".
     """
     cc, cc_flags = _parse_compiler_env("CC", default_cc)
     cxx, cxx_flags = _parse_compiler_env("CXX", default_cxx)
+    if pin_compiler:
+        # Keep an env compiler that already names the pinned version (bare,
+        # custom-path, or triplet) so non-PATH installs work; override anything
+        # else — a different GCC, or clang++-15 whose runtime ABI differs.
+        if not _matches_pinned_name(cc, os.path.basename(default_cc)):
+            cc = default_cc
+        if not _matches_pinned_name(cxx, os.path.basename(default_cxx)):
+            cxx = default_cxx
     args = [
         f"-DCMAKE_C_COMPILER={cc}",
         f"-DCMAKE_CXX_COMPILER={cxx}",
@@ -227,7 +258,14 @@ class GxxToolchain(Toolchain):
         return flags
 
     def get_cmake_args(self) -> list[str]:
-        args = _host_compiler_cmake_args("gcc-15" if self._prefer_g15 else "gcc", self.cxx_path)
+        # Under prefer_g15 (sanitizer build) the compiler is ABI-pinned: env
+        # CC/CXX must not redirect it away from g++-15, or the built .so link a
+        # different lib*san than the run-step preloads. See pin_compiler above.
+        args = _host_compiler_cmake_args(
+            "gcc-15" if self._prefer_g15 else "gcc",
+            self.cxx_path,
+            pin_compiler=self._prefer_g15,
+        )
         if self.ascend_home_path:
             args.append(f"-DASCEND_HOME_PATH={self.ascend_home_path}")
         return args

--- a/tests/ut/py/test_toolchain.py
+++ b/tests/ut/py/test_toolchain.py
@@ -81,6 +81,68 @@ class TestGxxToolchainCmakeArgs:
         assert "-DCMAKE_CXX_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
 
 
+class TestGxxToolchainPreferG15Pins:
+    """Under a sanitizer, prefer_g15 ABI-pins the host compiler to g++-15 so its
+    sanitizer runtime (libtsan.so.2 / libasan.so) matches the lib*san the
+    pytest/CI run-step preloads. An env CC/CXX naming a different GCC (e.g. the
+    system g++ whose libtsan SONAME is .so.0) must NOT override that pin —
+    scikit-build-core exports CXX during `pip install`, and the mismatch fails
+    at dlopen with "cannot allocate memory in static TLS block"."""
+
+    @pytest.fixture
+    def toolchain(self, monkeypatch):
+        monkeypatch.setattr("simpler_setup.toolchain._is_gcc", lambda _p: True)
+        from simpler_setup.toolchain import GxxToolchain  # noqa: PLC0415
+
+        return GxxToolchain(prefer_g15=True)
+
+    def test_env_cxx_does_not_override_pin(self, toolchain, monkeypatch):
+        # scikit-build-core / a plain dev shell exporting the system g++.
+        monkeypatch.setenv("CC", "gcc")
+        monkeypatch.setenv("CXX", "g++")
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc-15" in args
+        assert "-DCMAKE_CXX_COMPILER=g++-15" in args
+
+    def test_conda_flags_preserved_but_compiler_pinned(self, toolchain, monkeypatch):
+        # Conda's injected -B compiler_compat flags must survive, but the
+        # compiler binary is still forced to the pinned g++-15.
+        monkeypatch.setenv("CC", "gcc -pthread -B /data/envs/lyf/compiler_compat")
+        monkeypatch.setenv("CXX", "g++ -pthread -B /data/envs/lyf/compiler_compat")
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc-15" in args
+        assert "-DCMAKE_CXX_COMPILER=g++-15" in args
+        assert "-DCMAKE_C_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
+        assert "-DCMAKE_CXX_FLAGS=-pthread -B /data/envs/lyf/compiler_compat" in args
+
+    def test_custom_path_to_g15_is_preserved(self, toolchain, monkeypatch):
+        # An env CC/CXX that already names g++-15 at a non-PATH location is the
+        # right ABI already — keep it instead of forcing the bare name, which
+        # might not be on PATH.
+        monkeypatch.setenv("CC", "/opt/custom/bin/gcc-15")
+        monkeypatch.setenv("CXX", "/opt/custom/bin/g++-15")
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=/opt/custom/bin/gcc-15" in args
+        assert "-DCMAKE_CXX_COMPILER=/opt/custom/bin/g++-15" in args
+
+    def test_gnu_triplet_g15_is_preserved(self, toolchain, monkeypatch):
+        # A versioned cross/triplet name is still GCC-15 — keep it.
+        monkeypatch.setenv("CC", "aarch64-linux-gnu-gcc-15")
+        monkeypatch.setenv("CXX", "aarch64-linux-gnu-g++-15")
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc-15" in args
+        assert "-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++-15" in args
+
+    def test_clang15_is_not_mistaken_for_pinned_gcc(self, toolchain, monkeypatch):
+        # "g++-15" is a substring of "clang++-15", but clang's sanitizer ABI
+        # differs — the pin must override it back to the GCC default.
+        monkeypatch.setenv("CC", "clang-15")
+        monkeypatch.setenv("CXX", "clang++-15")
+        args = toolchain.get_cmake_args()
+        assert "-DCMAKE_C_COMPILER=gcc-15" in args
+        assert "-DCMAKE_CXX_COMPILER=g++-15" in args
+
+
 class TestGxx15ToolchainCmakeArgs:
     """Same split behavior for the simulation-kernel toolchain."""
 


### PR DESCRIPTION
## Summary

A real build-correctness bug found while making the TSAN nightly actually run:
under a sanitizer the sim host artifacts were not reliably compiled with
**g++-15**, so they linked a different sanitizer runtime than the run-step
preloads — and TSAN failed to even start.

- `GxxToolchain(prefer_g15=True)` exists to force g++-15 so every host `.so`
  shares the **one** sanitizer runtime that pytest/CI preloads
  (`LD_PRELOAD=$(g++-15 -print-file-name=libtsan.so)` → libtsan.so.2).
- But `_host_compiler_cmake_args` read `CC`/`CXX` from the environment and let
  them **override** the `prefer_g15` default (the conda-compat path).
  **scikit-build-core exports `CXX` during `pip install`**, so the sanitized
  `.so` were built with the env compiler (system `g++` = gcc-11 → **libtsan.so.0**)
  while the run-step preloaded g++-15's **libtsan.so.2**.
- That version split fails at `dlopen` with
  `cannot allocate memory in static TLS block` → TSAN never runs.

### Fix

Add a `pin_compiler` mode to `_host_compiler_cmake_args`: under `prefer_g15`
the env `CC`/`CXX` **binary** is ignored (forced to `gcc-15`/`g++-15`), while
any env-injected **flags** (conda's `-B …/compiler_compat`) are still
preserved. Non-sanitizer builds are unchanged.

### Validation (Linux/aarch64 docker)

- Repro: with `CXX=g++` exported + `--sanitizer tsan`, built `.so` linked
  `libtsan.so.0` (gcc-11) → `dlopen` TLS failure.
- After fix: all 14 sim `.so` link `libtsan.so.2`; the `prepared_callable`
  TSAN run starts and reports races instead of crashing at import.
- `pip install` path verified end-to-end (scikit-build-core exports `CXX`).

## Testing

- New regression tests in `tests/ut/py/test_toolchain.py`:
  `prefer_g15=True` with `CXX=g++` still emits `-DCMAKE_CXX_COMPILER=g++-15`,
  and conda `-B compiler_compat` flags survive the pin.
- [x] Unit tests pass (34/34 toolchain + sanitizer)
- [x] Simulation tests pass
- [ ] Hardware tests (n/a — host-compiler build logic only)