### PR TITLE
docs: rewrite scope-stats guide to lead with user workflow

### DIFF
--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -1,43 +1,153 @@
 # Scope Stats — Per-scope Resource Usage Peaks
 
-## 1. Background & Motivation
+Scope stats records the peak resource usage — task-window slots, heap
+bytes, tensormap entries — for every `PTO2_SCOPE` region in an
+orchestration, so you can see *which scope* drove each resource to its
+high-water mark. When a model runs out of task windows, heap, or
+tensormap entries, the failure tells you *which* resource is exhausted
+but not *where*; scope stats gives you the where.
 
-When a model runs out of task windows, heap, or dep/fanin pool entries,
-the failure message tells you *which* resource is exhausted but not
-*which scope* caused the peak. Without per-scope attribution, debugging
-requires binary-searching the orchestration code to find the offending
-scope — slow and error-prone.
+It is a diagnostic-only, opt-in feature for the
+**tensormap_and_ringbuffer (T&R)** runtime. When disabled (the default)
+it costs a single bool load per probe.
 
-Scope stats captures the peak resource usage (heap bytes, task
-in-flight, tensormap entries) for every `PTO2_SCOPE` region, so the
-output directly tells you which scope drove each resource to its
-high-water mark.
+## 1. Quick Start
 
-## 2. Overview
+The full workflow is three steps: enable the flag, run, then turn the
+resulting `scope_stats.jsonl` into an HTML report.
 
-- **One row per scope exit.** Peaks are sampled continuously inside the
-  scope and flushed to a shared buffer on `scope_end`.
-- **Per-ring breakdown.** Each ring's task allocator heap/task-window
-  is tracked independently.
-- **NDJSON output.** A `scope_stats.jsonl` lands under the per-task output
-  prefix: line 1 is run metadata (version / fatal / dropped / total), each
-  subsequent line is one per-scope record.
-- **Runtime-gated.** Controlled by `--enable-scope-stats` (bit 4 of
-  `enable_profiling_flag`). When off, every probe is a single bool
-  load — no measurement overhead.
-- **T&R runtime only.** See §6 for why.
+### Step 1 — Run with `--enable-scope-stats`
 
-Enable in one line:
+Pass the flag to any T&R example or scene test:
 
 ```bash
 python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-scope-stats
 ```
 
-## 3. Architecture
+The flag is bit 4 of `enable_profiling_flag`; on a T&R run it turns on
+per-scope peak tracking. On other runtimes the flag is accepted but
+produces no records.
 
-### 3.1 Layering
+### Step 2 — Locate the output
 
-Scope stats uses a clean platform-provides / runtime-calls pattern:
+The run writes `scope_stats.jsonl` under the per-task output prefix
+(the same directory other profiling artifacts land in for that run).
+It is NDJSON: line 1 is run metadata, every subsequent line is one
+scope sample. See [§3](#3-output-scope_statsjsonl) for the schema.
+
+### Step 3 — Visualize with `scope_stats_plot.py`
+
+```bash
+python tools/scope_stats_plot.py <output_prefix>/scope_stats.jsonl
+# writes <output_prefix>/scope_stats.html
+
+# or send the report elsewhere:
+python tools/scope_stats_plot.py path/to/scope_stats.jsonl --out-dir /tmp/report
+```
+
+| Argument | Required | Meaning |
+| -------- | -------- | ------- |
+| `jsonl` | yes | Path to a `scope_stats.jsonl` produced by Step 1 |
+| `--out-dir DIR` | no | Where to write `scope_stats.html` (default: next to the input) |
+
+The output is a single self-contained `scope_stats.html` — the SVG
+charts are inlined (no matplotlib, no external JS/CDN), so it opens
+offline and is trivial to share. Open it in any browser.
+
+### Reading the report
+
+The report groups charts by **ring**, and within each ring draws one
+line chart per resource (task_window, heap, tensormap). The x-axis is
+scopes in begin/end order; hover a point to see its source site. Each
+ring header lists the per-resource max capacity, and three metrics are
+plotted per ring/resource:
+
+| Metric | Formula | What it tells you |
+| ------ | ------- | ----------------- |
+| `scope_high_water` | `end.head − begin.tail` | Highest occupancy the scope held — residual not yet released on entry, plus what this scope added. The true peak. |
+| `real_occupancy` | `end.head − end.tail` | What is still occupied at scope exit (the live level on leaving). |
+| `scope_alloc` | `end.head − begin.head` | How far the allocation frontier advanced — this scope's own net (unreleased) allocation. |
+
+`head` is the ring's allocation frontier (`heap_top`); `tail` is its
+released boundary (`heap_tail`). Ring-buffer occupancy is non-negative,
+so a negative delta is folded back by one buffer length
+(`(head + cap − tail) % cap`) — a wrap past the buffer end. `tensormap`
+is reported as a single in-use value (no head/tail), so it shows only
+the `real_occupancy` curve.
+
+## 2. What gets captured
+
+- **The whole orchestration, automatically.** You do not mark a region
+  to profile — instrumentation lives inside the `PTO2_SCOPE` macro
+  itself, so *every* scope in the orchestration is recorded once the
+  flag is on. The executor wraps the orchestration entry in a root
+  `PTO2_SCOPE` (`depth` 0), and every user-written `PTO2_SCOPE` nests
+  under it, so the report covers the entire orch scope tree end to end.
+- **One sample per scope boundary.** Each `PTO2_SCOPE` emits a `begin`
+  record on entry and an `end` record on exit. The plot tool pairs them
+  by site to compute the metrics above.
+- **Per-ring.** Each ring's task allocator heap / task-window is tracked
+  independently; a scope only ever touches its own ring
+  (`ring = min(depth, MAX_RING_DEPTH−1)`).
+- **Capacity denominators.** The `*_max` capacities in the metadata line
+  are snapshots of what the runtime actually configured for that run, so
+  `used/cap` ratios are exact.
+- **Disk-bounded, no wrap.** Full buffers stream off the device during
+  the run, so the record count is bounded only by disk — there is no
+  fixed-ring overwrite.
+
+## 3. Output: `scope_stats.jsonl`
+
+NDJSON. Line 1 is run metadata; each subsequent line is one scope
+sample (`begin` or `end`). Schema version 4:
+
+```json
+{"version": 4, "fatal": false, "dropped": 0, "total": 4, "task_window_max": [8, 4], "heap_max": [268435456, 268435456], "tensormap_max": 65536}
+{"site": "example_orchestration.cpp:77", "phase": "begin", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 0, "heap_start": 0, "heap_end": 0, "tensormap": 0}
+{"site": "example_orchestration.cpp:77", "phase": "end", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 4, "heap_start": 0, "heap_end": 8192, "tensormap": 5}
+```
+
+Metadata line (line 1):
+
+| Field | Type | Meaning |
+| ----- | ---- | ------- |
+| `version` | int | Schema version (`4`) |
+| `fatal` | bool | `true` iff a fatal was latched during the run; records past it are diagnostic-only |
+| `dropped` | uint | Records dropped on device (free_queue empty / ready_queue full); `0` on a healthy run |
+| `total` | uint | Total records the device attempted (collected + dropped) |
+| `task_window_max` | int[] | Per-ring task-window capacity (indexed by `ring`) |
+| `heap_max` | int[] | Per-ring heap-byte capacity (indexed by `ring`) |
+| `tensormap_max` | int | Tensormap entry capacity (scalar) |
+
+Per-sample lines, oldest-first:
+
+| Field | Type | Description |
+| ----- | ---- | ----------- |
+| `site` | `"basename:line"` | Source location of the `PTO2_SCOPE()` call |
+| `phase` | `"begin"`/`"end"` | Scope entry or exit sample |
+| `depth` | int | Nesting depth (0 = root scope inside the executor) |
+| `ring` | int | Ring this scope used; indexes `task_window_max` / `heap_max` |
+| `task_window_start` | int | Task-window ring tail at this boundary |
+| `task_window_end` | int | Task-window ring head at this boundary |
+| `heap_start` | uint | Heap ring tail (released boundary) in bytes |
+| `heap_end` | uint | Heap ring head (allocation frontier) in bytes |
+| `tensormap` | int | Tensormap entries in use |
+
+`start`/`end` are the ring's tail/head pointers at that boundary — see
+the metric formulas in [§1](#reading-the-report) for how a scope's peak
+and occupancy are derived from a paired begin/end.
+
+---
+
+## 4. Internals
+
+This section is for maintainers wiring scope stats into a runtime; users
+do not need it. There is **no public C/C++ API** — the only external
+interfaces are the `--enable-scope-stats` flag and the plot tool above.
+
+### 4.1 Layering
+
+Scope stats uses a platform-provides / runtime-calls pattern:
 
 ```text
 platform/include/aicpu/scope_stats_collector_aicpu.h
@@ -45,202 +155,115 @@ platform/include/aicpu/scope_stats_collector_aicpu.h
 
 platform/shared/aicpu/scope_stats_collector_aicpu.cpp
     Owns all collector state (depth stack, peak arrays, shared buffer).
-    Implements scope lifecycle (begin/end), peak comparison logic,
-    capacity registration, and shared buffer record writes.
+    Scope lifecycle, peak comparison, capacity registration, record writes.
+
+platform/shared/host/scope_stats_collector.cpp
+    Host side: allocates the shared header/buffer pool, streams full
+    buffers off the device, reconciles counters, writes scope_stats.jsonl.
 
 runtime (pto_orchestrator.cpp, pto_scheduler.h)
     Calls platform APIs at instrumentation points, passing extracted
-    values (ring_id, heap_bytes, tasks_in_flight, etc.) as plain
-    integers. No scope_stats source files in the runtime directory.
+    values (ring_id, heap_bytes, ...) as plain integers. No scope_stats
+    source files live in the runtime directory.
 ```
 
-### 3.2 Platform API
+### 4.2 AICPU platform API
 
 Header:
-[`src/a2a3/platform/include/aicpu/scope_stats_collector_aicpu.h`](../../src/a2a3/platform/include/aicpu/scope_stats_collector_aicpu.h)
+[`src/common/platform/include/aicpu/scope_stats_collector_aicpu.h`](../../src/common/platform/include/aicpu/scope_stats_collector_aicpu.h)
 
-All entry points are `extern "C"` and take primitive types only — no
-runtime structs cross the boundary, so the same collector links into
-any runtime that wants to wire it up. Symbol resolution is unconditional
-(see §3.4), so callers do not need to guard the call sites.
+All entry points are `extern "C"` and take primitive types only, so the
+same collector links into any runtime that wires it up. Symbol
+resolution is unconditional (see §4.4), so call sites need no guards.
 
 Single-producer contract: all `*_peaks` updates use non-atomic
 read-max-write and assume the orchestrator thread is the only writer.
-Concurrent callers may lose peaks silently — that is acceptable for
-diagnostic data and saves an atomic on the hot path.
-
-#### Setter symbols (host → AICPU init)
+Concurrent callers may lose peaks silently — acceptable for diagnostic
+data, and it saves an atomic on the hot path.
 
 ```cpp
+// Host → AICPU init (called from kernel.cpp at kernel entry)
 void set_scope_stats_enabled(bool enable);
 void set_platform_scope_stats_base(uint64_t scope_stats_data_base);
-```
 
-`kernel.cpp` calls both at kernel entry from `KernelArgs`. `enable`
-mirrors the host's `--enable-scope-stats` flag; `scope_stats_data_base`
-is the device-visible address of the `ScopeStatsDataHeader` region the
-host `ScopeStatsCollector` allocates in `init_scope_stats()`.
-`set_platform_scope_stats_base` doubles as the device-side init: it maps
-the shared header + per-instance buffer state and resets collector-local
-state (the host owns the shared header / free_queue, so it is not zeroed
-here). When `enable=false` every probe early-returns after one bool load —
-that is the off-cost.
-
-#### Capacity registration (runtime → AICPU init)
-
-```cpp
-void scope_stats_set_ring_capacity(int ring_id, int32_t window_cap,
-                                   uint64_t heap_cap);
+// Runtime → AICPU init (once per ring at orchestrator init / scheduler attach)
+void scope_stats_set_ring_capacity(int ring_id, int32_t window_cap, uint64_t heap_cap);
 void scope_stats_set_tensormap_capacity(int32_t cap);
-```
 
-Called once per ring at orchestrator init / scheduler attach. Caps are
-copied verbatim into the buffer header so the host JSON can render
-`used/cap` ratios without a second device→host query. `ring_id` outside
-`[0, PTO2_SCOPE_STATS_MAX_RING_DEPTH)` is silently dropped.
-
-#### Scope lifecycle (runtime → AICPU per-scope)
-
-```cpp
+// Runtime → AICPU per-scope
 void scope_stats_set_pending_site(const char *file, int line);
-void scope_stats_begin(int ring_id, uint64_t heap_bytes,
-                       int32_t tasks_in_flight, int32_t tensormap_used);
-void scope_stats_end(int ring_id, uint64_t heap_bytes,
-                     int32_t tasks_in_flight, int32_t tensormap_used);
+void scope_stats_begin(int ring_id, uint64_t heap_bytes, int32_t tasks_in_flight, int32_t tensormap_used);
+void scope_stats_end(int ring_id, uint64_t heap_bytes, int32_t tasks_in_flight, int32_t tensormap_used);
 void scope_stats_on_fatal();
 ```
 
+`enable` mirrors the host's `--enable-scope-stats` flag;
+`scope_stats_data_base` is the device-visible address of the shared
+header the host allocates. `set_platform_scope_stats_base` doubles as
+device-side init (maps the header + per-instance buffer state, resets
+collector-local state). When `enable=false` every probe early-returns
+after one bool load.
+
 A scope costs exactly two collector calls — `begin` and `end` — each
-carrying that boundary's sample for the scope's own ring. The runtime gates
-both on the local weak `is_scope_stats_enabled()` stub first, so a disabled
-run pays neither the cross-`.so` calls nor the cross-agent `active_count()`
-read that feeds them (same idiom as `is_dep_gen_enabled`). This replaces the
-former `on_begin` + `update_peaks` + `on_end` fan-out (which crossed the
-`.so` ~5× per scope plus a separate `set_pending_site`).
+carrying that boundary's sample for the scope's own ring. The runtime
+gates both on the local weak `is_scope_stats_enabled()` stub first, so a
+disabled run pays neither the cross-`.so` calls nor the cross-agent
+`active_count()` read (same idiom as `is_dep_gen_enabled`).
+`PTO2_SCOPE()` expansion calls `set_pending_site(__FILE__, __LINE__)`
+before `begin`; `copy_basename` keeps the JSON readable without forcing
+the host to chase a device pointer into the orchestration `.so`'s string
+table. `on_fatal` sets `header.fatal_latched`, surfacing as
+`"fatal": true`; the host still emits whatever records made it.
 
-- `begin` pushes the depth/site and **seeds** the peak with the begin
-  sample. The begin sample is load-bearing: a prior same-ring scope may not
-  have released its resources yet, and that residual is part of this scope's
-  true high-water mark.
-- `end` folds the end sample into the peak (`max`), emits one record, and
-  tears down the depth/site bookkeeping.
+`ring_id` outside `[0, PTO2_SCOPE_STATS_MAX_RING_DEPTH)` is silently
+dropped. Caps are copied verbatim into the buffer header so the host can
+render `used/cap` without a second device→host query.
 
-`PTO2_SCOPE()` expansion calls `set_pending_site(__FILE__, __LINE__)` before
-`begin` so `end` can stamp the record with the source location — the
-basename copy (`copy_basename`) keeps the JSON readable without forcing the
-host to chase a device pointer into the orchestration `.so`'s string table.
-Peaks are **not** propagated to enclosing scopes: each scope samples only its
-own ring (`ring_id = min(depth, MAX_RING_DEPTH-1)`), so its usage appears
-only in its own record. `on_fatal` sets `header.fatal_latched`, surfacing as
-`"fatal": true` in the JSON; the host treats that as "diagnostic-only past
-this point" but still emits whatever records made it.
-
-### 3.3 Comparison with other profiling subsystems
+### 4.3 Comparison with other profiling subsystems
 
 | Feature | Layer | Runtime scope | Why |
 | ------- | ----- | ------------- | --- |
-| PMU | platform only | all runtimes | reads hardware registers (platform) |
-| L2 swimlane | platform only | all runtimes | reads AICore ring buffers (platform) |
-| dep_gen | platform only | all runtimes | traces `submit_task` (runtime-agnostic) |
-| tensor dump | platform only | all runtimes | dumps tensor data (platform) |
+| PMU | platform only | all runtimes | reads hardware registers |
+| L2 swimlane | platform only | all runtimes | reads AICore ring buffers |
+| dep_gen | platform only | all runtimes | traces `submit_task` |
+| tensor dump | platform only | all runtimes | dumps tensor data |
 | **scope stats** | **platform API + runtime call sites** | **T&R only** | runtime extracts values, platform tracks peaks |
 
-### 3.4 Symbol resolution flow
+### 4.4 Symbol resolution
 
-```text
-kernel.cpp (platform, shared by all runtimes)
-    ├── set_scope_stats_enabled(flag)
-    └── set_platform_scope_stats_base(addr)
+`kernel.cpp` (platform, shared by all runtimes) always calls
+`set_scope_stats_enabled` / `set_platform_scope_stats_base`, so the
+collector symbols resolve into every AICPU `.so`. Only the T&R runtime
+adds the `begin`/`end`/capacity call sites, so only it produces records;
+host_build_graph links the collector but never invokes it.
 
-For host_build_graph AICPU .so:
-    kernel.cpp ──links──> platform collector
-    → symbols resolve, .so loads, scope_stats is enabled but
-      no runtime call sites invoke begin/end → no records
-
-For tensormap_and_ringbuffer AICPU .so:
-    kernel.cpp ──links──> platform collector
-    runtime call sites invoke update/capacity APIs
-    → full peak tracking active
-```
-
-## 4. Data Flow
+### 4.5 Data flow
 
 ```text
 Host                              AICPU (T&R runtime)
 ─────                             ─────────────────────
 ScopeStatsCollector                platform scope_stats_collector_aicpu.cpp
   allocate header + buffer pool      set_platform_scope_stats_base(addr)
-  pre-fill free_queue                  └─ map header + buffer state
-  set kernel_args fields             set_scope_stats_enabled(true)
-  start mgmt + poll threads          scope_stats_aicpu_set_orch_thread_idx()
-  launch kernel                      runtime: scope_stats_set_ring_capacity()
-      │                              runtime: scope_stats_set_tensormap_capacity()
+  pre-fill free_queue                set_scope_stats_enabled(true)
+  set kernel_args fields             runtime: scope_stats_set_ring_capacity()
+  launch kernel                      runtime: scope_stats_set_tensormap_capacity()
       │                                  │
-  mgmt thread:                       on PTO2_SCOPE begin:
-   refill free_queue,                  runtime: scope_stats_begin()
-   drain ready_queue   ◀──ready──┐       └─ seed peak with begin sample
-      │                          │   on PTO2_SCOPE end:
-  poll thread:                   │     runtime: scope_stats_end()
-   append records to memory      │       ├─ fold end sample, emit record
-      │                          │       └─ append to current buffer;
-      │                          └────────── push full buffer to ready_queue
-      │                                  │
-  stop() (drain + join)              orch exit: scope_stats_aicpu_flush_buffers()
-  reconcile_counters()
+  poll thread:                       on PTO2_SCOPE begin/end:
+   append records to memory  ◀──┐      runtime: scope_stats_begin()/end()
+      │                         │         └─ emit record, append to buffer;
+  stop() (drain + join)         └──────────── push full buffer to ready_queue
+  reconcile_counters()               orch exit: flush remaining buffers
   write_jsonl()
 ```
-
-## 5. Output: `scope_stats.jsonl`
-
-The host streams full buffers off the device during the run and, after
-`stop()` + `reconcile_counters()`, emits `<output_prefix>/scope_stats.jsonl`
-(NDJSON). Line 1 is run metadata; each subsequent line is one record.
-Schema (version 3):
-
-```json
-{"version": 3, "fatal": false, "dropped": 0, "total": 2}
-{"site": "example_orchestration.cpp:77", "depth": 1, "ring": 1, "task_window": 4, "heap": "8192/268435456", "tensormap": "5/65536"}
-{"site": "kernel.cpp:80", "depth": 0, "ring": 0, "task_window": 1, "heap": "4096/268435456", "tensormap": "5/65536"}
-```
-
-Metadata line (line 1) fields:
-
-| Field | Type | Meaning |
-| ----- | ---- | ------- |
-| `version` | int | Always `3` |
-| `fatal` | bool | `true` iff `scope_stats_on_fatal()` fired during the run |
-| `dropped` | uint | Records dropped on device (free_queue empty / ready_queue full); `0` on a healthy run |
-| `total` | uint | Total `scope_end` events the device attempted to record (collected + dropped) |
-
-Per-record lines: one JSON object per `scope_end`, oldest-first. The
-effective record count is disk-bounded — full buffers stream off the
-device continuously, so there is no fixed-ring wrap. Fields:
-
-| Field | Type | Description |
-| ----- | ---- | ----------- |
-| `site` | `"basename:line"` | Source location of the `PTO2_SCOPE()` call |
-| `depth` | int | Nesting depth (0 = root scope inside the executor) |
-| `ring` | int | Ring this scope used (`min(depth, MAX_RING_DEPTH-1)`); indexes the cap arrays for `heap` |
-| `task_window` | int | Peak task-window slots in use on `ring` |
-| `heap` | `"used/cap"` | Peak heap bytes in use on `ring` |
-| `tensormap` | `"used/cap"` | Peak tensormap entries in use |
-
-A scope only ever touches its own `ring`, so a single ring's peak is
-recorded rather than a per-ring array (the other rings were always zero).
-The `cap` denominators come from `scope_stats_set_ring_capacity` /
-`scope_stats_set_tensormap_capacity` snapshots, so they always reflect
-the values the runtime actually configured for that run.
 
 A worked example is in
 [`tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py`](../../tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py)
 — it runs the `vector_example` orchestration with `--enable-scope-stats`
-and asserts the resulting NDJSON for the depth=0 / depth=1 records the
-outer-executor + inner `PTO2_SCOPE` produce.
+and asserts the resulting NDJSON.
 
-## 6. Future: Cross-runtime Support
+### 4.6 Future: cross-runtime support
 
-If host_build_graph adds scope-like concepts in the future, extending
-scope_stats only requires adding the same platform API call sites in
-the HBG runtime — no platform changes needed. The platform collector
-is already runtime-agnostic; it accepts plain values and has no
-knowledge of T&R types.
+If host_build_graph adds scope-like concepts, extending scope_stats only
+requires adding the same platform call sites in HBG — no platform
+changes. The collector is already runtime-agnostic: it accepts plain
+values and has no knowledge of T&R types.


### PR DESCRIPTION
## What

Rewrites [docs/dfx/scope-stats.md](docs/dfx/scope-stats.md) so it reads from the user's perspective — the end-to-end usage flow first, internals last. Docs-only change (single file).

## Why

The previous version led with collection principles and the internal collector API. Someone picking up the library first needs to know *how to use it*, not how it works inside. The visualization tool was also entirely undocumented, and the JSONL schema section was stale.

## Changes

- **User workflow front and center** — new Quick Start: enable `--enable-scope-stats` → locate `scope_stats.jsonl` → visualize with `tools/scope_stats_plot.py`.
- **Document the plot tool** — CLI args, self-contained offline HTML output, and how to read the report (per-ring grouping + `scope_high_water` / `real_occupancy` / `scope_alloc` metrics with formulas).
- **Fix stale schema (v3 → v4)** — actual output is two `phase` records per scope with `*_start`/`*_end` fields and per-ring `*_max` metadata; updated example and field tables to match the host writer.
- **Clarify coverage** — the entire orchestration scope tree is captured automatically once the flag is on; no manual region marking.
- **Demote internals** — collector API / architecture / data flow moved into a maintainer-only section; the only external interfaces are the flag and the plot tool.