### PR TITLE
Add: per-task and scope-filter granularity to scope_stats

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -173,9 +173,19 @@ def pytest_addoption(parser):
     )
     parser.addoption(
         "--enable-scope-stats",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="LINES",
+        help="Enable per-scope peak collection and emit <output_prefix>/scope_stats.jsonl (per-scope ring-fill "
+        "peaks). Optionally pass a comma-separated list of PTO2_SCOPE line numbers (e.g. --enable-scope-stats "
+        "42,108) to collect only those scopes; bare flag collects all.",
+    )
+    parser.addoption(
+        "--scope-stats-task",
         action="store_true",
         default=False,
-        help="Enable per-scope peak collection and emit <output_prefix>/scope_stats.jsonl (per-scope ring-fill peaks).",
+        help='Add per-task scope_stats records (one per submit_task, phase="task"). Implies --enable-scope-stats.',
     )
     parser.addoption(
         "--pto-isa-commit",

--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -24,25 +24,40 @@ Pass the flag to any T&R example or scene test:
 python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-scope-stats
 ```
 
-The flag is bit 4 of `enable_profiling_flag`; on a T&R run it turns on
-per-scope peak tracking. On other runtimes the flag is accepted but
-produces no records.
+On a T&R run it turns on per-scope peak tracking. On other runtimes the
+flag is accepted but produces no records.
+
+Two optional, orthogonal refinements layer on top — both keep the
+default (bare flag) behavior unchanged and are opt-in:
+
+| Flag | Effect |
+| ---- | ------ |
+| `--enable-scope-stats <lines>` | Collect **only** the listed `PTO2_SCOPE` line numbers (comma-separated, e.g. `--enable-scope-stats 42,108`). The orchestration is one source file, so a line uniquely identifies a scope. Bare flag = collect every scope. |
+| `--scope-stats-task` | Also emit one **per-task** record (`phase: "task"`) at every `submit_task`, carrying the submitted `task_id` and the ring/heap occupancy right after allocation. Implies `--enable-scope-stats`. |
+
+The two compose: `--enable-scope-stats 77 --scope-stats-task` records the
+per-task occupancy curve **inside the scope at line 77 only** — the usual
+way to see which task drove a specific scope to its peak without the
+volume of per-task sampling everywhere.
+
+Equivalent `CallConfig` fields for programmatic use:
+`config.scope_stats_scope = "42,108"` and `config.scope_stats_task = True`.
 
 ### Step 2 — Locate the output
 
-The run writes `scope_stats.jsonl` under the per-task output prefix
-(the same directory other profiling artifacts land in for that run).
+The run writes `scope_stats.jsonl` into a `scope_stats/` subdirectory of
+the per-task output prefix (`<output_prefix>/scope_stats/scope_stats.jsonl`).
 It is NDJSON: line 1 is run metadata, every subsequent line is one
 scope sample. See [§3](#3-output-scope_statsjsonl) for the schema.
 
 ### Step 3 — Visualize with `scope_stats_plot.py`
 
 ```bash
-python simpler_setup/tools/scope_stats_plot.py <output_prefix>/scope_stats.jsonl
-# writes <output_prefix>/scope_stats.html
+python simpler_setup/tools/scope_stats_plot.py <output_prefix>/scope_stats/scope_stats.jsonl
+# writes <output_prefix>/scope_stats/scope_stats.html
 
 # or send the report elsewhere:
-python simpler_setup/tools/scope_stats_plot.py path/to/scope_stats.jsonl --out-dir /tmp/report
+python simpler_setup/tools/scope_stats_plot.py path/to/scope_stats/scope_stats.jsonl --out-dir /tmp/report
 ```
 
 | Argument | Required | Meaning |
@@ -80,12 +95,19 @@ the `real_occupancy` curve.
 - **The whole orchestration, automatically.** You do not mark a region
   to profile — instrumentation lives inside the `PTO2_SCOPE` macro
   itself, so *every* scope in the orchestration is recorded once the
-  flag is on. The executor wraps the orchestration entry in a root
-  `PTO2_SCOPE` (`depth` 0), and every user-written `PTO2_SCOPE` nests
-  under it, so the report covers the entire orch scope tree end to end.
+  flag is on. The executor opens an implicit root scope around the
+  orchestration entry (`depth` 0, rendered as site `<root>` since it has
+  no `PTO2_SCOPE` source location), and every user-written `PTO2_SCOPE`
+  nests under it, so the report covers the entire orch scope tree.
 - **One sample per scope boundary.** Each `PTO2_SCOPE` emits a `begin`
   record on entry and an `end` record on exit. The plot tool pairs them
   by site to compute the metrics above.
+- **Optionally narrowed or refined.** `--enable-scope-stats <lines>`
+  restricts collection to specific scope sites; `--scope-stats-task`
+  adds intermediate `task` records inside a scope (see [§1](#step-1--run-with---enable-scope-stats)).
+  Both are device-side gated — a filtered-out scope is never appended
+  and does not count toward `total`, and the per-task probe costs one
+  bool load when off.
 - **Per-ring.** Each ring's task allocator heap / task-window is tracked
   independently; a scope only ever touches its own ring
   (`ring = min(depth, MAX_RING_DEPTH−1)`).
@@ -98,13 +120,15 @@ the `real_occupancy` curve.
 
 ## 3. Output: `scope_stats.jsonl`
 
-NDJSON. Line 1 is run metadata; each subsequent line is one scope
-sample (`begin` or `end`). Schema version 4:
+NDJSON. Line 1 is run metadata; each subsequent line is one sample —
+`begin`/`end` at scope boundaries, plus `task` records in between when
+`--scope-stats-task` is on. Schema version 4:
 
 ```json
 {"version": 4, "fatal": false, "dropped": 0, "total": 4, "task_window_max": [8, 4], "heap_max": [268435456, 268435456], "tensormap_max": 65536}
-{"site": "example_orchestration.cpp:77", "phase": "begin", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 0, "heap_start": 0, "heap_end": 0, "tensormap": 0}
-{"site": "example_orchestration.cpp:77", "phase": "end", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 4, "heap_start": 0, "heap_end": 8192, "tensormap": 5}
+{"site": "example_orchestration.cpp:77", "phase": "begin", "task_id": 0, "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 0, "heap_start": 0, "heap_end": 0, "tensormap": 0}
+{"site": "example_orchestration.cpp:77", "phase": "task", "task_id": 4294967296, "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 1, "heap_start": 0, "heap_end": 2048, "tensormap": 1}
+{"site": "example_orchestration.cpp:77", "phase": "end", "task_id": 0, "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 4, "heap_start": 0, "heap_end": 8192, "tensormap": 5}
 ```
 
 Metadata line (line 1):
@@ -123,9 +147,10 @@ Per-sample lines, oldest-first:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
-| `site` | `"basename:line"` | Source location of the `PTO2_SCOPE()` call |
-| `phase` | `"begin"`/`"end"` | Scope entry or exit sample |
-| `depth` | int | Nesting depth (0 = root scope inside the executor) |
+| `site` | `"basename:line"` | Source location of the `PTO2_SCOPE()` call (`<root>:0` for the implicit root scope) |
+| `phase` | `"begin"`/`"end"`/`"task"` | Scope entry, scope exit, or a per-task sample (`--scope-stats-task`) |
+| `task_id` | uint | Submitted task id for `task` records; `0` for `begin`/`end` |
+| `depth` | int | Nesting depth (0 = implicit root scope, site `<root>`) |
 | `ring` | int | Ring this scope used; indexes `task_window_max` / `heap_max` |
 | `task_window_start` | int | Task-window ring tail at this boundary |
 | `task_window_end` | int | Task-window ring head at this boundary |
@@ -143,7 +168,9 @@ and occupancy are derived from a paired begin/end.
 
 This section is for maintainers wiring scope stats into a runtime; users
 do not need it. There is **no public C/C++ API** — the only external
-interfaces are the `--enable-scope-stats` flag and the plot tool above.
+interfaces are the `--enable-scope-stats` / `--scope-stats-task` flags
+(and the `CallConfig.scope_stats_scope` / `scope_stats_task` fields they
+map to) and the plot tool above.
 
 ### 4.1 Layering
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -651,6 +651,31 @@ NB_MODULE(_task_interface, m) {
                 std::memcpy(c.output_prefix, s.data(), s.size());
             }
         )
+        .def_prop_rw(
+            "scope_stats_scope",
+            [](const CallConfig &c) -> std::string {
+                return std::string(c.scope_stats_scope, ::strnlen(c.scope_stats_scope, sizeof(c.scope_stats_scope)));
+            },
+            [](CallConfig &c, const std::string &s) {
+                if (s.size() >= sizeof(c.scope_stats_scope)) {
+                    throw std::invalid_argument(
+                        "CallConfig.scope_stats_scope length " + std::to_string(s.size()) + " exceeds buffer (" +
+                        std::to_string(sizeof(c.scope_stats_scope) - 1) + " bytes)"
+                    );
+                }
+                std::memset(c.scope_stats_scope, 0, sizeof(c.scope_stats_scope));
+                std::memcpy(c.scope_stats_scope, s.data(), s.size());
+            }
+        )
+        .def_prop_rw(
+            "scope_stats_task",
+            [](const CallConfig &c) {
+                return static_cast<bool>(c.scope_stats_task);
+            },
+            [](CallConfig &c, bool v) {
+                c.scope_stats_task = v ? 1 : 0;
+            }
+        )
         .def("__repr__", [](const CallConfig &self) -> std::string {
             std::ostringstream os;
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -114,9 +114,10 @@ _OFF_CONFIG = 16
 # Packed CallConfig wire layout — must match call_config.h byte for byte:
 # 7 int32 (block_dim, aicpu_thread_num, enable_l2_swimlane, enable_dump_tensor,
 # enable_pmu, enable_dep_gen, enable_scope_stats) + 1024-byte NUL-terminated
-# output_prefix. Log config travels separately via ChipWorker.init(log_level,
+# output_prefix + 128-byte NUL-terminated scope_stats_scope + scope_stats_task
+# int32. Log config travels separately via ChipWorker.init(log_level,
 # log_info_v) — not on per-task wire.
-_CFG_FMT = struct.Struct("=iiiiiii1024s")
+_CFG_FMT = struct.Struct("=iiiiiii1024s128si")
 # Args region starts after CONFIG, rounded up to 8 bytes so the first
 # ContinuousTensor.data (uint64_t at OFF_ARGS+8) is 8-byte aligned, avoiding
 # SIGBUS on strict-alignment platforms (aarch64 atomics, some ARM cores).
@@ -728,7 +729,9 @@ def _chip_process_loop(
 
 def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     """Reconstruct a CallConfig from the unified mailbox layout."""
-    block_dim, aicpu_tn, swl, dt, pmu, dep_gen, scope_stats, prefix_bytes = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
+    (block_dim, aicpu_tn, swl, dt, pmu, dep_gen, scope_stats, prefix_bytes, scope_bytes, scope_task) = (
+        _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
+    )
     cfg = CallConfig()
     cfg.block_dim = block_dim
     cfg.aicpu_thread_num = aicpu_tn
@@ -739,6 +742,9 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     cfg.enable_scope_stats = bool(scope_stats)
     # NUL-terminated C string in a 1024-byte field.
     cfg.output_prefix = prefix_bytes.split(b"\x00", 1)[0].decode("utf-8")
+    # NUL-terminated C string in a 128-byte field (comma-separated scope lines).
+    cfg.scope_stats_scope = scope_bytes.split(b"\x00", 1)[0].decode("utf-8")
+    cfg.scope_stats_task = bool(scope_task)
     return cfg
 
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -678,6 +678,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     enable_pmu,
     enable_dep_gen,
     enable_scope_stats,
+    scope_stats_scope="",
+    scope_stats_task=False,
 ):
     """Execute a pre-filtered list of cases for one class (layers 5-6).
 
@@ -709,6 +711,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
+                scope_stats_scope=scope_stats_scope,
+                scope_stats_task=scope_stats_task,
                 output_prefix=str(prefix) if diagnostics_on else "",
             )
         finally:
@@ -884,6 +888,8 @@ class SceneTestCase:
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         *,
         output_prefix="",
     ):
@@ -901,6 +907,9 @@ class SceneTestCase:
         config.enable_pmu = enable_pmu  # 0=disabled, >0=enabled with event type
         config.enable_dep_gen = enable_dep_gen
         config.enable_scope_stats = enable_scope_stats
+        if scope_stats_scope:
+            config.scope_stats_scope = scope_stats_scope
+        config.scope_stats_task = scope_stats_task
         # `output_prefix` is required by CallConfig::validate() whenever any
         # diagnostic flag is enabled. Caller threads it down from the per-case
         # directory built by _build_output_prefix().
@@ -938,6 +947,8 @@ class SceneTestCase:
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         if self._st_level == 2:
@@ -952,6 +963,8 @@ class SceneTestCase:
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
+                scope_stats_scope=scope_stats_scope,
+                scope_stats_task=scope_stats_task,
                 output_prefix=output_prefix,
             )
         elif self._st_level == 3:
@@ -967,6 +980,8 @@ class SceneTestCase:
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
+                scope_stats_scope=scope_stats_scope,
+                scope_stats_task=scope_stats_task,
                 output_prefix=output_prefix,
             )
 
@@ -982,6 +997,8 @@ class SceneTestCase:
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         params = case.get("params", {})
@@ -1032,6 +1049,8 @@ class SceneTestCase:
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
+                scope_stats_scope=scope_stats_scope,
+                scope_stats_task=scope_stats_task,
                 output_prefix=output_prefix,
             )
 
@@ -1059,6 +1078,8 @@ class SceneTestCase:
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         # Defensive belt-and-braces: the pytest dispatcher and run_module both
@@ -1114,6 +1135,8 @@ class SceneTestCase:
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
+                scope_stats_scope=scope_stats_scope,
+                scope_stats_task=scope_stats_task,
                 output_prefix=output_prefix,
             )
 
@@ -1167,7 +1190,16 @@ class SceneTestCase:
         enable_dump_tensor = request.config.getoption("--dump-tensor", default=0)
         enable_pmu = request.config.getoption("--enable-pmu", default=0)
         enable_dep_gen = self._effective_enable_dep_gen(request, warn=True)
-        enable_scope_stats = request.config.getoption("--enable-scope-stats", default=False)
+        # nargs="?": None = flag absent, "" = bare flag (collect all), a string
+        # like "42,108" = collect only those PTO2_SCOPE line numbers. The line
+        # filter rides to the device collector via CallConfig.scope_stats_scope
+        # (set in _build_config, parsed host-side in init_scope_stats).
+        scope_stats_opt = request.config.getoption("--enable-scope-stats", default=None)
+        scope_stats_task = request.config.getoption("--scope-stats-task", default=False)
+        # --scope-stats-task implies --enable-scope-stats (the collector only
+        # initializes when scope_stats is on).
+        enable_scope_stats = scope_stats_opt is not None or scope_stats_task
+        scope_stats_scope = scope_stats_opt if isinstance(scope_stats_opt, str) else ""
         if rounds > 1:
             if enable_l2_swimlane:
                 logger.warning("Profiling disabled: --rounds > 1")
@@ -1181,6 +1213,7 @@ class SceneTestCase:
             if enable_scope_stats:
                 logger.warning("scope_stats disabled: --rounds > 1")
                 enable_scope_stats = False
+                scope_stats_task = False
 
         cls_name = type(self).__name__
         callable_obj = self.build_callable(st_platform)
@@ -1222,6 +1255,8 @@ class SceneTestCase:
             enable_pmu=enable_pmu,
             enable_dep_gen=enable_dep_gen,
             enable_scope_stats=enable_scope_stats,
+            scope_stats_scope=scope_stats_scope,
+            scope_stats_task=scope_stats_task,
         )
 
     # ------------------------------------------------------------------
@@ -1308,10 +1343,20 @@ class SceneTestCase:
         )
         parser.add_argument(
             "--enable-scope-stats",
+            nargs="?",
+            const="",
+            default=None,
+            metavar="LINES",
+            help="Enable per-scope peak collection and emit <output_prefix>/scope_stats/scope_stats.jsonl "
+            "(per-scope ring-fill peaks). Optionally pass a comma-separated list of PTO2_SCOPE line "
+            "numbers (e.g. --enable-scope-stats 42,108) to collect only those scopes; bare flag collects all.",
+        )
+        parser.add_argument(
+            "--scope-stats-task",
             action="store_true",
             default=False,
-            help="Enable per-scope peak collection and emit <output_prefix>/scope_stats/scope_stats.jsonl "
-            "(per-scope ring-fill peaks).",
+            help='Add per-task scope_stats records (one per submit_task, phase="task"). Implies '
+            "--enable-scope-stats; combine with a scope filter to restrict to one scope.",
         )
         parser.add_argument(
             "--runtime",
@@ -1394,9 +1439,13 @@ class SceneTestCase:
         if args.rounds > 1 and args.enable_dep_gen:
             logger.warning("dep_gen disabled: --rounds > 1")
             args.enable_dep_gen = False
-        if args.rounds > 1 and args.enable_scope_stats:
+        # --enable-scope-stats is nargs="?": None = absent, "" = bare (all
+        # scopes), "42,108" = only those PTO2_SCOPE lines. The line filter
+        # rides via CallConfig.scope_stats_scope (set in run_class_cases below).
+        if args.rounds > 1 and (args.enable_scope_stats is not None or args.scope_stats_task):
             logger.warning("scope_stats disabled: --rounds > 1")
-            args.enable_scope_stats = False
+            args.enable_scope_stats = None
+            args.scope_stats_task = False
 
         from .parallel_scheduler import default_max_parallel, device_range_to_list  # noqa: PLC0415
 
@@ -1526,7 +1575,11 @@ class SceneTestCase:
                                 enable_dump_tensor=args.dump_tensor,
                                 enable_pmu=args.enable_pmu,
                                 enable_dep_gen=args.enable_dep_gen,
-                                enable_scope_stats=args.enable_scope_stats,
+                                enable_scope_stats=(args.enable_scope_stats is not None or args.scope_stats_task),
+                                scope_stats_scope=(
+                                    args.enable_scope_stats if isinstance(args.enable_scope_stats, str) else ""
+                                ),
+                                scope_stats_task=args.scope_stats_task,
                             )
                             print("PASSED")
                         except Exception as e:  # noqa: BLE001
@@ -1568,8 +1621,11 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
         common.append("--dump-tensor")
     if args.enable_dep_gen:
         common.append("--enable-dep-gen")
-    if args.enable_scope_stats:
-        common.append("--enable-scope-stats")
+    if args.enable_scope_stats is not None:
+        # Preserve the optional line-filter value ("" = bare flag = collect all).
+        common += ["--enable-scope-stats", args.enable_scope_stats]
+    if args.scope_stats_task:
+        common.append("--scope-stats-task")
 
     # ----- L3 phase: one subprocess per class (not per case).
     # The child's _create_standalone_worker allocates max(cls.CASES.device_count)

--- a/simpler_setup/tools/scope_stats_plot.py
+++ b/simpler_setup/tools/scope_stats_plot.py
@@ -9,22 +9,31 @@
 # -----------------------------------------------------------------------------------------------------------
 """Post-process a scope_stats.jsonl into a single self-contained HTML report.
 
-Groups records by ``ring``; within a ring, each ``begin`` is paired with the
-first later ``end`` that shares the same ``site`` (cpp file:line). For each
-resource (task_window, heap, tensormap) three deltas are computed and drawn as
-inline-SVG line charts:
+Records carry a ``phase``: ``begin`` / ``end`` are the scope boundaries, and
+``task`` is a per-task sample taken at each ``submit_task`` (carrying the
+submitted ``task_id``, encoded as ``(ring << 32) | local``). Records are grouped
+by ``ring`` and two complementary views are drawn per ring/resource:
 
-  1. scope_high_water  = end.<res>_head - begin.<res>_tail
-  2. real_occupancy    = end.<res>_head - end.<res>_tail
-  3. scope_alloc       = end.<res>_head - begin.<res>_head
+1. **Task timeline** — every record in stream order (begin → task… → end) as a
+   single occupancy curve, so per-task resource growth is visible at the finest
+   granularity. Markers are coloured by phase (begin = green, task = blue,
+   end = red); scope boundaries are thus readable without a second overlapping
+   curve.
+2. **Per-scope deltas** — each ``begin`` paired with the first later ``end`` of
+   the same ``site`` (cpp file:line), giving one point per scope for three
+   deltas:
+
+     - scope_high_water  = end.<res>_head - begin.<res>_tail
+     - real_occupancy    = end.<res>_head - end.<res>_tail
+     - scope_alloc       = end.<res>_head - begin.<res>_head
 
 Naming: the ``begin.`` / ``end.`` prefix is the *scope's* entry/exit sample;
 ``_head`` / ``_tail`` are the *ring's* pointers (head = allocation frontier
 heap_top, tail = released boundary heap_tail). The JSON fields are still named
 ``<res>_start`` (tail) and ``<res>_end`` (head).
 
-tensormap is reported as a single in-use value (no head/tail), so it
-degenerates to a single real_occupancy curve.
+tensormap is reported as a single in-use value (no head/tail), so its per-scope
+view degenerates to a single real_occupancy curve.
 
 Output: one self-contained ``<out_dir>/scope_stats.html`` with all rings and
 resources. The SVG is inlined (no matplotlib, no external JS/CDN) so the file
@@ -112,6 +121,33 @@ def _pair_by_ring(records: list[dict]) -> dict[int, list[tuple[dict, dict]]]:
     return pairs
 
 
+def _ordered_by_ring(records: list[dict]) -> dict[int, list[dict]]:
+    """Return ring -> records in stream order (begin / task / end interleaved).
+    Drives the task-grained timeline view."""
+    by_ring: dict[int, list[dict]] = defaultdict(list)
+    for rec in records:
+        by_ring[rec["ring"]].append(rec)
+    return by_ring
+
+
+def _occupancy(rec: dict, resource: str, size: int | None) -> int:
+    """Single-sample live occupancy for one record (no begin/end pairing).
+    Ring resources fold wrap-around; tensormap is the in-use count directly."""
+    if resource == "tensormap":
+        return rec["tensormap"]
+    return _wrap(rec[f"{resource}_end"] - rec[f"{resource}_start"], size)
+
+
+def _task_label(rec: dict) -> str:
+    """Human-readable phase tag for a timeline tooltip; task records decode the
+    (ring << 32) | local task_id."""
+    phase = rec["phase"]
+    if phase == "task":
+        tid = rec.get("task_id", 0)
+        return f"task r{tid >> 32}:{tid & 0xFFFFFFFF}"
+    return phase
+
+
 _SVG_W = 720
 _SVG_H = 160
 _PAD_L = 56
@@ -167,29 +203,102 @@ def _svg_chart(label: str, series: list[float], sites: list[str], unit: str, fmt
     return f'<figure class="metric"><figcaption>{_esc(label)}</figcaption>{"".join(parts)}</figure>'
 
 
-def _ring_section(ring: int, pairs: list[tuple[dict, dict]], resource: str, size: int | None) -> str:
+def _svg_timeline(records: list[dict], resource: str, size: int | None, unit: str, fmt: str, divisor: int) -> str:
+    """One inline-SVG occupancy curve over the ring's records in stream order.
+    Markers are coloured by phase so scope boundaries (begin/end) stand out
+    against the per-task samples without a second overlapping curve."""
+    series = [_occupancy(r, resource, size) / divisor for r in records]
+    n = len(series)
+    peak = max(series) if series else 0.0
+    y_max = peak if peak > 0 else 1.0
+    plot_w = _SVG_W - _PAD_L - _PAD_R
+    plot_h = _SVG_H - _PAD_T - _PAD_B
+
+    def sx(i: int) -> float:
+        return _PAD_L + (plot_w * i / (n - 1) if n > 1 else plot_w / 2)
+
+    def sy(v: float) -> float:
+        return _PAD_T + plot_h * (1 - v / y_max)
+
+    parts = [f'<svg viewBox="0 0 {_SVG_W} {_SVG_H}" class="chart" preserveAspectRatio="xMidYMid meet">']
+    parts.append(f'<line x1="{_PAD_L}" y1="{_PAD_T}" x2="{_PAD_L}" y2="{_PAD_T + plot_h}" class="axis"/>')
+    parts.append(
+        f'<line x1="{_PAD_L}" y1="{_PAD_T + plot_h}" x2="{_SVG_W - _PAD_R}" y2="{_PAD_T + plot_h}" class="axis"/>'
+    )
+    parts.append(
+        f'<text x="{_PAD_L - 6}" y="{sy(y_max):.1f}" class="ylab" text-anchor="end">'
+        f"{fmt.format(y_max)} {_esc(unit)}</text>"
+    )
+    parts.append(f'<text x="{_PAD_L - 6}" y="{sy(0):.1f}" class="ylab" text-anchor="end">0</text>')
+    parts.append(f'<text x="{_PAD_L}" y="{_SVG_H - 8}" class="alab">task</text>')
+    parts.append(
+        f'<text x="{_PAD_L + plot_w}" y="{_SVG_H - 8}" class="alab" text-anchor="end">'
+        f"peak {fmt.format(peak)} {_esc(unit)}</text>"
+    )
+
+    if n > 0:
+        pts = " ".join(f"{sx(i):.1f},{sy(v):.1f}" for i, v in enumerate(series))
+        parts.append(f'<polyline points="{pts}" class="line"/>')
+        for i, (v, rec) in enumerate(zip(series, records)):
+            phase = rec["phase"]
+            cls = {"begin": "dot-begin", "end": "dot-end"}.get(phase, "dot-task")
+            r = 3.0 if phase != "task" else 2.2
+            title = f"#{i} {_task_label(rec)} {fmt.format(v)} {unit} — {rec.get('site', '?')}"
+            parts.append(
+                f'<circle cx="{sx(i):.1f}" cy="{sy(v):.1f}" r="{r}" class="{cls}"><title>{_esc(title)}</title></circle>'
+            )
+
+    parts.append("</svg>")
+    cap = "live occupancy per record (begin=green, task=blue, end=red)"
+    return f'<figure class="metric"><figcaption>{cap}</figcaption>{"".join(parts)}</figure>'
+
+
+def _ring_section(
+    ring: int, pairs: list[tuple[dict, dict]], ordered: list[dict], resource: str, size: int | None
+) -> str:
     unit, divisor = RESOURCES[resource]
     fmt = "{:.1f}" if divisor > 1 else "{:.0f}"
+    timeline = _svg_timeline(ordered, resource, size, unit, fmt, divisor)
     sites = [e.get("site", "?") for _, e in pairs]
-    charts = []
+    scope_charts = []
     for label, fn in _metrics(resource):
         series = [_wrap(fn(b, e), size) / divisor for b, e in pairs]
-        charts.append(_svg_chart(label, series, sites, unit, fmt))
-    return (
-        f'<section class="ring"><h3>ring {ring} — {_esc(resource)} ({len(pairs)} pairs)</h3>{"".join(charts)}</section>'
+        scope_charts.append(_svg_chart(label, series, sites, unit, fmt))
+    # Two visually distinct groups so the per-task (stream-order) view and the
+    # per-scope (begin/end delta) view are not mistaken for one another.
+    task_group = (
+        f'<div class="group group-task">'
+        f'<div class="group-hd">per-task timeline — {len(ordered)} records (stream order)</div>'
+        f"{timeline}</div>"
     )
+    scope_group = (
+        f'<div class="group group-scope">'
+        f'<div class="group-hd">per-scope deltas — {len(pairs)} scope pairs (begin/end)</div>'
+        f"{''.join(scope_charts)}</div>"
+    )
+    return f'<section class="ring"><h3>ring {ring} — {_esc(resource)}</h3>{task_group}{scope_group}</section>'
 
 
 _STYLE = """
 body{font-family:system-ui,Arial,sans-serif;margin:24px;color:#222}
 h1{font-size:20px} h2{font-size:16px;margin-top:28px;border-bottom:1px solid #ddd;padding-bottom:4px}
 h3{font-size:14px;color:#555;margin:16px 0 4px}
-.metric{margin:0 0 8px;display:inline-block;width:740px;vertical-align:top}
+.group{margin:6px 0 16px;padding:6px 10px 10px;border-radius:6px;border:1px solid #e2e2e8}
+.group-task{background:#f3f8ff;border-color:#cfe0fb}
+.group-scope{background:#fbf8f2;border-color:#ecdcc0}
+.group-hd{font-size:12px;font-weight:600;letter-spacing:.02em;margin:2px 0 6px}
+.group-task .group-hd{color:#1d4ed8}
+.group-scope .group-hd{color:#b45309}
+.metric{margin:0 0 8px;display:inline-block;width:740px;vertical-align:top;
+background:#fff;border-radius:4px;padding:4px}
 figcaption{font-size:12px;color:#333;margin-bottom:2px}
 .chart{width:100%;height:auto;border:1px solid #eee;background:#fff}
 .axis{stroke:#999;stroke-width:1}
 .line{fill:none;stroke:#2563eb;stroke-width:1.4}
 .dot{fill:#2563eb}
+.dot-task{fill:#2563eb}
+.dot-begin{fill:#16a34a}
+.dot-end{fill:#dc2626}
 .ylab,.alab{font-size:10px;fill:#666}
 .intro{background:#f7f7f9;border:1px solid #e2e2e8;border-radius:6px;
 padding:12px 16px;margin:8px 0 20px;max-width:760px}
@@ -244,6 +353,15 @@ how far the allocation frontier (head) advanced, i.e. this scope's own net
 (unreleased) allocation.</p>
 <p>tensormap reports a single in-use value (no head/tail), so it shows just one
 real_occupancy curve.</p>
+<p>Each ring is split into two groups: a blue
+<span class="name">per-task timeline</span> and an amber
+<span class="name">per-scope deltas</span> block, so the stream-order view and
+the begin/end-delta view are not mistaken for one another. The timeline is live
+occupancy sampled at every record in stream order, so per-task growth is
+visible at the finest granularity. Markers are coloured by phase —
+<b style="color:#16a34a">begin</b>, <b style="color:#2563eb">task</b>,
+<b style="color:#dc2626">end</b> — and a task point's tooltip decodes its
+<code>(ring &lt;&lt; 32) | local</code> task_id.</p>
 {_capacity_summary(meta)}
 </div>
 """
@@ -254,15 +372,17 @@ def process(jsonl_path: Path, out_dir: Path | None = None) -> list[Path]:
     out_dir.mkdir(parents=True, exist_ok=True)
     meta, records = _load(jsonl_path)
     pairs_by_ring = _pair_by_ring(records)
+    ordered_by_ring = _ordered_by_ring(records)
 
     body = [f"<h1>scope_stats — {_esc(jsonl_path.name)}</h1>", _intro(meta)]
     for resource in RESOURCES:
         sections = []
-        for ring in sorted(pairs_by_ring):
-            pairs = pairs_by_ring[ring]
-            if not pairs:
+        for ring in sorted(ordered_by_ring):
+            ordered = ordered_by_ring[ring]
+            if not ordered:
                 continue
-            sections.append(_ring_section(ring, pairs, resource, _resource_size(meta, resource, ring)))
+            pairs = pairs_by_ring.get(ring, [])
+            sections.append(_ring_section(ring, pairs, ordered, resource, _resource_size(meta, resource, ring)))
         if sections:
             body.append(f"<h2>{_esc(resource)}</h2>{''.join(sections)}")
 

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -615,7 +615,12 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = scope_stats_collector_.init(num_threads, alloc_cb, register_cb, free_cb, device_id);
+    // Scope site filter is the raw comma-separated CallConfig.scope_stats_scope
+    // (e.g. "42,108"); the collector parses + applies it. Empty = collect every
+    // scope.
+    int rc = scope_stats_collector_.init(
+        num_threads, alloc_cb, register_cb, free_cb, device_id, scope_stats_scope().c_str(), scope_stats_task()
+    );
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -705,7 +705,10 @@ int DeviceRunner::init_scope_stats(int num_threads) {
         return mem_alloc_.free(dev_ptr);
     };
 
-    int rc = scope_stats_collector_.init(num_threads, alloc_cb, /*register_cb=*/nullptr, free_cb, /*device_id=*/-1);
+    int rc = scope_stats_collector_.init(
+        num_threads, alloc_cb, /*register_cb=*/nullptr, free_cb, /*device_id=*/-1, scope_stats_scope().c_str(),
+        scope_stats_task()
+    );
     if (rc != 0) {
         return rc;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -66,6 +66,7 @@ dep_gen_aicpu_record_submit(uint64_t, bool, int, const void *const *, const uint
 // host builds fall back to this weak `false`. Gating here still skips the
 // cross-agent occupancy reads that feed the sample when scope_stats is disabled.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
+extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_task_enabled() { return false; }
 
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
@@ -515,6 +516,18 @@ static TaskOutputTensors submit_task_common(
         return result;
     }
     uint8_t ring_id = prepared.task_id.ring();
+#if PTO2_PROFILING
+    // scope_stats per-task probe: sample ring/heap occupancy here, right after
+    // allocation and before the slot is exposed to the scheduler, so the record
+    // is not timing-dependent on async task completion advancing the ring tail.
+    if (is_scope_stats_task_enabled()) {
+        auto &alloc = orch->rings[ring_id].task_allocator;
+        scope_stats_record_task(
+            prepared.task_id.raw, ring_id, alloc.task_tail(), alloc.task_head(), alloc.heap_tail(), alloc.heap_top(),
+            orch->tensor_map.current_used()
+        );
+    }
+#endif
     PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_header->rings[ring_id].fc;
     PTO2TaskId task_id = prepared.task_id;

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -505,7 +505,13 @@ int DeviceRunner::init_scope_stats(int num_threads, int device_id) {
     // a5: register_cb=nullptr, so the collector mallocs a host shadow per
     // device buffer + rtMemcpy's the zeroed shadow to device (see
     // ProfilerBase::alloc_paired_buffer). No halHostRegister on a5.
-    int rc = scope_stats_collector_.init(num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, device_id);
+    // Scope site filter (raw comma-separated CallConfig.scope_stats_scope; the
+    // collector parses + applies it) and per-task sampling. Empty/false = the
+    // baseline per-scope behavior.
+    int rc = scope_stats_collector_.init(
+        num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, device_id, scope_stats_scope().c_str(),
+        scope_stats_task()
+    );
     if (rc != 0) {
         return rc;
     }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -646,7 +646,8 @@ int DeviceRunner::init_scope_stats(int num_threads) {
     // device buffer; sim's profiling_copy_* are plain memcpys, so the dev/host
     // shadow path collapses to one allocation pair without address-space tricks.
     int rc = scope_stats_collector_.init(
-        num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*device_id=*/-1
+        num_threads, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, /*device_id=*/-1,
+        scope_stats_scope().c_str(), scope_stats_task()
     );
     if (rc != 0) {
         return rc;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -65,6 +65,7 @@ dep_gen_aicpu_record_submit(uint64_t, bool, int, const void *const *, const uint
 // builds fall back to this weak `false`. Gating here still skips the
 // cross-agent occupancy reads that feed the sample when scope_stats is disabled.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
+extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_task_enabled() { return false; }
 #endif
 
 // =============================================================================
@@ -514,6 +515,18 @@ static TaskOutputTensors submit_task_common(
         return result;
     }
     uint8_t ring_id = prepared.task_id.ring();
+#if PTO2_PROFILING
+    // scope_stats per-task probe: sample ring/heap occupancy here, right after
+    // allocation and before the slot is exposed to the scheduler, so the record
+    // is not timing-dependent on async task completion advancing the ring tail.
+    if (is_scope_stats_task_enabled()) {
+        auto &alloc = orch->rings[ring_id].task_allocator;
+        scope_stats_record_task(
+            prepared.task_id.raw, ring_id, alloc.task_tail(), alloc.task_head(), alloc.heap_tail(), alloc.heap_top(),
+            orch->tensor_map.current_used()
+        );
+    }
+#endif
     PTO2SchedulerState *sched = orch->scheduler;
     PTO2RingFlowControl &fc = orch->sm_header->rings[ring_id].fc;
     PTO2TaskId task_id = prepared.task_id;

--- a/src/common/platform/include/aicpu/scope_stats_collector_aicpu.h
+++ b/src/common/platform/include/aicpu/scope_stats_collector_aicpu.h
@@ -48,6 +48,22 @@ void scope_stats_begin(
 void scope_stats_end(
     int ring_id, int32_t task_start, int32_t task_end, uint64_t heap_start, uint64_t heap_end, int32_t tensormap_used
 );
+
+// Per-task probe (scope_stats_task). Emits one PHASE_TASK record carrying the
+// submitted task_id plus the current ring/heap occupancy, attributed to the
+// enclosing scope. No-op unless per-task sampling is enabled and the enclosing
+// scope passes the site filter. Called from submit_task; the orchestrator gates
+// on is_scope_stats_task_enabled() first so a disabled run pays one bool load.
+void scope_stats_record_task(
+    uint64_t task_id, int ring_id, int32_t task_start, int32_t task_end, uint64_t heap_start, uint64_t heap_end,
+    int32_t tensormap_used
+);
+
+// Per-task sampling enabled-state predicate (host-written run-constant cached at
+// set_platform_scope_stats_base). Queried by the orchestrator as its submit-time
+// gate; the orchestrator declares a weak `false` fallback for host builds.
+bool is_scope_stats_task_enabled();
+
 void scope_stats_on_fatal();
 
 // --- Site tracking ---

--- a/src/common/platform/include/common/scope_stats.h
+++ b/src/common/platform/include/common/scope_stats.h
@@ -52,13 +52,19 @@
 #define PTO2_SCOPE_STATS_MAX_RING_DEPTH 4
 #define PTO2_SCOPE_STATS_MAX_SCOPE_DEPTH 64
 
+// Max distinct PTO2_SCOPE line numbers the host-side site filter can hold.
+#define PTO2_SCOPE_STATS_MAX_SITE_FILTERS 16
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// Phase tag: which scope boundary a record was sampled at.
+// Phase tag: which sampling point a record was taken at. BEGIN/END are the
+// per-scope boundaries; TASK is a per-task sample taken at submit_task when
+// scope_stats_task is enabled (carries the submitted task_id).
 #define SCOPE_STATS_PHASE_BEGIN 0
 #define SCOPE_STATS_PHASE_END 1
+#define SCOPE_STATS_PHASE_TASK 2
 
 // One record per scope boundary (begin or end). Layout MUST stay in sync with
 // the device-side writer in platform/shared/aicpu/scope_stats_collector_aicpu.cpp
@@ -83,13 +89,14 @@ struct ScopeStatsRecord {
                                   // orchestration .so, not in shared memory).
     uint64_t heap_start;          // Heap ring reclaim pointer (heap_tail_).
     uint64_t heap_end;            // Heap ring allocation pointer (heap_top_).
+    uint64_t task_id;             // PTO2TaskId.raw for PHASE_TASK records; 0 for begin/end.
     int32_t site_line;
     int32_t task_start;      // Task ring tail (last_task_alive).
     int32_t task_end;        // Task ring head (next task id).
     int32_t tensormap_used;  // tensormap pool live-entry count (not a ring).
     int16_t depth;
     int16_t ring_id;  // Ring whose start/end this record carries.
-    int16_t phase;    // SCOPE_STATS_PHASE_BEGIN / _END.
+    int16_t phase;    // SCOPE_STATS_PHASE_BEGIN / _END / _TASK.
     int16_t _pad;
 };
 
@@ -157,7 +164,23 @@ struct ScopeStatsDataHeader {
     uint64_t heap_cap[PTO2_SCOPE_STATS_MAX_RING_DEPTH];
     int32_t tensormap_cap;
     volatile uint32_t fatal_latched;  // AICPU sets to 1 on first fatal.
-    uint32_t _pad[2];
+
+    // Scope site filter — host-written run-constant (count == 0 = no filter,
+    // the default: every scope is collected). The orchestration is a single
+    // source file, so a PTO2_SCOPE site is uniquely identified by its line
+    // number; the filter is just a list of line numbers. When count > 0 the
+    // AICPU collector emits records only for scopes whose site_line appears in
+    // site_filter_lines[0..count). Depth/site bookkeeping is unaffected so
+    // nesting stays correct; filtered-out scopes are not appended and do not
+    // count toward total_record_count.
+    int32_t site_filter_lines[PTO2_SCOPE_STATS_MAX_SITE_FILTERS];
+    int32_t site_filter_count;
+
+    // Per-task sampling (scope_stats_task). Host-written run-constant: when
+    // non-zero, the AICPU collector also emits a PHASE_TASK record at each
+    // submit_task (subject to the same site filter). 0 = scope boundaries only.
+    int32_t task_enabled;
+    uint32_t _pad[1];
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -134,9 +134,14 @@ public:
     static constexpr int kIdleTimeoutSec = PLATFORM_SCOPE_STATS_TIMEOUT_SECONDS;
     static constexpr const char *kSubsystemName = "ScopeStats";
 
+    // site_filter_csv is a comma-separated list of PTO2_SCOPE line numbers to
+    // restrict collection to (e.g. "42,108"); nullptr/empty = no filter, collect
+    // every scope. Parsed here and written into the device-visible
+    // ScopeStatsDataHeader at init so callers only pass the raw string.
     int init(
         int num_threads, const ScopeStatsAllocCallback &alloc_cb, ScopeStatsRegisterCallback register_cb,
-        const ScopeStatsFreeCallback &free_cb, int device_id
+        const ScopeStatsFreeCallback &free_cb, int device_id, const char *site_filter_csv = nullptr,
+        bool task_enabled = false
     );
 
     // Device pointer to the ScopeStatsDataHeader. Set

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -320,7 +320,8 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, const char *output_prefix, PtoRunTiming *out_timing
+    int enable_scope_stats, const char *scope_stats_scope, int scope_stats_task, const char *output_prefix,
+    PtoRunTiming *out_timing
 ) {
     if (out_timing != NULL) {
         out_timing->host_wall_ns = 0;
@@ -393,6 +394,8 @@ int run_prepared(
         // without dep_gen falls through to the base no-op.
         runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_scope_stats_enabled(enable_scope_stats != 0);
+        runner->set_scope_stats_scope(scope_stats_scope);
+        runner->set_scope_stats_task(scope_stats_task != 0);
         runner->set_output_prefix(output_prefix);
 
         rc = runner->run(*r, block_dim, aicpu_thread_num);

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -390,6 +390,13 @@ public:
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
     void set_scope_stats_enabled(bool enable) { enable_scope_stats_ = enable; }
+    // Comma-separated PTO2_SCOPE line numbers to restrict scope_stats to
+    // (empty = collect every scope). Parsed where the collector is initialized.
+    void set_scope_stats_scope(const char *scope) { scope_stats_scope_ = (scope != nullptr) ? scope : ""; }
+    const std::string &scope_stats_scope() const { return scope_stats_scope_; }
+    // Per-task scope_stats sampling (scope_stats_task).
+    void set_scope_stats_task(bool enable) { scope_stats_task_ = enable; }
+    bool scope_stats_task() const { return scope_stats_task_; }
 
     /**
      * Directory under which all diagnostic artifacts
@@ -767,6 +774,8 @@ protected:
     L2SwimlaneLevel l2_swimlane_level_{L2SwimlaneLevel::DISABLED};  // resolved from set_l2_swimlane_enabled()
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};   // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                   // diagnostic artifact root directory
+    std::string scope_stats_scope_{};                               // scope_stats line filter (empty = all scopes)
+    bool scope_stats_task_{false};                                  // per-task scope_stats sampling
 };
 
 #endif  // SIMPLER_COMMON_PLATFORM_ONBOARD_HOST_DEVICE_RUNNER_BASE_H

--- a/src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
@@ -33,6 +33,9 @@
 
 int32_t scope_stats_depth = -1;
 static bool scope_stats_enabled = false;
+// Cached from ScopeStatsDataHeader.task_enabled at set_platform_scope_stats_base
+// so the submit-time predicate is a single bool load (no header deref).
+static bool scope_stats_task_enabled = false;
 
 // Streaming transport state — single dep_gen-style instance (the orchestrator).
 static ScopeStatsDataHeader *s_scope_stats_header = nullptr;
@@ -48,7 +51,10 @@ const char *s_scope_site_file[PTO2_SCOPE_STATS_MAX_SCOPE_DEPTH] = {};
 int32_t s_scope_site_line[PTO2_SCOPE_STATS_MAX_SCOPE_DEPTH] = {};
 
 inline const char *basename_of(const char *path) {
-    if (!path) return "(unknown)";
+    // A null site comes only from the framework's implicit top-level scope
+    // (opened by the executor's rt_scope_begin, not a PTO2_SCOPE — so it has no
+    // __builtin_FILE). Label it "<root>" rather than "(unknown)".
+    if (!path) return "<root>";
     const char *base = path;
     for (const char *p = path; *p; ++p) {
         if (*p == '/' || *p == '\\') base = p + 1;
@@ -76,6 +82,23 @@ inline void copy_basename(char (&dst)[32], const char *src) {
         s_cached_src = src;
         memcpy(s_cached, dst, sizeof(dst));
     }
+}
+
+// Scope site filter gate. The orchestration is a single source file, so a
+// PTO2_SCOPE site is uniquely identified by its line number. Returns true when
+// the scope should be collected: either no filter is set (the default,
+// site_filter_count == 0) or the site's line appears in the host-written
+// site_filter_lines list. Cheap when unset (one count check); the linear scan
+// runs only when a filter is active and over at most a handful of lines.
+bool site_passes_filter(int32_t line) {
+    if (s_scope_stats_header == nullptr) return true;
+    int32_t count = s_scope_stats_header->site_filter_count;
+    if (count <= 0) return true;  // no filter set: collect every scope
+    if (count > PTO2_SCOPE_STATS_MAX_SITE_FILTERS) count = PTO2_SCOPE_STATS_MAX_SITE_FILTERS;
+    for (int32_t i = 0; i < count; i++) {
+        if (s_scope_stats_header->site_filter_lines[i] == line) return true;
+    }
+    return false;
 }
 
 // Enqueue a full buffer onto the orchestrator thread's ready_queue. Returns 0
@@ -169,8 +192,8 @@ void switch_buffer() {
 // tagged with the current depth/site and the boundary phase. Called once per
 // scope boundary.
 void append_record_snapshot(
-    int ring_id, int16_t phase, int32_t task_start, int32_t task_end, uint64_t heap_start, uint64_t heap_end,
-    int32_t tensormap_used
+    int ring_id, int16_t phase, uint64_t task_id, int32_t task_start, int32_t task_end, uint64_t heap_start,
+    uint64_t heap_end, int32_t tensormap_used
 ) {
     if (s_scope_stats_state == nullptr) return;
     // Single volatile read of current_buf_ptr (re-read only after a pop/switch).
@@ -200,6 +223,7 @@ void append_record_snapshot(
     rec.ring_id = static_cast<int16_t>(ring_id);
     rec.phase = phase;
     rec._pad = 0;
+    rec.task_id = task_id;
     rec.task_start = task_start;
     rec.task_end = task_end;
     rec.tensormap_used = tensormap_used;
@@ -218,14 +242,20 @@ extern "C" void set_scope_stats_enabled(bool enable) { scope_stats_enabled = ena
 
 extern "C" bool is_scope_stats_enabled() { return scope_stats_enabled; }
 
+extern "C" bool is_scope_stats_task_enabled() { return scope_stats_enabled && scope_stats_task_enabled; }
+
 extern "C" void set_platform_scope_stats_base(uint64_t scope_stats_data_base) {
     void *base = reinterpret_cast<void *>(scope_stats_data_base);
     if (base != nullptr) {
         s_scope_stats_header = get_scope_stats_header(base);
         s_scope_stats_state = get_scope_stats_buffer_state(base, /*instance_index=*/0);
+        // Cache the host-written per-task run-constant so the submit-time gate
+        // is a bool load rather than a header deref on the hot path.
+        scope_stats_task_enabled = (s_scope_stats_header->task_enabled != 0);
     } else {
         s_scope_stats_header = nullptr;
         s_scope_stats_state = nullptr;
+        scope_stats_task_enabled = false;
     }
     // Reset collector-local statics so a prior run that crashed mid-scope (or
     // reused the same AICPU .so process) can't leak stale depth/peak data into
@@ -287,9 +317,13 @@ extern "C" void scope_stats_begin(
     s_scope_site_line[d] = s_pending_site_line;
     s_pending_site_file = nullptr;
     s_pending_site_line = 0;
-    append_record_snapshot(
-        ring_id, SCOPE_STATS_PHASE_BEGIN, task_start, task_end, heap_start, heap_end, tensormap_used
-    );
+    // Depth/site stack is pushed above unconditionally so nesting stays correct;
+    // only the record emission is gated by the scope site filter.
+    if (site_passes_filter(s_scope_site_line[d])) {
+        append_record_snapshot(
+            ring_id, SCOPE_STATS_PHASE_BEGIN, /*task_id=*/0, task_start, task_end, heap_start, heap_end, tensormap_used
+        );
+    }
 }
 
 // Emit the end-boundary record, then tear down depth/site.
@@ -299,10 +333,29 @@ extern "C" void scope_stats_end(
     if (!scope_stats_enabled) return;
     if (scope_stats_depth < 0) return;
     int32_t d = scope_stats_depth;
-    append_record_snapshot(ring_id, SCOPE_STATS_PHASE_END, task_start, task_end, heap_start, heap_end, tensormap_used);
+    if (site_passes_filter(s_scope_site_line[d])) {
+        append_record_snapshot(
+            ring_id, SCOPE_STATS_PHASE_END, /*task_id=*/0, task_start, task_end, heap_start, heap_end, tensormap_used
+        );
+    }
     s_scope_site_file[d] = nullptr;
     s_scope_site_line[d] = 0;
     --scope_stats_depth;
+}
+
+// Emit one PHASE_TASK record for the submitted task, attributed to the current
+// scope. Gated on per-task sampling and the enclosing scope's site filter so a
+// filtered-out scope's tasks are not recorded.
+extern "C" void scope_stats_record_task(
+    uint64_t task_id, int ring_id, int32_t task_start, int32_t task_end, uint64_t heap_start, uint64_t heap_end,
+    int32_t tensormap_used
+) {
+    if (!scope_stats_enabled || !scope_stats_task_enabled) return;
+    if (scope_stats_depth < 0) return;  // task submitted outside any scope: nothing to attribute
+    if (!site_passes_filter(s_scope_site_line[scope_stats_depth])) return;
+    append_record_snapshot(
+        ring_id, SCOPE_STATS_PHASE_TASK, task_id, task_start, task_end, heap_start, heap_end, tensormap_used
+    );
 }
 
 extern "C" void scope_stats_on_fatal() {

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -49,9 +49,28 @@ ScopeStatsCollector::~ScopeStatsCollector() { stop(); }
 // init
 // ---------------------------------------------------------------------------
 
+// Parse a comma-separated list of PTO2_SCOPE line numbers ("42,108") into
+// out_lines (capacity PTO2_SCOPE_STATS_MAX_SITE_FILTERS). Non-numeric
+// separators are skipped; only positive values are kept. Returns the count.
+static int parse_site_filter_csv(const char *csv, int32_t *out_lines) {
+    int count = 0;
+    if (csv == nullptr) return 0;
+    for (const char *p = csv; *p != '\0' && count < PTO2_SCOPE_STATS_MAX_SITE_FILTERS;) {
+        char *end = nullptr;
+        long v = strtol(p, &end, 10);
+        if (end == p) {
+            p++;  // skip a non-numeric separator
+            continue;
+        }
+        if (v > 0) out_lines[count++] = static_cast<int32_t>(v);
+        p = end;
+    }
+    return count;
+}
+
 int ScopeStatsCollector::init(
     int num_threads, const ScopeStatsAllocCallback &alloc_cb, ScopeStatsRegisterCallback register_cb,
-    const ScopeStatsFreeCallback &free_cb, int device_id
+    const ScopeStatsFreeCallback &free_cb, int device_id, const char *site_filter_csv, bool task_enabled
 ) {
     if (num_threads <= 0 || alloc_cb == nullptr || free_cb == nullptr) {
         LOG_ERROR("ScopeStatsCollector::init: invalid arguments");
@@ -93,6 +112,17 @@ int ScopeStatsCollector::init(
     std::memset(shm_host_local, 0, shm_size);
     ScopeStatsDataHeader *hdr = get_scope_stats_header(shm_host_local);
     hdr->num_instances = static_cast<uint32_t>(num_instances);
+
+    // Scope site filter (run-constant; count == 0 = collect every scope).
+    int n = parse_site_filter_csv(site_filter_csv, hdr->site_filter_lines);
+    hdr->site_filter_count = n;
+    if (n > 0) {
+        LOG_INFO_V0("ScopeStats: site filter active for %d scope line(s)", n);
+    }
+    hdr->task_enabled = task_enabled ? 1 : 0;
+    if (task_enabled) {
+        LOG_INFO_V0("ScopeStats: per-task sampling enabled");
+    }
 
     const size_t buf_size = sizeof(ScopeStatsBuffer);
     ScopeStatsBufferState *state = get_scope_stats_buffer_state(shm_host_local, 0);
@@ -270,17 +300,21 @@ int ScopeStatsCollector::write_jsonl(const std::string &output_dir) {
     std::scoped_lock lock(records_mutex_);
     std::string out;
     out.reserve(records_.size() * 128);
-    char line[320];
+    char line[384];
     for (const ScopeStatsRecord &rec : records_) {
         const int site_len = static_cast<int>(strnlen(rec.site_file_basename, sizeof(rec.site_file_basename)));
-        const char *phase = (rec.phase == SCOPE_STATS_PHASE_BEGIN) ? "begin" : "end";
+        // "phase" distinguishes per-scope boundaries (begin/end) from per-task
+        // samples (task). PHASE_TASK records also carry the submitted task_id.
+        const char *phase = (rec.phase == SCOPE_STATS_PHASE_BEGIN) ? "begin" :
+                            (rec.phase == SCOPE_STATS_PHASE_TASK)  ? "task" :
+                                                                     "end";
         int n = std::snprintf(
             line, sizeof(line),
-            "{\"site\": \"%.*s:%d\", \"phase\": \"%s\", \"depth\": %d, \"ring\": %d, "
+            "{\"site\": \"%.*s:%d\", \"phase\": \"%s\", \"task_id\": %" PRIu64 ", \"depth\": %d, \"ring\": %d, "
             "\"task_window_start\": %d, \"task_window_end\": %d, "
             "\"heap_start\": %" PRIu64 ", \"heap_end\": %" PRIu64 ", "
             "\"tensormap\": %d}\n",
-            site_len, rec.site_file_basename, rec.site_line, phase, rec.depth, rec.ring_id, rec.task_start,
+            site_len, rec.site_file_basename, rec.site_line, phase, rec.task_id, rec.depth, rec.ring_id, rec.task_start,
             rec.task_end, rec.heap_start, rec.heap_end, rec.tensormap_used
         );
         if (n > 0) out.append(line, static_cast<size_t>(n < static_cast<int>(sizeof(line)) ? n : sizeof(line) - 1));

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -285,7 +285,8 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, const char *output_prefix, PtoRunTiming *out_timing
+    int enable_scope_stats, const char *scope_stats_scope, int scope_stats_task, const char *output_prefix,
+    PtoRunTiming *out_timing
 ) {
     if (out_timing != NULL) {
         out_timing->host_wall_ns = 0;
@@ -346,6 +347,8 @@ int run_prepared(
         runner->set_pmu_enabled(enable_pmu);
         runner->set_dep_gen_enabled(enable_dep_gen != 0);
         runner->set_scope_stats_enabled(enable_scope_stats != 0);
+        runner->set_scope_stats_scope(scope_stats_scope);
+        runner->set_scope_stats_task(scope_stats_task != 0);
         runner->set_output_prefix(output_prefix);
 
         rc = runner->run(*r, block_dim, aicpu_thread_num);

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -119,6 +119,13 @@ public:
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
     void set_scope_stats_enabled(bool enable) { enable_scope_stats_ = enable; }
+    // scope_stats refinements: line-number filter (empty = all scopes) and
+    // per-task sampling. Stored for parity with the onboard runner; applied
+    // where the collector is initialized.
+    void set_scope_stats_scope(const char *scope) { scope_stats_scope_ = (scope != nullptr) ? scope : ""; }
+    const std::string &scope_stats_scope() const { return scope_stats_scope_; }
+    void set_scope_stats_task(bool enable) { scope_stats_task_ = enable; }
+    bool scope_stats_task() const { return scope_stats_task_; }
     // Diagnostic artifact root directory (CallConfig::validate() enforces non-empty
     // upstream when any diagnostic is enabled).
     void set_output_prefix(const char *prefix) { output_prefix_ = (prefix != nullptr) ? prefix : ""; }
@@ -256,6 +263,8 @@ protected:
     L2SwimlaneLevel l2_swimlane_level_{L2SwimlaneLevel::DISABLED};  // resolved from set_l2_swimlane_enabled()
     PmuEventType pmu_event_type_{PmuEventType::PIPE_UTILIZATION};   // resolved from set_pmu_enabled()
     std::string output_prefix_{};                                   // diagnostic artifact root directory
+    std::string scope_stats_scope_{};                               // scope_stats line filter (empty = all scopes)
+    bool scope_stats_task_{false};                                  // per-task scope_stats sampling
 };
 
 namespace simpler::common::sim_host {

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -58,6 +58,15 @@ struct CallConfig {
     int32_t enable_dep_gen = 0;
     int32_t enable_scope_stats = 0;  // writes <output_prefix>/scope_stats.json
     char output_prefix[1024] = {};
+    // Optional scope site filter: comma-separated PTO2_SCOPE line numbers
+    // (e.g. "42,108") restricting scope_stats collection to those scopes.
+    // Empty = collect every scope. Parsed host-side in init_scope_stats.
+    // Sized to hold a full PTO2_SCOPE_STATS_MAX_SITE_FILTERS (16) CSV of
+    // multi-digit line numbers without truncation.
+    char scope_stats_scope[128] = {};
+    // Per-task scope_stats sampling: when non-zero, emit one PHASE_TASK record
+    // per submit_task (subject to scope_stats_scope). 0 = scope boundaries only.
+    int32_t scope_stats_task = 0;
 
     bool diagnostics_any() const noexcept {
         return enable_l2_swimlane != 0 || enable_dump_tensor != 0 || enable_pmu != 0 || enable_dep_gen != 0 ||
@@ -80,4 +89,4 @@ struct CallConfig {
     }
 };
 #pragma pack(pop)
-static_assert(sizeof(CallConfig) == 7 * sizeof(int32_t) + 1024, "CallConfig wire layout drift");
+static_assert(sizeof(CallConfig) == 8 * sizeof(int32_t) + 1024 + 128, "CallConfig wire layout drift");

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -324,7 +324,7 @@ RunTiming ChipWorker::run(int32_t callable_id, const ChipStorageTaskArgs *args, 
     int rc = run_prepared_fn_(
         device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, config.enable_l2_swimlane,
         config.enable_dump_tensor, config.enable_pmu, config.enable_dep_gen, config.enable_scope_stats,
-        config.output_prefix, &timing
+        config.scope_stats_scope, config.scope_stats_task, config.output_prefix, &timing
     );
     if (rc != 0) {
         throw std::runtime_error("run_prepared failed with code " + std::to_string(rc));

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -142,8 +142,10 @@ private:
     using SimplerInitFn =
         int (*)(void *, int, const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *, size_t);
     using PrepareCallableFn = int (*)(void *, int32_t, const void *);
-    using RunPreparedFn =
-        int (*)(void *, void *, int32_t, const void *, int, int, int, int, int, int, int, const char *, PtoRunTiming *);
+    using RunPreparedFn = int (*)(
+        void *, void *, int32_t, const void *, int, int, int, int, int, int, int, const char *, int, const char *,
+        PtoRunTiming *
+    );
     using UnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);
     using FinalizeDeviceFn = int (*)(void *);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -194,7 +194,8 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, const char *output_prefix, PtoRunTiming *out_timing
+    int enable_scope_stats, const char *scope_stats_scope, int scope_stats_task, const char *output_prefix,
+    PtoRunTiming *out_timing
 );
 
 /**

--- a/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -108,6 +108,8 @@ class TestPreparedCallableHbg(SceneTestCase):
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         params = case.get("params", {})

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -98,7 +98,9 @@ class TestScopeStats(SceneTestCase):
 
     def test_run(self, st_platform, st_worker, request):
         super().test_run(st_platform, st_worker, request)
-        if not request.config.getoption("--enable-scope-stats", default=False):
+        if request.config.getoption("--enable-scope-stats", default=None) is None and not request.config.getoption(
+            "--scope-stats-task", default=False
+        ):
             return
         for case in self.CASES:
             if st_platform in case["platforms"]:

--- a/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -109,6 +109,8 @@ class TestPreparedCallable(SceneTestCase):
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         params = case.get("params", {})

--- a/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -97,6 +97,8 @@ class TestPreparedCallableHbgA5(SceneTestCase):
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         params = case.get("params", {})

--- a/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/prepared_callable/test_prepared_callable.py
@@ -110,6 +110,8 @@ class TestPreparedCallable(SceneTestCase):
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
+        scope_stats_scope="",
+        scope_stats_task=False,
         output_prefix="",
     ):
         params = case.get("params", {})


### PR DESCRIPTION
Extend scope_stats (#858) with two orthogonal, opt-in axes on top of the existing per-scope begin/end sampling (#902):

- Scope filter (--enable-scope-stats <lines>): restrict collection to the listed PTO2_SCOPE line numbers via CallConfig.scope_stats_scope. Empty = every scope (unchanged default). The orchestration is one source file, so a line uniquely identifies a scope.
- Per-task sampling (--scope-stats-task): emit one phase="task" record per submit_task carrying task_id and ring/heap occupancy, attributed to the enclosing scope and subject to the scope filter.

Both travel through CallConfig to the device collector. The runtime only calls the scope_stats_* interface (one weak-gated scope_stats_record_task in submit_task_common); the collector parses the filter CSV and gates record emission, leaving depth/site bookkeeping intact so nesting stays correct. Filtered-out scopes are not appended and do not count toward total. The implicit top-level scope now renders as "<root>" not "(unknown)". jsonl gains "phase" (begin/end/task) and "task_id" fields.

Mirrored across a2a3/a5 and onboard/sim; docs/dfx/scope-stats.md updated.