### PR TITLE
Refactor: drop fanout from a5 L2 swimlane hot path

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -2,18 +2,20 @@
 
 ## 1. Background & Motivation
 
-The swimlane profiler's per-task `fanout[]` array is the obvious place to
-read "which tasks did task X feed into?" — but it is **structurally
-incomplete on real hardware**.
+The swimlane profiler used to expose a per-task `fanout[]` array — the
+obvious place to read "which tasks did task X feed into?" — but it was
+**structurally incomplete on real hardware**, so it has been removed from
+the record entirely. The device hot path no longer carries fanout;
+`deps.json` is now the sole source of truth for swimlane edges.
 
-Each producer task carries its own `L2SwimlaneAicpuTaskRecord.fanout[RUNTIME_MAX_FANOUT]`,
-populated by the AICPU scheduler at the moment it wires a downstream
-consumer. If a producer has already finished and transitioned to
-`PTO2_TASK_COMPLETED` by the time a later submit wants to register a
-dependency on it, the consumer's edge has nowhere to go — the record is
-sealed, the slot is closed, and the edge is silently dropped. This is
-not a bug in fanout itself; fanout is "successors known at runtime", not
-"successors discoverable from the orchestrator's input". Race window in
+When it existed, each producer task carried its own
+`L2SwimlaneAicpuTaskRecord.fanout[]`, populated by the AICPU scheduler at the
+moment it wired a downstream consumer. If a producer had already finished and
+transitioned to `PTO2_TASK_COMPLETED` by the time a later submit wanted to
+register a dependency on it, the consumer's edge had nowhere to go — the
+record was sealed, the slot was closed, and the edge was silently dropped.
+This was not a bug in fanout itself; fanout is "successors known at runtime",
+not "successors discoverable from the orchestrator's input". Race window in
 [#599](https://github.com/hw-native-sys/simpler/issues/599); see also the
 PR #500 archive for the historical attempt to fix this in-place.
 
@@ -23,9 +25,9 @@ PR #500 archive for the historical attempt to fix this in-place.
 `compute_task_fanin` / `register_task_outputs` primitives the device
 orchestrator uses. The host replay sees every submit — there is no
 "already retired" producer because nothing retires during replay. The
-output, `deps.json`, is a strict superset of fanout: every fanout edge
-appears in deps.json, and the edges fanout dropped due to the race
-appear too.
+output, `deps.json`, was a strict superset of the old fanout edges: every
+fanout edge appeared in deps.json, plus the edges fanout dropped due to the
+race — which is why deps.json now fully replaces the removed `fanout[]`.
 
 ---
 
@@ -86,9 +88,8 @@ because:
 - `deps.json` is the dep_gen artifact.
 - `l2_swimlane_records.json` (from swimlane) is the timing artifact;
   `merged_swimlane.json` (the Perfetto trace) uses `deps.json` for
-  dependency arrows when both files exist.
-- The "fanout ⊆ deps" validation gate fires only when both files are
-  present.
+  dependency arrows when both files exist (without it, the trace has no
+  dependency arrows — the record no longer carries `fanout[]`).
 
 For perf-sensitive runs where you'd rather measure each profiler in
 isolation, see the **split workflow** described in
@@ -293,20 +294,20 @@ When checking fanout coverage, project annotated edges down to a
 sources / args / slices, so the raw `edges[]` count is a superset of the
 underlying task-pair count.
 
-`deps.json` (projected) is a **superset** of the fanout edges in
-`l2_swimlane_records.json`:
+`deps.json` (projected) was a **superset** of the now-removed `fanout[]`
+edges — which is exactly why it replaced them as the sole edge source:
 
 | Edge source | Captures | Drops on race? |
 | ----------- | -------- | -------------- |
-| `task.fanout[]` (L2SwimlaneAicpuTaskRecord) | Successors known at producer-retire time | **Yes** — sealed when producer retires |
+| `task.fanout[]` (removed; formerly on L2SwimlaneAicpuTaskRecord) | Successors known at producer-retire time | **Yes** — sealed when producer retires |
 | `deps.json` (this feature) | Every consumer → producer reachable via tensormap / explicit_deps | No — replay sees every submit |
 
 `tests/st/{a2a3,a5}/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py`
 enforces the 6-edge expectation against the `vector_example`
 orchestration as a validation gate: any edge missing from `deps.json`
-is a replay-side regression and fails the test. Cases where
-`deps - fanout ≠ ∅` are the dep_gen sweet spot — those are
-exactly the race-window edges fanout dropped. The
+is a replay-side regression and fails the test. (The record no longer
+carries `fanout[]`, so there is no longer a `fanout ⊆ deps` cross-check —
+`deps.json` is the only edge source.) The
 `swimlane_converter.py` uses `deps.json` (when present) as the source
 of flow events in the Perfetto trace, and flags any edge whose
 `pred.end_time > succ.start_time` as `hb_violation` (rendered as a

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -295,9 +295,7 @@ The analysis tools share the same input format - the `l2_swimlane_records_*.json
       "end_time_us": 55.9,
       "duration_us": 8.44,
       "dispatch_time_us": 45.94,
-      "finish_time_us": 60.52,
-      "fanout": [4294967299, 4294967297, 4294967296],
-      "fanout_count": 3
+      "finish_time_us": 60.52
     },
     {
       "task_id": 4294967296,
@@ -309,9 +307,7 @@ The analysis tools share the same input format - the `l2_swimlane_records_*.json
       "end_time_us": 70.42,
       "duration_us": 1.74,
       "dispatch_time_us": 68.24,
-      "finish_time_us": 71.2,
-      "fanout": [4294967298],
-      "fanout_count": 1
+      "finish_time_us": 71.2
     }
   ]
 }

--- a/src/a5/platform/include/aicpu/l2_swimlane_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/l2_swimlane_collector_aicpu.h
@@ -70,9 +70,7 @@ void l2_swimlane_aicpu_init(int worker_count);
  * Reads from the per-core L2SwimlaneAicoreRing dual-issue slot
  * (`s_perf_aicore_rings[core_id]->dual_issue_slots[reg_task_id & ...]`),
  * validates task_id match, and commits the record into
- * `state->current_buf_ptr->records[count++]`. Callers must pre-extract
- * fanout into a plain uint64_t array (platform layer cannot depend on
- * runtime linked-list types).
+ * `state->current_buf_ptr->records[count++]`.
  *
  * @param core_id               Core ID owning the destination buffer (resolved via s_aicpu_task_pools)
  * @param thread_idx            Owning AICPU thread (used when rotating records buffer)
@@ -82,8 +80,6 @@ void l2_swimlane_aicpu_init(int worker_count);
  * @param core_type             Core type (AIC/AIV)
  * @param dispatch_time         AICPU timestamp when task was dispatched
  * @param finish_time           AICPU timestamp when task completion was observed
- * @param fanout                Pre-extracted successor task ID array (nullptr if none)
- * @param fanout_count          Number of entries in fanout array (0 if none)
  *
  * Routes the destination via state->current_buf_ptr (not Handshake), so that
  * flush()-clearing current_buf_ptr deterministically halts subsequent commits
@@ -91,7 +87,7 @@ void l2_swimlane_aicpu_init(int worker_count);
  */
 int l2_swimlane_aicpu_complete_task(
     int core_id, int thread_idx, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
-    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+    uint64_t dispatch_time, uint64_t finish_time
 );
 
 /**

--- a/src/a5/platform/include/common/l2_swimlane_profiling.h
+++ b/src/a5/platform/include/common/l2_swimlane_profiling.h
@@ -60,11 +60,6 @@
 #include "common/core_type.h"
 #include "common/platform_config.h"
 
-// Maximum number of successor tasks per L2SwimlaneAicpuTaskRecord (matches Task::fanout)
-#ifndef RUNTIME_MAX_FANOUT
-#define RUNTIME_MAX_FANOUT 128
-#endif
-
 // =============================================================================
 // L2 swimlane_level — granularity ladder for the L2 swimlane profiler.
 //
@@ -82,7 +77,7 @@
 enum class L2SwimlaneLevel : uint32_t {
     DISABLED = 0,       // No collection at all
     AICORE_TIMING = 1,  // AICore per-task start/end timestamps + task record buffer
-    AICPU_TIMING = 2,   // + AICPU dispatch/finish timestamps + fanout dependency list
+    AICPU_TIMING = 2,   // + AICPU dispatch/finish timestamps
     SCHED_PHASES = 3,   // + scheduler main-loop phase records (SCHED_COMPLETE/DISPATCH/IDLE_WAIT)
     ORCH_PHASES = 4,    // + orchestrator phase records
 };
@@ -92,7 +87,13 @@ enum class L2SwimlaneLevel : uint32_t {
 // =============================================================================
 
 /**
- * Single task execution record
+ * Single task execution record.
+ *
+ * Fanout edges live in the static DAG (deps.json from dep_gen) — not in
+ * this record. Keeping fanout out of the hot AICPU commit path avoids a
+ * per-task ~1 KB GM store + a linked-list walk on the scheduler's
+ * critical fanin tail. The host swimlane export emits no fanout fields;
+ * `swimlane_converter.py` joins deps.json at post-process time.
  */
 struct L2SwimlaneAicpuTaskRecord {
     // Timing information (device clock timestamps)
@@ -111,10 +112,6 @@ struct L2SwimlaneAicpuTaskRecord {
     uint64_t task_id;
     uint32_t func_id;    // Kernel function identifier
     CoreType core_type;  // Core type (AIC/AIV)
-
-    // Dependency relationship (fanout only)
-    uint64_t fanout[RUNTIME_MAX_FANOUT];  // Successor task task_id array
-    int32_t fanout_count;                 // Number of successor tasks
 } __attribute__((aligned(64)));
 
 static_assert(
@@ -299,7 +296,7 @@ struct L2SwimlaneDataHeader {
 
     // Metadata (Host initializes, Device read-only)
     uint32_t num_cores;          // Actual number of cores launched
-    uint32_t l2_swimlane_level;  // 0=off, 1=AICore timing, 2=+dispatch/fanout,
+    uint32_t l2_swimlane_level;  // 0=off, 1=AICore timing, 2=+dispatch,
                                  // 3=+sched phases, 4=+orch phases. Host writes
                                  // at init; AICPU reads in l2_swimlane_aicpu_init.
 } __attribute__((aligned(64)));

--- a/src/a5/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
+++ b/src/a5/platform/shared/aicpu/l2_swimlane_collector_aicpu.cpp
@@ -225,7 +225,7 @@ static void switch_records_buffer(int core_id, int thread_idx) {
 
 int l2_swimlane_aicpu_complete_task(
     int core_id, int thread_idx, uint32_t expected_reg_task_id, uint64_t task_id, uint32_t func_id, CoreType core_type,
-    uint64_t dispatch_time, uint64_t finish_time, const uint64_t *fanout, int32_t fanout_count
+    uint64_t dispatch_time, uint64_t finish_time
 ) {
     if (core_id < 0 || core_id >= PLATFORM_MAX_CORES) {
         return -1;
@@ -287,23 +287,13 @@ int l2_swimlane_aicpu_complete_task(
     record->func_id = func_id;
     record->core_type = core_type;
 
-    // AICPU_TIMING and above: dispatch/finish timing and fanout dependency info
+    // AICPU_TIMING and above: dispatch/finish timing
     if (g_l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) {
         record->dispatch_time = dispatch_time;
         record->finish_time = finish_time;
-        if (fanout != nullptr && fanout_count > 0) {
-            int32_t n = (fanout_count > RUNTIME_MAX_FANOUT) ? RUNTIME_MAX_FANOUT : fanout_count;
-            for (int32_t i = 0; i < n; i++) {
-                record->fanout[i] = fanout[i];
-            }
-            record->fanout_count = n;
-        } else {
-            record->fanout_count = 0;
-        }
     } else {
         record->dispatch_time = 0;
         record->finish_time = 0;
-        record->fanout_count = 0;
     }
 
     uint32_t new_count = count + 1;

--- a/src/a5/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/a5/platform/shared/host/l2_swimlane_collector.cpp
@@ -577,18 +577,9 @@ int L2SwimlaneCollector::export_swimlane_json() {
         outfile << "      \"end_time_us\": " << std::fixed << std::setprecision(3) << end_us << ",\n";
         outfile << "      \"duration_us\": " << std::fixed << std::setprecision(3) << duration_us << ",\n";
         outfile << "      \"dispatch_time_us\": " << std::fixed << std::setprecision(3) << dispatch_us << ",\n";
-        outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << ",\n";
-        outfile << "      \"fanout\": [";
-        int safe_fanout_count =
-            (record.fanout_count >= 0 && record.fanout_count <= RUNTIME_MAX_FANOUT) ? record.fanout_count : 0;
-        for (int j = 0; j < safe_fanout_count; ++j) {
-            outfile << record.fanout[j];
-            if (j < safe_fanout_count - 1) {
-                outfile << ", ";
-            }
-        }
-        outfile << "],\n";
-        outfile << "      \"fanout_count\": " << record.fanout_count << "\n";
+        outfile << "      \"finish_time_us\": " << std::fixed << std::setprecision(3) << finish_us << "\n";
+        // Fanout is no longer carried on the device hot path — dep_gen replay
+        // (deps.json) is the sole source of truth, joined in by tooling.
         outfile << "    }";
         if (i < tagged_records.size() - 1) {
             outfile << ",";

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -745,18 +745,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                     if (prev_running_id != AICPU_TASK_INVALID) {
                         Task *prev_task = &runtime.tasks[prev_running_id];
-                        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                        int fanout_count = 0;
-                        if (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) {
-                            for (int i = 0; i < prev_task->fanout_count; i++) {
-                                fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
-                            }
-                            fanout_count = prev_task->fanout_count;
-                        }
                         if (l2_swimlane_aicpu_complete_task(
                                 core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
+                                dispatch_timestamps_[core_id], finish_ts
                             ) != 0) {
                             LOG_ERROR(
                                 "Core %d: l2_swimlane_aicpu_complete_task failed for implicit task %d", core_id,
@@ -770,18 +762,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 
                     finish_ts = (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
                     Task *task = &runtime.tasks[completed_task_id];
-                    uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                    int fanout_count = 0;
-                    if (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) {
-                        for (int i = 0; i < task->fanout_count; i++) {
-                            fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
-                        }
-                        fanout_count = task->fanout_count;
-                    }
                     if (l2_swimlane_aicpu_complete_task(
                             core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
+                            dispatch_timestamps_[core_id], finish_ts
                         ) != 0) {
                         LOG_ERROR(
                             "Core %d: l2_swimlane_aicpu_complete_task failed for task %d", core_id, completed_task_id
@@ -867,18 +851,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                         uint64_t finish_ts =
                             (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
                         Task *prev_task = &runtime.tasks[prev_running_id];
-                        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                        int fanout_count = 0;
-                        if (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) {
-                            for (int i = 0; i < prev_task->fanout_count; i++) {
-                                fanout_arr[i] = static_cast<uint64_t>(prev_task->fanout[i]);
-                            }
-                            fanout_count = prev_task->fanout_count;
-                        }
                         if (l2_swimlane_aicpu_complete_task(
                                 core_id, thread_idx, static_cast<uint32_t>(prev_running_id),
                                 static_cast<uint64_t>(prev_running_id), prev_task->func_id, h->core_type,
-                                dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
+                                dispatch_timestamps_[core_id], finish_ts
                             ) != 0) {
                             LOG_ERROR(
                                 "Core %d: l2_swimlane_aicpu_complete_task failed for implicit task %d", core_id,
@@ -918,18 +894,10 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
                 if (l2_swimlane_enabled) {
                     uint64_t finish_ts = (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) ? get_sys_cnt_aicpu() : 0;
                     Task *task = &runtime.tasks[completed_task_id];
-                    uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-                    int fanout_count = 0;
-                    if (l2_swimlane_level >= L2SwimlaneLevel::AICPU_TIMING) {
-                        for (int i = 0; i < task->fanout_count; i++) {
-                            fanout_arr[i] = static_cast<uint64_t>(task->fanout[i]);
-                        }
-                        fanout_count = task->fanout_count;
-                    }
                     if (l2_swimlane_aicpu_complete_task(
                             core_id, thread_idx, static_cast<uint32_t>(completed_task_id),
                             static_cast<uint64_t>(completed_task_id), task->func_id, h->core_type,
-                            dispatch_timestamps_[core_id], finish_ts, fanout_arr, fanout_count
+                            dispatch_timestamps_[core_id], finish_ts
                         ) != 0) {
                         LOG_ERROR(
                             "Core %d: l2_swimlane_aicpu_complete_task failed for task %d", core_id, completed_task_id

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -255,7 +255,7 @@ header just like on onboard.
 | ----- | -------- |
 | 0 | Nothing (disabled) |
 | 1 | AICore timing only (start/end/task_id/func_id/core_type) |
-| 2 | + dispatch_time, finish_time, fanout |
+| 2 | + dispatch_time, finish_time |
 | 3 | + Scheduler phases (`SCHED_*`) |
 | 4 | + Orchestrator phases (full) |
 
@@ -271,7 +271,7 @@ content it depends on instead of relying on magic numbers:
 // Cheap binary check, available immediately after kernel entry.
 if (is_l2_swimlane_enabled()) { ... }
 
-// AICPU dispatch/finish timestamps + fanout.
+// AICPU dispatch/finish timestamps.
 // Granular checks below require l2_swimlane_aicpu_init to have already run
 // (so the level has been promoted from the shared-memory header).
 if (get_l2_swimlane_level() >= L2SwimlaneLevel::AICPU_TIMING) { ... }

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.h
@@ -25,7 +25,7 @@
  * extra I/O and an extra file in the output directory.
  *
  * deps.json is the sole source of truth for fanout: the L2 swimlane hot
- * path no longer records ``L2PerfRecord::fanout[]`` (taking the per-task
+ * path no longer records ``L2SwimlaneAicpuTaskRecord::fanout[]`` (taking the per-task
  * 1 KB GM store off the scheduler critical path). Replay sees every
  * submit and reconstructs the complete dependency graph.
  *

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -184,23 +184,15 @@ void SchedulerContext::complete_slot_task(
         uint64_t t_perf_start = get_sys_cnt_aicpu();
 #endif
         uint64_t finish_ts = 0;
-        uint64_t fanout_arr[RUNTIME_MAX_FANOUT];
-        int32_t fanout_n = 0;
 
         if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
             finish_ts = get_sys_cnt_aicpu();
-            PTO2DepListEntry *cur = slot_state.fanout_head;
-            while (cur != nullptr && fanout_n < RUNTIME_MAX_FANOUT) {
-                fanout_arr[fanout_n++] = cur->slot_state->task->task_id.raw;
-                cur = cur->next;
-            }
         }
 
         int32_t perf_slot_idx = static_cast<int32_t>(subslot);
         if (l2_swimlane_aicpu_complete_task(
                 core_id, thread_idx, static_cast<uint32_t>(expected_reg_task_id), slot_state.task->task_id.raw,
-                slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts, fanout_arr,
-                fanout_n
+                slot_state.task->kernel_id[perf_slot_idx], hank[core_id].core_type, dispatch_ts, finish_ts
             ) != 0) {
             LOG_ERROR(
                 "Core %d: l2_swimlane_aicpu_complete_task failed for task 0x%" PRIx64, core_id,

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -20,7 +20,7 @@ Verifies the end-to-end dep_gen pipeline on a5sim:
   implicitly: if it broke, deps.json would be empty or wrong.
 
 deps.json is now the sole source of truth for fanout edges — the device
-hot path no longer records L2PerfRecord::fanout[], so there is no
+hot path no longer records L2SwimlaneAicpuTaskRecord::fanout[], so there is no
 "fanout ⊆ deps" cross-check to run. swimlane_converter.py joins
 deps.json into the Perfetto trace at post-process time.
 


### PR DESCRIPTION
Align a5 with a2a3 (PR #863): the device hot path no longer collects per-task fanout. deps.json (dep_gen replay) is the sole source of truth for swimlane dependency edges, joined in by swimlane_converter.py at post-process time. No consumer reads task["fanout"], so this is a pure producer-side cleanup.

- Remove fanout[]/fanout_count from L2SwimlaneAicpuTaskRecord and the RUNTIME_MAX_FANOUT define orphaned in the swimlane header
- Drop the fanout params from l2_swimlane_aicpu_complete_task and the fanout extraction at all 5 call sites (host_build_graph x4, scheduler_completion x1)
- Stop emitting "fanout"/"fanout_count" in the host swimlane JSON
- Sync docs/comments: dep_gen.md, profiling_levels.md, tools/README.md, and fix two stale L2PerfRecord references left from the #916 rename