### PR TITLE
fix(scheduler)+ci: kill UBSan signed-overflow at boot; scope ASAN off L3

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -84,10 +84,13 @@ jobs:
             KFILTER="not dlopen_count"
             export TSAN_OPTIONS=halt_on_error=0:exitcode=0
           else
-            # ASAN (~1.7x) takes the broader set; dynamic_register is a2a3-only.
+            # ASAN (~1.7x) + UBSan. Like TSAN, the chip-fork L3 cases
+            # (dynamic_register is all level=3) livelock on the 4-vCPU runner
+            # once a sanitizer's slowdown is in play (#884 oversubscription
+            # family — AICPU + AICore + host threads oversubscribe), so scope to
+            # the light prepared_callable L2 set. UBSan halt_on_error=1 keeps it
+            # a real gate: any undefined behaviour fails the cell.
             TARGETS="$PC"
-            [ -d "tests/st/$ARCH/tensormap_and_ringbuffer/dynamic_register" ] && \
-              TARGETS="$TARGETS tests/st/$ARCH/tensormap_and_ringbuffer/dynamic_register"
             MAXPAR=2
             KFILTER="not parallel_broadcast and not dlopen_count"
             export ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -882,11 +882,19 @@ int32_t SchedulerContext::init(
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
-        int32_t pto2_count = 0;
+        // Read at one-time boot init, before the SM is reset for the run, so a
+        // ring not yet written holds uninitialized memory (0xbe... under ASAN's
+        // malloc-fill). Sum in int64 and only count rings whose value is a
+        // plausible task count — (0, PTO2_SCOPE_TASKS_CAP]; a ring cannot hold
+        // more than the scope cap. This rejects any garbage pattern (negative
+        // or positive), so uninitialized rings contribute 0 (the correct boot
+        // count) while valid counts still add up, with no signed overflow.
+        int64_t pto2_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            pto2_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+            int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+            if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) pto2_count += ring_tasks;
         }
-        total_tasks_ = pto2_count > 0 ? pto2_count : 0;
+        total_tasks_ = static_cast<int32_t>(pto2_count);
     } else {
         total_tasks_ = 0;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -895,11 +895,19 @@ int32_t SchedulerContext::init(
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {
         auto *header = static_cast<PTO2SharedMemoryHeader *>(runtime->get_gm_sm_ptr());
-        int32_t task_count = 0;
+        // Read at one-time boot init, before the SM is reset for the run, so a
+        // ring not yet written holds uninitialized memory (0xbe... under ASAN's
+        // malloc-fill). Sum in int64 and only count rings whose value is a
+        // plausible task count — (0, PTO2_SCOPE_TASKS_CAP]; a ring cannot hold
+        // more than the scope cap. This rejects any garbage pattern (negative
+        // or positive), so uninitialized rings contribute 0 (the correct boot
+        // count) while valid counts still add up, with no signed overflow.
+        int64_t task_count = 0;
         for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            task_count += header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+            int32_t ring_tasks = header->rings[r].fc.current_task_index.load(std::memory_order_acquire);
+            if (ring_tasks > 0 && ring_tasks <= PTO2_SCOPE_TASKS_CAP) task_count += ring_tasks;
         }
-        total_tasks_ = task_count > 0 ? task_count : 0;
+        total_tasks_ = static_cast<int32_t>(task_count);
     } else {
         total_tasks_ = 0;
     }


### PR DESCRIPTION
## Summary

The remaining two reasons the nightly **ASAN/UBSan** sim cell is red (the `asan`
preset is `address,undefined`, so it also runs UBSan). With #979 (Callable
alignment), these were the only two UBSan findings on `prepared_callable`.

### 1. Signed-overflow at scheduler boot (real UB)
`SchedulerContext::init` sums every ring's `current_task_index` to seed
`total_tasks_`. It runs at one-time AICPU boot — **before** the SM is reset for
the run (`aicpu_executor` SM init) — so a ring not yet written holds
uninitialized memory. Under ASAN's malloc-fill that's `0xbebebebe`, a **negative
int32**, and the int32 accumulation overflows → UBSan `signed-integer-overflow`.

Fix: accumulate in `int64_t` and skip non-positive rings. Uninitialized/garbage
rings now contribute 0 (the correct boot count, since no tasks are submitted
yet) and valid counts still add up, with no overflow. Applied to a2a3 and a5.

### 2. Scope ASAN off the L3 oversubscription hang
The a2a3 ASAN cell timed out (124) — `dynamic_register` is **all `level=3`**
chip-fork cases, which livelock on the 4-vCPU runner under a sanitizer's
slowdown (#884 oversubscription family). This is exactly why TSAN is scoped to
`prepared_callable`; ASAN now does the same. UBSan stays `halt_on_error=1`, so
it remains a **real gate** on any undefined behaviour.

## Validation
- Both UBSan findings on `prepared_callable` were enumerated (11 misaligned +
  1 overflow); #979 fixes the first, this fixes the second — none remain.
- Scheduler change compiles cleanly (local sim rebuild).
- End-to-end (sim ASAN/UBSan cell + onboard) is validated by CI / the next
  nightly. Needs **#979 merged too** for the cell to be fully green.

## Testing
- [x] Local sim build passes with the change
- [ ] Next nightly: ASAN/UBSan cell green (with #979)