### PR TITLE
docs: add remote l3 worker contract

### DIFF
--- a/docs/hierarchical_level_runtime.md
+++ b/docs/hierarchical_level_runtime.md
@@ -18,6 +18,8 @@ For details of each component's internals, see:
 - [scheduler.md](scheduler.md) — dispatch loop, queues, completion handling
 - [worker-manager.md](worker-manager.md) — WorkerThread pool, fork + mailbox
 - [task-flow.md](task-flow.md) — Callable / TaskArgs / CallConfig data flow, execution leaves
+- [remote-l3-worker-design.md](remote-l3-worker-design.md) — design proposal
+  for scheduling remote L3 workers as NEXT_LEVEL children
 
 For the L2 chip-level details (host `.so`, AICPU, AICore), see
 [chip-level-arch.md](chip-level-arch.md).
@@ -47,14 +49,18 @@ L0  CORE  / AIV, AIC   ── individual compute core (hardware-managed)
   atomics and barriers.
 - **L3–L6** (host/cluster): each level runs the same scheduling engine
   composed of Orchestrator + Scheduler + Worker pool. Communication via IPC
-  (fork + shm at L3 today; RDMA / sockets at L4+).
+  (fork + shm for today's L3 and for local recursive L4+ composition).
+  Cross-host L4/L5/L6 composition, where a parent schedules a remote L3
+  endpoint over RoCE/HCCS/UB/sockets, now has the local endpoint/eligibility
+  boundary and socket-backed simulation session runner implemented; HCOMM
+  hardware profiles are still pending.
 
 | Level | Workers it contains | Status |
 | ----- | ------------------- | ------ |
 | L3 (Host) | `ChipWorker` ×N + `SubWorker` ×M | Implemented |
-| L4 (Pod) | `Worker(level=3)` ×N + `SubWorker` ×M | Implemented |
-| L5 (SuperNode) | `Worker(level=4)` ×N | Same code as L4 (untested) |
-| L6 (Cluster) | `Worker(level=5)` ×N | Same code as L4 (untested) |
+| L4 (Pod) | `Worker(level=3)` ×N + `SubWorker` ×M | Local implemented; remote sim implemented; HCOMM profiles pending |
+| L5 (SuperNode) | `Worker(level=4)` ×N | Local L4 code path, untested; remote proposed |
+| L6 (Cluster) | `Worker(level=5)` ×N | Local L4 code path, untested; remote proposed |
 
 `Worker` is a single C++ class that handles every level from L3 upward — the
 `level` parameter is a diagnostic label; behavior does not branch on it. The
@@ -75,7 +81,9 @@ first argument of `submit_*`. Runs single-threaded on the user's thread.
 Owns:
 
 - `Ring` — fixed-size slot pool, allocates with back-pressure
-- `TensorMap` — `tensor_base_ptr → producer_slot` lookup, drives automatic dep inference
+- `TensorMap` — tensor dependency key to producer slot lookup, drives automatic
+  dep inference. Local keys contain a pointer; remote keys contain buffer
+  identity and logical offset.
 - `Scope` — lifetime management for intermediate tensors
 
 One `submit_next_level(callable, task_args, config)` call:
@@ -108,7 +116,7 @@ The **execution layer**. `WorkerManager` holds two pools of `WorkerThread`s
 (next-level pool and sub pool). Each `WorkerThread` owns one std::thread that
 encodes `(callable, config, args_blob)` into a `MAILBOX_SIZE`-byte shared
 memory region, signals the pre-forked Python child, and spin-polls
-`TASK_DONE`.
+  `TASK_DONE`, returning an explicit completion outcome to the Scheduler.
 
 - Next-level (chip) children run `_chip_process_loop`, which constructs a
   `ChipWorker` and dispatches each kernel through it.
@@ -143,10 +151,10 @@ what flows through `ChipWorker::run`.
                  │                                 │ wt.dispatch(slot_id) ──────► WorkerThread
                  │                                 │                              encode mailbox → spin-poll TASK_DONE
                  │                                 │                              (blocking; child runs the kernel)
-                 │                                 │◄── completion_queue ────── on_complete_(slot_id)
+                 │                                 │◄── completion_queue ────── on_complete_(completion)
                  │                                 │ on_task_complete:
-                 │                                 │   fanout release
-                 │                                 │   wake downstream
+                 │                                 │   success → COMPLETED
+                 │                                 │   failure → FAILED + poison downstream
                  │                                 │   try_consume → ring release
                  │ drain() ◄── notify when all done │
 ```
@@ -157,7 +165,7 @@ Communication channels:
 | ---- | --------- | ------- |
 | Orch → Scheduler | wiring_queue (mutex + CV) | slot id |
 | Scheduler → WorkerThread | WorkerThread internal queue | slot id |
-| WorkerThread → Scheduler | completion_queue (mutex + CV) | slot id |
+| WorkerThread → Scheduler | completion_queue (mutex + CV) | slot id + group index + outcome |
 | WorkerThread ↔ child | shm mailbox (state + error + task data) | encoded blob |
 | Python ↔ C++ | nanobind bindings | TaskArgs / CallConfig / callable handle |
 | Tensor data | `torch.share_memory_()` or host malloc | zero-copy shared address |
@@ -223,7 +231,7 @@ walk-through.
 | Callable registration | owns handle/hashid registries and child-local Python dispatch mappings | — |
 | Orchestration DAG | user's orch fn, `submit_*` calls | `Orchestrator::submit_*` engine |
 | Scheduling | — | `Scheduler` thread, queues, `WorkerThread` pool |
-| Dispatch | — | `WorkerThread::dispatch_process`, mailbox IPC |
+| Dispatch | — | `WorkerThread::dispatch` → `WorkerEndpoint::run`, mailbox IPC for local endpoints |
 | Runtime execution | — | `ChipWorker` via dlsym'd runtime `.so` |
 
 Python handles **when** things happen (fork ordering, lifecycle). C++ handles
@@ -285,6 +293,8 @@ device allocation algorithm.
 | `src/common/hierarchical/orchestrator.{h,cpp}` | `Orchestrator`: submit, TensorMap, Scope |
 | `src/common/hierarchical/scheduler.{h,cpp}` | `Scheduler`: dispatch loop + queues |
 | `src/common/hierarchical/worker_manager.{h,cpp}` | `WorkerManager` + `WorkerThread`: pool, mailbox-IPC dispatch |
+| `src/common/hierarchical/remote_endpoint.{h,cpp}` | `RemoteL3Endpoint` transport-neutral TASK/COMPLETION boundary |
+| `src/common/hierarchical/remote_wire.{h,cpp}` | Versioned remote L3 frame codec |
 | `src/common/hierarchical/worker.{h,cpp}` | `Worker` (L3+): composes the above |
 | `src/common/hierarchical/ring.{h,cpp}` | slot allocator |
 | `src/common/hierarchical/tensormap.{h,cpp}` | base_ptr → producer slot |

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -33,10 +33,16 @@ public:
     // --- Internal submit API (tags inside TaskArgs drive deps) ---
     SubmitResult submit_next_level(const CallableIdentity &callable,
                                     const TaskArgs &args,
-                                    const CallConfig &config);
+                                    const CallConfig &config,
+                                    int8_t worker = -1,
+                                    const std::vector<int32_t> &eligible_endpoint_ids = {},
+                                    const RemoteTaskArgsSidecar &remote_sidecar = {});
     SubmitResult submit_next_level_group(const CallableIdentity &callable,
                                           const std::vector<TaskArgs> &args_list,
-                                          const CallConfig &config);
+                                          const CallConfig &config,
+                                          const std::vector<int8_t> &workers = {},
+                                          const std::vector<std::vector<int32_t>> &eligible_endpoint_ids = {},
+                                          const std::vector<RemoteTaskArgsSidecar> &remote_sidecars = {});
     SubmitResult submit_sub(const CallableIdentity &callable,
                             const TaskArgs &args);
     SubmitResult submit_sub_group(const CallableIdentity &callable,
@@ -64,6 +70,13 @@ struct SubmitResult { TaskSlot task_slot; };  // internal only; not bound to Pyt
 `scope_begin` / `scope_end` / `drain` are invoked from Python `Worker.run` via
 `_scope_begin` / `_scope_end` / `_drain` bindings. They are not part of the
 user-facing orch-fn API.
+
+Remote L3 submit adds two hidden pieces of metadata: final eligible endpoint
+sets and optional `RemoteTaskArgsSidecar` entries aligned by tensor index.
+Python `RemoteCallable` handles supply callable eligibility, and
+`RemoteTaskArgs` supplies tensor sidecars. The Orchestrator validates affinity,
+endpoint existence, local-vs-remote compatibility, bare host pointers, and
+remote null OUTPUT tensors before committing the slot.
 
 ---
 
@@ -94,15 +107,15 @@ SubmitResult Orchestrator::submit_next_level(const CallableIdentity &callable,
     std::unordered_set<TaskSlot> producers_seen;
     for (int i = 0; i < s.task_args.tensor_count(); i++) {
         TensorArgType tag = s.task_args.tag(i);
-        uint64_t ptr      = s.task_args.tensor(i).data;
+        TensorKey key     = key_for_tensor_or_remote_sidecar(i);
 
         if (tag == INPUT || tag == INOUT) {
-            if (TaskSlot prod = tensormap_.lookup(ptr); prod != INVALID)
+            if (TaskSlot prod = tensormap_.lookup(key); prod != INVALID)
                 if (producers_seen.insert(prod).second)
                     producers.push_back(prod);
         }
         if (tag == OUTPUT || tag == INOUT || tag == OUTPUT_EXISTING) {
-            tensormap_.insert(ptr, sid);
+            tensormap_.insert(key, sid);
         }
         // NO_DEP: skip both
     }
@@ -136,6 +149,9 @@ small POD copied by value. `callable` is a `uint64_t` opaque handle (see
 **Step 3 — tag walk**: The only place tags are consumed. After this step tags
 are never inspected again; they are not carried into the slot's stored
 `task_args` value during dispatch (see [task-flow.md](task-flow.md) §3).
+Local tensors key TensorMap by `(LOCAL_HOST, ptr)` or
+`(LOCAL_CHILD, worker, ptr)`. Remote tensors with sidecars key by
+`(address_kind, owner_endpoint_id, buffer_id, generation, offset)`.
 
 | Tag | `tensormap.lookup` | `tensormap.insert` |
 | --- | ------------------ | ------------------ |
@@ -147,7 +163,9 @@ are never inspected again; they are not carried into the slot's stored
 
 `OUTPUT_EXISTING` differs from `OUTPUT` in runtime semantics (user-provided
 buffer vs. runtime-allocated) but dependency tracking is identical: both
-register this task as the new producer of `tensor.data`.
+register this task as the new producer of the tensor's dependency key. For
+local tensors this key contains `tensor.data`; for remote sidecars it contains
+remote buffer identity and logical offset.
 
 **Step 4 — fanin count**: The number of live producers. Decremented by
 `fanin_released++` each time a producer completes; when `fanin_released ==
@@ -498,45 +516,46 @@ concurrent hash map can replace it.
 Each `TaskSlotState.state` progresses through:
 
 ```text
-FREE ──► PENDING ──► COMPLETED ──► CONSUMED ──► FREE
- ↑         │            │             │
- │       submit      worker(s)     all refs
- │                   done          released
- │                                 (scope + fanout)
- │                                     │
- └──────── ring.release(sid) ◄─────────┘
+FREE ──► PENDING ──► READY ──► RUNNING ──► COMPLETED ──► CONSUMED ──► FREE
+                             │               │
+                             └──────────────► FAILED ─────► CONSUMED ──► FREE
 ```
 
 - **FREE**: slot in the ring pool, not allocated
-- **PENDING**: allocated; remains PENDING through "waiting on producers",
-  "queued in ready_queue", and "dispatched to a worker"
+- **PENDING**: allocated; waiting on live fanin producers
+- **READY**: all fanins satisfied; queued for Scheduler dispatch
+- **RUNNING**: dispatched to one or more endpoints
 - **COMPLETED**: worker(s) done; may still be referenced by fanout / scope
+- **FAILED**: a worker/endpoint failed, or a failed producer poisoned this
+  slot. Failed slots are never dispatched if they were not already running.
 - **CONSUMED**: all references released; Scheduler calls `ring.release(sid)`
   and the slot returns to FREE
 
-There is no separate READY or RUNNING state — readiness is derived from
-`fanin_refcount == fanin_count` and running-vs-idle from the per-core
-`running_slot_state` pointer. State transitions are driven by atomic
-operations:
+State transitions are driven by atomic operations:
 
 - Orch: FREE → PENDING at submit time
-- Scheduler: PENDING → COMPLETED → CONSUMED during completion
+- Scheduler: PENDING → READY → RUNNING during dispatch
+- Scheduler: RUNNING → COMPLETED or RUNNING/PENDING/READY → FAILED during
+  completion / dependency poisoning
+- Scheduler/Orch cleanup: COMPLETED/FAILED → CONSUMED
 
 ### Fanout-release threshold
 
-Both paths that can trigger COMPLETED → CONSUMED (the scheduler's
+Both paths that can trigger COMPLETED/FAILED → CONSUMED (the scheduler's
 `try_consume` and the scope-end `release_ref`) use the same threshold:
 
 ```cpp
-if (fanout_released >= fanout_total + 1 && state == COMPLETED) on_consumed(slot);
+if (fanout_released >= fanout_total + 1 &&
+    (state == COMPLETED || state == FAILED))
+    on_consumed(slot);
 ```
 
 The `+1` accounts for the slot's own self-release contribution, which normal
 tasks emit from `on_task_complete` (`try_consume(slot)` self-call). Alloc
 slots (§8b) bypass the scheduler and pre-bump `fanout_released` to `1` at
 `alloc()` time to stand in for the self-release. Both paths use `on_consumed`,
-which uses a CAS on `state` from `COMPLETED` to `CONSUMED` to remain idempotent
-when both fire concurrently at threshold.
+which CASes `state` from `COMPLETED` or `FAILED` to `CONSUMED` to remain
+idempotent when both fire concurrently at threshold.
 
 ---
 
@@ -587,7 +606,9 @@ per-slab free syscall.
 `infer_deps` treats `COMPLETED` producers specially: it still wires the
 fanout edge (so the producer waits for the consumer before being consumed and
 freeing its buffer) but does not bump `live_fanins` (the consumer is
-immediately ready because the producer is already done).
+immediately ready because the producer is already done). A producer that is
+already `FAILED` is not a successful fanin; downstream consumers are poisoned
+by the Scheduler rather than dispatched.
 
 ```cpp
 if (ps_state == TaskState::CONSUMED) continue;  // already gone

--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -1,0 +1,597 @@
+# Remote L3 Worker Design
+
+This document describes how to extend the L3+ hierarchical runtime so a
+parent `Worker` can schedule a remote `Worker(level=3)` as a NEXT_LEVEL
+worker. The first target is an L4 parent dispatching to remote L3 workers.
+The same contracts can later serve L5/L6.
+
+Detailed protocol, buffer, transport, and rollout notes live in:
+
+- [protocol.md](remote-l3-worker-design/protocol.md)
+- [buffers-and-transports.md](remote-l3-worker-design/buffers-and-transports.md)
+- [implementation-plan.md](remote-l3-worker-design/implementation-plan.md)
+- [pr-split-and-audit-plan.md][split-audit-plan]
+
+[split-audit-plan]: remote-l3-worker-design/pr-split-and-audit-plan.md
+
+Related callable registration and serialization contracts:
+
+- [callable-ipc-dynamic-register.md](callable-ipc-dynamic-register.md)
+- [callable-identity-registration.md](callable-identity-registration.md)
+- [python-callable-serialization.md](python-callable-serialization.md)
+
+`callable-identity-registration.md` is a prerequisite refinement for this
+design: remote L3 callable routing should use `hashid` identities and
+target-private execution slots instead of cross-worker integer routing.
+
+The current implementation uses pre-forked local child processes and a
+4096-byte shared-memory mailbox. That model depends on copy-on-write callable
+registries, identical virtual addresses for `MAP_SHARED` regions, and
+parent-visible child PIDs. None of those assumptions holds across hosts.
+
+## Current Implementation Status
+
+The local PR #866 cut has landed the transport-neutral runtime boundary, but
+not the production daemon/HCOMM backends.
+
+Implemented:
+
+- `WorkerEndpoint` with `LocalMailboxEndpoint` and `RemoteL3Endpoint`.
+  `LocalMailboxEndpoint` keeps the existing 4096-byte mailbox local-only.
+  `RemoteL3Endpoint` encodes versioned TASK frames through a
+  `RemoteL3Transport` interface and waits for matching COMPLETION frames.
+- Explicit endpoint outcomes: success, task failure, endpoint failure, and
+  skipped group members. Failed producers poison downstream consumers instead
+  of completing successfully.
+- Stable NEXT_LEVEL `endpoint_id` metadata, submit-time endpoint eligibility,
+  worker affinity validation against eligibility, and Scheduler selection from
+  only eligible idle endpoints.
+- C++ remote tensor sidecars, remote-aware `TensorKey` values, and submit-time
+  rejection of remote sidecars against local endpoints, bare host pointers, and
+  remote null OUTPUT tensors without a sidecar.
+- Python `RemoteCallable("module:qualname")`, `PYTHON_IMPORT`, and
+  `REMOTE_TASK_DISPATCHER` callable identity. Registration requires an
+  explicit `workers=[...]` list naming ids returned by `add_remote_worker()`.
+- Python `RemoteBufferHandle`, `RemoteTensorRef`, and `RemoteTaskArgs`
+  wrappers. They keep `ContinuousTensor.data == 0` and carry the remote
+  descriptor sidecar into C++ submit.
+- Canonical little-endian `remote_wire.{h,cpp}` frame codec with bounds checks
+  for TASK payloads, remote tensor descriptors, COMPLETION, CONTROL_REPLY, and
+  ordered command-lane sequencing.
+- Socket-backed simulation remote sessions via `simpler-remote-worker` and
+  `simpler-remote-l3-session`, including `HELLO READY`, TASK/COMPLETION,
+  CONTROL/CONTROL_REPLY, SHUTDOWN, and an independent health lane.
+- Simulation remote buffer allocation, copy, export, import, release-import,
+  imported-handle scheduling eligibility, and deferred owner free.
+- Registry-scope-aware remote callable manifest/control install for dispatcher
+  `PYTHON_IMPORT`, inner `PYTHON_IMPORT`, and inner inline `CHIP_CALLABLE`.
+
+Still pending:
+
+- A2 RoCE, A3 HCCS, and A5 UB HCOMM profiles.
+- Remote `CommDomain` allocation/import and hardware-gated validation.
+- Negotiated `PYTHON_SERIALIZED` remote callable payloads and staged
+  `CHIP_CALLABLE` blob adapters.
+
+## Scope
+
+Goals:
+
+- Preserve the Orchestrator/Scheduler DAG model.
+- Replace the local mailbox endpoint under `WorkerThread` with a pluggable
+  NEXT_LEVEL endpoint.
+- Support HCOMM-backed remote communication profiles for A2 RoCE, A3 HCCS,
+  and A5 UB.
+- Carry task dispatch, control commands, completion, error messages, and
+  buffer lifetime over the remote endpoint.
+
+Non-goals:
+
+- Rewriting kernel allreduce or PTO-ISA collective kernels.
+- Shipping Python closures without an explicit serialization contract.
+- Designing general cross-host Python dependency or code distribution for
+  arbitrary closures.
+- Replacing the local fork/shm path for chip and sub workers.
+- Changing the L2 `ChipWorker::run` ABI.
+- Exposing `RemoteL3Endpoint`, HCOMM, RDMA, or socket details to
+  `Orchestrator`; endpoint selection and materialization stay behind
+  `WorkerEndpoint`.
+- Redesigning remote `CommDomain` or the device `CommContext` ABI in the first
+  Remote L3 task-dispatch cut.
+
+Remote callable registration follows the public callable identity lifecycle
+defined by PR #891: `Worker.register()` returns a `CallableHandle`, `hashid` is
+the stable cross-process identity, and each target owns a private
+`hashid -> local_slot` mapping. A registration becomes visible to the selected
+Python-capable endpoint only after the registration control reply succeeds.
+Final unregister prevents reuse of endpoint-private execution state until stale
+state is cleared or the endpoint is marked failed, and stale callable residue
+must not be observable by later TASK frames. The remote design reuses those
+lifecycle semantics, but it does not reuse PR #891's local mailbox commands,
+POSIX shm names, process-local pointers, or exact serialized payload wire
+shape.
+
+The required baseline remote callable descriptor is an import path such as
+`pkg.module:orch_fn`. Serialized Python callable payloads follow
+[python-callable-serialization.md](python-callable-serialization.md), but they
+are a negotiated remote capability, not part of the first required remote L3
+baseline. When enabled, the payload travels as a versioned remote CONTROL
+payload and must negotiate serializer version, payload limits, Python
+ABI/runtime compatibility, and dependency/runtime-environment compatibility.
+
+## Current Seams
+
+Relevant code paths:
+
+- `python/simpler/worker.py`
+  - `_start_hierarchical()` forks local child workers.
+  - `_child_worker_loop()` runs a nested `Worker` child via shm mailbox.
+  - `_run_chip_main_loop()` handles task and control mailbox states.
+- `src/common/hierarchical/worker_manager.{h,cpp}`
+  - `WorkerThread` owns one local mailbox and blocks until `TASK_DONE`.
+  - Control commands share the same mailbox and serialize on `mailbox_mu_`.
+  - Errors are reported through `MAILBOX_OFF_ERROR` and
+    `MAILBOX_OFF_ERROR_MSG`.
+- `src/common/hierarchical/orchestrator.{h,cpp}`
+  - `submit_next_level()` stores `TaskArgs`, `CallConfig`,
+    `CallableIdentity`, and optional worker affinity in a parent-side slot.
+  - Dependency inference happens before dispatch from tags in `TaskArgs`.
+- `src/common/task_interface/task_args.h`
+  - Process dispatch writes `[T][S][ContinuousTensor x T][uint64 x S]`.
+  - Tags are stripped after submit.
+- `docs/comm-domain.md`
+  - Dynamic communication domains already model deferred release after
+    `drain()`.
+
+The Scheduler should not inspect transport details, but it does need enough
+metadata to avoid dispatching a task to an endpoint that cannot run it. Remote
+tensor identity must be resolved before a slot becomes ready, because
+TensorMap dependency inference and buffer-reference capture happen at submit
+time.
+
+`Orchestrator` consumes tags, computes dependency keys, and stores endpoint
+eligibility metadata. It must not call `RemoteL3Endpoint`, HCOMM, RDMA, or
+socket APIs directly. `WorkerThread` and `WorkerEndpoint` own the child
+boundary and materialization mechanics.
+
+## Target Architecture
+
+Introduce a communication-neutral `WorkerEndpoint` under `WorkerThread` with
+`caps`, `run`, `control`, and `shutdown` operations. `LocalMailboxEndpoint`
+wraps the current shm mailbox code without changing wire behavior.
+`RemoteL3Endpoint` implements the same interface with a bootstrap socket for
+session setup, then HCOMM-backed RPC and data adapters for steady-state
+traffic.
+
+`caps()` is part of the endpoint contract because submit-time eligibility must
+know whether an endpoint can resolve a callable `hashid` and consume the tensors
+in a slot. It is read-only capability metadata, not a transport escape hatch:
+the Scheduler sees logical features such as callable kinds, resolver scopes,
+memory directions, address spaces, and health state, while `RemoteL3Endpoint`
+remains the only layer that knows the selected HCOMM protocol or adapter
+handles.
+
+On dispatch, `WorkerThread` builds a task packet from `TaskSlotState`, calls
+the endpoint, reports endpoint errors, and notifies the Scheduler with an
+explicit success/failure outcome.
+
+Ready queues, group dispatch, affinities, fanin/fanout, and ring release remain
+in the existing runtime. The first-error-wins policy remains only as the error
+reporting policy for choosing which root error `drain()` raises. The important
+change is that completion is no longer implicitly success; every endpoint,
+including `LocalMailboxEndpoint`, must report an explicit success/failure
+outcome.
+
+## Fork-Safe Remote Process Model
+
+The remote runtime must preserve the repository's fork ordering invariant:
+all chip/sub child processes are forked before any C++ Scheduler,
+`WorkerThread`, transport, or health threads are started.
+
+Use a two-process remote model:
+
+1. `simpler-remote-worker` is a small control daemon. It accepts session
+   requests and validates bootstrap manifests on the daemon control channel.
+   It never constructs an inner `Worker` and never forks chip/sub children
+   after starting transport worker threads.
+2. For each accepted session, the daemon starts a fresh
+   `simpler-remote-l3-session` runner process, preferably by `exec`.
+3. The daemon passes the validated manifest to the runner through a simple
+   pre-fork handoff such as an inherited fd, a manifest file path in env, or a
+   single-threaded pipe. This handoff is not the remote transport protocol.
+4. The session runner reads the manifest before starting transport threads and
+   constructs `Worker(level=3)`.
+5. The runner then performs an explicit prestart step equivalent to
+   `inner_worker.init()` plus `_start_hierarchical()` for the inner Worker:
+   allocate local mailboxes, fork local chip/sub children, register local
+   endpoints with the inner C++ Worker, and start the inner Scheduler and
+   `WorkerThread`s.
+6. Only after this local L3 child tree is established does the session runner
+   bring up sockets, RDMA queue pairs, health threads, or UB doorbells for task
+   traffic.
+7. The runner then performs the remote protocol `HELLO`/ready handshake over
+   the ordered command lane. `HELLO` confirms session identity, endpoint
+   identity, protocol version, comm profile, and negotiated features; it does
+   not carry the bootstrap manifest.
+8. Session shutdown rejects new frames, completes or fails in-flight tasks,
+   drains cleanup, closes the inner Worker, and exits the runner process.
+
+This keeps the local L3 fork/shm implementation intact while preventing a
+multi-threaded network daemon from becoming the process that performs the
+forks.
+
+`HELLO ready_state=READY` is a scheduling barrier, not just a liveness signal.
+The parent must not put a remote endpoint into the schedulable set until the
+runner has completed prestart, installed the bootstrap registries, initialized
+the buffer/import registry, started the command and health lanes, and confirmed
+the negotiated feature set. This mirrors the distributed-system convention that
+a worker or actor becomes visible only after runtime and dependency
+initialization has completed.
+
+## Endpoint Identity and Callable Routing
+
+Remote scheduling needs explicit callable resolver scopes and an explicit
+mapping from callable identities to eligible NEXT_LEVEL endpoints. The current
+scheduler can otherwise choose any idle worker, which is only correct when
+every NEXT_LEVEL child has the same callable registry.
+
+Required contracts:
+
+- Every local or remote NEXT_LEVEL child has a stable `endpoint_id` equal to
+  its logical worker id in `WorkerManager`.
+- `register(callable, workers=...)` is the single public registration API.
+  Local Python/callable objects keep the existing local registration path.
+  `RemoteCallable` descriptors use the remote control path and bind the
+  returned `CallableHandle.hashid` to one or more remote endpoint ids.
+- PR866 extends the PR #891 callable identity surface with one parent-facing
+  remote callable kind, `PYTHON_IMPORT`, and one parent-facing resolver scope,
+  `REMOTE_TASK_DISPATCHER`. `RemoteCallable("pkg.module:orch_fn")`
+  registration returns a normal `CallableHandle` whose `kind` is
+  `PYTHON_IMPORT`, whose resolver scope is `REMOTE_TASK_DISPATCHER`, and whose
+  `hashid` is computed from the canonical remote import descriptor.
+- The first implementation requires `RemoteCallable` registration to pass an
+  explicit non-empty `workers=[...]` list. Future releases may replace raw
+  worker ids with named remote pools or placement policies, but implicit
+  broadcast to all remote endpoints is not part of the contract.
+- Bootstrap manifests are generated by the parent. Users provide remote
+  callable descriptors; users do not hand-author raw `hashid -> callable`
+  maps.
+- Remote callable descriptors have two Python forms:
+  - `PYTHON_IMPORT`: a bounded `module:qualname` import path. This is required
+    for the remote L3 baseline.
+  - `PYTHON_SERIALIZED`: a versioned payload that follows
+    [python-callable-serialization.md](python-callable-serialization.md). This
+    is rejected in remote protocol v1 unless parent and session explicitly
+    negotiate serializer version, payload limits, Python ABI/runtime
+    compatibility, and dependency/runtime-environment compatibility.
+- The parent computes each remote callable `hashid` from canonical descriptor
+  bytes before publication. `PYTHON_IMPORT` uses a remote descriptor schema
+  that includes descriptor schema version, callable kind, normalized module
+  string, and normalized qualname string; any future environment compatibility
+  digest or import policy field must bump the schema version.
+  `PYTHON_SERIALIZED` reuses the PR #891 serialized-payload descriptor
+  identity. Inner `CHIP_CALLABLE` entries reuse the PR #891 chip descriptor
+  identity.
+- Remote L3 uses one callable identity scheme: `hashid`. It still has two
+  resolver locations because different runtime objects consume the identity:
+  - **Remote TASK dispatcher registry**: the parent-facing entry registry in
+    the session runner. TASK frames from the L4 parent carry a hash digest; the
+    dispatcher resolves it to the remote L3 orchestration callable and then
+    invokes `inner_worker.run(...)`.
+  - **Inner L3 Worker registry**: remote-internal state owned by
+    `inner_worker = Worker(level=3)`. Remote L3 orchestration functions use
+    this Worker's own `CallableHandle` values when they call
+    `orch.submit_next_level(...)` or `orch.submit_sub(...)`.
+- The remote TASK dispatcher is not a Worker and must not reimplement
+  Scheduler, Orchestrator, TensorMap, or drain semantics. It is an RPC entry
+  adapter that resolves the outer callable, materializes `RemoteTaskArgs`,
+  calls the embedded `inner_worker`, and wraps completion/error reporting.
+- Resolver location is selected by execution context, not by a second identity
+  dimension. A remote TASK frame always resolves in the remote TASK dispatcher
+  registry; an inner `orch.submit_*` call resolves through the inner Worker's
+  normal PR #891 handle validation. The same hashid may appear in both
+  registries, but that means the same canonical descriptor was installed in two
+  places, not that the two registries share executable slots or eligibility.
+- Dynamic Python callable registration follows the public visibility and
+  hashid lifecycle semantics from local dynamic registration: registration is
+  synchronous per selected endpoint, future TASK frames may use the hashid only
+  after the control reply succeeds, unregister clears stale callable state, and
+  TASK/control ordering prevents a TASK from observing a partially registered
+  hashid.
+- Import-path descriptors are the required remote baseline. Serialized Python
+  callable payloads preserve the same hashid lifecycle but remain an optional
+  negotiated feature because they require Ray-like environment and serializer
+  compatibility checks that local fork/COW registration does not need.
+- Multi-endpoint `register(..., workers=[...])` is all-or-nothing by
+  default. The parent sends a prepare phase to every selected endpoint, commits
+  hashid only after every prepare succeeds, and exposes the hashid to future
+  TASK frames only after every commit reply succeeds. If any endpoint fails
+  prepare or commit, the parent aborts the transaction, keeps the hashid
+  invisible, and either rolls back successful endpoints or marks endpoints with
+  unknown state failed.
+- Final multi-endpoint unregister uses a tombstone state for the selected
+  endpoint/hashid pairs. The hashid remains dispatchable through any other live
+  handle that still owns a reference. Once the final reference is dropped for
+  an endpoint, that endpoint/hashid pair is unavailable for dispatch until
+  cleanup is confirmed or the endpoint is removed from eligibility and marked
+  failed. Failed-register rollback whose cleanup cannot be confirmed marks that
+  endpoint/hashid pair cleanup-uncertain and unusable for the current session.
+- `TaskSlotState` stores the final eligible endpoint set for the slot. This is
+  the intersection of endpoints that can resolve the callable hashid and
+  endpoints that can access every tensor/buffer referenced by the slot.
+- If the user passes `worker=N`, submit-time validation checks that endpoint
+  `N` is eligible for that hashid and for the slot's tensor sidecars.
+- If `worker=-1`, the Scheduler chooses only from idle endpoints in the
+  slot's eligible set.
+- Group submit validates each affinity independently. Unconstrained group
+  members are assigned distinct idle eligible endpoints.
+- Mixed local + remote NEXT_LEVEL pools are allowed only when the callable
+  hashid is registered on every endpoint that can receive the slot and the
+  slot's tensors are materialized in a representation those endpoints can
+  consume.
+  A callable registered on both local and remote endpoints does not make a
+  remote-buffer task eligible for the local endpoint.
+
+Example API shape:
+
+```python
+from simpler.worker import RemoteCallable, RemoteWorkerSpec, Worker
+
+w4 = Worker(level=4)
+
+l3 = RemoteWorkerSpec(
+    endpoint="node17:19073",
+    platform="a2a3",
+    runtime="tensormap_and_ringbuffer",
+    device_ids=list(range(16)),
+    num_sub_workers=2,
+    transport="roce",
+)
+
+l3_worker_id = w4.add_remote_worker(l3)
+l3_handle = w4.register(
+    RemoteCallable("my_pkg.remote_orch:l3_orch"),
+    workers=[l3_worker_id],
+)
+w4.init()
+```
+
+`add_worker(local_worker)` remains unchanged and continues to use fork/shm.
+
+Dynamic remote registration uses the same hashid lifecycle whether the
+descriptor is installed at bootstrap or through a later control frame. If a
+remote L3 orchestration callable refers to inner L3 callables, those are
+`CallableHandle` values owned by the embedded inner Worker. The parent may
+include inner Worker registry entries in the bootstrap manifest or send
+registry-scoped controls to install them, but it does not receive or submit a
+parent-facing handle whose resolver scope is `INNER_L3_WORKER`.
+
+Post-bootstrap inner registry controls use the same prepare/commit/abort and
+final-unregister visibility rules as dispatcher registration. `CHIP_CALLABLE`
+is valid only for `INNER_L3_WORKER`; the remote payload carries bounded inline
+blob bytes or a session-local staged blob token, never a parent-local POSIX
+shm name. A successful inner install makes the hashid visible only to
+`inner_worker = Worker(level=3)` and its chip/sub dispatch paths.
+Remote orchestration code that needs a post-bootstrap inner handle resolves
+the installed hashid through the session-runner-local
+`simpler.remote_l3_session.get_inner_handle(hashid)` helper. That helper
+returns a `CallableHandle` owned by the embedded `inner_worker`; it does not
+publish an `INNER_L3_WORKER` resolver scope to the parent.
+
+## Remote Worker Session
+
+The parent generates a bootstrap manifest and sends it to the
+`simpler-remote-worker` daemon as part of session creation. The daemon validates
+it and hands it to the session runner before the runner starts any transport
+threads:
+
+```text
+session_id
+parent_worker_level
+remote_worker_level = 3
+endpoint_id
+platform, runtime, build flag
+device_ids, num_sub_workers, heap_ring_size
+callable registry:
+  remote TASK dispatcher registry:
+    hashid -> remote L3 orch callable descriptor
+      descriptor = PYTHON_IMPORT or negotiated PYTHON_SERIALIZED
+  inner L3 Worker registry:
+    hashid -> ChipCallable register payload, when needed
+    hashid -> Python import descriptor, when needed
+comm policy: roce | hccs | ub | sim
+feature flags
+```
+
+The session runner installs the remote TASK dispatcher registry for parent
+TASK frames. It installs the inner registry into
+`inner_worker = Worker(level=3)` during prestart and before `HELLO READY`.
+`INNER_L3_WORKER` is a remote-internal install target in manifests and
+controls, not a parent-facing `CallableHandle` resolver scope.
+`inner_l3_worker` manifest entries use the same target/kind matrix and
+validation rules as `PREPARE_REGISTER_CALLABLE`: `PYTHON_IMPORT` entries carry
+`target = "module:qualname"` and inline `CHIP_CALLABLE` entries carry the
+versioned remote chip callable payload as `payload_hex`. Remote controls may
+add or remove entries in either registry location after bootstrap:
+
+- registering a remote TASK dispatcher Python callable changes what future L4
+  TASK frames can dispatch on this remote endpoint;
+- registering an inner Python callable changes what already-registered remote
+  L3 orch functions can submit to `inner_worker`;
+- registering an inner `ChipCallable` follows the existing dynamic callable IPC
+  cascade shape, but the remote control payload is a versioned remote frame
+  instead of a local POSIX-shm mailbox name.
+
+For a TASK frame, the session runner:
+
+1. Validates the session and sequence number.
+2. Decodes `RemoteTaskArgs`.
+3. Translates remote tensor descriptors into local `ContinuousTensor` values.
+4. Looks up the L3 orchestration function in the remote TASK dispatcher
+   registry by hashid.
+5. Calls `inner_worker.run(orch_fn, args, config)`.
+6. Sends completion with success or bounded traceback text.
+
+For a CONTROL frame, it forwards the operation to the inner worker or its
+buffer registry, then replies with a typed result.
+
+Session execution rules:
+
+- The baseline remote endpoint runs at most one TASK at a time. This matches
+  the current one-`WorkerThread`-per-child local scheduling model and keeps
+  ordering, buffer lifetime, and callable visibility simple.
+- State-changing CONTROL frames such as register, unregister, buffer free,
+  copy, export/import, and import release serialize with TASK execution on the
+  ordered command lane. They are not applied concurrently with a running TASK
+  on the same endpoint. Future Remote CommDomain controls follow the same
+  ordering rule when they enter scope.
+- Bulk data movement may use a separate data plane, but the state change that
+  makes staged bytes, callable payloads, or imported handles visible is ordered
+  by the command lane.
+- Health/liveness does not depend on the command lane making progress. Each
+  session has an independent health lane or equivalent transport-level health
+  signal so a long-running `inner_worker.run()` does not look like endpoint
+  failure merely because queued command-lane frames cannot be serviced.
+- Health expiry removes the endpoint from scheduler eligibility for the
+  current session. In-flight TASK/CONTROL waits receive fabricated failed
+  completions or replies; idle failed endpoints are not automatically re-added
+  by later health frames.
+
+## Remote TaskArgs Representation
+
+Keep `ContinuousTensor` as the L2 ABI. Do not overload raw pointer values to
+carry transport state.
+
+Public Python uses a sidecar representation:
+
+- `RemoteBufferHandle` identifies an allocated or imported remote buffer.
+- `RemoteTensorRef(handle, offset, shape, dtype)` is accepted by
+  `TaskArgs.add_tensor()` wherever a remote submit is legal.
+- The Python/C++ binding stores a normal tensor metadata entry plus a hidden
+  sidecar entry at the same tensor index.
+- Local endpoints reject remote tensor refs. `RemoteTensorRef` is transport
+  metadata, not a local mailbox ABI. A local fork/shm endpoint becomes eligible
+  only after the data has been explicitly imported, staged, or materialized into
+  a local-addressable `ContinuousTensor`.
+- Remote endpoints require a sidecar/descriptor for every tensor that carries
+  data over the remote protocol, including `HOST_INLINE` tensors. A null
+  sidecar is allowed only for metadata-only tensors with no data payload.
+  Remote endpoints reject bare host pointers unless an explicit staging API
+  produced a remote handle.
+- Remote submits reject `OUTPUT` tensors whose `ContinuousTensor.data == 0`
+  unless the caller has already supplied a `RemoteTensorRef` sidecar. The first
+  implementation does not auto-allocate remote outputs during submit.
+
+Parent-side slots therefore store existing `TaskArgs`, an optional
+`RemoteTaskArgsView`, eligible endpoint ids, and captured remote-buffer refs.
+
+`Orchestrator::infer_deps()` builds `TensorKey` from remote handle metadata
+when a sidecar exists. The first implementation intentionally preserves the
+current exact-start TensorMap semantics: local fork/shm keys use
+`(ptr, worker)`, while remote keys use
+`(address_kind, owner_endpoint_id, buffer_id, generation, offset)`. The tensor
+byte length is bounds-checked by the descriptor but does not participate in
+dependency lookup. This means two remote tensors that reference overlapping
+byte ranges with different offsets are not automatically ordered, matching the
+current local pointer-key behavior.
+
+## Failure Semantics
+
+Remote completion is explicit and sequence-based. Local mailbox completion must
+be adapted to the same outcome contract. Failure must not make downstream tasks
+run as if the producer succeeded.
+
+Required parent-side behavior:
+
+- `RemoteL3Endpoint::run()` blocks for the matching completion sequence.
+- `LocalMailboxEndpoint::run()` maps a non-zero mailbox error to
+  `task_failure` instead of reporting a successful completion.
+- Non-zero task or endpoint errors become candidates for the worker's first
+  reported error.
+- The worker still notifies the Scheduler so `drain()` cannot hang.
+- The notification carries an outcome: success, task failure, or endpoint
+  failure.
+- Failed slots transition to a failed/poisoned state rather than successful
+  `COMPLETED`.
+- Downstream consumers of a failed producer are marked failed/skipped and are
+  not dispatched.
+- `drain()` waits for bookkeeping and cleanup, then raises the first root
+  error with remote host, endpoint id, hashid, and sequence in the message.
+
+Local mailbox dispatch keeps first-error-wins only for final error reporting.
+It must not mark a failed child dispatch as successful `COMPLETED`. The remote
+buffer path and the local adapter both use the same poisoned dependency
+propagation before dependent tasks are exposed to failed producer outputs.
+
+Every blocking wait must have a configurable timeout. Remote transport must
+not copy the current local control path's infinite spin-wait failure mode.
+
+## Buffer Lifecycle
+
+Remote buffers need an owner, generation, and deferred physical free. The
+parent owns the visible handle state; the session runner owns remote physical
+memory and imported mappings.
+
+The v1 peer-buffer model separates owner allocations from imported mappings.
+`EXPORT_BUFFER` runs on the owner endpoint and returns an opaque
+session-scoped descriptor. `IMPORT_BUFFER` runs on the importer endpoint and
+creates an importer-local mapping handle. `RELEASE_IMPORT` tears down only that
+importer-local mapping; owner physical free waits until imports and captured
+slot refs have drained. Imported handles keep the original owner
+`(owner_endpoint_id, buffer_id, generation, offset)` as the dependency
+identity, so owner and peer views of the same logical buffer range serialize
+through the same TensorMap key.
+
+See
+[buffers-and-transports.md](remote-l3-worker-design/buffers-and-transports.md)
+for the handle schema, control commands, release policy, and A2/A3/A5 backend
+requirements.
+
+## Protocol
+
+Do not reuse the raw 4096-byte mailbox format across hosts. It has no version
+field, no sequence number, and assumes shared virtual memory.
+
+Remote endpoints use a versioned frame protocol with `HELLO`, `TASK`,
+`CONTROL`, `CONTROL_REPLY`, `COMPLETION`, `HEALTH`, and `SHUTDOWN` frames. The
+bootstrap socket carries only session setup and HCOMM bring-up frames. After
+HCOMM RPC is ready, steady-state control, task metadata, completions, and
+shutdown use the HCOMM-backed RPC adapter; tensor data and remote buffer
+operations use the HCOMM data adapter. The local path keeps the existing
+mailbox layout behind `LocalMailboxEndpoint`.
+
+Remote frames use canonical little-endian field encoding for `CallConfig`,
+`ContinuousTensor`, tensor descriptors, strings, counts, and enums; they do not
+memcpy local C++ POD structs onto the wire. Each endpoint has one ordered
+command lane for runtime state-changing frames, so TASK cannot overtake
+registry-changing CONTROL. Liveness uses a separate health lane or equivalent
+transport-level signal and is not queued behind user TASK execution.
+
+See [protocol.md](remote-l3-worker-design/protocol.md) for frame layout,
+remote tensor descriptors, ordering, and bounds-checking requirements.
+
+## Rollout
+
+The recommended first cut is conservative:
+
+1. Land the endpoint abstraction and local adapter. **Implemented.**
+2. Add remote tensor sidecars and endpoint eligibility metadata.
+   **Implemented for C++ submit, Python `RemoteTaskArgs`, owner buffers, and
+   imported simulation buffers.**
+3. Add the versioned frame codec and the independent health-lane contract.
+   **Implemented for the socket-backed simulation transport.**
+4. Add remote callable registration with all-or-nothing multi-endpoint
+   visibility and final-unregister cleanup. **Implemented for dispatcher
+   `PYTHON_IMPORT`, inner `PYTHON_IMPORT`, and inner inline
+   `CHIP_CALLABLE`.**
+5. Add the fork-safe simulation session runner with explicit prestart before
+   `HELLO READY`. **Implemented.**
+6. Prove local behavior is unchanged and remote sim behavior handles success,
+   failure, hashid mapping, timeouts, health, and buffer cleanup.
+   **Focused Python remote sim and C++ no-hardware UT coverage is present.**
+7. Add A2 RoCE, A3 HCCS, and A5 UB profiles behind the HCOMM adapter layer.
+   **Pending.**
+
+See
+[implementation-plan.md](remote-l3-worker-design/implementation-plan.md)
+for the detailed PR sequence and validation matrix.

--- a/docs/remote-l3-worker-design/buffers-and-transports.md
+++ b/docs/remote-l3-worker-design/buffers-and-transports.md
@@ -1,0 +1,427 @@
+# Remote L3 Buffers and Transports
+
+This document defines remote buffer lifetime and backend transport contracts
+for remote L3 NEXT_LEVEL endpoints.
+
+## Buffer Handles
+
+Remote buffers need an owner, generation, and deferred free point. The parent
+tracks user-visible handle state; the remote session runner owns physical
+memory and imported mappings.
+
+Parent-side handle:
+
+```text
+RemoteBufferHandle:
+  endpoint_id
+  owner_endpoint_id
+  buffer_id
+  generation
+  import_id
+  address_space
+  nbytes
+  offset
+  remote_addr
+  rkey_or_token
+  ub_ldst_va
+  access_flags
+  ref_state
+  live_slot_refs
+```
+
+For an owner allocation, `endpoint_id == owner_endpoint_id` and
+`import_id == 0`. For an imported peer mapping, `endpoint_id` is the importer
+that can consume the handle, `owner_endpoint_id` is the endpoint that owns the
+physical allocation, and `import_id` names the importer-local mapping. The
+public Python object stays opaque; it may expose endpoint, owner endpoint, size,
+address space, and release state, but not raw transport keys.
+
+`buffer_id` may be reused only with a new `generation`. Stale completions,
+imports, releases, or frees whose generation does not match are ignored or
+reported as session errors.
+
+## Public Memory API
+
+Remote memory APIs return handles, not bare integer pointers:
+
+```python
+buf = w4.remote_malloc(worker=l3_worker_id, nbytes=4096)
+w4.remote_copy_to(buf, host_ptr, 4096)
+
+exported = w4.remote_export(buf, offset=0, nbytes=4096, access="read")
+peer = w4.remote_import(exported, worker=peer_l3_worker_id)
+
+args = TaskArgs()
+args.add_tensor(
+    RemoteTensorRef(peer, offset=0, shape=(1024,), dtype=DataType.FLOAT32),
+    TensorArgType.INPUT,
+)
+orch.submit_next_level(l3_handle, args, cfg, worker=peer_l3_worker_id)
+orch.drain()
+
+w4.remote_release_import(peer)
+w4.remote_free(buf)
+```
+
+The binding stores a hidden remote sidecar beside the tensor metadata.
+`RemoteTensorRef` is transport metadata, not an extension of the local mailbox
+ABI. Local fork/shm endpoints reject it unless the buffer has first been
+explicitly imported, staged, or materialized into a local-addressable
+`ContinuousTensor`. Remote endpoints reject bare host pointers unless explicit
+staging produced a handle.
+
+`remote_export()` returns an opaque session-scoped export descriptor. It does
+not create a new user-releasable allocation. `remote_import()` consumes that
+descriptor on a target endpoint and returns an imported `RemoteBufferHandle`.
+`remote_release_import()` releases the importer-local mapping after all slot
+refs on that imported handle have drained. `remote_free()` on the owner handle
+releases the owner allocation after all imports and slot refs have drained.
+
+Current status: Python exposes `RemoteBufferHandle`, `RemoteTensorRef`, and
+`RemoteTaskArgs`. `RemoteTaskArgs.add_tensor(RemoteTensorRef(...), tag)` stores
+`ContinuousTensor.data == 0` in the underlying `TaskArgs` and keeps the remote
+descriptor in a same-index sidecar. Public `remote_malloc`, `remote_free`,
+`remote_copy_to`, `remote_copy_from`, `remote_export`, `remote_import`, and
+`remote_release_import` are implemented for the simulation backend.
+
+## TaskArgs Sidecar Contract
+
+`ContinuousTensor` remains the tensor metadata ABI. Remote transport metadata
+is stored in a per-`TaskArgs` sidecar keyed by tensor index.
+
+Python-facing rules:
+
+- `TaskArgs.add_tensor(RemoteTensorRef(...), tag)` appends one normal tensor
+  metadata entry and one remote sidecar entry at the same tensor index.
+- `RemoteTensorRef` is not converted to a fake integer pointer.
+- `RemoteBufferHandle` is opaque to user code. Users may inspect endpoint,
+  size, and release state, but not transport keys such as `rkey`.
+- A `TaskArgs` containing any remote sidecar is legal only when the final
+  selected endpoint set contains remote endpoints that can consume every
+  referenced sidecar.
+- Local `submit_next_level()` rejects remote sidecars before slot commit unless
+  an explicit import/staging API has converted them into local-addressable
+  `ContinuousTensor` values and removed the remote sidecar.
+- Remote submit rejects `OUTPUT` tensors with `ContinuousTensor.data == 0`
+  unless an explicit remote allocation API has already produced a
+  `RemoteTensorRef` sidecar for that tensor.
+
+Parent C++ slot rules:
+
+- `TaskSlotState` owns a copy of the sidecar for the slot lifetime.
+- Sidecar length must equal `tensor_count`; entries can be null only for
+  metadata-only tensors. `HOST_INLINE` payloads still have sidecar descriptors
+  so the frame codec has one validation path for every remote data payload.
+- Submit validation captures a live ref on every referenced
+  `RemoteBufferHandle` before the slot becomes visible to the Scheduler.
+- Validation fails before slot commit when the intersection of callable-eligible
+  endpoints and data-eligible endpoints is empty, or when a remote tensor names
+  an ineligible endpoint, stale generation, out-of-range offset, or released
+  handle.
+- Group submit stores one sidecar per group member, aligned with
+  `task_args_list[i]`.
+
+The current C++ implementation enforces these submit-time rules for
+`submit_next_level()` and group submit. It captures refs for owner-side
+and imported simulation handles.
+
+Endpoint rules:
+
+- `LocalMailboxEndpoint` rejects non-empty sidecars. It cannot encode remote
+  descriptors into the local 4096-byte mailbox, and its child processes expect
+  `ContinuousTensor.data` to be a local host/shm pointer or a local child-memory
+  pointer.
+- `RemoteL3Endpoint` requires a sidecar for every tensor payload that crosses
+  the remote protocol, including `HOST_INLINE` payloads.
+- Remote TASK frames write `ContinuousTensorWire.data == 0`; parent virtual
+  addresses never cross the remote protocol.
+- A remote tensor with `child_memory=True` and no sidecar is invalid. Local
+  child-memory pointers are meaningful only inside fork/shm topology.
+- The remote session runner translates each `RemoteTensorDesc` into a local
+  `ContinuousTensor` and fills `data` from its validated local mapping
+  immediately before invoking `inner_worker.run()`.
+
+## Remote OUTPUT Allocation Policy
+
+The first implementation does not mirror local HeapRing auto-allocation for
+remote outputs. In the local fork/shm path, an `OUTPUT` tensor with
+`ContinuousTensor.data == 0` is assigned a parent HeapRing pointer during
+submit, and forked children can dereference that shared virtual address. A
+remote L3 worker cannot use a parent-host HeapRing pointer.
+
+Remote callers must allocate or import output storage explicitly before submit:
+
+```python
+out = w4.remote_malloc(worker=l3_worker_id, nbytes=4096)
+
+args = TaskArgs()
+args.add_tensor(
+    RemoteTensorRef(out, offset=0, shape=(1024,), dtype=DataType.FLOAT32),
+    TensorArgType.OUTPUT,
+)
+orch.submit_next_level(l3_handle, args, cfg, worker=l3_worker_id)
+```
+
+This keeps submit-time validation simple: the slot already carries complete
+data eligibility, handle generation, bounds, and lifetime refs before it
+becomes visible to the Scheduler.
+
+Future work may add remote output auto-allocation, but only after the runtime
+has a well-defined pre-dispatch endpoint selection policy. Auto-allocation must
+decide which endpoint owns the output before slot commit, allocate or import the
+remote buffer, attach the generated sidecar to the correct tensor index, and
+handle group submits where each member may need storage on a different
+endpoint. Until those rules exist, remote null `OUTPUT` tensors fail fast.
+
+The implemented path follows this policy: local `OUTPUT` tensors still use the
+HeapRing auto-allocation path, while remote OUTPUT tensors with sidecars skip
+local HeapRing allocation and register remote dependency keys.
+
+## Required Controls
+
+| Command | Purpose |
+| ------- | ------- |
+| `ALLOC_REMOTE_BUFFER` | Allocate remote L3 host or chip memory. |
+| `FREE_REMOTE_BUFFER` | Mark a handle released; physical free is deferred. |
+| `COPY_TO_REMOTE` | Stage host data into a remote buffer. |
+| `COPY_FROM_REMOTE` | Pull remote output data back to host. |
+| `EXPORT_BUFFER` | Return RDMA key or UB mapping metadata. |
+| `IMPORT_BUFFER` | Import a peer buffer into a remote worker. |
+| `RELEASE_IMPORT` | Drop an imported peer mapping. |
+
+Control commands are typed remote protocol frames. They are not the local
+mailbox `CTRL_*` integers.
+
+## Export/Import Handle Semantics
+
+Owner allocations and imported mappings are separate handle kinds over the
+same physical buffer:
+
+```text
+owner handle:
+  endpoint_id = owner_endpoint_id = owner endpoint
+  buffer_id/generation = owner allocation identity
+  import_id = 0
+  address_space = REMOTE_DEVICE
+
+imported handle:
+  endpoint_id = importer endpoint
+  owner_endpoint_id = original owner endpoint
+  buffer_id/generation = owner allocation identity
+  import_id = importer-local mapping id
+  address_space = REMOTE_WINDOW or UB_LDST
+```
+
+The parent builds TASK descriptors from the handle that will be consumed by
+the selected endpoint. For owner handles, the selected endpoint must be the
+owner. For imported handles, the selected endpoint must be the importer. In
+both cases the descriptor preserves the original owner identity so dependency
+tracking sees all views of the same buffer as the same producer/consumer key
+when their logical start offset matches.
+
+Import does not clone storage. It creates a peer-visible mapping of an owner
+allocation range with a bounded access mask:
+
+- `read` imports can be used for INPUT tensors.
+- `write` imports can be used for OUTPUT tensors.
+- `readwrite` imports can be used for INOUT or mixed flows.
+- Submit validation rejects a tensor whose tag requires an access bit that the
+  handle does not carry.
+
+`EXPORT_BUFFER` is sent only to the owner endpoint and returns an opaque
+transport descriptor. The parent may keep this descriptor long enough to import
+the range into one or more peer endpoints, but Python user code must not depend
+on raw `rkey`, HCOMM descriptor, or UB address values.
+
+`IMPORT_BUFFER` is sent to each importer endpoint. A successful reply creates
+data eligibility for that endpoint only. It does not make the owner endpoint,
+other importers, or local fork/shm endpoints eligible.
+
+`RELEASE_IMPORT` is sent only to the importer endpoint. It tears down the
+importer-local mapping and removes that imported handle from future endpoint
+eligibility. It does not free the owner allocation and does not release imports
+on other endpoints.
+
+If a multi-endpoint import setup partially fails, the parent must roll back
+successful imports by sending `RELEASE_IMPORT`. If rollback is uncertain, the
+affected endpoint/buffer pair is removed from eligibility for the rest of the
+session. The owner allocation remains live until the owner handle is freed and
+all confirmed or uncertain imports have been resolved or the session shuts
+down.
+
+## Release Policy
+
+- Slot refs are acquired during `submit_next_level()` while walking `TaskArgs`.
+- Captured buffers stay live until every capturing slot has reached a terminal
+  state and every producer/consumer reference that can expose that buffer has
+  reached `CONSUMED` or failed cleanup.
+- Explicit buffers used only as INPUT still need slot refs. They have no
+  producer slot to protect them.
+- Runtime-managed OUTPUT buffers follow the producer slot's terminal cleanup.
+- `remote_free(owner_handle)` marks the owner handle released.
+  `FREE_REMOTE_BUFFER` physical free runs only when the owner handle has no
+  live slot refs and no live imported mappings.
+- `remote_release_import(imported_handle)` marks the imported handle released.
+  `RELEASE_IMPORT` teardown runs only when that imported handle has no live
+  slot refs.
+- `FREE_REMOTE_BUFFER` is invalid for imported handles, and `RELEASE_IMPORT`
+  is invalid for owner handles.
+- If a run fails, the same post-drain cleanup path runs before the next run.
+- Session shutdown rejects new work, releases importer mappings first, and
+  then frees session-owned owner allocations after completing or failing
+  in-flight tasks.
+
+The registry therefore needs both a user-visible release state and a live
+slot-ref count. Failed slots still release captured refs through the same
+terminal cleanup path as successful slots.
+
+## Dependency Keys
+
+`TensorKey` must grow beyond the current `{ptr, int8 worker}` shape for remote
+buffers while preserving the current exact-start lookup semantics. Today, local
+dependency tracking keys only on a tensor's start pointer and worker id; shape
+and byte length do not participate in lookup. Remote keys follow the same rule:
+
+```text
+address_kind
+owner_endpoint_id
+buffer_id
+offset_begin
+generation
+```
+
+Local fork/shm keys remain a compatibility subset:
+
+```text
+host pointer:        (LOCAL_HOST, -1, ptr)
+local child memory:  (LOCAL_CHILD, worker_id, ptr)
+```
+
+Known limitation: two remote tensors that reference overlapping byte ranges
+with different `offset_begin` values do not automatically depend on each other.
+For example, a producer writing `[0, 4096)` and a consumer reading
+`[1024, 2048)` map to different dependency keys. This matches the current local
+`ptr`-based TensorMap behavior, where a subview at `base + offset` is a
+different key from `base`.
+
+The first implementation chooses this route to keep remote scheduling behavior
+compatible with local fork/shm semantics and to avoid changing TensorMap into a
+range index as part of the transport bring-up. `offset_end`/`nbytes` remains in
+`RemoteTensorDesc` for bounds checks and for a future range-overlap TensorMap
+upgrade, but it is not part of the first dependency key.
+
+## HCOMM Adapter Contract
+
+Remote L3 uses HCOMM for steady-state communication in the first
+implementation. The bootstrap socket is only a setup path for session
+validation and HCOMM bring-up. Once HCOMM RPC is ready, task metadata,
+CONTROL, CONTROL_REPLY, COMPLETION, and SHUTDOWN frames use the HCOMM RPC
+adapter; tensor data and remote buffer copies use the HCOMM data adapter.
+
+The endpoint owns the adapter objects. `Orchestrator`, Scheduler, and
+`WorkerThread` see only `WorkerEndpoint::run()`, `WorkerEndpoint::control()`,
+and logical capability bits from `WorkerEndpoint::caps()`.
+
+Current status: `RemoteL3Endpoint` owns a transport-neutral
+`RemoteL3Transport` and the ordered TASK/COMPLETION boundary. The HCOMM RPC
+adapter, data adapter, buffer registry, and health lane described below remain
+to be implemented behind that transport boundary.
+
+The adapter family provides this logical contract:
+
+```text
+BootstrapSocketAdapter:
+  open(control_uri)
+  exchange hello/capability/HCOMM bootstrap frames
+  close after HCOMM_RPC_READY
+
+HcommRpcAdapter:
+  submit TASK or CONTROL frame on the ordered command lane
+  wait for matching COMPLETION or CONTROL_REPLY
+  send SHUTDOWN when no command is in flight
+
+HcommAdapter:
+  register/export/import memory
+  submit read/write/copy plans
+  wait/fence completion
+  release registrations and imports
+```
+
+Profile-specific buffer rules:
+
+- The simulation profile uses session-local `export_id` and `import_id` tokens.
+  It must not expose host process pointers through the public Python API.
+- RoCE and HCCS profiles encode HCOMM/RDMA registration metadata in
+  `rkey_or_token` and bounded transport descriptors. Import validates the
+  profile before publishing a peer mapping.
+- UB profiles may populate `ub_ldst_va` only after the mapping and fence rules
+  are proven for that platform. Bulk copies still use the HCOMM data adapter
+  unless the selected UB profile explicitly supports LD/ST completion ordering.
+
+HCOMM RPC enqueues request frames on the endpoint's ordered command lane.
+Data-plane transfers may use RoCE, HCCS, or UB HCOMM profiles, but TASK
+doorbells, CONTROL frames, replies, completions, and shutdown state are ordered
+by the command lane. Reply frames carry the request sequence they answer. A
+task completes only after an explicit remote `COMPLETION` frame; data-copy
+completion alone is never a task completion signal. `control()` returns only
+after the matching `CONTROL_REPLY` arrives or a timeout/disconnect is converted
+into a failed reply. Liveness is handled by an independent health lane or
+transport keepalive; it is not queued behind the ordered command lane.
+
+## A2 RoCE HCOMM Profile
+
+- Use HCOMM with `COMM_PROTOCOL_ROCE`.
+- Carry command frames and completion records through HCOMM RPC rings and
+  notify/fence operations.
+- Use a separate health HCOMM lane or transport keepalive for liveness.
+- Use registered staging buffers for large callable blobs and bulk data.
+- Export buffers as HCOMM memory descriptors plus RoCE-specific channel
+  metadata.
+- Complete tasks only after an HCOMM RPC `COMPLETION` frame from the session
+  runner.
+- Bound every wait with a timeout and convert disconnects into endpoint
+  failure completions.
+
+## A3 HCCS HCOMM Profile
+
+- Keep the same HCOMM adapter contract as A2.
+- Implement memory export/import through the HCCS-capable HCOMM profile.
+- Preserve the same command-lane ordering rules: task/control frames are
+  observed in sequence order, command frame visible before doorbell, and remote
+  writes complete before completion frame.
+- Provide health independently from command-lane progress so long-running TASK
+  execution does not cause false endpoint failure.
+- Reuse the frame codec, HCOMM RPC, and buffer registry tests from the A2 path.
+
+## A5 UB HCOMM Profile
+
+- Export both RDMA metadata and, when available, an LD/ST mapping token.
+- Use LD/ST for doorbells and small completion records only when the mapping
+  is coherent for the participating hosts.
+- Preserve the same per-endpoint command-lane order for TASK, CONTROL,
+  CONTROL_REPLY, COMPLETION, and SHUTDOWN frames.
+- Keep UB health doorbells or transport health independent from the command
+  lane used for state-changing frames.
+- Use RDMA for bulk transfers until platform benchmarks justify LD/ST bulk
+  copies.
+- Add explicit fences around:
+  - task payload writes before doorbell;
+  - remote output writes before completion;
+  - parent completion read before dependent task dispatch.
+- Keep RDMA fallback for all UB LD/ST paths.
+
+## Simulation Backend
+
+The simulation backend uses TCP or Unix sockets plus local files/shm for
+integration tests. It must exercise:
+
+- framed protocol encode/decode;
+- sequence numbers;
+- remote callable bootstrap;
+- endpoint eligibility validation;
+- success and error completions;
+- failed dependency poisoning;
+- buffer registry ref capture and deferred free;
+- timeout handling.
+
+It must not depend on A2/A3/A5 hardware.

--- a/docs/remote-l3-worker-design/implementation-plan.md
+++ b/docs/remote-l3-worker-design/implementation-plan.md
@@ -1,0 +1,388 @@
+# Remote L3 Implementation Plan
+
+Deliver remote L3 support in small PRs. Each step should keep existing local
+fork/shm behavior working.
+
+Status for the local PR #866 cut:
+
+- Steps 1-5 are implemented for the simulation transport, including an
+  independent health lane.
+- Step 6 is implemented for dispatcher `PYTHON_IMPORT`, inner manifest/control
+  `PYTHON_IMPORT`, and inner manifest/control inline `CHIP_CALLABLE`.
+  `PYTHON_SERIALIZED` remains a negotiated future extension, and
+  staged chip-callable blobs require a staged-blob adapter before use.
+- Steps 7-9 are implemented for the two-process simulation runner and sim
+  remote buffers, including export/import/release-import.
+- Steps 10-12 remain pending hardware-profile work. Remote CommDomain controls
+  remain reserved/unsupported in this cut.
+
+## PR Sequence
+
+1. Endpoint interface and local adapter. **Implemented.**
+   - Add `WorkerEndpoint`.
+   - Include read-only `WorkerEndpoint::caps()` capability metadata for
+     endpoint eligibility. `caps()` returns logical features only and must not
+     expose HCOMM/RDMA/socket handles to Scheduler or Orchestrator code.
+   - Define `WorkerEndpoint::run()` to return an explicit outcome: success,
+     task failure, or endpoint failure.
+   - Move current mailbox code into `LocalMailboxEndpoint`.
+   - Teach `LocalMailboxEndpoint` to map `MAILBOX_OFF_ERROR == 0` to success
+     and non-zero child mailbox errors to task failure.
+   - Treat local dispatch exceptions, child crash detection, and timeout paths
+     as endpoint failure once those paths are available.
+   - Keep `WorkerManager::add_next_level(void *mailbox)` working by wrapping
+     the mailbox in a local endpoint.
+   - Thread the endpoint outcome through the WorkerThread completion callback
+     without yet changing all downstream DAG poisoning behavior.
+   - Add local adapter regression tests for existing L3/L4 examples.
+
+2. Endpoint eligibility metadata. **Implemented.**
+   - Assign each NEXT_LEVEL child a stable `endpoint_id`.
+   - Store `callable hashid -> eligible endpoint ids` in parent runtime
+     metadata.
+   - Extend submit slots with final eligible endpoint sets computed as
+     callable eligibility intersected with tensor/buffer data eligibility.
+   - Teach Scheduler/WorkerManager to pick only eligible idle workers.
+   - Validate `worker=` affinity against the slot's final eligible set.
+   - Keep current docs in sync: describe local fork/shm as
+     `LocalMailboxEndpoint` and remote L3 as a framed endpoint, not as another
+     mailbox child loop.
+
+3. Remote task sidecars and dependency keys. **Implemented for explicit
+   sidecars, owner/imported simulation buffers, and slot-ref capture.**
+   - Add `RemoteBufferHandle`, `RemoteTensorRef`, and `RemoteTensorDesc`.
+   - Store a `RemoteTaskArgsView` sidecar beside existing `TaskArgs`.
+   - Extend `TensorKey` for remote endpoint, buffer id, generation, logical
+     start offset, and address kind.
+   - Teach `Orchestrator::infer_deps()` to use remote logical keys while
+     preserving existing local keys.
+   - Reject remote sidecars on local fork/shm endpoints unless an explicit
+     import/staging API has converted them into local-addressable tensors.
+   - Reject unstaged raw host pointers before a remote slot is committed.
+   - Reject remote `OUTPUT` tensors with `data == 0` unless an explicit remote
+     allocation API has already produced a `RemoteTensorRef` sidecar.
+
+4. Failed task poisoning. **Implemented.**
+   - Add per-member group state/outcome tracking so group failure can skip
+     unstarted members while waiting for already-dispatched members to finish.
+   - Add failed/poisoned slot handling.
+   - Prevent downstream consumers of failed producers from dispatching.
+   - Preserve `drain()` cleanup and first-error-wins reporting.
+
+5. Versioned remote frame codec. **Implemented for frame/TASK/COMPLETION/
+   CONTROL/CONTROL_REPLY, ordered command-lane tests, and simulation health
+   lane.**
+   - Add `remote_wire.h/.cpp`.
+   - Implement canonical little-endian encode/decode for `CallConfigWire`,
+     `ContinuousTensorWire`, frame headers, descriptors, counts, strings, and
+     enum values.
+   - Implement the `HOST_INLINE` inline byte arena with descriptor
+     `inline_payload_offset` / `inline_payload_len` validation.
+   - Keep local mailbox `write_blob` / `read_blob` local-only; remote codec must
+     not memcpy C++ POD structs as its wire format.
+   - Implement encode/decode bounds checks for all frame types.
+   - Define and test `CONTROL_REPLY` encode/decode for command success,
+     command failure, result payloads, and sequence matching.
+   - Define and test the per-endpoint ordered command lane for TASK, CONTROL,
+     CONTROL_REPLY, COMPLETION, and SHUTDOWN frames.
+   - Define and test an independent `HEALTH` lane or transport keepalive so
+     liveness is not queued behind long-running TASK execution.
+   - Include tests for corrupt lengths, tensor counts, sequence mismatch, and
+     bounded error payloads.
+   - Include tests that reject unknown enum values, non-zero reserved fields,
+     and truncated multi-byte fields.
+   - Include tests that reject non-zero `ContinuousTensorWire.data` in remote
+     TASK frames.
+
+6. Remote callable registry. **Implemented for dispatcher `PYTHON_IMPORT`,
+   inner manifest/control `PYTHON_IMPORT`, and inner manifest/control inline
+   `CHIP_CALLABLE` on the simulation path. Serialized Python remote payloads
+   and staged chip blobs remain negotiated extensions.**
+   - Implement `RemoteCallable("module:qualname")`.
+   - Preserve the public callable identity lifecycle from PR #891:
+     `Worker.register()` returns `CallableHandle`, TASK/control frames carry
+     the handle hash digest, endpoint-private execution slots stay hidden,
+     visibility starts only after register reply, unregister performs
+     stale-state cleanup, and TASK/control ordering prevents partially visible
+     hashids.
+   - Treat import-path callables as the baseline remote mode.
+   - Add `PYTHON_IMPORT` as the remote baseline callable kind and
+     `REMOTE_TASK_DISPATCHER` as the parent-facing resolver scope for
+     `RemoteCallable` handles.
+   - Support serialized Python callable payloads only as a negotiated feature
+     with serializer version, payload limit, Python ABI/runtime, and
+     dependency/runtime-environment compatibility checks. Follow the payload
+     contract in `docs/python-callable-serialization.md`.
+   - Extend the existing public `register(callable, workers=...)` flow so
+     `RemoteCallable` descriptors can target remote endpoints. Do not add a
+     separate public remote-only registration API.
+   - Require the first implementation to reject `RemoteCallable` registration
+     without an explicit non-empty `workers=[...]` list. Leave named remote
+     pools and placement policies as future API work, and do not define
+     implicit broadcast to all remote endpoints as a contract.
+   - Implement multi-endpoint all-or-nothing registration with prepare, commit,
+     and abort controls. Keep the hashid invisible until every selected
+     endpoint commits, and mark uncertain endpoints failed rather than leaving a
+     partially visible hashid.
+   - Implement final-unregister tombstones per endpoint/hashid pair. Do not
+     block dispatch through other live handles that still reference the same
+     hashid. If failed-register rollback cleanup is uncertain, block only the
+     affected endpoint/hashid pair for the current session.
+   - Keep `INNER_L3_WORKER` as a remote-internal install target, not a
+     parent-facing handle scope. Never assume a parent TASK hashid names an
+     inner chip/sub callable.
+   - Make canonical descriptors and their SHA-256 hashids the only public
+     callable identity source in each manifest registry scope; target-private
+     slots are allocated by the receiving endpoint.
+   - Define post-bootstrap registry-scope-aware prepare, commit, abort, and
+     unregister frames for Python callables and `ChipCallable` entries.
+   - Implement the protocol v1 target/kind matrix:
+     dispatcher `PYTHON_IMPORT`, optional negotiated dispatcher
+     `PYTHON_SERIALIZED`, inner `PYTHON_IMPORT`, optional negotiated inner
+     `PYTHON_SERIALIZED`, and inner `CHIP_CALLABLE`.
+   - Reject `CHIP_CALLABLE` for `REMOTE_TASK_DISPATCHER` and reject
+     `PYTHON_SERIALIZED` on any remote target unless the session feature set
+     explicitly negotiated serialized support.
+   - Implement `CHIP_CALLABLE` remote prepare with either bounded inline blob
+     bytes or a session-local staged blob token. Validate the PR #891
+     descriptor hash, executable blob SHA-256, target platform/runtime, and
+     signature hash before commit.
+   - On inner registry commit, install into `inner_worker = Worker(level=3)`;
+     do not add the hashid to the parent-facing dispatcher registry.
+   - Release staged callable bytes after confirmed commit or abort cleanup.
+
+7. Fork-safe simulation session runner. **Implemented for the socket-backed
+   simulation transport.**
+   - Add `simpler-remote-worker` control entry point.
+   - Add per-session `simpler-remote-l3-session` runner.
+   - Pass the validated bootstrap manifest from daemon to runner through an
+     inherited fd, manifest path in env, or single-threaded pipe before any
+     runner transport threads start.
+   - Add an explicit runner prestart step equivalent to `inner_worker.init()`
+     plus `_start_hierarchical()`: fork L3 chip/sub children, register local
+     endpoints, and start the inner Scheduler before any remote transport or
+     health threads are started.
+   - Start the sim transport only after the local L3 child tree is established,
+     then run the post-prestart `HELLO`/ready handshake.
+   - Treat `HELLO ready_state=READY` as a scheduling barrier; the parent must
+     not schedule an endpoint that is alive but not prestarted.
+   - Run TASK frames over the sim transport and return completions.
+   - Add localhost two-process integration tests.
+
+8. Remote control-plane parity. **Implemented for the simulation transport;
+   Remote CommDomain controls remain reserved/unsupported.**
+   - Map existing NEXT_LEVEL controls onto typed remote frames:
+     prepare, register, unregister, remote buffer allocation, remote buffer
+     free, copy to remote, copy from remote, export buffer, import buffer, and
+     release import.
+   - Implement versioned request/result codecs for every remote buffer control.
+     `EXPORT_BUFFER`, `IMPORT_BUFFER`, and `RELEASE_IMPORT` must use the v1
+     schemas in `protocol.md`; do not invent backend-specific ad hoc payloads.
+   - Keep `EXPORT_BUFFER` owner-scoped, `IMPORT_BUFFER` importer-scoped, and
+     `RELEASE_IMPORT` importer-scoped. The parent-visible dependency identity
+     for imported handles remains the original owner buffer identity.
+   - Implement rollback for partial import setup: if any importer fails, send
+     `RELEASE_IMPORT` to importers that succeeded and mark uncertain
+     endpoint/buffer pairs ineligible for the current session.
+   - Reserve remote `COMM_INIT`, `ALLOC_DOMAIN`, and `RELEASE_DOMAIN` opcodes
+     for the later Remote CommDomain phase; the first task-dispatch cut rejects
+     them as unsupported controls.
+   - Keep local mailbox sub-command ids local-only.
+   - Add tests for post-bootstrap ChipCallable registration and remote buffer
+     controls through the session runner, including export/import/release.
+
+9. Remote buffer registry. **Implemented for simulation owner/imported
+   buffers.**
+   - Add `ALLOC_REMOTE_BUFFER`, `FREE_REMOTE_BUFFER`, `COPY_TO_REMOTE`, and
+     `COPY_FROM_REMOTE`.
+   - Add owner export records and importer-local mapping records for
+     `EXPORT_BUFFER`, `IMPORT_BUFFER`, and `RELEASE_IMPORT`.
+   - De-duplicate live imports by
+     `(importer_endpoint_id, owner_endpoint_id, buffer_id, generation, offset,
+     nbytes, access_flags, transport_profile)` when the transport profile
+     supports reuse; otherwise return distinct `import_id` values and ref-count
+     each mapping independently.
+   - Track per-slot capture refs for explicit buffers and imported peer
+     buffers.
+   - Tie owner physical free to post-drain cleanup after all captured refs and
+     importer mappings drop.
+   - Tie release-import to post-drain cleanup after all captured refs on the
+     imported handle drop.
+
+10. A2 RoCE HCOMM profile.
+    - Implement HCOMM endpoint/channel setup with `COMM_PROTOCOL_ROCE`, HCOMM
+      RPC command rings, registered staging buffers, and timeout/error paths.
+    - Keep bootstrap sockets limited to session setup and HCOMM bring-up.
+      After HCOMM RPC is ready, task metadata, controls, completions, and
+      shutdown use the HCOMM RPC adapter.
+    - Add a hardware-gated smoke test with one remote L3 worker.
+
+11. A3 HCCS HCOMM profile.
+    - Implement the same HCOMM adapter contract with the HCCS protocol profile.
+    - Reuse the A2 frame, HCOMM RPC, and buffer registry tests.
+
+12. A5 UB HCOMM profile.
+    - Add UB export/import metadata through the HCOMM adapter.
+    - Implement LD/ST doorbell and completion paths only when the selected
+      profile proves the mapping and fence rules are valid.
+    - Keep RDMA/HCOMM fallback for bulk transfers.
+
+13. Remote `allocate_domain()` future work.
+    - Extend `CommDomainHandle` to carry remote endpoint ids.
+    - Allocate/import windows collectively across remote workers.
+    - Preserve deferred release after `drain()`.
+
+## Required Tests Before Hardware Backends
+
+| Test | Expected result |
+| ---- | --------------- |
+| Local adapter regression | Existing L3/L4 fork/shm behavior unchanged. |
+| Endpoint eligibility | Scheduler never picks an ineligible endpoint. |
+| Frame fuzz/bounds | Corrupt lengths and counts are rejected. |
+| Remote sim hello | Parent bootstraps remote L3 and shuts down cleanly. |
+| Manifest handoff | Runner reads manifest before transport starts. |
+| Prestart barrier | HELLO READY only after inner L3 scheduler is started. |
+| Remote sim task | L4 parent dispatches one L3 orch task successfully. |
+| Remote sim error | Remote orch raises; parent raises with host/seq/hashid. |
+| Failed dependency | Consumer of failed remote producer is not dispatched. |
+| Remote hashid mapping | Daemon resolves an outer remote-orch hashid. |
+| Remote dep key | Shared remote buffer serializes through TensorMap. |
+| Remote import eligibility | Imported peer handle makes only the importer endpoint eligible. |
+| Remote import dep key | Owner and imported views use the same owner-based TensorMap key. |
+| Raw pointer rejection | Unstaged host pointer fails before slot commit. |
+| Wire data zero | Non-zero remote TASK tensor data is rejected. |
+| HOST_INLINE desc | Inline payloads require a descriptor and bounds checks. |
+| Remote buffer copy | Host stages input, remote writes output, host pulls. |
+| Input-only free deferral | Released input buffer survives queued consumers. |
+| Import release deferral | Released import survives queued consumers, then tears down. |
+| Owner free with import | Owner free waits for live imports and captured refs. |
+| Import partial fail | Successful imports are released or marked uncertain/ineligible. |
+| Timeout | Killed session runner produces bounded failure. |
+| Health expiry idle | Expired idle endpoint is removed from schedulable set. |
+| Health expiry in-flight | Expiry fabricates failed reply/completion for in-flight work. |
+| Dynamic Python register | Import-path callable register/unregister works. |
+| Serialized gate | Unnegotiated serialized payload rejects without hashid install. |
+| Callable visibility | TASK with hashid works only after register reply. |
+| Prepare partial fail | Multi-endpoint register stays invisible and aborts prepared peers. |
+| Commit partial fail | Committed/uncertain endpoint hashids are cleaned or blocked. |
+| Abort cleanup fail | Only affected endpoint/hashid pair becomes cleanup-uncertain. |
+| Unregister tombstone | Final unregister keeps tombstone until endpoint cleanup. |
+| Command-lane order | TASK cannot overtake register/unregister control. |
+| Health during task | Health remains live while command lane runs a task. |
+| Callable kind gate | Unsupported kind rejects without hashid install. |
+| Dynamic inner Python register | Inner Python hashid can run only inside inner Worker. |
+| Dynamic inner chip register | Inner ChipCallable hashid runs through inner chip workers. |
+| Remote registry scope | Parent TASK resolves only in dispatcher. |
+| Inner registry target | Inner Worker install is not parent-facing. |
+| Remote control parity | Register/unregister/domain reaches target registry. |
+
+## Hardware-Gated Tests
+
+- A2 RoCE single remote L3 task.
+- A2 RoCE remote buffer copy round trip.
+- A3 HCCS single remote L3 task.
+- A5 UB LD/ST doorbell plus RDMA fallback.
+- Remote domain allocation and deferred release across two remote L3 workers
+  after Remote CommDomain enters scope.
+
+## Open Decisions
+
+- Exact platform HAL names for HCCS and UB export/import.
+- Authentication and isolation for remote daemon sessions.
+- Exact remote compatibility metadata required for serialized Python callable
+  payloads beyond the local payload contract, serializer version, and Python
+  ABI/runtime.
+- How much of `CommContext` should remain shared with PTO-ISA once remote UB
+  address metadata is added, when Remote CommDomain enters scope.
+
+The current cut lands endpoint abstraction, endpoint eligibility, remote
+callable identity, remote sidecars, frame codec, failure poisoning, the
+fork-safe simulation runner, and sim buffer import/export. Hardware HCOMM
+profiles and Remote CommDomain controls remain future work.
+
+## Failure Poisoning Contract
+
+Worker failures must finish DAG bookkeeping without pretending the producer
+succeeded. The contract applies to remote completions, endpoint failures, and
+local mailbox child errors reported by `LocalMailboxEndpoint`.
+
+State model:
+
+```text
+FREE -> PENDING -> READY -> RUNNING -> COMPLETED -> CONSUMED
+                                \-> FAILED    -> CONSUMED
+```
+
+Rules:
+
+- Worker completion carries `success`, `task_failure`, or `endpoint_failure`.
+- `success` transitions `RUNNING -> COMPLETED`.
+- `task_failure` or `endpoint_failure` transitions `RUNNING -> FAILED`.
+- `LocalMailboxEndpoint` converts a non-zero child mailbox error into
+  `task_failure`; first-error-wins controls only which root error message is
+  retained for `drain()`.
+- A `FAILED` producer releases fanout bookkeeping, but consumers are marked
+  `FAILED` instead of `READY`.
+- Failed consumers are never dispatched.
+- `FAILED -> CONSUMED` runs the same cleanup hooks as `COMPLETED -> CONSUMED`:
+  TensorMap erase, ring release, remote buffer ref release, and deferred free
+  scheduling.
+- `drain()` waits for all successful, failed, and skipped slots to become
+  `CONSUMED`, then rethrows the first root failure.
+
+Group task rules:
+
+`TaskSlotState` stores per-member execution state for group slots:
+
+```text
+GroupMemberState:
+  NOT_DISPATCHED
+  RUNNING
+  SUCCESS
+  FAILED
+  SKIPPED
+
+GroupMemberOutcome:
+  success
+  task_failure
+  endpoint_failure
+  skipped
+```
+
+Additional group bookkeeping:
+
+- `member_states[group_size]` and `member_outcomes[group_size]`;
+- `group_terminal_count`: members in `SUCCESS`, `FAILED`, or `SKIPPED`;
+- `group_dispatched_count`: members that reached `RUNNING`;
+- `group_failed`: set when any member reports `task_failure` or
+  `endpoint_failure`;
+- `group_first_failure_index`: first failed member used for root-error context.
+
+Rules:
+
+- A group slot is successful only if every member reaches `SUCCESS`.
+- On dispatch of member `i`, transition
+  `NOT_DISPATCHED -> RUNNING` before handing work to the endpoint.
+- On successful completion of member `i`, transition `RUNNING -> SUCCESS` and
+  increment `group_terminal_count`.
+- On failed completion of member `i`, transition `RUNNING -> FAILED`, set
+  `group_failed`, record `group_first_failure_index` if unset, and increment
+  `group_terminal_count`.
+- When `group_failed` becomes true, every member still in `NOT_DISPATCHED`
+  transitions to `SKIPPED` and increments `group_terminal_count`. Skipped
+  members are never dispatched.
+- Members already in `RUNNING` are allowed to complete so their endpoint state
+  and buffer refs can be cleaned up.
+- The group slot reaches terminal outcome only when
+  `group_terminal_count == group_size`.
+- If the terminal group has any `FAILED` member, the slot outcome is `FAILED`;
+  otherwise it is `COMPLETED`.
+- Slot cleanup runs once for the whole group after the group slot reaches its
+  terminal outcome.
+
+Error reporting:
+
+- The first root failure message includes remote host, endpoint id,
+  callable hashid, and sequence.
+- Poisoned downstream slots should reference the root producer slot instead of
+  overwriting the first-error-wins message.

--- a/docs/remote-l3-worker-design/implementation-record.md
+++ b/docs/remote-l3-worker-design/implementation-record.md
@@ -1,0 +1,158 @@
+# Remote L3 Implementation Record
+
+Baseline document commit: `565fede20ba0f259c1db0ef8c089c9dcbc2141d6`.
+
+This record tracks implementation against the PR-head remote L3 documents.
+It is updated as each documented feature is completed and verified.
+
+## Status
+
+| Step | Documented feature | Status | Notes |
+| ---- | ------------------ | ------ | ----- |
+| 1 | Endpoint interface and local adapter | In progress | Local adapter and remote sim endpoint are implemented; HCOMM endpoint adapters remain. |
+| 2 | Endpoint eligibility metadata | In progress | Callable endpoint sets are intersected with owner/imported remote sidecar eligibility. |
+| 3 | Remote task sidecars and dependency keys | In progress | Public `TaskArgs.add_tensor(RemoteTensorRef(...))` API, remote TensorMap keys, and remote payload-sidecar rejection are implemented. |
+| 4 | Failed task poisoning | In progress | Remote task-failure poisoning and session-exit endpoint failure are verified; explicit health-expiry-only coverage remains. |
+| 5 | Versioned remote frame codec | In progress | TASK/COMPLETION/CONTROL_REPLY/HELLO/CONTROL/HEALTH exist; core fuzz/bounds coverage is present, with more exhaustive corpus testing still possible. |
+| 6 | Remote callable registry | In progress | Dispatcher `PYTHON_IMPORT`, inner manifest/control `PYTHON_IMPORT`, and inner manifest/control inline `CHIP_CALLABLE` are implemented; serialized payloads and staged chip blobs remain negotiated extensions. |
+| 7 | Fork-safe simulation session runner | In progress | Daemon/session bootstrap and HELLO READY barrier are implemented for sim transport. |
+| 8 | Remote control-plane parity | In progress | Registry, alloc/free/copy, export/import/release-import controls are implemented for sim; Remote CommDomain controls are reserved/unsupported. |
+| 9 | Remote buffer registry | In progress | Sim owner/imported buffers, TASK materialization, public memory API, opaque handles, slot/import-ref capture, and deferred free/release-import are implemented. |
+| 10 | A2 RoCE HCOMM profile | Pending | Hardware-gated profile. |
+| 11 | A3 HCCS HCOMM profile | Pending | Hardware-gated profile. |
+| 12 | A5 UB HCOMM profile | Pending | Hardware-gated profile. |
+
+## Completed Items
+
+- Added a socket-backed `RemoteL3SocketTransport` and removed the fail-fast
+  placeholder endpoint path from the Python init flow.
+- Added `HELLO` payload encode/decode and made C++ endpoint registration wait
+  for `HELLO READY` before the endpoint becomes schedulable.
+- Added parent-side independent sim health-lane monitoring. The session runner
+  emits session/endpoint-scoped `HEALTH` frames on a separate socket after
+  prestart, and the C++ command-lane waits periodically check health failure
+  without depending on command-lane progress.
+- Added `simpler-remote-worker` and `simpler-remote-l3-session` entry points.
+  The session runner reads the manifest first, constructs and prestarts the
+  embedded L3 Worker, then opens command/health sockets.
+- Changed the public sidecar API to
+  `TaskArgs.add_tensor(RemoteTensorRef(...), tag)`.
+- Added typed remote `CONTROL` frames for PYTHON_IMPORT dispatcher
+  prepare/commit/abort/unregister, with commit-only TASK visibility in the
+  session runner.
+- Made register-family remote controls registry-scope-aware. The C++ endpoint
+  and nanobind binding now carry `REMOTE_TASK_DISPATCHER` or
+  `INNER_L3_WORKER` explicitly instead of hardcoding the dispatcher target.
+- Added session-runner inner registry support for post-bootstrap
+  `INNER_L3_WORKER` / `PYTHON_IMPORT`, including installation into
+  `inner_worker = Worker(level=3)` and a session-local
+  `get_inner_handle(hashid)` lookup for remote orchestration code.
+- Added bootstrap-manifest inner registry installation for `PYTHON_IMPORT` and
+  inline `CHIP_CALLABLE`. The runner rebuilds the same register commands used
+  by post-bootstrap controls, validates hash/descriptor/platform/runtime
+  before prestart, and publishes only session-local inner handles.
+- Added v1 inline `CHIP_CALLABLE` payload decode/validation for
+  `INNER_L3_WORKER`, including descriptor hash, executable blob SHA-256, and
+  endpoint platform/runtime context checks. `REMOTE_TASK_DISPATCHER` rejects
+  `CHIP_CALLABLE`, and remote `PYTHON_SERIALIZED` remains unsupported without
+  negotiated features.
+- Mapped `WorkerEndpoint::control_prepare(digest)` for remote endpoints to a
+  typed `PREPARE_CALLABLE` control. The session runner accepts it only for a
+  committed `REMOTE_TASK_DISPATCHER` / `PYTHON_IMPORT` digest.
+- Added typed sim `ALLOC_REMOTE_BUFFER`, `FREE_REMOTE_BUFFER`,
+  `COPY_TO_REMOTE`, and `COPY_FROM_REMOTE` handling in the session runner.
+- Added `Worker.remote_malloc()`, `remote_free()`, `remote_copy_to()`, and
+  `remote_copy_from()` public APIs. Remote handles are returned by the Worker
+  API and no longer expose transport keys as public attributes.
+- Fixed the nanobind `remote_malloc()` return path so the binding reacquires
+  the GIL before constructing the Python tuple of handle fields.
+- Added parent-side remote buffer slot-ref capture in the Python Orchestrator
+  facade. `remote_free()` marks a live handle released and defers the physical
+  `FREE_REMOTE_BUFFER` control until captured refs are released after
+  `drain()`.
+- Added session-side `RemoteTensorDesc` materialization before
+  `inner_worker.run()`: `HOST_INLINE` descriptors become local ctypes-backed
+  tensors and sim `REMOTE_DEVICE` descriptors resolve through the live session
+  buffer registry.
+- Removed the descriptor-dropping Python `task_args_from_wire()` helper so the
+  session runner has a single registry-backed materialization path.
+- Tightened parent/endpoint validation so remote task payload tensors require a
+  `RemoteTensorRef` sidecar; bare host pointers and non-materialized remote
+  payloads are rejected before remote dispatch.
+- Added submit-time intersection between remote callable endpoint eligibility
+  and remote tensor/buffer owner or importer eligibility.
+- Documented the v1 `EXPORT_BUFFER`, `IMPORT_BUFFER`, and `RELEASE_IMPORT`
+  wire schema, imported-handle identity, release deferral, and partial-import
+  rollback contract.
+- Implemented sim `EXPORT_BUFFER`, `IMPORT_BUFFER`, and `RELEASE_IMPORT`.
+  Imports use shared-memory backed mappings in the session runner, imported
+  handles remain opaque on the parent, and owner frees wait for live imports
+  and slot refs to drain.
+- Documented the v1 remote registry target/kind matrix, inner
+  `INNER_L3_WORKER` visibility rules, remote `CHIP_CALLABLE` staged/inline
+  payload contract, partial-register cleanup outcomes, and health-expiry
+  scheduling behavior.
+
+## Verification
+
+- Python focused sidecar/callable tests:
+  `tests/ut/py/test_task_interface.py tests/ut/py/test_callable_identity.py`
+  passed with `145 passed`.
+- Focused endpoint/data eligibility tests:
+  remote sidecar owner filtering and non-owner C++ direct-submit rejection
+  passed.
+- Remote sim daemon/session noop TASK integration:
+  noop TASK, prepare-callable control, error completion, post-init dynamic
+  registration, unregister/reregister, health, buffer copy, failed dependency,
+  session exit, input-free deferral, and `HOST_INLINE` integration passed with
+  `11 passed` outside the network-restricted sandbox. The same tests skip
+  inside the sandbox when local TCP sockets are denied.
+- Remote sim long TASK health integration:
+  a remote orch that keeps the command lane busy for 1 second completed while
+  the independent health lane stayed live.
+- Remote sim buffer copy integration:
+  `remote_malloc` + `COPY_TO_REMOTE` + remote TASK materialization/write +
+  `COPY_FROM_REMOTE` passed on the sim backend.
+- Remote sim input-only free deferral:
+  freeing an input buffer immediately after submit kept the remote allocation
+  alive until the captured slot ref dropped after drain.
+- Remote sim `HOST_INLINE` descriptor integration:
+  inline TASK payload materialized into a session-local tensor and fed a
+  remote output write.
+- C++ wire fuzz/bounds coverage:
+  bad frame version/type/flags, truncated control payload, and invalid remote
+  descriptor inline fields are rejected.
+- Remote sim failed-dependency integration:
+  a failed remote producer poisoned a downstream same-buffer remote consumer,
+  and the consumer did not dispatch or mutate the buffer.
+- Remote sim endpoint-failure integration:
+  a session runner exit during TASK returned a bounded endpoint failure to the
+  parent instead of hanging `drain()`.
+- Remote callable unregister/reregister integration:
+  final unregister cleared the dispatcher entry, and a later same-descriptor
+  registration became visible only after a new prepare/commit sequence.
+- Remote `PREPARE_CALLABLE` integration:
+  parent `control_prepare()` reached the session runner as a typed
+  `PREPARE_CALLABLE` frame and validated the committed dispatcher digest.
+- Remote inner Python import integration:
+  parent sent `INNER_L3_WORKER` prepare/commit controls, the session runner
+  installed the import-path callable into `inner_worker`, and a remote orch
+  resolved the handle with `get_inner_handle()` and submitted a `SUB` task.
+- Remote imported-buffer integration:
+  owner endpoint export plus peer endpoint import allowed a remote TASK to run
+  on the importer endpoint and mutate the owner's shared simulated buffer.
+- C++ no-hardware ctest:
+  `ctest --test-dir tests/ut/cpp/build-fetch -LE requires_hardware
+  --output-on-failure` passed with `39/39` tests.
+- Python unit tests:
+  `tests/ut/py -m "not requires_hardware" --clone-protocol https` passed with
+  `350 passed, 11 skipped, 10 deselected`.
+- Editable build with `CCACHE_DISABLE=1`: passed.
+- C++ focused UTs built and passed from `tests/ut/cpp/build-fetch`:
+  `test_orchestrator`, `test_remote_wire`, `test_remote_endpoint`.
+- ST smoke:
+  `examples/a2a3/tensormap_and_ringbuffer/vector_example --platform a2a3sim`
+  passed with `1 passed`.
+- The default `tests/ut/cpp/build` still links against a system GoogleTest
+  with a C++11 ABI mismatch; `tests/ut/cpp/build-fetch` uses the fetched
+  GoogleTest build and passes the focused C++ UTs.

--- a/docs/remote-l3-worker-design/pr-split-and-audit-artifacts.md
+++ b/docs/remote-l3-worker-design/pr-split-and-audit-artifacts.md
@@ -1,0 +1,166 @@
+# Remote L3 PR Split and Audit Artifacts
+
+This file records the pre-split audit artifacts for the remote L3 worker stack.
+It follows `pr-split-and-audit-plan.md` and stops before child branch creation.
+
+## Phase 0 Baseline
+
+| Item | Value |
+| ---- | ----- |
+| Date | 2026-06-08 |
+| Working branch | `remote-l3-worker-design` |
+| Feature HEAD | `4c1f4b53` (`CI: retrigger PR checks fifth time`) |
+| Upstream tracking branch | `puddingfjz/remote-l3-worker-design` |
+| Main baseline | `origin/main` at `ca29019d` |
+| Merge base | `ca29019d64493e958c07647bb9cbd32571348588` |
+| PR snapshot ref observed locally | `origin/pr/866` at `565fede2` |
+| Document baseline | PR-head documents on `remote-l3-worker-design` before split |
+
+### Drop-Only Commits
+
+These commits are empty CI retriggers and should not appear in any child PR:
+
+| Commit | Subject | Evidence |
+| ------ | ------- | -------- |
+| `362b8593` | `CI: retrigger PR checks` | Empty commit; no file stats |
+| `ea314277` | `CI: retrigger PR checks again` | Empty commit; no file stats |
+| `e6e4a6c8` | `CI: retrigger PR checks third time` | Empty commit; no file stats |
+| `5fff8140` | `CI: retrigger PR checks fourth time` | Empty commit; no file stats |
+| `4c1f4b53` | `CI: retrigger PR checks fifth time` | Empty commit; no file stats |
+
+### Fixup-Only Commits
+
+These commits should be squashed into the child PR that introduces the affected
+functional code:
+
+| Commit | Subject | Affected area |
+| ------ | ------- | ------------- |
+| `92709210` | `Fix: stabilize remote L3 CI controls` | Python orchestration/task interface/worker, C++ worker manager, callable identity tests |
+| `04de866b` | `Fix: resolve remote L3 CI checks` | bindings, Python protocol/session/worker, C++ orchestrator/wire, Python tests |
+| `d6500ea2` | `Fix: match CI clang-format output` | C++ remote endpoint, worker manager, scheduler test formatting |
+
+### Worktree Status
+
+Tracked local changes after Phase 3 audit fixes:
+
+| Path | Status | Notes |
+| ---- | ------ | ----- |
+| `docs/remote-l3-worker-design.md` | Modified | Adds a link to `pr-split-and-audit-plan.md`; pre-existing audit/doc change |
+| `src/common/hierarchical/remote_wire.cpp` | Modified | Phase 3 fix: include `enable_scope_stats` in `CallConfigWire v1` encode/decode |
+| `python/simpler/remote_l3_protocol.py` | Modified | Phase 3 fix: decode `enable_scope_stats` from TASK payloads |
+| `tests/ut/cpp/hierarchical/test_remote_wire.cpp` | Modified | Phase 3 regression coverage for `enable_scope_stats` TASK round trip |
+| `tests/ut/py/test_task_interface.py` | Modified | Phase 3 regression coverage for Python TASK decode of `enable_scope_stats` |
+| `tests/ut/py/test_callable_identity.py` | Modified | Phase 3 coverage for `PYTHON_SERIALIZED` and `STAGED_BLOB` unsupported negotiation paths |
+
+Untracked files existed before this artifact was created. They are preserved
+unless later audit work explicitly needs one of them.
+
+### Stop Point
+
+This audit has completed Phases 0 through 3 and intentionally stops before
+Phase 4 child branch creation / PR split execution. No child PR branches have
+been created by this audit.
+
+## Document Compliance Matrix
+
+| Req | Source | Class | Implementation | Tests | Gap/Drift | PR |
+| --- | ------ | ----- | -------------- | ----- | --------- | -- |
+| R1 Endpoint abstraction keeps local mailbox local-only and routes remote L3 through `WorkerEndpoint` / `RemoteL3Endpoint` | `remote-l3-worker-design.md` §Target Architecture; `implementation-plan.md` step 1; `worker-manager.md` §4 | required in this PR cut | `WorkerEndpoint`, `LocalMailboxEndpoint`, `RemoteL3Endpoint`, `WorkerManager::add_next_level_endpoint`, `Worker::add_remote_l3_socket` | `test_remote_endpoint`, `test_scheduler`, `test_remote_sim_noop_task_roundtrip` | None found | PR 4 / PR 5 |
+| R2 Endpoint outcomes distinguish success, task failure, endpoint failure, and skipped group members | `remote-l3-worker-design.md` §Failure Semantics; `implementation-plan.md` steps 1, 4 and Failure Poisoning Contract; `scheduler.md` §§2,6,9 | required in this PR cut | `EndpointOutcome`; endpoint completion mapping; scheduler failure poisoning and group skip state | `RemoteTaskErrorMapsToTaskFailure`, `FailedProducerPoisonsDependentTask`, `GroupFailureWaitsForRunningMembersThenConsumes`, remote sim error/exit tests | None found | PR 4 / PR 5 |
+| R3 Scheduler dispatch uses stable endpoint ids and final eligible endpoint sets; `worker=` affinity is validated | `remote-l3-worker-design.md` §Endpoint Identity and Callable Routing; `implementation-plan.md` step 2; `scheduler.md` §5 | required in this PR cut | `Orchestrator::validate_endpoint_eligibility`, `WorkerManager::pick_idle_excluding_eligible`, Python endpoint-set intersection | `EndpointEligibilityRestrictsIdleSelection`, `AffinityMustBeInEligibleEndpointSet`, Python remote callable endpoint intersection tests | None found | PR 4 |
+| R4 Mixed local/remote pools are allowed only when callable and tensor representations are consumable by the selected endpoint | `remote-l3-worker-design.md` §Endpoint Identity and Callable Routing; `buffers-and-transports.md` §TaskArgs Sidecar Contract | required in this PR cut | Python `Orchestrator` only allows `RemoteTensorRef` for `RemoteCallable`; C++ rejects remote sidecars on local endpoints and non-owner remote-device dispatch without import | `RemoteSidecarRejectsLocalEndpointEligibility`, `RemoteSidecarRejectsNonOwnerEligibleEndpointWithoutImport`, Python RemoteCallable sidecar tests | No blocking drift; add a future end-to-end mixed local+remote smoke during split validation | PR 4 |
+| R5 Remote sidecars are hidden metadata aligned by tensor index; local endpoints reject sidecars; remote endpoints reject bare host pointers | `remote-l3-worker-design.md` §Remote TaskArgs Representation; `buffers-and-transports.md` §§Public Memory API, TaskArgs Sidecar Contract; `protocol.md` §TASK Payload | required in this PR cut | `RemoteTaskArgsSidecar`, Python `_remote_sidecar_for`, C++ `validate_remote_sidecars`, `LocalMailboxEndpoint::run`, `RemoteL3Endpoint::build_task_payload` | `TestRemoteTaskArgsSidecar`, `RemoteBarePayloadFailsBeforeSlotCommit`, `BareHostPointerWithoutSidecarIsEndpointFailure` | None found | PR 4 / PR 6 |
+| R6 Remote null `OUTPUT` tensors fail fast unless the caller supplies an explicit `RemoteTensorRef` | `remote-l3-worker-design.md` §Remote TaskArgs Representation; `buffers-and-transports.md` §Remote OUTPUT Allocation Policy; `implementation-plan.md` step 3 | required in this PR cut | `Orchestrator::validate_remote_sidecars` requires sidecar for remote OUTPUT; `reserve_outputs_and_slot` skips local HeapRing only when sidecar present | `RemoteOutputSidecarSkipsLocalAutoAllocAndRegistersRemoteKey`, remote sim OUTPUT buffer tests | No code drift; add a narrow negative test for null remote OUTPUT without sidecar when carving PR 4 | PR 4 / PR 6 |
+| R7 Remote dependency keys use `(address_kind, owner_endpoint_id, buffer_id, generation, offset)` and preserve exact-start semantics | `remote-l3-worker-design.md` §Remote TaskArgs Representation; `buffers-and-transports.md` §Dependency Keys; `orchestrator.md` §2 | required in this PR cut | `TensorKey::remote_buffer`, `Orchestrator::infer_deps` remote path, `TensorMap` remote keys | `RemoteInputSidecarUsesRemoteTensorMapKey`, `test_remote_sim_failed_dependency_skips_consumer` | Range-overlap support remains future/open decision | PR 4 |
+| R8 Remote callable identity uses canonical hashid descriptors, not target-private slots or cross-worker integer ids | `remote-l3-worker-design.md` §Endpoint Identity and Callable Routing; `task-flow.md` §Callable Identity; `implementation-plan.md` step 6 | required in this PR cut | `callable_identity.py`, `CallableHandle`, descriptor builders, `Worker._identity_registry` | hash stability, public export, forged/mutated handle, cleanup-uncertain tests | None found | PR 2 / PR 6 |
+| R9 `RemoteCallable("module:qualname")` is the required baseline with explicit non-empty `workers=[...]` | `remote-l3-worker-design.md` §Endpoint Identity and Callable Routing; `protocol.md` §CONTROL Payload; `implementation-plan.md` step 6 | required in this PR cut | `RemoteCallable`, `parse_python_import_target`, `_build_callable_registration`, explicit remote worker validation | target validation and explicit remote worker tests | None found | PR 2 / PR 6 |
+| R10 Multi-endpoint remote registration is all-or-nothing with prepare, commit, abort, cleanup-uncertain blocking, and final-unregister tombstones | `remote-l3-worker-design.md` §Endpoint Identity and Callable Routing; `protocol.md` §CONTROL Payload; `implementation-plan.md` step 6 | required in this PR cut | `Worker._post_start_register_remote`, `remote_prepare/commit/abort/unregister`, pending unregister tombstones, uncertain hashid guard | post-init register, unregister/reregister, inner register/unregister, uncertain cleanup guard | Partial-failure cleanup path is complex; keep as high-risk review item | PR 2 / PR 5 / PR 6 |
+| R11 `INNER_L3_WORKER` is remote-internal; parent TASK frames resolve only in `REMOTE_TASK_DISPATCHER` | `remote-l3-worker-design.md` §§Endpoint Identity and Callable Routing, Remote Worker Session; `protocol.md` §CONTROL Payload; `task-flow.md` §Callable Identity | required in this PR cut | session dispatcher registry vs inner registry; `_prepare_register_callable`; `get_inner_handle` | dispatcher rejects chip target, inner Python import/chip callable install, inner sub-task integration | None found | PR 5 / PR 6 |
+| R12 `PYTHON_SERIALIZED` remote callables reject unless serialized support is explicitly negotiated | `remote-l3-worker-design.md` §§Scope, Endpoint Identity and Callable Routing; `protocol.md` §CONTROL Payload; `implementation-plan.md` step 6 | required explicit unsupported behavior | `_prepare_register_callable` rejects `CallableKind.PYTHON_SERIALIZED` before install | `test_remote_register_rejects_python_serialized_without_negotiation` | Phase 3 added missing coverage | PR 6 |
+| R13 `CHIP_CALLABLE` is valid only for `INNER_L3_WORKER`; inline blobs are supported by sim, staged blobs reject unless negotiated | `protocol.md` §CONTROL Payload; `implementation-plan.md` step 6; `implementation-record.md` §Completed Items | required in this PR cut plus required explicit unsupported behavior for staged blobs | `_prepare_inner_chip_callable`; dispatcher rejects chip target; staged blob reject | inner chip manifest install, dispatcher reject test, `test_remote_inner_chip_callable_rejects_staged_blob_without_negotiation` | Phase 3 added missing staged-blob coverage | PR 5 / PR 6 |
+| R14 Bootstrap manifest installs dispatcher and inner registries before `HELLO READY`; unsupported negotiated manifest extensions reject rather than partially install | `remote-l3-worker-design.md` §Remote Worker Session; `protocol.md` §CONTROL Payload; `implementation-plan.md` steps 6-7 | required in this PR cut | `remote_l3_session.run_session`, `_install_manifest_inner_registry`, daemon manifest validation | manifest inner Python/chip install tests; remote sim roundtrip tests | None found | PR 6 |
+| R15 Fork ordering preserves prestart before command/health transport threads; `HELLO READY` is a scheduling barrier | `remote-l3-worker-design.md` §Fork-Safe Remote Process Model; `protocol.md` §HELLO Payload; `hierarchical_level_runtime.md` §Process Model | required in this PR cut | daemon writes manifest, session prestarts `inner_worker`, then binds command/health and sends HELLO READY; parent `add_remote_l3_socket` waits for READY | remote unreachable daemon test; remote sim roundtrip/prep tests | None found | PR 6 |
+| R16 Remote frame protocol uses versioned canonical little-endian encoding and never memcpy's C++ POD structs | `remote-l3-worker-design.md` §Protocol; `protocol.md` §§Frames, Wire Encoding; `implementation-plan.md` step 5 | required in this PR cut | `remote_wire.cpp` explicit put/get helpers; Python `_Reader`; local mailbox remains same-binary POD IPC only | `FrameRoundTripValidatesHeader`, Python decode tests | Found and fixed `CallConfigWire.enable_scope_stats` drift in Phase 3 | PR 3 |
+| R17 Frame codec rejects bad magic/version/type/flags, oversized/truncated payloads, unknown enums, non-zero reserved fields, and malformed counts | `protocol.md` §§Frames, Wire Encoding, Bounds and Fuzz Tests; `implementation-plan.md` step 5 | required in this PR cut | C++ and Python decode validation for headers, counts, enums, reserved fields, payload sizes | remote wire bad header/truncation/reserved tests; Python materialization/decode tests | No blocking drift found | PR 3 |
+| R18 TASK payload carries digest, `CallConfigWire`, and `RemoteTaskArgsWire`; tensor wire `data` must be zero; `HOST_INLINE` must be descriptor-backed and bounds-checked | `protocol.md` §§TASK Payload, RemoteTensorDesc, Bounds and Fuzz Tests; `buffers-and-transports.md` §TaskArgs Sidecar Contract | required in this PR cut | `encode_task_payload`, `decode_task_payload`, `RemoteL3Endpoint::build_task_payload`, Python `_materialize_task_args` | non-zero tensor data rejection, HOST_INLINE descriptor bounds, host-inline materialization/roundtrip | Phase 3 fixed and tested missing `enable_scope_stats` field | PR 3 / PR 5 |
+| R19 COMPLETION and CONTROL_REPLY match sequence/name/version, bound error text, and fabricate failures on health expiry or process exit | `protocol.md` §§COMPLETION Payload, CONTROL_REPLY Payload, Ordering; `remote-l3-worker-design.md` §Failure Semantics | required in this PR cut | `decode_completion`, `decode_control_reply`, remote endpoint reply validation, session `_format_remote_error`, health monitor | sequence/name mismatch tests, remote sim error completion and process exit tests | None found | PR 3 / PR 5 / PR 6 |
+| R20 Each endpoint has one ordered command lane; TASK, state-changing CONTROL, SHUTDOWN, replies, and visibility are sequence ordered | `remote-l3-worker-design.md` §§Remote Worker Session, Protocol; `protocol.md` §Ordering; `buffers-and-transports.md` §HCOMM Adapter Contract | required in this PR cut | `OrderedCommandLane`, endpoint command mutex, session command loop, SHUTDOWN frame path | `OrderedCommandLaneIsSingleFlight`, remote prepare/register tests | None found | PR 3 / PR 5 / PR 6 |
+| R21 Health/liveness is independent from command-lane progress; health expiry removes endpoint eligibility and fails pending/in-flight work | `remote-l3-worker-design.md` §Remote Worker Session; `protocol.md` §Ordering; `implementation-plan.md` steps 5,7 | required in this PR cut | separate health socket/thread, remote endpoint health monitor, process-exit endpoint failure | long-task health-lane test, process-exit endpoint failure test | Broader multi-endpoint health-removal coverage should remain in PR 5/6 verification | PR 5 / PR 6 |
+| R22 Remote memory APIs expose opaque handles and simulation alloc/free/copy/export/import/release-import controls | `buffers-and-transports.md` §§Buffer Handles, Public Memory API, Required Controls; `implementation-plan.md` steps 8-9 | required in this PR cut | Python `RemoteBufferHandle`, Worker remote memory APIs, C++ controls, session sim buffer registry | opaque handle tests, buffer copy roundtrip, export/import controls roundtrip | None found | PR 5 / PR 6 |
+| R23 Owner/imported handle semantics preserve owner identity, endpoint eligibility, access flags, and import rollback behavior | `remote-l3-worker-design.md` §Buffer Lifecycle; `buffers-and-transports.md` §§Export/Import Handle Semantics, Release Policy; `protocol.md` §Remote Buffer Export and Import Controls | required in this PR cut | export/import descriptors, access flag validation, owner/import endpoint routing, imported address-space materialization | remote buffer export/import wire tests, imported buffer runs on peer endpoint | Import rollback is implementation-reviewed but should get split-specific failure injection | PR 5 / PR 6 |
+| R24 Owner free and release-import defer physical cleanup until slot refs and imports drain; failed runs use the same post-drain cleanup path | `remote-l3-worker-design.md` §Buffer Lifecycle; `buffers-and-transports.md` §Release Policy; `implementation-plan.md` step 9 | required in this PR cut | Python slot refs, pending remote frees/import releases, `run`/`close` cleanup flush | owner-free-waits-for-import-release, input-free-deferred-until-slot-refs-drop | None found | PR 4 / PR 5 / PR 6 |
+| R25 Remote CommDomain controls `COMM_INIT`, `ALLOC_DOMAIN`, and `RELEASE_DOMAIN` are reserved and rejected as unsupported in this cut | `remote-l3-worker-design.md` §Scope; `protocol.md` §CONTROL Payload; `implementation-plan.md` steps 8,13 | required explicit unsupported behavior | session control loop returns error for reserved domain controls; local C++ mailbox CommDomain controls remain local-only | Implementation inspected; no direct UT found | Add direct reserved-control negative in PR 6 verification | PR 5 / PR 6 |
+| R26 A2 RoCE, A3 HCCS, and A5 UB HCOMM profiles are documented contracts but pending hardware-profile work, not part of this split cut | `remote-l3-worker-design.md` §§Current Implementation Status, Rollout; `buffers-and-transports.md` §§HCOMM Adapter Contract, A2/A3/A5 Profiles; `implementation-plan.md` steps 10-12 | reserved or future work | daemon accepts only `transport="sim"`; export/import simulation rejects unsupported profiles | Implementation inspected; remote worker manifest validation covers sim-only | Future only; do not include HCOMM adapters in child PRs | Future |
+| R27 Exact HCCS/UB HAL names, daemon auth/isolation, serialized compatibility metadata, and future CommContext split remain open decisions | `implementation-plan.md` §Open Decisions | open decision | Documented only | Not applicable | Future only | Future |
+| R28 Top-of-stack verification excludes unavailable hardware except through `task-submit`, covers Python UT, C++ UT, pre-commit docs, sim ST, and remote sim integration | `pr-split-and-audit-plan.md` §Review and Verification; `.claude/rules/task-submit-isolation.md` | required in this PR cut | Audit follows local UT only here; hardware remains `task-submit` only | Current run log below | Full child PR verification remains to be run after split | All |
+
+## Phase 3 Drift Fixes
+
+| Item | Finding | Fix | Verification |
+| ---- | ------- | --- | ------------ |
+| `CallConfigWire.enable_scope_stats` | `protocol.md` requires the field, but C++ omitted it and Python decoded it as `False` | Updated C++ encode/decode and Python decode; added C++ and Python round-trip tests | `test_remote_wire`; targeted Python protocol test |
+| `PYTHON_SERIALIZED` unsupported behavior | Implementation rejected it, but coverage was missing | Added direct `_prepare_register_callable` negative test | targeted Python callable identity test |
+| `STAGED_BLOB` unsupported behavior | Implementation rejected it, but coverage was missing | Added direct inner `CHIP_CALLABLE` staged-blob negative test | targeted Python callable identity test |
+
+## Split Map
+
+| File or hunk | Owner PR | Reason | Depends on | Tests |
+| ------------ | -------- | ------ | ---------- | ----- |
+| `docs/remote-l3-worker-design.md`, `docs/remote-l3-worker-design/*`, related docs (`worker-manager.md`, `scheduler.md`, `orchestrator.md`, `task-flow.md`, `hierarchical_level_runtime.md`) | PR 1 | Establish design, protocol, buffer lifecycle, rollout, and audit artifacts | None | docs/pre-commit checks |
+| `python/simpler/callable_identity.py`, callable descriptor/hashid portions of `python/simpler/worker.py`, callable-handle portions of tests | PR 2 | Make callable identity reviewable before remote endpoint behavior | PR 1 docs | callable identity Python UT |
+| `src/common/hierarchical/remote_wire.*`, `python/simpler/remote_l3_protocol.py`, remote-wire-focused tests | PR 3 | Stable cross-host protocol and codec validation | PR 1 docs; PR 2 enum/identity definitions | C++ `test_remote_wire`; Python protocol decode tests |
+| Scheduler and slot-state hunks in `src/common/hierarchical/types.*`, `orchestrator.*`, `scheduler.*`, `worker_manager.*` | PR 4 | Endpoint eligibility, outcomes, sidecars, dependency keys, failure poisoning | PR 2 identity; PR 3 types/protocol where referenced | C++ `test_orchestrator`, `test_scheduler` |
+| C++ remote endpoint and binding hunks in `remote_endpoint.*`, `worker_manager.*`, `worker.h`, `python/bindings/worker_bind.h` | PR 5 | Transport endpoint, command lane, controls, and Python C++ facade | PR 3 wire; PR 4 endpoint abstraction | C++ `test_remote_endpoint`, `test_remote_wire`; binding smoke |
+| Python remote session/runtime hunks in `python/simpler/worker.py`, `orchestrator.py`, `task_interface.py`, `remote_l3_worker.py`, `remote_l3_session.py` | PR 6 | Remote daemon/session runner, registration choreography, sim memory controls, lifecycle cleanup | PR 2-5 | Python remote sim integration tests |
+| Fixup commit `92709210` | Squash into PR 4 / PR 5 / PR 6 hunks | Stabilizes CI controls across Python orchestration, task interface, worker manager, and tests | Matching child PRs | Matching child PR tests |
+| Fixup commit `04de866b` | Squash into PR 3 / PR 5 / PR 6 hunks | Resolves protocol/session/binding/orchestrator CI failures | Matching child PRs | Matching child PR tests |
+| Fixup commit `d6500ea2` | Squash into PR 5 plus affected C++ tests | clang-format-only formatting for remote endpoint/worker manager/scheduler tests | Matching child PRs | formatting / C++ UT |
+| Empty CI retrigger commits | Drop | No functional or document content | None | Not applicable |
+
+## Risk Register
+
+| Risk | Location | Failure mode | Mitigation | Test |
+| ---- | -------- | ------------ | ---------- | ---- |
+| Protocol drift between C++ endpoint and Python session | `remote_wire.cpp`, `remote_l3_protocol.py`, `protocol.md` | Remote TASK decode shifts fields or drops config flags | Keep PR 3 protocol-first; add round-trip tests for every `CallConfigWire` field | Phase 3 `enable_scope_stats` tests; `test_remote_wire` |
+| Partial remote registration cleanup | `Worker._post_start_register_remote`, remote prepare/commit/abort controls | Some endpoints commit while others fail, leaving stale registry state | Preserve prepare/commit/abort/tombstone design; review cleanup-uncertain guard in PR 6 | post-init register/unregister tests; add failure injection in PR 6 |
+| Endpoint failure poisoning | `scheduler.cpp`, `remote_endpoint.cpp`, `remote_l3_session.py` | Failed producer or dead endpoint lets consumers dispatch with stale data | First-error-wins, dependency poisoning, health/process-exit failures | scheduler failed producer; remote sim process-exit and failed-dependency tests |
+| Remote buffer lifetime | `worker.py`, `task_interface.py`, `remote_l3_session.py` | Owner freed while imported/slot-ref still active | Slot refs, import refs, pending free/release queues | owner-free/import-release and slot-ref-deferred free tests |
+| Hidden sidecar integrity | `task_interface.py`, `orchestrator.cpp`, `remote_endpoint.cpp` | Bare host pointer or mismatched descriptor count reaches remote worker | Python sidecar storage, C++ validation, remote endpoint fail-fast | sidecar unit tests, bare host pointer endpoint failure |
+| Future controls accidentally treated as supported | `remote_l3_session.py`, HCOMM docs | Reviewer believes CommDomain/HCOMM or serialized/staged paths are ready | Explicit unsupported tests and Future Work list | Phase 3 serialized/staged tests; add CommDomain negative |
+| Verification build environment | `tests/ut/cpp/build` | System GoogleTest ABI mismatch blocks C++ UT link | Use `tests/ut/cpp/build-fetch` or rebuild system gtest per troubleshooting doc | Current run log records fallback |
+
+## Per-PR Verification Checklist
+
+| PR | Verification |
+| -- | ------------ |
+| PR 1 Docs | Review rendered docs; run docs/pre-commit hooks if available |
+| PR 2 Callable Identity | Python UT for descriptor hashing, opaque handles, local registration/unregistration, forged/mutated handle rejection |
+| PR 3 Protocol | C++ `test_remote_wire`; Python protocol decode/materialization tests; verify no POD memcpy in remote wire |
+| PR 4 Scheduler / Eligibility | C++ `test_orchestrator` and `test_scheduler`; negative tests for remote sidecar/local endpoint and null remote OUTPUT |
+| PR 5 C++ Remote Endpoint / Bindings | C++ `test_remote_endpoint`; binding import smoke; command lane/control reply checks |
+| PR 6 Python Session / Sim Runtime | Python remote sim integration tests in `test_callable_identity.py`; memory alloc/copy/export/import/release tests; reserved-control negative |
+| All | No hardware commands locally; hardware verification only through `task-submit` per repo rule |
+
+## Future Work
+
+| Item | Source | Notes |
+| ---- | ------ | ----- |
+| A2 RoCE remote data plane | `buffers-and-transports.md` A2 profile | HCOMM adapter and hardware verification are out of this split |
+| A3 HCCS remote data plane | `buffers-and-transports.md` A3 profile | Exact HAL/API names remain open |
+| A5 UB LD/ST profile | `buffers-and-transports.md` A5 profile | UB address-space support is documented but future |
+| Remote CommDomain controls | `implementation-plan.md` steps 8,13 | `COMM_INIT`, `ALLOC_DOMAIN`, `RELEASE_DOMAIN` remain reserved/unsupported remotely |
+| `PYTHON_SERIALIZED` negotiated support | `protocol.md` CONTROL payload | Requires compatibility metadata and negotiation |
+| `CHIP_CALLABLE` `STAGED_BLOB` support | `protocol.md` CONTROL payload | Requires staged-blob adapter and negotiation |
+| Remote OUTPUT autoallocation | `buffers-and-transports.md` Remote OUTPUT policy | Current cut requires explicit `RemoteTensorRef` |
+| Remote dependency range overlap | `buffers-and-transports.md` Dependency Keys | Current key uses exact-start semantics |
+| Daemon auth/isolation | `implementation-plan.md` Open Decisions | Security model is future work |
+| Future CommContext split | `implementation-plan.md` Open Decisions | Kept out of current split |
+
+## Current Verification Run Log
+
+| Command | Result | Notes |
+| ------- | ------ | ----- |
+| `.venv/bin/python -m pytest tests/ut/py/test_task_interface.py::TestRemoteL3SessionTaskArgsMaterialization::test_task_payload_decode_preserves_scope_stats_config tests/ut/py/test_callable_identity.py::test_remote_register_rejects_python_serialized_without_negotiation tests/ut/py/test_callable_identity.py::test_remote_inner_chip_callable_rejects_staged_blob_without_negotiation -q` | Passed | 3 passed; non-fatal pto-isa network update warning appeared in sandbox |
+| `cmake --build tests/ut/cpp/build --target test_remote_wire -j2` | Failed at link | Existing system GoogleTest ABI mismatch; compile reached modified C++ objects |
+| `cmake --build tests/ut/cpp/build-fetch --target test_remote_wire -j2` | Passed | Uses FetchContent GoogleTest build |
+| `ctest --test-dir tests/ut/cpp/build-fetch -R '^test_remote_wire$' --output-on-failure` | Passed | 1/1 test passed |

--- a/docs/remote-l3-worker-design/pr-split-and-audit-plan.md
+++ b/docs/remote-l3-worker-design/pr-split-and-audit-plan.md
@@ -90,7 +90,7 @@ Use this matrix shape:
 
 | Req | Source | Class | Implementation | Tests | Gap/Drift | PR |
 | --- | ------ | ----- | -------------- | ----- | --------- | -- |
-|     |        |       |                |       |           |    |
+| | | | | | | |
 
 The split map must assign every changed file and major hunk to one child PR.
 If one hunk does not belong cleanly to one PR, split the hunk before opening
@@ -100,7 +100,7 @@ Use this split-map shape:
 
 | File or hunk | Owner PR | Reason | Depends on | Tests |
 | ------------ | -------- | ------ | ---------- | ----- |
-|              |          |        |            |       |
+| | | | | |
 
 The risk register must include at least:
 
@@ -118,7 +118,7 @@ Use this risk-register shape:
 
 | Risk | Location | Failure mode | Mitigation | Test |
 | ---- | -------- | ------------ | ---------- | ---- |
-|      |          |              |            |      |
+| | | | | |
 
 The future-work list must be explicit about what the current split does not
 implement. For this PR cut, expected future work includes hardware HCOMM

--- a/docs/remote-l3-worker-design/pr-split-and-audit-plan.md
+++ b/docs/remote-l3-worker-design/pr-split-and-audit-plan.md
@@ -1,0 +1,385 @@
+# PR Split and Audit Plan
+
+This plan defines how to split the large PR #866 remote L3 branch into
+reviewable stacked PRs without losing the document contract or hiding
+correctness, race, and resource-lifetime risks across PR boundaries.
+
+## Decision
+
+Use this order:
+
+1. Audit the current whole PR against the PR-head documents.
+2. Fix or remove clear design drift in the current branch.
+3. Split the corrected branch into stacked PRs.
+4. Run deep risk review on each smaller PR.
+
+Do not split first. A split performed before the contract audit can spread one
+design error across several smaller PRs, making the error harder to see and
+harder to revert.
+
+Goals:
+
+- Preserve the remote L3 documents as the source of truth.
+- Make each child PR independently reviewable.
+- Keep tests with the feature they verify.
+- Separate protocol, scheduler, endpoint, and Python runtime concerns.
+- Keep unsupported and future work explicit.
+- Avoid transition-only public APIs.
+
+Non-goals:
+
+- Do not redesign the protocol while splitting.
+- Do not add hardware HCOMM profiles only to make the split look complete.
+- Do not move feature tests into a separate test-only PR.
+- Do not preserve empty CI retrigger commits in any split PR.
+
+Inputs:
+
+- `docs/remote-l3-worker-design.md`
+- `docs/remote-l3-worker-design/protocol.md`
+- `docs/remote-l3-worker-design/buffers-and-transports.md`
+- `docs/remote-l3-worker-design/implementation-plan.md`
+- `docs/remote-l3-worker-design/implementation-record.md`
+- Related contract docs:
+  - `docs/orchestrator.md`
+  - `docs/scheduler.md`
+  - `docs/worker-manager.md`
+  - `docs/task-flow.md`
+  - `docs/hierarchical_level_runtime.md`
+
+Use PR-head documents, not stale local notes. Drop empty CI retrigger commits
+during the split. Fixup formatting and CI stabilization commits into the
+functional PR that introduced the affected code.
+
+## Required Artifacts
+
+Create these before opening the child PRs:
+
+- Document compliance matrix.
+- Split map.
+- Risk register.
+- Per-PR verification checklist.
+- Future-work list.
+
+Use these verdicts in the compliance matrix:
+
+- `ok`: implemented exactly as documented.
+- `gap`: documented requirement is missing or only partially implemented.
+- `drift`: implementation adds behavior not justified by the documents.
+- `unsupported`: implementation explicitly rejects a documented future or
+  reserved path.
+- `future`: document says the behavior is outside this PR cut.
+- `open`: document leaves a decision unresolved.
+
+The document compliance matrix must record:
+
+- Requirement source document and section.
+- Requirement classification:
+  - required in this PR cut
+  - required explicit unsupported behavior
+  - reserved or future work
+  - open decision
+- Implementation files and symbols.
+- Test coverage.
+- Missing pieces.
+- Extra behavior not described by the documents.
+- Whether extra behavior is necessary, harmless, or design drift.
+- Target split PR.
+
+Use this matrix shape:
+
+| Req | Source | Class | Implementation | Tests | Gap/Drift | PR |
+| --- | ------ | ----- | -------------- | ----- | --------- | -- |
+|     |        |       |                |       |           |    |
+
+The split map must assign every changed file and major hunk to one child PR.
+If one hunk does not belong cleanly to one PR, split the hunk before opening
+the child branch.
+
+Use this split-map shape:
+
+| File or hunk | Owner PR | Reason | Depends on | Tests |
+| ------------ | -------- | ------ | ---------- | ----- |
+|              |          |        |            |       |
+
+The risk register must include at least:
+
+- Register prepare, commit, abort, unregister cleanup.
+- Scheduler endpoint selection and completion ordering.
+- Group partial failure and downstream poison propagation.
+- Command-lane serialization and sequence matching.
+- Health lane and session teardown.
+- Remote buffer owner free, import, release-import, and slot refs.
+- Fork-before-thread ordering.
+- Nanobind GIL release and reacquire boundaries.
+- Unsupported reserved controls.
+
+Use this risk-register shape:
+
+| Risk | Location | Failure mode | Mitigation | Test |
+| ---- | -------- | ------------ | ---------- | ---- |
+|      |          |              |            |      |
+
+The future-work list must be explicit about what the current split does not
+implement. For this PR cut, expected future work includes hardware HCOMM
+profiles and Remote CommDomain support unless the documents are changed.
+
+## Workflow
+
+Phase 0: freeze and normalize.
+
+1. Record branch name, feature HEAD, and document baseline.
+2. Mark empty CI retrigger commits as drop-only.
+3. Mark formatting or CI-fix commits as fixup-only.
+4. Confirm there are no unrelated tracked changes.
+5. Do not create new feature commits until the document audit is complete.
+
+Expected output:
+
+- A short baseline note with branch, HEAD, docs baseline, drop commits, and
+  fixup commits.
+
+Phase 1: inventory document requirements.
+
+1. Read the PR-head remote L3 documents.
+2. Extract every required behavior.
+3. Classify each behavior as required, unsupported, future, or open decision.
+4. Record success behavior and failure behavior.
+5. Record which layer owns the behavior:
+   protocol, Python API, binding, scheduler, endpoint, session runner, or
+   tests.
+
+Stop if a requirement is ambiguous enough that two incompatible
+implementations would both look plausible. Update the document or ask for a
+decision before coding or splitting.
+
+Phase 2: map current implementation.
+
+1. Map each requirement to concrete files and symbols.
+2. Map each requirement to tests.
+3. Record missing pieces.
+4. Record extra behavior not described by the documents.
+5. Decide whether the extra behavior is necessary, harmless, or design drift.
+6. Assign each requirement and major hunk to a child PR.
+
+Stop if a requirement has unresolved design drift, depends on a temporary API,
+or only works because two future child PRs are merged together.
+
+Phase 3: remove drift before splitting.
+
+1. Delete behavior that is not required and not justified by the documents.
+2. Convert future work into explicit unsupported errors where required.
+3. Update docs when an accepted schema or lifecycle rule was missing.
+4. Add focused tests for required unsupported behavior.
+
+Examples:
+
+- Hardware profiles may stay pending only if the docs say A2 RoCE, A3 HCCS,
+  and A5 UB HCOMM are future hardware-profile work.
+- Remote CommDomain controls should be explicit unsupported paths in this cut
+  if the docs reserve them for a later phase.
+- `PYTHON_SERIALIZED` should be rejected unless negotiated if the docs define
+  it as a negotiated future extension.
+
+Phase 4: split into stacked PRs.
+
+1. Create child branches in stack order.
+2. Move only the files and hunks assigned to each PR.
+3. Keep tests with the feature under test.
+4. Squash fixup commits into the affected functional PR.
+5. Drop empty CI commits.
+6. Re-run the per-PR verification checklist after each split.
+
+Suggested split mechanics:
+
+1. Create a clean base branch from the document baseline.
+2. Create `remote-l3-docs` for PR 1.
+3. Create each later child branch from the previous child branch.
+4. Move only assigned files and hunks onto each child branch.
+5. Prefer `git restore --source <feature-head> -- <path>` for whole-file
+   slices.
+6. Use interactive staging or patch application for mixed files such as
+   `python/simpler/worker.py` and `worker_manager.cpp`.
+7. Build and test each child branch before creating the next branch.
+8. At the top of the stack, verify that the combined diff matches the
+   corrected feature branch except for dropped CI-only commits.
+
+Stop before opening a child PR if:
+
+- It requires a later child PR to pass its own unit tests.
+- It exposes a public API that exists only to make the split convenient.
+- It contains behavior classified as unresolved drift.
+- It makes a future feature partially visible instead of explicitly
+  unsupported.
+- It moves tests away from the feature under test.
+- Its PR description cannot name the document requirements it satisfies.
+
+## Split Stack
+
+PR 1: remote L3 contract documents.
+
+Scope:
+
+- Remote L3 landing doc.
+- Protocol document.
+- Buffer and transport document.
+- Scheduler, orchestrator, worker-manager, and task-flow contracts.
+- This split and audit plan if useful for reviewers.
+
+Acceptance criteria:
+
+- Required, unsupported, reserved, and future work are separated.
+- Required controls have schemas or explicit unsupported behavior.
+- Hardware profiles are clearly marked as future if not implemented.
+- No document promises behavior that later PRs do not implement.
+
+PR 2: callable identity and run contract.
+
+Scope:
+
+- Callable descriptors, digest/hashid identity, and target namespaces.
+- `ChipWorker.prepare_callable()` handle semantics.
+- `ChipWorker.run()` and `Worker.run()` timing return contract.
+- Python import callable descriptors needed by remote registration.
+- Focused Python unit tests.
+
+Acceptance criteria:
+
+- Target-private slots are not public routing IDs.
+- Prepare rollback and unregister refcount behavior are tested.
+- Descriptor hashing is stable.
+- `RunTiming` introspection contract is preserved.
+
+PR 3: remote wire codec.
+
+Scope:
+
+- C++ `remote_wire`.
+- Python `remote_l3_protocol`.
+- Frame, TASK, COMPLETION, CONTROL, CONTROL_REPLY, HELLO, HEALTH, and buffer
+  control codecs.
+
+Acceptance criteria:
+
+- Bounds checks reject malformed payloads.
+- Unknown enums and non-zero reserved fields are rejected.
+- Sequence matching is tested.
+- Error payloads are bounded.
+- Remote wire format does not memcpy C++ POD structs.
+
+PR 4: scheduler and endpoint abstraction.
+
+Scope:
+
+- `WorkerEndpoint` interface.
+- `LocalMailboxEndpoint` adapter.
+- Endpoint capability metadata and eligible endpoint sets.
+- `WorkerCompletion` outcome propagation.
+- Failed task poisoning.
+- Remote tensor sidecars and dependency keys, without a live remote session.
+- C++ scheduler, orchestrator, and worker-manager tests.
+
+Acceptance criteria:
+
+- Scheduler chooses only eligible idle endpoints.
+- Worker affinity is validated against eligibility.
+- Group partial failure and downstream poison are tested.
+- Slot release and `drain()` behavior are correct after success and failure.
+
+PR 5: C++ remote endpoint and bindings.
+
+Scope:
+
+- `RemoteL3Endpoint`.
+- Transport-neutral command lane.
+- C++ remote endpoint control methods.
+- Nanobind exposure for remote controls and remote buffer descriptors.
+- Endpoint-level C++ unit tests.
+
+Acceptance criteria:
+
+- Per-endpoint command serialization is enforced.
+- Control and completion replies match sequence numbers.
+- Health failure can surface while command lane waits.
+- Endpoint failure and task failure are classified distinctly.
+- Bindings do not build Python return values while the GIL is released.
+
+PR 6: Python remote session and simulation runtime.
+
+Scope:
+
+- `simpler-remote-worker`.
+- `simpler-remote-l3-session`.
+- Python `RemoteCallable`, `RemoteBufferHandle`, `RemoteTensorRef`, and
+  `RemoteTaskArgs` integration.
+- Simulation remote buffer allocation, copy, export, import, and release.
+- Remote dispatcher and inner worker registry controls.
+- Simulation integration tests.
+
+Acceptance criteria:
+
+- Fork-before-thread invariant is preserved.
+- `HELLO READY` is a scheduling barrier.
+- Session shutdown and health expiry are tested.
+- Partial register and partial import cleanup are tested.
+- Owner frees wait for slot refs and imports to drain.
+- Reserved Remote CommDomain controls fail explicitly.
+- A2 RoCE, A3 HCCS, and A5 UB HCOMM are not included unless they are their
+  own hardware-profile PRs.
+
+## Review and Verification
+
+Each child PR review must answer:
+
+1. Which document requirements does this PR satisfy?
+2. Which required requirements remain for later stacked PRs?
+3. Which future or reserved behaviors are explicitly unsupported?
+4. What state is shared across threads or processes?
+5. What happens if prepare, task, control, copy, import, or release fails
+   halfway through?
+6. What cleanup runs after `drain()` throws?
+7. What cleanup runs during `Worker.close()`?
+8. Which user-visible errors are bounded and deterministic?
+9. Which tests prove success paths?
+10. Which tests prove failure and cleanup paths?
+
+Minimum risk checklist:
+
+- No lock inversion across scheduler, ring, worker manager, and endpoint code.
+- No task slot is released before captured refs are safe to drop.
+- No endpoint receives TASK for a prepared, aborted, or partially committed
+  digest.
+- No partially failed remote register leaves a visible hashid.
+- No imported buffer is used after `RELEASE_IMPORT`.
+- No owner buffer is physically freed while an import or slot ref is live.
+- No health thread can outlive the transport or session object it references.
+- No command-lane wait can hide health failure indefinitely.
+- No Python session forks after network or C++ worker threads start.
+- No nanobind return value is constructed while the GIL is released.
+
+Minimum verification:
+
+- PR 1: markdown and pre-commit docs checks.
+- PR 2: callable identity and task interface Python unit tests.
+- PR 3: C++ remote wire tests and Python protocol codec tests.
+- PR 4: C++ scheduler, orchestrator, and worker-manager tests.
+- PR 5: C++ remote endpoint tests and binding smoke tests.
+- PR 6: remote simulation integration tests, buffer export/import/release
+  tests, health lane tests, and session-exit failure tests.
+
+Top-of-stack verification:
+
+- Python unit tests excluding hardware-only marks.
+- C++ unit tests excluding hardware-only labels.
+- Pre-commit checks that do not require unavailable network downloads.
+- Simulation scene tests for at least one A2/A3 path and one A5 path.
+- Hardware ST only through `task-submit --device ...`.
+
+Onboard CI failures must be classified by affected job and stack trace. Do not
+treat an onboard runner failure as a remote L3 regression unless the failing
+stack enters remote L3 code or a split PR changed the failing runtime path.
+
+The split is done when every document requirement maps to a child PR or a
+future-work item, every child PR has tests, unsupported controls fail
+explicitly, empty CI commits are absent, and the top of the stack passes the
+agreed non-hardware test set.

--- a/docs/remote-l3-worker-design/protocol.md
+++ b/docs/remote-l3-worker-design/protocol.md
@@ -1,0 +1,751 @@
+# Remote L3 Protocol
+
+This document defines the remote wire protocol used by
+`RemoteL3Endpoint`. The local fork/shm path keeps the existing mailbox layout
+behind `LocalMailboxEndpoint`.
+
+The bootstrap socket carries only setup and HCOMM bring-up frames. After HCOMM
+RPC is ready, steady-state TASK, CONTROL, CONTROL_REPLY, COMPLETION, and
+SHUTDOWN frames travel through the HCOMM RPC adapter. Tensor data moves through
+the HCOMM data adapter and is referenced from TASK frames by descriptors, not
+by host pointers.
+
+## Frames
+
+Remote transport must not reuse the raw 4096-byte mailbox format. Define a
+versioned frame header:
+
+```text
+FrameHeader:
+  magic = "SLR3"
+  version = 1
+  frame_type =
+    HELLO | TASK | CONTROL | CONTROL_REPLY | COMPLETION | HEALTH | SHUTDOWN
+  session_id
+  endpoint_id
+  sequence
+  payload_bytes
+  flags
+```
+
+Rules:
+
+- `magic` and `version` are validated before reading payload fields.
+- `session_id` protects against stale frames from prior sessions.
+- `endpoint_id` must match the logical NEXT_LEVEL worker selected by the
+  parent scheduler.
+- For parent-to-runner command requests, `sequence` is monotonic per endpoint
+  on the ordered command lane. This includes `TASK`, state-changing `CONTROL`,
+  and `SHUTDOWN`.
+- `HEALTH` frames travel on an independent health lane, or use an equivalent
+  transport-level health signal. They carry their own health sequence and must
+  not be queued behind long-running TASK execution.
+- Reply frames such as `COMPLETION` and `CONTROL_REPLY` carry the sequence of
+  the request they answer. They do not allocate a new command sequence.
+- `payload_bytes` is bounds-checked before allocation or decode.
+- Unknown frame types, versions, flags, or oversized payloads fail the
+  session instead of falling back to best-effort parsing.
+
+## Wire Encoding
+
+Remote frames use canonical field encoding. They do not memcpy C++ POD structs
+such as `CallConfig` or `ContinuousTensor` onto the wire. The local fork/shm
+mailbox may continue to use the raw POD layout because both endpoints are
+fork-related processes running the same binary; remote endpoints must treat the
+wire schema below as the compatibility contract.
+
+Encoding rules:
+
+- Multi-byte integers are little-endian.
+- Boolean values are encoded as `uint8`, where `0` is false and `1` is true.
+- Enum values are encoded as fixed-width integers. Unknown enum values reject
+  the frame.
+- Strings are `uint32 byte_len` followed by UTF-8 bytes, with per-field maximum
+  lengths.
+- Bounded byte blobs are `uint32 byte_len` followed by raw bytes, with
+  per-field maximum lengths.
+- Repeated fields are `uint32 count` followed by that many elements, with
+  configured maximum counts.
+- Reserved fields must be written as zero and rejected when non-zero unless a
+  later protocol version assigns them.
+
+`CallConfigWire v1` encodes the current `CallConfig` fields explicitly:
+
+```text
+block_dim: int32
+aicpu_thread_num: int32
+enable_l2_swimlane: int32
+enable_dump_tensor: int32
+enable_pmu: int32
+enable_dep_gen: int32
+enable_scope_stats: int32
+output_prefix: string(max=1024)
+```
+
+The local codec implementation in `src/common/hierarchical/remote_wire.*`
+encodes these fields explicitly and rejects drift through decode-time bounds
+checks. The local fork/shm mailbox continues to memcpy the packed `CallConfig`
+POD because it is same-binary IPC, not the cross-host protocol.
+
+`ContinuousTensorWire v1` encodes tensor metadata explicitly. In remote TASK
+frames, `data` is not a transferable pointer; it is reserved and must be zero.
+
+```text
+data: uint64  # reserved in remote TASK frames; must be 0
+shapes: uint32[CONTINUOUS_TENSOR_MAX_DIMS]
+ndims: uint32
+dtype: uint32
+child_memory: uint8
+reserved: uint8[7]
+```
+
+The session runner decodes these wire records into local `CallConfig` and
+`ContinuousTensor` values before calling `inner_worker.run()`. For tensors with
+a remote descriptor, the runner fills the local `ContinuousTensor.data` from
+its buffer/import registry after validating the descriptor. Local ABI structs
+therefore remain the in-process execution ABI, not the remote transport ABI.
+
+## HELLO Payload
+
+`HELLO` is a post-prestart command-lane handshake. The session runner sends or
+accepts it only after it has read the bootstrap manifest from the daemon
+handoff, constructed `Worker(level=3)`, performed an explicit prestart that
+forks local chip/sub children, started the inner scheduler, installed bootstrap
+registries, initialized the buffer/import registry, and brought up the command
+and health lanes. `HELLO` does not carry the bootstrap manifest.
+
+```text
+session_id
+endpoint_id
+protocol_version
+comm profile
+feature flags
+ready_state
+```
+
+The parent treats the endpoint as schedulable only after the `HELLO` exchange
+confirms `ready_state=READY`, matching `session_id`, matching `endpoint_id`,
+and compatible protocol and feature sets.
+
+`READY` is a scheduling barrier. A session that can answer liveness probes but
+has not completed prestart reports a non-ready state and must not receive TASK
+frames.
+
+## TASK Payload
+
+```text
+callable_hash_digest: uint8[32]
+config: CallConfigWire v1
+args: RemoteTaskArgsWire v1
+```
+
+The TASK payload has exactly these top-level fields: callable digest,
+`CallConfigWire`, and `RemoteTaskArgsWire`. `RemoteTaskArgsWire` then carries
+tensor metadata, remote tensor descriptors, scalars, and optional inline bytes.
+
+TASK frames carry the raw digest from the submitted parent-facing
+`CallableHandle.hashid`. Parent-side dependency inference has already consumed
+`TaskArgs` tags; tags are Orchestrator input, not the remote L3 wire contract.
+A TASK frame always resolves `callable_hash_digest` in the remote TASK
+dispatcher registry. The dispatcher is not a Worker: it resolves the digest to
+its private orchestration callable slot, materializes the remote arguments, and
+then invokes the embedded `inner_worker = Worker(level=3)`. The endpoint uses
+the sidecar descriptors captured at submit time to materialize local
+`ContinuousTensor` values on the session runner.
+
+The current `RemoteL3Endpoint` implementation builds this payload from
+`TaskSlotState`, zeros every tensor metadata `data` field, and submits the
+encoded frame through `RemoteL3Transport`. The simulation session runner
+resolves the digest in its dispatcher registry, materializes the sidecar
+descriptors, and calls `inner_worker.run()`.
+
+`RemoteTaskArgsWire v1` contains:
+
+```text
+tensor_count: uint32
+scalar_count: uint32
+tensor_metadata: ContinuousTensorWire[tensor_count]
+remote_desc: OptionalRemoteTensorDescWire[tensor_count]
+scalars: uint64[scalar_count]
+inline_payload_bytes_len: uint32
+inline_payload_bytes: uint8[inline_payload_bytes_len]
+```
+
+For each tensor index, exactly one of these is true:
+
+- `remote_desc[i]` is present and names a remote buffer, imported peer buffer,
+  UB mapping, or allowed small `HOST_INLINE` payload.
+- The tensor is metadata-only and has no data pointer and no remote descriptor.
+
+`tensor_metadata[i].data` must be zero in both cases. Bare host pointers are
+rejected for remote endpoints unless an explicit staging API has produced a
+remote handle and sidecar descriptor.
+
+`HOST_INLINE` is for small payloads that should travel inside the TASK frame.
+It still requires a `RemoteTensorDescWire` with `address_space=HOST_INLINE`;
+the descriptor points into `inline_payload_bytes`. Regular and large tensor
+data must use `RemoteBufferHandle` / `RemoteTensorDesc` and the remote
+data-plane transport, not inline bytes.
+
+## RemoteTensorDesc
+
+```text
+RemoteTensorDescWire:
+  address_space:
+    HOST_INLINE
+    REMOTE_DEVICE
+    REMOTE_WINDOW
+    UB_LDST
+  owner_endpoint_id
+  buffer_id
+  offset
+  nbytes
+  remote_addr
+  rkey_or_token
+  generation
+  inline_payload_offset
+  inline_payload_len
+  flags
+```
+
+Rules:
+
+- `ContinuousTensor` remains the L2 ABI. The session runner translates
+  descriptors into local `ContinuousTensor` values immediately before
+  `inner_worker.run()`.
+- When a descriptor is present, the incoming `ContinuousTensorWire.data` is
+  reserved and must be zero. The session runner derives the executable local
+  address only from the validated descriptor and its live buffer/import
+  registry.
+- Metadata-only tensors also require `ContinuousTensorWire.data == 0`.
+- Parent-side dependency keys use a stable logical start-address key derived at
+  submit time:
+  `(address_kind, owner_endpoint_id, buffer_id, generation, offset)`.
+  `nbytes` bounds the descriptor and is kept for validation and future overlap
+  detection, but it is not part of the first implementation's TensorMap lookup.
+- `offset + nbytes` must fit inside the referenced handle.
+- `generation` must match the parent registry entry and the remote daemon's
+  live handle entry.
+- For `HOST_INLINE`, `inline_payload_offset + inline_payload_len` must fit
+  inside `inline_payload_bytes_len`, and `inline_payload_len` must equal
+  `nbytes`. Remote handle fields (`owner_endpoint_id`, `buffer_id`,
+  `remote_addr`, `rkey_or_token`, `generation`) are reserved and must be zero.
+- For non-`HOST_INLINE` descriptors, `inline_payload_len` must be zero.
+- A tensor owned by endpoint 3 cannot be submitted to endpoint 5 unless the
+  parent has first created an imported peer handle through `IMPORT_BUFFER`.
+  The descriptor sent to endpoint 5 still keeps `owner_endpoint_id=3` and the
+  original `(buffer_id, generation, offset, nbytes)` identity; endpoint 5
+  resolves it through its live importer-local registry entry.
+- `child_memory=1` keeps its local meaning: the data is managed by a
+  next-level worker. For remote workers, ownership is resolved through the
+  remote sidecar, not through a local pointer alone.
+
+## COMPLETION Payload
+
+```text
+sequence
+error_code
+error_message_len
+error_message bytes
+```
+
+Rules:
+
+- `sequence` must match the request being waited on.
+- `error_code=0` means task success.
+- Non-zero error means task failure. The parent marks the slot failed/poisoned
+  and does not dispatch downstream consumers.
+- `error_message` is bounded UTF-8. It should include remote host,
+  `endpoint_id`, callable hashid, and `sequence`.
+- If health expires or the process exits, the parent fabricates an endpoint
+  failure completion for every in-flight sequence.
+
+## CONTROL Payload
+
+```text
+control_name
+control_version
+command-specific bytes
+```
+
+Remote control frames use typed names and versioned payloads. Local mailbox
+sub-command ids remain local-only and must not leak into the remote protocol.
+Every `CONTROL` request produces exactly one `CONTROL_REPLY` frame with the
+same `sequence`.
+
+Required remote controls:
+
+- `UNREGISTER_CALLABLE`
+- `PREPARE_REGISTER_CALLABLE`
+- `COMMIT_REGISTER_CALLABLE`
+- `ABORT_REGISTER_CALLABLE`
+- `PREPARE_CALLABLE`
+- `ALLOC_REMOTE_BUFFER`
+- `FREE_REMOTE_BUFFER`
+- `COPY_TO_REMOTE`
+- `COPY_FROM_REMOTE`
+- `EXPORT_BUFFER`
+- `IMPORT_BUFFER`
+- `RELEASE_IMPORT`
+
+Reserved future controls for Remote CommDomain:
+
+- `COMM_INIT`
+- `ALLOC_DOMAIN`
+- `RELEASE_DOMAIN`
+
+The first Remote L3 task-dispatch cut rejects the reserved domain controls
+with an unsupported-control reply. They become required only when Remote
+CommDomain enters scope.
+
+The register-family controls are registry-scope-aware.
+`PREPARE_REGISTER_CALLABLE` carries:
+
+```text
+target_registry:
+  REMOTE_TASK_DISPATCHER
+  INNER_L3_WORKER
+callable_kind:
+  PYTHON_IMPORT
+  CHIP_CALLABLE
+  PYTHON_SERIALIZED  # optional negotiated extension
+callable_hash_digest: uint8[32]
+payload_version: uint32
+payload bytes
+```
+
+Valid target/kind combinations in protocol v1:
+
+| Target registry | Callable kind | Status |
+| --------------- | ------------- | ------ |
+| `REMOTE_TASK_DISPATCHER` | `PYTHON_IMPORT` | Required baseline. |
+| `REMOTE_TASK_DISPATCHER` | `PYTHON_SERIALIZED` | Optional negotiated extension. |
+| `REMOTE_TASK_DISPATCHER` | `CHIP_CALLABLE` | Invalid. |
+| `INNER_L3_WORKER` | `PYTHON_IMPORT` | Required for inner Python callables. |
+| `INNER_L3_WORKER` | `PYTHON_SERIALIZED` | Optional negotiated extension. |
+| `INNER_L3_WORKER` | `CHIP_CALLABLE` | Required for inner chip callables. |
+
+Unsupported target/kind combinations are rejected during prepare and must not
+create a prepared hashid entry.
+
+Rules:
+
+- `REMOTE_TASK_DISPATCHER` registers callables that can be selected by future
+  parent TASK frames. Only Python callable kinds are valid in this parent-facing
+  registry.
+- `INNER_L3_WORKER` registers callables on the session runner's
+  `inner_worker = Worker(level=3)`. It is a remote-internal install target, not
+  a parent-facing `CallableHandle` resolver scope. Python callables become
+  valid targets for inner `submit_sub` / recursive orchestration;
+  `CHIP_CALLABLE` follows the existing prepare/register path for chip workers.
+  A successful inner registration never makes the hashid valid for parent TASK
+  frames.
+- Remote orchestration code resolves committed inner handles through the
+  session-runner-local `simpler.remote_l3_session.get_inner_handle(hashid)`
+  helper. The returned handle is owned by `inner_worker` and is valid only
+  inside that session process.
+- `PYTHON_IMPORT` payloads carry a bounded UTF-8 `module:qualname` string.
+  The payload parser trims surrounding ASCII whitespace, splits on exactly one
+  colon, rejects empty parts, rejects relative module names, and rejects
+  `<locals>`. Module and qualname components must be Python identifiers joined
+  by dots. `PYTHON_IMPORT` uses callable kind value `3`, extending the PR #891
+  values `1 = CHIP_CALLABLE` and `2 = PYTHON_SERIALIZED`.
+
+  The canonical descriptor uses the PR #891 descriptor primitive encoding:
+  `uint32` fields are unsigned little-endian, and strings are encoded as
+  `uint32 byte_len` followed by UTF-8 bytes. It stores:
+
+  ```text
+  REMOTE_PYTHON_IMPORT:
+    uint32 descriptor_schema_version = 1
+    uint32 callable_kind = 3  # PYTHON_IMPORT
+    string module
+    string qualname
+  ```
+
+  PR866 adds `PYTHON_IMPORT` as a stable callable kind in the PR #891 identity
+  model. The parent and endpoint rebuild the same descriptor, compute
+  `sha256(descriptor)`, and compare it with `callable_hash_digest` before
+  staging the import.
+- `PYTHON_SERIALIZED` payloads follow
+  [../python-callable-serialization.md](../python-callable-serialization.md).
+  They are rejected in remote protocol v1 unless parent and session explicitly
+  negotiate serializer version, payload limits, Python ABI/runtime
+  compatibility, and dependency/runtime compatibility. Support is optional;
+  `PYTHON_IMPORT` remains the required baseline. Rejection happens before any
+  staged entry is published.
+- A session that does not advertise a requested callable kind rejects the
+  control request before installing the hashid.
+- The endpoint recomputes the canonical descriptor hashid from the staged
+  descriptor/payload and rejects the control if it does not match
+  `callable_hash_digest`.
+- `CHIP_CALLABLE` is valid only for `INNER_L3_WORKER`. The remote frame never
+  embeds a local POSIX shm name from the parent process. The endpoint validates
+  the payload against the PR #891 `CHIP_CALLABLE` canonical descriptor before
+  installing the hashid.
+- `COMMIT_REGISTER_CALLABLE` and `ABORT_REGISTER_CALLABLE` carry
+  `target_registry`, `callable_kind`, and `callable_hash_digest`.
+- `UNREGISTER_CALLABLE` carries the same `target_registry`, `callable_kind`,
+  and `callable_hash_digest` so cleanup is scoped to the intended registry.
+
+`CHIP_CALLABLE` remote payload version 1 uses either inline bytes for the
+simulation/small-payload path or a session-local staged blob reference for
+large hardware payloads:
+
+```text
+RemoteChipCallablePayloadWire v1:
+  descriptor_bytes: bytes(max=4096)
+  blob_location:
+    INLINE_BLOB
+    STAGED_BLOB
+  blob_size: uint64
+  blob_sha256: uint8[32]
+  inline_blob: bytes(max=control_payload_max)
+  staged_blob_token: bytes(max=1024)
+  reserved: uint32 = 0
+```
+
+Rules:
+
+- `descriptor_bytes` must decode as the PR #891 `CHIP_CALLABLE` canonical
+  descriptor and hash to `callable_hash_digest`.
+- The descriptor's `callable_blob_sha256` must equal `blob_sha256`.
+- For `INLINE_BLOB`, `inline_blob` is present, `staged_blob_token` is empty,
+  `inline_blob.size == blob_size`, and the full CONTROL payload fits within
+  the endpoint's negotiated payload limit.
+- For `STAGED_BLOB`, `staged_blob_token` names bytes already staged in this
+  session by the selected data-plane adapter, `inline_blob` is empty, and the
+  staged byte length must equal `blob_size`.
+- The endpoint computes SHA-256 over the executable blob bytes before install
+  and rejects the prepare if it does not match `blob_sha256`.
+- The descriptor's target architecture, platform, runtime, and signature hash
+  are validated by the inner worker path before the hashid is committed.
+- Staged bytes are owned by the prepare transaction. They are released after
+  commit succeeds or after abort/cleanup confirms the hashid was not published.
+
+The current simulation implementation supports `INLINE_BLOB`. `STAGED_BLOB`
+is rejected unless a staged-blob adapter has been negotiated for the session.
+
+Bootstrap manifest entries use the same validation model as
+`PREPARE_REGISTER_CALLABLE`; the manifest only changes transport of the
+already-defined fields, not callable identity semantics:
+
+```text
+inner_l3_worker[]:
+  hashid: lowercase hex sha256 digest, with or without "sha256:" prefix
+  target_registry: "INNER_L3_WORKER"
+  kind: "PYTHON_IMPORT" | "CHIP_CALLABLE" | negotiated future kind
+  payload_version: uint32 = 1
+
+  # PYTHON_IMPORT
+  target: "module:qualname"
+
+  # CHIP_CALLABLE
+  payload_hex: hex(RemoteChipCallablePayloadWire v1)
+```
+
+The runner rebuilds the register command from each manifest entry, applies the
+same descriptor/hash/platform/runtime checks as post-bootstrap controls, and
+installs successful entries into `inner_worker` before `HELLO READY`.
+Unsupported negotiated extensions, including `PYTHON_SERIALIZED` and
+`STAGED_BLOB`, are rejected rather than partially installed.
+
+Multi-endpoint parent registration uses two-phase visibility:
+
+1. The parent sends `PREPARE_REGISTER_CALLABLE` to every selected endpoint.
+   Each endpoint validates the descriptor/payload, checks feature gates, stages
+   any callable bytes, and records the hashid as prepared but not visible to
+   TASK.
+2. If every prepare succeeds, the parent sends `COMMIT_REGISTER_CALLABLE` to
+   every selected endpoint. A successful commit makes the hashid visible to
+   later TASK frames on that endpoint.
+3. If any prepare or commit fails, the parent sends `ABORT_REGISTER_CALLABLE`
+   to endpoints with prepared or uncertain state, keeps the hashid invisible,
+   and marks endpoints failed when their final registry state cannot be proven.
+
+Partial failure outcomes:
+
+- Prepare failure on an endpoint means that endpoint did not publish the
+  hashid. The parent aborts endpoints that prepared successfully and does not
+  publish the handle.
+- Commit failure or timeout means the parent cannot assume all endpoints have
+  the same visible state. It keeps the handle unpublished, sends cleanup to any
+  endpoint that may have prepared or committed, and removes endpoints with
+  uncertain cleanup from eligibility for that endpoint/hashid pair.
+- Abort or cleanup failure leaves only the affected endpoint/hashid pair in a
+  cleanup-uncertain state. Other endpoint/hashid pairs remain usable if their
+  state is confirmed.
+- Final unregister failure leaves the endpoint/hashid tombstone in place. The
+  same endpoint/hashid pair cannot be re-registered or dispatched until cleanup
+  is confirmed or the endpoint is failed for the session.
+
+Final unregister creates a parent-side tombstone for the selected
+endpoint/hashid pairs. The hashid remains dispatchable through any other live
+handle that still owns a reference. Once the final reference is dropped for an
+endpoint, that endpoint/hashid pair cannot be dispatched or published by a new
+handle until cleanup is confirmed, or until any non-responsive endpoint has
+been removed from eligibility and marked failed. If register rollback cleanup
+cannot be confirmed, that endpoint/hashid pair enters a cleanup-uncertain state
+and is unusable for the current session.
+
+### Remote Buffer Export and Import Controls
+
+Remote buffer export/import uses owner-stable identity plus importer-local
+mapping ids. Public Python handles remain opaque; raw transport keys, HCOMM
+descriptors, and UB addresses are protocol/session data, not user-visible
+integers.
+
+`EXPORT_BUFFER` is sent to the endpoint that owns the allocation:
+
+```text
+ExportBufferRequestWire v1:
+  owner_endpoint_id: int32
+  buffer_id: uint64
+  generation: uint64
+  offset: uint64
+  nbytes: uint64
+  access_flags: uint32  # bit 0 = read, bit 1 = write
+  transport_profile: string(max=128)
+  reserved: uint32 = 0
+```
+
+Rules:
+
+- `owner_endpoint_id` must match the endpoint that receives the control.
+- `buffer_id` and `generation` must name a live owner allocation.
+- `offset + nbytes` must fit inside that allocation and `nbytes` must be
+  non-zero.
+- `access_flags` must request at least one supported access bit and no unknown
+  bits.
+- `transport_profile` must match a profile advertised by the owner endpoint
+  for this session.
+- The control may create or reuse a transport registration for the same
+  `(buffer_id, generation, offset, nbytes, access_flags, transport_profile)`.
+  There is no separate public release-export command in v1; the owner endpoint
+  releases export registrations when the owner allocation is physically freed
+  after all imports and slot refs have drained.
+
+On success, `EXPORT_BUFFER` returns:
+
+```text
+ExportBufferResultWire v1:
+  owner_endpoint_id: int32
+  buffer_id: uint64
+  generation: uint64
+  address_space: uint32  # REMOTE_WINDOW or UB_LDST
+  offset: uint64
+  nbytes: uint64
+  export_id: uint64
+  remote_addr: uint64
+  rkey_or_token: uint64
+  ub_ldst_va: uint64
+  access_flags: uint32
+  transport_profile: string(max=128)
+  transport_descriptor: bytes(max=4096)
+  reserved: uint32 = 0
+```
+
+`export_id` is an opaque session-local capability issued by the owner endpoint.
+For the simulation profile it may be the only meaningful token. For RoCE/HCCS
+it identifies the HCOMM/RDMA memory registration described by
+`rkey_or_token` and `transport_descriptor`. For UB it may also carry a
+validated `ub_ldst_va`. `REMOTE_DEVICE` is not a valid export result address
+space because peer endpoints consume the export through a window or UB mapping,
+not by dereferencing the owner's local device pointer.
+
+`IMPORT_BUFFER` is sent to the endpoint that will consume the peer buffer. Its
+payload carries the owner-produced export descriptor plus the importer target:
+
+```text
+ImportBufferRequestWire v1:
+  importer_endpoint_id: int32
+  requested_access_flags: uint32
+  export_desc: ExportBufferResultWire v1
+  reserved: uint32 = 0
+```
+
+Rules:
+
+- `importer_endpoint_id` must match the endpoint that receives the control.
+- `requested_access_flags` must be a non-empty subset of
+  `export_desc.access_flags`.
+- The importer must advertise the same `transport_profile` and support
+  `export_desc.address_space`.
+- The importer validates `owner_endpoint_id`, `buffer_id`, `generation`,
+  `offset`, `nbytes`, `export_id`, transport metadata, and access flags before
+  publishing a mapping in its local import registry.
+- A live import makes the buffer range data-eligible on the importer endpoint.
+  Without a live import, non-owner endpoints remain ineligible for descriptors
+  that name the owner's allocation.
+- The dependency key for an imported handle remains the owner identity
+  `(address_kind, owner_endpoint_id, buffer_id, generation, offset)`. The
+  importer endpoint id and `import_id` are mapping details, not producer/consumer
+  identity. This keeps tasks on different endpoints ordered when they touch the
+  same physical remote buffer at the same logical start offset.
+
+On success, `IMPORT_BUFFER` returns:
+
+```text
+ImportBufferResultWire v1:
+  importer_endpoint_id: int32
+  owner_endpoint_id: int32
+  buffer_id: uint64
+  generation: uint64
+  import_id: uint64
+  address_space: uint32  # REMOTE_WINDOW or UB_LDST
+  offset: uint64
+  nbytes: uint64
+  remote_addr: uint64
+  rkey_or_token: uint64
+  ub_ldst_va: uint64
+  access_flags: uint32
+  transport_profile: string(max=128)
+  import_descriptor: bytes(max=4096)
+  reserved: uint32 = 0
+```
+
+`import_id` is opaque and unique within
+`(session_id, importer_endpoint_id)`. The parent stores it inside the imported
+`RemoteBufferHandle`; user code does not inspect it. TASK descriptors built
+from the imported handle carry the original owner identity and the importer
+mapping metadata from `ImportBufferResultWire`. The session runner rejects a
+TASK descriptor if the corresponding importer-local mapping is no longer live.
+
+`RELEASE_IMPORT` is sent to the importer endpoint:
+
+```text
+ReleaseImportRequestWire v1:
+  importer_endpoint_id: int32
+  owner_endpoint_id: int32
+  buffer_id: uint64
+  generation: uint64
+  import_id: uint64
+  reserved: uint32 = 0
+```
+
+Rules:
+
+- `importer_endpoint_id` must match the endpoint that receives the control.
+- The request releases only the importer-local mapping. It never frees the
+  owner allocation and never invalidates imports on other endpoints.
+- The parent sends `RELEASE_IMPORT` only after all slot refs captured from the
+  imported handle have drained. If user code requests release earlier, the
+  parent marks the imported handle released and defers the control.
+- The endpoint may treat release of an already-released matching import as
+  idempotent success. A mismatched owner, buffer, generation, or import id is a
+  control failure.
+- The reply has empty `result_bytes`.
+
+Multi-endpoint import setup is owner-first and rollback-aware:
+
+1. The parent sends `EXPORT_BUFFER` to the owner endpoint.
+2. The parent sends `IMPORT_BUFFER` to each selected importer endpoint.
+3. If any import fails, the parent sends `RELEASE_IMPORT` to importers that
+   succeeded. If cleanup cannot be confirmed, those importer mappings enter an
+   import-cleanup-uncertain state and the affected endpoint/buffer pair is
+   unusable for new TASK dispatch in the current session.
+4. `FREE_REMOTE_BUFFER` on the owner marks the owner handle released but
+   defers physical free while exports, imports, or slot refs are live.
+5. All three controls are state-changing command-lane controls and serialize
+   with TASK on their target endpoint.
+
+## CONTROL_REPLY Payload
+
+```text
+sequence
+control_name
+control_version
+error_code
+error_message_len
+error_message bytes
+result_bytes_len
+result_bytes
+```
+
+Rules:
+
+- `sequence` must match one in-flight `CONTROL` request on the same endpoint.
+- `control_name` and `control_version` must match the request being answered.
+- `error_code=0` means the control succeeded and `result_bytes` contains the
+  command-specific result, if any.
+- Non-zero `error_code` means the remote session did not apply the requested
+  state change, except for commands whose versioned contract explicitly allows
+  best-effort partial cleanup.
+- `error_message` is bounded UTF-8. It should include remote host,
+  `endpoint_id`, `control_name`, and `sequence`.
+- `result_bytes` uses the same canonical encoding rules as other remote
+  payloads. For example, `ALLOC_REMOTE_BUFFER` returns a buffer id,
+  generation, address space, size, and transport-specific export metadata.
+- If health expires or the process exits, the parent fabricates a failed
+  `CONTROL_REPLY` for every in-flight control sequence.
+
+Control waits obey the same timeout policy as task waits.
+
+## Ordering
+
+Each endpoint has one ordered command lane. Runtime state-changing requests use
+this lane even when their bulk bytes are staged through a separate data plane.
+The remote session observes parent-to-runner requests in increasing `sequence`
+order, and state changes caused by a request happen-before later requests on
+the same endpoint. Reply frames carry the answered request sequence and become
+visible only after the corresponding request side effects.
+
+The baseline endpoint admits at most one TASK in flight. State-changing CONTROL
+frames serialize with that TASK and are not applied concurrently with
+`inner_worker.run()`. This keeps callable registry visibility, buffer release,
+import release, and domain lifetime consistent with the local one-mailbox
+model.
+
+`HEALTH` frames are not state-changing command-lane requests. The parent uses a
+separate health lane, RDMA completion health signal, or transport-native
+keepalive so a long-running TASK does not block liveness observation. Health
+success does not imply task completion; task completion is only a matching
+`COMPLETION` frame.
+
+Health expiry is an endpoint failure for the current session:
+
+- If a TASK or CONTROL is in flight, the parent fabricates the matching failed
+  `COMPLETION` or `CONTROL_REPLY` with bounded endpoint-failure text.
+- If no command is in flight, the endpoint is removed from the schedulable set
+  before new work can be assigned to it.
+- Later health frames from the same endpoint do not automatically make it
+  schedulable again. Recovery requires creating a new remote session or an
+  explicit future reconnect protocol.
+- Pending slots whose final eligible set becomes empty after health expiry are
+  failed rather than dispatched to an ineligible endpoint.
+
+All transports must provide the following visibility rules:
+
+- Task payload writes are visible before the task doorbell.
+- Remote output writes are complete before the completion frame is visible.
+- Parent completion reads happen before dependent task dispatch.
+- Control request payload writes are visible before the control doorbell.
+- Control side effects are visible before the matching `CONTROL_REPLY`.
+- Register-family controls and `UNREGISTER_CALLABLE` serialize with TASK
+  dispatch on the same endpoint. A successful commit reply happens-before later
+  TASK frames that use the hashid. A successful final-unregister reply
+  happens-before later same-hashid re-registration or dispatch on the affected
+  endpoint.
+- Health messages may be observed while a TASK is running, but they must not
+  expose or mutate task, callable, buffer, or domain state.
+
+RoCE and HCCS can satisfy this with SEND/RECV ordering plus explicit flush or
+completion requirements. UB LD/ST paths require explicit memory fences around
+doorbell and completion state transitions.
+
+## Bounds and Fuzz Tests
+
+The frame codec must reject:
+
+- bad magic or unsupported version;
+- payload length larger than configured maximum;
+- truncated frame headers or payloads;
+- tensor/scalar counts that overflow decoded payload size;
+- descriptor offsets outside the referenced handle;
+- `HOST_INLINE` payload offsets or lengths outside the inline byte arena;
+- non-`HOST_INLINE` descriptors with non-zero inline payload lengths;
+- non-zero `ContinuousTensorWire.data` in remote TASK frames;
+- stale generations;
+- unknown control names or control versions;
+- completion sequence mismatch;
+- control reply sequence or control-name mismatch.

--- a/docs/scheduler.md
+++ b/docs/scheduler.md
@@ -22,9 +22,10 @@ The Scheduler's job:
   submitted slots; if all producers are already done, promote to the ready queue.
 - Drain the **ready queue** (Phase 1): for each ready slot, pick an idle
   `WorkerThread` from the appropriate pool and hand off.
-- Drain the **completion queue** (Phase 2): for each completed slot, release
-  its fanout references, wake downstream consumers, and (if all refs
-  released) retire the ring slot.
+- Drain the **completion queue** (Phase 2): for each worker completion,
+  transition the slot to `COMPLETED` or `FAILED`, release fanout references,
+  wake or poison downstream consumers, and (if all refs released) retire the
+  ring slot.
 
 One Scheduler per `Worker` instance, one thread per Scheduler. The Scheduler
 **does not inspect task data** — it moves slot ids between queues and
@@ -48,9 +49,9 @@ class Scheduler {
     ReadyQueue *ready_next_level_queue_;
     ReadyQueue *ready_sub_queue_;
 
-    // Producer: WorkerThread (on worker->run() return).
+    // Producer: WorkerThread (on endpoint->run() return).
     // Consumer: Scheduler's own loop, Phase 2.
-    LockFreeQueue<TaskSlot> completion_queue_;
+    std::queue<WorkerCompletion> completion_queue_;
 };
 ```
 
@@ -96,9 +97,12 @@ for the other.
 
 ### Completion queue
 
-Slots whose worker returned. The Scheduler runs completion handling
-(fanout release, downstream wake, try_consume) in its own thread so that
-WorkerThreads can immediately return to their next task.
+Endpoint completions whose worker returned or failed. Each
+`WorkerCompletion` carries `{slot, group_index, outcome, error_message}`;
+`outcome` is success, task failure, endpoint failure, or skipped. The
+Scheduler runs completion handling (fanout release, downstream wake/poison,
+try_consume) in its own thread so that WorkerThreads can immediately return to
+their next task.
 
 ---
 
@@ -117,8 +121,9 @@ void Scheduler::run() {
         dispatch_ready();
 
         // Phase 2: completion
-        while (completion_queue_.try_pop(sid)) {
-            on_task_complete(sid);   // see §6
+        WorkerCompletion c;
+        while (completion_queue_.try_pop(c)) {
+            on_task_complete(c);   // see §6
         }
 
         // If all three queues empty, block on a condition variable until
@@ -150,9 +155,14 @@ void Scheduler::wire_fanout(const WiringEntry &w) {
     for (TaskSlot psid : w.producers) {
         TaskSlotState &p = slots_[psid];
         std::lock_guard lk(p.fanout_mu);
-        // If producer has already reached COMPLETED/CONSUMED, its fanout is
-        // already finalized — consumer sees it as "done", no edge to add.
-        if (p.state.load() >= TaskState::COMPLETED) continue;
+        // COMPLETED producers are already done; FAILED producers poison this
+        // consumer instead of making it ready.
+        if (p.state.load() == TaskState::COMPLETED ||
+            p.state.load() == TaskState::CONSUMED) continue;
+        if (p.state.load() == TaskState::FAILED) {
+            poison_task(csid, p.failure_message);
+            continue;
+        }
         p.fanout_consumers.push_back(csid);
         p.fanout_total++;
         actual_live++;
@@ -193,13 +203,26 @@ void Scheduler::dispatch_ready() {
             TaskSlotState &s = slots_[slot];
             int N = s.group_size();  // 1 for single-task slots
 
-            auto workers = manager_->pick_n_idle(s.worker_type, N);
+            std::vector<WorkerThread *> workers;
+            for (int i = 0; i < N; i++) {
+                WorkerThread *wt = nullptr;
+                int8_t affinity = s.get_affinity(i);
+                if (affinity >= 0) {
+                    wt = manager_->get_worker(s.worker_type, affinity);
+                    if (wt && (!wt->idle() || !s.endpoint_allowed(i, wt->endpoint_id())))
+                        wt = nullptr;
+                } else {
+                    wt = manager_->pick_idle_excluding_eligible(
+                        s.worker_type, workers, s.eligible_endpoints_for(i));
+                }
+                if (!wt) break;
+                workers.push_back(wt);
+            }
             if (static_cast<int>(workers.size()) < N) {
                 q->push(slot);   // put back; try again after a completion
                 break;
             }
-            // Slot stays in PENDING through dispatch; running-vs-idle is
-            // tracked via the worker's running_slot_state pointer.
+            s.state.store(TaskState::RUNNING);
             for (int i = 0; i < N; i++) {
                 workers[i]->dispatch({slot, i});
             }
@@ -216,29 +239,35 @@ Dispatch hands off a `WorkerDispatch {slot, group_index}` to a
 and encodes it into the per-WT mailbox — see
 [worker-manager.md](worker-manager.md) §3 for the dispatch protocol.
 
-**Pick-idle back-pressure**: when `pick_n_idle` returns fewer workers
-than the task needs, the slot is pushed back onto *its* queue and that
-queue's drain halts; the other-type queue's drain continues. The ring's
-back-pressure at the Orch side already caps the total number of
-in-flight tasks across both types.
+**Pick-idle back-pressure**: when the manager cannot provide enough idle
+workers that also satisfy affinity and endpoint eligibility, the slot is
+pushed back onto *its* queue and that queue's drain halts; the other-type
+queue's drain continues. The ring's back-pressure at the Orch side already
+caps the total number of in-flight tasks across both types.
+
+Endpoint eligibility is opaque scheduling metadata. The Scheduler compares
+endpoint ids and capability bits exposed through `WorkerEndpoint::caps()`, but
+does not inspect HCOMM, RDMA, socket, or remote buffer internals.
 
 ---
 
 ## 6. Phase 2 — completion
 
-Called by `WorkerThread::on_complete_(sid)` which pushes to
+Called by `WorkerThread::on_complete_(completion)` which pushes to
 `completion_queue_`. The Scheduler then:
 
 ```cpp
-void Scheduler::on_task_complete(TaskSlot sid) {
+void Scheduler::on_task_complete(const WorkerCompletion &completion) {
+    TaskSlot sid = completion.task_slot;
     TaskSlotState &s = slots_[sid];
 
-    // Group tasks require all sub-workers to finish
+    // Group tasks aggregate per-member outcomes before the slot is terminal.
     if (s.group_size > 0) {
-        if (s.sub_complete_count.fetch_add(1) + 1 < s.group_size) return;
+        if (!record_group_member_completion(completion)) return;
     }
 
-    s.state.store(TaskState::COMPLETED);
+    bool failed = completion.outcome != EndpointOutcome::SUCCESS;
+    s.state.store(failed ? TaskState::FAILED : TaskState::COMPLETED);
 
     // Release fanout refs on downstream consumers
     std::vector<TaskSlot> consumers;
@@ -247,6 +276,10 @@ void Scheduler::on_task_complete(TaskSlot sid) {
         consumers = s.fanout_consumers;    // snapshot (mutex protects vector)
     }
     for (TaskSlot csid : consumers) {
+        if (failed) {
+            poison_task(csid, completion.error_message);
+            continue;
+        }
         TaskSlotState &c = slots_[csid];
         if (++c.fanin_released == c.fanin_count) {
             // Strict-4: push to the queue matching the *consumer's*
@@ -268,7 +301,8 @@ void Scheduler::on_task_complete(TaskSlot sid) {
 ```cpp
 void Scheduler::try_consume(TaskSlot sid) {
     TaskSlotState &s = slots_[sid];
-    if (s.state.load() != TaskState::COMPLETED) return;
+    if (s.state.load() != TaskState::COMPLETED &&
+        s.state.load() != TaskState::FAILED) return;
     if (s.fanout_released.load() != s.fanout_total) return;
 
     s.state.store(TaskState::CONSUMED);
@@ -318,13 +352,12 @@ void Scheduler::stop() {
 ## 8. Completion channel from WorkerThread
 
 ```cpp
-// In WorkerThread, after the mailbox round-trip returns TASK_DONE:
+// In WorkerThread, after endpoint->run() returns:
 void WorkerThread::loop() {
     for (;;) {
         TaskSlot sid = queue_.pop();
-        // dispatch_process: encode mailbox, spin-poll TASK_DONE
-        // (see worker-manager.md §3 for the mailbox protocol)
-        scheduler_->completion_queue_.push(sid);   // notify Scheduler
+        WorkerCompletion c = endpoint_->run(ring_, {sid, group_index});
+        scheduler_->completion_queue_.push(c);   // notify Scheduler
     }
 }
 ```
@@ -341,14 +374,19 @@ by completion-handling cost.
 1. **Scheduler is single-threaded**: all three phase handlers run in the
    Scheduler's own thread. Atomics/mutexes on slot state are only needed for
    Orch/WorkerThread ↔ Scheduler coordination.
-2. **Slot transitions are monotonic**: `FREE → PENDING → COMPLETED →
-   CONSUMED` never reverses within one allocation.
+2. **Slot transitions are monotonic**: success follows
+   `FREE → PENDING → READY → RUNNING → COMPLETED → CONSUMED`; failure follows
+   `FREE → PENDING/READY/RUNNING → FAILED → CONSUMED`.
 3. **Dispatch consumes one ready entry**: every `ready_queue.push` is
    matched by exactly one `pick_idle + dispatch`. Group tasks push once,
    dispatch N times via `pick_n_idle`.
-4. **Completion is per-worker for groups**: `on_task_complete` is called
-   `group_size` times; only the last one triggers the actual transition.
-5. **`try_consume` is idempotent on CONSUMED**: a repeated call after
+4. **Completion is per-worker for groups**: `worker_done` is called
+   `group_size` times; only the terminal aggregate pushes one slot completion.
+   If any member fails, not-yet-dispatched members become skipped and already
+   running members are allowed to finish.
+5. **Failed producers poison consumers**: consumers of a failed producer move
+   to `FAILED`, are never dispatched, and still run normal cleanup.
+6. **`try_consume` is idempotent on CONSUMED**: a repeated call after
    CONSUMED is a no-op.
 
 ---

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -60,11 +60,16 @@ to C++:
 | ------- | --------- | ----------------- |
 | `w3.submit_next_level(handle, …)` dispatched to a chip child | `LOCAL_CHIP` | child resolves digest to its private chip slot, then calls `ChipWorker::run(local_slot, …)` |
 | `w4.submit_next_level(handle, …)` dispatched to an L3 `Worker` child | `LOCAL_PYTHON` | child resolves digest to an orchestration function and calls `inner_worker.run(orch_fn, …)` |
+| remote `w4.submit_next_level(handle, …)` dispatched to remote L3 | `REMOTE_TASK_DISPATCHER` | remote endpoint resolves digest in its dispatcher registry and calls its embedded L3 Worker |
 | `w3.submit_sub(handle, …)` dispatched to a SUB child | `LOCAL_PYTHON` | child resolves digest to a Python callable and calls `fn(args)` |
 
 All three paths share one mailbox wire format: `MAILBOX_OFF_CALLABLE` is
 reserved, and the 32-byte digest prefixes the args blob. The receiving child
 does the digest-to-slot resolve in its own address space.
+
+The proposed remote L3 path keeps the same callable identity contract, but
+sends it in a versioned TASK frame. The remote endpoint resolves the digest
+against its own registry after it has reported `HELLO READY`.
 
 ### Lifetime — materialize before dispatch
 
@@ -72,6 +77,15 @@ Pre-start registration is captured in the startup snapshot inherited by child
 processes. Post-start registration uses the local control plane and completes
 only after every active target in scope has installed the digest or reported
 failure. A task is dispatched only after registration succeeds.
+
+Remote L3 cannot rely on fork-time COW inheritance. Remote callable
+registration uses explicit descriptors: required `PYTHON_IMPORT` paths,
+optional negotiated PR #839 serialized Python callable payloads, and
+`CHIP_CALLABLE` payloads for inner L3 chip work. A remote callable identity
+becomes visible only after the selected endpoint replies success.
+The current Python surface implements `RemoteCallable("module:qualname")` as
+the required `PYTHON_IMPORT` baseline and requires an explicit `workers=[...]`
+list naming remote endpoint ids.
 
 ---
 
@@ -98,6 +112,13 @@ public:
 
 `TensorArgType` has five values (matches existing `tensor_arg.h:53-59`):
 `INPUT`, `OUTPUT`, `INOUT`, `OUTPUT_EXISTING`, `NO_DEP`.
+
+For remote L3 submits, public Python uses `RemoteTaskArgs` as a wrapper around
+the same `TaskArgs` builder. Each `RemoteTensorRef` appends a normal
+`ContinuousTensor` metadata entry with `data == 0` plus a hidden remote
+sidecar at the same tensor index. The local mailbox path rejects non-empty
+remote sidecars; the remote framed path encodes the sidecar as a
+`RemoteTensorDescWire`.
 
 ### Representation at each phase
 
@@ -159,7 +180,7 @@ View does **not** own memory. Valid for the duration of a single
      ▼
 ② slot.task_args: TaskArgs           — parent heap, stored in slot
      │
-     │ WorkerThread::dispatch_process: memcpy into shm mailbox blob
+     │ LocalMailboxEndpoint::run: memcpy into shm mailbox blob
      │   layout = [int32 T][int32 S][ContinuousTensor × T][uint64 × S]
      ▼
 ③ shm mailbox bytes (MAP_SHARED)     — visible to forked child
@@ -189,6 +210,7 @@ struct CallConfig {
     int32_t enable_dump_tensor = 0;
     int32_t enable_pmu = 0;           // 0 = disabled; >0 selects PMU event type
     int32_t enable_dep_gen = 0;
+    int32_t enable_scope_stats = 0;
     char    output_prefix[1024] = {};
     // future fields here - same POD used at all levels
 };
@@ -198,10 +220,13 @@ Propagated by value throughout:
 
 1. User builds `CallConfig` and passes into `submit_next_level`
 2. Orchestrator stores it inline in `slot.config` (POD copy)
-3. Dispatch: `WorkerThread::dispatch_process` memcpys the slot's `CallConfig`
+3. Dispatch: `LocalMailboxEndpoint::run` memcpys the slot's `CallConfig`
    into the shm mailbox
-4. Child reads `CallConfig` from mailbox by value
-5. `ChipWorker::run` receives `const CallConfig&`; passed on to
+4. Remote dispatch: `RemoteL3Endpoint::run` encodes the fields into
+   `CallConfigWire` instead of memcpying the POD
+5. Child reads `CallConfig` from mailbox by value, or the remote session
+   runner reconstructs it from `CallConfigWire`
+6. `ChipWorker::run` receives `const CallConfig&`; passed on to
    `pto2_run_runtime` at the L2 edge
 
 Same type at every level. Used directly at the L2 runtime ABI.
@@ -257,7 +282,10 @@ dispatches to an L3 child, the child process runs `_child_worker_loop`,
 which resolves the digest to the registered orch fn and calls
 `inner_worker.run(orch_fn, args, config)` — i.e. the L3 `Worker.run`
 Python method, not a C++ leaf. The kernel-running leaves stay at L2
-(`ChipWorker`); higher levels just compose more scheduling engines.
+(`ChipWorker`); higher levels just compose more scheduling engines. A remote
+L3 session runner follows the same execution shape after it has prestarted its
+inner L3 Worker, but task/control/completion bytes travel through the remote
+framed protocol instead of the local mailbox.
 
 ---
 
@@ -349,16 +377,18 @@ reclaim independently of outer-scope tasks. See
 ## 8. Data flow on completion
 
 When the child finishes the kernel, it writes `TASK_DONE` to the mailbox;
-the parent's `WorkerThread::dispatch_process` exits its spin-poll and
-calls `on_complete_(slot_id)`, which pushes the slot onto
-`Scheduler::completion_queue_`.
+`LocalMailboxEndpoint::run` exits its spin-poll, reads the mailbox error
+fields, and returns a `WorkerCompletion`. `MAILBOX_OFF_ERROR == 0` maps to
+success; a non-zero child error maps to task failure. The parent
+`WorkerThread` pushes that completion onto `Scheduler::completion_queue_`.
 
 At this point:
 
 - Tensor output data is already written to shm (kernel wrote via
   `ContinuousTensor.data` pointer → shm page visible to parent)
-- Control returns to the Scheduler, which releases fanout refs and wakes
-  downstream consumers
+- Control returns to the Scheduler, which marks the slot `COMPLETED` on
+  success or `FAILED` on task/endpoint failure, then releases fanout refs and
+  either wakes or poisons downstream consumers
 
 For the completion-side mechanics (fanout release, `try_consume`, ring
 release), see [scheduler.md](scheduler.md) §6.
@@ -369,8 +399,8 @@ release), see [scheduler.md](scheduler.md) §6.
 
 A higher-level `Worker` registers a lower-level `Worker` as a
 NEXT_LEVEL child via a mailbox just like L3 does for `ChipWorker`. The
-parent side is uniform — `WorkerThread::dispatch_process` doesn't care
-what kind of child is on the other end of the mailbox. The forked
+parent side is uniform — `WorkerThread` calls the endpoint `run()` contract and
+doesn't care what kind of child is on the other end. The local forked
 child runs `_child_worker_loop`, which resolves each dispatched digest and
 delegates to
 `inner_worker.run(...)` — i.e. another full scheduling engine inside.
@@ -440,7 +470,7 @@ L4 parent process
 | 8 | L3 sub child | child resolves digest to its local Python callable and executes `verify_result()` |
 | 9 | L3 drain | all L3 tasks complete; `scope_end` + `drain` return |
 | 10 | L3 child | `inner_worker.run()` returns; `_child_worker_loop` writes `TASK_DONE` |
-| 11 | L4 WorkerThread | sees `TASK_DONE`; calls `on_complete_(slot)` |
+| 11 | L4 LocalMailboxEndpoint | sees `TASK_DONE`; returns success completion |
 | 12 | L4 drain | L4 scope_end + drain; `w4.run()` returns |
 
 Each level's orch fn receives **its own** `Orchestrator` — the recursion is
@@ -489,7 +519,7 @@ Step-by-step (one chip worker):
 | 7 | `ChipWorker::run` | assemble `ChipStorageTaskArgs` POD (memcpy view); call `pto2_run_runtime(local_slot, &chip_storage, &cfg)` |
 | 8 | runtime.so | translate host ptrs → device ptrs; dispatch AICPU / AICore; write output into `c`'s shm |
 | 9 | chip_0 child | `run` returns; write `TASK_DONE` |
-| 10 | WT_chip_0 parent | see `TASK_DONE`; call `on_complete_(slot)` |
+| 10 | WT_chip_0 parent | see `TASK_DONE`; push success completion |
 | 11 | Scheduler | mark slot COMPLETED; fanout release (none in this DAG); scope_end will release scope ref |
 | 12 | `Worker::run` returns | user's `w3.run(...)` returns; `c` contains result in shm, visible to user |
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -6,16 +6,28 @@ slot. Older callable-id snippets below are historical shorthand for
 target-local internals. See
 [callable-identity-registration.md](callable-identity-registration.md).
 
-`WorkerManager` and `WorkerThread` together implement the **execution layer**
-of a `Worker` engine. `WorkerManager` owns two pools of `WorkerThread`s (one
-for next-level workers, one for sub workers); each `WorkerThread` drives a
-shared-memory mailbox that a forked Python child consumes — the child runs
-the real worker (a `ChipWorker` for NEXT_LEVEL, a Python callable for SUB)
-in its own address space.
+`WorkerManager`, `WorkerThread`, and `WorkerEndpoint` together implement the
+**execution layer** of a `Worker` engine. In today's local implementation,
+`WorkerManager` owns two pools of `WorkerThread`s (one for next-level workers,
+one for sub workers); each `WorkerThread` owns a `LocalMailboxEndpoint` that
+drives a shared-memory mailbox consumed by a forked Python child. The child
+runs the real worker (a `ChipWorker` for NEXT_LEVEL, a Python callable for
+SUB) in its own address space.
+
+The remote L3 design keeps this local fork/shm path behind
+`LocalMailboxEndpoint` and reserves the same `WorkerEndpoint` boundary for a
+framed `RemoteL3Endpoint` for cross-host NEXT_LEVEL children. A remote endpoint
+is not another child loop that polls the 4096-byte mailbox; it uses the
+contracts in
+[remote-l3-worker-design.md](remote-l3-worker-design.md).
+The current code includes that `RemoteL3Endpoint` boundary, a socket-backed
+simulation transport, and the daemon/session runner used by
+`Worker.add_remote_worker()` for sim remote L3 endpoints. HCOMM hardware
+profiles are still pending.
 
 For the high-level role of this layer among the three engine components, see
 [hierarchical_level_runtime.md](hierarchical_level_runtime.md). For what
-runs on the other side of the mailbox, see [task-flow.md](task-flow.md).
+runs on the other side of the local mailbox, see [task-flow.md](task-flow.md).
 For where dispatched tasks come from, see [scheduler.md](scheduler.md).
 
 ---
@@ -29,6 +41,7 @@ public:
     // MAP_SHARED region; the real worker (a `ChipWorker` for NEXT_LEVEL,
     // a Python callable for SUB) lives in the forked child.
     void add_next_level(void *mailbox);
+    void add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint);
     void add_sub       (void *mailbox);
 
     // Lifecycle
@@ -38,6 +51,10 @@ public:
     // Scheduler API
     WorkerThread *pick_idle(WorkerType type) const;
     std::vector<WorkerThread *> pick_n_idle(WorkerType type, int n) const;
+    WorkerThread *get_worker_by_endpoint_id(WorkerType type, int32_t endpoint_id) const;
+    WorkerThread *pick_idle_excluding_eligible(WorkerType type,
+                                               const std::vector<WorkerThread *> &exclude,
+                                               const std::vector<int32_t> &eligible_endpoint_ids) const;
 
 private:
     std::vector<void *> next_level_entries_;
@@ -53,6 +70,9 @@ private:
   calls
 - **Idle selection**: `pick_idle(type)` finds a WorkerThread whose queue is
   empty; returns nullptr if none available
+- **Endpoint eligibility**: remote-aware NEXT_LEVEL slots carry final eligible
+  endpoint ids. Scheduler dispatch calls `pick_idle_excluding_eligible()` so a
+  task cannot land on a worker that lacks the callable or tensor sidecars.
 
 ---
 
@@ -69,26 +89,29 @@ struct WorkerDispatch {
 class WorkerThread {
 public:
     void start(Ring *ring, WorkerManager *manager,
-               const std::function<void(TaskSlot)> &on_complete,
-               void *mailbox);
+               const std::function<void(WorkerCompletion)> &on_complete,
+               std::unique_ptr<WorkerEndpoint> endpoint);
     void stop();
     void dispatch(WorkerDispatch d);       // slot id + group sub-index
     bool idle() const;
+    const WorkerEndpointCaps &caps() const;
+    int32_t endpoint_id() const;
 
 private:
     Ring *ring_;                       // reads slot state via ring->slot_state(id)
-    void *mailbox_ = nullptr;          // MAP_SHARED region the child polls
+    std::unique_ptr<WorkerEndpoint> endpoint_;
     std::thread thread_;
     std::queue<WorkerDispatch> queue_;
     std::mutex mu_;
     std::condition_variable cv_;
 
     void loop();
-    void dispatch_process(TaskSlotState &s, int32_t group_index);
+    WorkerCompletion dispatch_process(WorkerDispatch d);
 };
 ```
 
-The WorkerThread's `std::thread` pumps the internal queue and drives the
+The WorkerThread's `std::thread` pumps the internal queue and calls
+`endpoint->run(...)` once per dispatch. `LocalMailboxEndpoint::run` drives the
 shm handshake — one mailbox round trip per dispatch. The forked child loop
 that consumes the mailbox lives in Python (`_chip_process_loop` /
 `_sub_worker_loop` in `python/simpler/worker.py`); the parent does not fork
@@ -107,17 +130,17 @@ group sub-index.
 
 ## 3. Dispatch via shm mailbox
 
-Each WorkerThread drives a `MAILBOX_SIZE`-byte `MAP_SHARED` region. The
-Python facade forks one child per mailbox **before** `WorkerManager::start()`
-(so the parent has only the Python main thread when fork runs, avoiding the
-classical "fork in a multi-threaded process" hazard) and the child polls
-the mailbox for the lifetime of the worker.
+Each `LocalMailboxEndpoint` drives a `MAILBOX_SIZE`-byte `MAP_SHARED` region.
+The Python facade forks one child per mailbox **before**
+`WorkerManager::start()` (so the parent has only the Python main thread when
+fork runs, avoiding the classical "fork in a multi-threaded process" hazard)
+and the child polls the mailbox for the lifetime of the worker.
 
 ### 3.1 Parent-side dispatch
 
 ```cpp
-void WorkerThread::dispatch_process(WorkerDispatch d) {
-    TaskSlotState &s = *ring_->slot_state(d.task_slot);
+WorkerCompletion LocalMailboxEndpoint::run(Ring *ring, WorkerDispatch d) {
+    TaskSlotState &s = *ring->slot_state(d.task_slot);
     char *m = static_cast<char *>(mailbox_);
 
     // Write task data: reserved callable field, config, digest prefix, then
@@ -139,7 +162,10 @@ void WorkerThread::dispatch_process(WorkerDispatch d) {
 
     int err = read_error(mailbox_);
     write_state(mailbox_, MailboxState::IDLE);
-    on_complete_(d.task_slot, err);
+    return err == 0
+        ? WorkerCompletion{d.task_slot, d.group_index, EndpointOutcome::SUCCESS, ""}
+        : WorkerCompletion{d.task_slot, d.group_index, EndpointOutcome::TASK_FAILURE,
+                           read_error_msg(mailbox_)};
 }
 ```
 
@@ -149,6 +175,7 @@ Parent-side cost per dispatch:
   TaskArgs blob
 - One signal (`write_state`)
 - Poll loop with `sleep_for(50us)` (not busy-wait)
+- One explicit completion outcome: success, task failure, or endpoint failure
 
 Total ~nanoseconds overhead; the wait is dominated by actual kernel execution.
 
@@ -186,28 +213,37 @@ possible so the two sides cannot drift silently.
 ### 3.4 Shutdown
 
 `WorkerManager::shutdown_children()` writes `SHUTDOWN` to every registered
-mailbox; each child loop sees it on its next poll and exits. The Python
-facade owns the child PIDs and calls `waitpid()` after writing `SHUTDOWN`
-to its own mailbox copy. The parent's `WorkerThread::stop()` only joins
-the C++ dispatcher thread — it does not own the child process.
+endpoint; for `LocalMailboxEndpoint` this writes `SHUTDOWN` to the mailbox.
+Each child loop sees it on its next poll and exits. The Python facade owns the
+child PIDs and calls `waitpid()` after writing `SHUTDOWN` to its own mailbox
+copy. The parent's `WorkerThread::stop()` only joins the C++ dispatcher thread
+— it does not own the child process.
 
 ---
 
-## 4. Adding a new worker kind
+## 4. Local vs. Remote Endpoints
 
-To add a new worker type (e.g., a RemoteWorker over RPC):
+The mailbox protocol is the local endpoint contract. Adding another local
+forked worker kind still follows the existing pattern:
 
-1. Define the kernel-running entry point (a C++ class with a `run` method
-   or a Python callable — there is no abstract interface to inherit from).
-2. Write a child-process loop (mirroring `_chip_process_loop` or
-   `_sub_worker_loop`) that polls the mailbox, decodes the args blob, and
-   invokes that entry point.
-3. Register the per-child mailbox via `manager.add_next_level(mailbox)`
-   or `manager.add_sub(mailbox)`.
+1. Define the worker entry point.
+2. Write a child-process loop that polls the mailbox, decodes the args blob,
+   and invokes that entry point.
+3. Register the mailbox via `manager.add_next_level(mailbox)` or
+   `manager.add_sub(mailbox)`.
 
-The parent side (WorkerManager / WorkerThread) doesn't change — it
-only knows the mailbox protocol, not who runs the kernel on the other
-end.
+Remote L3 is different. It cannot reuse the mailbox wire format because the
+remote side does not share virtual addresses, fork-time COW registries, POSIX
+shm names, or parent-visible child PIDs. The remote design introduces a
+transport-neutral endpoint under `WorkerThread`: `LocalMailboxEndpoint` wraps
+this local mailbox path, while `RemoteL3Endpoint` sends framed TASK, CONTROL,
+COMPLETION, HEALTH, and SHUTDOWN messages over the negotiated transport.
+
+The implemented `RemoteL3Endpoint` sends TASK and CONTROL frames, waits for
+COMPLETION and CONTROL_REPLY frames through `RemoteL3Transport`, and monitors
+an independent simulation health lane. Python remote worker specs open a
+session through `simpler-remote-worker`; the endpoint is schedulable only after
+the session runner reports `HELLO READY`.
 
 ### 4.1 Nested fork ordering (L4+ Worker children)
 


### PR DESCRIPTION
## Summary

This is PR 1 of the remote L3 worker split stack. It adds the document
contract for the remote L3 worker design and the audit artifacts used to split
the original large remote L3 branch into smaller, reviewable PRs.

The intent of this PR is to make the contract reviewable before the code that
implements it lands. Later PRs in the stack should be reviewed against these
documents.


  ## Relationship to PR #866 and split stack

  This PR is part of the split stack extracted from #866.

  Stack:
  - #1006: docs: add remote L3 worker contract
  - #1007: feat: add remote import callable descriptors
  - #1008: feat: add remote L3 wire codec
  - #1009: feat: add remote endpoint eligibility scheduling
  - #1010: feat: add remote L3 endpoint facade
  - #1011: feat: add remote L3 Python session runtime

  The top of the stack was verified to match the corrected `remote-l3-worker-design`
  branch content from #866, excluding empty CI retrigger commits.


## Stack position

- Base: `main`
- Head: `remote-l3-split-docs`
- Next PR: `remote-l3-split-callable-identity`

## Scope

This PR documents:

- The remote L3 worker model and the host/session/worker responsibilities.
- The remote L3 protocol surface, including frames, task submission,
  completion, control messages, health, and reserved fields.
- Buffer and transport responsibilities, including ownership, import,
  release, and future transport work.
- Updates to scheduler, orchestrator, worker-manager, task-flow, and
  hierarchical runtime documents so remote endpoints fit the existing runtime
  model.
- The split and audit plan used to divide the original remote L3 branch.
- Audit artifacts: compliance matrix, split map, risk register,
  verification checklist, and future-work list.

## Requirements covered

This PR establishes the source of truth for the rest of the stack:

- Separates required behavior from explicitly unsupported behavior.
- Marks hardware HCOMM profiles as future work for this split.
- Keeps Remote CommDomain support reserved for a later PR instead of exposing a
  partial implementation.
- Requires unsupported or reserved protocol paths to fail explicitly.
- Records the expected review boundaries for callable identity, wire codec,
  scheduler eligibility, C++ remote endpoint, and Python session runtime work.

## Important exclusions

This PR intentionally does not implement runtime behavior. It only defines the
contract and review artifacts. The implementation arrives in later stacked PRs.

The following remain future work unless a later dedicated PR changes the
contract:

- A2 RoCE hardware profile support.
- A3 HCCS hardware profile support.
- A5 UB HCOMM hardware profile support.
- Remote CommDomain support.

## Verification

- Documentation-only split PR.
- The split plan was used to audit the original branch before opening child
  PRs.
- The audit artifacts map requirements, implementation files, tests, known
  risks, and future work before code is introduced in the stack.

## Reviewer notes

Please review this PR first. Later implementation PRs should not be treated as
complete unless their behavior matches the contract introduced here or the
contract is explicitly updated.



