### PR TITLE
Doc: split out docs/sanitizers.md (design + invariants) + scope investigation

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -70,7 +70,7 @@ on a 4-vCPU runner — so the scope is parallelism-limited per sanitizer:
   suppressions file is a follow-up).
 
 Both sanitizer jobs gate (no `continue-on-error`). Not a PR gate; see
-[testing.md](testing.md#sanitizer-builds-asan--tsan).
+[sanitizers.md](sanitizers.md) for the design + usage.
 
 ### Parallel ST runs on hardware
 

--- a/docs/investigations/2026-06-sanitizer-scope.md
+++ b/docs/investigations/2026-06-sanitizer-scope.md
@@ -1,0 +1,102 @@
+# Sanitizer rollout scope: macOS, TSAN gating, LSan
+
+**Date**: 2026-06-01
+**Verdict**: scoped — ASAN/UBSan gate on Linux CI only; TSAN
+deferred-to-report-only; LSan deferred-pending-arena-suppressions
+
+## Question
+
+The opt-in sanitizer feature (`--sanitizer`, #915) instruments
+host-compiled sim code (runtime + per-test kernels + orchestration) and runs
+nightly. Three scoping questions recur — a future contributor will reasonably
+ask "why not just turn this on too?" This entry records why each landed where
+it did and the condition to re-open it. The "what currently happens" lives in
+`docs/sanitizers.md` (design + usage) and `docs/ci.md` § sanitizer-sim; this is
+the *why*.
+
+## 1. Why ASAN/UBSan run only on Linux CI (not macOS)
+
+**The pull**: the infra already has a darwin preload path
+(`sanitizers.py::preload_command` emits `DYLD_INSERT_LIBRARIES` on macOS), so
+adding a macOS leg to the nightly looks free, and most contributors develop on
+macOS.
+
+**Why not (now)**:
+
+- Sim host artifacts unify on Homebrew **g++-15**. Linking `-fsanitize=address`
+  through Apple's `ld` fails with `ld: library 'asan' not found` — Apple's
+  linker does not resolve GCC's `libasan`. The sanitizer build does not link
+  cleanly on macOS.
+- `DYLD_INSERT_LIBRARIES` is stripped under **SIP** for protected binaries, so
+  even a working build would have unreliable runtime preloading.
+- The deployment target is Linux; that is where the toolchain is consistent and
+  where the bugs that matter reproduce.
+
+TSAN is a harder "no" than ASAN: there is no macOS `libtsan` at all, so
+`validate()` rejects `thread` on any non-Linux platform outright.
+
+**When to reconsider**: if the sim host build gains an Apple-clang path on macOS
+(clang ships its own `libasan`/`ld` integration), or a macOS-only host bug needs
+catching that the Linux leg cannot reproduce.
+
+## 2. Why TSAN is report-only (not a hard gate)
+
+**The pull**: ASAN gates the job (any finding fails CI); TSAN should too,
+otherwise a real data race could land unnoticed.
+
+**What was found**: ran TSAN on the real build in Linux/aarch64 docker and
+triaged every reported race (see #947, #949).
+
+**Result**: all races sit on the **device-shared region** — register MMIO
+(`platform_regs.cpp`), the AICPU↔AICore handshake (`scheduler_*.cpp`,
+`aicpu_executor.cpp`, `aicore_executor.cpp`), and the shared device arena /
+tensors. The sim models the chip's **lock-free hardware handshake** (`volatile`
+MMIO ordered by `wmb()`/`rmb()` barriers), which TSAN treats as
+non-synchronizing — so it flags every cross-thread access. None are genuine
+software bugs. The one host-side residual (the `device_runner.cpp` wall-clock
+stamp) faithfully mirrors onboard `kernel.cpp`'s documented
+*"last-writer-wins — wall measurements are µs-scale tolerant."*
+
+**Why not (now)**: a hard gate needs the by-design races eliminated, not just
+tolerated. Two routes, both deferred:
+
+- A **suppressions file** — but JIT-compiled kernel frames symbolize as
+  `<null>` (no function/file), so file-scoped `race:` suppressions cannot match
+  them precisely without over-suppressing the host dispatch hub.
+- **`__tsan_acquire`/`__tsan_release` annotations** at the handshake
+  publish/observe points — the correct fix (TSAN would then *understand* the
+  ordering and the false races vanish), but a large, invasive change across two
+  arches' hot paths.
+
+So the cell runs `TSAN_OPTIONS=halt_on_error=0:exitcode=0`: races go to the log,
+the job gates only on hang / crash / test failure.
+
+**When to reconsider**: when the handshake gains TSAN happens-before annotations
+(the false races disappear and the gate becomes meaningful), or if a genuine
+host-side race appears in the residual that is worth catching.
+
+## 3. Why LSan (leak detection) is disabled
+
+**The pull**: ASAN bundles LSan and defaults to `detect_leaks=1` on Linux —
+leak detection looks like a free add-on. The nightly explicitly sets
+`detect_leaks=0`, i.e. turns it *off*.
+
+**Why not (now)**: the sim allocates large device **custom arenas**
+(`DeviceArena` / `HeapRing`, ~1 GB) that are intentionally long-lived (released
+at process exit) and bypass ASAN redzones. LSan reports these as leaks → mass
+false-positives that would redden the ASAN job before any real leak is visible.
+
+**When to reconsider**: after an `lsan.supp` triages the device-arena and static
+allocations as known non-leaks. Then flip `detect_leaks=1` and let genuine leaks
+surface — the same shape of follow-up as the TSAN suppressions above.
+
+## References
+
+- PRs: #915 (feature), #931 (nightly pass — ASAN gate, TSAN informational),
+  #947 (TSAN cell scope + report-only + `exitcode=0`), #949 (g++-15 ABI pin —
+  the build bug that kept TSAN from running at all: env `CC`/`CXX` overrode the
+  pin so the `.so` linked `libtsan.so.0` while the run preloaded `libtsan.so.2`,
+  failing at `dlopen` with "cannot allocate memory in static TLS block").
+- `docs/sanitizers.md` (design + usage), `docs/ci.md` § sanitizer-sim.
+- `simpler_setup/sanitizers.py` — `validate()` platform gate, `preload_lib` /
+  `host_cxx` runtime mapping.

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -84,4 +84,5 @@ that ...".
 
 Newest first.
 
+- [2026-06 — Sanitizer rollout scope: macOS, TSAN gating, LSan](2026-06-sanitizer-scope.md)
 - [2026-06 — L2 swimlane: defer per-task wmb to rotation](2026-06-l2-swimlane-defer-wmb.md)

--- a/docs/sanitizers.md
+++ b/docs/sanitizers.md
@@ -1,0 +1,124 @@
+# Compiler Sanitizers (ASAN / UBSan / TSAN)
+
+Opt-in `-fsanitize` instrumentation of **host-compiled** code, driven by a
+single `--sanitizer` selection. This page is the design + usage reference. The
+nightly CI job lives in [ci.md](ci.md#sanitizer-sim); the *scoping* rationale
+(why macOS is excluded, why TSAN is report-only, why LSan is off) lives in
+[investigations/2026-06-sanitizer-scope.md](investigations/2026-06-sanitizer-scope.md).
+
+## What it instruments
+
+Sanitizers instrument **host-compiled** code only — on sim that is the runtime
+(`host`/`aicpu`/`aicore`), the per-test kernels, and orchestration; on onboard
+only the host runtime. Device code (ccec AICore `.o`, aarch64 AICPU) cannot
+carry a host sanitizer, and device custom arenas (`DeviceArena`/`HeapRing`)
+bypass ASAN redzones, so device-side heap bugs are **not** caught.
+
+## Architecture
+
+It is a **two-part flag** — a build-time half and a run-time half — wired
+through one single source of truth.
+
+- **Build-time** — `SIMPLER_SANITIZER=<preset>` (a cmake define on
+  `pip install`) flows to `build_runtimes.py`, which sets
+  `RuntimeCompiler._sanitizers`. Only **host** targets honor it:
+  `BuildTarget.gen_cmake_args` gates the `-fsanitize` injection on
+  `toolchain.is_host`, and `cmake/sanitizers.cmake::simpler_apply_sanitizers`
+  applies the flags. Device toolchains (ccec / aarch64) never see it.
+- **Run-time** — `--sanitizer <preset>` (pytest `conftest.py` or standalone
+  `scene_test.py`) compiles the per-test kernels/orchestration to match, and a
+  **fail-fast guard** refuses to run unless the matching runtime is preloaded,
+  printing the exact `LD_PRELOAD` command.
+
+**Why preload is mandatory.** The instrumented `.so` are `dlopen`'d into a
+**vanilla, un-instrumented Python**. A sanitizer runtime must be the very first
+thing mapped into the process, so it cannot be pulled in late via `dlopen` — it
+must be `LD_PRELOAD`'d (`DYLD_INSERT_LIBRARIES` on macOS) ahead of the
+interpreter.
+
+**Single source of truth.** [`simpler_setup/sanitizers.py`](../simpler_setup/sanitizers.py)
+owns the preset table, the mutual-exclusion rule, and the runtime-library
+mapping. The build, the per-test kernel compile, and the preload glue all read
+from it, so adding a sanitizer is one dict entry (see [Extending](#extending)).
+
+## Load-bearing invariants
+
+Violating any of these produces a confusing failure that looks like a code bug
+but is a build/ABI mismatch. They are enforced in code; this is the *why*.
+
+1. **One sanitizer runtime per process (ABI unification).** Under a sanitizer,
+   **every host artifact must link the same compiler's runtime, and the
+   preload must be that same compiler's `lib*san`.** Sim unifies on **g++-15**
+   (`GxxToolchain(prefer_g15=True)`), because the sanitizer runtime is
+   ABI-versioned: mixing g++ and g++-15 runtimes, or preloading a different one
+   than the `.so` link, fails at `dlopen` with **"cannot allocate memory in
+   static TLS block"**. This is exactly the #949 bug — env `CC`/`CXX` (exported
+   by scikit-build-core during `pip install`) silently overrode the g++-15 pin,
+   so the `.so` linked `libtsan.so.0` while the run preloaded `libtsan.so.2`.
+   The pin in `_host_compiler_cmake_args` now keeps it consistent.
+2. **Host-only instrumentation.** Only `is_host` toolchains receive
+   `-fsanitize`; device toolchains never. Device-side heap bugs are out of
+   scope (custom arenas bypass redzones).
+3. **ASAN and TSAN are mutually exclusive** — separate, incompatible builds.
+   `validate()` rejects `thread` combined with `address`/`leak`/`memory`, and
+   rejects `thread` on any non-Linux platform (no macOS `libtsan`).
+4. **Run-time `--sanitizer` must match build-time `SIMPLER_SANITIZER`.** The
+   fail-fast guard enforces that the matching runtime is preloaded; a mismatch
+   stops before any test runs.
+
+## Usage
+
+Two parts — install the runtime instrumented, then run with the matching
+runtime preloaded.
+
+```bash
+# 1. Build the runtime with the sanitizer (ASAN bundles UBSan).
+pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=asan .
+
+# 2. Run, preloading the matching runtime. Sim unifies on g++-15, so preload
+#    g++-15's runtime — plain g++'s would mismatch the kernels' ABI (see
+#    invariant 1) and fail at load.
+LD_PRELOAD=$(g++-15 -print-file-name=libasan.so) \
+ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1 \
+UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+pytest examples tests/st --platform a2a3sim --sanitizer asan -v
+```
+
+**TSAN is a separate, mutually-exclusive build** and is **Linux-only**:
+
+```bash
+pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=tsan .
+LD_PRELOAD=$(g++-15 -print-file-name=libtsan.so) TSAN_OPTIONS=halt_on_error=1 \
+pytest examples tests/st --platform a2a3sim --sanitizer tsan -v
+```
+
+`detect_leaks=0` is recommended initially — LSan false-positives on the device
+custom arenas until suppressions are added (see the scope investigation).
+
+## Presets
+
+`--sanitizer` (and `SIMPLER_SANITIZER`) take a preset name or a raw
+`-fsanitize` token list. Presets expand in `sanitizers.py::SANITIZER_PRESETS`:
+
+| Preset | `-fsanitize` tokens | Notes |
+| ------ | ------------------- | ----- |
+| `none` | *(empty)* | No instrumentation. |
+| `asan` | `address,undefined` | ASAN bundles UBSan (compatible, cheap). |
+| `ubsan` | `undefined` | UBSan alone. |
+| `tsan` | `thread` | Separate build; Linux-only. |
+
+## Extending
+
+- **Add a sanitizer** — one entry in `SANITIZER_PRESETS`; if it needs a new
+  runtime library, add it to `preload_lib()`. `cmake/sanitizers.cmake` does not
+  change.
+- **Add a platform** — `host_cxx()` decides which compiler's runtime gets
+  preloaded (sim → g++-15, onboard → g++).
+
+## See also
+
+- [ci.md](ci.md#sanitizer-sim) — the nightly `sanitizer-sim` job (matrix,
+  scope, gating).
+- [investigations/2026-06-sanitizer-scope.md](investigations/2026-06-sanitizer-scope.md)
+  — why macOS is excluded, why TSAN is report-only, why LSan is off, and the
+  condition to re-open each.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -651,47 +651,14 @@ Key fields:
 
 If similar coverage exists in both `examples/` and `tests/st/`, collapse it into a single `test_*.py`: small cases get `platforms: ["a2a3sim", "a2a3"]`; large benchmark cases get `platforms: ["a2a3"], "manual": True`.
 
-## Sanitizer builds (ASAN / TSAN)
+## Sanitizer builds (ASAN / UBSan / TSAN)
 
-Sanitizers instrument **host-compiled** code only — on sim that is the runtime
-(`host`/`aicpu`/`aicore`), the per-test kernels, and orchestration; on onboard
-only the host runtime. Device code (ccec AICore `.o`, aarch64 AICPU) cannot
-carry a host sanitizer, and device custom arenas (`DeviceArena`/`HeapRing`)
-bypass ASAN redzones, so device-side heap bugs are not caught.
-
-It is a two-part flag — **install-time** (which sanitizer the binaries are
-built with) and **run-time** (preload + match):
-
-```bash
-# 1. Build the runtime with the sanitizer (ASAN bundles UBSan).
-pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=asan .
-
-# 2. Run, preloading the matching runtime (the instrumented .so are dlopen'd
-#    into a vanilla Python, so the sanitizer runtime must come first). Sim
-#    unifies on g++-15, so preload g++-15's runtime — using plain g++'s would
-#    mismatch the kernels' ABI and fail at load.
-LD_PRELOAD=$(g++-15 -print-file-name=libasan.so) \
-ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1 \
-UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
-pytest examples tests/st --platform a2a3sim --sanitizer asan -v
-```
-
-`--sanitizer` must match the `SIMPLER_SANITIZER` the runtime was installed with;
-it compiles the per-test kernels/orchestration to match and fails fast (with the
-exact `LD_PRELOAD` command) if the runtime isn't preloaded. Presets: `asan`
-(`address,undefined`), `ubsan`, `tsan`; a raw `-fsanitize` token list also works.
-
-**TSAN is a separate, mutually-exclusive build** (cannot coexist with ASAN) and
-is **Linux-only** (no macOS `libtsan`):
-
-```bash
-pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=tsan .
-LD_PRELOAD=$(g++-15 -print-file-name=libtsan.so) TSAN_OPTIONS=halt_on_error=1 \
-pytest examples tests/st --platform a2a3sim --sanitizer tsan -v
-```
-
-`detect_leaks=0` is recommended initially — LSan false-positives on the device
-custom arenas until suppressions are added.
+Opt-in `-fsanitize` instrumentation of host-compiled code via `--sanitizer`
+(build with `SIMPLER_SANITIZER=...`, run with the matching runtime preloaded).
+The design, load-bearing invariants, usage, and presets now live in their own
+page — see **[sanitizers.md](sanitizers.md)**. The nightly CI job is in
+[ci.md](ci.md#sanitizer-sim); the scoping rationale (macOS / TSAN / LSan) is in
+[investigations/2026-06-sanitizer-scope.md](investigations/2026-06-sanitizer-scope.md).
 
 ## CI Pipeline
 


### PR DESCRIPTION
## Summary

The sanitizer story was scattered — how-to buried in the 780-line `testing.md`,
CI in `ci.md`, and the **architecture / load-bearing invariants nowhere**.
Consolidate into a focused page + a scope investigation.

### `docs/sanitizers.md` (new — design + usage reference)
- The **two-part flag** model (build-time `SIMPLER_SANITIZER` / run-time
  `--sanitizer`), the **dlopen-into-vanilla-Python → preload** requirement, and
  the single-source-of-truth (`sanitizers.py`).
- **Load-bearing invariants**, chiefly the **g++-15 ABI unification** — the one
  whose absence caused the #949 `"cannot allocate memory in static TLS block"`
  crash. This is the connective tissue that existed only as scattered code.
- Pulls the how-to out of `testing.md` (which was 780 lines, past the
  doc-consistency split threshold) — that section is now a 6-line pointer.

### `docs/investigations/2026-06-sanitizer-scope.md` (new — the *why*)
Why the rollout is scoped as it is and when to re-open each, per the
`docs/investigations/` template (#951):
- **macOS excluded** — Apple `ld` won't link g++-15's `libasan`; SIP breaks
  `DYLD_INSERT_LIBRARIES`; no macOS `libtsan` at all.
- **TSAN report-only** — all races are the sim modeling lock-free hardware; a
  real gate needs handshake `__tsan_acquire/release` or suppressions the JIT
  `<null>` frames defeat.
- **LSan off** — device custom arenas false-positive until an `lsan.supp`.

### Cross-links reconciled
`ci.md` and the investigation now point at `sanitizers.md`; `testing.md` keeps
its `## Sanitizer builds` heading (anchor preserved) as a pointer.

## Testing
- [x] markdownlint passes on all changed docs
- Docs-only change.