### PR TITLE
feat: add remote import callable descriptors

### DIFF
--- a/python/simpler/callable_identity.py
+++ b/python/simpler/callable_identity.py
@@ -22,11 +22,13 @@ CALLABLE_DESCRIPTOR_SCHEMA_VERSION = 1
 CALLABLE_HASH_DIGEST_BYTES = 32
 CALLABLE_KIND_CHIP = 1
 CALLABLE_KIND_PYTHON_SERIALIZED = 2
+CALLABLE_KIND_PYTHON_IMPORT = 3
 TARGET_NAMESPACE_LOCAL_CHIP = "LOCAL_CHIP"
 TARGET_NAMESPACE_LOCAL_PYTHON = "LOCAL_PYTHON"
+TARGET_NAMESPACE_REMOTE_TASK_DISPATCHER = "REMOTE_TASK_DISPATCHER"
 
-CallableKindName = Literal["CHIP_CALLABLE", "PYTHON_SERIALIZED"]
-TargetNamespaceName = Literal["LOCAL_CHIP", "LOCAL_PYTHON"]
+CallableKindName = Literal["CHIP_CALLABLE", "PYTHON_SERIALIZED", "PYTHON_IMPORT"]
+TargetNamespaceName = Literal["LOCAL_CHIP", "LOCAL_PYTHON", "REMOTE_TASK_DISPATCHER"]
 
 __all__ = [
     "CALLABLE_HASH_DIGEST_BYTES",
@@ -35,9 +37,11 @@ __all__ = [
     "TargetNamespaceName",
     "build_chip_callable_descriptor",
     "build_chip_signature_schema",
+    "build_python_import_descriptor",
     "build_python_serialized_descriptor",
     "compute_callable_hashid",
     "hashid_to_digest",
+    "parse_python_import_target",
     "parse_python_callable_payload",
     "validate_hashid",
 ]
@@ -63,6 +67,14 @@ def _pack_string(value: str) -> bytes:
 
 def _pack_bytes(value: bytes) -> bytes:
     return _pack_u32(len(value)) + value
+
+
+def _validate_dotted_ident(value: str, *, field_name: str) -> None:
+    parts = value.split(".")
+    if any(not part for part in parts):
+        raise ValueError(f"{field_name} must contain non-empty dot-separated identifiers")
+    if any(not part.isidentifier() for part in parts):
+        raise ValueError(f"{field_name} contains a non-identifier component: {value!r}")
 
 
 def _sha256_digest(data: bytes) -> bytes:
@@ -144,6 +156,34 @@ def build_python_serialized_descriptor(payload: bytes) -> bytes:
     return bytes(data)
 
 
+def parse_python_import_target(target: str) -> tuple[str, str]:
+    if not isinstance(target, str):
+        raise TypeError("RemoteCallable target must be a string")
+    normalized = target.strip(" \t\r\n")
+    if normalized.count(":") != 1:
+        raise ValueError("RemoteCallable target must have exactly one ':' separator")
+    module, qualname = normalized.split(":", 1)
+    if not module or not qualname:
+        raise ValueError("RemoteCallable module and qualname must be non-empty")
+    if module.startswith("."):
+        raise ValueError("RemoteCallable module must be absolute")
+    if "<locals>" in qualname.split("."):
+        raise ValueError("RemoteCallable qualname must not contain <locals>")
+    _validate_dotted_ident(module, field_name="RemoteCallable module")
+    _validate_dotted_ident(qualname, field_name="RemoteCallable qualname")
+    return module, qualname
+
+
+def build_python_import_descriptor(module: str, qualname: str) -> bytes:
+    parse_python_import_target(f"{module}:{qualname}")
+    data = bytearray()
+    data += _pack_u32(CALLABLE_DESCRIPTOR_SCHEMA_VERSION)
+    data += _pack_u32(CALLABLE_KIND_PYTHON_IMPORT)
+    data += _pack_string(module)
+    data += _pack_string(qualname)
+    return bytes(data)
+
+
 def compute_callable_hashid(descriptor: bytes) -> str:
     return _sha256_hashid(descriptor)
 
@@ -205,9 +245,13 @@ class CallableHandle:
         return handle
 
     def _validate_public_fields(self) -> None:
-        if self.kind not in ("CHIP_CALLABLE", "PYTHON_SERIALIZED"):
+        if self.kind not in ("CHIP_CALLABLE", "PYTHON_SERIALIZED", "PYTHON_IMPORT"):
             raise ValueError(f"CALLABLE_KIND_UNSUPPORTED: {self.kind}")
-        if self.target_namespace not in (TARGET_NAMESPACE_LOCAL_CHIP, TARGET_NAMESPACE_LOCAL_PYTHON):
+        if self.target_namespace not in (
+            TARGET_NAMESPACE_LOCAL_CHIP,
+            TARGET_NAMESPACE_LOCAL_PYTHON,
+            TARGET_NAMESPACE_REMOTE_TASK_DISPATCHER,
+        ):
             raise ValueError(f"unsupported callable target namespace: {self.target_namespace}")
 
     @property

--- a/tests/ut/py/test_callable_identity.py
+++ b/tests/ut/py/test_callable_identity.py
@@ -16,9 +16,11 @@ from simpler.callable_identity import (
     CallableKindName,
     TargetNamespaceName,
     build_chip_callable_descriptor,
+    build_python_import_descriptor,
     build_python_serialized_descriptor,
     compute_callable_hashid,
     hashid_to_digest,
+    parse_python_import_target,
     validate_hashid,
 )
 from simpler.task_interface import ChipCallable
@@ -46,6 +48,36 @@ def test_chip_descriptor_changes_when_callable_blob_changes():
     assert compute_callable_hashid(build_chip_callable_descriptor(target=first)) != compute_callable_hashid(
         build_chip_callable_descriptor(target=second)
     )
+
+
+def test_python_import_descriptor_hash_is_stable():
+    module, qualname = parse_python_import_target("pkg.mod:Class.method")
+    descriptor = build_python_import_descriptor(module, qualname)
+
+    assert (module, qualname) == ("pkg.mod", "Class.method")
+    assert compute_callable_hashid(descriptor) == compute_callable_hashid(
+        build_python_import_descriptor("pkg.mod", "Class.method")
+    )
+    assert len(hashid_to_digest(compute_callable_hashid(descriptor))) == 32
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "pkg.mod.fn",
+        ":fn",
+        "pkg:",
+        ".pkg:fn",
+        "pkg..mod:fn",
+        "pkg.mod:Class..method",
+        "pkg.mod:<locals>.fn",
+        "pkg.mod:bad-name",
+        object(),
+    ],
+)
+def test_python_import_target_validation_rejects_invalid_targets(target):
+    with pytest.raises((TypeError, ValueError)):
+        parse_python_import_target(target)
 
 
 @pytest.mark.parametrize("hashid", ["", "sha256:ABC", "md5:" + "0" * 64, "sha256:" + "0" * 63])
@@ -89,6 +121,19 @@ def test_callable_handle_public_constructor_returns_unbound_handle():
     assert handle._owner_id is None
     assert not hasattr(handle, "slot_id")
     assert not hasattr(handle, "cid")
+
+
+def test_callable_handle_accepts_remote_dispatcher_import_namespace():
+    descriptor = build_python_import_descriptor("pkg.mod", "remote_entry")
+    handle = CallableHandle(
+        compute_callable_hashid(descriptor),
+        cast(CallableKindName, "PYTHON_IMPORT"),
+        cast(TargetNamespaceName, "REMOTE_TASK_DISPATCHER"),
+    )
+
+    assert handle.kind == "PYTHON_IMPORT"
+    assert handle.target_namespace == "REMOTE_TASK_DISPATCHER"
+    assert handle.digest == hashid_to_digest(handle.hashid)
 
 
 def test_forged_public_handle_is_rejected_by_worker_apis():


### PR DESCRIPTION
## Summary

This is PR 2 of the remote L3 worker split stack. It adds the callable identity
and run-contract pieces needed before remote registration can safely reference
Python callables across process boundaries.

The main purpose is to make callable descriptors stable, target-scoped, and
testable without introducing the remote wire protocol or remote endpoint
runtime yet.

  ## Relationship to PR #866 and split stack

  This PR is part of the split stack extracted from #866.

  Stack:
  - #1006: docs: add remote L3 worker contract
  - #1007: feat: add remote import callable descriptors
  - #1008: feat: add remote L3 wire codec
  - #1009: feat: add remote endpoint eligibility scheduling
  - #1010: feat: add remote L3 endpoint facade
  - #1011: feat: add remote L3 Python session runtime

  The top of the stack was verified to match the corrected `remote-l3-worker-design`
  branch content from #866, excluding empty CI retrigger commits.


## Stack position

- Base: `remote-l3-split-docs`
- Head: `remote-l3-split-callable-identity`
- Previous PR: `remote-l3-split-docs`
- Next PR: `remote-l3-split-remote-wire`

## Scope

This PR adds or updates:

- Python import callable descriptors.
- Callable digest/hashid identity helpers.
- Target namespace handling for callable identity.
- `ChipWorker.prepare_callable()` handle semantics.
- `ChipWorker.run()` / `Worker.run()` timing return contract.
- Focused Python unit coverage for descriptor stability, registration
  lifecycle, rollback, unregister, and timing introspection.

## Requirements covered

This PR covers the callable identity requirements from the remote L3 contract:

- Callable identity is described by importable module/name descriptors.
- Digest/hashid generation is stable for equivalent descriptors.
- Target-private slots are not exposed as public routing IDs.
- Prepare/register rollback does not leave a visible prepared callable after a
  failed registration path.
- Unregister behavior respects references and removes only the intended
  prepared callable state.
- The existing run timing introspection contract remains available to callers.

## Why this is separate

Remote workers need to refer to callables by a stable identity before the wire
protocol can submit work to them. Splitting this first keeps the callable
contract reviewable without mixing it with serialization, scheduler, endpoint,
or session-runtime concerns.

## Important exclusions

This PR intentionally does not add:

- Remote wire frame encoding.
- Remote endpoint scheduling.
- C++ `RemoteL3Endpoint`.
- Python remote session or daemon runtime.
- Hardware HCOMM profiles.

Those are handled by later PRs in the stack.

## Verification

Targeted verification already run during the split:

- Callable identity Python unit tests: passed.
- Task interface Python unit coverage relevant to run timing and callable
  preparation: passed.

The split keeps tests with the feature under test so this PR can be reviewed
and validated independently of later remote runtime work.

## Reviewer notes

The key review question for this PR is whether the callable identity contract is
stable enough for a later remote process to register and run the same callable
without exposing local slot IDs as part of the public protocol.
