### PR TITLE
feat: add remote l3 wire codec

### DIFF
--- a/python/simpler/remote_l3_protocol.py
+++ b/python/simpler/remote_l3_protocol.py
@@ -328,6 +328,21 @@ def _validate_access_flags(flags: int, field_name: str) -> None:
         raise ValueError(f"remote_wire: {field_name} contains unknown bits")
 
 
+def _validate_export_result_identity(result: ExportBufferResult) -> None:
+    if result.owner_endpoint_id < 0 or result.buffer_id == 0 or result.generation == 0:
+        raise ValueError("remote_wire: export result requires live owner buffer identity")
+
+
+def _validate_import_result_identity(result: ImportBufferResult) -> None:
+    if (
+        result.importer_endpoint_id < 0
+        or result.owner_endpoint_id < 0
+        or result.buffer_id == 0
+        or result.generation == 0
+    ):
+        raise ValueError("remote_wire: import result requires live imported buffer identity")
+
+
 def encode_frame(header: FrameHeader, payload: bytes) -> bytes:
     if len(payload) > MAX_FRAME_PAYLOAD_BYTES:
         raise ValueError("remote_wire: frame payload exceeds maximum")
@@ -643,6 +658,7 @@ def decode_remote_chip_callable_payload(data: bytes) -> RemoteChipCallablePayloa
 
 
 def encode_export_buffer_result(result: ExportBufferResult) -> bytes:
+    _validate_export_result_identity(result)
     _validate_access_flags(result.access_flags, "export result access_flags")
     if result.address_space not in (RemoteAddressSpace.REMOTE_WINDOW, RemoteAddressSpace.UB_LDST):
         raise ValueError("remote_wire: export result address_space is invalid")
@@ -718,6 +734,7 @@ def decode_export_buffer_result(data: bytes) -> ExportBufferResult:
     if reader.u32() != 0:
         raise ValueError("remote_wire: export result reserved field must be zero")
     reader.done("export result")
+    _validate_export_result_identity(result)
     _validate_access_flags(result.access_flags, "export result access_flags")
     if result.address_space not in (RemoteAddressSpace.REMOTE_WINDOW, RemoteAddressSpace.UB_LDST):
         raise ValueError("remote_wire: export result address_space is invalid")
@@ -747,6 +764,7 @@ def decode_import_buffer_request(data: bytes) -> ImportBufferRequest:
 
 
 def encode_import_buffer_result(result: ImportBufferResult) -> bytes:
+    _validate_import_result_identity(result)
     _validate_access_flags(result.access_flags, "import result access_flags")
     if result.address_space not in (RemoteAddressSpace.REMOTE_WINDOW, RemoteAddressSpace.UB_LDST):
         raise ValueError("remote_wire: import result address_space is invalid")

--- a/python/simpler/remote_l3_protocol.py
+++ b/python/simpler/remote_l3_protocol.py
@@ -1,0 +1,820 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Python codec for the Remote L3 wire protocol used by session runners."""
+
+from __future__ import annotations
+
+import enum
+import socket
+import struct
+from dataclasses import dataclass
+
+from .task_interface import CONTINUOUS_TENSOR_MAX_DIMS, CallConfig, ContinuousTensor, DataType
+
+PROTOCOL_VERSION = 1
+MAX_FRAME_PAYLOAD_BYTES = 16 * 1024 * 1024
+MAX_STRING_BYTES = 1024
+MAX_ERROR_BYTES = 4096
+MAX_TENSORS = 4096
+MAX_SCALARS = 4096
+MAX_INLINE_PAYLOAD_BYTES = 1024 * 1024
+MAX_TRANSPORT_PROFILE_BYTES = 128
+MAX_TRANSPORT_DESCRIPTOR_BYTES = 4096
+MAX_CHIP_CALLABLE_DESCRIPTOR_BYTES = 4096
+MAX_STAGED_BLOB_TOKEN_BYTES = 1024
+REMOTE_BUFFER_ACCESS_READ = 1 << 0
+REMOTE_BUFFER_ACCESS_WRITE = 1 << 1
+REMOTE_BUFFER_ACCESS_READ_WRITE = REMOTE_BUFFER_ACCESS_READ | REMOTE_BUFFER_ACCESS_WRITE
+CALLABLE_HASH_DIGEST_BYTES = 32
+FRAME_HEADER_BYTES = 40
+MAGIC = b"SLR3"
+
+
+class FrameType(enum.IntEnum):
+    HELLO = 1
+    TASK = 2
+    CONTROL = 3
+    CONTROL_REPLY = 4
+    COMPLETION = 5
+    HEALTH = 6
+    SHUTDOWN = 7
+
+
+class ControlName(enum.IntEnum):
+    UNREGISTER_CALLABLE = 1
+    PREPARE_REGISTER_CALLABLE = 2
+    COMMIT_REGISTER_CALLABLE = 3
+    ABORT_REGISTER_CALLABLE = 4
+    PREPARE_CALLABLE = 5
+    ALLOC_REMOTE_BUFFER = 6
+    FREE_REMOTE_BUFFER = 7
+    COPY_TO_REMOTE = 8
+    COPY_FROM_REMOTE = 9
+    EXPORT_BUFFER = 10
+    IMPORT_BUFFER = 11
+    RELEASE_IMPORT = 12
+    COMM_INIT = 13
+    ALLOC_DOMAIN = 14
+    RELEASE_DOMAIN = 15
+
+
+class RemoteRegistryTarget(enum.IntEnum):
+    REMOTE_TASK_DISPATCHER = 1
+    INNER_L3_WORKER = 2
+
+
+class CallableKind(enum.IntEnum):
+    CHIP_CALLABLE = 1
+    PYTHON_SERIALIZED = 2
+    PYTHON_IMPORT = 3
+
+
+class ChipCallableBlobLocation(enum.IntEnum):
+    INLINE_BLOB = 1
+    STAGED_BLOB = 2
+
+
+class ReadyState(enum.IntEnum):
+    NOT_READY = 0
+    READY = 1
+
+
+class RemoteAddressSpace(enum.IntEnum):
+    HOST_INLINE = 1
+    REMOTE_DEVICE = 2
+    REMOTE_WINDOW = 3
+    UB_LDST = 4
+
+
+@dataclass(frozen=True)
+class FrameHeader:
+    frame_type: FrameType
+    session_id: int
+    endpoint_id: int
+    sequence: int
+    payload_bytes: int = 0
+    flags: int = 0
+
+
+@dataclass(frozen=True)
+class Frame:
+    header: FrameHeader
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class HelloPayload:
+    session_id: int
+    endpoint_id: int
+    protocol_version: int
+    comm_profile: str
+    feature_flags: int
+    ready_state: ReadyState
+
+
+@dataclass(frozen=True)
+class RemoteTensorDesc:
+    address_space: RemoteAddressSpace
+    owner_endpoint_id: int
+    buffer_id: int
+    offset: int
+    nbytes: int
+    remote_addr: int
+    rkey_or_token: int
+    generation: int
+    inline_payload_offset: int
+    inline_payload_len: int
+    flags: int
+
+
+@dataclass(frozen=True)
+class RemoteTensorSidecar:
+    present: bool
+    desc: RemoteTensorDesc | None = None
+
+
+@dataclass(frozen=True)
+class RemoteTaskArgsWire:
+    tensor_metadata: tuple[ContinuousTensor, ...]
+    remote_desc: tuple[RemoteTensorSidecar, ...]
+    scalars: tuple[int, ...]
+    inline_payload: bytes
+
+
+@dataclass(frozen=True)
+class TaskPayloadWire:
+    callable_digest: bytes
+    config: CallConfig
+    args: RemoteTaskArgsWire
+
+
+@dataclass(frozen=True)
+class ControlPayload:
+    control_name: ControlName
+    control_version: int
+    command_bytes: bytes
+
+
+@dataclass(frozen=True)
+class RegisterCallableCommand:
+    target_registry: RemoteRegistryTarget
+    callable_kind: CallableKind
+    digest: bytes
+    payload_version: int
+    payload: bytes
+
+
+@dataclass(frozen=True)
+class DigestCallableCommand:
+    target_registry: RemoteRegistryTarget
+    callable_kind: CallableKind
+    digest: bytes
+
+
+@dataclass(frozen=True)
+class ExportBufferRequest:
+    owner_endpoint_id: int
+    buffer_id: int
+    generation: int
+    offset: int
+    nbytes: int
+    access_flags: int
+    transport_profile: str
+
+
+@dataclass(frozen=True)
+class ExportBufferResult:
+    owner_endpoint_id: int
+    buffer_id: int
+    generation: int
+    address_space: RemoteAddressSpace
+    offset: int
+    nbytes: int
+    export_id: int
+    remote_addr: int
+    rkey_or_token: int
+    ub_ldst_va: int
+    access_flags: int
+    transport_profile: str
+    transport_descriptor: bytes
+
+
+@dataclass(frozen=True)
+class ImportBufferRequest:
+    importer_endpoint_id: int
+    requested_access_flags: int
+    export_desc: ExportBufferResult
+
+
+@dataclass(frozen=True)
+class ImportBufferResult:
+    importer_endpoint_id: int
+    owner_endpoint_id: int
+    buffer_id: int
+    generation: int
+    import_id: int
+    address_space: RemoteAddressSpace
+    offset: int
+    nbytes: int
+    remote_addr: int
+    rkey_or_token: int
+    ub_ldst_va: int
+    access_flags: int
+    transport_profile: str
+    import_descriptor: bytes
+
+
+@dataclass(frozen=True)
+class ReleaseImportRequest:
+    importer_endpoint_id: int
+    owner_endpoint_id: int
+    buffer_id: int
+    generation: int
+    import_id: int
+
+
+@dataclass(frozen=True)
+class RemoteChipCallablePayload:
+    descriptor_bytes: bytes
+    blob_location: ChipCallableBlobLocation
+    blob_size: int
+    blob_sha256: bytes
+    inline_blob: bytes
+    staged_blob_token: bytes
+
+
+class _Reader:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+        self.offset = 0
+
+    def require(self, n: int, what: str) -> None:
+        if self.offset > len(self.data) or n > len(self.data) - self.offset:
+            raise ValueError(f"remote_wire: truncated {what}")
+
+    def u8(self) -> int:
+        self.require(1, "uint8")
+        v = self.data[self.offset]
+        self.offset += 1
+        return v
+
+    def u32(self) -> int:
+        self.require(4, "uint32")
+        v = struct.unpack_from("<I", self.data, self.offset)[0]
+        self.offset += 4
+        return int(v)
+
+    def i32(self) -> int:
+        self.require(4, "int32")
+        v = struct.unpack_from("<i", self.data, self.offset)[0]
+        self.offset += 4
+        return int(v)
+
+    def u64(self) -> int:
+        self.require(8, "uint64")
+        v = struct.unpack_from("<Q", self.data, self.offset)[0]
+        self.offset += 8
+        return int(v)
+
+    def raw(self, n: int, what: str) -> bytes:
+        self.require(n, what)
+        out = self.data[self.offset : self.offset + n]
+        self.offset += n
+        return out
+
+    def string(self, max_bytes: int, field_name: str) -> str:
+        n = self.u32()
+        if n > max_bytes:
+            raise ValueError(f"remote_wire: {field_name} exceeds max length")
+        return self.raw(n, field_name).decode("utf-8")
+
+    def blob(self, max_bytes: int, field_name: str) -> bytes:
+        n = self.u32()
+        if n > max_bytes:
+            raise ValueError(f"remote_wire: {field_name} exceeds max length")
+        return self.raw(n, field_name)
+
+    def done(self, what: str) -> None:
+        if self.offset != len(self.data):
+            raise ValueError(f"remote_wire: trailing bytes after {what}")
+
+
+def _put_string(out: bytearray, value: str, max_bytes: int, field_name: str) -> None:
+    data = value.encode("utf-8")
+    if len(data) > max_bytes:
+        raise ValueError(f"remote_wire: {field_name} exceeds max length")
+    out.extend(struct.pack("<I", len(data)))
+    out.extend(data)
+
+
+def _put_blob(out: bytearray, value: bytes, max_bytes: int, field_name: str) -> None:
+    data = bytes(value)
+    if len(data) > max_bytes:
+        raise ValueError(f"remote_wire: {field_name} exceeds max length")
+    out.extend(struct.pack("<I", len(data)))
+    out.extend(data)
+
+
+def _validate_access_flags(flags: int, field_name: str) -> None:
+    if int(flags) == 0:
+        raise ValueError(f"remote_wire: {field_name} must be non-zero")
+    if int(flags) & ~REMOTE_BUFFER_ACCESS_READ_WRITE:
+        raise ValueError(f"remote_wire: {field_name} contains unknown bits")
+
+
+def encode_frame(header: FrameHeader, payload: bytes) -> bytes:
+    if len(payload) > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: frame payload exceeds maximum")
+    if header.flags != 0:
+        raise ValueError("remote_wire: frame flags are reserved in v1")
+    return (
+        MAGIC
+        + struct.pack(
+            "<IIQiQII",
+            PROTOCOL_VERSION,
+            int(header.frame_type),
+            int(header.session_id),
+            int(header.endpoint_id),
+            int(header.sequence),
+            len(payload),
+            int(header.flags),
+        )
+        + payload
+    )
+
+
+def decode_frame(data: bytes) -> Frame:
+    if len(data) < FRAME_HEADER_BYTES:
+        raise ValueError("remote_wire: truncated frame header")
+    if data[:4] != MAGIC:
+        raise ValueError("remote_wire: bad frame magic")
+    version, raw_type, session_id, endpoint_id, sequence, payload_bytes, flags = struct.unpack_from("<IIQiQII", data, 4)
+    if version != PROTOCOL_VERSION:
+        raise ValueError("remote_wire: unsupported frame version")
+    try:
+        frame_type = FrameType(raw_type)
+    except ValueError as exc:
+        raise ValueError("remote_wire: unknown frame type") from exc
+    if flags != 0:
+        raise ValueError("remote_wire: frame flags are reserved in v1")
+    if payload_bytes > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: frame payload exceeds maximum")
+    if len(data) - FRAME_HEADER_BYTES != payload_bytes:
+        raise ValueError("remote_wire: frame payload length mismatch")
+    return Frame(
+        FrameHeader(frame_type, int(session_id), int(endpoint_id), int(sequence), int(payload_bytes), int(flags)),
+        data[FRAME_HEADER_BYTES:],
+    )
+
+
+def read_exact(sock: socket.socket, n: int) -> bytes:
+    chunks = bytearray()
+    while len(chunks) < n:
+        data = sock.recv(n - len(chunks))
+        if not data:
+            raise EOFError("remote socket closed")
+        chunks.extend(data)
+    return bytes(chunks)
+
+
+def read_frame(sock: socket.socket) -> Frame:
+    header = read_exact(sock, FRAME_HEADER_BYTES)
+    payload_bytes = struct.unpack_from("<I", header, 32)[0]
+    if payload_bytes > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: frame payload exceeds maximum")
+    return decode_frame(header + read_exact(sock, payload_bytes))
+
+
+def send_frame(sock: socket.socket, header: FrameHeader, payload: bytes = b"") -> None:
+    sock.sendall(encode_frame(header, payload))
+
+
+def encode_hello(payload: HelloPayload) -> bytes:
+    out = bytearray()
+    out.extend(struct.pack("<QiI", int(payload.session_id), int(payload.endpoint_id), int(payload.protocol_version)))
+    _put_string(out, payload.comm_profile, MAX_STRING_BYTES, "HELLO.comm_profile")
+    out.extend(struct.pack("<QI", int(payload.feature_flags), int(payload.ready_state)))
+    return bytes(out)
+
+
+def decode_call_config(reader: _Reader) -> CallConfig:
+    cfg = CallConfig()
+    cfg.block_dim = reader.i32()
+    cfg.aicpu_thread_num = reader.i32()
+    cfg.enable_l2_swimlane = reader.i32()
+    cfg.enable_dump_tensor = reader.i32()
+    cfg.enable_pmu = reader.i32()
+    cfg.enable_dep_gen = bool(reader.i32())
+    cfg.enable_scope_stats = bool(reader.i32())
+    prefix = reader.string(MAX_STRING_BYTES, "CallConfig.output_prefix")
+    cfg.output_prefix = prefix
+    return cfg
+
+
+def decode_continuous_tensor(reader: _Reader) -> ContinuousTensor:
+    data = reader.u64()
+    if data != 0:
+        raise ValueError("remote_wire: remote TASK tensor data must be zero")
+    shapes = [reader.u32() for _ in range(CONTINUOUS_TENSOR_MAX_DIMS)]
+    ndims = reader.u32()
+    if ndims > CONTINUOUS_TENSOR_MAX_DIMS:
+        raise ValueError("remote_wire: tensor ndims exceeds maximum")
+    dtype = DataType(reader.u32())
+    child_memory = reader.u8()
+    if child_memory not in (0, 1):
+        raise ValueError("remote_wire: tensor child_memory must be 0 or 1")
+    for _ in range(7):
+        if reader.u8() != 0:
+            raise ValueError("remote_wire: ContinuousTensor reserved bytes must be zero")
+    return ContinuousTensor.make(0, tuple(shapes[:ndims]), dtype, bool(child_memory))
+
+
+def decode_remote_tensor_desc(reader: _Reader) -> RemoteTensorDesc:
+    return RemoteTensorDesc(
+        address_space=RemoteAddressSpace(reader.u32()),
+        owner_endpoint_id=reader.i32(),
+        buffer_id=reader.u64(),
+        offset=reader.u64(),
+        nbytes=reader.u64(),
+        remote_addr=reader.u64(),
+        rkey_or_token=reader.u64(),
+        generation=reader.u64(),
+        inline_payload_offset=reader.u64(),
+        inline_payload_len=reader.u64(),
+        flags=reader.u64(),
+    )
+
+
+def _validate_desc(desc: RemoteTensorDesc, inline_payload_len: int) -> None:
+    if desc.flags != 0:
+        raise ValueError("remote_wire: RemoteTensorDesc flags are reserved in v1")
+    if desc.offset + desc.nbytes > 0xFFFFFFFFFFFFFFFF:
+        raise ValueError("remote_wire: RemoteTensorDesc offset+nbytes overflows")
+    if desc.address_space == RemoteAddressSpace.HOST_INLINE:
+        if (
+            desc.owner_endpoint_id != 0
+            or desc.buffer_id != 0
+            or desc.remote_addr != 0
+            or desc.rkey_or_token != 0
+            or desc.generation != 0
+        ):
+            raise ValueError("remote_wire: HOST_INLINE remote handle fields must be zero")
+        if desc.inline_payload_len != desc.nbytes:
+            raise ValueError("remote_wire: HOST_INLINE inline length must equal nbytes")
+        if desc.inline_payload_offset + desc.inline_payload_len > inline_payload_len:
+            raise ValueError("remote_wire: HOST_INLINE payload range exceeds inline arena")
+    else:
+        if desc.inline_payload_offset != 0 or desc.inline_payload_len != 0:
+            raise ValueError("remote_wire: non-HOST_INLINE inline fields must be zero")
+        if desc.owner_endpoint_id < 0:
+            raise ValueError("remote_wire: remote descriptor owner endpoint must be non-negative")
+        if desc.buffer_id == 0 or desc.generation == 0:
+            raise ValueError("remote_wire: remote descriptor buffer_id and generation must be non-zero")
+
+
+def decode_remote_task_args(data: bytes) -> RemoteTaskArgsWire:
+    reader = _Reader(data)
+    tensor_count = reader.u32()
+    scalar_count = reader.u32()
+    if tensor_count > MAX_TENSORS:
+        raise ValueError("remote_wire: tensor count exceeds maximum")
+    if scalar_count > MAX_SCALARS:
+        raise ValueError("remote_wire: scalar count exceeds maximum")
+    tensors = tuple(decode_continuous_tensor(reader) for _ in range(tensor_count))
+    sidecars: list[RemoteTensorSidecar] = []
+    for _ in range(tensor_count):
+        present = reader.u8()
+        if present not in (0, 1):
+            raise ValueError("remote_wire: remote descriptor presence must be 0 or 1")
+        sidecars.append(
+            RemoteTensorSidecar(False, None)
+            if present == 0
+            else RemoteTensorSidecar(True, decode_remote_tensor_desc(reader))
+        )
+    scalars = tuple(reader.u64() for _ in range(scalar_count))
+    inline_len = reader.u32()
+    if inline_len > MAX_INLINE_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: inline payload exceeds maximum")
+    inline_payload = reader.raw(inline_len, "inline payload")
+    reader.done("RemoteTaskArgs")
+    for sidecar in sidecars:
+        if sidecar.present:
+            assert sidecar.desc is not None
+            _validate_desc(sidecar.desc, len(inline_payload))
+    return RemoteTaskArgsWire(tensors, tuple(sidecars), scalars, inline_payload)
+
+
+def decode_task_payload(data: bytes) -> TaskPayloadWire:
+    reader = _Reader(data)
+    digest = reader.raw(CALLABLE_HASH_DIGEST_BYTES, "callable digest")
+    cfg = decode_call_config(reader)
+    args = decode_remote_task_args(data[reader.offset :])
+    return TaskPayloadWire(digest, cfg, args)
+
+
+def encode_completion(sequence: int, error_code: int, error_message: str) -> bytes:
+    data = error_message.encode("utf-8")
+    if len(data) > MAX_ERROR_BYTES:
+        data = data[:MAX_ERROR_BYTES]
+    return struct.pack("<QiI", int(sequence), int(error_code), len(data)) + data
+
+
+def decode_control(data: bytes) -> ControlPayload:
+    reader = _Reader(data)
+    control_name = ControlName(reader.u32())
+    control_version = reader.u32()
+    if control_version == 0:
+        raise ValueError("remote_wire: control version must be non-zero")
+    command_len = reader.u32()
+    if command_len > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: control payload too large")
+    command_bytes = reader.raw(command_len, "control payload")
+    reader.done("control")
+    return ControlPayload(control_name, control_version, command_bytes)
+
+
+def decode_register_callable_command(data: bytes) -> RegisterCallableCommand:
+    reader = _Reader(data)
+    target_registry = RemoteRegistryTarget(reader.u32())
+    callable_kind = CallableKind(reader.u32())
+    digest = reader.raw(CALLABLE_HASH_DIGEST_BYTES, "callable digest")
+    payload_version = reader.u32()
+    if payload_version == 0:
+        raise ValueError("remote_wire: callable payload version must be non-zero")
+    payload_len = reader.u32()
+    if payload_len > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: callable payload too large")
+    payload = reader.raw(payload_len, "callable payload")
+    reader.done("register callable command")
+    return RegisterCallableCommand(target_registry, callable_kind, digest, payload_version, payload)
+
+
+def encode_register_callable_command(
+    target_registry: RemoteRegistryTarget,
+    callable_kind: CallableKind,
+    digest: bytes,
+    payload_version: int,
+    payload: bytes,
+) -> bytes:
+    if len(digest) != CALLABLE_HASH_DIGEST_BYTES:
+        raise ValueError("remote_wire: callable digest must be 32 bytes")
+    if int(payload_version) == 0:
+        raise ValueError("remote_wire: callable payload version must be non-zero")
+    payload_bytes = bytes(payload)
+    if len(payload_bytes) > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: callable payload too large")
+    out = bytearray()
+    out.extend(struct.pack("<II", int(target_registry), int(callable_kind)))
+    out.extend(bytes(digest))
+    out.extend(struct.pack("<II", int(payload_version), len(payload_bytes)))
+    out.extend(payload_bytes)
+    return bytes(out)
+
+
+def decode_digest_callable_command(data: bytes) -> DigestCallableCommand:
+    reader = _Reader(data)
+    target_registry = RemoteRegistryTarget(reader.u32())
+    callable_kind = CallableKind(reader.u32())
+    digest = reader.raw(CALLABLE_HASH_DIGEST_BYTES, "callable digest")
+    reader.done("digest callable command")
+    return DigestCallableCommand(target_registry, callable_kind, digest)
+
+
+def encode_digest_callable_command(
+    target_registry: RemoteRegistryTarget,
+    callable_kind: CallableKind,
+    digest: bytes,
+) -> bytes:
+    if len(digest) != CALLABLE_HASH_DIGEST_BYTES:
+        raise ValueError("remote_wire: callable digest must be 32 bytes")
+    return struct.pack("<II", int(target_registry), int(callable_kind)) + bytes(digest)
+
+
+def encode_remote_chip_callable_payload(payload: RemoteChipCallablePayload) -> bytes:
+    if len(payload.blob_sha256) != CALLABLE_HASH_DIGEST_BYTES:
+        raise ValueError("remote_wire: CHIP_CALLABLE blob_sha256 must be 32 bytes")
+    blob_size = int(payload.blob_size)
+    if blob_size <= 0:
+        raise ValueError("remote_wire: CHIP_CALLABLE blob_size must be non-zero")
+    location = ChipCallableBlobLocation(payload.blob_location)
+    if location == ChipCallableBlobLocation.INLINE_BLOB:
+        if len(payload.inline_blob) != blob_size or payload.staged_blob_token:
+            raise ValueError("remote_wire: CHIP_CALLABLE inline payload fields are inconsistent")
+    elif location == ChipCallableBlobLocation.STAGED_BLOB:
+        if payload.inline_blob or not payload.staged_blob_token:
+            raise ValueError("remote_wire: CHIP_CALLABLE staged payload fields are inconsistent")
+    out = bytearray()
+    _put_blob(out, payload.descriptor_bytes, MAX_CHIP_CALLABLE_DESCRIPTOR_BYTES, "CHIP_CALLABLE.descriptor_bytes")
+    out.extend(struct.pack("<IQ", int(location), blob_size))
+    out.extend(payload.blob_sha256)
+    _put_blob(out, payload.inline_blob, MAX_FRAME_PAYLOAD_BYTES, "CHIP_CALLABLE.inline_blob")
+    _put_blob(out, payload.staged_blob_token, MAX_STAGED_BLOB_TOKEN_BYTES, "CHIP_CALLABLE.staged_blob_token")
+    out.extend(struct.pack("<I", 0))
+    return bytes(out)
+
+
+def decode_remote_chip_callable_payload(data: bytes) -> RemoteChipCallablePayload:
+    reader = _Reader(data)
+    descriptor_bytes = reader.blob(MAX_CHIP_CALLABLE_DESCRIPTOR_BYTES, "CHIP_CALLABLE.descriptor_bytes")
+    blob_location = ChipCallableBlobLocation(reader.u32())
+    blob_size = reader.u64()
+    blob_sha256 = reader.raw(CALLABLE_HASH_DIGEST_BYTES, "CHIP_CALLABLE.blob_sha256")
+    inline_blob = reader.blob(MAX_FRAME_PAYLOAD_BYTES, "CHIP_CALLABLE.inline_blob")
+    staged_blob_token = reader.blob(MAX_STAGED_BLOB_TOKEN_BYTES, "CHIP_CALLABLE.staged_blob_token")
+    if reader.u32() != 0:
+        raise ValueError("remote_wire: CHIP_CALLABLE reserved field must be zero")
+    reader.done("CHIP_CALLABLE payload")
+    payload = RemoteChipCallablePayload(
+        descriptor_bytes=descriptor_bytes,
+        blob_location=blob_location,
+        blob_size=blob_size,
+        blob_sha256=blob_sha256,
+        inline_blob=inline_blob,
+        staged_blob_token=staged_blob_token,
+    )
+    encode_remote_chip_callable_payload(payload)
+    return payload
+
+
+def encode_export_buffer_result(result: ExportBufferResult) -> bytes:
+    _validate_access_flags(result.access_flags, "export result access_flags")
+    if result.address_space not in (RemoteAddressSpace.REMOTE_WINDOW, RemoteAddressSpace.UB_LDST):
+        raise ValueError("remote_wire: export result address_space is invalid")
+    if result.nbytes <= 0 or result.export_id == 0:
+        raise ValueError("remote_wire: export result requires non-zero nbytes and export_id")
+    out = bytearray()
+    out.extend(
+        struct.pack(
+            "<iQQIQQQQQQI",
+            int(result.owner_endpoint_id),
+            int(result.buffer_id),
+            int(result.generation),
+            int(result.address_space),
+            int(result.offset),
+            int(result.nbytes),
+            int(result.export_id),
+            int(result.remote_addr),
+            int(result.rkey_or_token),
+            int(result.ub_ldst_va),
+            int(result.access_flags),
+        )
+    )
+    _put_string(out, result.transport_profile, MAX_TRANSPORT_PROFILE_BYTES, "export result transport_profile")
+    _put_blob(
+        out,
+        result.transport_descriptor,
+        MAX_TRANSPORT_DESCRIPTOR_BYTES,
+        "export result transport_descriptor",
+    )
+    out.extend(struct.pack("<I", 0))
+    return bytes(out)
+
+
+def decode_export_buffer_request(data: bytes) -> ExportBufferRequest:
+    reader = _Reader(data)
+    request = ExportBufferRequest(
+        owner_endpoint_id=reader.i32(),
+        buffer_id=reader.u64(),
+        generation=reader.u64(),
+        offset=reader.u64(),
+        nbytes=reader.u64(),
+        access_flags=reader.u32(),
+        transport_profile=reader.string(MAX_TRANSPORT_PROFILE_BYTES, "EXPORT_BUFFER.transport_profile"),
+    )
+    if reader.u32() != 0:
+        raise ValueError("remote_wire: EXPORT_BUFFER reserved field must be zero")
+    reader.done("EXPORT_BUFFER")
+    if request.owner_endpoint_id < 0 or request.buffer_id == 0 or request.generation == 0:
+        raise ValueError("remote_wire: EXPORT_BUFFER requires live owner buffer identity")
+    if request.nbytes <= 0:
+        raise ValueError("remote_wire: EXPORT_BUFFER nbytes must be non-zero")
+    _validate_access_flags(request.access_flags, "EXPORT_BUFFER access_flags")
+    return request
+
+
+def decode_export_buffer_result(data: bytes) -> ExportBufferResult:
+    reader = _Reader(data)
+    result = ExportBufferResult(
+        owner_endpoint_id=reader.i32(),
+        buffer_id=reader.u64(),
+        generation=reader.u64(),
+        address_space=RemoteAddressSpace(reader.u32()),
+        offset=reader.u64(),
+        nbytes=reader.u64(),
+        export_id=reader.u64(),
+        remote_addr=reader.u64(),
+        rkey_or_token=reader.u64(),
+        ub_ldst_va=reader.u64(),
+        access_flags=reader.u32(),
+        transport_profile=reader.string(MAX_TRANSPORT_PROFILE_BYTES, "export result transport_profile"),
+        transport_descriptor=reader.blob(MAX_TRANSPORT_DESCRIPTOR_BYTES, "export result transport_descriptor"),
+    )
+    if reader.u32() != 0:
+        raise ValueError("remote_wire: export result reserved field must be zero")
+    reader.done("export result")
+    _validate_access_flags(result.access_flags, "export result access_flags")
+    if result.address_space not in (RemoteAddressSpace.REMOTE_WINDOW, RemoteAddressSpace.UB_LDST):
+        raise ValueError("remote_wire: export result address_space is invalid")
+    if result.nbytes <= 0 or result.export_id == 0:
+        raise ValueError("remote_wire: export result requires non-zero nbytes and export_id")
+    return result
+
+
+def decode_import_buffer_request(data: bytes) -> ImportBufferRequest:
+    reader = _Reader(data)
+    importer_endpoint_id = reader.i32()
+    requested_access_flags = reader.u32()
+    export_start = reader.offset
+    if len(data) < export_start + 4:
+        raise ValueError("remote_wire: IMPORT_BUFFER payload is truncated")
+    export_desc = decode_export_buffer_result(data[export_start:-4])
+    reader.offset = len(data) - 4
+    if reader.u32() != 0:
+        raise ValueError("remote_wire: IMPORT_BUFFER reserved field must be zero")
+    reader.done("IMPORT_BUFFER")
+    if importer_endpoint_id < 0:
+        raise ValueError("remote_wire: IMPORT_BUFFER importer endpoint must be non-negative")
+    _validate_access_flags(requested_access_flags, "IMPORT_BUFFER requested_access_flags")
+    if requested_access_flags & ~export_desc.access_flags:
+        raise ValueError("remote_wire: IMPORT_BUFFER requested access is not a subset of export access")
+    return ImportBufferRequest(importer_endpoint_id, requested_access_flags, export_desc)
+
+
+def encode_import_buffer_result(result: ImportBufferResult) -> bytes:
+    _validate_access_flags(result.access_flags, "import result access_flags")
+    if result.address_space not in (RemoteAddressSpace.REMOTE_WINDOW, RemoteAddressSpace.UB_LDST):
+        raise ValueError("remote_wire: import result address_space is invalid")
+    if result.import_id == 0 or result.nbytes <= 0:
+        raise ValueError("remote_wire: import result requires non-zero import_id and nbytes")
+    out = bytearray()
+    out.extend(
+        struct.pack(
+            "<iiQQQIQQQQQI",
+            int(result.importer_endpoint_id),
+            int(result.owner_endpoint_id),
+            int(result.buffer_id),
+            int(result.generation),
+            int(result.import_id),
+            int(result.address_space),
+            int(result.offset),
+            int(result.nbytes),
+            int(result.remote_addr),
+            int(result.rkey_or_token),
+            int(result.ub_ldst_va),
+            int(result.access_flags),
+        )
+    )
+    _put_string(out, result.transport_profile, MAX_TRANSPORT_PROFILE_BYTES, "import result transport_profile")
+    _put_blob(out, result.import_descriptor, MAX_TRANSPORT_DESCRIPTOR_BYTES, "import result import_descriptor")
+    out.extend(struct.pack("<I", 0))
+    return bytes(out)
+
+
+def decode_release_import_request(data: bytes) -> ReleaseImportRequest:
+    reader = _Reader(data)
+    request = ReleaseImportRequest(
+        importer_endpoint_id=reader.i32(),
+        owner_endpoint_id=reader.i32(),
+        buffer_id=reader.u64(),
+        generation=reader.u64(),
+        import_id=reader.u64(),
+    )
+    if reader.u32() != 0:
+        raise ValueError("remote_wire: RELEASE_IMPORT reserved field must be zero")
+    reader.done("RELEASE_IMPORT")
+    if (
+        request.importer_endpoint_id < 0
+        or request.owner_endpoint_id < 0
+        or request.buffer_id == 0
+        or request.generation == 0
+        or request.import_id == 0
+    ):
+        raise ValueError("remote_wire: RELEASE_IMPORT requires live importer and owner identity")
+    return request
+
+
+def encode_control_reply(
+    sequence: int,
+    control_name: ControlName,
+    control_version: int,
+    error_code: int,
+    error_message: str,
+    result_bytes: bytes = b"",
+) -> bytes:
+    msg = error_message.encode("utf-8")
+    if len(msg) > MAX_ERROR_BYTES:
+        msg = msg[:MAX_ERROR_BYTES]
+    if len(result_bytes) > MAX_FRAME_PAYLOAD_BYTES:
+        raise ValueError("remote_wire: control reply result too large")
+    return (
+        struct.pack("<QIIiI", int(sequence), int(control_name), int(control_version), int(error_code), len(msg))
+        + msg
+        + struct.pack("<I", len(result_bytes))
+        + result_bytes
+    )

--- a/python/simpler/remote_l3_protocol.py
+++ b/python/simpler/remote_l3_protocol.py
@@ -536,7 +536,7 @@ def decode_task_payload(data: bytes) -> TaskPayloadWire:
 def encode_completion(sequence: int, error_code: int, error_message: str) -> bytes:
     data = error_message.encode("utf-8")
     if len(data) > MAX_ERROR_BYTES:
-        data = data[:MAX_ERROR_BYTES]
+        raise ValueError("remote_wire: completion error message too long")
     return struct.pack("<QiI", int(sequence), int(error_code), len(data)) + data
 
 
@@ -827,7 +827,7 @@ def encode_control_reply(
 ) -> bytes:
     msg = error_message.encode("utf-8")
     if len(msg) > MAX_ERROR_BYTES:
-        msg = msg[:MAX_ERROR_BYTES]
+        raise ValueError("remote_wire: control reply error message too long")
     if len(result_bytes) > MAX_FRAME_PAYLOAD_BYTES:
         raise ValueError("remote_wire: control reply result too large")
     return (

--- a/src/common/hierarchical/remote_wire.cpp
+++ b/src/common/hierarchical/remote_wire.cpp
@@ -226,6 +226,8 @@ void validate_desc_against_inline_payload(const RemoteTensorDesc &desc, size_t i
         ensure(desc.inline_payload_offset == 0, "remote_wire: non-HOST_INLINE inline offset must be zero");
         ensure(desc.inline_payload_len == 0, "remote_wire: non-HOST_INLINE inline length must be zero");
         ensure(desc.owner_endpoint_id >= 0, "remote_wire: remote descriptor owner endpoint must be non-negative");
+        ensure(desc.buffer_id != 0, "remote_wire: remote descriptor buffer_id must be non-zero");
+        ensure(desc.generation != 0, "remote_wire: remote descriptor generation must be non-zero");
     }
 }
 

--- a/src/common/hierarchical/remote_wire.cpp
+++ b/src/common/hierarchical/remote_wire.cpp
@@ -1,0 +1,867 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "remote_wire.h"
+
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+
+namespace remote_l3 {
+namespace {
+
+static constexpr uint8_t MAGIC[4] = {'S', 'L', 'R', '3'};
+static constexpr size_t FRAME_HEADER_BYTES = 40;
+
+void ensure(bool condition, const std::string &message) {
+    if (!condition) throw std::runtime_error(message);
+}
+
+void ensure_available(size_t size, size_t offset, size_t n, const char *what) {
+    if (offset > size || n > size - offset) {
+        throw std::runtime_error(std::string("remote_wire: truncated ") + what);
+    }
+}
+
+void put_u8(std::vector<uint8_t> &out, uint8_t v) { out.push_back(v); }
+
+void put_u32(std::vector<uint8_t> &out, uint32_t v) {
+    for (int i = 0; i < 4; ++i)
+        out.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xffU));
+}
+
+void put_i32(std::vector<uint8_t> &out, int32_t v) { put_u32(out, static_cast<uint32_t>(v)); }
+
+void put_u64(std::vector<uint8_t> &out, uint64_t v) {
+    for (int i = 0; i < 8; ++i)
+        out.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xffU));
+}
+
+uint8_t get_u8(const uint8_t *data, size_t size, size_t &offset) {
+    ensure_available(size, offset, 1, "uint8");
+    return data[offset++];
+}
+
+uint32_t get_u32(const uint8_t *data, size_t size, size_t &offset) {
+    ensure_available(size, offset, 4, "uint32");
+    uint32_t v = 0;
+    for (int i = 0; i < 4; ++i)
+        v |= static_cast<uint32_t>(data[offset++]) << (8 * i);
+    return v;
+}
+
+int32_t get_i32(const uint8_t *data, size_t size, size_t &offset) {
+    return static_cast<int32_t>(get_u32(data, size, offset));
+}
+
+uint64_t get_u64(const uint8_t *data, size_t size, size_t &offset) {
+    ensure_available(size, offset, 8, "uint64");
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i)
+        v |= static_cast<uint64_t>(data[offset++]) << (8 * i);
+    return v;
+}
+
+void put_bytes(std::vector<uint8_t> &out, const uint8_t *data, size_t n) {
+    if (n == 0) return;
+    out.insert(out.end(), data, data + n);
+}
+
+void put_string(std::vector<uint8_t> &out, const std::string &value, uint32_t max_bytes, const char *field_name) {
+    ensure(value.size() <= max_bytes, std::string("remote_wire: ") + field_name + " exceeds max length");
+    put_u32(out, static_cast<uint32_t>(value.size()));
+    put_bytes(out, reinterpret_cast<const uint8_t *>(value.data()), value.size());
+}
+
+void put_blob(
+    std::vector<uint8_t> &out, const std::vector<uint8_t> &value, uint32_t max_bytes, const char *field_name
+) {
+    ensure(value.size() <= max_bytes, std::string("remote_wire: ") + field_name + " exceeds max length");
+    put_u32(out, static_cast<uint32_t>(value.size()));
+    put_bytes(out, value.data(), value.size());
+}
+
+std::string get_string(const uint8_t *data, size_t size, size_t &offset, uint32_t max_bytes, const char *field_name) {
+    uint32_t n = get_u32(data, size, offset);
+    ensure(n <= max_bytes, std::string("remote_wire: ") + field_name + " exceeds max length");
+    ensure_available(size, offset, n, field_name);
+    std::string out(reinterpret_cast<const char *>(data + offset), n);
+    offset += n;
+    return out;
+}
+
+std::vector<uint8_t>
+get_blob(const uint8_t *data, size_t size, size_t &offset, uint32_t max_bytes, const char *field_name) {
+    uint32_t n = get_u32(data, size, offset);
+    ensure(n <= max_bytes, std::string("remote_wire: ") + field_name + " exceeds max length");
+    ensure_available(size, offset, n, field_name);
+    std::vector<uint8_t> out(data + offset, data + offset + n);
+    offset += n;
+    return out;
+}
+
+void validate_access_flags(uint32_t flags, const char *field_name) {
+    ensure(flags != 0, std::string("remote_wire: ") + field_name + " must be non-zero");
+    ensure(
+        (flags & ~REMOTE_BUFFER_ACCESS_READ_WRITE) == 0,
+        std::string("remote_wire: ") + field_name + " contains unknown bits"
+    );
+}
+
+bool valid_frame_type(uint32_t v) {
+    switch (static_cast<FrameType>(v)) {
+    case FrameType::HELLO:
+    case FrameType::TASK:
+    case FrameType::CONTROL:
+    case FrameType::CONTROL_REPLY:
+    case FrameType::COMPLETION:
+    case FrameType::HEALTH:
+    case FrameType::SHUTDOWN:
+        return true;
+    }
+    return false;
+}
+
+bool valid_control_name(uint32_t v) {
+    switch (static_cast<ControlName>(v)) {
+    case ControlName::UNREGISTER_CALLABLE:
+    case ControlName::PREPARE_REGISTER_CALLABLE:
+    case ControlName::COMMIT_REGISTER_CALLABLE:
+    case ControlName::ABORT_REGISTER_CALLABLE:
+    case ControlName::PREPARE_CALLABLE:
+    case ControlName::ALLOC_REMOTE_BUFFER:
+    case ControlName::FREE_REMOTE_BUFFER:
+    case ControlName::COPY_TO_REMOTE:
+    case ControlName::COPY_FROM_REMOTE:
+    case ControlName::EXPORT_BUFFER:
+    case ControlName::IMPORT_BUFFER:
+    case ControlName::RELEASE_IMPORT:
+    case ControlName::COMM_INIT:
+    case ControlName::ALLOC_DOMAIN:
+    case ControlName::RELEASE_DOMAIN:
+        return true;
+    }
+    return false;
+}
+
+bool valid_ready_state(uint32_t v) {
+    switch (static_cast<ReadyState>(v)) {
+    case ReadyState::NOT_READY:
+    case ReadyState::READY:
+        return true;
+    }
+    return false;
+}
+
+bool valid_remote_registry_target(uint32_t v) {
+    switch (static_cast<RemoteRegistryTarget>(v)) {
+    case RemoteRegistryTarget::REMOTE_TASK_DISPATCHER:
+    case RemoteRegistryTarget::INNER_L3_WORKER:
+        return true;
+    }
+    return false;
+}
+
+bool valid_callable_kind(uint32_t v) {
+    switch (static_cast<CallableKind>(static_cast<int32_t>(v))) {
+    case CallableKind::CHIP_CALLABLE:
+    case CallableKind::PYTHON_SERIALIZED:
+    case CallableKind::PYTHON_IMPORT:
+        return true;
+    }
+    return false;
+}
+
+bool valid_address_space(uint32_t v) {
+    switch (static_cast<RemoteAddressSpace>(v)) {
+    case RemoteAddressSpace::HOST_INLINE:
+    case RemoteAddressSpace::REMOTE_DEVICE:
+    case RemoteAddressSpace::REMOTE_WINDOW:
+    case RemoteAddressSpace::UB_LDST:
+        return true;
+    }
+    return false;
+}
+
+bool valid_import_address_space(RemoteAddressSpace space) {
+    return space == RemoteAddressSpace::REMOTE_WINDOW || space == RemoteAddressSpace::UB_LDST;
+}
+
+bool valid_dtype(uint32_t v) { return v < static_cast<uint32_t>(DataType::DATA_TYPE_NUM); }
+
+std::string call_config_prefix(const CallConfig &config) {
+    size_t n = 0;
+    while (n < sizeof(config.output_prefix) && config.output_prefix[n] != '\0')
+        ++n;
+    return std::string(config.output_prefix, config.output_prefix + n);
+}
+
+void validate_desc_against_inline_payload(const RemoteTensorDesc &desc, size_t inline_payload_len) {
+    ensure(desc.flags == 0, "remote_wire: RemoteTensorDesc flags are reserved in v1");
+    ensure(
+        desc.nbytes <= std::numeric_limits<uint64_t>::max() - desc.offset,
+        "remote_wire: RemoteTensorDesc offset+nbytes overflows"
+    );
+    if (desc.address_space == RemoteAddressSpace::HOST_INLINE) {
+        ensure(desc.owner_endpoint_id == 0, "remote_wire: HOST_INLINE owner_endpoint_id must be zero");
+        ensure(desc.buffer_id == 0, "remote_wire: HOST_INLINE buffer_id must be zero");
+        ensure(desc.remote_addr == 0, "remote_wire: HOST_INLINE remote_addr must be zero");
+        ensure(desc.rkey_or_token == 0, "remote_wire: HOST_INLINE rkey_or_token must be zero");
+        ensure(desc.generation == 0, "remote_wire: HOST_INLINE generation must be zero");
+        ensure(desc.inline_payload_len == desc.nbytes, "remote_wire: HOST_INLINE inline length must equal nbytes");
+        ensure(
+            desc.inline_payload_offset <= static_cast<uint64_t>(inline_payload_len) &&
+                desc.inline_payload_len <= static_cast<uint64_t>(inline_payload_len) - desc.inline_payload_offset,
+            "remote_wire: HOST_INLINE payload range exceeds inline arena"
+        );
+    } else {
+        ensure(desc.inline_payload_offset == 0, "remote_wire: non-HOST_INLINE inline offset must be zero");
+        ensure(desc.inline_payload_len == 0, "remote_wire: non-HOST_INLINE inline length must be zero");
+        ensure(desc.owner_endpoint_id >= 0, "remote_wire: remote descriptor owner endpoint must be non-negative");
+    }
+}
+
+}  // namespace
+
+std::vector<uint8_t> encode_frame(const FrameHeader &header, const std::vector<uint8_t> &payload) {
+    ensure(payload.size() <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: frame payload exceeds maximum");
+    ensure(header.flags == 0, "remote_wire: frame flags are reserved in v1");
+    std::vector<uint8_t> out;
+    out.reserve(FRAME_HEADER_BYTES + payload.size());
+    put_bytes(out, MAGIC, sizeof(MAGIC));
+    put_u32(out, PROTOCOL_VERSION);
+    put_u32(out, static_cast<uint32_t>(header.frame_type));
+    put_u64(out, header.session_id);
+    put_i32(out, header.endpoint_id);
+    put_u64(out, header.sequence);
+    put_u32(out, static_cast<uint32_t>(payload.size()));
+    put_u32(out, header.flags);
+    put_bytes(out, payload.data(), payload.size());
+    return out;
+}
+
+DecodedFrame decode_frame(const uint8_t *data, size_t size) {
+    ensure(size >= FRAME_HEADER_BYTES, "remote_wire: truncated frame header");
+    ensure(std::memcmp(data, MAGIC, sizeof(MAGIC)) == 0, "remote_wire: bad frame magic");
+    size_t offset = sizeof(MAGIC);
+    uint32_t version = get_u32(data, size, offset);
+    ensure(version == PROTOCOL_VERSION, "remote_wire: unsupported frame version");
+    uint32_t raw_type = get_u32(data, size, offset);
+    ensure(valid_frame_type(raw_type), "remote_wire: unknown frame type");
+    DecodedFrame frame;
+    frame.header.frame_type = static_cast<FrameType>(raw_type);
+    frame.header.session_id = get_u64(data, size, offset);
+    frame.header.endpoint_id = get_i32(data, size, offset);
+    frame.header.sequence = get_u64(data, size, offset);
+    frame.header.payload_bytes = get_u32(data, size, offset);
+    frame.header.flags = get_u32(data, size, offset);
+    ensure(frame.header.flags == 0, "remote_wire: frame flags are reserved in v1");
+    ensure(frame.header.payload_bytes <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: frame payload exceeds maximum");
+    ensure(size - offset == frame.header.payload_bytes, "remote_wire: frame payload length mismatch");
+    frame.payload.assign(data + offset, data + size);
+    return frame;
+}
+
+DecodedFrame decode_frame(const std::vector<uint8_t> &data) { return decode_frame(data.data(), data.size()); }
+
+std::vector<uint8_t> encode_hello(const HelloPayload &payload) {
+    ensure(payload.session_id != 0, "remote_wire: HELLO session_id must be non-zero");
+    ensure(payload.endpoint_id >= 0, "remote_wire: HELLO endpoint_id must be non-negative");
+    ensure(payload.protocol_version == PROTOCOL_VERSION, "remote_wire: HELLO protocol version mismatch");
+    std::vector<uint8_t> out;
+    put_u64(out, payload.session_id);
+    put_i32(out, payload.endpoint_id);
+    put_u32(out, payload.protocol_version);
+    put_string(out, payload.comm_profile, MAX_STRING_BYTES, "HELLO.comm_profile");
+    put_u64(out, payload.feature_flags);
+    put_u32(out, static_cast<uint32_t>(payload.ready_state));
+    return out;
+}
+
+HelloPayload decode_hello(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    HelloPayload payload;
+    payload.session_id = get_u64(data, size, offset);
+    ensure(payload.session_id != 0, "remote_wire: HELLO session_id must be non-zero");
+    payload.endpoint_id = get_i32(data, size, offset);
+    ensure(payload.endpoint_id >= 0, "remote_wire: HELLO endpoint_id must be non-negative");
+    payload.protocol_version = get_u32(data, size, offset);
+    ensure(payload.protocol_version == PROTOCOL_VERSION, "remote_wire: HELLO protocol version mismatch");
+    payload.comm_profile = get_string(data, size, offset, MAX_STRING_BYTES, "HELLO.comm_profile");
+    payload.feature_flags = get_u64(data, size, offset);
+    uint32_t ready = get_u32(data, size, offset);
+    ensure(valid_ready_state(ready), "remote_wire: unknown HELLO ready_state");
+    payload.ready_state = static_cast<ReadyState>(ready);
+    ensure(offset == size, "remote_wire: trailing bytes after HELLO");
+    return payload;
+}
+
+std::vector<uint8_t> encode_call_config(const CallConfig &config) {
+    std::vector<uint8_t> out;
+    put_i32(out, config.block_dim);
+    put_i32(out, config.aicpu_thread_num);
+    put_i32(out, config.enable_l2_swimlane);
+    put_i32(out, config.enable_dump_tensor);
+    put_i32(out, config.enable_pmu);
+    put_i32(out, config.enable_dep_gen);
+    put_i32(out, config.enable_scope_stats);
+    put_string(out, call_config_prefix(config), MAX_STRING_BYTES, "CallConfig.output_prefix");
+    return out;
+}
+
+CallConfig decode_call_config(const uint8_t *data, size_t size, size_t &offset) {
+    CallConfig config{};
+    config.block_dim = get_i32(data, size, offset);
+    config.aicpu_thread_num = get_i32(data, size, offset);
+    config.enable_l2_swimlane = get_i32(data, size, offset);
+    config.enable_dump_tensor = get_i32(data, size, offset);
+    config.enable_pmu = get_i32(data, size, offset);
+    config.enable_dep_gen = get_i32(data, size, offset);
+    config.enable_scope_stats = get_i32(data, size, offset);
+    std::string prefix = get_string(data, size, offset, MAX_STRING_BYTES, "CallConfig.output_prefix");
+    ensure(prefix.size() < sizeof(config.output_prefix), "remote_wire: CallConfig.output_prefix is too long");
+    std::memset(config.output_prefix, 0, sizeof(config.output_prefix));
+    std::memcpy(config.output_prefix, prefix.data(), prefix.size());
+    config.validate();
+    return config;
+}
+
+std::vector<uint8_t> encode_continuous_tensor(const ContinuousTensor &tensor) {
+    std::vector<uint8_t> out;
+    put_u64(out, tensor.data);
+    for (uint32_t shape : tensor.shapes)
+        put_u32(out, shape);
+    put_u32(out, tensor.ndims);
+    put_u32(out, static_cast<uint32_t>(tensor.dtype));
+    put_u8(out, tensor.child_memory);
+    for (int i = 0; i < 7; ++i)
+        put_u8(out, 0);
+    return out;
+}
+
+ContinuousTensor decode_continuous_tensor(const uint8_t *data, size_t size, size_t &offset, bool remote_task) {
+    ContinuousTensor tensor{};
+    tensor.data = get_u64(data, size, offset);
+    if (remote_task) ensure(tensor.data == 0, "remote_wire: remote TASK tensor data must be zero");
+    for (uint32_t &shape : tensor.shapes)
+        shape = get_u32(data, size, offset);
+    tensor.ndims = get_u32(data, size, offset);
+    ensure(tensor.ndims <= CONTINUOUS_TENSOR_MAX_DIMS, "remote_wire: tensor ndims exceeds maximum");
+    uint32_t dtype = get_u32(data, size, offset);
+    ensure(valid_dtype(dtype), "remote_wire: unknown tensor dtype");
+    tensor.dtype = static_cast<DataType>(dtype);
+    tensor.child_memory = get_u8(data, size, offset);
+    ensure(tensor.child_memory == 0 || tensor.child_memory == 1, "remote_wire: tensor child_memory must be 0 or 1");
+    for (int i = 0; i < 7; ++i) {
+        ensure(get_u8(data, size, offset) == 0, "remote_wire: ContinuousTensor reserved bytes must be zero");
+    }
+    return tensor;
+}
+
+std::vector<uint8_t> encode_remote_tensor_desc(const RemoteTensorDesc &desc) {
+    std::vector<uint8_t> out;
+    put_u32(out, static_cast<uint32_t>(desc.address_space));
+    put_i32(out, desc.owner_endpoint_id);
+    put_u64(out, desc.buffer_id);
+    put_u64(out, desc.offset);
+    put_u64(out, desc.nbytes);
+    put_u64(out, desc.remote_addr);
+    put_u64(out, desc.rkey_or_token);
+    put_u64(out, desc.generation);
+    put_u64(out, desc.inline_payload_offset);
+    put_u64(out, desc.inline_payload_len);
+    put_u64(out, desc.flags);
+    return out;
+}
+
+RemoteTensorDesc decode_remote_tensor_desc(const uint8_t *data, size_t size, size_t &offset) {
+    uint32_t raw_space = get_u32(data, size, offset);
+    ensure(valid_address_space(raw_space), "remote_wire: unknown RemoteTensorDesc address_space");
+    RemoteTensorDesc desc{};
+    desc.address_space = static_cast<RemoteAddressSpace>(raw_space);
+    desc.owner_endpoint_id = get_i32(data, size, offset);
+    desc.buffer_id = get_u64(data, size, offset);
+    desc.offset = get_u64(data, size, offset);
+    desc.nbytes = get_u64(data, size, offset);
+    desc.remote_addr = get_u64(data, size, offset);
+    desc.rkey_or_token = get_u64(data, size, offset);
+    desc.generation = get_u64(data, size, offset);
+    desc.inline_payload_offset = get_u64(data, size, offset);
+    desc.inline_payload_len = get_u64(data, size, offset);
+    desc.flags = get_u64(data, size, offset);
+    return desc;
+}
+
+std::vector<uint8_t> encode_remote_task_args(const RemoteTaskArgsWire &args) {
+    ensure(args.tensor_metadata.size() <= MAX_TENSORS, "remote_wire: tensor count exceeds maximum");
+    ensure(args.scalars.size() <= MAX_SCALARS, "remote_wire: scalar count exceeds maximum");
+    ensure(args.inline_payload.size() <= MAX_INLINE_PAYLOAD_BYTES, "remote_wire: inline payload exceeds maximum");
+    ensure(
+        args.remote_desc.empty() || args.remote_desc.size() == args.tensor_metadata.size(),
+        "remote_wire: remote descriptor count must match tensor count"
+    );
+    std::vector<uint8_t> out;
+    put_u32(out, static_cast<uint32_t>(args.tensor_metadata.size()));
+    put_u32(out, static_cast<uint32_t>(args.scalars.size()));
+    for (const auto &tensor : args.tensor_metadata) {
+        ensure(tensor.data == 0, "remote_wire: remote TASK tensor data must be zero");
+        auto encoded = encode_continuous_tensor(tensor);
+        put_bytes(out, encoded.data(), encoded.size());
+    }
+    for (size_t i = 0; i < args.tensor_metadata.size(); ++i) {
+        RemoteTensorSidecar sidecar{};
+        if (!args.remote_desc.empty()) sidecar = args.remote_desc[i];
+        put_u8(out, sidecar.present ? 1 : 0);
+        if (sidecar.present) {
+            validate_desc_against_inline_payload(sidecar.desc, args.inline_payload.size());
+            auto encoded = encode_remote_tensor_desc(sidecar.desc);
+            put_bytes(out, encoded.data(), encoded.size());
+        }
+    }
+    for (uint64_t scalar : args.scalars)
+        put_u64(out, scalar);
+    put_u32(out, static_cast<uint32_t>(args.inline_payload.size()));
+    put_bytes(out, args.inline_payload.data(), args.inline_payload.size());
+    return out;
+}
+
+RemoteTaskArgsWire decode_remote_task_args(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    uint32_t tensor_count = get_u32(data, size, offset);
+    uint32_t scalar_count = get_u32(data, size, offset);
+    ensure(tensor_count <= MAX_TENSORS, "remote_wire: tensor count exceeds maximum");
+    ensure(scalar_count <= MAX_SCALARS, "remote_wire: scalar count exceeds maximum");
+
+    RemoteTaskArgsWire args;
+    args.tensor_metadata.reserve(tensor_count);
+    for (uint32_t i = 0; i < tensor_count; ++i)
+        args.tensor_metadata.push_back(decode_continuous_tensor(data, size, offset, true));
+
+    args.remote_desc.reserve(tensor_count);
+    for (uint32_t i = 0; i < tensor_count; ++i) {
+        uint8_t present = get_u8(data, size, offset);
+        ensure(present == 0 || present == 1, "remote_wire: remote descriptor presence must be 0 or 1");
+        RemoteTensorSidecar sidecar{};
+        sidecar.present = present != 0;
+        if (sidecar.present) sidecar.desc = decode_remote_tensor_desc(data, size, offset);
+        args.remote_desc.push_back(sidecar);
+    }
+
+    args.scalars.reserve(scalar_count);
+    for (uint32_t i = 0; i < scalar_count; ++i)
+        args.scalars.push_back(get_u64(data, size, offset));
+
+    uint32_t inline_len = get_u32(data, size, offset);
+    ensure(inline_len <= MAX_INLINE_PAYLOAD_BYTES, "remote_wire: inline payload exceeds maximum");
+    ensure_available(size, offset, inline_len, "inline payload");
+    args.inline_payload.assign(data + offset, data + offset + inline_len);
+    offset += inline_len;
+    ensure(offset == size, "remote_wire: trailing bytes after RemoteTaskArgs");
+
+    for (const auto &sidecar : args.remote_desc) {
+        if (sidecar.present) validate_desc_against_inline_payload(sidecar.desc, args.inline_payload.size());
+    }
+    return args;
+}
+
+std::vector<uint8_t> encode_task_payload(const TaskPayloadWire &payload) {
+    std::vector<uint8_t> out;
+    put_bytes(out, payload.callable_digest.data(), payload.callable_digest.size());
+    auto config = encode_call_config(payload.config);
+    put_bytes(out, config.data(), config.size());
+    auto args = encode_remote_task_args(payload.args);
+    put_bytes(out, args.data(), args.size());
+    return out;
+}
+
+TaskPayloadWire decode_task_payload(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    ensure_available(size, offset, CALLABLE_HASH_DIGEST_SIZE, "callable digest");
+    TaskPayloadWire payload;
+    std::memcpy(payload.callable_digest.data(), data + offset, CALLABLE_HASH_DIGEST_SIZE);
+    offset += CALLABLE_HASH_DIGEST_SIZE;
+    payload.config = decode_call_config(data, size, offset);
+    payload.args = decode_remote_task_args(data + offset, size - offset);
+    return payload;
+}
+
+std::vector<uint8_t> encode_completion(const CompletionPayload &payload) {
+    ensure(payload.error_message.size() <= MAX_ERROR_BYTES, "remote_wire: completion error message too long");
+    std::vector<uint8_t> out;
+    put_u64(out, payload.sequence);
+    put_i32(out, payload.error_code);
+    put_string(out, payload.error_message, MAX_ERROR_BYTES, "completion.error_message");
+    return out;
+}
+
+CompletionPayload decode_completion(const uint8_t *data, size_t size, uint64_t expected_sequence) {
+    size_t offset = 0;
+    CompletionPayload payload;
+    payload.sequence = get_u64(data, size, offset);
+    ensure(payload.sequence == expected_sequence, "remote_wire: completion sequence mismatch");
+    payload.error_code = get_i32(data, size, offset);
+    payload.error_message = get_string(data, size, offset, MAX_ERROR_BYTES, "completion.error_message");
+    ensure(offset == size, "remote_wire: trailing bytes after completion");
+    return payload;
+}
+
+std::vector<uint8_t> encode_control(const ControlPayload &payload) {
+    ensure(valid_control_name(static_cast<uint32_t>(payload.control_name)), "remote_wire: unknown control name");
+    ensure(payload.control_version != 0, "remote_wire: control version must be non-zero");
+    ensure(payload.command_bytes.size() <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: control payload too large");
+    std::vector<uint8_t> out;
+    put_u32(out, static_cast<uint32_t>(payload.control_name));
+    put_u32(out, payload.control_version);
+    put_u32(out, static_cast<uint32_t>(payload.command_bytes.size()));
+    put_bytes(out, payload.command_bytes.data(), payload.command_bytes.size());
+    return out;
+}
+
+ControlPayload decode_control(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    uint32_t raw_control = get_u32(data, size, offset);
+    ensure(valid_control_name(raw_control), "remote_wire: unknown control name");
+    ControlPayload payload;
+    payload.control_name = static_cast<ControlName>(raw_control);
+    payload.control_version = get_u32(data, size, offset);
+    ensure(payload.control_version != 0, "remote_wire: control version must be non-zero");
+    uint32_t command_len = get_u32(data, size, offset);
+    ensure(command_len <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: control payload too large");
+    ensure_available(size, offset, command_len, "control payload");
+    payload.command_bytes.assign(data + offset, data + offset + command_len);
+    offset += command_len;
+    ensure(offset == size, "remote_wire: trailing bytes after control");
+    return payload;
+}
+
+std::vector<uint8_t> encode_register_callable_command(
+    RemoteRegistryTarget target_registry, CallableKind callable_kind,
+    const std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> &digest, uint32_t payload_version,
+    const std::vector<uint8_t> &payload
+) {
+    ensure(
+        valid_remote_registry_target(static_cast<uint32_t>(target_registry)), "remote_wire: unknown registry target"
+    );
+    ensure(valid_callable_kind(static_cast<uint32_t>(callable_kind)), "remote_wire: unknown callable kind");
+    ensure(payload_version != 0, "remote_wire: callable payload version must be non-zero");
+    ensure(payload.size() <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: callable payload too large");
+    std::vector<uint8_t> out;
+    put_u32(out, static_cast<uint32_t>(target_registry));
+    put_u32(out, static_cast<uint32_t>(callable_kind));
+    put_bytes(out, digest.data(), digest.size());
+    put_u32(out, payload_version);
+    put_u32(out, static_cast<uint32_t>(payload.size()));
+    put_bytes(out, payload.data(), payload.size());
+    return out;
+}
+
+std::vector<uint8_t> encode_digest_callable_command(
+    RemoteRegistryTarget target_registry, CallableKind callable_kind,
+    const std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> &digest
+) {
+    ensure(
+        valid_remote_registry_target(static_cast<uint32_t>(target_registry)), "remote_wire: unknown registry target"
+    );
+    ensure(valid_callable_kind(static_cast<uint32_t>(callable_kind)), "remote_wire: unknown callable kind");
+    std::vector<uint8_t> out;
+    put_u32(out, static_cast<uint32_t>(target_registry));
+    put_u32(out, static_cast<uint32_t>(callable_kind));
+    put_bytes(out, digest.data(), digest.size());
+    return out;
+}
+
+std::vector<uint8_t> encode_export_buffer_request(const ExportBufferRequest &request) {
+    ensure(request.owner_endpoint_id >= 0, "remote_wire: EXPORT_BUFFER owner endpoint must be non-negative");
+    ensure(request.buffer_id != 0, "remote_wire: EXPORT_BUFFER buffer_id must be non-zero");
+    ensure(request.generation != 0, "remote_wire: EXPORT_BUFFER generation must be non-zero");
+    ensure(request.nbytes != 0, "remote_wire: EXPORT_BUFFER nbytes must be non-zero");
+    ensure(
+        request.nbytes <= std::numeric_limits<uint64_t>::max() - request.offset,
+        "remote_wire: EXPORT_BUFFER offset+nbytes overflows"
+    );
+    validate_access_flags(request.access_flags, "EXPORT_BUFFER access_flags");
+    std::vector<uint8_t> out;
+    put_i32(out, request.owner_endpoint_id);
+    put_u64(out, request.buffer_id);
+    put_u64(out, request.generation);
+    put_u64(out, request.offset);
+    put_u64(out, request.nbytes);
+    put_u32(out, request.access_flags);
+    put_string(out, request.transport_profile, MAX_TRANSPORT_PROFILE_BYTES, "EXPORT_BUFFER.transport_profile");
+    put_u32(out, 0);
+    return out;
+}
+
+ExportBufferRequest decode_export_buffer_request(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    ExportBufferRequest request;
+    request.owner_endpoint_id = get_i32(data, size, offset);
+    request.buffer_id = get_u64(data, size, offset);
+    request.generation = get_u64(data, size, offset);
+    request.offset = get_u64(data, size, offset);
+    request.nbytes = get_u64(data, size, offset);
+    request.access_flags = get_u32(data, size, offset);
+    request.transport_profile =
+        get_string(data, size, offset, MAX_TRANSPORT_PROFILE_BYTES, "EXPORT_BUFFER.transport_profile");
+    ensure(get_u32(data, size, offset) == 0, "remote_wire: EXPORT_BUFFER reserved field must be zero");
+    ensure(offset == size, "remote_wire: trailing bytes after EXPORT_BUFFER");
+    ensure(request.owner_endpoint_id >= 0, "remote_wire: EXPORT_BUFFER owner endpoint must be non-negative");
+    ensure(request.buffer_id != 0, "remote_wire: EXPORT_BUFFER buffer_id must be non-zero");
+    ensure(request.generation != 0, "remote_wire: EXPORT_BUFFER generation must be non-zero");
+    ensure(request.nbytes != 0, "remote_wire: EXPORT_BUFFER nbytes must be non-zero");
+    ensure(
+        request.nbytes <= std::numeric_limits<uint64_t>::max() - request.offset,
+        "remote_wire: EXPORT_BUFFER offset+nbytes overflows"
+    );
+    validate_access_flags(request.access_flags, "EXPORT_BUFFER access_flags");
+    return request;
+}
+
+std::vector<uint8_t> encode_export_buffer_result(const RemoteBufferExport &result) {
+    ensure(result.owner_endpoint_id >= 0, "remote_wire: export result owner endpoint must be non-negative");
+    ensure(result.buffer_id != 0, "remote_wire: export result buffer_id must be non-zero");
+    ensure(result.generation != 0, "remote_wire: export result generation must be non-zero");
+    ensure(result.nbytes != 0, "remote_wire: export result nbytes must be non-zero");
+    ensure(result.export_id != 0, "remote_wire: export result export_id must be non-zero");
+    ensure(valid_import_address_space(result.address_space), "remote_wire: export result address_space is invalid");
+    validate_access_flags(result.access_flags, "export result access_flags");
+    std::vector<uint8_t> out;
+    put_i32(out, result.owner_endpoint_id);
+    put_u64(out, result.buffer_id);
+    put_u64(out, result.generation);
+    put_u32(out, static_cast<uint32_t>(result.address_space));
+    put_u64(out, result.offset);
+    put_u64(out, result.nbytes);
+    put_u64(out, result.export_id);
+    put_u64(out, result.remote_addr);
+    put_u64(out, result.rkey_or_token);
+    put_u64(out, result.ub_ldst_va);
+    put_u32(out, result.access_flags);
+    put_string(out, result.transport_profile, MAX_TRANSPORT_PROFILE_BYTES, "export result transport_profile");
+    put_blob(out, result.transport_descriptor, MAX_TRANSPORT_DESCRIPTOR_BYTES, "export result transport_descriptor");
+    put_u32(out, 0);
+    return out;
+}
+
+RemoteBufferExport decode_export_buffer_result(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    RemoteBufferExport result;
+    result.owner_endpoint_id = get_i32(data, size, offset);
+    result.buffer_id = get_u64(data, size, offset);
+    result.generation = get_u64(data, size, offset);
+    uint32_t raw_space = get_u32(data, size, offset);
+    ensure(valid_address_space(raw_space), "remote_wire: export result unknown address_space");
+    result.address_space = static_cast<RemoteAddressSpace>(raw_space);
+    result.offset = get_u64(data, size, offset);
+    result.nbytes = get_u64(data, size, offset);
+    result.export_id = get_u64(data, size, offset);
+    result.remote_addr = get_u64(data, size, offset);
+    result.rkey_or_token = get_u64(data, size, offset);
+    result.ub_ldst_va = get_u64(data, size, offset);
+    result.access_flags = get_u32(data, size, offset);
+    result.transport_profile =
+        get_string(data, size, offset, MAX_TRANSPORT_PROFILE_BYTES, "export result transport_profile");
+    result.transport_descriptor =
+        get_blob(data, size, offset, MAX_TRANSPORT_DESCRIPTOR_BYTES, "export result transport_descriptor");
+    ensure(get_u32(data, size, offset) == 0, "remote_wire: export result reserved field must be zero");
+    ensure(offset == size, "remote_wire: trailing bytes after export result");
+    ensure(result.owner_endpoint_id >= 0, "remote_wire: export result owner endpoint must be non-negative");
+    ensure(result.buffer_id != 0, "remote_wire: export result buffer_id must be non-zero");
+    ensure(result.generation != 0, "remote_wire: export result generation must be non-zero");
+    ensure(result.nbytes != 0, "remote_wire: export result nbytes must be non-zero");
+    ensure(result.export_id != 0, "remote_wire: export result export_id must be non-zero");
+    ensure(valid_import_address_space(result.address_space), "remote_wire: export result address_space is invalid");
+    validate_access_flags(result.access_flags, "export result access_flags");
+    return result;
+}
+
+std::vector<uint8_t> encode_import_buffer_request(const ImportBufferRequest &request) {
+    ensure(request.importer_endpoint_id >= 0, "remote_wire: IMPORT_BUFFER importer endpoint must be non-negative");
+    validate_access_flags(request.requested_access_flags, "IMPORT_BUFFER requested_access_flags");
+    ensure(
+        (request.requested_access_flags & ~request.export_desc.access_flags) == 0,
+        "remote_wire: IMPORT_BUFFER requested access is not a subset of export access"
+    );
+    std::vector<uint8_t> out;
+    put_i32(out, request.importer_endpoint_id);
+    put_u32(out, request.requested_access_flags);
+    auto encoded_export = encode_export_buffer_result(request.export_desc);
+    put_bytes(out, encoded_export.data(), encoded_export.size());
+    put_u32(out, 0);
+    return out;
+}
+
+ImportBufferRequest decode_import_buffer_request(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    ImportBufferRequest request;
+    request.importer_endpoint_id = get_i32(data, size, offset);
+    request.requested_access_flags = get_u32(data, size, offset);
+    ensure(size >= offset + 4, "remote_wire: IMPORT_BUFFER payload is truncated");
+    request.export_desc = decode_export_buffer_result(data + offset, size - offset - 4);
+    offset = size - 4;
+    ensure(get_u32(data, size, offset) == 0, "remote_wire: IMPORT_BUFFER reserved field must be zero");
+    ensure(offset == size, "remote_wire: trailing bytes after IMPORT_BUFFER");
+    ensure(request.importer_endpoint_id >= 0, "remote_wire: IMPORT_BUFFER importer endpoint must be non-negative");
+    validate_access_flags(request.requested_access_flags, "IMPORT_BUFFER requested_access_flags");
+    ensure(
+        (request.requested_access_flags & ~request.export_desc.access_flags) == 0,
+        "remote_wire: IMPORT_BUFFER requested access is not a subset of export access"
+    );
+    return request;
+}
+
+std::vector<uint8_t> encode_import_buffer_result(const RemoteBufferHandle &result) {
+    ensure(result.endpoint_id >= 0, "remote_wire: import result importer endpoint must be non-negative");
+    ensure(result.owner_endpoint_id >= 0, "remote_wire: import result owner endpoint must be non-negative");
+    ensure(result.buffer_id != 0, "remote_wire: import result buffer_id must be non-zero");
+    ensure(result.generation != 0, "remote_wire: import result generation must be non-zero");
+    ensure(result.import_id != 0, "remote_wire: import result import_id must be non-zero");
+    ensure(valid_import_address_space(result.address_space), "remote_wire: import result address_space is invalid");
+    validate_access_flags(result.access_flags, "import result access_flags");
+    std::vector<uint8_t> out;
+    put_i32(out, result.endpoint_id);
+    put_i32(out, result.owner_endpoint_id);
+    put_u64(out, result.buffer_id);
+    put_u64(out, result.generation);
+    put_u64(out, result.import_id);
+    put_u32(out, static_cast<uint32_t>(result.address_space));
+    put_u64(out, result.offset);
+    put_u64(out, result.nbytes);
+    put_u64(out, result.remote_addr);
+    put_u64(out, result.rkey_or_token);
+    put_u64(out, result.ub_ldst_va);
+    put_u32(out, result.access_flags);
+    put_string(out, "", MAX_TRANSPORT_PROFILE_BYTES, "import result transport_profile");
+    std::vector<uint8_t> empty_descriptor;
+    put_blob(out, empty_descriptor, MAX_TRANSPORT_DESCRIPTOR_BYTES, "import result import_descriptor");
+    put_u32(out, 0);
+    return out;
+}
+
+RemoteBufferHandle decode_import_buffer_result(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    RemoteBufferHandle result;
+    result.endpoint_id = get_i32(data, size, offset);
+    result.owner_endpoint_id = get_i32(data, size, offset);
+    result.buffer_id = get_u64(data, size, offset);
+    result.generation = get_u64(data, size, offset);
+    result.import_id = get_u64(data, size, offset);
+    uint32_t raw_space = get_u32(data, size, offset);
+    ensure(valid_address_space(raw_space), "remote_wire: import result unknown address_space");
+    result.address_space = static_cast<RemoteAddressSpace>(raw_space);
+    result.offset = get_u64(data, size, offset);
+    result.nbytes = get_u64(data, size, offset);
+    result.remote_addr = get_u64(data, size, offset);
+    result.rkey_or_token = get_u64(data, size, offset);
+    result.ub_ldst_va = get_u64(data, size, offset);
+    result.access_flags = get_u32(data, size, offset);
+    (void)get_string(data, size, offset, MAX_TRANSPORT_PROFILE_BYTES, "import result transport_profile");
+    (void)get_blob(data, size, offset, MAX_TRANSPORT_DESCRIPTOR_BYTES, "import result import_descriptor");
+    ensure(get_u32(data, size, offset) == 0, "remote_wire: import result reserved field must be zero");
+    ensure(offset == size, "remote_wire: trailing bytes after import result");
+    ensure(result.endpoint_id >= 0, "remote_wire: import result importer endpoint must be non-negative");
+    ensure(result.owner_endpoint_id >= 0, "remote_wire: import result owner endpoint must be non-negative");
+    ensure(result.buffer_id != 0, "remote_wire: import result buffer_id must be non-zero");
+    ensure(result.generation != 0, "remote_wire: import result generation must be non-zero");
+    ensure(result.import_id != 0, "remote_wire: import result import_id must be non-zero");
+    ensure(valid_import_address_space(result.address_space), "remote_wire: import result address_space is invalid");
+    validate_access_flags(result.access_flags, "import result access_flags");
+    return result;
+}
+
+std::vector<uint8_t> encode_release_import_request(const ReleaseImportRequest &request) {
+    ensure(request.importer_endpoint_id >= 0, "remote_wire: RELEASE_IMPORT importer endpoint must be non-negative");
+    ensure(request.owner_endpoint_id >= 0, "remote_wire: RELEASE_IMPORT owner endpoint must be non-negative");
+    ensure(request.buffer_id != 0, "remote_wire: RELEASE_IMPORT buffer_id must be non-zero");
+    ensure(request.generation != 0, "remote_wire: RELEASE_IMPORT generation must be non-zero");
+    ensure(request.import_id != 0, "remote_wire: RELEASE_IMPORT import_id must be non-zero");
+    std::vector<uint8_t> out;
+    put_i32(out, request.importer_endpoint_id);
+    put_i32(out, request.owner_endpoint_id);
+    put_u64(out, request.buffer_id);
+    put_u64(out, request.generation);
+    put_u64(out, request.import_id);
+    put_u32(out, 0);
+    return out;
+}
+
+ReleaseImportRequest decode_release_import_request(const uint8_t *data, size_t size) {
+    size_t offset = 0;
+    ReleaseImportRequest request;
+    request.importer_endpoint_id = get_i32(data, size, offset);
+    request.owner_endpoint_id = get_i32(data, size, offset);
+    request.buffer_id = get_u64(data, size, offset);
+    request.generation = get_u64(data, size, offset);
+    request.import_id = get_u64(data, size, offset);
+    ensure(get_u32(data, size, offset) == 0, "remote_wire: RELEASE_IMPORT reserved field must be zero");
+    ensure(offset == size, "remote_wire: trailing bytes after RELEASE_IMPORT");
+    ensure(request.importer_endpoint_id >= 0, "remote_wire: RELEASE_IMPORT importer endpoint must be non-negative");
+    ensure(request.owner_endpoint_id >= 0, "remote_wire: RELEASE_IMPORT owner endpoint must be non-negative");
+    ensure(request.buffer_id != 0, "remote_wire: RELEASE_IMPORT buffer_id must be non-zero");
+    ensure(request.generation != 0, "remote_wire: RELEASE_IMPORT generation must be non-zero");
+    ensure(request.import_id != 0, "remote_wire: RELEASE_IMPORT import_id must be non-zero");
+    return request;
+}
+
+std::vector<uint8_t> encode_control_reply(const ControlReplyPayload &payload) {
+    ensure(payload.error_message.size() <= MAX_ERROR_BYTES, "remote_wire: control reply error message too long");
+    ensure(payload.result_bytes.size() <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: control reply result too large");
+    std::vector<uint8_t> out;
+    put_u64(out, payload.sequence);
+    put_u32(out, static_cast<uint32_t>(payload.control_name));
+    put_u32(out, payload.control_version);
+    put_i32(out, payload.error_code);
+    put_string(out, payload.error_message, MAX_ERROR_BYTES, "control_reply.error_message");
+    put_u32(out, static_cast<uint32_t>(payload.result_bytes.size()));
+    put_bytes(out, payload.result_bytes.data(), payload.result_bytes.size());
+    return out;
+}
+
+ControlReplyPayload decode_control_reply(
+    const uint8_t *data, size_t size, uint64_t expected_sequence, ControlName expected_control_name,
+    uint32_t expected_control_version
+) {
+    size_t offset = 0;
+    ControlReplyPayload payload;
+    payload.sequence = get_u64(data, size, offset);
+    ensure(payload.sequence == expected_sequence, "remote_wire: control reply sequence mismatch");
+    uint32_t raw_control = get_u32(data, size, offset);
+    ensure(valid_control_name(raw_control), "remote_wire: unknown control reply name");
+    payload.control_name = static_cast<ControlName>(raw_control);
+    ensure(payload.control_name == expected_control_name, "remote_wire: control reply name mismatch");
+    payload.control_version = get_u32(data, size, offset);
+    ensure(payload.control_version == expected_control_version, "remote_wire: control reply version mismatch");
+    payload.error_code = get_i32(data, size, offset);
+    payload.error_message = get_string(data, size, offset, MAX_ERROR_BYTES, "control_reply.error_message");
+    uint32_t result_len = get_u32(data, size, offset);
+    ensure(result_len <= MAX_FRAME_PAYLOAD_BYTES, "remote_wire: control reply result too large");
+    ensure_available(size, offset, result_len, "control reply result");
+    payload.result_bytes.assign(data + offset, data + offset + result_len);
+    offset += result_len;
+    ensure(offset == size, "remote_wire: trailing bytes after control reply");
+    return payload;
+}
+
+uint64_t OrderedCommandLane::begin_command() {
+    ensure(!in_flight_, "remote_wire: ordered command lane already has an in-flight command");
+    in_flight_ = true;
+    in_flight_sequence_ = next_sequence_++;
+    return in_flight_sequence_;
+}
+
+void OrderedCommandLane::finish_reply(uint64_t sequence) {
+    ensure(in_flight_, "remote_wire: ordered command lane has no in-flight command");
+    ensure(sequence == in_flight_sequence_, "remote_wire: ordered command lane reply sequence mismatch");
+    in_flight_ = false;
+    in_flight_sequence_ = 0;
+}
+
+}  // namespace remote_l3

--- a/src/common/hierarchical/remote_wire.h
+++ b/src/common/hierarchical/remote_wire.h
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "../task_interface/call_config.h"
+#include "../task_interface/tensor_arg.h"
+#include "types.h"
+
+namespace remote_l3 {
+
+static constexpr uint32_t PROTOCOL_VERSION = 1;
+static constexpr uint32_t MAX_FRAME_PAYLOAD_BYTES = 16U * 1024U * 1024U;
+static constexpr uint32_t MAX_STRING_BYTES = 1024U;
+static constexpr uint32_t MAX_ERROR_BYTES = 4096U;
+static constexpr uint32_t MAX_TENSORS = 4096U;
+static constexpr uint32_t MAX_SCALARS = 4096U;
+static constexpr uint32_t MAX_INLINE_PAYLOAD_BYTES = 1024U * 1024U;
+static constexpr uint32_t MAX_TRANSPORT_PROFILE_BYTES = 128U;
+static constexpr uint32_t MAX_TRANSPORT_DESCRIPTOR_BYTES = 4096U;
+static constexpr uint32_t REMOTE_BUFFER_ACCESS_READ = 1U << 0;
+static constexpr uint32_t REMOTE_BUFFER_ACCESS_WRITE = 1U << 1;
+static constexpr uint32_t REMOTE_BUFFER_ACCESS_READ_WRITE = REMOTE_BUFFER_ACCESS_READ | REMOTE_BUFFER_ACCESS_WRITE;
+
+enum class FrameType : uint32_t {
+    HELLO = 1,
+    TASK = 2,
+    CONTROL = 3,
+    CONTROL_REPLY = 4,
+    COMPLETION = 5,
+    HEALTH = 6,
+    SHUTDOWN = 7,
+};
+
+enum class ControlName : uint32_t {
+    UNREGISTER_CALLABLE = 1,
+    PREPARE_REGISTER_CALLABLE = 2,
+    COMMIT_REGISTER_CALLABLE = 3,
+    ABORT_REGISTER_CALLABLE = 4,
+    PREPARE_CALLABLE = 5,
+    ALLOC_REMOTE_BUFFER = 6,
+    FREE_REMOTE_BUFFER = 7,
+    COPY_TO_REMOTE = 8,
+    COPY_FROM_REMOTE = 9,
+    EXPORT_BUFFER = 10,
+    IMPORT_BUFFER = 11,
+    RELEASE_IMPORT = 12,
+    COMM_INIT = 13,
+    ALLOC_DOMAIN = 14,
+    RELEASE_DOMAIN = 15,
+};
+
+enum class ReadyState : uint32_t {
+    NOT_READY = 0,
+    READY = 1,
+};
+
+enum class RemoteRegistryTarget : uint32_t {
+    REMOTE_TASK_DISPATCHER = 1,
+    INNER_L3_WORKER = 2,
+};
+
+struct FrameHeader {
+    FrameType frame_type{FrameType::HELLO};
+    uint64_t session_id{0};
+    int32_t endpoint_id{-1};
+    uint64_t sequence{0};
+    uint32_t payload_bytes{0};
+    uint32_t flags{0};
+};
+
+struct DecodedFrame {
+    FrameHeader header{};
+    std::vector<uint8_t> payload;
+};
+
+struct HelloPayload {
+    uint64_t session_id{0};
+    int32_t endpoint_id{-1};
+    uint32_t protocol_version{PROTOCOL_VERSION};
+    std::string comm_profile;
+    uint64_t feature_flags{0};
+    ReadyState ready_state{ReadyState::NOT_READY};
+};
+
+struct RemoteTaskArgsWire {
+    std::vector<ContinuousTensor> tensor_metadata;
+    std::vector<RemoteTensorSidecar> remote_desc;
+    std::vector<uint64_t> scalars;
+    std::vector<uint8_t> inline_payload;
+};
+
+struct TaskPayloadWire {
+    std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> callable_digest{};
+    CallConfig config{};
+    RemoteTaskArgsWire args;
+};
+
+struct CompletionPayload {
+    uint64_t sequence{0};
+    int32_t error_code{0};
+    std::string error_message;
+};
+
+struct ControlPayload {
+    ControlName control_name{ControlName::PREPARE_CALLABLE};
+    uint32_t control_version{1};
+    std::vector<uint8_t> command_bytes;
+};
+
+struct ControlReplyPayload {
+    uint64_t sequence{0};
+    ControlName control_name{ControlName::PREPARE_CALLABLE};
+    uint32_t control_version{1};
+    int32_t error_code{0};
+    std::string error_message;
+    std::vector<uint8_t> result_bytes;
+};
+
+struct ExportBufferRequest {
+    int32_t owner_endpoint_id{-1};
+    uint64_t buffer_id{0};
+    uint64_t generation{0};
+    uint64_t offset{0};
+    uint64_t nbytes{0};
+    uint32_t access_flags{0};
+    std::string transport_profile;
+};
+
+struct ImportBufferRequest {
+    int32_t importer_endpoint_id{-1};
+    uint32_t requested_access_flags{0};
+    RemoteBufferExport export_desc{};
+};
+
+struct ReleaseImportRequest {
+    int32_t importer_endpoint_id{-1};
+    int32_t owner_endpoint_id{-1};
+    uint64_t buffer_id{0};
+    uint64_t generation{0};
+    uint64_t import_id{0};
+};
+
+std::vector<uint8_t> encode_frame(const FrameHeader &header, const std::vector<uint8_t> &payload);
+DecodedFrame decode_frame(const uint8_t *data, size_t size);
+DecodedFrame decode_frame(const std::vector<uint8_t> &data);
+
+std::vector<uint8_t> encode_hello(const HelloPayload &payload);
+HelloPayload decode_hello(const uint8_t *data, size_t size);
+
+std::vector<uint8_t> encode_call_config(const CallConfig &config);
+CallConfig decode_call_config(const uint8_t *data, size_t size, size_t &offset);
+
+std::vector<uint8_t> encode_continuous_tensor(const ContinuousTensor &tensor);
+ContinuousTensor decode_continuous_tensor(const uint8_t *data, size_t size, size_t &offset, bool remote_task);
+
+std::vector<uint8_t> encode_remote_tensor_desc(const RemoteTensorDesc &desc);
+RemoteTensorDesc decode_remote_tensor_desc(const uint8_t *data, size_t size, size_t &offset);
+
+std::vector<uint8_t> encode_remote_task_args(const RemoteTaskArgsWire &args);
+RemoteTaskArgsWire decode_remote_task_args(const uint8_t *data, size_t size);
+
+std::vector<uint8_t> encode_task_payload(const TaskPayloadWire &payload);
+TaskPayloadWire decode_task_payload(const uint8_t *data, size_t size);
+
+std::vector<uint8_t> encode_completion(const CompletionPayload &payload);
+CompletionPayload decode_completion(const uint8_t *data, size_t size, uint64_t expected_sequence);
+
+std::vector<uint8_t> encode_control(const ControlPayload &payload);
+ControlPayload decode_control(const uint8_t *data, size_t size);
+
+std::vector<uint8_t> encode_register_callable_command(
+    RemoteRegistryTarget target_registry, CallableKind callable_kind,
+    const std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> &digest, uint32_t payload_version,
+    const std::vector<uint8_t> &payload
+);
+std::vector<uint8_t> encode_digest_callable_command(
+    RemoteRegistryTarget target_registry, CallableKind callable_kind,
+    const std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> &digest
+);
+
+std::vector<uint8_t> encode_export_buffer_request(const ExportBufferRequest &request);
+ExportBufferRequest decode_export_buffer_request(const uint8_t *data, size_t size);
+std::vector<uint8_t> encode_export_buffer_result(const RemoteBufferExport &result);
+RemoteBufferExport decode_export_buffer_result(const uint8_t *data, size_t size);
+std::vector<uint8_t> encode_import_buffer_request(const ImportBufferRequest &request);
+ImportBufferRequest decode_import_buffer_request(const uint8_t *data, size_t size);
+std::vector<uint8_t> encode_import_buffer_result(const RemoteBufferHandle &result);
+RemoteBufferHandle decode_import_buffer_result(const uint8_t *data, size_t size);
+std::vector<uint8_t> encode_release_import_request(const ReleaseImportRequest &request);
+ReleaseImportRequest decode_release_import_request(const uint8_t *data, size_t size);
+
+std::vector<uint8_t> encode_control_reply(const ControlReplyPayload &payload);
+ControlReplyPayload decode_control_reply(
+    const uint8_t *data, size_t size, uint64_t expected_sequence, ControlName expected_control_name,
+    uint32_t expected_control_version
+);
+
+class OrderedCommandLane {
+public:
+    uint64_t begin_command();
+    void finish_reply(uint64_t sequence);
+    bool in_flight() const { return in_flight_; }
+
+private:
+    uint64_t next_sequence_{1};
+    uint64_t in_flight_sequence_{0};
+    bool in_flight_{false};
+};
+
+}  // namespace remote_l3

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -130,6 +130,12 @@ enum class RemoteAddressSpace : int32_t {
     UB_LDST = 4,
 };
 
+// RemoteBufferHandle combines wire-visible identity/mapping metadata
+// (`endpoint_id`, `owner_endpoint_id`, `buffer_id`, `generation`, `import_id`,
+// `address_space`, `nbytes`, `offset`, `remote_addr`, `rkey_or_token`,
+// `ub_ldst_va`, `access_flags`) with parent-local lifecycle state (`released`,
+// `live_slot_refs`). Keep wire formats in remote_wire.cpp explicit; do not
+// serialize this struct by raw POD copy.
 struct RemoteBufferHandle {
     int32_t endpoint_id{-1};
     int32_t owner_endpoint_id{-1};

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -35,6 +35,7 @@
 #include <functional>
 #include <mutex>
 #include <queue>
+#include <string>
 #include <vector>
 
 #include "../task_interface/call_config.h"
@@ -85,11 +86,13 @@ static constexpr size_t CALLABLE_HASH_DIGEST_SIZE = 32;
 enum class CallableKind : int32_t {
     CHIP_CALLABLE = 1,
     PYTHON_SERIALIZED = 2,
+    PYTHON_IMPORT = 3,
 };
 
 enum class TargetNamespace : int32_t {
     LOCAL_CHIP = 1,
     LOCAL_PYTHON = 2,
+    REMOTE_TASK_DISPATCHER = 3,
 };
 
 struct CallableIdentity {
@@ -118,6 +121,83 @@ enum class TaskState : int32_t {
     RUNNING = 3,    // dispatched to a worker
     COMPLETED = 4,  // worker finished, outputs may still be referenced
     CONSUMED = 5,   // all references released, slot may be reused
+};
+
+enum class RemoteAddressSpace : int32_t {
+    HOST_INLINE = 1,
+    REMOTE_DEVICE = 2,
+    REMOTE_WINDOW = 3,
+    UB_LDST = 4,
+};
+
+struct RemoteBufferHandle {
+    int32_t endpoint_id{-1};
+    int32_t owner_endpoint_id{-1};
+    uint64_t buffer_id{0};
+    uint64_t generation{0};
+    uint64_t import_id{0};
+    RemoteAddressSpace address_space{RemoteAddressSpace::REMOTE_DEVICE};
+    uint64_t nbytes{0};
+    uint64_t offset{0};
+    uint64_t remote_addr{0};
+    uint64_t rkey_or_token{0};
+    uint64_t ub_ldst_va{0};
+    uint32_t access_flags{0};
+    bool released{false};
+    int32_t live_slot_refs{0};
+};
+
+struct RemoteBufferExport {
+    int32_t owner_endpoint_id{-1};
+    uint64_t buffer_id{0};
+    uint64_t generation{0};
+    RemoteAddressSpace address_space{RemoteAddressSpace::REMOTE_WINDOW};
+    uint64_t offset{0};
+    uint64_t nbytes{0};
+    uint64_t export_id{0};
+    uint64_t remote_addr{0};
+    uint64_t rkey_or_token{0};
+    uint64_t ub_ldst_va{0};
+    uint32_t access_flags{0};
+    std::string transport_profile;
+    std::vector<uint8_t> transport_descriptor;
+};
+
+struct RemoteTensorDesc {
+    RemoteAddressSpace address_space{RemoteAddressSpace::REMOTE_DEVICE};
+    int32_t owner_endpoint_id{-1};
+    uint64_t buffer_id{0};
+    uint64_t offset{0};
+    uint64_t nbytes{0};
+    uint64_t remote_addr{0};
+    uint64_t rkey_or_token{0};
+    uint64_t generation{0};
+    uint64_t inline_payload_offset{0};
+    uint64_t inline_payload_len{0};
+    uint64_t flags{0};
+};
+
+struct RemoteTensorSidecar {
+    bool present{false};
+    RemoteTensorDesc desc{};
+};
+
+struct RemoteTaskArgsSidecar {
+    std::vector<RemoteTensorSidecar> tensors;
+    std::vector<uint8_t> inline_payload;
+
+    bool empty() const {
+        if (!inline_payload.empty()) return false;
+        for (const auto &tensor : tensors) {
+            if (tensor.present) return false;
+        }
+        return true;
+    }
+
+    void clear() {
+        tensors.clear();
+        inline_payload.clear();
+    }
 };
 
 // =============================================================================

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -131,6 +131,7 @@ add_library(hierarchical_objs OBJECT
     ${HIERARCHICAL_SRC_DIR}/tensormap.cpp
     ${HIERARCHICAL_SRC_DIR}/ring.cpp
     ${HIERARCHICAL_SRC_DIR}/scope.cpp
+    ${HIERARCHICAL_SRC_DIR}/remote_wire.cpp
     ${HIERARCHICAL_SRC_DIR}/orchestrator.cpp
     ${HIERARCHICAL_SRC_DIR}/worker_manager.cpp
     ${HIERARCHICAL_SRC_DIR}/scheduler.cpp
@@ -279,6 +280,7 @@ add_hierarchical_test(test_ring  hierarchical/test_ring.cpp)
 add_hierarchical_test(test_scope      hierarchical/test_scope.cpp)
 add_hierarchical_test(test_orchestrator hierarchical/test_orchestrator.cpp)
 add_hierarchical_test(test_scheduler  hierarchical/test_scheduler.cpp)
+add_hierarchical_test(test_remote_wire hierarchical/test_remote_wire.cpp)
 
 # ---------------------------------------------------------------------------
 # Types / task_interface tests (src/common/task_interface/)

--- a/tests/ut/cpp/hierarchical/test_remote_wire.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_wire.cpp
@@ -160,6 +160,27 @@ TEST(RemoteWire, NonHostInlineDescriptorRejectsInlinePayloadFields) {
     EXPECT_THROW((void)remote_l3::encode_remote_task_args(args), std::runtime_error);
 }
 
+TEST(RemoteWire, NonHostInlineDescriptorRejectsMissingBufferIdentity) {
+    remote_l3::RemoteTaskArgsWire args;
+    args.tensor_metadata.push_back(metadata_tensor());
+
+    RemoteTensorSidecar sidecar;
+    sidecar.present = true;
+    sidecar.desc.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    sidecar.desc.owner_endpoint_id = 3;
+    sidecar.desc.buffer_id = 9;
+    sidecar.desc.generation = 1;
+    sidecar.desc.nbytes = 4;
+    args.remote_desc.push_back(sidecar);
+
+    args.remote_desc[0].desc.buffer_id = 0;
+    EXPECT_THROW((void)remote_l3::encode_remote_task_args(args), std::runtime_error);
+
+    args.remote_desc[0].desc.buffer_id = 9;
+    args.remote_desc[0].desc.generation = 0;
+    EXPECT_THROW((void)remote_l3::encode_remote_task_args(args), std::runtime_error);
+}
+
 TEST(RemoteWire, CompletionAndControlReplyMatchSequences) {
     remote_l3::CompletionPayload completion;
     completion.sequence = 42;

--- a/tests/ut/cpp/hierarchical/test_remote_wire.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_wire.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+#include "remote_wire.h"
+
+namespace {
+
+ContinuousTensor metadata_tensor() {
+    ContinuousTensor t{};
+    t.data = 0;
+    t.ndims = 1;
+    t.shapes[0] = 4;
+    t.dtype = DataType::UINT8;
+    t.child_memory = 0;
+    return t;
+}
+
+}  // namespace
+
+TEST(RemoteWire, FrameRoundTripValidatesHeader) {
+    std::vector<uint8_t> payload{1, 2, 3};
+    remote_l3::FrameHeader header;
+    header.frame_type = remote_l3::FrameType::TASK;
+    header.session_id = 7;
+    header.endpoint_id = 2;
+    header.sequence = 9;
+
+    auto encoded = remote_l3::encode_frame(header, payload);
+    auto decoded = remote_l3::decode_frame(encoded);
+
+    EXPECT_EQ(decoded.header.frame_type, remote_l3::FrameType::TASK);
+    EXPECT_EQ(decoded.header.session_id, 7u);
+    EXPECT_EQ(decoded.header.endpoint_id, 2);
+    EXPECT_EQ(decoded.header.sequence, 9u);
+    EXPECT_EQ(decoded.header.payload_bytes, payload.size());
+    EXPECT_EQ(decoded.payload, payload);
+
+    encoded[0] = 'X';
+    EXPECT_THROW((void)remote_l3::decode_frame(encoded), std::runtime_error);
+}
+
+TEST(RemoteWire, FrameRejectsBadVersionFlagsAndUnknownType) {
+    remote_l3::FrameHeader header;
+    header.frame_type = remote_l3::FrameType::HEALTH;
+    header.session_id = 7;
+    header.endpoint_id = 2;
+    header.sequence = 9;
+    auto encoded = remote_l3::encode_frame(header, {});
+
+    auto bad_version = encoded;
+    bad_version[4] = 0xFF;
+    EXPECT_THROW((void)remote_l3::decode_frame(bad_version), std::runtime_error);
+
+    auto bad_type = encoded;
+    bad_type[8] = 0xFF;
+    EXPECT_THROW((void)remote_l3::decode_frame(bad_type), std::runtime_error);
+
+    auto bad_flags = encoded;
+    bad_flags[36] = 1;
+    EXPECT_THROW((void)remote_l3::decode_frame(bad_flags), std::runtime_error);
+}
+
+TEST(RemoteWire, TaskPayloadRejectsNonZeroTensorData) {
+    remote_l3::TaskPayloadWire payload;
+    payload.callable_digest.fill(0xAB);
+    payload.args.tensor_metadata.push_back(metadata_tensor());
+    payload.args.scalars.push_back(0xCAFE);
+
+    auto encoded = remote_l3::encode_task_payload(payload);
+    auto decoded = remote_l3::decode_task_payload(encoded.data(), encoded.size());
+    ASSERT_EQ(decoded.args.tensor_metadata.size(), 1u);
+    EXPECT_EQ(decoded.callable_digest[0], 0xAB);
+    EXPECT_EQ(decoded.args.scalars[0], 0xCAFEu);
+
+    payload.args.tensor_metadata[0].data = 0x1234;
+    EXPECT_THROW((void)remote_l3::encode_task_payload(payload), std::runtime_error);
+}
+
+TEST(RemoteWire, TaskPayloadPreservesScopeStatsCallConfig) {
+    remote_l3::TaskPayloadWire payload;
+    payload.callable_digest.fill(0xAB);
+    payload.config.block_dim = 7;
+    payload.config.aicpu_thread_num = 5;
+    payload.config.enable_scope_stats = 1;
+    const char *prefix = "/tmp/remote-scope";
+    std::memcpy(payload.config.output_prefix, prefix, std::strlen(prefix));
+    payload.args.tensor_metadata.push_back(metadata_tensor());
+
+    auto encoded = remote_l3::encode_task_payload(payload);
+    auto decoded = remote_l3::decode_task_payload(encoded.data(), encoded.size());
+
+    EXPECT_EQ(decoded.config.block_dim, 7);
+    EXPECT_EQ(decoded.config.aicpu_thread_num, 5);
+    EXPECT_EQ(decoded.config.enable_scope_stats, 1);
+    EXPECT_STREQ(decoded.config.output_prefix, prefix);
+}
+
+TEST(RemoteWire, TruncatedControlPayloadIsRejected) {
+    std::vector<uint8_t> truncated{1, 0, 0};
+    EXPECT_THROW((void)remote_l3::decode_control(truncated.data(), truncated.size()), std::runtime_error);
+}
+
+TEST(RemoteWire, HostInlineDescriptorBoundsAreChecked) {
+    remote_l3::RemoteTaskArgsWire args;
+    args.tensor_metadata.push_back(metadata_tensor());
+    args.inline_payload = {1, 2, 3, 4};
+
+    RemoteTensorSidecar sidecar;
+    sidecar.present = true;
+    sidecar.desc.address_space = RemoteAddressSpace::HOST_INLINE;
+    sidecar.desc.owner_endpoint_id = 0;
+    sidecar.desc.buffer_id = 0;
+    sidecar.desc.offset = 0;
+    sidecar.desc.nbytes = 2;
+    sidecar.desc.generation = 0;
+    sidecar.desc.inline_payload_offset = 1;
+    sidecar.desc.inline_payload_len = 2;
+    args.remote_desc.push_back(sidecar);
+
+    auto encoded = remote_l3::encode_remote_task_args(args);
+    auto decoded = remote_l3::decode_remote_task_args(encoded.data(), encoded.size());
+    ASSERT_EQ(decoded.remote_desc.size(), 1u);
+    EXPECT_TRUE(decoded.remote_desc[0].present);
+    EXPECT_EQ(decoded.remote_desc[0].desc.inline_payload_offset, 1u);
+
+    args.remote_desc[0].desc.inline_payload_offset = 3;
+    EXPECT_THROW((void)remote_l3::encode_remote_task_args(args), std::runtime_error);
+}
+
+TEST(RemoteWire, NonHostInlineDescriptorRejectsInlinePayloadFields) {
+    remote_l3::RemoteTaskArgsWire args;
+    args.tensor_metadata.push_back(metadata_tensor());
+
+    RemoteTensorSidecar sidecar;
+    sidecar.present = true;
+    sidecar.desc.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    sidecar.desc.owner_endpoint_id = 3;
+    sidecar.desc.buffer_id = 9;
+    sidecar.desc.generation = 1;
+    sidecar.desc.nbytes = 4;
+    sidecar.desc.inline_payload_len = 1;
+    args.remote_desc.push_back(sidecar);
+
+    EXPECT_THROW((void)remote_l3::encode_remote_task_args(args), std::runtime_error);
+}
+
+TEST(RemoteWire, CompletionAndControlReplyMatchSequences) {
+    remote_l3::CompletionPayload completion;
+    completion.sequence = 42;
+    completion.error_code = 1;
+    completion.error_message = "remote failure";
+    auto completion_bytes = remote_l3::encode_completion(completion);
+    auto decoded_completion = remote_l3::decode_completion(completion_bytes.data(), completion_bytes.size(), 42);
+    EXPECT_EQ(decoded_completion.error_code, 1);
+    EXPECT_EQ(decoded_completion.error_message, "remote failure");
+    EXPECT_THROW(
+        (void)remote_l3::decode_completion(completion_bytes.data(), completion_bytes.size(), 43), std::runtime_error
+    );
+
+    remote_l3::ControlReplyPayload reply;
+    reply.sequence = 8;
+    reply.control_name = remote_l3::ControlName::PREPARE_REGISTER_CALLABLE;
+    reply.control_version = 1;
+    reply.result_bytes = {9, 9};
+    auto reply_bytes = remote_l3::encode_control_reply(reply);
+    auto decoded_reply = remote_l3::decode_control_reply(
+        reply_bytes.data(), reply_bytes.size(), 8, remote_l3::ControlName::PREPARE_REGISTER_CALLABLE, 1
+    );
+    EXPECT_EQ(decoded_reply.result_bytes, reply.result_bytes);
+    EXPECT_THROW(
+        (void)remote_l3::decode_control_reply(
+            reply_bytes.data(), reply_bytes.size(), 8, remote_l3::ControlName::COMMIT_REGISTER_CALLABLE, 1
+        ),
+        std::runtime_error
+    );
+}
+
+TEST(RemoteWire, RemoteBufferExportImportControlsRoundTrip) {
+    remote_l3::ExportBufferRequest export_request;
+    export_request.owner_endpoint_id = 3;
+    export_request.buffer_id = 11;
+    export_request.generation = 2;
+    export_request.offset = 16;
+    export_request.nbytes = 64;
+    export_request.access_flags = remote_l3::REMOTE_BUFFER_ACCESS_READ_WRITE;
+    export_request.transport_profile = "sim";
+
+    auto export_request_bytes = remote_l3::encode_export_buffer_request(export_request);
+    auto decoded_export_request =
+        remote_l3::decode_export_buffer_request(export_request_bytes.data(), export_request_bytes.size());
+    EXPECT_EQ(decoded_export_request.owner_endpoint_id, 3);
+    EXPECT_EQ(decoded_export_request.offset, 16u);
+    EXPECT_EQ(decoded_export_request.transport_profile, "sim");
+
+    RemoteBufferExport export_result;
+    export_result.owner_endpoint_id = 3;
+    export_result.buffer_id = 11;
+    export_result.generation = 2;
+    export_result.address_space = RemoteAddressSpace::REMOTE_WINDOW;
+    export_result.offset = 16;
+    export_result.nbytes = 64;
+    export_result.export_id = 5;
+    export_result.remote_addr = 0x1000;
+    export_result.rkey_or_token = 5;
+    export_result.access_flags = remote_l3::REMOTE_BUFFER_ACCESS_READ_WRITE;
+    export_result.transport_profile = "sim";
+    export_result.transport_descriptor = {'s', 'h', 'm'};
+
+    auto export_result_bytes = remote_l3::encode_export_buffer_result(export_result);
+    auto decoded_export_result =
+        remote_l3::decode_export_buffer_result(export_result_bytes.data(), export_result_bytes.size());
+    EXPECT_EQ(decoded_export_result.export_id, 5u);
+    EXPECT_EQ(decoded_export_result.transport_descriptor, export_result.transport_descriptor);
+
+    remote_l3::ImportBufferRequest import_request;
+    import_request.importer_endpoint_id = 4;
+    import_request.requested_access_flags = remote_l3::REMOTE_BUFFER_ACCESS_READ;
+    import_request.export_desc = export_result;
+    auto import_request_bytes = remote_l3::encode_import_buffer_request(import_request);
+    auto decoded_import_request =
+        remote_l3::decode_import_buffer_request(import_request_bytes.data(), import_request_bytes.size());
+    EXPECT_EQ(decoded_import_request.importer_endpoint_id, 4);
+    EXPECT_EQ(decoded_import_request.requested_access_flags, remote_l3::REMOTE_BUFFER_ACCESS_READ);
+    EXPECT_EQ(decoded_import_request.export_desc.owner_endpoint_id, 3);
+
+    RemoteBufferHandle import_result;
+    import_result.endpoint_id = 4;
+    import_result.owner_endpoint_id = 3;
+    import_result.buffer_id = 11;
+    import_result.generation = 2;
+    import_result.import_id = 7;
+    import_result.address_space = RemoteAddressSpace::REMOTE_WINDOW;
+    import_result.offset = 16;
+    import_result.nbytes = 64;
+    import_result.rkey_or_token = 7;
+    import_result.access_flags = remote_l3::REMOTE_BUFFER_ACCESS_READ;
+    auto import_result_bytes = remote_l3::encode_import_buffer_result(import_result);
+    auto decoded_import_result =
+        remote_l3::decode_import_buffer_result(import_result_bytes.data(), import_result_bytes.size());
+    EXPECT_EQ(decoded_import_result.endpoint_id, 4);
+    EXPECT_EQ(decoded_import_result.owner_endpoint_id, 3);
+    EXPECT_EQ(decoded_import_result.import_id, 7u);
+
+    remote_l3::ReleaseImportRequest release_request;
+    release_request.importer_endpoint_id = 4;
+    release_request.owner_endpoint_id = 3;
+    release_request.buffer_id = 11;
+    release_request.generation = 2;
+    release_request.import_id = 7;
+    auto release_bytes = remote_l3::encode_release_import_request(release_request);
+    auto decoded_release = remote_l3::decode_release_import_request(release_bytes.data(), release_bytes.size());
+    EXPECT_EQ(decoded_release.importer_endpoint_id, 4);
+    EXPECT_EQ(decoded_release.import_id, 7u);
+}
+
+TEST(RemoteWire, RemoteBufferControlsRejectInvalidAccessAndReservedBytes) {
+    remote_l3::ExportBufferRequest request;
+    request.owner_endpoint_id = 3;
+    request.buffer_id = 11;
+    request.generation = 2;
+    request.nbytes = 64;
+    request.transport_profile = "sim";
+    request.access_flags = 0;
+    EXPECT_THROW((void)remote_l3::encode_export_buffer_request(request), std::runtime_error);
+
+    request.access_flags = 8;
+    EXPECT_THROW((void)remote_l3::encode_export_buffer_request(request), std::runtime_error);
+
+    request.access_flags = remote_l3::REMOTE_BUFFER_ACCESS_READ;
+    auto bytes = remote_l3::encode_export_buffer_request(request);
+    bytes.back() = 1;
+    EXPECT_THROW((void)remote_l3::decode_export_buffer_request(bytes.data(), bytes.size()), std::runtime_error);
+}
+
+TEST(RemoteWire, OrderedCommandLaneIsSingleFlight) {
+    remote_l3::OrderedCommandLane lane;
+    uint64_t first = lane.begin_command();
+    EXPECT_TRUE(lane.in_flight());
+    EXPECT_THROW((void)lane.begin_command(), std::runtime_error);
+    EXPECT_THROW(lane.finish_reply(first + 1), std::runtime_error);
+    lane.finish_reply(first);
+    EXPECT_FALSE(lane.in_flight());
+    EXPECT_EQ(lane.begin_command(), first + 1);
+}

--- a/tests/ut/py/test_remote_l3_protocol.py
+++ b/tests/ut/py/test_remote_l3_protocol.py
@@ -11,8 +11,10 @@ import struct
 
 import pytest
 from simpler.remote_l3_protocol import (
+    MAX_ERROR_BYTES,
     REMOTE_BUFFER_ACCESS_READ,
     CallableKind,
+    ControlName,
     ExportBufferResult,
     ImportBufferResult,
     RemoteAddressSpace,
@@ -20,6 +22,8 @@ from simpler.remote_l3_protocol import (
     decode_export_buffer_result,
     decode_register_callable_command,
     decode_task_payload,
+    encode_completion,
+    encode_control_reply,
     encode_export_buffer_result,
     encode_import_buffer_result,
     encode_register_callable_command,
@@ -58,6 +62,20 @@ def test_register_callable_command_round_trips_python_import_target():
     assert decoded.digest == digest
     assert decoded.payload_version == 1
     assert decoded.payload == target
+
+
+def test_completion_rejects_oversized_utf8_error_message():
+    message = "中" * (MAX_ERROR_BYTES // len("中".encode()) + 1)
+
+    with pytest.raises(ValueError, match="completion error message too long"):
+        encode_completion(1, 1, message)
+
+
+def test_control_reply_rejects_oversized_utf8_error_message():
+    message = "中" * (MAX_ERROR_BYTES // len("中".encode()) + 1)
+
+    with pytest.raises(ValueError, match="control reply error message too long"):
+        encode_control_reply(1, ControlName.PREPARE_CALLABLE, 1, 1, message)
 
 
 def _export_result(**overrides):

--- a/tests/ut/py/test_remote_l3_protocol.py
+++ b/tests/ut/py/test_remote_l3_protocol.py
@@ -9,11 +9,19 @@
 
 import struct
 
+import pytest
 from simpler.remote_l3_protocol import (
+    REMOTE_BUFFER_ACCESS_READ,
     CallableKind,
+    ExportBufferResult,
+    ImportBufferResult,
+    RemoteAddressSpace,
     RemoteRegistryTarget,
+    decode_export_buffer_result,
     decode_register_callable_command,
     decode_task_payload,
+    encode_export_buffer_result,
+    encode_import_buffer_result,
     encode_register_callable_command,
 )
 
@@ -50,3 +58,89 @@ def test_register_callable_command_round_trips_python_import_target():
     assert decoded.digest == digest
     assert decoded.payload_version == 1
     assert decoded.payload == target
+
+
+def _export_result(**overrides):
+    fields = {
+        "owner_endpoint_id": 1,
+        "buffer_id": 2,
+        "generation": 3,
+        "address_space": RemoteAddressSpace.REMOTE_WINDOW,
+        "offset": 0,
+        "nbytes": 4,
+        "export_id": 5,
+        "remote_addr": 0,
+        "rkey_or_token": 0,
+        "ub_ldst_va": 0,
+        "access_flags": REMOTE_BUFFER_ACCESS_READ,
+        "transport_profile": "sim",
+        "transport_descriptor": b"",
+    }
+    fields.update(overrides)
+    return ExportBufferResult(**fields)
+
+
+def _import_result(**overrides):
+    fields = {
+        "importer_endpoint_id": 1,
+        "owner_endpoint_id": 2,
+        "buffer_id": 3,
+        "generation": 4,
+        "import_id": 5,
+        "address_space": RemoteAddressSpace.REMOTE_WINDOW,
+        "offset": 0,
+        "nbytes": 4,
+        "remote_addr": 0,
+        "rkey_or_token": 0,
+        "ub_ldst_va": 0,
+        "access_flags": REMOTE_BUFFER_ACCESS_READ,
+        "transport_profile": "sim",
+        "import_descriptor": b"",
+    }
+    fields.update(overrides)
+    return ImportBufferResult(**fields)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("owner_endpoint_id", -1),
+        ("buffer_id", 0),
+        ("generation", 0),
+    ],
+)
+def test_export_buffer_result_rejects_invalid_live_identity(field, value):
+    with pytest.raises(ValueError, match="live owner buffer identity"):
+        encode_export_buffer_result(_export_result(**{field: value}))
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("owner_endpoint_id", -1),
+        ("buffer_id", 0),
+        ("generation", 0),
+    ],
+)
+def test_export_buffer_result_decode_rejects_invalid_live_identity(field, value):
+    encoded = encode_export_buffer_result(_export_result())
+    values = list(struct.unpack_from("<iQQ", encoded, 0))
+    values[["owner_endpoint_id", "buffer_id", "generation"].index(field)] = value
+    corrupted = struct.pack("<iQQ", *values) + encoded[20:]
+
+    with pytest.raises(ValueError, match="live owner buffer identity"):
+        decode_export_buffer_result(corrupted)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("importer_endpoint_id", -1),
+        ("owner_endpoint_id", -1),
+        ("buffer_id", 0),
+        ("generation", 0),
+    ],
+)
+def test_import_buffer_result_rejects_invalid_live_identity(field, value):
+    with pytest.raises(ValueError, match="live imported buffer identity"):
+        encode_import_buffer_result(_import_result(**{field: value}))

--- a/tests/ut/py/test_remote_l3_protocol.py
+++ b/tests/ut/py/test_remote_l3_protocol.py
@@ -1,0 +1,52 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import struct
+
+from simpler.remote_l3_protocol import (
+    CallableKind,
+    RemoteRegistryTarget,
+    decode_register_callable_command,
+    decode_task_payload,
+    encode_register_callable_command,
+)
+
+
+def test_task_payload_decode_preserves_scope_stats_config():
+    prefix = b"/tmp/remote-scope"
+    config = struct.pack("<iiiiiii", 7, 5, 0, 0, 0, 0, 1) + struct.pack("<I", len(prefix)) + prefix
+    args = struct.pack("<III", 0, 0, 0)
+    wire = (b"\xab" * 32) + config + args
+
+    payload = decode_task_payload(wire)
+
+    assert payload.config.block_dim == 7
+    assert payload.config.aicpu_thread_num == 5
+    assert payload.config.enable_scope_stats is True
+    assert payload.config.output_prefix == prefix.decode()
+
+
+def test_register_callable_command_round_trips_python_import_target():
+    digest = b"\x12" * 32
+    target = b"pkg.mod:remote_entry"
+    encoded = encode_register_callable_command(
+        RemoteRegistryTarget.REMOTE_TASK_DISPATCHER,
+        CallableKind.PYTHON_IMPORT,
+        digest,
+        1,
+        target,
+    )
+
+    decoded = decode_register_callable_command(encoded)
+
+    assert decoded.target_registry == RemoteRegistryTarget.REMOTE_TASK_DISPATCHER
+    assert decoded.callable_kind == CallableKind.PYTHON_IMPORT
+    assert decoded.digest == digest
+    assert decoded.payload_version == 1
+    assert decoded.payload == target

--- a/tests/ut/py/test_remote_l3_protocol.py
+++ b/tests/ut/py/test_remote_l3_protocol.py
@@ -30,6 +30,11 @@ from simpler.remote_l3_protocol import (
 )
 
 
+def _oversized_multibyte_error_message():
+    multi_byte = chr(0x20AC)
+    return multi_byte * (MAX_ERROR_BYTES // len(multi_byte.encode("utf-8")) + 1)
+
+
 def test_task_payload_decode_preserves_scope_stats_config():
     prefix = b"/tmp/remote-scope"
     config = struct.pack("<iiiiiii", 7, 5, 0, 0, 0, 0, 1) + struct.pack("<I", len(prefix)) + prefix
@@ -65,14 +70,14 @@ def test_register_callable_command_round_trips_python_import_target():
 
 
 def test_completion_rejects_oversized_utf8_error_message():
-    message = "中" * (MAX_ERROR_BYTES // len("中".encode()) + 1)
+    message = _oversized_multibyte_error_message()
 
     with pytest.raises(ValueError, match="completion error message too long"):
         encode_completion(1, 1, message)
 
 
 def test_control_reply_rejects_oversized_utf8_error_message():
-    message = "中" * (MAX_ERROR_BYTES // len("中".encode()) + 1)
+    message = _oversized_multibyte_error_message()
 
     with pytest.raises(ValueError, match="control reply error message too long"):
         encode_control_reply(1, ControlName.PREPARE_CALLABLE, 1, 1, message)


### PR DESCRIPTION
## Summary

This is PR 3 of the remote L3 worker split stack. It adds the transport-neutral
remote L3 wire codec in both C++ and Python.

This PR defines how remote L3 messages are encoded, decoded, validated, and
round-tripped. It does not add scheduling, a live remote endpoint, or a Python
session runtime.

  ## Relationship to PR #866 and split stack

  This PR is part of the split stack extracted from #866.

  Stack:
  - #1006: docs: add remote L3 worker contract
  - #1007: feat: add remote import callable descriptors
  - #1008: feat: add remote L3 wire codec
  - #1009: feat: add remote endpoint eligibility scheduling
  - #1010: feat: add remote L3 endpoint facade
  - #1011: feat: add remote L3 Python session runtime

  The top of the stack was verified to match the corrected `remote-l3-worker-design`
  branch content from #866, excluding empty CI retrigger commits.


## Stack position

- Base: `remote-l3-split-callable-identity`
- Head: `remote-l3-split-remote-wire`
- Previous PR: `remote-l3-split-callable-identity`
- Next PR: `remote-l3-split-scheduler-eligibility`

## Scope

This PR adds or updates:

- C++ `remote_wire` encode/decode helpers.
- Python `remote_l3_protocol` encode/decode helpers.
- Frame handling for remote L3 message categories.
- TASK and COMPLETION payload encoding.
- CONTROL and CONTROL_REPLY payload encoding.
- HELLO and HEALTH message encoding.
- Remote buffer control codecs.
- Tests for valid round trips and malformed payload rejection.

## Requirements covered

This PR covers the protocol requirements from the remote L3 contract:

- Wire format is explicit and transport-neutral.
- C++ does not serialize by copying raw POD structs as wire payloads.
- Unknown enum values are rejected.
- Non-zero reserved fields are rejected unless explicitly allowed by the
  contract.
- Malformed or truncated payloads fail deterministically.
- Error payloads are bounded.
- Command/control sequence numbers are encoded and available for later
  sequence matching.
- TASK call configuration preserves required fields, including
  `enable_scope_stats`.
- Reserved/future payload modes such as negotiated Python serialization and
  staged blobs are explicitly rejected in this split.

## Why this is separate

The scheduler and endpoint PRs need a stable protocol layer, but they should not
hide codec review inside higher-level runtime behavior. Keeping the codec in
its own PR makes bounds checks, reserved-field handling, and C++/Python parity
straightforward to review.

## Important exclusions

This PR intentionally does not add:

- Endpoint selection or worker scheduling behavior.
- Live command-lane transport.
- `RemoteL3Endpoint`.
- Python session process management.
- Hardware transport profiles.

Those are handled by later PRs.

## Verification

Targeted verification already run during the split:

- C++ remote wire unit test: passed.
- Python remote L3 protocol codec tests: passed.
- Scope-stats TASK round-trip coverage: passed.
- Unsupported `PYTHON_SERIALIZED` and `STAGED_BLOB` payload coverage: passed.

## Reviewer notes

Please focus on wire compatibility, strict validation, and whether all reserved
fields/future extensions are either rejected now or clearly documented as
future work.
