### PR TITLE
Update: leveled --dump-tensor (off/partial/full); race-free selective dump

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -146,7 +146,15 @@ def pytest_addoption(parser):
         help="Enable L2 swimlane. Bare flag=level 4 (full). "
         "1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases",
     )
-    parser.addoption("--dump-tensor", action="store_true", default=False, help="Dump per-task tensor I/O at runtime")
+    parser.addoption(
+        "--dump-tensor",
+        nargs="?",
+        const=1,
+        type=int,
+        default=0,
+        help="Dump per-task tensor I/O at runtime. Level: 0=off, 1=partial (only "
+        "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks).",
+    )
     parser.addoption(
         "--enable-dep-gen",
         action="store_true",

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -32,43 +32,58 @@ saw, without the timing distortion of inline printing.
 - **Cross-architecture.** Same flags and on-disk layout family on
   `a2a3` and `a5`. Both runtimes are wired through.
 
-Enable dump capture in one line:
+Enable in one line (`2` = full dump, every task):
 
 ```bash
-python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor
+python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor 2
 ```
 
 ## 3. How to Use
 
 ### 3.1 Enable Tensor Dump
 
+`--dump-tensor` takes an optional **level**:
+
+| Level | Meaning |
+| ----- | ------- |
+| `0` (or flag absent) | off — zero overhead |
+| `1` (bare `--dump-tensor`) | **partial** — only tasks marked with `Arg::dump(...)` (see §3.2) |
+| `2` (`--dump-tensor 2`) | **full** — every task's tensor inputs and outputs |
+
 ```bash
 # Standalone runner
-python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor
-python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --dump-tensor
+python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor 2     # full
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --dump-tensor   # partial (level 1)
 
 # pytest
-pytest tests/st/<case> --platform a5sim --dump-tensor
-pytest examples/a5/host_build_graph/vector_example --platform a5sim --dump-tensor
+pytest tests/st/<case> --platform a5sim --dump-tensor 2
+pytest examples/a5/host_build_graph/vector_example --platform a5sim --dump-tensor 2
 ```
 
-`--dump-tensor` flips `CallConfig::enable_dump_tensor`. The host
+The level sets `CallConfig::enable_dump_tensor` (0/1/2). The host then
 allocates dump storage, publishes its base address through
 `kernel_args.dump_data_base`, and sets `PROFILING_FLAG_DUMP_TENSOR`
-in the worker profiling bitmask. AICPU reads the storage base via
-`set_platform_dump_base()` and the enable state via
-`set_dump_tensor_enabled(...)`.
+(levels 1 and 2) in each worker handshake's `enable_profiling_flag` for
+the enable/disable decision. The **partial-vs-full** distinction is
+carried as a `DumpTensorLevel` in the dump shared-memory header
+(`DumpDataHeader::dump_tensor_level`, host-written before launch) rather
+than in the profiling-flag bitmask. The on-device AICPU reads the storage base
+via `set_platform_dump_base()`, the enable bit via
+`set_dump_tensor_enabled(GET_PROFILING_FLAG(...))`, and latches selective
+mode in `dump_tensor_init()` from the header level (`PARTIAL` →
+selective). Because the level is decided host-side **before any task is
+dispatched**, it is latched up front — there is no dependence on task
+submission order. AICore executors read the same `PROFILING_FLAG_DUMP_TENSOR`
+bit to insert a `pipe_barrier(PIPE_ALL)` before FIN when dump is on, so
+`AFTER_COMPLETION` snapshots see the kernel's final writes.
 
-### 3.2 Select Specific Task Tensors
+### 3.2 Partial Dump — Select Specific Tasks / Tensors
 
-By default, `--dump-tensor` dumps every task's tensor inputs and
-outputs. Device-side orchestration can opt into tensor-argument selection
-by enabling selective mode at the beginning of the orchestration and
-marking the tensor arguments on each `Arg` before submission:
+Partial dump (level 1) captures only the tasks whose `Arg` is marked
+with `dump(...)`; every unmarked task is skipped. Mark the arguments on
+the relevant `Arg` before submission:
 
 ```cpp
-enable_dump_tensor_selective();
-
 Arg args;
 args.add_input(x);
 args.add_input(y);
@@ -87,14 +102,33 @@ selected tensor is captured:
 - output tensors are dumped after completion.
 - inout tensors follow the existing inout dump behavior.
 
-With `enable_dump_tensor_selective()`, tasks without any `dump(...)` marker
-are skipped during AICPU collection. For marked tasks, only the selected
-tensor arguments are dumped. Without `enable_dump_tensor_selective()`, the
-legacy full-dump behavior is unchanged even if an `Arg` carries a
-`dump(...)` marker.
+Selective dump comes at two granularities, both expressed with the same
+`dump(...)` marker:
 
-`--dump-tensor` remains the top-level enable switch; `Arg::dump(...)`
-only narrows what gets recorded after tensor dump is enabled.
+- **Tensor granularity** — `dump(x, y, z)` selects specific tensor
+  arguments of the task (the example above).
+- **Task granularity** — `dump()` with no arguments selects the whole
+  task (every tensor argument on the `Arg`), without enumerating them:
+
+  ```cpp
+  Arg args;
+  args.add_input(x);
+  args.add_input(y);
+  args.add_output(z);
+  args.dump();        // whole task: every tensor arg on this Arg
+  rt_submit_aiv_task(FUNC_ADD, args);
+  ```
+
+Partial vs full is chosen by the **dump level** (§3.1), latched host-side
+before any dispatch — not inferred from the markers, so it never depends
+on task submission order. At level 1, tasks without a marker are skipped
+and marked tasks dump only their selected arguments. At level 2, the
+markers are ignored and every task's tensors are dumped. With no
+`--dump-tensor` (level 0) dump is off entirely.
+
+If you run at level 1 but place no `dump(...)` markers anywhere, the
+manifest is empty — that is the deliberate "only what I marked" contract.
+Use `--dump-tensor 2` when you want everything.
 
 ### 3.3 Output
 
@@ -269,7 +303,8 @@ DumpDataHeader                                  (host init, AICPU reads)
 ├── queue_heads / queue_tails (per-thread)
 ├── num_dump_threads
 ├── records_per_buffer
-└── magic = 0x44554D50 ("DUMP")
+├── magic = 0x44554D50 ("DUMP")
+└── dump_tensor_level  (DumpTensorLevel: 0=off, 1=partial, 2=full; AICPU latches in dump_tensor_init)
 
 DumpBufferState[num_dump_threads]               (per-thread)
 ├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
@@ -750,11 +785,16 @@ Per-thread arena =
 ## 8. FAQ / Debug Guide
 
 **No `tensor_dump/` directory in the output.** Check that
-`--dump-tensor` was passed; without it the host does not allocate
-dump storage. Verify the run wrote to the expected
+`--dump-tensor` was passed; without it (level 0) the host does not
+allocate dump storage. Verify the run wrote to the expected
 `<output_prefix>` and that the kernel actually executed (a kernel
 that exits early before any task dispatch produces an empty
 manifest).
+
+**`tensor_dump/` exists but the manifest captured nothing.** You are
+most likely at the default partial level (`--dump-tensor` = level 1)
+with no `Arg::dump(...)` markers in the orchestration, so every task is
+skipped. Add markers (§3.2), or pass `--dump-tensor 2` for a full dump.
 
 **Manifest has tasks but `tensors[]` is empty.** AICPU received a
 task whose `TensorInfo` was missing or inconsistent. Look for a

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -602,10 +602,18 @@ NB_MODULE(_task_interface, m) {
         .def_prop_rw(
             "enable_dump_tensor",
             [](const CallConfig &c) {
-                return static_cast<bool>(c.enable_dump_tensor);
+                return c.enable_dump_tensor;
             },
-            [](CallConfig &c, bool v) {
-                c.enable_dump_tensor = v ? 1 : 0;
+            // Accept either an int dump level (0=off, 1=partial, 2=full) or a
+            // Python bool. `True` maps to level 1 (partial) — the default when
+            // --dump-tensor is passed without a value; `False` maps to 0.
+            [](CallConfig &c, nb::object v) {
+                if (PyBool_Check(v.ptr())) {
+                    c.enable_dump_tensor = nb::cast<bool>(v) ? 1 : 0;
+                } else {
+                    int level = nb::cast<int>(v);
+                    c.enable_dump_tensor = (level < 0) ? 0 : (level > 2) ? 2 : level;
+                }
             }
         )
         .def_rw("enable_pmu", &CallConfig::enable_pmu)
@@ -647,8 +655,8 @@ NB_MODULE(_task_interface, m) {
             std::ostringstream os;
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
                << ", enable_l2_swimlane=" << self.enable_l2_swimlane
-               << ", enable_dump_tensor=" << (self.enable_dump_tensor ? "True" : "False")
-               << ", enable_pmu=" << self.enable_pmu << ", enable_dep_gen=" << (self.enable_dep_gen ? "True" : "False")
+               << ", enable_dump_tensor=" << self.enable_dump_tensor << ", enable_pmu=" << self.enable_pmu
+               << ", enable_dep_gen=" << (self.enable_dep_gen ? "True" : "False")
                << ", enable_scope_stats=" << (self.enable_scope_stats ? "True" : "False");
             if (self.output_prefix_set()) {
                 os << ", output_prefix='" << self.output_prefix << "'";

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -733,7 +733,7 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     cfg.block_dim = block_dim
     cfg.aicpu_thread_num = aicpu_tn
     cfg.enable_l2_swimlane = swl
-    cfg.enable_dump_tensor = bool(dt)
+    cfg.enable_dump_tensor = int(dt)
     cfg.enable_pmu = pmu
     cfg.enable_dep_gen = bool(dep_gen)
     cfg.enable_scope_stats = bool(scope_stats)

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1164,7 +1164,7 @@ class SceneTestCase:
         rounds = request.config.getoption("--rounds", default=1)
         skip_golden = request.config.getoption("--skip-golden", default=False)
         enable_l2_swimlane = request.config.getoption("--enable-l2-swimlane", default=0)
-        enable_dump_tensor = request.config.getoption("--dump-tensor", default=False)
+        enable_dump_tensor = request.config.getoption("--dump-tensor", default=0)
         enable_pmu = request.config.getoption("--enable-pmu", default=0)
         enable_dep_gen = self._effective_enable_dep_gen(request, warn=True)
         enable_scope_stats = request.config.getoption("--enable-scope-stats", default=False)
@@ -1174,7 +1174,7 @@ class SceneTestCase:
                 enable_l2_swimlane = 0
             if enable_dump_tensor:
                 logger.warning("Dump tensor disabled: --rounds > 1")
-                enable_dump_tensor = False
+                enable_dump_tensor = 0
             if enable_pmu:
                 logger.warning("PMU disabled: --rounds > 1")
                 enable_pmu = 0
@@ -1282,7 +1282,15 @@ class SceneTestCase:
             help="Enable L2 swimlane. Bare flag=level 4 (full). "
             "1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases",
         )
-        parser.add_argument("--dump-tensor", action="store_true", help="Dump per-task tensor I/O at runtime")
+        parser.add_argument(
+            "--dump-tensor",
+            nargs="?",
+            const=1,
+            type=int,
+            default=0,
+            help="Dump per-task tensor I/O at runtime. Level: 0=off, 1=partial (only "
+            "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks).",
+        )
         parser.add_argument(
             "--enable-dep-gen",
             action="store_true",

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -220,6 +220,15 @@ struct DumpReadyQueueEntry {
  * - Queue empty: head == tail
  * - Queue full: (tail + 1) % capacity == head
  */
+
+// Tensor-dump level. Carried in DumpDataHeader so the
+// AICPU latches the mode in dump_tensor_init() before any task is dispatched.
+enum class DumpTensorLevel : uint32_t {
+    OFF = 0,      // no dump
+    PARTIAL = 1,  // only tasks marked with Arg::dump(...)
+    FULL = 2,     // every task's tensor I/O
+};
+
 struct DumpDataHeader {
     // Per-thread ready queues
     DumpReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_DUMP_READYQUEUE_SIZE];
@@ -231,7 +240,7 @@ struct DumpDataHeader {
     uint32_t records_per_buffer;
     uint64_t arena_size_per_thread;
     uint32_t magic;
-    uint32_t pad;
+    uint32_t dump_tensor_level;  // DumpTensorLevel: 0=off, 1=partial, 2=full
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -517,7 +517,9 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, register_cb, free_cb, output_prefix_);
+    int rc = dump_collector_.initialize(
+        num_dump_threads, device_id, alloc_cb, register_cb, free_cb, output_prefix_, dump_tensor_level_
+    );
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -650,7 +650,9 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = dump_collector_.initialize(num_dump_threads, device_id, alloc_cb, nullptr, free_cb, output_prefix_);
+    int rc = dump_collector_.initialize(
+        num_dump_threads, device_id, alloc_cb, nullptr, free_cb, output_prefix_, dump_tensor_level_
+    );
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -143,8 +143,6 @@ struct PTO2Runtime {
     PTO2ScopeMode pending_scope_mode;
 };
 
-static inline void enable_dump_tensor_selective() { set_tensor_dump_selective_requested(true); }
-
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -36,7 +36,6 @@
 #include "pto_types.h"
 #include "tensor.h"
 
-extern "C" void set_dump_tensor_selective_mode(bool enable);
 extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
 
 #if PTO2_PROFILING
@@ -649,9 +648,10 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    if (args.tensor_dump_selective_requested()) {
-        set_dump_tensor_selective_mode(true);
-    }
+    // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+    // (host-decided before any dispatch), so it is race-free regardless of
+    // submission order. Here we only record each marked task's arg mask, which
+    // selective collection consults.
     if (args.tensor_dump_arg_mask() != 0) {
         set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -45,15 +45,6 @@
 #define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
 #define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 
-inline bool &tensor_dump_selective_requested_ref() {
-    static bool requested = false;
-    return requested;
-}
-
-inline void set_tensor_dump_selective_requested(bool enable) { tensor_dump_selective_requested_ref() = enable; }
-
-inline bool is_tensor_dump_selective_requested() { return tensor_dump_selective_requested_ref(); }
-
 typedef enum {
     ASYNC_ENGINE_SDMA = 0,
     ASYNC_ENGINE_ROCE = 1,
@@ -190,7 +181,6 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         has_error = false;
         error_msg = nullptr;
         tensor_dump_arg_mask_ = 0;
-        tensor_dump_selective_requested_ = is_tensor_dump_selective_requested();
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
     }
@@ -204,7 +194,6 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     template <typename... Args>
     void dump(Args &&...args) {
-        static_assert(sizeof...(Args) >= 1, "dump: at least one tensor argument required");
         static_assert(
             (std::is_lvalue_reference_v<Args> && ...),
             "dump: temporaries are not allowed — pass tensors already added to this Arg"
@@ -214,12 +203,14 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
              ...),
             "dump: all arguments must be Tensor or TensorCreateInfo"
         );
-        tensor_dump_selective_requested_ = is_tensor_dump_selective_requested();
-        (mark_tensor_dump_arg(args), ...);
+        if constexpr (sizeof...(Args) == 0) {
+            mark_all_tensor_dump_arg();
+        } else {
+            (mark_tensor_dump_arg(args), ...);
+        }
     }
 
     uint64_t tensor_dump_arg_mask() const { return tensor_dump_arg_mask_; }
-    bool tensor_dump_selective_requested() const { return tensor_dump_selective_requested_; }
 
     template <typename... Args>
     void add_input(Args &&...args) {
@@ -386,9 +377,19 @@ private:
     // Caller-owned dependency array; lifetime must extend through submit.
     static_assert(MAX_TENSOR_ARGS <= 64, "tensor dump arg mask assumes at most 64 tensor arguments");
     uint64_t tensor_dump_arg_mask_{0};
-    bool tensor_dump_selective_requested_{is_tensor_dump_selective_requested()};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+
+    // No-arg dump(): mark every tensor arg already added to this Arg.
+    void mark_all_tensor_dump_arg() {
+        if (tensor_count_ == 0) {
+            set_error("dump: no tensor arguments added to this Arg");
+            return;
+        }
+        for (int32_t i = 0; i < tensor_count_; i++) {
+            tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+        }
+    }
 
     void mark_tensor_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -224,6 +224,15 @@ struct DumpReadyQueueEntry {
  * - Queue empty: head == tail
  * - Queue full: (tail + 1) % capacity == head
  */
+
+// Tensor-dump level. Carried in DumpDataHeader so the
+// AICPU latches the mode in dump_tensor_init() before any task is dispatched.
+enum class DumpTensorLevel : uint32_t {
+    OFF = 0,      // no dump
+    PARTIAL = 1,  // only tasks marked with Arg::dump(...)
+    FULL = 2,     // every task's tensor I/O
+};
+
 struct DumpDataHeader {
     // Per-thread ready queues
     DumpReadyQueueEntry queues[PLATFORM_MAX_AICPU_THREADS][PLATFORM_DUMP_READYQUEUE_SIZE];
@@ -235,7 +244,7 @@ struct DumpDataHeader {
     uint32_t records_per_buffer;
     uint64_t arena_size_per_thread;
     uint32_t magic;
-    uint32_t pad;
+    uint32_t dump_tensor_level;  // DumpTensorLevel: 0=off, 1=partial, 2=full
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -363,7 +363,8 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.aicpu_thread_num;
 
     int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_
+        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_,
+        dump_tensor_level_
     );
     if (rc != 0) {
         return rc;

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -559,7 +559,8 @@ int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
     int num_dump_threads = runtime.aicpu_thread_num;
 
     int rc = dump_collector_.initialize(
-        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_
+        num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_,
+        dump_tensor_level_
     );
     if (rc != 0) {
         return rc;

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -143,8 +143,6 @@ struct PTO2Runtime {
     PTO2ScopeMode pending_scope_mode;
 };
 
-static inline void enable_dump_tensor_selective() { set_tensor_dump_selective_requested(true); }
-
 // =============================================================================
 // Inline Convenience Wrappers (call through ops table)
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -34,7 +34,6 @@
 #include "pto_types.h"
 #include "tensor.h"
 
-extern "C" void set_dump_tensor_selective_mode(bool enable);
 extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
 
 #if PTO2_PROFILING
@@ -595,9 +594,10 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    if (args.tensor_dump_selective_requested()) {
-        set_dump_tensor_selective_mode(true);
-    }
+    // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+    // (host-decided before any dispatch), so it is race-free regardless of
+    // submission order. Here we only record each marked task's arg mask, which
+    // selective collection consults.
     if (args.tensor_dump_arg_mask() != 0) {
         set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -47,15 +47,6 @@
 #define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
 #define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 
-inline bool &tensor_dump_selective_requested_ref() {
-    static bool requested = false;
-    return requested;
-}
-
-inline void set_tensor_dump_selective_requested(bool enable) { tensor_dump_selective_requested_ref() = enable; }
-
-inline bool is_tensor_dump_selective_requested() { return tensor_dump_selective_requested_ref(); }
-
 typedef enum {
     ASYNC_ENGINE_SDMA = 0,
     ASYNC_ENGINE_ROCE = 1,
@@ -188,7 +179,6 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     void clear() {
         TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
         tensor_dump_arg_mask_ = 0;
-        tensor_dump_selective_requested_ = is_tensor_dump_selective_requested();
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
     }
@@ -208,7 +198,6 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     template <typename... Args>
     void dump(Args &&...args) {
-        static_assert(sizeof...(Args) >= 1, "dump: at least one tensor argument required");
         static_assert(
             (std::is_lvalue_reference_v<Args> && ...),
             "dump: temporaries are not allowed — pass tensors already added to this Arg"
@@ -218,12 +207,14 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
              ...),
             "dump: all arguments must be Tensor or TensorCreateInfo"
         );
-        tensor_dump_selective_requested_ = is_tensor_dump_selective_requested();
-        (mark_tensor_dump_arg(args), ...);
+        if constexpr (sizeof...(Args) == 0) {
+            mark_all_tensor_dump_arg();
+        } else {
+            (mark_tensor_dump_arg(args), ...);
+        }
     }
 
     uint64_t tensor_dump_arg_mask() const { return tensor_dump_arg_mask_; }
-    bool tensor_dump_selective_requested() const { return tensor_dump_selective_requested_; }
 
     template <typename... Args>
     void add_input(Args &&...args) {
@@ -390,9 +381,19 @@ private:
     // Caller-owned dependency array; lifetime must extend through submit.
     static_assert(MAX_TENSOR_ARGS <= 64, "tensor dump arg mask assumes at most 64 tensor arguments");
     uint64_t tensor_dump_arg_mask_{0};
-    bool tensor_dump_selective_requested_{is_tensor_dump_selective_requested()};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+
+    // No-arg dump(): mark every tensor arg already added to this Arg.
+    void mark_all_tensor_dump_arg() {
+        if (tensor_count_ == 0) {
+            set_error("dump: no tensor arguments added to this Arg");
+            return;
+        }
+        for (int32_t i = 0; i < tensor_count_; i++) {
+            tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+        }
+    }
 
     void mark_tensor_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -199,11 +199,14 @@ public:
      * @param free_cb           Memory free callback
      * @param user_data         Opaque pointer forwarded to callbacks
      * @param output_prefix     Per-task directory; tensor_dump/ subdir lands here
+     * @param dump_tensor_level OFF / PARTIAL (only Arg::dump()-marked tasks) /
+     *                          FULL. Written to DumpDataHeader so the AICPU
+     *                          latches the mode before any dispatch.
      * @return 0 on success, error code on failure
      */
     int initialize(
         int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
-        const DumpFreeCallback &free_cb, const std::string &output_prefix
+        const DumpFreeCallback &free_cb, const std::string &output_prefix, DumpTensorLevel dump_tensor_level
     );
 
     /**

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -387,7 +387,7 @@ int run_prepared(
         }
 
         runner->set_l2_swimlane_enabled(enable_l2_swimlane);
-        runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
+        runner->set_dump_tensor_enabled(enable_dump_tensor);
         runner->set_pmu_enabled(enable_pmu);
         // Virtual: a2a3 wires through to its enable_dep_gen_; a5 is a no-op
         // (dep_gen isn't implemented on a5 today).

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -381,7 +381,10 @@ public:
         l2_swimlane_level_ = static_cast<L2SwimlaneLevel>(level);
         enable_l2_swimlane_ = (l2_swimlane_level_ != L2SwimlaneLevel::DISABLED);
     }
-    void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
+    void set_dump_tensor_enabled(int level) {
+        dump_tensor_level_ = static_cast<DumpTensorLevel>(level);
+        enable_dump_tensor_ = (dump_tensor_level_ != DumpTensorLevel::OFF);
+    }
     void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
@@ -758,6 +761,7 @@ protected:
     // `run()`, read inside `run()` and its helpers.
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
+    DumpTensorLevel dump_tensor_level_{DumpTensorLevel::OFF};  // resolved from set_dump_tensor_enabled()
     bool enable_pmu_{false};
     bool enable_scope_stats_{false};
     L2SwimlaneLevel l2_swimlane_level_{L2SwimlaneLevel::DISABLED};  // resolved from set_l2_swimlane_enabled()

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -439,6 +439,12 @@ void dump_tensor_init(int num_dump_threads) {
 
     s_dump_header = get_dump_header(dump_base);
 
+    // Latch dump mode from the host-written header before any task is dumped.
+    // PARTIAL → selective (only Arg::dump()-marked tasks); FULL → every task.
+    set_dump_tensor_selective_mode(
+        static_cast<DumpTensorLevel>(s_dump_header->dump_tensor_level) == DumpTensorLevel::PARTIAL
+    );
+
     LOG_INFO_V0("Initializing tensor dump for %d threads", num_dump_threads);
 
     // Pop initial metadata buffer from free_queue for each thread

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -47,7 +47,7 @@ TensorDumpCollector::~TensorDumpCollector() { stop(); }
 
 int TensorDumpCollector::initialize(
     int num_dump_threads, int device_id, const DumpAllocCallback &alloc_cb, DumpRegisterCallback register_cb,
-    const DumpFreeCallback &free_cb, const std::string &output_prefix
+    const DumpFreeCallback &free_cb, const std::string &output_prefix, DumpTensorLevel dump_tensor_level
 ) {
     if (shm_host_ != nullptr) {
         LOG_ERROR("TensorDumpCollector already initialized");
@@ -88,6 +88,7 @@ int TensorDumpCollector::initialize(
     header->magic = TENSOR_DUMP_MAGIC;
     header->num_dump_threads = static_cast<uint32_t>(num_dump_threads);
     header->records_per_buffer = PLATFORM_DUMP_RECORDS_PER_BUFFER;
+    header->dump_tensor_level = static_cast<uint32_t>(dump_tensor_level);
 
     uint64_t arena_size = calc_dump_arena_size();
     header->arena_size_per_thread = arena_size;

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -342,7 +342,7 @@ int run_prepared(
         }
 
         runner->set_l2_swimlane_enabled(enable_l2_swimlane);
-        runner->set_dump_tensor_enabled(enable_dump_tensor != 0);
+        runner->set_dump_tensor_enabled(enable_dump_tensor);
         runner->set_pmu_enabled(enable_pmu);
         runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_scope_stats_enabled(enable_scope_stats != 0);

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -110,7 +110,10 @@ public:
         l2_swimlane_level_ = static_cast<L2SwimlaneLevel>(level);
         enable_l2_swimlane_ = (l2_swimlane_level_ != L2SwimlaneLevel::DISABLED);
     }
-    void set_dump_tensor_enabled(bool enable) { enable_dump_tensor_ = enable; }
+    void set_dump_tensor_enabled(int level) {
+        dump_tensor_level_ = static_cast<DumpTensorLevel>(level);
+        enable_dump_tensor_ = (dump_tensor_level_ != DumpTensorLevel::OFF);
+    }
     void set_pmu_enabled(int enable_pmu) {
         enable_pmu_ = (enable_pmu > 0);
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
@@ -247,6 +250,7 @@ protected:
     // Enablement flags. Written via setters before run(); read inside run().
     bool enable_l2_swimlane_{false};
     bool enable_dump_tensor_{false};
+    DumpTensorLevel dump_tensor_level_{DumpTensorLevel::OFF};  // resolved from set_dump_tensor_enabled()
     bool enable_pmu_{false};
     bool enable_scope_stats_{false};
     L2SwimlaneLevel l2_swimlane_level_{L2SwimlaneLevel::DISABLED};  // resolved from set_l2_swimlane_enabled()

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -24,8 +24,6 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
 }
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    enable_dump_tensor_selective();
-
     Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
     Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
     Tensor ext_f = from_tensor_arg(orch_args.tensor(2));
@@ -63,6 +61,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t3.add_input(e);
         params_t3.add_output(inter_ci);
         params_t3.add_scalar(3u);
+        // Partial dump, tensor granularity: select specific tensors of this task
+        // (input d + the output; input e is left unmarked).
+        params_t3.dump(d, inter_ci);
         TaskOutputTensors outs_t3 = rt_submit_aiv_task(2, params_t3);
         const Tensor &g = outs_t3.get_ref(0);
 
@@ -70,7 +71,9 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);
-        params_t4.dump(g, c, ext_f);
+        // Partial dump, task granularity: no-arg dump() selects the whole task
+        // (every tensor arg on this Arg).
+        params_t4.dump();
         rt_submit_aiv_task(0, params_t4);
     }
 }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
@@ -32,11 +32,25 @@ KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestTensorDump(SceneTestCase):
-    """Vector example with --dump-tensor, then assert tensor_dump/."""
+    """tensor_dump capture smoke, level-aware on the ``--dump-tensor`` level.
+
+    Uses ``partial_dump_orch`` (5 tasks; two carry ``dump(...)`` markers) so a
+    single orchestration exercises both modes:
+
+    - ``--dump-tensor 1`` (partial): only the two marked tasks are captured —
+      task ``0x..02`` via ``dump(d, inter_ci)`` (tensor granularity: args 0+2,
+      input ``e`` excluded), task ``0x..03`` via no-arg ``dump()`` (task
+      granularity: all three args). Mode is latched host-side before dispatch,
+      so it is race-free regardless of submission order.
+    - ``--dump-tensor 2`` (full): markers are ignored, every task is dumped.
+
+    The dump level comes straight from the CLI ``--dump-tensor`` value
+    (no per-case override).
+    """
 
     CALLABLE = {
         "orchestration": {
-            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "source": "kernels/orchestration/partial_dump_orch.cpp",
             "function_name": "aicpu_orchestration_entry",
             "signature": [D.IN, D.IN, D.OUT],
         },
@@ -84,17 +98,12 @@ class TestTensorDump(SceneTestCase):
 
     def test_run(self, st_platform, st_worker, request):
         super().test_run(st_platform, st_worker, request)
-        if not request.config.getoption("--dump-tensor", default=False):
+        level = int(request.config.getoption("--dump-tensor", default=0))
+        if not level:
             return
-        for case in self.CASES:
-            if st_platform in case["platforms"]:
-                self._validate_dump_artifact(case)
-
-    def _validate_dump_artifact(self, case):
-        safe_label = _sanitize_for_filename(f"TestTensorDump_{case['name']}")
+        safe_label = _sanitize_for_filename("TestTensorDump_default")
         matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
-        if not matches:
-            return
+        assert matches, "tensor dump output directory missing"
         dump_dir = matches[-1] / "tensor_dump"
         assert dump_dir.is_dir(), f"tensor_dump/ missing under {matches[-1]} — dump capture failed?"
         manifest = dump_dir / "tensor_dump.json"
@@ -105,22 +114,38 @@ class TestTensorDump(SceneTestCase):
         assert bin_name, f"manifest missing bin_file field: {data}"
         bin_path = dump_dir / bin_name
         assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
-        # Tensors list is keyed by run / task / arg — exact shape varies with
-        # the collector's chosen schema across runtimes, but we know
-        # vector_example reads/writes ≥1 tensor and the manifest can't be empty
-        # if anything was captured. Robust to schema add/remove of new fields.
         tensors = data.get("tensors", [])
         assert tensors, f"tensor_dump.json has no entries: {data}"
         assert bin_path.stat().st_size > 0, "tensor_dump.bin is empty"
+
+        # Unified manifest (#792): tensors and scalar args share one
+        # tensor_dump.json keyed by a "kind" field; no separate args files.
         assert not (dump_dir / "args_dump.json").exists(), "args_dump.json should not be emitted"
         assert not (dump_dir / "kernel_args_dump.json").exists(), "kernel_args_dump.json should not be emitted"
-
         assert all("kind" in t for t in tensors), tensors
-
         scalar_entries = [t for t in tensors if t.get("kind") == "scalar"]
         assert all(t.get("stage") == "before_dispatch" for t in scalar_entries), scalar_entries
         assert all(t.get("bin_size") == 0 for t in scalar_entries), scalar_entries
         assert all("value" in t for t in scalar_entries), scalar_entries
+
+        # Level-aware checks operate on the tensor entries.
+        tensor_entries = [t for t in tensors if t.get("kind") == "tensor"]
+        task_ids = {t["task_id"] for t in tensor_entries}
+        if level == 1:
+            # Partial: only the two dump()-marked tasks, race-free (host-latched).
+            assert len(tensor_entries) == 5, f"partial expected 5 tensor entries, got {len(tensor_entries)}"
+            assert task_ids == {"0x0000000100000002", "0x0000000100000003"}
+            # Tensor granularity: dump(d, inter_ci) captured args 0 + 2, not arg 1 (e).
+            t02 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000002")
+            assert t02 == [0, 2]
+            # Task granularity: dump() captured all three tensor args.
+            t03 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000003")
+            assert t03 == [0, 1, 2]
+            # Selective mode also confines scalar-arg dumps to the marked tasks.
+            assert {t["task_id"] for t in scalar_entries} <= task_ids, scalar_entries
+        else:
+            # Full (level 2): markers ignored — every one of the 5 tasks is dumped.
+            assert len(task_ids) >= 5, f"full dump should cover all 5 tasks, got {sorted(task_ids)}"
 
         # ---- Tool smoke: dump_viewer ----
         # Exit-code-only check; the no-filter default lists every captured
@@ -131,47 +156,6 @@ class TestTensorDump(SceneTestCase):
             check=True,
             timeout=60,
         )
-
-
-@scene_test(level=2, runtime="tensormap_and_ringbuffer")
-class TestTensorDumpPartial(SceneTestCase):
-    """Vector example with one task explicitly selected for tensor dump."""
-
-    CALLABLE = {
-        "orchestration": {
-            "source": "kernels/orchestration/partial_dump_orch.cpp",
-            "function_name": "aicpu_orchestration_entry",
-            "signature": [D.IN, D.IN, D.OUT],
-        },
-        "incores": TestTensorDump.CALLABLE["incores"],
-    }
-
-    CASES = TestTensorDump.CASES
-
-    def generate_args(self, params):
-        return TestTensorDump.generate_args(self, params)
-
-    def compute_golden(self, args, params):
-        return TestTensorDump.compute_golden(self, args, params)
-
-    def test_run(self, st_platform, st_worker, request):
-        super().test_run(st_platform, st_worker, request)
-        if not request.config.getoption("--dump-tensor", default=False):
-            return
-        safe_label = _sanitize_for_filename("TestTensorDumpPartial_default")
-        matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
-        assert matches, "partial tensor dump output directory missing"
-        dump_dir = matches[-1] / "tensor_dump"
-        manifest = dump_dir / "tensor_dump.json"
-        assert manifest.exists(), f"tensor_dump.json missing under {dump_dir}"
-        with manifest.open() as f:
-            data = json.load(f)
-        tensors = data.get("tensors", [])
-        assert len(tensors) == 3
-        assert data.get("before_dispatch") == 2
-        assert data.get("after_completion") == 1
-        assert {t["task_id"] for t in tensors} == {"0x0000000100000003"}
-        assert [t["role"] for t in tensors] == ["input", "input", "output"]
 
 
 if __name__ == "__main__":

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -24,7 +24,7 @@ class TestCallConfig:
         assert config.block_dim == 0
         assert config.aicpu_thread_num == 3
         assert config.enable_l2_swimlane == 0
-        assert config.enable_dump_tensor is False
+        assert config.enable_dump_tensor == 0
         assert config.enable_pmu == 0
         assert config.enable_dep_gen is False
 
@@ -43,6 +43,14 @@ class TestCallConfig:
         assert config.enable_l2_swimlane == 2
         config.enable_l2_swimlane = False
         assert config.enable_l2_swimlane == 0
+        # enable_dump_tensor is likewise a level (0=off, 1=partial, 2=full):
+        # `True` maps to level 1 (partial), explicit ints select the level.
+        config.enable_dump_tensor = True
+        assert config.enable_dump_tensor == 1
+        config.enable_dump_tensor = 2
+        assert config.enable_dump_tensor == 2
+        config.enable_dump_tensor = False
+        assert config.enable_dump_tensor == 0
 
     def test_diagnostics_subfeatures_are_parallel(self):
         # Guard against drift: the four diagnostics sub-features under the
@@ -53,12 +61,12 @@ class TestCallConfig:
         config.enable_pmu = 2
         config.enable_dep_gen = True
         assert config.enable_l2_swimlane == 4
-        assert config.enable_dump_tensor is True
+        assert config.enable_dump_tensor == 1
         assert config.enable_pmu == 2
         assert config.enable_dep_gen is True
         r = repr(config)
         assert "enable_l2_swimlane=4" in r
-        assert "enable_dump_tensor=True" in r
+        assert "enable_dump_tensor=1" in r
         assert "enable_pmu=2" in r
         assert "enable_dep_gen=True" in r
 


### PR DESCRIPTION
## Summary

Simplifies and hardens the `tensormap_and_ringbuffer` selective tensor-dump API (follow-up to #844), per #903. Replaces the removed `enable_dump_tensor_selective()` toggle with a **host-decided dump level** that mirrors `--enable-l2-swimlane`.

## `--dump-tensor` is now leveled

| Level | Meaning |
| ----- | ------- |
| `0` (flag absent) | off — zero overhead |
| `1` (bare `--dump-tensor`) | **partial** — only tasks marked with `Arg::dump(...)` |
| `2` (`--dump-tensor 2`) | **full** — every task's tensor I/O |

## Key changes

- **`Arg::dump()`** with no args marks the whole task; `dump(x, y, z)` marks specific tensors. Both operate on tensors already added to the `Arg` (snapshot at call time, consistent with each other). `dump()` on an `Arg` with no tensor args is an error (`set_error`, same path as `dump(x)`'s validation).
- **Removed** `enable_dump_tensor_selective()` and the device-side selective-requested global, plus the marker-inferred selective mode in the orchestrator.
- **Level transport mirrors l2_swimlane**: a `DumpTensorLevel` enum (`OFF`/`PARTIAL`/`FULL`) is carried in `DumpDataHeader::dump_tensor_level` (host-written before launch, repurposing the struct's spare `pad`); the AICPU latches selective mode in `dump_tensor_init()` from that level — exactly like `header->l2_swimlane_level`. `PROFILING_FLAG_DUMP_TENSOR` still only carries on/off (used by the AICore barrier).
- **Race-free**: because the level is decided host-side *before any task is dispatched*, selective-vs-full is latched up front. This fixes the submission-order race where unmarked tasks dispatched before the first marker could leak into a full dump — the nondeterministic `st-onboard-a2a3` dump count (`6 != 5`) the inference approach hit.
- The runner setter is `set_dump_tensor_enabled(int level)` (name mirrors `set_l2_swimlane_enabled`); `enable_dump_tensor` flows host→device as a level int.

## Tests / docs

- `partial_dump_orch.cpp` marks two tasks at both granularities (`dump(d, inter_ci)` by tensor + `dump()` whole-task).
- `test_tensor_dump.py` is a single **level-aware** class: asserts the selective 5-tensor result at level 1 (task `0x..02` args {0,2}, task `0x..03` args {0,1,2}) and full coverage at level 2; CLI-driven level (no per-case override).
- `docs/dfx/tensor-dump.md` §3.1/§3.2/§5.1 updated.

## Testing

- [x] `pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump --platform a2a3sim --dump-tensor` (partial, level 1) — pass
- [x] same with `--dump-tensor 2` (full) — pass
- [x] `pytest tests/st/a5/tensormap_and_ringbuffer/mixed_example --platform a5sim` — pass
- [ ] onboard (`st-onboard-a2a3` / `st-onboard-a5`) — via CI

Fixes #903