### PR TITLE
Add: add scalar float type data dump support.

### DIFF
--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -26,9 +26,11 @@ saw, without the timing distortion of inline printing.
 - **Manifest + binary payload.** `--dump-tensor` writes a JSON
   manifest plus one `.bin` payload per run; tensor entries carry
   `bin_offset` / `bin_size`, while scalar entries stay manifest-only.
-- **Unified scalar args.** Scalar callable slots are emitted as
+- **Unified scalar args.** Scalar values are emitted as
   `kind: scalar`, `stage: before_dispatch`, zero-dim records in
-  `tensor_dump.json`; there is no separate args-only manifest.
+  `tensor_dump.json`; there is no separate args-only manifest. Their
+  final `dtype` is registered at submit time in a dump-only per-task side table
+  and resolved by AICPU when writing each scalar dump record.
 - **Cross-architecture.** Same flags and on-disk layout family on
   `a2a3` and `a5`. Both runtimes are wired through.
 
@@ -274,8 +276,9 @@ What you can read out of `tensor_dump.json` + `tensor_dump.bin`:
 - **Per-task input snapshots** (`role: input`, `stage:
   before_dispatch`) — what each kernel was given.
 - **Per-dispatch scalar args** (`kind: scalar`, `stage:
-  before_dispatch`) — the raw callable-slot scalar values AICPU
-  handed to the kernel.
+  before_dispatch`) — the raw per-task scalar-slot values AICPU
+  handed to the kernel, tagged with the dump-only dtype captured at
+  submit time.
 - **Per-task output snapshots** (`role: output`, `stage:
   after_completion`) — what each kernel produced. The barrier
   ensures these reflect the kernel's final writes.
@@ -284,8 +287,8 @@ What you can read out of `tensor_dump.json` + `tensor_dump.bin`:
 - **Logical view reconstruction** — `shape` / `strides` /
   `start_offset` / `is_contiguous` plus the gathered
   logical-contiguous payload.
-- **Per-task identity** — `task_id` / `subtask_id` / `func_id`
-  correlates dump entries with swimlane and PMU rows.
+- **Per-task identity** — `task_id`, `stage`, `role`, and `arg_index`
+  identify each dumped argument within a task.
 - **Loss accounting** — `truncated` / `overwritten` per-record
   flags, plus aggregate `dropped_records` / `dropped_overwrite` in
   the summary.
@@ -361,10 +364,13 @@ Each runtime's scheduler dispatch code calls
 └──────────────────────────────────────┘
 ```
 
-`dump_tensors_for_task` walks the formal callable signature,
-matches each non-scalar slot to a `TensorDumpInfo` (dtype + shape +
-strides + start offset + device address), and calls
-`dump_tensor_record` for slots that match the current stage.
+`dump_tensors_for_task` walks the formal callable signature for
+non-scalar tensor slots, matches each tensor slot to a
+`TensorDumpInfo` (dtype + shape + strides + start offset + device
+address), and calls `dump_tensor_record` for slots that match the
+current stage. Scalar values are dumped separately from the flat
+payload `scalars[]`; their dtype table is registered at submit time
+and emitted as a dump-only metadata record at `BEFORE_DISPATCH`.
 
 When dump is enabled, AICore executors also issue
 `pipe_barrier(PIPE_ALL)` after kernel execution and before writing

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -51,8 +51,11 @@ DTYPE_INFO = {
     "int64": ("q", 8),
     "uint64": ("Q", 8),
     "int16": ("h", 2),
+    "uint16": ("H", 2),
     "int8": ("b", 1),
     "uint8": ("B", 1),
+    "uint32": ("I", 4),
+    "bool": ("?", 1),
 }
 
 
@@ -103,6 +106,7 @@ def write_tensor(tensor: dict, bin_path: Path, out):
     out.write(f"# stage: {t['stage']}\n")
     out.write(f"# arg_index: {t['arg_index']}\n")
     out.write(f"# dtype: {t['dtype']}\n")
+    out.write(f"# kind: {t.get('kind', 'tensor')}\n")
     out.write(f"# is_contiguous: {t['is_contiguous']}\n")
     out.write(f"# shape: {t['shape']}\n")
     out.write(f"# strides: {t['strides']}\n")
@@ -113,6 +117,13 @@ def write_tensor(tensor: dict, bin_path: Path, out):
         return
     if t.get("truncated"):
         out.write("# DATA TRUNCATED (tensor too large for arena)\n")
+
+    if t.get("kind") == "scalar":
+        val = t.get("value")
+        if t.get("dtype", "").upper() == "BOOL":
+            val = "true" if val else "false"
+        out.write(f"# value: {val}\n")
+        return
 
     bin_size = t.get("bin_size", 0)
     if bin_size == 0:

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -36,10 +36,9 @@
 #include "pto_types.h"
 #include "tensor.h"
 
-extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
-
 #if PTO2_PROFILING
 #include "aicpu/scope_stats_collector_aicpu.h"
+#include "aicpu/tensor_dump_aicpu.h"
 #endif
 
 // Verify the captured Tensor blob size in DepGenRecord matches the runtime
@@ -648,12 +647,19 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
-    // (host-decided before any dispatch), so it is race-free regardless of
-    // submission order. Here we only record each marked task's arg mask, which
-    // selective collection consults.
-    if (args.tensor_dump_arg_mask() != 0) {
-        set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+    if (is_dump_tensor_enabled()) {
+        if (args.scalar_count() > 0) {
+            set_dump_tensor_task_scalar_dtypes(
+                task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
+            );
+        }
+        // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+        // (host-decided before any dispatch), so it is race-free regardless of
+        // submission order. Here we only record each marked task's arg mask, which
+        // selective collection consults.
+        if (args.tensor_dump_arg_mask() != 0) {
+            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+        }
     }
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -32,6 +32,7 @@
 #include <arm_neon.h>
 #endif
 
+#include "data_type.h"
 #include "pto_submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
@@ -183,6 +184,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         tensor_dump_arg_mask_ = 0;
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
+        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
     }
 
     void set_error(const char *msg) {
@@ -312,7 +314,9 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
-        ((scalars_[scalar_count_++] = to_u64(args)), ...);
+        ((scalars_[scalar_count_] = to_u64(args),
+          scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<Args>>>(), ++scalar_count_),
+         ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
@@ -370,8 +374,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
+        memcpy(&scalar_dtypes_[scalar_count_], &src.scalar_dtypes_[src_offset], count * sizeof(uint8_t));
         scalar_count_ += count;
     }
+
+    const uint8_t *scalar_dtypes() const { return scalar_dtypes_; }
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
@@ -379,6 +386,7 @@ private:
     uint64_t tensor_dump_arg_mask_{0};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+    uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
     // No-arg dump(): mark every tensor arg already added to this Arg.
     void mark_all_tensor_dump_arg() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -36,7 +36,9 @@
 #include "pto_types.h"
 #include "tensor.h"
 
-extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
+#if PTO2_PROFILING
+#include "aicpu/tensor_dump_aicpu.h"
+#endif
 
 // Verify the captured Tensor blob size in DepGenRecord matches the runtime
 // Tensor layout. The platform header defines DEP_GEN_TENSOR_SIZE without
@@ -647,12 +649,19 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
-    // (host-decided before any dispatch), so it is race-free regardless of
-    // submission order. Here we only record each marked task's arg mask, which
-    // selective collection consults.
-    if (args.tensor_dump_arg_mask() != 0) {
-        set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+    if (is_dump_tensor_enabled()) {
+        if (args.scalar_count() > 0) {
+            set_dump_tensor_task_scalar_dtypes(
+                task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
+            );
+        }
+        // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+        // (host-decided before any dispatch), so it is race-free regardless of
+        // submission order. Here we only record each marked task's arg mask, which
+        // selective collection consults.
+        if (args.tensor_dump_arg_mask() != 0) {
+            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+        }
     }
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -28,12 +28,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <utility>
-
 #if defined(__aarch64__)
 #include <arm_neon.h>
 #endif
 
+#include <utility>
+
+#include "data_type.h"
 #include "pto_submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
@@ -181,6 +182,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         tensor_dump_arg_mask_ = 0;
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
+        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
     }
 
     void reset() {
@@ -316,7 +318,9 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
-        ((scalars_[scalar_count_++] = to_u64(args)), ...);
+        ((scalars_[scalar_count_] = to_u64(args),
+          scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<Args>>>(), ++scalar_count_),
+         ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
@@ -374,8 +378,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
+        memcpy(&scalar_dtypes_[scalar_count_], &src.scalar_dtypes_[src_offset], count * sizeof(uint8_t));
         scalar_count_ += count;
     }
+
+    const uint8_t *scalar_dtypes() const { return scalar_dtypes_; }
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
@@ -383,6 +390,7 @@ private:
     uint64_t tensor_dump_arg_mask_{0};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+    uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
     // No-arg dump(): mark every tensor arg already added to this Arg.
     void mark_all_tensor_dump_arg() {

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -76,6 +76,8 @@ void set_dump_tensor_selective_mode(bool enable);
 bool is_dump_tensor_selective_mode();
 void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask);
 TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id);
+void set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes);
+bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes);
 
 #ifdef __cplusplus
 }
@@ -123,8 +125,8 @@ inline void dump_tensors_for_task(
         if (try_log_tensor_dump_layout_mismatch()) {
             LOG_WARN(
                 "Thread %d: tensor dump skipped for task 0x%" PRIx64
-                ": active callable tensor count (%d) does not match payload tensor count (%d). "
-                "Task-level dump assumes payload tensors are concatenated by active subtask order.",
+                ": active callable tensor args (%d) do not match payload tensor args (%d). "
+                "Task-level dump assumes payload tensor args are concatenated by active subtask order.",
                 thread_idx, static_cast<uint64_t>(slot_state.task->task_id.raw), total_tensor_args, pl.tensor_count
             );
         }
@@ -172,19 +174,26 @@ inline void dump_tensors_for_task(
             arg_index++;
             tensor_index++;
         }
-        if (stage == TensorDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
-            for (int32_t i = 0; i < pl.scalar_count; i++) {
-                TensorDumpInfo info = {};
-                info.task_id = slot_state.task->task_id.raw;
-                info.role = TensorDumpRole::INPUT;
-                info.stage = stage;
-                info.dtype = static_cast<uint8_t>(DataType::UINT64);
-                info.ndims = 0;
-                info.arg_index = static_cast<uint32_t>(pl.tensor_count + i);
-                info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
-                info.scalar_value = pl.scalars[i];
-                dump_tensor_record(thread_idx, info);
-            }
+    }
+
+    if (stage == TensorDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
+        uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS] = {};
+        uint32_t dtype_scalar_count = 0;
+        bool has_scalar_dtypes =
+            get_dump_tensor_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
+        for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
+            TensorDumpInfo info = {};
+            info.task_id = slot_state.task->task_id.raw;
+            info.role = TensorDumpRole::INPUT;
+            info.stage = stage;
+            info.dtype = (has_scalar_dtypes && scalar_index < static_cast<int32_t>(dtype_scalar_count)) ?
+                             scalar_dtypes[scalar_index] :
+                             static_cast<uint8_t>(DataType::UINT64);
+            info.ndims = 0;
+            info.arg_index = static_cast<uint32_t>(pl.tensor_count + scalar_index);
+            info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
+            info.scalar_value = pl.scalars[scalar_index];
+            dump_tensor_record(thread_idx, info);
         }
     }
 }

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -59,9 +59,15 @@ struct DumpTaskMaskEntry {
     uint64_t task_id;
     TensorDumpArgMask mask;
 };
+struct DumpTaskScalarDtypeEntry {
+    uint64_t task_id;
+    uint32_t scalar_count;
+    uint8_t scalar_dtypes[32];
+};
 static constexpr uint64_t DUMP_TASK_MASK_EMPTY_TASK_ID = UINT64_MAX;
 static constexpr uint32_t DUMP_TASK_MASK_TABLE_CAPACITY = 32768;
 static DumpTaskMaskEntry *g_dump_mask_table = nullptr;
+static DumpTaskScalarDtypeEntry *g_dump_scalar_dtype_table = nullptr;
 static bool ensure_dump_mask_table() {
     if (g_dump_mask_table != nullptr) {
         return true;
@@ -79,14 +85,101 @@ static bool ensure_dump_mask_table() {
     return true;
 }
 
-static void clear_dump_mask_table() {
-    if (g_dump_mask_table == nullptr) {
-        return;
+static bool ensure_dump_scalar_dtype_table() {
+    if (g_dump_scalar_dtype_table != nullptr) {
+        return true;
+    }
+    g_dump_scalar_dtype_table = static_cast<DumpTaskScalarDtypeEntry *>(
+        malloc(sizeof(DumpTaskScalarDtypeEntry) * DUMP_TASK_MASK_TABLE_CAPACITY)
+    );
+    if (g_dump_scalar_dtype_table == nullptr) {
+        LOG_ERROR("Failed to allocate tensor dump scalar dtype table");
+        return false;
     }
     for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
-        g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
-        g_dump_mask_table[i].mask = TENSOR_DUMP_ARG_MASK_NONE;
+        g_dump_scalar_dtype_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
+        g_dump_scalar_dtype_table[i].scalar_count = 0;
+        memset(g_dump_scalar_dtype_table[i].scalar_dtypes, 0, sizeof(g_dump_scalar_dtype_table[i].scalar_dtypes));
     }
+    return true;
+}
+
+static void clear_dump_mask_table() {
+    if (g_dump_mask_table != nullptr) {
+        for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
+            g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
+            g_dump_mask_table[i].mask = TENSOR_DUMP_ARG_MASK_NONE;
+        }
+    }
+    if (g_dump_scalar_dtype_table != nullptr) {
+        for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
+            g_dump_scalar_dtype_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
+            g_dump_scalar_dtype_table[i].scalar_count = 0;
+            memset(g_dump_scalar_dtype_table[i].scalar_dtypes, 0, sizeof(g_dump_scalar_dtype_table[i].scalar_dtypes));
+        }
+    }
+}
+
+static bool resolve_dump_task_slot(uint64_t task_id, uint32_t *idx_out) {
+    uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
+    if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
+        return false;
+    }
+    uint32_t slot = static_cast<uint32_t>(task_id) & TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK;
+    *idx_out = (ring_id * TENSOR_DUMP_MASK_POOL_MAX_SLOTS + slot) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
+    return true;
+}
+
+extern "C" void
+set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes) {
+    if (scalar_count == 0 || scalar_dtypes == nullptr) {
+        return;
+    }
+    if (scalar_count > 32) {
+        LOG_ERROR("tensor dump scalar dtype count exceeds max (%u > 32)", scalar_count);
+        return;
+    }
+    if (!ensure_dump_scalar_dtype_table()) {
+        return;
+    }
+    uint32_t idx = 0;
+    if (!resolve_dump_task_slot(task_id, &idx)) {
+        return;
+    }
+    for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
+        DumpTaskScalarDtypeEntry &entry =
+            g_dump_scalar_dtype_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
+        if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID || entry.task_id == task_id) {
+            entry.task_id = task_id;
+            entry.scalar_count = scalar_count;
+            memcpy(entry.scalar_dtypes, scalar_dtypes, scalar_count * sizeof(uint8_t));
+            return;
+        }
+    }
+    LOG_ERROR("tensor dump scalar dtype table is full");
+}
+
+extern "C" bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes) {
+    if (g_dump_scalar_dtype_table == nullptr || scalar_count == nullptr || scalar_dtypes == nullptr) {
+        return false;
+    }
+    uint32_t idx = 0;
+    if (!resolve_dump_task_slot(task_id, &idx)) {
+        return false;
+    }
+    for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
+        const DumpTaskScalarDtypeEntry &entry =
+            g_dump_scalar_dtype_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
+        if (entry.task_id == task_id) {
+            *scalar_count = entry.scalar_count;
+            memcpy(scalar_dtypes, entry.scalar_dtypes, entry.scalar_count * sizeof(uint8_t));
+            return true;
+        }
+        if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID) {
+            return false;
+        }
+    }
+    return false;
 }
 
 extern "C" void set_dump_tensor_enabled(bool enable) {
@@ -509,13 +602,14 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
 
     // Reserve space in arena
     // Compute actual tensor data size from shape (not buffer.size which may include padding)
+    TensorDumpKind kind = static_cast<TensorDumpKind>(info.kind);
     uint64_t actual_elements = get_tensor_dump_num_elements(info);
     uint64_t elem_sz = get_element_size(static_cast<DataType>(info.dtype));
     uint64_t bytes = actual_elements * elem_sz;
     uint64_t copy_bytes = bytes;
     bool truncated = false;
     bool is_contiguous = tensor_dump_is_contiguous(info);
-    bool is_scalar = static_cast<TensorDumpKind>(info.kind) == TensorDumpKind::SCALAR;
+    bool is_scalar = kind == TensorDumpKind::SCALAR;
 
     if (is_scalar) {
         copy_bytes = 0;

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -27,9 +27,11 @@
 
 #include "host/tensor_dump_collector.h"
 
+#include "data_type.h"
+
 #include <algorithm>
 #include <chrono>
-#include <cstdlib>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -226,12 +228,13 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         dt.is_contiguous = (rec.is_contiguous != 0);
         dt.truncated = (rec.truncated != 0);
         dt.overwritten = false;
-        if (dt.truncated && ++total_truncated_count_ == 1) {
-            LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
-        }
         dt.start_offset = rec.start_offset;
         std::memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
         std::memcpy(dt.strides, rec.strides, sizeof(dt.strides));
+
+        if (dt.truncated && ++total_truncated_count_ == 1) {
+            LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
+        }
 
         if (dt.kind == TensorDumpKind::TENSOR && thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
             ArenaInfo &ai = arenas_[thread_idx];
@@ -402,6 +405,43 @@ static const char *tensor_dump_kind_name(TensorDumpKind kind) {
     return "unknown";
 }
 
+static void write_scalar_json_value(std::ofstream &json, const DumpedTensor &dt) {
+    uint64_t raw = dt.scalar_value;
+    if (dt.dtype == static_cast<uint8_t>(DataType::FLOAT32)) {
+        float f;
+        memcpy(&f, &raw, sizeof(float));
+        if (std::isnan(f)) {
+            json << ", \"value\": null";
+        } else if (std::isinf(f)) {
+            json << ", \"value\": " << (f < 0 ? "\"-$Inf\"" : "\"$Inf\"");
+        } else {
+            std::ostringstream val_ss;
+            val_ss << f;
+            std::string val_str = val_ss.str();
+            if (val_str.find('.') == std::string::npos && val_str.find('e') == std::string::npos) {
+                val_str += ".0";
+            }
+            json << ", \"value\": " << val_str;
+        }
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::INT32)) {
+        int32_t val;
+        memcpy(&val, &raw, sizeof(int32_t));
+        json << ", \"value\": " << val;
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::UINT32)) {
+        uint32_t val;
+        memcpy(&val, &raw, sizeof(uint32_t));
+        json << ", \"value\": " << val;
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::BOOL)) {
+        json << ", \"value\": " << (raw != 0 ? "true" : "false");
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::INT64)) {
+        int64_t val;
+        memcpy(&val, &raw, sizeof(int64_t));
+        json << ", \"value\": " << val;
+    } else {
+        json << ", \"value\": " << raw;
+    }
+}
+
 static std::string dims_to_string(const uint32_t dims[], int ndims) {
     std::ostringstream ss;
     ss << "[";
@@ -555,14 +595,15 @@ int TensorDumpCollector::export_dump_files() {
         first_entry = false;
 
         json << "    {\"task_id\": \"0x" << std::hex << std::setfill('0') << std::setw(16) << dt.task_id << std::dec
-             << "\", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
+             << "\"";
+        json << ", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
              << "\", \"stage\": \"" << tensor_dump_stage_name(dt.stage) << "\", \"kind\": \""
              << tensor_dump_kind_name(dt.kind) << "\", \"dtype\": \"" << dtype_name
              << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false") << ", \"shape\": " << shape_str
              << ", \"strides\": " << strides_str << ", \"start_offset\": " << dt.start_offset
              << ", \"numel\": " << numel;
         if (dt.kind == TensorDumpKind::SCALAR) {
-            json << ", \"value\": " << dt.scalar_value;
+            write_scalar_json_value(json, dt);
         }
         json << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
              << ", \"truncated\": " << (dt.truncated ? "true" : "false")

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -43,6 +43,7 @@ enum class DataType : uint8_t {
     UINT64,    // 8 bytes
     UINT16,    // 2 bytes
     UINT32,    // 4 bytes
+    BOOL,      // 1 byte (stored as 1/0 in uint64_t slot)
     DATA_TYPE_NUM,
 };
 
@@ -68,6 +69,7 @@ inline uint64_t get_element_size(DataType dtype) {
         8,  // DataType::UINT64
         2,  // DataType::UINT16
         4,  // DataType::UINT32
+        1,  // DataType::BOOL
     };
     return data_type_size[static_cast<int>(dtype)];
 }
@@ -102,6 +104,8 @@ inline const char *get_dtype_name(DataType dtype) {
         return "UINT16";
     case DataType::UINT32:
         return "UINT32";
+    case DataType::BOOL:
+        return "BOOL";
     default:
         return "UNKNOWN";
     }
@@ -136,7 +140,42 @@ inline const char *get_dtype_name(DataType dtype) {
 //
 // Named convenience functions (from_u64_f32 etc.) are removed — use the
 // template form from_u64<T>() / to_u64() directly.
-// -----------------------------------------------------------------------------
+
+/**
+ * Map a C++ type to its DataType enum value.
+ *
+ * Used to preserve original scalar type information through the
+ * Arg -> PTO2TaskPayload -> tensor dump pipeline.
+ */
+template <typename T>
+inline constexpr uint8_t dtype_of() {
+    static_assert(is_supported_scalar_arg_v<T>, "dtype_of: type must be arithmetic or enum");
+    if constexpr (std::is_same_v<T, float>) {
+        return static_cast<uint8_t>(DataType::FLOAT32);
+    } else if constexpr (std::is_same_v<T, double>) {
+        return static_cast<uint8_t>(DataType::FLOAT32);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return static_cast<uint8_t>(DataType::INT32);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return static_cast<uint8_t>(DataType::UINT32);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return static_cast<uint8_t>(DataType::INT64);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return static_cast<uint8_t>(DataType::UINT64);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return static_cast<uint8_t>(DataType::INT16);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return static_cast<uint8_t>(DataType::UINT16);
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+        return static_cast<uint8_t>(DataType::INT8);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return static_cast<uint8_t>(DataType::UINT8);
+    } else if constexpr (std::is_same_v<T, bool>) {
+        return static_cast<uint8_t>(DataType::BOOL);
+    } else {
+        return static_cast<uint8_t>(DataType::UINT64);
+    }
+}
 
 /**
  * Pack a value into uint64_t storage (zero-extends smaller types).


### PR DESCRIPTION
## Summary

Preserve real scalar dtypes in tensor dump artifacts and export scalar `value` in a dtype-aware format instead of always treating scalar payloads as raw `UINT64` bit patterns.

## Changes

### 1. Transient scalar dtype tracking in `Arg`

`src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_types.h`

- Add transient `scalar_dtypes_` storage alongside scalar raw values.
- Record dtype in `add_scalar(...)`, `add_scalars(values, dtypes, count)`, and `add_scalars_i32(...)`.
- Copy scalar dtype metadata in `append_scalars_from(...)`.
- Keep `scalar_dtypes_` reset in `clear()`.

### 2. No dtype expansion in `PTO2TaskPayload`

`src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h`

- Keep `PTO2TaskPayload` unchanged for hot-path layout.
- Continue carrying only tensor metadata and scalar raw values in the payload.
- Avoid pushing dump-only dtype metadata into the ring buffer footprint.

### 3. Dump-only scalar dtype side table at submit time

`src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp`

- When tensor dump is enabled, register scalar dtypes by task instance.
- Store `(task_id, tensor_count, scalar_count, scalar_dtypes[])` in a dump-only side table.
- Keep this path gated by both profiling build guards and runtime dump enablement.

### 4. AICPU writes dtype directly into each scalar dump record

`src/common/platform/include/aicpu/tensor_dump_aicpu.h`

- Read scalar dtype metadata from the task-level side table during `BEFORE_DISPATCH`.
- Write the resolved dtype directly into each emitted `SCALAR` record.
- Fall back to `UINT64` if dtype metadata is unavailable.

### 5. Remove host-side scalar dtype join flow

`src/common/platform/shared/host/tensor_dump_collector.cpp`

- Delete `SCALAR_DTYPE_TABLE` handling from the host collector path.
- Remove `DumpedScalarDtypeTable`, `scalar_dtype_tables_`, and `join_scalar_dtypes()`.
- Decode scalar JSON output directly from `rec.dtype` carried by each `SCALAR` record.

### 6. Dtype-aware scalar JSON export and viewer support

`src/common/platform/shared/host/tensor_dump_collector.cpp`
`tools/dump_viewer.py` and related viewer paths

- Export `FLOAT32` scalars as decoded float values.
- Export `INT32`, `UINT32`, `BOOL`, and `INT64` scalars with dtype-aware formatting.
- Keep raw `UINT64` fallback for unsupported or missing dtype cases.
- Extend viewer-side scalar presentation for additional dtypes such as `uint16`, `uint32`, and `bool`.


## Validation

Validated from the repo root with full tensor dump enabled on both a2a3sim and a5sim.

`--dump-tensor 2` means **full dump**: dump data is collected for every task's tensor/scalar records.

If `--dump-tensor` is omitted, the dump level is `0` (**off**), so no tensor dump storage is initialized and no `tensor_dump.bin` / `tensor_dump.json` artifacts are produced.

For reference:

- `--dump-tensor` or `--dump-tensor 1` = **partial dump** (only tasks explicitly marked via `Arg::dump(...)`)
- `--dump-tensor 2` = **full dump** (all tasks)

Commands:

```bash
pytest examples/a2a3/tensormap_and_ringbuffer/paged_attention/test_paged_attention.py \
    --platform a2a3sim \
    --case TestPagedAttention::CaseSmall1 \
    --dump-tensor 2
```

Results:

- PagedAttention: passed
- Vector example: passed
- Scalar entries in `tensor_dump.json` now preserve real dtype and show decoded values such as `1.0`, `2.0`, and `3`
- JSON no longer relies on `func_id` or host-side scalar dtype table join logic

Fixes #965