### PR TITLE
Feat: a5 AICPU topology-aware filter affinity gate (1 orch + 4 sched)

### DIFF
--- a/src/a5/docs/hardware.md
+++ b/src/a5/docs/hardware.md
@@ -149,3 +149,85 @@ report what user code can address.
 For cross-generation portable code: **always go through ACL or CANN
 ini, never HAL**. HAL's CORE_NUM semantics shift between a3 and a5 in
 ways that have no public documentation.
+
+## CANN AICPU thread dispatch under varying launch budgets
+
+How CANN distributes N AICPU threads across the user pool determines
+whether a device-side affinity gate — the "every launched thread reads
+`sched_getcpu()`, the gate keeps some and drops the rest" pattern used
+in [`src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp`](../../common/platform/onboard/aicpu/platform_aicpu_affinity.cpp)
+— has real choice over the user-schedulable cpu_ids. Documented here so
+the gate design has empirical ground truth rather than inference.
+
+### What we measured
+
+[`tools/cann-examples/aicpu-thread-spread/`](../../../tools/cann-examples/aicpu-thread-spread/README.md)
+launches N AICPU threads via `rtsLaunchCpuKernel`; each thread reads
+`sched_getcpu()` and writes the result to a GM slot, the host prints
+back the cpu_id histogram. The dispatcher bootstrap path is identical
+to `aicpu-device-query`'s — only the inner SO and the launch
+`aicpu_num` change.
+
+Verified on a5 device 0 of one box (`Ascend950PR_9599`, OCCUPY=0x1f8 →
+6 user cores at cpu_id 3..8):
+
+| `aicpu_num` | cpu_ids hit (sorted, with duplicates) |
+| ----------- | ------------------------------------- |
+| 1 | 8 |
+| 6 | 3 4 5 6 7 8 |
+| 7 | 3 4 5 6 7 8 **8** |
+| 8 | 3 4 5 6 7 **8 8 8** |
+| 14 | 3 3 4 4 5 5 6 6 7 7 **8 8 8 8** |
+
+### Findings
+
+1. **CANN dispatch set = OCCUPY exactly.** Threads only land on
+   user-schedulable cpu_ids. Asking for `N > popcount(OCCUPY)` does
+   **not** reach more cpus.
+2. **Over-launch doubles up on a sink cpu** (cpu_id 8 here, the highest
+   in OCCUPY). The 7th, 8th, ... thread re-uses an already-busy cpu_id
+   rather than expanding the set.
+3. **`launch_count = popcount(OCCUPY)` is the sweet spot.** Fewer
+   means some user cpus get no thread (the gate has no representative
+   on them to inspect); more is wasted (extras share an already-occupied
+   cpu and there is nothing new to learn from them).
+
+### Implication for the affinity gate
+
+Post-hoc device-side selection is **sound** on a5 — but only when the
+runtime launch count equals `popcount(OCCUPY)`. Empirically observed on
+Scenario A (OCCUPY=0x1f8, 6 user cpus):
+
+- `launch < popcount(OCCUPY)`: gate doesn't see every user cpu, so
+  cluster-aware packing can't choose freely across the pool.
+- `launch == popcount(OCCUPY)`: each user cpu has exactly one
+  representative thread; classifier picks the best 5.
+- `launch > popcount(OCCUPY)`: extras over-subscribe a sink cpu (cpu_id
+  8 in the table above). The minimal spread tool tolerates this, but
+  the **production AICPU kernel deadlocks**: contended init paths on
+  shared cpus prevent the gate barrier from ever closing. CANN reports
+  the failure as `aclrtSynchronizeStream rc=507000` (runtime internal)
+  after the launch.
+
+The runtime implements the safe choice: the host's topology probe sets
+`runtime->aicpu_launch_count = popcount(OCCUPY)` after reading the
+device-side OCCUPY, and the host's `rtsLaunchCpuKernel` is called with
+that exact value. `PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 14`
+remains a compile-time **upper bound** (array sizes, headroom), not the
+actual launch count. See:
+
+- `src/a5/platform/onboard/host/aicpu_topology_probe.{h,cpp}` — probe +
+  cluster-first packing
+- `src/a5/platform/onboard/host/device_runner.cpp` — fills
+  `aicpu_allowed_cpus[]` + `aicpu_launch_count` in Runtime, launches
+  with that count
+- `src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp` —
+  `platform_aicpu_affinity_gate_filter()` (the post-hoc classifier)
+
+The 0x7ffe SKU's dispatch behavior at `aicpu_num=14` has **not yet
+been measured** — once an a5 0x7ffe device runs an a5 onboard test,
+update this section with the observed (cpu_id → thread) spread. If
+launching 14 threads on 0x7ffe does not reach all 14 cpu_ids (i.e.
+CANN has a tighter dispatch policy than OCCUPY implies), that is a
+stronger constraint and `compute_allowed_cpus` would need to factor in
+the actual reachable set.

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -52,12 +52,39 @@ constexpr int PLATFORM_AIV_CORES_PER_BLOCKDIM = 2;
 constexpr int PLATFORM_MAX_AICPU_THREADS = 7;
 
 /**
- * Maximum AICPU launch threads (physical)
- * Upper bound for the number of AICPU threads that can be launched by Host.
- * Can be larger than PLATFORM_MAX_AICPU_THREADS to allow threads to be dropped
- * from scheduling while still participating in affinity (e.g. 6 launch, 4 active).
+ * Compile-time upper bound on the number of AICPU threads CANN may
+ * start per launch. The actual launch count is runtime-derived:
+ * the host topology probe sets runtime.aicpu_launch_count =
+ * popcount(OCCUPY), and DeviceRunner passes that count (not this
+ * constant) to rtsLaunchCpuKernel.
+ *
+ * The bound exists for the static gate buffers in
+ * src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+ * (s_filter_thread_cpu[MAX_GATE_THREADS] etc.) — keep it ≥ any
+ * runtime aicpu_launch_count we expect to see.
+ *
+ * Two over-subscription failure modes to keep in mind when choosing
+ * the runtime launch count vs this bound:
+ *   1. "Duplicate drop after barrier" — happens when CANN over-fills
+ *      a subset of OCCUPY cpus (duplicates land on the sink cpu).
+ *      The filter gate first barriers all launched threads, then
+ *      classifies cpu_id and drops the duplicates (only the first
+ *      thread to land on each ALLOWED slot survives). Safe.
+ *   2. "Barrier never closes" — happens when launch_count exceeds
+ *      popcount(OCCUPY) on the production AICPU kernel: contended
+ *      init paths on the over-subscribed sink prevent some threads
+ *      from reaching the barrier publish counter, the wait spins
+ *      forever, and CANN reports aclrtSynchronizeStream rc=507000
+ *      after the stream timeout. This is the reason the runtime
+ *      uses popcount(OCCUPY) rather than this constant.
+ *
+ * Current value 14 = worst-case popcount(OCCUPY) on the Ascend950PR
+ * 0x7ffe SKU (7 phys × 2 SMT = 14 user logical cpus). See
+ * src/a5/docs/hardware.md "CANN AICPU thread dispatch" for the
+ * empirical data and src/a5/platform/onboard/host/device_runner.cpp
+ * for where the runtime count is decided.
  */
-constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 7;
+constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 14;
 
 /**
  * AICore op execution timeout (microseconds).

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -112,9 +112,31 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     set_scope_stats_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_SCOPE_STATS));
     set_platform_scope_stats_base(k_args->scope_stats_data_base);
 
-    // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
-        LOG_INFO_V0("Thread dropped by cluster affinity");
+    // Filter-style affinity gate (a5). Host probed the topology, computed
+    // ALLOWED_CPUS, and wrote it into runtime->aicpu_allowed_cpus[]. The
+    // gate barriers exactly runtime->aicpu_launch_count threads (= the
+    // count CANN was told to launch, which equals popcount(OCCUPY) — see
+    // src/a5/platform/onboard/host/device_runner.cpp), keeps those whose
+    // sched_getcpu() ∈ allowed_cpus, and exposes the deterministic
+    // exec_idx via platform_aicpu_affinity_thread_idx() — the executor
+    // reads it to assign sched/orch role.
+    //
+    // If the host probe didn't populate the gate inputs (allowed_count or
+    // launch_count is 0) the gate would unconditionally drop every thread
+    // and we'd silently return success without ever calling aicpu_execute.
+    // That's a host-side bug; fail loud so it surfaces instead of
+    // producing nothing at runtime.
+    if (runtime->aicpu_allowed_cpu_count <= 0 || runtime->aicpu_launch_count <= 0) {
+        LOG_ERROR(
+            "AICPU affinity inputs missing: allowed_cpu_count=%d launch_count=%d (host probe must run before exec)",
+            runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+        );
+        return -1;
+    }
+    if (!platform_aicpu_affinity_gate_filter(
+            runtime->aicpu_allowed_cpus, runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+        )) {
+        LOG_INFO_V0("Thread dropped by filter affinity gate");
         return 0;
     }
 

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS
 set(HOST_RUNTIME_SOURCES "")
 list(APPEND HOST_RUNTIME_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/aicpu_topology_probe.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/profiling_copy.cpp"

--- a/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
+++ b/src/a5/platform/onboard/host/aicpu_topology_probe.cpp
@@ -1,0 +1,366 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "aicpu_topology_probe.h"
+
+#include <dlfcn.h>
+
+#include <algorithm>
+#include <cstring>
+#include <mutex>
+#include <unordered_map>
+
+#include "common/unified_log.h"
+
+namespace pto::a5 {
+
+namespace {
+
+// HAL constants — replicated locally so we don't need to pull
+// driver/ascend_hal_base.h into the public header.  Values match
+// `tools/cann-examples/query/query.cpp`'s usage.
+constexpr int32_t kModuleAicpu = 1;
+constexpr int32_t kModuleSystem = 0;
+constexpr int32_t kInfoOccupy = 8;
+constexpr int32_t kInfoCpuTopo = 59;
+
+// DSMI constants for SOC_INFO + CPU_TOPO. Verified against
+// $ASCEND_HOME_PATH/aarch64-linux/include/driver/dsmi_common_interface.h:
+// the dsmi_main_cmd enum jumps from CAN=3 to UPGRADE=5, so SOC_INFO = 14
+// (0x0e), NOT 0x10. Reference tools/cann-examples/query/query.cpp picks
+// it up via the header symbol; we hardcode here to keep the runtime SO
+// dependency-free.
+constexpr unsigned int kDsmiSocInfoMainCmd = 14;       // DSMI_MAIN_CMD_SOC_INFO
+constexpr unsigned int kDsmiSocInfoSubCmdCpuTopo = 2;  // SUB_CMD_CPU_TOPO
+constexpr unsigned int kCpuTopoMaxLogical = 64;        // headroom for any a5 SKU
+
+// Natural-alignment layout (no pack pragma). Mirrors
+// tools/cann-examples/query/query.cpp's struct; the HAL/DSMI driver
+// expects this byte layout — packing breaks the size check inside the
+// driver and yields rc=65534.
+struct DsmiSingleCpu {
+    uint64_t cpu_mask;
+    uint8_t cpu_id;
+    uint8_t is_share;
+    uint8_t phy_cpu_id;
+    uint8_t hyperthread_id;
+};
+struct DsmiCpuTopo {
+    uint32_t total_nums;
+    DsmiSingleCpu cpus[kCpuTopoMaxLogical];
+};
+
+// dlsym helpers — keep error reporting at WARN, callers fall back.
+using HalGetDeviceInfoFn = int (*)(uint64_t deviceId, int32_t moduleType, int32_t infoType, int64_t *value);
+using HalGetDeviceInfoByBuffFn =
+    int (*)(uint64_t deviceId, int32_t moduleType, int32_t infoType, void *buf, int32_t *size);
+using DsmiGetDeviceInfoFn =
+    int (*)(uint32_t device_id, unsigned int main_cmd, unsigned int sub_cmd, void *buf, unsigned int *size);
+
+HalGetDeviceInfoFn load_hal_get_device_info() {
+    auto fn = reinterpret_cast<HalGetDeviceInfoFn>(dlsym(nullptr, "halGetDeviceInfo"));
+    if (fn == nullptr) {
+        LOG_WARN("aicpu_topology_probe: halGetDeviceInfo not found via dlsym");
+    }
+    return fn;
+}
+
+HalGetDeviceInfoByBuffFn load_hal_get_device_info_by_buff() {
+    return reinterpret_cast<HalGetDeviceInfoByBuffFn>(dlsym(nullptr, "halGetDeviceInfoByBuff"));
+}
+
+DsmiGetDeviceInfoFn load_dsmi_get_device_info() {
+    // First try the global namespace — works if some other component
+    // already loaded libdrvdsmi_host.so. The simpler runtime doesn't, so
+    // explicitly dlopen the driver library before re-trying. RTLD_GLOBAL
+    // makes the symbols visible to future dlsym(nullptr,...) calls.
+    auto fn = reinterpret_cast<DsmiGetDeviceInfoFn>(dlsym(nullptr, "dsmi_get_device_info"));
+    if (fn != nullptr) return fn;
+    static const char *const kDsmiLibs[] = {
+        "libdrvdsmi_host.so",
+        "/usr/local/Ascend/driver/lib64/driver/libdrvdsmi_host.so",
+    };
+    for (const char *path : kDsmiLibs) {
+        if (dlopen(path, RTLD_LAZY | RTLD_GLOBAL) != nullptr) break;
+    }
+    fn = reinterpret_cast<DsmiGetDeviceInfoFn>(dlsym(nullptr, "dsmi_get_device_info"));
+    if (fn == nullptr) LOG_WARN("aicpu_topology_probe: dsmi_get_device_info not found after dlopen fallback");
+    return fn;
+}
+
+bool query_occupy(uint32_t device_id, uint64_t &out_mask) {
+    auto fn = load_hal_get_device_info();
+    if (fn == nullptr) return false;
+    int64_t v = 0;
+    int rc = fn(static_cast<uint64_t>(device_id), kModuleAicpu, kInfoOccupy, &v);
+    if (rc != 0) {
+        LOG_WARN("aicpu_topology_probe: halGetDeviceInfo(AICPU,OCCUPY) rc=%d", rc);
+        return false;
+    }
+    out_mask = static_cast<uint64_t>(v);
+    return true;
+}
+
+bool query_cpu_topo(uint32_t device_id, DsmiCpuTopo &out) {
+    std::memset(&out, 0, sizeof(out));
+    if (auto fn = load_hal_get_device_info_by_buff(); fn != nullptr) {
+        int32_t sz = static_cast<int32_t>(sizeof(out));
+        int rc = fn(static_cast<uint64_t>(device_id), kModuleSystem, kInfoCpuTopo, &out, &sz);
+        if (rc == 0 && out.total_nums > 0 && out.total_nums <= kCpuTopoMaxLogical) return true;
+        LOG_WARN("aicpu_topology_probe: halGetDeviceInfoByBuff(CPU_TOPO) rc=%d total=%u", rc, out.total_nums);
+    }
+    if (auto fn = load_dsmi_get_device_info(); fn != nullptr) {
+        unsigned int sz = static_cast<unsigned int>(sizeof(out));
+        int rc = fn(device_id, kDsmiSocInfoMainCmd, kDsmiSocInfoSubCmdCpuTopo, &out, &sz);
+        if (rc == 0 && out.total_nums > 0 && out.total_nums <= kCpuTopoMaxLogical) return true;
+        LOG_WARN("aicpu_topology_probe: dsmi_get_device_info(CPU_TOPO) rc=%d total=%u", rc, out.total_nums);
+    }
+    return false;
+}
+
+}  // namespace
+
+namespace {
+
+// AICPU topology is a per-device hardware fact — OCCUPY bitmap and DSMI
+// CPU_TOPO don't change across runs of the same device, so probe once
+// per device_id and cache. Subsequent launches reuse the cached result;
+// only `compute_allowed_cpus` re-runs (it's pure logic, microseconds).
+std::mutex s_topo_cache_mu;
+std::unordered_map<uint32_t, std::vector<AicpuLogicalCpu>> s_topo_cache;
+
+bool probe_aicpu_topology_uncached(uint32_t device_id, std::vector<AicpuLogicalCpu> &out_user_cpus) {
+    out_user_cpus.clear();
+
+    uint64_t occupy = 0;
+    if (!query_occupy(device_id, occupy)) return false;
+
+    DsmiCpuTopo topo{};
+    if (!query_cpu_topo(device_id, topo)) return false;
+
+    for (uint32_t i = 0; i < topo.total_nums; ++i) {
+        const DsmiSingleCpu &c = topo.cpus[i];
+        // Skip any cpu_id not in the device-side OCCUPY pool. Guard the
+        // shift against cpu_id >= 64 (UB in C++) — no a5 SKU is expected
+        // to expose more than 64 logical AICPU cpus, but a driver bug or
+        // future SKU change shouldn't trip undefined behavior here.
+        if (c.cpu_id >= 64 || ((occupy >> c.cpu_id) & 1ULL) == 0) continue;
+        AicpuLogicalCpu e{};
+        e.cpu_id = static_cast<int32_t>(c.cpu_id);
+        e.phy_cpu_id = static_cast<int32_t>(c.phy_cpu_id);
+        e.hyperthread_id = static_cast<int32_t>(c.hyperthread_id);
+        // a5 cluster mapping: 2 phy/cluster, 2 cluster/die.
+        e.cluster_id = e.phy_cpu_id / 2;
+        e.die_id = e.phy_cpu_id / 4;
+        out_user_cpus.push_back(e);
+    }
+    std::sort(out_user_cpus.begin(), out_user_cpus.end(), [](const AicpuLogicalCpu &a, const AicpuLogicalCpu &b) {
+        return a.cpu_id < b.cpu_id;
+    });
+    return !out_user_cpus.empty();
+}
+
+}  // namespace
+
+bool probe_aicpu_topology(uint32_t device_id, std::vector<AicpuLogicalCpu> &out_user_cpus) {
+    {
+        std::lock_guard<std::mutex> lk(s_topo_cache_mu);
+        auto it = s_topo_cache.find(device_id);
+        if (it != s_topo_cache.end()) {
+            out_user_cpus = it->second;
+            return !out_user_cpus.empty();
+        }
+    }
+
+    // Cache miss — probe outside the lock so concurrent probes on different
+    // devices don't serialize on the driver calls.
+    std::vector<AicpuLogicalCpu> probed;
+    bool ok = probe_aicpu_topology_uncached(device_id, probed);
+    if (!ok) {
+        // Don't cache failures — caller (or next launch) can retry.
+        out_user_cpus.clear();
+        return false;
+    }
+
+    LOG_INFO_V0("AICPU topology probed for device %u: %zu user-schedulable cpu_ids (cached)", device_id, probed.size());
+
+    {
+        std::lock_guard<std::mutex> lk(s_topo_cache_mu);
+        // Last-writer-wins if another thread raced us. The probe is
+        // deterministic for a given device so any result is equivalent.
+        s_topo_cache[device_id] = probed;
+    }
+    out_user_cpus = std::move(probed);
+    return true;
+}
+
+namespace {
+
+// Step 1 — return indices into `user_cpus` for n_sched threads placed
+// inside the tightest unit available.
+//
+// The unit is identified by a predicate over `user_cpus` (same cluster,
+// same die). For each candidate unit, we count its logical cpus; if any
+// has >= n_sched we pick the highest-id unit (tiebreaker: closer to die
+// 1 / cluster 3).
+//
+// "Fill phys round-robin": within the chosen unit, sort entries by
+// (phy_cpu_id ASC, hyperthread_id ASC), then pick the first n_sched in
+// the order [ph_a ht_0, ph_b ht_0, ..., ph_a ht_1, ph_b ht_1, ...].
+// This consumes all ht=0 logical cpus first before doubling onto SMT
+// siblings.
+template <class GetGroup>
+bool try_fit_in_one(
+    const std::vector<AicpuLogicalCpu> &user_cpus, int32_t n_sched, GetGroup get_group,
+    std::vector<int32_t> &out_sched_indices
+) {
+    // Build group buckets, indexed by group id; group ids are dense small
+    // ints (cluster_id ∈ [0, ~3], die_id ∈ [0, 1]).
+    int32_t max_group = -1;
+    for (const auto &c : user_cpus)
+        max_group = std::max(max_group, get_group(c));
+    if (max_group < 0) return false;
+
+    std::vector<std::vector<int32_t>> buckets(max_group + 1);
+    for (int32_t i = 0; i < static_cast<int32_t>(user_cpus.size()); ++i) {
+        buckets[get_group(user_cpus[i])].push_back(i);
+    }
+
+    // Pick the highest-id group with enough logical cpus.
+    int32_t chosen = -1;
+    for (int32_t g = max_group; g >= 0; --g) {
+        if (static_cast<int32_t>(buckets[g].size()) >= n_sched) {
+            chosen = g;
+            break;
+        }
+    }
+    if (chosen < 0) return false;
+
+    // Within the chosen unit, lay out by (phy_cpu_id ASC, hyperthread_id ASC,
+    // cpu_id ASC). This pairs SMT siblings adjacently in the output:
+    //   sched 0 = phy_a ht 0
+    //   sched 1 = phy_a ht 1   (SMT sibling of sched 0)
+    //   sched 2 = phy_b ht 0
+    //   sched 3 = phy_b ht 1   (SMT sibling of sched 2)
+    // Matches the confirmed user-facing layout (see commit message / the
+    // discussion in src/a5/docs/hardware.md "CANN AICPU thread dispatch").
+    std::vector<int32_t> ordered = buckets[chosen];
+    std::sort(ordered.begin(), ordered.end(), [&](int32_t a, int32_t b) {
+        const auto &ca = user_cpus[a];
+        const auto &cb = user_cpus[b];
+        if (ca.phy_cpu_id != cb.phy_cpu_id) return ca.phy_cpu_id < cb.phy_cpu_id;
+        if (ca.hyperthread_id != cb.hyperthread_id) return ca.hyperthread_id < cb.hyperthread_id;
+        return ca.cpu_id < cb.cpu_id;
+    });
+
+    out_sched_indices.assign(ordered.begin(), ordered.begin() + n_sched);
+    return true;
+}
+
+// Step 1.3 — spread across dies. We just take the first n_sched cpus from
+// `user_cpus` sorted by cpu_id; this guarantees a deterministic result.
+void fit_spread(const std::vector<AicpuLogicalCpu> &user_cpus, int32_t n_sched, std::vector<int32_t> &out_indices) {
+    out_indices.clear();
+    for (int32_t i = 0;
+         i < static_cast<int32_t>(user_cpus.size()) && static_cast<int32_t>(out_indices.size()) < n_sched; ++i) {
+        out_indices.push_back(i);
+    }
+}
+
+// Pick the lowest cpu_id from `user_cpus` that satisfies `pred` AND is
+// not already in `used`. Returns -1 if no candidate.
+template <class Pred>
+int32_t
+pick_lowest_for_orch(const std::vector<AicpuLogicalCpu> &user_cpus, const std::vector<int32_t> &used, Pred pred) {
+    int32_t best = -1;
+    for (int32_t i = 0; i < static_cast<int32_t>(user_cpus.size()); ++i) {
+        if (std::find(used.begin(), used.end(), i) != used.end()) continue;
+        if (!pred(user_cpus[i])) continue;
+        if (best < 0 || user_cpus[i].cpu_id < user_cpus[best].cpu_id) best = i;
+    }
+    return best;
+}
+
+}  // namespace
+
+bool compute_allowed_cpus(
+    const std::vector<AicpuLogicalCpu> &user_cpus, int32_t n_sched, int32_t n_orch,
+    std::vector<int32_t> &out_allowed_cpus
+) {
+    out_allowed_cpus.clear();
+    if (n_sched < 0 || n_orch < 0) return false;
+    if (static_cast<int32_t>(user_cpus.size()) < n_sched + n_orch) return false;
+
+    // Step 1 — place sched.
+    std::vector<int32_t> sched_indices;
+    auto by_cluster = [](const AicpuLogicalCpu &c) {
+        return c.cluster_id;
+    };
+    auto by_die = [](const AicpuLogicalCpu &c) {
+        return c.die_id;
+    };
+    if (n_sched > 0) {
+        if (!try_fit_in_one(user_cpus, n_sched, by_cluster, sched_indices)) {
+            if (!try_fit_in_one(user_cpus, n_sched, by_die, sched_indices)) {
+                fit_spread(user_cpus, n_sched, sched_indices);
+            }
+        }
+        if (static_cast<int32_t>(sched_indices.size()) != n_sched) return false;
+    }
+
+    // Step 2 — place orch with priority same-cluster > same-die > spread.
+    // We currently expect n_orch == 1 but keep the loop general.
+    std::vector<int32_t> orch_indices;
+    for (int32_t k = 0; k < n_orch; ++k) {
+        std::vector<int32_t> taken = sched_indices;
+        taken.insert(taken.end(), orch_indices.begin(), orch_indices.end());
+
+        // Determine the cluster_ids / die_ids occupied by sched so far.
+        auto sched_has_cluster = [&](int32_t cid) {
+            for (int32_t i : sched_indices)
+                if (user_cpus[i].cluster_id == cid) return true;
+            return false;
+        };
+        auto sched_has_die = [&](int32_t did) {
+            for (int32_t i : sched_indices)
+                if (user_cpus[i].die_id == did) return true;
+            return false;
+        };
+
+        // 2.1 — same cluster as any sched.
+        int32_t pick = pick_lowest_for_orch(user_cpus, taken, [&](const AicpuLogicalCpu &c) {
+            return sched_has_cluster(c.cluster_id);
+        });
+        // 2.2 — fall back to same die.
+        if (pick < 0) {
+            pick = pick_lowest_for_orch(user_cpus, taken, [&](const AicpuLogicalCpu &c) {
+                return sched_has_die(c.die_id);
+            });
+        }
+        // 2.3 — spread (any free cpu).
+        if (pick < 0) {
+            pick = pick_lowest_for_orch(user_cpus, taken, [](const AicpuLogicalCpu &) {
+                return true;
+            });
+        }
+        if (pick < 0) return false;
+        orch_indices.push_back(pick);
+    }
+
+    // Emit in the canonical [sched..., orch...] order.
+    for (int32_t i : sched_indices)
+        out_allowed_cpus.push_back(user_cpus[i].cpu_id);
+    for (int32_t i : orch_indices)
+        out_allowed_cpus.push_back(user_cpus[i].cpu_id);
+    return true;
+}
+
+}  // namespace pto::a5

--- a/src/a5/platform/onboard/host/aicpu_topology_probe.h
+++ b/src/a5/platform/onboard/host/aicpu_topology_probe.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A5_PLATFORM_ONBOARD_HOST_AICPU_TOPOLOGY_PROBE_H_
+#define SRC_A5_PLATFORM_ONBOARD_HOST_AICPU_TOPOLOGY_PROBE_H_
+
+#include <cstdint>
+#include <vector>
+
+namespace pto::a5 {
+
+// Per-cpu_id metadata used by the packing algorithm. Filled from DSMI
+// CPU_TOPO + halGetDeviceInfo(AICPU, OCCUPY). cluster/die ids derive from
+// phy_cpu_id via the a5 mapping (cluster = phy/2, die = phy/4).
+struct AicpuLogicalCpu {
+    int32_t cpu_id;
+    int32_t phy_cpu_id;
+    int32_t hyperthread_id;  // 0 or 1; 0 for non-SMT phys
+    int32_t cluster_id;      // phy_cpu_id / 2
+    int32_t die_id;          // phy_cpu_id / 4
+};
+
+// Probe device-side AICPU topology. Returns true iff the user pool was
+// successfully resolved (at least one entry in `out_user_cpus`). The output
+// only contains cpu_ids that are in the device-side OCCUPY bitmap (i.e.
+// user-schedulable), sorted by cpu_id ascending.
+//
+// This function performs three driver calls:
+//   * halGetDeviceInfo(AICPU, OCCUPY) — user-schedulable bitmap
+//   * halGetDeviceInfoByBuff(SYSTEM, CPU_TOPO)  (primary)
+//   * dsmi_get_device_info(SOC_INFO, CPU_TOPO)  (fallback)
+//
+// All driver entry points are dlsym'd from the host process (CANN is
+// expected to be already loaded by the surrounding `aclInit` path).
+bool probe_aicpu_topology(uint32_t device_id, std::vector<AicpuLogicalCpu> &out_user_cpus);
+
+// Compute the `ALLOWED_CPUS` selection for the surviving threads.
+//
+// Inputs:
+//   * `user_cpus`  — the user-schedulable pool from `probe_aicpu_topology`
+//   * `n_sched`    — number of scheduler threads (sched 0..n_sched-1)
+//   * `n_orch`     — number of orchestrator threads (currently always 1)
+//
+// Output:
+//   * `out_allowed_cpus` — n_sched + n_orch cpu_ids, ordered as
+//     [sched 0..n_sched-1, orch 0..n_orch-1].  The on-device gate uses
+//     this as `ALLOWED_CPUS[]`; the index in this array IS the deterministic
+//     `exec_idx` the surviving thread receives, so the role assignment in
+//     `aicpu_executor.cpp` (sched / orch) is fully driven by the order here.
+//
+// Placement policy:
+//   Step 1 (sched): smallest containing unit wins —
+//     1.1 a single cluster with >= n_sched logical cpus, else
+//     1.2 a single die with  >= n_sched user logical cpus, else
+//     1.3 spread across dies.
+//     Within the chosen unit, fill phys round-robin (ht 0 of each phy
+//     before doubling up SMT siblings) to minimise pairwise SMT contention.
+//     Tiebreaker between candidate units: highest cluster_id / die_id
+//     (= farthest from cpu_id 0 / AICPU OS).
+//
+//   Step 2 (orch): placed AFTER sched, in the sched-relative priority
+//     order  same cluster > same die > different die.  Within the chosen
+//     unit, the lowest free cpu_id wins.
+//
+// Returns true iff `out_allowed_cpus.size() == n_sched + n_orch`.
+bool compute_allowed_cpus(
+    const std::vector<AicpuLogicalCpu> &user_cpus, int32_t n_sched, int32_t n_orch,
+    std::vector<int32_t> &out_allowed_cpus
+);
+
+}  // namespace pto::a5
+
+#endif  // SRC_A5_PLATFORM_ONBOARD_HOST_AICPU_TOPOLOGY_PROBE_H_

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 
+#include "aicpu_topology_probe.h"
 #include "callable.h"
 #include "callable_protocol.h"
 #include "utils/elf_build_id.h"
@@ -156,6 +157,61 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     if (prepare_runtime_for_launch(runtime, block_dim, launch_aicpu_num) != 0) return -1;
 
+    // a5-specific: probe the AICPU topology + compute ALLOWED_CPUS for the
+    // filter-style gate (see src/common/platform/onboard/aicpu/
+    // platform_aicpu_affinity.cpp::platform_aicpu_affinity_gate_filter).
+    // Convention: indices 0..n_sched-1 = sched slots, last = orch slot.
+    // n_sched = launch_aicpu_num - 1 (one orch + the rest sched). When
+    // launch_aicpu_num == 1 (init-only path) we leave allowed_cpus empty —
+    // the gate is a no-op for a single thread.
+    {
+        std::vector<pto::a5::AicpuLogicalCpu> user_cpus;
+        std::vector<int32_t> allowed;
+        const int32_t n_orch = 1;
+        const int32_t n_sched = (launch_aicpu_num > 1) ? (launch_aicpu_num - n_orch) : 0;
+        runtime.aicpu_allowed_cpu_count = 0;
+        if (n_sched > 0) {
+            if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
+                LOG_ERROR("AICPU topology probe failed; affinity gate will drop all threads");
+                return -1;
+            }
+            if (!pto::a5::compute_allowed_cpus(user_cpus, n_sched, n_orch, allowed)) {
+                LOG_ERROR(
+                    "AICPU topology has %zu user cpus, cannot fit %d sched + %d orch", user_cpus.size(), n_sched, n_orch
+                );
+                return -1;
+            }
+            const size_t cap = sizeof(runtime.aicpu_allowed_cpus) / sizeof(runtime.aicpu_allowed_cpus[0]);
+            if (allowed.size() > cap) {
+                LOG_ERROR("compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
+                return -1;
+            }
+            for (size_t i = 0; i < allowed.size(); ++i)
+                runtime.aicpu_allowed_cpus[i] = allowed[i];
+            runtime.aicpu_allowed_cpu_count = static_cast<int32_t>(allowed.size());
+            // Launch one AICPU thread per OCCUPY-visible user cpu so CANN
+            // spreads exactly across the user pool — over-subscription on a
+            // SKU with fewer user cpus than the compile-time bound deadlocks
+            // the production AICPU kernel. Capped by the compile-time array
+            // sizing in case the SKU exceeds expectation.
+            int32_t launch_n = static_cast<int32_t>(user_cpus.size());
+            if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
+                launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+            }
+            runtime.aicpu_launch_count = launch_n;
+            std::string dump;
+            for (size_t i = 0; i < allowed.size(); ++i) {
+                if (i) dump += ", ";
+                dump += std::to_string(allowed[i]);
+                if (i + 1 == allowed.size()) dump += "(orch)";
+            }
+            LOG_INFO_V0(
+                "AICPU ALLOWED_CPUS = [%s] (n_sched=%d, n_orch=%d, launch=%d, user_cpus=%zu)", dump.c_str(), n_sched,
+                n_orch, launch_n, user_cpus.size()
+            );
+        }
+    }
+
     // Scope guards for cleanup on all exit paths
     auto regs_cleanup = RAIIScopeGuard([this]() {
         if (kernel_args_.args.regs != 0) {
@@ -229,9 +285,15 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
-    rc = launch_aicpu_kernel(
-        stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
-    );
+    // launch_count = popcount(OCCUPY) from the topology probe — one thread
+    // per user-schedulable cpu_id. The filter gate barriers exactly this
+    // many threads (runtime.aicpu_launch_count is read on the device side
+    // by kernel.cpp). Fall back to the caller-requested active count when
+    // the probe was skipped (single-thread init / launch_aicpu_num == 1)
+    // — over-launching to the compile-time bound on that path would
+    // start 14 threads to do a 1-thread job and deadlock the device.
+    int aicpu_launch_n = (runtime.aicpu_launch_count > 0) ? runtime.aicpu_launch_count : launch_aicpu_num;
+    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         return rc;

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -18,6 +18,7 @@
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/pmu_collector_aicpu.h"
+#include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "callable.h"
@@ -1114,9 +1115,16 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 }
 
 int AicpuExecutor::run(Runtime *runtime) {
-    int thread_idx = thread_idx_++;
+    // Prefer the filter gate's deterministic exec_idx (host-computed
+    // ALLOWED_CPUS slot) over fetch-add arrival order. host_build_graph
+    // has no orch/sched split — every surviving thread runs the same
+    // dispatch loop — but using exec_idx keeps the (cpu_id, thread_idx)
+    // mapping stable across launches, which matters for the
+    // core_assignments_[thread_idx] tables here and for log readability.
+    int affinity_exec_idx = platform_aicpu_affinity_thread_idx();
+    int thread_idx = (affinity_exec_idx >= 0) ? affinity_exec_idx : (thread_idx_++);
 
-    LOG_INFO_V0("Thread %d: Start", thread_idx);
+    LOG_INFO_V0("Thread %d: Start (exec_idx=%d)", thread_idx, affinity_exec_idx);
 
     const int *cur_thread_cores = core_assignments_[thread_idx];
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,6 +45,9 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     aicpu_thread_num = 1;
+    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
+    aicpu_allowed_cpu_count = 0;
+    aicpu_launch_count = 0;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;
     tensor_allocation_storage_ = nullptr;

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -223,6 +223,28 @@ public:
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
+    // Filter-style affinity gate input (a5 onboard). Placed AFTER `tasks`
+    // because AICore reads runtime->tasks[] by offset (see
+    // src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp); inserting
+    // fields before `tasks` shifts that offset and silently produces NaN
+    // outputs in any test that exercises the AICore task-execute path.
+    // Host fills before launch from device-side OCCUPY + DSMI CPU_TOPO via
+    // pto::a5::compute_allowed_cpus. The on-device gate keeps threads whose
+    // sched_getcpu() lands on one of these cpu_ids; exec_idx = position in
+    // this array drives sched/orch role assignment. Indices 0..count-2 are
+    // scheduler slots, index count-1 is the orchestrator slot. Sized to
+    // PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH for headroom — current
+    // policy is 4 sched + 1 orch = 5 active.
+    int32_t aicpu_allowed_cpus[16];
+    int32_t aicpu_allowed_cpu_count;
+    // Actual AICPU thread launch count for this run. Set by the host
+    // topology probe to popcount(OCCUPY) so CANN spreads threads across
+    // every user-schedulable cpu_id (one per cpu, no over-subscription on
+    // the same physical cpu — over-subscription deadlocks the production
+    // AICPU kernel on SKUs with fewer user cpus than the compile-time
+    // PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH bound).
+    int32_t aicpu_launch_count;
+
 private:
     int next_task_id;  // Next available task ID
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -24,6 +24,7 @@
 
 #include "aicpu/device_time.h"
 #include "aicpu/orch_so_file.h"
+#include "aicpu/platform_aicpu_affinity.h"
 #include "callable_protocol.h"
 #include "pto2_dispatch_payload.h"
 #include "runtime.h"
@@ -211,9 +212,15 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
 int32_t AicpuExecutor::run(Runtime *runtime) {
-    int32_t thread_idx = thread_idx_++;
+    // Prefer the filter gate's deterministic exec_idx so role assignment
+    // (sched 0..N-2 / orch N-1) is driven by host-computed ALLOWED_CPUS,
+    // not arrival order. Fall back to the legacy fetch-add counter on
+    // platforms where the filter gate is inactive (sim sets exec_idx via
+    // its own stub; the fallback covers any path that bypassed the gate).
+    int32_t affinity_exec_idx = platform_aicpu_affinity_thread_idx();
+    int32_t thread_idx = (affinity_exec_idx >= 0) ? affinity_exec_idx : (thread_idx_++);
     int32_t run_rc = 0;
-    LOG_INFO_V0("Thread %d: Start", thread_idx);
+    LOG_INFO_V0("Thread %d: Start (exec_idx=%d)", thread_idx, affinity_exec_idx);
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -200,6 +200,21 @@ public:
     int aicpu_thread_num;
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
+    // Filter-style affinity gate input (a5 onboard). Host fills before
+    // launch from device-side OCCUPY + DSMI CPU_TOPO via
+    // pto::a5::compute_allowed_cpus. The on-device gate keeps threads whose
+    // sched_getcpu() lands on one of these cpu_ids; exec_idx = position in
+    // this array drives sched/orch role assignment. Indices 0..count-2 are
+    // scheduler slots, index count-1 is the orchestrator slot. Sized to
+    // PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH for headroom — current
+    // policy is 4 sched + 1 orch = 5 active.
+    int32_t aicpu_allowed_cpus[16];
+    int32_t aicpu_allowed_cpu_count;
+    // Actual AICPU thread launch count for this run. Host sets from
+    // popcount(OCCUPY) via the topology probe. See the matching field in
+    // src/a5/runtime/host_build_graph/runtime/runtime.h for rationale.
+    int32_t aicpu_launch_count;
+
     // Ring buffer size overrides (0 = use compile-time defaults)
     uint64_t task_window_size;
     uint64_t heap_size;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -34,6 +34,9 @@ Runtime::Runtime() {
     worker_count = 0;
     aicpu_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
+    aicpu_allowed_cpu_count = 0;
+    aicpu_launch_count = 0;
     task_window_size = 0;
     heap_size = 0;
     dep_pool_size = 0;

--- a/src/common/platform/include/aicpu/platform_aicpu_affinity.h
+++ b/src/common/platform/include/aicpu/platform_aicpu_affinity.h
@@ -16,4 +16,38 @@
 // Returns false if this thread should exit (dropped).
 // logical_count: desired active threads (from runtime.aicpu_thread_num)
 // total_launched: actual threads launched (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)
+//
+// Used by a2a3 (cluster-majority heuristic) and a5 sim. a5 onboard uses the
+// _filter variant below instead.
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched);
+
+// Filter-style affinity gate. Every launched thread reads sched_getcpu(),
+// barriers, and the gate keeps exactly those whose cpu_id appears in
+// `allowed_cpus[0..allowed_count-1]`. The deterministic survivor index
+// (its position in `allowed_cpus`) is exposed through
+// platform_aicpu_affinity_thread_idx() and drives role assignment
+// downstream (sched / orch).
+//
+// Convention used by a5: indices 0..allowed_count-2 are scheduler slots,
+// index allowed_count-1 is the orchestrator slot. The host builds
+// `allowed_cpus` from device-side OCCUPY + DSMI CPU_TOPO via
+// `pto::a5::compute_allowed_cpus` (see
+// src/a5/platform/onboard/host/aicpu_topology_probe.h) and passes the
+// array down through the Runtime struct.
+//
+// total_launched is the number of AICPU threads CANN actually launched
+// (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH on the target arch); the
+// gate stops exactly that many threads on its barrier and lets only the
+// allowed_count survivors continue.
+bool platform_aicpu_affinity_gate_filter(const int32_t *allowed_cpus, int32_t allowed_count, int32_t total_launched);
+
+// Deterministic position (0..allowed_count-1) of the calling thread in the
+// `allowed_cpus[]` array that was passed to the most recent
+// platform_aicpu_affinity_gate_filter() invocation on this thread.
+// Returns -1 if this thread was dropped or did not go through the filter
+// gate.
+//
+// Stable across the lifetime of the surviving thread — safe to call from
+// aicpu_executor as the per-launch role identifier (sched 0..N-2 / orch
+// N-1).
+int32_t platform_aicpu_affinity_thread_idx();

--- a/src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -21,7 +21,10 @@
 static constexpr int32_t AICPU_CORES_PER_CHIP = 8;
 static constexpr int32_t MAX_CLUSTERS = 2;
 static constexpr int32_t CPUS_PER_CLUSTER = 4;
-static constexpr int32_t MAX_GATE_THREADS = 8;
+// 16 = headroom for a5's launch budget (14 logical user cpus on the
+// 0x7ffe SKU) + a small over-launch margin. a2a3 only ever launches 6
+// threads and never approaches this bound.
+static constexpr int32_t MAX_GATE_THREADS = 16;
 
 static std::atomic<uint64_t> s_cpumask{0};
 static std::atomic<int32_t> s_reported{0};
@@ -147,3 +150,140 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     return survive;
 }
+
+// =============================================================================
+// Filter-style gate (a5 onboard).
+// =============================================================================
+//
+// All `total_launched` threads enter, each reads sched_getcpu() and reports
+// to s_filter_thread_cpu[]. After the barrier, the CAS-winner classifies:
+// for each report, look up cpu_id in `allowed_cpus[]`; if found, the thread
+// survives and gets exec_idx = index in allowed_cpus[]. Misses are dropped.
+//
+// State is shared with the legacy gate where harmless (s_reported,
+// s_gate_init, s_gate_ready, s_cleanup) — only one variant runs in any
+// given build (a2a3 uses the legacy gate; a5 onboard uses this one).
+
+// Per-thread output of the filter gate. -1 = dropped (this thread was not
+// in allowed_cpus when the CAS-winner classified). Otherwise = position in
+// allowed_cpus[0..allowed_count-1], used downstream as sched/orch role id.
+static thread_local int32_t tl_filter_exec_idx = -1;
+
+// Per-launch barrier + classification state, parallel to the legacy gate.
+// Two counters: s_filter_claim hands out a unique slot via fetch_add so each
+// thread writes to a distinct s_filter_thread_cpu[idx]. s_filter_published
+// is bumped (release) AFTER the cpu write — the classification barrier
+// waits on the publish counter (acquire), so when it equals total_launched
+// every thread's cpu write is visible. A single counter cannot do this:
+// if the barrier waits on the same counter that fetch_add already moved,
+// the cpu store between fetch_add and the barrier check is unordered.
+static std::atomic<int32_t> s_filter_claim{0};
+static std::atomic<int32_t> s_filter_published{0};
+static std::atomic<int32_t> s_filter_classify_init{0};
+static std::atomic<int32_t> s_filter_classify_ready{0};
+static std::atomic<int32_t> s_filter_cleanup{0};
+static int32_t s_filter_thread_cpu[MAX_GATE_THREADS];
+static int32_t s_filter_thread_exec_idx[MAX_GATE_THREADS];
+
+bool platform_aicpu_affinity_gate_filter(const int32_t *allowed_cpus, int32_t allowed_count, int32_t total_launched) {
+    tl_filter_exec_idx = -1;
+
+    // Bound-check both inputs against the static slot buffers
+    // (s_filter_thread_cpu[MAX_GATE_THREADS] etc.) before any indexing.
+    // Without this, allowed_count or total_launched > MAX_GATE_THREADS
+    // would silently truncate the classification loop and let the
+    // diagnostic dump read past `allowed_cpus[]`.
+    if (allowed_cpus == nullptr || allowed_count <= 0 || allowed_count > MAX_GATE_THREADS || total_launched <= 0 ||
+        total_launched > MAX_GATE_THREADS) {
+        LOG_ERROR(
+            "AICPU filter gate: invalid config allowed_count=%d total_launched=%d (max=%d) — dropping all threads",
+            allowed_count, total_launched, MAX_GATE_THREADS
+        );
+        return false;
+    }
+
+    int32_t idx = s_filter_claim.fetch_add(1, std::memory_order_acq_rel);
+#if defined(__aarch64__) || defined(__x86_64__)
+    int32_t cpu = sched_getcpu();
+#else
+    int32_t cpu = -1;
+#endif
+
+    if (idx < MAX_GATE_THREADS) s_filter_thread_cpu[idx] = cpu;
+
+    // Publish: release-ordered increment ensures the s_filter_thread_cpu[idx]
+    // store above is visible to any thread that observes the new published
+    // value via acquire load.
+    s_filter_published.fetch_add(1, std::memory_order_release);
+    // Barrier: wait until every launched thread has published its cpu.
+    while (s_filter_published.load(std::memory_order_acquire) < total_launched) {}
+
+    // One thread classifies for everyone.
+    int32_t expected = 0;
+    if (s_filter_classify_init.compare_exchange_strong(
+            expected, 1, std::memory_order_acq_rel, std::memory_order_acquire
+        )) {
+        for (int32_t i = 0; i < total_launched && i < MAX_GATE_THREADS; ++i)
+            s_filter_thread_exec_idx[i] = -1;
+
+        // For each reporting thread, see if its cpu is in allowed_cpus.
+        // O(total_launched * allowed_count) — both ≤ ~16, fine.
+        // We DO allow duplicate cpu_id landings (CANN over-subscribes the
+        // sink cpu when launch_count >= popcount(OCCUPY)). The first thread
+        // that lands on each allowed cpu wins; later duplicates are dropped.
+        bool slot_filled[MAX_GATE_THREADS] = {false};
+        for (int32_t tid = 0; tid < total_launched && tid < MAX_GATE_THREADS; ++tid) {
+            int32_t my_cpu = s_filter_thread_cpu[tid];
+            if (my_cpu < 0) continue;
+            for (int32_t a = 0; a < allowed_count && a < MAX_GATE_THREADS; ++a) {
+                if (allowed_cpus[a] == my_cpu && !slot_filled[a]) {
+                    s_filter_thread_exec_idx[tid] = a;
+                    slot_filled[a] = true;
+                    break;
+                }
+            }
+        }
+
+        // Diagnostic: dump the allowed table once.
+        // (Lower-volume than a per-thread line; cheaper at INFO.)
+        LOG_INFO_V0("AICPU filter gate: allowed_count=%d total_launched=%d", allowed_count, total_launched);
+        for (int32_t a = 0; a < allowed_count; ++a) {
+            const char *role = (a == allowed_count - 1) ? "orch" : "sched";
+            LOG_INFO_V0("AICPU filter gate:   allowed[%d] = cpu_id %d  role=%s", a, allowed_cpus[a], role);
+        }
+
+        s_filter_classify_ready.store(1, std::memory_order_release);
+    }
+
+    while (s_filter_classify_ready.load(std::memory_order_acquire) == 0) {}
+
+    bool survive;
+    if (idx < total_launched && idx < MAX_GATE_THREADS) {
+        tl_filter_exec_idx = s_filter_thread_exec_idx[idx];
+        survive = (tl_filter_exec_idx >= 0);
+    } else {
+        tl_filter_exec_idx = -1;
+        survive = false;
+    }
+
+    // Reset gate state after the last thread has read its result.
+    if (s_filter_cleanup.fetch_add(1, std::memory_order_acq_rel) + 1 == total_launched) {
+        s_filter_claim.store(0, std::memory_order_release);
+        s_filter_published.store(0, std::memory_order_release);
+        s_filter_classify_init.store(0, std::memory_order_release);
+        s_filter_classify_ready.store(0, std::memory_order_release);
+        s_filter_cleanup.store(0, std::memory_order_release);
+    }
+
+    if (survive) {
+        const char *role = (tl_filter_exec_idx == allowed_count - 1) ? "orch" : "sched";
+        LOG_INFO_V0(
+            "AICPU filter gate: thread idx=%d cpu=%d exec_idx=%d ACTIVE(%s)", idx, cpu, tl_filter_exec_idx, role
+        );
+    } else {
+        LOG_INFO_V0("AICPU filter gate: thread idx=%d cpu=%d DROPPED", idx, cpu);
+    }
+    return survive;
+}
+
+int32_t platform_aicpu_affinity_thread_idx() { return tl_filter_exec_idx; }

--- a/src/common/platform/sim/aicpu/platform_aicpu_affinity.cpp
+++ b/src/common/platform/sim/aicpu/platform_aicpu_affinity.cpp
@@ -42,3 +42,45 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 
     return survive;
 }
+
+// =============================================================================
+// Filter-style gate (sim stub).
+//
+// Sim threads run on arbitrary host cores; the cpu_id pinning the onboard
+// filter gate reasons about does not exist. We approximate the surviving
+// semantics by mapping the first `allowed_count` arriving threads to
+// exec_idx 0..allowed_count-1 (which downstream interprets as sched 0..N-2
+// + orch N-1) and dropping the rest. Role classification still works; the
+// actual SMT/cluster locality the onboard gate provides is not applicable.
+// =============================================================================
+
+static thread_local int32_t tl_filter_exec_idx = -1;
+static std::atomic<int32_t> s_filter_counter{0};
+static std::atomic<int32_t> s_filter_cleanup{0};
+
+bool platform_aicpu_affinity_gate_filter(
+    const int32_t * /*allowed_cpus*/, int32_t allowed_count, int32_t total_launched
+) {
+    tl_filter_exec_idx = -1;
+    if (allowed_count <= 0) return false;
+
+    int32_t idx = s_filter_counter.fetch_add(1, std::memory_order_acq_rel);
+    bool survive = (idx < allowed_count);
+    tl_filter_exec_idx = survive ? idx : -1;
+
+    if (!survive) {
+        LOG_INFO_V0(
+            "AICPU filter gate (sim): thread idx=%d DROPPED (allowed=%d, launched=%d)", idx, allowed_count,
+            total_launched
+        );
+    }
+
+    int32_t cleanup_idx = s_filter_cleanup.fetch_add(1, std::memory_order_acq_rel);
+    if (cleanup_idx + 1 == total_launched) {
+        s_filter_counter.store(0, std::memory_order_release);
+        s_filter_cleanup.store(0, std::memory_order_release);
+    }
+    return survive;
+}
+
+int32_t platform_aicpu_affinity_thread_idx() { return tl_filter_exec_idx; }

--- a/tools/cann-examples/aicpu-thread-spread/README.md
+++ b/tools/cann-examples/aicpu-thread-spread/README.md
@@ -1,0 +1,138 @@
+# aicpu-thread-spread
+
+Asks CANN to launch **N AICPU threads** via `rtsLaunchCpuKernel` and
+reads back what `cpu_id` each thread landed on. Answers the question
+"if I ask for N threads, which user cpus does CANN actually distribute
+them to?" — a hard prerequisite for any device-side affinity / packing
+design that wants to do post-hoc selection over the AICPU user pool.
+
+Reuses the same dispatcher bootstrap path as
+[`aicpu-device-query`](../aicpu-device-query/README.md); the only
+difference is the inner SO records `sched_getcpu()` instead of running
+HAL queries, and the launch is multi-threaded.
+
+## What it answered
+
+On a5 device 0 of one dev box (`Ascend950PR_9599`, OCCUPY=0x1f8, 6 user
+cores at cpu_id 3..8):
+
+| `aicpu_num` | cpu_ids hit (with duplicates) | observation |
+| ----------- | ----------------------------- | ----------- |
+| 1 | 8 | default sink cpu |
+| 6 | 3 4 5 6 7 8 | exactly fills the user pool |
+| 7 | 3 4 5 6 7 8 **8** | over-launch doubles up on cpu_id 8 |
+| 8 | 3 4 5 6 7 **8 8 8** | three threads share cpu_id 8 |
+| 14 | 3 3 4 4 5 5 6 6 7 7 **8 8 8 8** | every cpu doubled, sink quadrupled |
+
+Conclusions (recorded in
+[`src/a5/docs/hardware.md`](../../../src/a5/docs/hardware.md#cann-aicpu-thread-dispatch-under-varying-launch-budgets)):
+
+1. CANN dispatch set = OCCUPY exactly — threads never land on a non-OCCUPY cpu_id
+2. Over-launch (N > popcount(OCCUPY)) doubles up on a "sink" cpu rather than expanding the set
+3. `launch_count = popcount(OCCUPY)` is the sweet spot for device-side affinity gates
+
+This only confirms behavior on the **0x1f8 SKU** (Scenario A). The
+0x7ffe SKU (Scenario B, 14 user cores) needs the same test on a chip
+that exposes it — see "Run" below.
+
+## Architecture
+
+Three pieces, same wiring as
+[`aicpu-device-query`](../aicpu-device-query/) (which reuses the
+production dispatcher):
+
+```text
++---------------------+        rtAicpuKernelLaunchExWithArgs (KFC, libaicpu_extend_kernels)
+|   host launcher     | ---->  bootstrap: dispatcher SO dlopens, writes inner SO bytes to
+|  aicpu_thread_spread|        /usr/lib64/aicpu_kernels/0/aicpu_kernels_device/simpler_inner_<fp>_<dev>.so
++---------------------+
+          |
+          | rtsBinaryLoadFromFile (JSON), rtsFuncGetByName, rtsLaunchCpuKernel(aicpu_num=N)
+          v
++----------------------+
+| libaicpu_thread_     |   N AICPU OS threads enter simpler_aicpu_spread:
+|   spread.so          |     - sched_getcpu()
+| (inner SO)           |     - claim slot via static atomic
++----------------------+     - write {thread_idx, cpu_id} to GM
+          |
+          | D2H aclrtMemcpy
+          v
++---------------------+
+|   host launcher     | pretty-print: arrival order + cpu_id histogram
++---------------------+
+```
+
+`simpler_aicpu_init` is launched single-threaded once per probe call to
+reset the static slot counter — same idiom production uses
+([`src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp`](../../../src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp)
+resets `thread_idx_` in `deinit`).
+
+The dispatcher SO comes from a normal `pip install .` runtime build —
+build the runtime first if you have not. Either `a5` or `a2a3` works;
+both arches accept the same inner SO body.
+
+## Build
+
+```bash
+export ASCEND_HOME_PATH=/usr/local/Ascend/ascend-toolkit/latest
+
+# 1. cross-compile device SO
+(cd tools/cann-examples/aicpu-thread-spread/device && \
+   mkdir -p build && cd build && \
+   cmake .. -DCMAKE_C_COMPILER=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu-gcc \
+            -DCMAKE_CXX_COMPILER=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu-g++ && \
+   cmake --build .)
+
+# 2. host launcher
+(cd tools/cann-examples/aicpu-thread-spread/host && \
+   mkdir -p build && cd build && cmake .. && cmake --build .)
+```
+
+## Run
+
+```bash
+REPO=$PWD
+export SIMPLER_DISPATCHER_SO=$REPO/build/lib/a5/dispatcher/libsimpler_aicpu_dispatcher.so
+export SIMPLER_AICPU_SPREAD_SO=$REPO/tools/cann-examples/aicpu-thread-spread/device/build/libaicpu_thread_spread.so
+
+# Always run hardware work via task-submit on shared dev boxes (see
+# .claude/rules/task-submit-isolation.md).
+task-submit --device auto --device-num 1 \
+    --run "for N in 1 6 7 8 14; do
+             echo '====== launch_count='\$N' ======'
+             $REPO/tools/cann-examples/aicpu-thread-spread/host/build/aicpu_thread_spread \$TASK_DEVICE \$N
+           done"
+```
+
+Each run prints arrival order (`thread_idx -> cpu_id`) and a sorted
+histogram of cpu_ids hit. To know your device's OCCUPY before reading
+the spread, run
+[`aicpu-device-query`](../aicpu-device-query/README.md) first.
+
+## Validating Scenario B (0x7ffe SKU)
+
+On a chip that reports `AICPU + OCCUPY = 0x7ffe` device-side (14 user
+cpu_ids 1..14), the expected outcome is:
+
+- `aicpu_num=7` lands on a subset (likely cpu_id 1..7 or a similar
+  low-half bias) — the spread tool will show which
+- `aicpu_num=14` should reach all 14 user cpu_ids, each exactly once
+- `aicpu_num=15+` should over-saturate the sink cpu the same way
+
+If the 14-thread launch does **not** spread to all 14 cpu_ids on a
+0x7ffe SKU, that's a stronger constraint than the dispatch-equals-OCCUPY
+rule observed on 0x1f8 — record the actual spread and update both this
+README and `src/a5/docs/hardware.md`.
+
+## Scope and limits
+
+- Only the AICPU OS user pool is probed — kernel cpu placement on the
+  host or AICore is unrelated.
+- Single-launch per pretty-print run; static slot counter is reset by
+  `simpler_aicpu_init` between launches. Concurrent `--device` clients
+  would each get an independent process and an independent SO instance.
+- Inner SO uses local device id `0` (`self_did = 0`) where the
+  dispatcher convention requires it — same as `aicpu-device-query`.
+- This tool is a diagnostic spike. The host launcher reuses
+  `aicpu-device-query`'s bootstrap boilerplate verbatim; if that tool's
+  load mechanism breaks, this one will too.

--- a/tools/cann-examples/aicpu-thread-spread/device/CMakeLists.txt
+++ b/tools/cann-examples/aicpu-thread-spread/device/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+#
+# Cross-compiles aicpu_thread_spread.so for the AICPU device side.
+# Caller must set CMAKE_C_COMPILER / CMAKE_CXX_COMPILER to the aarch64 cross
+# toolchain (e.g. ${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu-g++).
+
+cmake_minimum_required(VERSION 3.16)
+project(aicpu_thread_spread LANGUAGES C CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(FATAL_ERROR "ASCEND_HOME_PATH must be set")
+endif()
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+
+add_library(aicpu_thread_spread SHARED aicpu_thread_spread.cpp)
+
+target_include_directories(aicpu_thread_spread PRIVATE
+    ${ASCEND_HOME_PATH}/include
+)
+
+target_compile_options(aicpu_thread_spread PRIVATE
+    -Wall -Wextra -O2 -fPIC -fno-common -g
+)
+
+# Build-id needed: dispatcher fingerprints by ELF Build-ID (FNV-1a fallback only
+# fires when no build-id note is present).
+set_target_properties(aicpu_thread_spread PROPERTIES
+    LINK_FLAGS "-Wl,--build-id"
+    OUTPUT_NAME "aicpu_thread_spread"
+)

--- a/tools/cann-examples/aicpu-thread-spread/device/aicpu_thread_spread.cpp
+++ b/tools/cann-examples/aicpu-thread-spread/device/aicpu_thread_spread.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+//
+// aicpu_thread_spread — diagnostic inner SO that records what cpu_id CANN
+// dispatches each AICPU thread to under a given launch budget.
+//
+// Per-launch protocol (host side):
+//   1. zero the GM output region
+//   2. launch simpler_aicpu_init (1 thread) — resets the static counter
+//   3. launch simpler_aicpu_spread (N threads) — each writes one slot
+//   4. sync + read back
+//
+// Static atomics work in the AICPU process (same pattern as production
+// aicpu_executor.cpp's thread_idx_); GM-side atomics from device glibc
+// appear to trap, so we use the static-counter route.
+
+#include <sched.h>
+
+#include <atomic>
+#include <cstdint>
+
+namespace {
+
+struct DeviceArgs {
+    uint64_t reserved_pre[12];  // 0..95 — unused on this path
+    uint64_t output_addr;       // 96
+    uint64_t max_slots;         // 104
+};
+
+struct KernelArgs {
+    uint64_t _pad[5];
+    void *device_args;
+};
+
+#pragma pack(push, 4)
+struct SpreadRecord {
+    int32_t thread_idx;
+    int32_t cpu_id;
+};
+struct SpreadOutput {
+    uint32_t claim_counter;  // host zeroes before launch; threads bump on write
+    uint32_t _pad;
+    SpreadRecord records[1];  // capacity = max_slots
+};
+#pragma pack(pop)
+static_assert(sizeof(SpreadRecord) == 8, "SpreadRecord size drift");
+
+extern "C" void DlogRecord(int moduleId, int level, const char *fmt, ...);
+constexpr int kDlogModuleCcecpu = 3;
+constexpr int kDlogLevelError = 3;
+void DiagLog(const char *msg) { DlogRecord(kDlogModuleCcecpu, kDlogLevelError, "[aicpu-spread] %s", msg); }
+
+// Per-launch static counter. Reset by simpler_aicpu_init before each spread
+// launch. Lives in AICPU process memory — safe for atomic ops, unlike GM.
+std::atomic<uint32_t> s_claim{0};
+
+}  // namespace
+
+extern "C" {
+
+__attribute__((visibility("default"))) int simpler_aicpu_init(void *args) {
+    (void)args;
+    s_claim.store(0, std::memory_order_release);
+    return 0;
+}
+
+__attribute__((visibility("default"))) int simpler_aicpu_spread(void *args) {
+    if (args == nullptr) {
+        DiagLog("simpler_aicpu_spread: args==nullptr");
+        return 1;
+    }
+    auto *k = reinterpret_cast<KernelArgs *>(args);
+    auto *d = reinterpret_cast<DeviceArgs *>(k->device_args);
+    if (d == nullptr || d->output_addr == 0 || d->max_slots == 0) {
+        DiagLog("simpler_aicpu_spread: missing GM I/O");
+        return 1;
+    }
+
+    auto *out = reinterpret_cast<SpreadOutput *>(d->output_addr);
+    const uint32_t cap = static_cast<uint32_t>(d->max_slots);
+
+    int cpu = sched_getcpu();
+
+    uint32_t idx = s_claim.fetch_add(1u, std::memory_order_acq_rel);
+    if (idx < cap) {
+        out->records[idx].thread_idx = static_cast<int32_t>(idx);
+        out->records[idx].cpu_id = static_cast<int32_t>(cpu);
+        // Host can't atomically read the static counter (it lives in the AICPU
+        // process), so each thread bumps the GM-side claim_counter as a
+        // best-effort "how many slots to scan" hint. Concurrent stores race,
+        // but bounded by launch_count anyway.
+        out->claim_counter = idx + 1;
+    }
+    return 0;
+}
+
+}  // extern "C"

--- a/tools/cann-examples/aicpu-thread-spread/host/CMakeLists.txt
+++ b/tools/cann-examples/aicpu-thread-spread/host/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+project(aicpu_thread_spread LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(FATAL_ERROR "ASCEND_HOME_PATH must be set")
+endif()
+set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+
+add_executable(aicpu_thread_spread aicpu_thread_spread.cpp)
+
+target_include_directories(aicpu_thread_spread PRIVATE
+    ${ASCEND_HOME_PATH}/include
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc/runtime
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc/runtime/runtime
+    ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/pkg_inc/profiling
+)
+
+target_link_directories(aicpu_thread_spread PRIVATE
+    ${ASCEND_HOME_PATH}/lib64
+    ${ASCEND_HOME_PATH}/runtime/lib64
+)
+
+target_link_libraries(aicpu_thread_spread PRIVATE ascendcl runtime)

--- a/tools/cann-examples/aicpu-thread-spread/host/aicpu_thread_spread.cpp
+++ b/tools/cann-examples/aicpu-thread-spread/host/aicpu_thread_spread.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+//
+// aicpu_thread_spread — host launcher that asks CANN to start N AICPU
+// threads and reads back what cpu_id each thread landed on.
+//
+// Usage: aicpu_thread_spread <device_id> <launch_count>
+//
+// Pipeline is the same as aicpu-device-query (dispatcher bootstrap + inner
+// SO via rtsBinaryLoadFromFile + rtsLaunchCpuKernel), only:
+//   * launch_count threads instead of 1 (passed as aicpu_num to
+//     rtsLaunchCpuKernel)
+//   * inner SO is aicpu_thread_spread.so; entry point simpler_aicpu_spread
+//   * GM output is SpreadOutput { claim_counter; SpreadRecord[] }
+
+#include <acl/acl.h>
+#include <runtime/rt.h>
+#include <runtime/runtime/rts/rts_kernel.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+// ELF Build-ID fingerprinting — must match the dispatcher's hash so the
+// derived preinstall basename agrees. Identical to query_device_hal.cpp
+// (kept inline to keep this tool standalone).
+namespace fp {
+
+bool ElfBuildId(const char *data, size_t len, uint64_t *out) {
+    if (len < 64) return false;
+    if (std::memcmp(
+            data,
+            "\x7f"
+            "ELF",
+            4
+        ) != 0)
+        return false;
+    if (data[4] != 2) return false;
+    uint64_t e_shoff;
+    uint16_t e_shentsize, e_shnum, e_shstrndx;
+    std::memcpy(&e_shoff, data + 40, 8);
+    std::memcpy(&e_shentsize, data + 58, 2);
+    std::memcpy(&e_shnum, data + 60, 2);
+    std::memcpy(&e_shstrndx, data + 62, 2);
+    if (e_shentsize != 64 || e_shoff + (uint64_t)e_shentsize * e_shnum > len) return false;
+    const char *strtab = nullptr;
+    {
+        const char *sh = data + e_shoff + (uint64_t)e_shentsize * e_shstrndx;
+        uint64_t off;
+        uint64_t sz;
+        std::memcpy(&off, sh + 24, 8);
+        std::memcpy(&sz, sh + 32, 8);
+        if (off + sz > len) return false;
+        strtab = data + off;
+    }
+    for (uint16_t i = 0; i < e_shnum; ++i) {
+        const char *sh = data + e_shoff + (uint64_t)e_shentsize * i;
+        uint32_t sh_name;
+        uint32_t sh_type;
+        uint64_t sh_off;
+        uint64_t sh_size;
+        std::memcpy(&sh_name, sh + 0, 4);
+        std::memcpy(&sh_type, sh + 4, 4);
+        std::memcpy(&sh_off, sh + 24, 8);
+        std::memcpy(&sh_size, sh + 32, 8);
+        if (sh_type != 7) continue;
+        const char *nm = strtab + sh_name;
+        if (std::strcmp(nm, ".note.gnu.build-id") != 0) continue;
+        if (sh_size < 16 || sh_off + sh_size > len) return false;
+        const char *p = data + sh_off;
+        uint32_t namesz, descsz, type;
+        std::memcpy(&namesz, p + 0, 4);
+        std::memcpy(&descsz, p + 4, 4);
+        std::memcpy(&type, p + 8, 4);
+        if (type != 3 || descsz < 8) return false;
+        size_t name_aligned = (namesz + 3u) & ~3u;
+        const char *desc = p + 12 + name_aligned;
+        std::memcpy(out, desc, 8);
+        return true;
+    }
+    return false;
+}
+
+uint64_t Fnv1a(const char *data, size_t len) {
+    uint64_t h = 0xcbf29ce484222325ULL;
+    for (size_t i = 0; i < len; ++i) {
+        h ^= (unsigned char)data[i];
+        h *= 0x100000001b3ULL;
+    }
+    return h;
+}
+
+uint64_t Compute(const char *data, size_t len) {
+    uint64_t fp;
+    if (ElfBuildId(data, len, &fp)) return fp;
+    return Fnv1a(data, len);
+}
+
+}  // namespace fp
+
+namespace {
+
+constexpr size_t kDeviceArgsBytes = 160;
+constexpr uint32_t kMaxSlots = 64;  // upper bound on launch_count we accept
+
+#define ACL_CHECK(call, msg)                                                    \
+    do {                                                                        \
+        aclError _rc = (call);                                                  \
+        if (_rc != ACL_SUCCESS) {                                               \
+            std::fprintf(stderr, "%s failed: %d (%s)\n", #call, (int)_rc, msg); \
+            return 1;                                                           \
+        }                                                                       \
+    } while (0)
+
+#define RT_CHECK(call, msg)                                                     \
+    do {                                                                        \
+        rtError_t _rc = (call);                                                 \
+        if (_rc != RT_ERROR_NONE) {                                             \
+            std::fprintf(stderr, "%s failed: %d (%s)\n", #call, (int)_rc, msg); \
+            return 1;                                                           \
+        }                                                                       \
+    } while (0)
+
+bool ReadFile(const std::string &path, std::vector<char> *out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f.is_open()) {
+        std::fprintf(stderr, "open %s failed: %s\n", path.c_str(), std::strerror(errno));
+        return false;
+    }
+    f.seekg(0, std::ios::end);
+    out->resize((size_t)f.tellg());
+    f.seekg(0);
+    f.read(out->data(), out->size());
+    return f.good() || f.eof();
+}
+
+struct DevBuf {
+    void *ptr{nullptr};
+    aclError Alloc(size_t n) {
+        aclError rc = aclrtMalloc(&ptr, n, ACL_MEM_MALLOC_HUGE_FIRST);
+        if (rc != ACL_SUCCESS) ptr = nullptr;
+        return rc;
+    }
+    ~DevBuf() {
+        if (ptr) aclrtFree(ptr);
+    }
+};
+
+#pragma pack(push, 4)
+struct SpreadRecord {
+    int32_t thread_idx;
+    int32_t cpu_id;
+};
+struct SpreadOutput {
+    volatile uint32_t claim_counter;
+    uint32_t _pad;
+    SpreadRecord records[kMaxSlots];
+};
+#pragma pack(pop)
+static_assert(sizeof(SpreadRecord) == 8, "SpreadRecord size drift");
+
+// DeviceArgs layout — same offsets as aicpu-device-query so the dispatcher
+// bootstrap path is unchanged. We just repurpose the post-bootstrap slots:
+//   bootstrap:
+//     96  aicpu_so_bin  (dispatcher bytes)
+//     104 aicpu_so_len
+//     112 device_id
+//     120 inner_so_bin
+//     128 inner_so_len
+//   spread (overwrites slots 96, 104 after bootstrap):
+//     96  output_addr  (SpreadOutput*)
+//     104 max_slots
+constexpr size_t kBootstrapDispBin = 96;
+constexpr size_t kBootstrapDispLen = 104;
+constexpr size_t kBootstrapDevId = 112;
+constexpr size_t kBootstrapInnerBin = 120;
+constexpr size_t kBootstrapInnerLen = 128;
+constexpr size_t kSpreadOutputAddr = 96;
+constexpr size_t kSpreadMaxSlots = 104;
+
+void WriteU64(char *buf, size_t off, uint64_t v) { std::memcpy(buf + off, &v, sizeof(v)); }
+
+std::string MakePreinstallPath(uint64_t fp, int device_id) {
+    char buf[256];
+    std::snprintf(
+        buf, sizeof(buf), "/usr/lib64/aicpu_kernels/0/aicpu_kernels_device/simpler_inner_%016lx_%d.so", fp, device_id
+    );
+    return buf;
+}
+
+std::string MakeJsonDescriptor(uint64_t fp, const std::string &so_basename) {
+    char init_op[128], spread_op[128];
+    std::snprintf(init_op, sizeof(init_op), "simpler_aicpu_init_%016lx", fp);
+    std::snprintf(spread_op, sizeof(spread_op), "simpler_aicpu_spread_%016lx", fp);
+    auto entry = [&](const char *op, const char *fn) {
+        std::string s = "  \"";
+        s += op;
+        s += "\": {\n    \"opInfo\": {\n";
+        s += "      \"functionName\": \"";
+        s += fn;
+        s += "\",\n      \"kernelSo\": \"";
+        s += so_basename;
+        s += "\",\n      \"opKernelLib\": \"AICPUKernel\",\n";
+        s += "      \"computeCost\": \"100\",\n";
+        s += "      \"engine\": \"DNN_VM_AICPU\",\n";
+        s += "      \"flagAsync\": \"False\",\n";
+        s += "      \"flagPartial\": \"False\",\n";
+        s += "      \"userDefined\": \"False\"\n";
+        s += "    }\n  }";
+        return s;
+    };
+    std::string s = "{\n";
+    s += entry(init_op, "simpler_aicpu_init");
+    s += ",\n";
+    s += entry(spread_op, "simpler_aicpu_spread");
+    s += "\n}\n";
+    return s;
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        std::fprintf(stderr, "usage: %s <device_id> <launch_count>\n", argv[0]);
+        return 1;
+    }
+    int device_id = std::atoi(argv[1]);
+    int launch_count = std::atoi(argv[2]);
+    if (launch_count < 1 || launch_count > (int)kMaxSlots) {
+        std::fprintf(stderr, "launch_count %d out of range [1, %u]\n", launch_count, kMaxSlots);
+        return 1;
+    }
+
+    const char *dispatcher_path_env = std::getenv("SIMPLER_DISPATCHER_SO");
+    if (dispatcher_path_env == nullptr) {
+        std::fprintf(stderr, "SIMPLER_DISPATCHER_SO env var required\n");
+        return 1;
+    }
+    std::string dispatcher_path = dispatcher_path_env;
+    const char *inner_path_env = std::getenv("SIMPLER_AICPU_SPREAD_SO");
+    std::string inner_path = inner_path_env ?
+                                 inner_path_env :
+                                 "tools/cann-examples/aicpu-thread-spread/device/build/libaicpu_thread_spread.so";
+
+    std::vector<char> dispatcher_bytes;
+    std::vector<char> inner_bytes;
+    if (!ReadFile(dispatcher_path, &dispatcher_bytes)) return 1;
+    if (!ReadFile(inner_path, &inner_bytes)) return 1;
+
+    ACL_CHECK(aclInit(nullptr), "aclInit");
+    ACL_CHECK(aclrtSetDevice(device_id), "aclrtSetDevice");
+    aclrtStream stream = nullptr;
+    ACL_CHECK(aclrtCreateStream(&stream), "aclrtCreateStream");
+
+    DevBuf dev_dispatcher, dev_inner, dev_args, dev_out;
+    ACL_CHECK(dev_dispatcher.Alloc(dispatcher_bytes.size()), "dispatcher GM");
+    ACL_CHECK(dev_inner.Alloc(inner_bytes.size()), "inner GM");
+    ACL_CHECK(dev_args.Alloc(kDeviceArgsBytes), "DeviceArgs GM");
+    ACL_CHECK(dev_out.Alloc(sizeof(SpreadOutput)), "SpreadOutput GM");
+
+    ACL_CHECK(
+        aclrtMemcpy(
+            dev_dispatcher.ptr, dispatcher_bytes.size(), dispatcher_bytes.data(), dispatcher_bytes.size(),
+            ACL_MEMCPY_HOST_TO_DEVICE
+        ),
+        "H2D dispatcher"
+    );
+    ACL_CHECK(
+        aclrtMemcpy(
+            dev_inner.ptr, inner_bytes.size(), inner_bytes.data(), inner_bytes.size(), ACL_MEMCPY_HOST_TO_DEVICE
+        ),
+        "H2D inner"
+    );
+    char hostargs[kDeviceArgsBytes] = {};
+    WriteU64(hostargs, kBootstrapDispBin, reinterpret_cast<uint64_t>(dev_dispatcher.ptr));
+    WriteU64(hostargs, kBootstrapDispLen, dispatcher_bytes.size());
+    WriteU64(hostargs, kBootstrapDevId, (uint64_t)device_id);
+    WriteU64(hostargs, kBootstrapInnerBin, reinterpret_cast<uint64_t>(dev_inner.ptr));
+    WriteU64(hostargs, kBootstrapInnerLen, inner_bytes.size());
+    ACL_CHECK(
+        aclrtMemcpy(dev_args.ptr, kDeviceArgsBytes, hostargs, kDeviceArgsBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+        "H2D DeviceArgs(bootstrap)"
+    );
+
+    // Bootstrap dispatcher (writes our inner SO to /usr/lib64/aicpu_kernels/...).
+    {
+        struct Args {
+            struct {
+                uint64_t unused[5] = {0};
+                uint64_t device_args_ptr = 0;
+                uint64_t pad[20] = {0};
+            } k_args;
+            char kernel_name[32];
+            char so_name[32];
+            char op_name[32];
+        } args = {};
+        args.k_args.device_args_ptr = reinterpret_cast<uint64_t>(dev_args.ptr);
+        std::strncpy(args.kernel_name, "DynTileFwkKernelServerInit", sizeof(args.kernel_name) - 1);
+        std::strncpy(args.so_name, "libaicpu_extend_kernels.so", sizeof(args.so_name) - 1);
+        args.op_name[0] = '\0';
+
+        rtAicpuArgsEx_t rt_args = {};
+        rt_args.args = &args;
+        rt_args.argsSize = sizeof(args);
+        rt_args.kernelNameAddrOffset = offsetof(Args, kernel_name);
+        rt_args.soNameAddrOffset = offsetof(Args, so_name);
+
+        RT_CHECK(
+            rtAicpuKernelLaunchExWithArgs(
+                rtKernelType_t::KERNEL_TYPE_AICPU_KFC, "AST_DYN_AICPU", 1, &rt_args, nullptr, stream, 0
+            ),
+            "rtAicpuKernelLaunchExWithArgs(bootstrap)"
+        );
+    }
+    ACL_CHECK(aclrtSynchronizeStream(stream), "sync after bootstrap");
+
+    // Fingerprint + JSON descriptor.
+    uint64_t fp = fp::Compute(inner_bytes.data(), inner_bytes.size());
+    std::string so_basename = "simpler_inner_" + [&] {
+        char b[24];
+        std::snprintf(b, sizeof(b), "%016lx_%d.so", fp, device_id);
+        return std::string(b);
+    }();
+    std::printf("[bootstrap] inner SO at %s (fp=%016lx)\n", MakePreinstallPath(fp, device_id).c_str(), fp);
+
+    char json_path_buf[128];
+    std::snprintf(json_path_buf, sizeof(json_path_buf), "/tmp/simpler_inner_%016lx_%d.json", fp, getpid());
+    std::string json_path = json_path_buf;
+    {
+        std::string json = MakeJsonDescriptor(fp, so_basename);
+        std::ofstream f(json_path);
+        if (!f.is_open()) {
+            std::fprintf(stderr, "open %s failed\n", json_path.c_str());
+            return 1;
+        }
+        f << json;
+    }
+
+    rtLoadBinaryOption_t option = {};
+    option.optionId = RT_LOAD_BINARY_OPT_CPU_KERNEL_MODE;
+    option.value.cpuKernelMode = 0;
+    rtLoadBinaryConfig_t load_config = {};
+    load_config.options = &option;
+    load_config.numOpt = 1;
+    void *binary_handle = nullptr;
+    RT_CHECK(rtsBinaryLoadFromFile(json_path.c_str(), &load_config, &binary_handle), "rtsBinaryLoadFromFile");
+    std::remove(json_path.c_str());
+
+    rtFuncHandle init_handle = nullptr, spread_handle = nullptr;
+    {
+        char init_op[128], spread_op[128];
+        std::snprintf(init_op, sizeof(init_op), "simpler_aicpu_init_%016lx", fp);
+        std::snprintf(spread_op, sizeof(spread_op), "simpler_aicpu_spread_%016lx", fp);
+        RT_CHECK(rtsFuncGetByName(binary_handle, init_op, &init_handle), "rtsFuncGetByName init");
+        RT_CHECK(rtsFuncGetByName(binary_handle, spread_op, &spread_handle), "rtsFuncGetByName spread");
+    }
+
+    // Zero-init the output (claim_counter = 0) and point DeviceArgs at it.
+    SpreadOutput host_out_init = {};
+    ACL_CHECK(
+        aclrtMemcpy(dev_out.ptr, sizeof(SpreadOutput), &host_out_init, sizeof(SpreadOutput), ACL_MEMCPY_HOST_TO_DEVICE),
+        "H2D zero SpreadOutput"
+    );
+
+    std::memset(hostargs, 0, sizeof(hostargs));
+    WriteU64(hostargs, kSpreadOutputAddr, reinterpret_cast<uint64_t>(dev_out.ptr));
+    WriteU64(hostargs, kSpreadMaxSlots, (uint64_t)kMaxSlots);
+    ACL_CHECK(
+        aclrtMemcpy(dev_args.ptr, kDeviceArgsBytes, hostargs, kDeviceArgsBytes, ACL_MEMCPY_HOST_TO_DEVICE),
+        "H2D DeviceArgs(spread)"
+    );
+
+    // Per-launch dance: launch single-threaded init (resets static counter
+    // in the AICPU process), then launch N spread threads.
+    struct LaunchArgs {
+        uint64_t _pad[5] = {0};
+        uint64_t device_args_ptr = 0;
+        uint64_t reserved[20] = {0};
+    } la = {};
+    la.device_args_ptr = reinterpret_cast<uint64_t>(dev_args.ptr);
+
+    rtCpuKernelArgs_t cpu_args = {};
+    cpu_args.baseArgs.args = &la;
+    cpu_args.baseArgs.argsSize = sizeof(la);
+    rtLaunchKernelAttr_t attr = {};
+    rtKernelLaunchCfg_t cfg = {&attr, 0};
+
+    RT_CHECK(rtsLaunchCpuKernel(init_handle, 1u, stream, &cfg, &cpu_args), "rtsLaunchCpuKernel init");
+    ACL_CHECK(aclrtSynchronizeStream(stream), "sync after init");
+
+    // Launch N AICPU threads — aicpu_num = launch_count is the whole point of
+    // this tool. CANN distributes the threads across cpu_ids; we want to see
+    // which cpu_ids it picks.
+    RT_CHECK(
+        rtsLaunchCpuKernel(spread_handle, (uint32_t)launch_count, stream, &cfg, &cpu_args), "rtsLaunchCpuKernel spread"
+    );
+    ACL_CHECK(aclrtSynchronizeStream(stream), "sync after spread");
+
+    SpreadOutput host_out{};
+    ACL_CHECK(
+        aclrtMemcpy(&host_out, sizeof(SpreadOutput), dev_out.ptr, sizeof(SpreadOutput), ACL_MEMCPY_DEVICE_TO_HOST),
+        "D2H SpreadOutput"
+    );
+
+    std::printf(
+        "\n=== device=%d  launch_count=%d  threads_reported=%u ===\n", device_id, launch_count, host_out.claim_counter
+    );
+    // claim_counter on the device is updated via racing non-atomic stores
+    // (last-writer-wins) and can under-report, so use launch_count to
+    // bound the scan — slots [0, launch_count) are deterministically
+    // filled by the device-side fetch_add. claim_counter is kept above
+    // as a diagnostic hint only.
+    uint32_t reported =
+        static_cast<uint32_t>(launch_count) < kMaxSlots ? static_cast<uint32_t>(launch_count) : kMaxSlots;
+    // Sort by claim order for readability (which is also fetch-add order on the
+    // device side, i.e. arrival order at the gate).
+    std::vector<SpreadRecord> rs(reported);
+    for (uint32_t i = 0; i < reported; ++i)
+        rs[i] = host_out.records[i];
+    std::printf("  By claim order (thread_idx -> cpu_id):\n");
+    for (uint32_t i = 0; i < reported; ++i) {
+        std::printf("    idx=%-2d  cpu_id=%d\n", rs[i].thread_idx, rs[i].cpu_id);
+    }
+    // Histogram of unique cpu_ids hit.
+    std::vector<int> cpus;
+    for (uint32_t i = 0; i < reported; ++i)
+        cpus.push_back(rs[i].cpu_id);
+    std::sort(cpus.begin(), cpus.end());
+    std::printf("  cpu_id histogram (sorted, may repeat if CANN over-subscribed):\n    ");
+    for (size_t i = 0; i < cpus.size(); ++i)
+        std::printf("%s%d", (i ? " " : ""), cpus[i]);
+    std::printf("\n");
+
+    ACL_CHECK(aclrtDestroyStream(stream), "destroy stream");
+    ACL_CHECK(aclrtResetDevice(device_id), "reset device");
+    aclFinalize();
+    return 0;
+}


### PR DESCRIPTION
## Summary

Replace the a3-style cluster-majority affinity gate on a5 with a filter-style gate driven by a host-computed `ALLOWED_CPUS` table.

- **Host probe** (cached per `device_id`): DSMI `CPU_TOPO` + `halGetDeviceInfo(AICPU, OCCUPY)` → list of user-schedulable cpus annotated with `(phy_cpu_id, cluster_id = phy/2, die_id = phy/4)`.
- **Host packing** (`compute_allowed_cpus`): place 4 sched preferring **single cluster → single die → spread**, then orch into **same cluster → same die → different die**. Sched-first reserves the tightest unit for ready-queue locality.
- **Device gate** (`platform_aicpu_affinity_gate_filter`): barriers all launched threads, filters by `sched_getcpu() ∈ allowed_cpus`, exposes a stable `exec_idx` (= position in array) via `platform_aicpu_affinity_thread_idx()`. The executor reads `exec_idx` for role assignment: indices `0..n-2` = sched, `n-1` = orch.

Two non-obvious decisions baked in:

- **`launch_count` is runtime-derived from `popcount(OCCUPY)`**, not the compile-time bound. SKUs with fewer user cpus than the bound over-subscribe a sink cpu under the higher count, and the production AICPU kernel deadlocks on contended init paths. `PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 14` stays as upper bound only.
- **The new Runtime fields are placed AFTER `tasks[]`** in `host_build_graph/runtime.h`. AICore reads `runtime->tasks[]` by compile-time offset; inserting before `tasks` shifts that offset and silently produces NaN outputs in any test that exercises the AICore task-execute path. (Found this the hard way.)

a2a3's cluster-majority gate is untouched.

## Layout summary

For 1 orch + 4 sched on a5:

| | Scenario A (this dev box, `OCCUPY = 0x1f8`, 6 user cpus, no SMT) | Scenario B (target, `OCCUPY = 0x7ffe`, 14 user cpus, SMT-2) |
| --- | --- | --- |
| `ALLOWED_CPUS` | `{5, 6, 7, 8, 3}` | `{11, 12, 13, 14, 7}` (predicted) |
| sched location | die 1, clusters 2+3 (each cluster has only 2 logical → falls through to "single die") | cluster 3 (4 SMT-paired logical) |
| orch location | die 0 cluster 1 (different die — die 1 is full) | die 1 cluster 2 (same die, different cluster) |
| `launch_count` | 6 | 14 |

## Test plan

- [x] All 17 a5 ST tests pass on Scenario A device (`host_build_graph` + `tensormap_and_ringbuffer`)
- [x] `ALLOWED_CPUS` log shows `{5, 6, 7, 8, 3}` with `n_sched = 4, n_orch = 1, launch = 6`
- [x] a2a3 path unchanged — legacy `platform_aicpu_affinity_gate` symbol still exported with same semantics
- [ ] **Scenario B verification (left for a 0x7ffe-SKU machine)**: run any a5 onboard test and check the host log for `AICPU ALLOWED_CPUS = [11, 12, 13, 14, 7(orch)] (..., launch=14, user_cpus=14)`. If the layout differs, post the observed line so the algorithm can be re-tuned.

## Companion spike tool

`tools/cann-examples/aicpu-thread-spread/` is a diagnostic tool that launches N AICPU threads and reads back each thread's `sched_getcpu()`. Used during development to confirm "CANN dispatch set = OCCUPY exactly" on Scenario A (the empirical basis for `launch_count = popcount(OCCUPY)`). README has a "Validating Scenario B" section with the exact recipe for reproducing the check on a 0x7ffe SKU.

## Files

- `src/a5/platform/onboard/host/aicpu_topology_probe.{h,cpp}` (NEW) — probe + packing
- `src/a5/platform/onboard/host/{device_runner.cpp,CMakeLists.txt}` — invoke probe, fill Runtime, launch with `aicpu_launch_count`
- `src/a5/platform/onboard/aicpu/kernel.cpp` — switch to filter gate
- `src/a5/runtime/{host_build_graph,tensormap_and_ringbuffer}/runtime/runtime.{h,cpp}` — add `aicpu_allowed_cpus[16]` + `_count` + `_launch_count` fields
- `src/a5/runtime/{host_build_graph,tensormap_and_ringbuffer}/aicpu/aicpu_executor.cpp` — use `exec_idx` for role assignment
- `src/common/platform/{include/aicpu,onboard/aicpu,sim/aicpu}/platform_aicpu_affinity.{h,cpp}` — add `platform_aicpu_affinity_gate_filter` + `_thread_idx`; legacy gate untouched
- `src/a5/platform/include/common/platform_config.h` — `PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH` 7 → 14 (upper bound)
- `src/a5/docs/hardware.md` — document the dispatch behavior and the gate design
- `tools/cann-examples/aicpu-thread-spread/` (NEW) — diagnostic spike + README