### PR TITLE
feat(examples): add L3 ring allreduce skeleton (chunked RS+AG)

### DIFF
--- a/examples/workers/l3/README.md
+++ b/examples/workers/l3/README.md
@@ -64,6 +64,7 @@ Two things to know before reading the example:
 | [`multi_chip_dispatch/`](multi_chip_dispatch/) | Two chips + one SubWorker. An orchestration fn dispatches a `ChipCallable` to each chip, then submits a Python callable to collect/verify results. |
 | [`child_memory/`](child_memory/) | `orch.malloc` + `ContinuousTensor(child_memory=True)` to load a weight once and reuse it across multiple kernel invocations on the same chip. |
 | [`allreduce_distributed/`](allreduce_distributed/) | One communication domain allocated inside the orchestration via `orch.allocate_domain`, with PTO-ISA remote reads over the domain window. |
+| [`allreduce_ring_distributed/`](allreduce_ring_distributed/) | Same domain/window setup as mesh allreduce, but phase-3 uses **ring** reduce-scatter + allgather (chunked, O(P) rounds) instead of reading every peer's full scratch slot. |
 | [`allgather_distributed/`](allgather_distributed/) | One communication domain via `orch.allocate_domain`; each rank stages its slice, synchronizes across ranks, then gathers every rank's window data into a full output. |
 | [`reduce_scatter_distributed/`](reduce_scatter_distributed/) | One communication domain via `orch.allocate_domain`; each rank stages all input chunks, synchronizes, then reduces the per-rank chunk across peers into a rank-local output. |
 | [`broadcast_distributed/`](broadcast_distributed/) | One communication domain via `orch.allocate_domain`; root stages into the window, synchronizes, then every rank reads the root's scratch slot into its output. |

--- a/examples/workers/l3/allreduce_ring_distributed/__init__.py
+++ b/examples/workers/l3/allreduce_ring_distributed/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Package marker so ``test_*.py`` can do ``from .main import run``."""

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -14,13 +14,17 @@
  * Contrasts with mesh ``allreduce_kernel.cpp`` (O(P) full-vector remote reads):
  * each of the (P-1) reduce-scatter and (P-1) allgather rounds moves one chunk
  * to the right neighbour; left neighbour reads the published exchange slot via
- * CommRemotePtr + TLOAD.
+ * CommRemotePtr + TLOAD (same local-write / barrier / remote-read pattern as mesh).
  *
  * Scratch layout (float region then int32 signals):
  *   [0 .. P*chunk)           P chunk slots owned by this rank
  *   [P*chunk .. (P+1)*chunk) single-chunk exchange publish area
- *   tail                     2*(P-1)*kMaxSupportedRanks int32 barrier slots
- *                            (one row per round, indexed by rank)
+ *   tail                     kMaxSupportedRanks int32 barrier slots (one row)
+ *
+ * Multi-round barriers reuse the same signal row with monotonically increasing
+ * generation counters (AtomicAdd + TWAIT GE generation).  Do not zero signal
+ * slots between rounds — a faster rank's TNOTIFY can arrive while a slower
+ * rank is still resetting, which loses the wakeup and deadlocks TWAIT.
  *
  * args layout (see allreduce_ring_orch.cpp):
  *   tensor(0) = input    (ALLREDUCE_COUNT floats)
@@ -62,14 +66,14 @@ using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYN
 using Global = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
 using TileData = pto::Tile<pto::TileType::Vec, float, 1, CHUNK_MAX, pto::BLayout::RowMajor, -1, -1>;
 
-AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_base, int my_rank, int nranks,
-                                int round) {
-    __gm__ int32_t *round_signals = signal_base + round * kMaxSupportedRanks;
+// Mesh-style device barrier with cumulative generation counter on a single signal row.
+AICORE inline void
+DeviceBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_base, int my_rank, int nranks, int32_t generation) {
     for (int peer = 0; peer < nranks; ++peer) {
         if (peer == my_rank) {
             continue;
         }
-        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, round_signals + my_rank, peer);
+        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, signal_base + my_rank, peer);
         pto::comm::Signal sig(remote_signal);
         pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
     }
@@ -77,8 +81,8 @@ AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_
         if (peer == my_rank) {
             continue;
         }
-        pto::comm::Signal sig(round_signals + peer);
-        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
+        pto::comm::Signal sig(signal_base + peer);
+        pto::comm::TWAIT(sig, generation, pto::comm::WaitCmp::GE);
     }
     pipe_barrier(PIPE_ALL);
 }
@@ -96,8 +100,9 @@ AICORE inline void CopyChunkGm(__gm__ float *dst, __gm__ float *src, int chunk_e
     wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
-AICORE inline void RecvExchangeFromLeft(__gm__ CommContext *ctx, __gm__ float *exchange_local, int my_rank, int nranks,
-                                        int chunk_elems, TileData &recvTile) {
+AICORE inline void RecvExchangeFromLeft(
+    __gm__ CommContext *ctx, __gm__ float *exchange_local, int my_rank, int nranks, int chunk_elems, TileData &recvTile
+) {
     int left = (my_rank - 1 + nranks) % nranks;
     __gm__ float *remote_exchange = CommRemotePtr(ctx, exchange_local, left);
     ShapeDyn shape(1, 1, 1, 1, chunk_elems);
@@ -133,6 +138,12 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     __gm__ int32_t *signal_base =
         reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>((nranks + 1) * chunk_elems));
 
+    // Zero-init once per invocation (handles stale HCCL window state from a prior run).
+    for (int i = 0; i < nranks; ++i) {
+        signal_base[i] = 0;
+    }
+    pipe_barrier(PIPE_ALL);
+
     TileData chunkTile(1, chunk_elems);
     TileData recvTile(1, chunk_elems);
     TASSIGN(chunkTile, 0x0);
@@ -141,16 +152,20 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
     StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
 
+    int32_t generation = 0;
+
     // ------------------------------------------------------------------
     // Stage-in: partition local input into P chunk slots in the window.
     // ------------------------------------------------------------------
     for (int chunk = 0; chunk < nranks; ++chunk) {
-        CopyChunkGm(chunks + static_cast<size_t>(chunk * chunk_elems), input + static_cast<size_t>(chunk * chunk_elems),
-                    chunk_elems, chunkTile);
+        CopyChunkGm(
+            chunks + static_cast<size_t>(chunk * chunk_elems), input + static_cast<size_t>(chunk * chunk_elems),
+            chunk_elems, chunkTile
+        );
     }
     pipe_barrier(PIPE_ALL);
 
-    int round = 0;
+    DeviceBarrier(commCtx, signal_base, my_rank, nranks, ++generation);
 
     // ------------------------------------------------------------------
     // Reduce-scatter: (P-1) ring steps; rank r ends with fully reduced chunk r.
@@ -162,7 +177,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         CopyChunkGm(exchange, chunks + static_cast<size_t>(send_idx * chunk_elems), chunk_elems, chunkTile);
         pipe_barrier(PIPE_ALL);
 
-        RoundBarrier(commCtx, signal_base, my_rank, nranks, round++);
+        DeviceBarrier(commCtx, signal_base, my_rank, nranks, ++generation);
 
         RecvExchangeFromLeft(commCtx, exchange, my_rank, nranks, chunk_elems, recvTile);
 
@@ -189,7 +204,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         CopyChunkGm(exchange, chunks + static_cast<size_t>(send_idx * chunk_elems), chunk_elems, chunkTile);
         pipe_barrier(PIPE_ALL);
 
-        RoundBarrier(commCtx, signal_base, my_rank, nranks, round++);
+        DeviceBarrier(commCtx, signal_base, my_rank, nranks, ++generation);
 
         RecvExchangeFromLeft(commCtx, exchange, my_rank, nranks, chunk_elems, recvTile);
 
@@ -206,8 +221,10 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // Stage-out: concatenated chunks → local output tensor.
     // ------------------------------------------------------------------
     for (int chunk = 0; chunk < nranks; ++chunk) {
-        CopyChunkGm(output + static_cast<size_t>(chunk * chunk_elems),
-                    chunks + static_cast<size_t>(chunk * chunk_elems), chunk_elems, chunkTile);
+        CopyChunkGm(
+            output + static_cast<size_t>(chunk * chunk_elems), chunks + static_cast<size_t>(chunk * chunk_elems),
+            chunk_elems, chunkTile
+        );
     }
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Ring AllReduce kernel — chunked RS + AG over a logical ring.
+ *
+ * Contrasts with mesh ``allreduce_kernel.cpp`` (O(P) full-vector remote reads):
+ * each of the (P-1) reduce-scatter and (P-1) allgather rounds moves one chunk
+ * to the right neighbour; left neighbour reads the published exchange slot via
+ * CommRemotePtr + TLOAD.
+ *
+ * Scratch layout (float region then int32 signals):
+ *   [0 .. P*chunk)           P chunk slots owned by this rank
+ *   [P*chunk .. (P+1)*chunk) single-chunk exchange publish area
+ *   tail                     2*(P-1)*kMaxSupportedRanks int32 barrier slots
+ *                            (one row per round, indexed by rank)
+ *
+ * args layout (see allreduce_ring_orch.cpp):
+ *   tensor(0) = input    (ALLREDUCE_COUNT floats)
+ *   tensor(1) = output   (ALLREDUCE_COUNT floats)
+ *   tensor(2) = scratch  (HCCL window slot)
+ *   scalar(0) = nranks
+ *   scalar(1) = CommContext device pointer
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+#include "platform_comm/comm_context.h"
+#include "pto/comm/comm_types.hpp"
+#include "pto/comm/pto_comm_inst.hpp"
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+static constexpr size_t ALLREDUCE_COUNT = 256;
+static constexpr int kMaxSupportedRanks = 16;
+// Minimum rank count is 2, so the largest chunk is ALLREDUCE_COUNT / 2.
+static constexpr size_t CHUNK_MAX = ALLREDUCE_COUNT / 2;
+
+template <typename T>
+AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPtr, int pe) {
+    uint64_t localBase = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = (uint64_t)localPtr - localBase;
+    return (__gm__ T *)(ctx->windowsIn[pe] + offset);
+}
+
+using ShapeDyn = pto::Shape<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+using StrideDyn = pto::Stride<pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC, pto::DYNAMIC>;
+using Global = pto::GlobalTensor<float, ShapeDyn, StrideDyn, pto::Layout::ND>;
+using TileData = pto::Tile<pto::TileType::Vec, float, 1, CHUNK_MAX, pto::BLayout::RowMajor, -1, -1>;
+
+AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_base, int my_rank, int nranks,
+                                int round) {
+    __gm__ int32_t *round_signals = signal_base + round * kMaxSupportedRanks;
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) {
+            continue;
+        }
+        __gm__ int32_t *remote_signal = CommRemotePtr(ctx, round_signals + my_rank, peer);
+        pto::comm::Signal sig(remote_signal);
+        pto::comm::TNOTIFY(sig, (int32_t)1, pto::comm::NotifyOp::AtomicAdd);
+    }
+    for (int peer = 0; peer < nranks; ++peer) {
+        if (peer == my_rank) {
+            continue;
+        }
+        pto::comm::Signal sig(round_signals + peer);
+        pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
+    }
+    pipe_barrier(PIPE_ALL);
+}
+
+AICORE inline void CopyChunkGm(__gm__ float *dst, __gm__ float *src, int chunk_elems, TileData &tile) {
+    ShapeDyn shape(1, 1, 1, 1, chunk_elems);
+    StrideDyn stride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
+    Global srcG(src, shape, stride);
+    Global dstG(dst, shape, stride);
+    TLOAD(tile, srcG);
+    set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstG, tile);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+}
+
+AICORE inline void RecvExchangeFromLeft(__gm__ CommContext *ctx, __gm__ float *exchange_local, int my_rank, int nranks,
+                                        int chunk_elems, TileData &recvTile) {
+    int left = (my_rank - 1 + nranks) % nranks;
+    __gm__ float *remote_exchange = CommRemotePtr(ctx, exchange_local, left);
+    ShapeDyn shape(1, 1, 1, 1, chunk_elems);
+    StrideDyn stride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
+    Global remoteG(remote_exchange, shape, stride);
+    TLOAD(recvTile, remoteG);
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *scratch_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    int nranks = static_cast<int>(args[3]);
+    __gm__ CommContext *commCtx = reinterpret_cast<__gm__ CommContext *>(args[4]);
+
+    __gm__ float *input = reinterpret_cast<__gm__ float *>(input_tensor->buffer.addr) + input_tensor->start_offset;
+    __gm__ float *output = reinterpret_cast<__gm__ float *>(output_tensor->buffer.addr) + output_tensor->start_offset;
+    __gm__ float *scratch =
+        reinterpret_cast<__gm__ float *>(scratch_tensor->buffer.addr) + scratch_tensor->start_offset;
+
+    int my_rank = static_cast<int>(commCtx->rankId);
+
+    if (nranks <= 1 || nranks > kMaxSupportedRanks || (ALLREDUCE_COUNT % static_cast<size_t>(nranks)) != 0) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+
+    const int chunk_elems = static_cast<int>(ALLREDUCE_COUNT / static_cast<size_t>(nranks));
+    __gm__ float *chunks = scratch;
+    __gm__ float *exchange = scratch + static_cast<size_t>(nranks * chunk_elems);
+    __gm__ int32_t *signal_base =
+        reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>((nranks + 1) * chunk_elems));
+
+    TileData chunkTile(1, chunk_elems);
+    TileData recvTile(1, chunk_elems);
+    TASSIGN(chunkTile, 0x0);
+    TASSIGN(recvTile, 0x10000);
+
+    ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
+    StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
+
+    // ------------------------------------------------------------------
+    // Stage-in: partition local input into P chunk slots in the window.
+    // ------------------------------------------------------------------
+    for (int chunk = 0; chunk < nranks; ++chunk) {
+        CopyChunkGm(chunks + static_cast<size_t>(chunk * chunk_elems), input + static_cast<size_t>(chunk * chunk_elems),
+                    chunk_elems, chunkTile);
+    }
+    pipe_barrier(PIPE_ALL);
+
+    int round = 0;
+
+    // ------------------------------------------------------------------
+    // Reduce-scatter: (P-1) ring steps; rank r ends with fully reduced chunk r.
+    // ------------------------------------------------------------------
+    for (int step = 1; step < nranks; ++step) {
+        const int send_idx = (my_rank - step + nranks) % nranks;
+        const int recv_add_idx = (my_rank - step - 1 + nranks) % nranks;
+
+        CopyChunkGm(exchange, chunks + static_cast<size_t>(send_idx * chunk_elems), chunk_elems, chunkTile);
+        pipe_barrier(PIPE_ALL);
+
+        RoundBarrier(commCtx, signal_base, my_rank, nranks, round++);
+
+        RecvExchangeFromLeft(commCtx, exchange, my_rank, nranks, chunk_elems, recvTile);
+
+        Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
+        TLOAD(chunkTile, accG);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        TADD(chunkTile, chunkTile, recvTile);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(accG, chunkTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        pipe_barrier(PIPE_ALL);
+    }
+
+    // ------------------------------------------------------------------
+    // Allgather: (P-1) ring steps; every rank collects all reduced chunks.
+    // ------------------------------------------------------------------
+    for (int step = 1; step < nranks; ++step) {
+        const int send_idx = (my_rank - step + 1 + nranks) % nranks;
+        const int recv_idx = (my_rank - step + nranks) % nranks;
+
+        CopyChunkGm(exchange, chunks + static_cast<size_t>(send_idx * chunk_elems), chunk_elems, chunkTile);
+        pipe_barrier(PIPE_ALL);
+
+        RoundBarrier(commCtx, signal_base, my_rank, nranks, round++);
+
+        RecvExchangeFromLeft(commCtx, exchange, my_rank, nranks, chunk_elems, recvTile);
+
+        Global dstG(chunks + static_cast<size_t>(recv_idx * chunk_elems), chunkShape, chunkStride);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, recvTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        pipe_barrier(PIPE_ALL);
+    }
+
+    // ------------------------------------------------------------------
+    // Stage-out: concatenated chunks → local output tensor.
+    // ------------------------------------------------------------------
+    for (int chunk = 0; chunk < nranks; ++chunk) {
+        CopyChunkGm(output + static_cast<size_t>(chunk * chunk_elems),
+                    chunks + static_cast<size_t>(chunk * chunk_elems), chunk_elems, chunkTile);
+    }
+    pipe_barrier(PIPE_ALL);
+}

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/orchestration/allreduce_ring_orch.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/orchestration/allreduce_ring_orch.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Ring AllReduce orchestration — kernel shim (same arg layout as mesh allreduce).
+ *
+ *   tensor(0) input   INPUT
+ *   tensor(1) output  OUTPUT_EXISTING
+ *   tensor(2) scratch INOUT
+ *   scalar(0) nranks
+ *   scalar(1) CommContext device pointer
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+allreduce_ring_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 5,  // 3 tensors + 2 scalars
+    };
+}
+
+__attribute__((visibility("default"))) void allreduce_ring_orchestration(const ChipStorageTaskArgs &orch_args) {
+    Tensor input = from_tensor_arg(orch_args.tensor(0));
+    Tensor output = from_tensor_arg(orch_args.tensor(1));
+    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+
+    Arg params;
+    params.add_input(input);
+    params.add_output(output);
+    params.add_inout(scratch);
+    params.add_scalar(orch_args.scalar(0));  // nranks
+    params.add_scalar(orch_args.scalar(1));  // CommContext
+    rt_submit_aiv_task(0, params);
+}
+
+}  // extern "C"

--- a/examples/workers/l3/allreduce_ring_distributed/main.py
+++ b/examples/workers/l3/allreduce_ring_distributed/main.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""End-to-end distributed ring allreduce — chunked reduce-scatter + allgather.
+
+Each rank owns private input/output tensors.  Cross-rank traffic follows a
+logical ring (send to ``(rank+1) % P``, receive from ``(rank-1+P) % P``):
+
+  Stage-in        partition input into P chunk slots in the HCCL window
+  Reduce-scatter  (P-1) rounds — each rank ends with the fully reduced chunk
+                  it owns (same golden as mesh ``allreduce_distributed``)
+  Allgather       (P-1) rounds — propagate reduced chunks around the ring
+  Stage-out       concatenate chunks → output
+
+Compared to mesh ``allreduce_distributed/`` (O(P) full-vector remote reads
+per rank), ring moves one chunk per round — bandwidth scales as
+``2(P-1)/P × M`` for large ``M``.  P=4 is the minimum interesting width for
+the schedule; P=2 is supported for regression.
+
+Run:
+    python examples/workers/l3/allreduce_ring_distributed/main.py -p a2a3sim -d 0-3
+
+Compare mesh baseline on the same host:
+    python examples/workers/l3/allreduce_distributed/main.py -p a2a3sim -d 0-3
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import torch  # noqa: E402
+from simpler.task_interface import (  # noqa: E402
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    CommBufferSpec,
+    ContinuousTensor,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    TensorArgType,
+)
+from simpler.worker import Worker  # noqa: E402
+
+from simpler_setup.elf_parser import extract_text_section  # noqa: E402
+from simpler_setup.kernel_compiler import KernelCompiler  # noqa: E402
+from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: E402
+from simpler_setup.torch_interop import make_tensor_arg  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Must match ALLREDUCE_COUNT in kernels/aiv/allreduce_ring_kernel.cpp.
+ALLREDUCE_COUNT = 256
+K_MAX_SUPPORTED_RANKS = 16
+CHUNK_MAX = ALLREDUCE_COUNT // 2  # largest chunk (P=2)
+SCRATCH_FLOAT_ELEMS = (K_MAX_SUPPORTED_RANKS + 1) * CHUNK_MAX
+SIGNAL_SLOTS = 2 * (K_MAX_SUPPORTED_RANKS - 1) * K_MAX_SUPPORTED_RANKS
+SCRATCH_NBYTES = SCRATCH_FLOAT_ELEMS * 4 + SIGNAL_SLOTS * 4
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        ids = list(range(lo, hi + 1))
+    else:
+        ids = [int(spec)]
+    if not (2 <= len(ids) <= K_MAX_SUPPORTED_RANKS):
+        raise ValueError(
+            f"allreduce_ring_distributed needs between 2 and {K_MAX_SUPPORTED_RANKS} devices, "
+            f"got {len(ids)} ({ids})"
+        )
+    if ALLREDUCE_COUNT % len(ids) != 0:
+        raise ValueError(
+            f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={len(ids)} for even chunking"
+        )
+    return ids
+
+
+def build_chip_callable(platform: str, pto_isa_commit: str | None) -> ChipCallable:
+    """Compile the ring allreduce AIV kernel + orchestration shim."""
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol="https")
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    kernel_include_dirs = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+    kernel_bytes = kc.compile_incore(
+        source_path=os.path.join(HERE, "kernels/aiv/allreduce_ring_kernel.cpp"),
+        core_type="aiv",
+        pto_isa_root=pto_isa_root,
+        extra_include_dirs=kernel_include_dirs,
+    )
+    if not platform.endswith("sim"):
+        kernel_bytes = extract_text_section(kernel_bytes)
+
+    orch_bytes = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/allreduce_ring_orch.cpp"),
+    )
+    core_callable = CoreCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
+        binary=kernel_bytes,
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.INOUT],
+        func_name="allreduce_ring_orchestration",
+        config_name="allreduce_ring_orchestration_config",
+        binary=orch_bytes,
+        children=[(0, core_callable)],
+    )
+
+
+def expected_output(nranks: int) -> list[float]:
+    """Same golden as mesh allreduce: output[i] = sum_r (i + r*100)."""
+    return [float(nranks * i + 100 * nranks * (nranks - 1) // 2) for i in range(ALLREDUCE_COUNT)]
+
+
+def run(
+    device_ids: list[int],
+    platform: str = "a2a3",
+    pto_isa_commit: str | None = None,
+) -> int:
+    """Core logic — callable from both CLI and pytest."""
+    nranks = len(device_ids)
+    window_size = max(SCRATCH_NBYTES, 4 * 1024)
+
+    print(f"[ring-allreduce] platform={platform} devices={device_ids} nranks={nranks}")
+
+    host_inputs = [
+        torch.tensor([i + rank * 100 for i in range(ALLREDUCE_COUNT)], dtype=torch.float32).share_memory_()
+        for rank in range(nranks)
+    ]
+    host_outputs = [torch.zeros(ALLREDUCE_COUNT, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+
+    print("[ring-allreduce] compiling kernels...")
+    chip_callable = build_chip_callable(platform, pto_isa_commit)
+
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+    )
+    chip_cid = worker.register(chip_callable)
+
+    try:
+        print("[ring-allreduce] init worker (forks chip children; base comm is lazy)...")
+        worker.init()
+
+        def orch_fn(orch, _args, cfg):
+            with orch.allocate_domain(
+                name="default",
+                workers=list(range(nranks)),
+                window_size=window_size,
+                buffers=[
+                    CommBufferSpec(
+                        name="scratch",
+                        dtype="float32",
+                        count=SCRATCH_FLOAT_ELEMS,
+                        nbytes=SCRATCH_NBYTES,
+                    )
+                ],
+            ) as handle:
+                for i in range(nranks):
+                    domain = handle[i]
+                    print(
+                        f"[ring-allreduce] chip {i}: rank={domain.domain_rank}/{domain.domain_size} "
+                        f"window=[0x{domain.local_window_base:x} +{domain.actual_window_size}B] "
+                        f"scratch=0x{domain.buffer_ptrs['scratch']:x}"
+                    )
+                    chip_args = TaskArgs()
+                    chip_args.add_tensor(make_tensor_arg(host_inputs[i]), TensorArgType.INPUT)
+                    chip_args.add_tensor(make_tensor_arg(host_outputs[i]), TensorArgType.OUTPUT_EXISTING)
+                    chip_args.add_tensor(
+                        ContinuousTensor.make(
+                            data=domain.buffer_ptrs["scratch"],
+                            shapes=(SCRATCH_FLOAT_ELEMS,),
+                            dtype=DataType.FLOAT32,
+                            child_memory=True,
+                        ),
+                        TensorArgType.INOUT,
+                    )
+                    chip_args.add_scalar(domain.domain_size)
+                    chip_args.add_scalar(domain.device_ctx)
+                    orch.submit_next_level(chip_cid, chip_args, cfg, worker=i)
+
+        print(f"[ring-allreduce] running {nranks}-chip ring allreduce DAG...")
+        worker.run(orch_fn, args=None, config=CallConfig())
+
+        expected = torch.tensor(expected_output(nranks), dtype=torch.float32)
+        ok = True
+        for i in range(nranks):
+            max_diff = float(torch.max(torch.abs(host_outputs[i] - expected)))
+            print(f"[ring-allreduce] chip {i}: max |out - expected| = {max_diff:.3e}")
+            if max_diff > 1e-3:
+                ok = False
+                for j in range(min(4, ALLREDUCE_COUNT)):
+                    print(f"  output[{j}]={float(host_outputs[i][j])!r} expected={float(expected[j])!r}")
+
+        if not ok:
+            print("[ring-allreduce] golden check FAILED")
+            return 1
+        print("[ring-allreduce] all ranks matched golden ✅")
+        return 0
+    finally:
+        worker.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+
+    parser.add_argument("-p", "--platform", default="a2a3", help="Platform backend, e.g. a2a3 or a2a3sim.")
+    parser.add_argument(
+        "-d",
+        "--device",
+        default="0-3",
+        help="Device range, e.g. '0-3' (recommended) or '0-1'. 2 to 16 chips; COUNT must divide nranks.",
+    )
+    parser.add_argument("--pto-isa-commit", default=None, help="Optional PTO ISA commit/tag to fetch before compiling.")
+    cli = parser.parse_args()
+
+    return run(parse_device_range(cli.device), platform=cli.platform, pto_isa_commit=cli.pto_isa_commit)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/workers/l3/allreduce_ring_distributed/main.py
+++ b/examples/workers/l3/allreduce_ring_distributed/main.py
@@ -65,7 +65,8 @@ ALLREDUCE_COUNT = 256
 K_MAX_SUPPORTED_RANKS = 16
 CHUNK_MAX = ALLREDUCE_COUNT // 2  # largest chunk (P=2)
 SCRATCH_FLOAT_ELEMS = (K_MAX_SUPPORTED_RANKS + 1) * CHUNK_MAX
-SIGNAL_SLOTS = 2 * (K_MAX_SUPPORTED_RANKS - 1) * K_MAX_SUPPORTED_RANKS
+# One int32 signal row (same as mesh allreduce); kernel bumps generation each round.
+SIGNAL_SLOTS = K_MAX_SUPPORTED_RANKS
 SCRATCH_NBYTES = SCRATCH_FLOAT_ELEMS * 4 + SIGNAL_SLOTS * 4
 
 
@@ -77,13 +78,10 @@ def parse_device_range(spec: str) -> list[int]:
         ids = [int(spec)]
     if not (2 <= len(ids) <= K_MAX_SUPPORTED_RANKS):
         raise ValueError(
-            f"allreduce_ring_distributed needs between 2 and {K_MAX_SUPPORTED_RANKS} devices, "
-            f"got {len(ids)} ({ids})"
+            f"allreduce_ring_distributed needs between 2 and {K_MAX_SUPPORTED_RANKS} devices, got {len(ids)} ({ids})"
         )
     if ALLREDUCE_COUNT % len(ids) != 0:
-        raise ValueError(
-            f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={len(ids)} for even chunking"
-        )
+        raise ValueError(f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must be divisible by nranks={len(ids)} for even chunking")
     return ids
 
 

--- a/examples/workers/l3/allreduce_ring_distributed/test_allreduce.py
+++ b/examples/workers/l3/allreduce_ring_distributed/test_allreduce.py
@@ -1,0 +1,38 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""ST for examples/workers/l3/allreduce_ring_distributed."""
+
+import pytest
+
+from .main import run
+
+
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim", "a5"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.device_count(2)
+def test_ring_allreduce_distributed(st_platform, st_device_ids):
+    assert len(st_device_ids) == 2
+    rc = run([int(d) for d in st_device_ids], platform=st_platform)
+    assert rc == 0
+
+
+# P=4 is the primary ring schedule width; split from the 2-rank case so a5
+# CI (2 NPUs only) does not abort the whole resource phase.
+@pytest.mark.platforms(["a2a3sim", "a2a3", "a5sim"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.parametrize(
+    "n_devices",
+    [
+        pytest.param(4, marks=pytest.mark.device_count(4)),
+    ],
+)
+def test_ring_allreduce_distributed_multi_rank(st_platform, st_device_ids, n_devices):
+    assert len(st_device_ids) == n_devices
+    rc = run([int(d) for d in st_device_ids], platform=st_platform)
+    assert rc == 0


### PR DESCRIPTION
Adds a new L3 example `allreduce_ring_distributed/` implementing **chunked ring allreduce** (P−1 reduce-scatter + P−1 allgather rounds) over the HCCL communication window.

## Verification status

| Phase | Status |
|-------|--------|
| **A — L3 driver** | NPU P=2 PASS @ `8fb6316e` (a2a3, devices 5–6; temporary mesh-binary fallback) |
| **B/C — Ring RS+AG kernel** | Kernel + `allreduce_ring_common.hpp` wired; `main.py` compiles ring sources; **NPU verify pending** |

## What changed

**New:** `examples/workers/l3/allreduce_ring_distributed/`

| Component | Description |
|-----------|-------------|
| `kernels/aiv/allreduce_ring_kernel.cpp` | Stage-in → (P−1) RS ring steps → (P−1) AG ring steps → stage-out |
| `kernels/aiv/allreduce_ring_common.hpp` | Chunk copy, per-round barrier, left-neighbour recv helpers |
| `kernels/orchestration/allreduce_ring_orch.cpp` | Same 3-tensor + 2-scalar arg layout as mesh allreduce |
| `main.py` | Worker/orchestration glue; ring scratch sizing; same golden as mesh |
| `test_allreduce.py` | P=2 + P=4 pytest (split for a5 2-NPU CI, same pattern as mesh) |

**Edit:** `examples/workers/l3/README.md` — documents the new example.

**Scratch layout (per rank, in window):**
- `P` chunk slots (partitioned input / working buffers)
- 1 exchange publish slot (one chunk, visible to left neighbour)
- Signal tail: `2(P−1) × kMaxSupportedRanks` int32 slots (one row per round)

**Golden:** identical to mesh — `output[i] = sum_r (i + r×100)` for all ranks (256-element float32 vectors; `ALLREDUCE_COUNT` must divide `nranks`).

## NPU re-verify (after ring kernel wired)

```bash
python examples/workers/l3/allreduce_distributed/main.py -p a2a3 -d 5-6   # baseline
python examples/workers/l3/allreduce_ring_distributed/main.py -p a2a3 -d 5-6
python examples/workers/l3/allreduce_ring_distributed/main.py -p a2a3sim -d 0-3
```