### PR TITLE
fix(task_interface): align Callable.storage_ for 8-byte child structs

### DIFF
--- a/src/common/task_interface/callable.h
+++ b/src/common/task_interface/callable.h
@@ -107,7 +107,12 @@ struct Callable {
     int32_t child_count_;
     char config_name_[CALLABLE_FUNC_NAME_MAX];
     uint32_t config_name_len_;
-    char storage_[];
+    // Children live in storage_ at CALLABLE_ALIGN-aligned offsets, but the
+    // all-uint32 header above can leave offsetof(storage_) at 4-mod-8, which
+    // would place an 8-byte-aligned Child (CoreCallable has a uint64) on a
+    // misaligned address — UB on reference binding (caught by UBSan). Align
+    // storage_ to the child's alignment so every child lands aligned.
+    alignas(alignof(Child)) char storage_[];
 
     ArgDirection sig(int32_t i) const {
         if (i < 0 || i >= sig_count_) throw std::out_of_range("Callable: sig index out of range");
@@ -153,6 +158,15 @@ private:
 using CoreCallable = Callable<void, CORE_MAX_TENSOR_ARGS, 0>;
 using ChipCallable = Callable<CoreCallable, CHIP_MAX_TENSOR_ARGS, 1024>;
 
+// storage_ holds CoreCallable children at CALLABLE_ALIGN-aligned offsets; for
+// child() to bind a reference without UB, storage_ itself must be aligned for
+// CoreCallable (which has a uint64 -> alignof 8). The alignas on storage_
+// guarantees this; assert it so a future header tweak can't silently regress.
+static_assert(
+    offsetof(ChipCallable, storage_) % alignof(CoreCallable) == 0,
+    "ChipCallable.storage_ must be aligned for its CoreCallable children"
+);
+
 // ============================================================================
 // Factory: make_callable for static leaf
 // ============================================================================
@@ -186,7 +200,12 @@ template <typename Child, int MaxSig, int MaxChildren>
 std::vector<uint8_t> make_callable(
     const ArgDirection *sig, int32_t sig_count, const char *func_name, const void *binary, uint32_t binary_size,
     const int32_t *child_func_ids, const std::vector<uint8_t> *child_buffers, int32_t child_count,
-    const char *config_name = nullptr
+    // No default arg here: the friend declaration above has none, so a default
+    // on this definition is a "redeclaration may not have default arguments"
+    // error once ChipCallable is instantiated (the static_assert below does
+    // that). Both call sites pass config_name explicitly (the binding defaults
+    // it to "" at the nb::arg level), so the default was dead anyway.
+    const char *config_name
 ) {
     if (sig_count > MaxSig) throw std::invalid_argument("make_callable: sig_count exceeds MaxSig");
     if (child_count > MaxChildren) throw std::invalid_argument("make_callable: child_count exceeds MaxChildren");


### PR DESCRIPTION
## Summary

A real **undefined-behaviour bug surfaced by the nightly sanitizer sweep**. The
`asan` cell is `address,undefined`, so it also runs UBSan — which flagged
*reference binding to a misaligned address* for `const CoreCallable&` /
`const Callable&` on the `prepare_callable` upload path, on **both** a2a3 and a5
(11 sites). This was the cause of the a5 `sanitizer-sim (asan, a5sim)` cell
exiting 1 with no report (UBSan `halt_on_error=1` kills the forked child).

### Root cause
`ChipCallable` (`Callable<CoreCallable, 128, 1024>`) has an all-`uint32` header,
so `offsetof(ChipCallable, storage_) == 8852` — **4 mod 8**. Children are
`CoreCallable`, which has a `uint64_t resolved_addr_` → **alignof 8**, placed in
`storage_` at `CALLABLE_ALIGN(64)`-aligned offsets. Net: every child lands at a
4-mod-8 absolute address, and `child()` binding `const Child&` to it is UB. The
host/sim CPU tolerates unaligned loads so it "worked", but it's genuine UB and
the **misaligned buffer is uploaded to the device**.

### Fix
`alignas(alignof(Child))` on `storage_` → `offsetof(storage_)` pads to 8856
(8-aligned), `alignof(ChipCallable)` becomes 8 (`vector::data()` is ≥16-aligned,
so no custom allocator needed). Emit (`make_callable`, in the binding) and read
(`compute_chip_callable_layout`, in the runtime) both use `offsetof(T, storage_)`,
so the layout stays consistent across the host↔device boundary.

A compile-time `static_assert` guards it — it **fails to compile** without the
fix (verified), so the misalignment can't silently regress.

### Validation
- Structural: `offsetof` 8852→8856, `alignof` 4→8, confirmed by compiling with
  the real types; `static_assert` passes with the fix, fails without it.
- End-to-end (sim UBSan + onboard device layout) is left to this PR's CI — a
  local clean rebuild was blocked by an unrelated dev-container env issue.

## Testing
- [x] Compile-time `static_assert` regression guard (fails pre-fix)
- [ ] CI: ASAN/UBSan sim cell no longer hits the misaligned UB
- [ ] CI: onboard a2a3/a5 validate the device buffer layout

## Notes
This removes one of the two UBSan findings. The nightly `asan` cell additionally
needs: (a) the a2a3 cell's `dynamic_register` oversubscription hang scoped out
(like TSAN), and (b) a separate signed-overflow UB at `scheduler_cold_path.cpp:905`
(reads not-yet-initialized PTO2 `current_task_index` = `0xbebebebe`; result is
clamped, so benign-but-UB). Tracked separately.