### PR TITLE
feat: add remote endpoint eligibility scheduling

### DIFF
--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -137,6 +137,7 @@ inline void bind_worker(nb::module_ &m) {
         .value("READY", TaskState::READY)
         .value("RUNNING", TaskState::RUNNING)
         .value("COMPLETED", TaskState::COMPLETED)
+        .value("FAILED", TaskState::FAILED)
         .value("CONSUMED", TaskState::CONSUMED);
 
     // --- Orchestrator (DAG builder, exposed via Worker.get_orchestrator()) ---

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -248,6 +248,8 @@ SubmitResult Orchestrator::submit_impl(
     // producer is already done. CONSUMED producers are gone (resources freed),
     // so we skip them entirely.
     int32_t live_fanins = 0;
+    bool poisoned_by_failed_producer = false;
+    std::string poison_message;
     for (TaskSlot prod : producers) {
         TaskSlotState &ps = slot_state(prod);
         std::lock_guard<std::mutex> lk(ps.fanout_mu);
@@ -259,7 +261,10 @@ SubmitResult Orchestrator::submit_impl(
         ps.fanout_consumers.push_back(slot);
         ps.fanout_total++;
         s.fanin_producers.push_back(prod);
-        if (ps_state != TaskState::COMPLETED) {
+        if (ps_state == TaskState::FAILED) {
+            poisoned_by_failed_producer = true;
+            if (poison_message.empty()) poison_message = ps.failure_message;
+        } else if (ps_state != TaskState::COMPLETED) {
             live_fanins++;
         }
     }
@@ -275,6 +280,18 @@ SubmitResult Orchestrator::submit_impl(
     s.fanout_released.store(0, std::memory_order_relaxed);
 
     if (scope_ref > 0) scope_->register_task(slot);
+
+    if (poisoned_by_failed_producer) {
+        if (poison_message.empty()) poison_message = "producer task failed";
+        s.failure_message = poison_message;
+        s.state.store(TaskState::FAILED, std::memory_order_release);
+        std::vector<TaskSlot> fanin_producers = s.fanin_producers;
+        try_consume(slot);
+        for (TaskSlot prod : fanin_producers) {
+            try_consume(prod);
+        }
+        return SubmitResult{slot};
+    }
 
     // --- Step 6: If no live fanins → READY ---
     // Strict-4: push to the queue dedicated to this task's worker type so a
@@ -587,6 +604,10 @@ void Orchestrator::scope_end() {
 // =============================================================================
 
 void Orchestrator::release_ref(TaskSlot slot) {
+    try_consume(slot);
+}
+
+void Orchestrator::try_consume(TaskSlot slot) {
     TaskSlotState &s = slot_state(slot);
     int32_t released = s.fanout_released.fetch_add(1, std::memory_order_acq_rel) + 1;
     int32_t total;
@@ -594,12 +615,10 @@ void Orchestrator::release_ref(TaskSlot slot) {
         std::lock_guard<std::mutex> lk(s.fanout_mu);
         total = s.fanout_total;
     }
-    // Threshold matches Scheduler::try_consume: total contributors are
-    // 1 (self try_consume from on_task_complete, or the alloc-time sim) +
-    // N (per consumer's deferred try_consume) + 1 (this scope_end release)
-    // = N + 2 = total + 1 where total = scope_ref + N.
-    // Using `>= total + 1` keeps scope_end from prematurely consuming while
-    // a consumer (or a HeapRing peer) is still live.
+    // Threshold matches Scheduler::try_consume. fanout_total counts
+    // scope_ref + N consumer refs; the extra +1 is the terminal self
+    // release. These refs can be released from completion, poison, or
+    // scope_end paths in different orders.
     TaskState state = s.state.load(std::memory_order_acquire);
     if (released >= total + 1 && (state == TaskState::COMPLETED || state == TaskState::FAILED)) {
         on_consumed(slot);

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -137,18 +137,29 @@ ContinuousTensor Orchestrator::alloc(const std::vector<uint32_t> &shape, DataTyp
 // =============================================================================
 
 SubmitResult Orchestrator::submit_next_level(
-    const CallableIdentity &callable, const TaskArgs &args, const CallConfig &config, int8_t worker
+    const CallableIdentity &callable, const TaskArgs &args, const CallConfig &config, int8_t worker,
+    const std::vector<int32_t> &eligible_endpoint_ids, const RemoteTaskArgsSidecar &remote_sidecar
 ) {
     std::vector<int8_t> affinities;
     if (worker >= 0) affinities = {worker};
-    return submit_impl(WorkerType::NEXT_LEVEL, callable, config, {args}, std::move(affinities));
+    std::vector<std::vector<int32_t>> endpoint_sets;
+    if (!eligible_endpoint_ids.empty()) endpoint_sets = {eligible_endpoint_ids};
+    std::vector<RemoteTaskArgsSidecar> sidecars;
+    if (!remote_sidecar.tensors.empty() || !remote_sidecar.inline_payload.empty()) sidecars = {remote_sidecar};
+    return submit_impl(
+        WorkerType::NEXT_LEVEL, callable, config, {args}, std::move(affinities), std::move(endpoint_sets),
+        std::move(sidecars)
+    );
 }
 
 SubmitResult Orchestrator::submit_next_level_group(
     const CallableIdentity &callable, const std::vector<TaskArgs> &args_list, const CallConfig &config,
-    const std::vector<int8_t> &workers
+    const std::vector<int8_t> &workers, const std::vector<std::vector<int32_t>> &eligible_endpoint_ids,
+    const std::vector<RemoteTaskArgsSidecar> &remote_sidecars
 ) {
-    return submit_impl(WorkerType::NEXT_LEVEL, callable, config, args_list, workers);
+    return submit_impl(
+        WorkerType::NEXT_LEVEL, callable, config, args_list, workers, eligible_endpoint_ids, remote_sidecars
+    );
 }
 
 SubmitResult Orchestrator::submit_sub(const CallableIdentity &callable, const TaskArgs &args) {
@@ -165,10 +176,13 @@ SubmitResult Orchestrator::submit_sub_group(const CallableIdentity &callable, co
 
 SubmitResult Orchestrator::submit_impl(
     WorkerType worker_type, const CallableIdentity &callable, const CallConfig &config, std::vector<TaskArgs> args_list,
-    std::vector<int8_t> affinities
+    std::vector<int8_t> affinities, std::vector<std::vector<int32_t>> eligible_endpoint_ids,
+    std::vector<RemoteTaskArgsSidecar> remote_sidecars
 ) {
     if (args_list.empty()) throw std::invalid_argument("Orchestrator: args_list must not be empty");
     config.validate();
+    validate_endpoint_eligibility(worker_type, args_list.size(), affinities, eligible_endpoint_ids);
+    validate_remote_sidecars(args_list, remote_sidecars, eligible_endpoint_ids);
 
     // Fail-fast: if a previously-dispatched task has already failed, abort
     // this submit before any bookkeeping so the orch fn unwinds promptly
@@ -188,7 +202,7 @@ SubmitResult Orchestrator::submit_impl(
     // arrived with a null data pointer. Both resources come from the same
     // merged allocator (Strict-2) so there is no partial-failure rollback
     // path.
-    AllocResult ar = reserve_outputs_and_slot(args_list);
+    AllocResult ar = reserve_outputs_and_slot(args_list, remote_sidecars);
     if (ar.slot == INVALID_SLOT) {
         active_tasks_.fetch_sub(1, std::memory_order_relaxed);
         throw std::runtime_error("Orchestrator: allocator shutdown");
@@ -201,12 +215,13 @@ SubmitResult Orchestrator::submit_impl(
     s.worker_type = worker_type;
     s.callable = callable;
     s.config = config;
+    s.eligible_endpoint_ids = std::move(eligible_endpoint_ids);
 
     // --- Step 2: Walk tags → tensormap.lookup (deps) + tensormap.insert
     // (outputs). Must happen before we move args_list into the slot because
     // infer_deps reads tensor data pointers and tags from it.
     std::vector<TaskSlot> producers;
-    infer_deps(slot, args_list, affinities, producers, s.output_keys);
+    infer_deps(slot, args_list, affinities, remote_sidecars, producers, s.output_keys);
 
     // --- Step 3: Store TaskArgs directly (no chip-storage pre-build) ---
     // Dispatch builds a TaskArgsView on demand via `slot.args_view(i)`
@@ -216,9 +231,11 @@ SubmitResult Orchestrator::submit_impl(
     if (args_list.size() == 1) {
         s.is_group_ = false;
         s.task_args = std::move(args_list.front());
+        if (!remote_sidecars.empty()) s.remote_sidecar = std::move(remote_sidecars.front());
     } else {
         s.is_group_ = true;
         s.task_args_list = std::move(args_list);
+        s.remote_sidecars = std::move(remote_sidecars);
     }
     s.affinities = std::move(affinities);
 
@@ -272,6 +289,149 @@ SubmitResult Orchestrator::submit_impl(
     return SubmitResult{slot};
 }
 
+void Orchestrator::validate_endpoint_eligibility(
+    WorkerType worker_type, size_t args_count, const std::vector<int8_t> &affinities,
+    const std::vector<std::vector<int32_t>> &eligible_endpoint_ids
+) const {
+    if (!affinities.empty() && affinities.size() != args_count) {
+        throw std::invalid_argument(
+            "Orchestrator: workers affinity length " + std::to_string(affinities.size()) +
+            " does not match args length " + std::to_string(args_count)
+        );
+    }
+    if (!eligible_endpoint_ids.empty() && eligible_endpoint_ids.size() != args_count) {
+        throw std::invalid_argument(
+            "Orchestrator: eligible endpoint-set length " + std::to_string(eligible_endpoint_ids.size()) +
+            " does not match args length " + std::to_string(args_count)
+        );
+    }
+
+    for (size_t i = 0; i < args_count; ++i) {
+        const auto &eligible = eligible_endpoint_ids.empty() ? std::vector<int32_t>{} : eligible_endpoint_ids[i];
+        if (!eligible_endpoint_ids.empty() && eligible.empty()) {
+            throw std::invalid_argument(
+                "Orchestrator: final eligible endpoint set is empty for member " + std::to_string(i)
+            );
+        }
+        int8_t affinity = affinities.empty() ? int8_t(-1) : affinities[i];
+        if (affinity < 0) continue;
+
+        if (manager_ != nullptr) {
+            auto *wt = manager_->get_worker(worker_type, affinity);
+            if (wt == nullptr) {
+                throw std::invalid_argument(
+                    "Orchestrator: worker affinity " + std::to_string(affinity) + " is not a registered endpoint"
+                );
+            }
+            int32_t endpoint_id = wt->endpoint_id();
+            bool allowed = eligible_endpoint_ids.empty();
+            for (int32_t id : eligible) {
+                if (id == endpoint_id) {
+                    allowed = true;
+                    break;
+                }
+            }
+            if (!allowed) {
+                throw std::invalid_argument(
+                    "Orchestrator: worker affinity " + std::to_string(affinity) +
+                    " is not in the slot's final eligible endpoint set"
+                );
+            }
+        } else if (!eligible_endpoint_ids.empty()) {
+            bool allowed = false;
+            for (int32_t id : eligible) {
+                if (id == affinity) {
+                    allowed = true;
+                    break;
+                }
+            }
+            if (!allowed) {
+                throw std::invalid_argument(
+                    "Orchestrator: worker affinity " + std::to_string(affinity) +
+                    " is not in the slot's final eligible endpoint set"
+                );
+            }
+        }
+    }
+}
+
+void Orchestrator::validate_remote_sidecars(
+    const std::vector<TaskArgs> &args_list, const std::vector<RemoteTaskArgsSidecar> &remote_sidecars,
+    const std::vector<std::vector<int32_t>> &eligible_endpoint_ids
+) const {
+    if (remote_sidecars.empty()) return;
+    if (remote_sidecars.size() != args_list.size()) {
+        throw std::invalid_argument(
+            "Orchestrator: remote sidecar length " + std::to_string(remote_sidecars.size()) +
+            " does not match args length " + std::to_string(args_list.size())
+        );
+    }
+    if (eligible_endpoint_ids.empty()) {
+        throw std::invalid_argument("Orchestrator: remote sidecars require an explicit eligible endpoint set");
+    }
+    for (size_t g = 0; g < args_list.size(); ++g) {
+        const TaskArgs &args = args_list[g];
+        const RemoteTaskArgsSidecar &sidecar = remote_sidecars[g];
+        if (sidecar.empty() && args.tensor_count() == 0) continue;
+        if (sidecar.tensors.size() != static_cast<size_t>(args.tensor_count())) {
+            throw std::invalid_argument("Orchestrator: remote sidecar tensor count does not match TaskArgs");
+        }
+        for (int32_t endpoint_id : eligible_endpoint_ids[g]) {
+            if (manager_ == nullptr) continue;
+            WorkerThread *wt = manager_->get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, endpoint_id);
+            if (wt == nullptr) {
+                throw std::invalid_argument(
+                    "Orchestrator: remote sidecar names an unknown endpoint " + std::to_string(endpoint_id)
+                );
+            }
+            if (!wt->caps().remote) {
+                throw std::invalid_argument(
+                    "Orchestrator: remote sidecar cannot be submitted to local endpoint " + std::to_string(endpoint_id)
+                );
+            }
+        }
+        for (int32_t i = 0; i < args.tensor_count(); ++i) {
+            const ContinuousTensor &tensor = args.tensor(i);
+            const RemoteTensorSidecar &tensor_sidecar = sidecar.tensors[static_cast<size_t>(i)];
+            if (tensor_sidecar.present && tensor.data != 0) {
+                throw std::invalid_argument("Orchestrator: remote tensor metadata data field must be zero");
+            }
+            if (!tensor_sidecar.present && tensor.data != 0) {
+                throw std::invalid_argument("Orchestrator: remote tensor uses a bare host pointer without sidecar");
+            }
+            if (args.tag(i) == TensorArgType::OUTPUT && tensor.data == 0 && !tensor_sidecar.present) {
+                throw std::invalid_argument("Orchestrator: remote OUTPUT tensor requires a RemoteTensorRef sidecar");
+            }
+            if (!tensor_sidecar.present && tensor.nbytes() != 0) {
+                throw std::invalid_argument("Orchestrator: remote tensor payload requires a RemoteTensorRef sidecar");
+            }
+            if (tensor.is_child_memory() && !tensor_sidecar.present) {
+                throw std::invalid_argument("Orchestrator: remote child-memory tensor requires a sidecar");
+            }
+            if (tensor_sidecar.present && tensor_sidecar.desc.address_space != RemoteAddressSpace::HOST_INLINE) {
+                if (tensor_sidecar.desc.owner_endpoint_id < 0) {
+                    throw std::invalid_argument("Orchestrator: remote tensor sidecar has invalid owner endpoint");
+                }
+                bool has_allowed_endpoint = false;
+                for (int32_t endpoint_id : eligible_endpoint_ids[g]) {
+                    has_allowed_endpoint = true;
+                    if (tensor_sidecar.desc.address_space == RemoteAddressSpace::REMOTE_DEVICE &&
+                        endpoint_id != tensor_sidecar.desc.owner_endpoint_id) {
+                        throw std::invalid_argument(
+                            "Orchestrator: remote tensor sidecar requires IMPORT_BUFFER before submitting to "
+                            "endpoint " +
+                            std::to_string(endpoint_id)
+                        );
+                    }
+                }
+                if (!has_allowed_endpoint) {
+                    throw std::invalid_argument("Orchestrator: remote tensor has no final eligible endpoint");
+                }
+            }
+        }
+    }
+}
+
 // =============================================================================
 // reserve_outputs_and_slot — atomic slot + heap carve-up for this submit
 // =============================================================================
@@ -283,12 +443,19 @@ SubmitResult Orchestrator::submit_impl(
 // OUTPUT.data themselves). The single allocator call owns both the slot and
 // the heap range, so there is no partial-failure rollback.
 
-AllocResult Orchestrator::reserve_outputs_and_slot(std::vector<TaskArgs> &args_list) {
+AllocResult Orchestrator::reserve_outputs_and_slot(
+    std::vector<TaskArgs> &args_list, const std::vector<RemoteTaskArgsSidecar> &remote_sidecars
+) {
     uint64_t total_bytes = 0;
-    for (const TaskArgs &a : args_list) {
+    for (size_t g = 0; g < args_list.size(); ++g) {
+        const TaskArgs &a = args_list[g];
         for (int32_t i = 0; i < a.tensor_count(); ++i) {
             if (a.tag(i) != TensorArgType::OUTPUT) continue;
             if (a.tensor(i).data != 0) continue;  // user supplied a pointer — leave alone
+            bool remote_output = !remote_sidecars.empty() &&
+                                 static_cast<size_t>(i) < remote_sidecars[g].tensors.size() &&
+                                 remote_sidecars[g].tensors[static_cast<size_t>(i)].present;
+            if (remote_output) continue;
             total_bytes += output_alloc_bytes(a.tensor(i));
         }
     }
@@ -299,11 +466,16 @@ AllocResult Orchestrator::reserve_outputs_and_slot(std::vector<TaskArgs> &args_l
     // Hand slabs out in the same order we counted them.
     uint64_t off = 0;
     char *base = static_cast<char *>(ar.heap_ptr);
-    for (TaskArgs &a : args_list) {
+    for (size_t g = 0; g < args_list.size(); ++g) {
+        TaskArgs &a = args_list[g];
         for (int32_t i = 0; i < a.tensor_count(); ++i) {
             if (a.tag(i) != TensorArgType::OUTPUT) continue;
             ContinuousTensor &t = a.tensor(i);
             if (t.data != 0) continue;
+            bool remote_output = !remote_sidecars.empty() &&
+                                 static_cast<size_t>(i) < remote_sidecars[g].tensors.size() &&
+                                 remote_sidecars[g].tensors[static_cast<size_t>(i)].present;
+            if (remote_output) continue;
             uint64_t slab = output_alloc_bytes(t);
             t.data = reinterpret_cast<uint64_t>(base + off);
             off += slab;
@@ -318,7 +490,8 @@ AllocResult Orchestrator::reserve_outputs_and_slot(std::vector<TaskArgs> &args_l
 
 void Orchestrator::infer_deps(
     TaskSlot slot, const std::vector<TaskArgs> &args_list, const std::vector<int8_t> &affinities,
-    std::vector<TaskSlot> &producers, std::vector<TensorKey> &output_keys
+    const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<TaskSlot> &producers,
+    std::vector<TensorKey> &output_keys
 ) {
     auto add_unique_producer = [&](TaskSlot p) {
         // Group submits walk many TaskArgs under one slot: if two entries in
@@ -348,8 +521,27 @@ void Orchestrator::infer_deps(
         const TaskArgs &a = args_list[g];
         for (int32_t i = 0; i < a.tensor_count(); ++i) {
             const ContinuousTensor &t = a.tensor(i);
-            if (t.data == 0) continue;  // null tensor — nothing to track
-            TensorKey key{t.data, t.is_child_memory() ? worker_id : int8_t(-1)};
+            TensorKey key{};
+            bool has_key = false;
+            if (!remote_sidecars.empty()) {
+                const auto &sidecar = remote_sidecars[g];
+                if (static_cast<size_t>(i) < sidecar.tensors.size() &&
+                    sidecar.tensors[static_cast<size_t>(i)].present) {
+                    const RemoteTensorDesc &desc = sidecar.tensors[static_cast<size_t>(i)].desc;
+                    TensorAddressKind kind = desc.address_space == RemoteAddressSpace::HOST_INLINE ?
+                                                 TensorAddressKind::HOST_INLINE :
+                                                 TensorAddressKind::REMOTE_BUFFER;
+                    key = TensorKey::remote_buffer(
+                        kind, desc.owner_endpoint_id, desc.buffer_id, desc.generation, desc.offset
+                    );
+                    has_key = true;
+                }
+            }
+            if (!has_key) {
+                if (t.data == 0) continue;  // null tensor — nothing to track
+                key = t.is_child_memory() ? TensorKey::local_child(t.data, worker_id) : TensorKey::local_host(t.data);
+                has_key = true;
+            }
             TensorArgType tag = a.tag(i);
             switch (tag) {
             case TensorArgType::INPUT: {
@@ -408,7 +600,8 @@ void Orchestrator::release_ref(TaskSlot slot) {
     // = N + 2 = total + 1 where total = scope_ref + N.
     // Using `>= total + 1` keeps scope_end from prematurely consuming while
     // a consumer (or a HeapRing peer) is still live.
-    if (released >= total + 1 && s.state.load(std::memory_order_acquire) == TaskState::COMPLETED) {
+    TaskState state = s.state.load(std::memory_order_acquire);
+    if (released >= total + 1 && (state == TaskState::COMPLETED || state == TaskState::FAILED)) {
         on_consumed(slot);
     }
 }
@@ -424,7 +617,12 @@ bool Orchestrator::on_consumed(TaskSlot slot) {
     if (!s.state.compare_exchange_strong(
             expected, TaskState::CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
         )) {
-        return false;
+        expected = TaskState::FAILED;
+        if (!s.state.compare_exchange_strong(
+                expected, TaskState::CONSUMED, std::memory_order_acq_rel, std::memory_order_acquire
+            )) {
+            return false;
+        }
     }
 
     tensormap_->erase_task_outputs(s.output_keys);

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -603,9 +603,7 @@ void Orchestrator::scope_end() {
 // Reference release helpers
 // =============================================================================
 
-void Orchestrator::release_ref(TaskSlot slot) {
-    try_consume(slot);
-}
+void Orchestrator::release_ref(TaskSlot slot) { try_consume(slot); }
 
 void Orchestrator::try_consume(TaskSlot slot) {
     TaskSlotState &s = slot_state(slot);

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -230,4 +230,5 @@ private:
     // Release one fanout reference on 'slot'.
     // If all references are released → transition to CONSUMED.
     void release_ref(TaskSlot slot);
+    void try_consume(TaskSlot slot);
 };

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -99,14 +99,16 @@ public:
     // null data are auto-allocated from the HeapRing.
     // `worker`: logical worker id for affinity (-1 = unconstrained).
     SubmitResult submit_next_level(
-        const CallableIdentity &callable, const TaskArgs &args, const CallConfig &config, int8_t worker = -1
+        const CallableIdentity &callable, const TaskArgs &args, const CallConfig &config, int8_t worker = -1,
+        const std::vector<int32_t> &eligible_endpoint_ids = {}, const RemoteTaskArgsSidecar &remote_sidecar = {}
     );
 
     // Submit a group of NEXT_LEVEL tasks: N args -> N workers, 1 DAG node.
     // `workers`: per-args affinity (empty = all unconstrained).
     SubmitResult submit_next_level_group(
         const CallableIdentity &callable, const std::vector<TaskArgs> &args_list, const CallConfig &config,
-        const std::vector<int8_t> &workers = {}
+        const std::vector<int8_t> &workers = {}, const std::vector<std::vector<int32_t>> &eligible_endpoint_ids = {},
+        const std::vector<RemoteTaskArgsSidecar> &remote_sidecars = {}
     );
 
     // Submit a SUB task by registered callable identity.
@@ -150,7 +152,7 @@ public:
     // Called by Scheduler (via Worker) when a task becomes CONSUMED:
     // erases TensorMap entries, releases the allocator slot (and implicitly
     // the slot's heap slab via last_alive).
-    // Returns true iff this call performed the COMPLETED -> CONSUMED transition.
+    // Returns true iff this call performed the COMPLETED/FAILED -> CONSUMED transition.
     // Idempotent: concurrent callers (release_ref vs try_consume) race on a
     // CAS — only the winner returns true and runs cleanup; losers return false.
     bool on_consumed(TaskSlot slot);
@@ -190,7 +192,9 @@ private:
     // can patch `tensor.data` on OUTPUT tensors flagged for auto-allocation.
     SubmitResult submit_impl(
         WorkerType worker_type, const CallableIdentity &callable, const CallConfig &config,
-        std::vector<TaskArgs> args_list, std::vector<int8_t> affinities = {}
+        std::vector<TaskArgs> args_list, std::vector<int8_t> affinities = {},
+        std::vector<std::vector<int32_t>> eligible_endpoint_ids = {},
+        std::vector<RemoteTaskArgsSidecar> remote_sidecars = {}
     );
 
     // Size, in aligned bytes, an OUTPUT tensor should occupy in the HeapRing.
@@ -201,7 +205,9 @@ private:
     // consumed, and populates `slot` / `heap_ptr` / `heap_end_offset` via the
     // output params (reused for book-keeping on the slot state). Throws on
     // back-pressure timeout.
-    AllocResult reserve_outputs_and_slot(std::vector<TaskArgs> &args_list);
+    AllocResult reserve_outputs_and_slot(
+        std::vector<TaskArgs> &args_list, const std::vector<RemoteTaskArgsSidecar> &remote_sidecars
+    );
 
     // Walk the tags of each TaskArgs in `args_list`, accumulating producer
     // slots (for INPUT/INOUT tags) and registering outputs in the tensormap
@@ -209,8 +215,17 @@ private:
     // `affinities` maps args_list[i] → worker id for TensorKey construction.
     void infer_deps(
         TaskSlot slot, const std::vector<TaskArgs> &args_list, const std::vector<int8_t> &affinities,
-        std::vector<TaskSlot> &producers, std::vector<TensorKey> &output_keys
+        const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<TaskSlot> &producers,
+        std::vector<TensorKey> &output_keys
     );
+    void validate_endpoint_eligibility(
+        WorkerType worker_type, size_t args_count, const std::vector<int8_t> &affinities,
+        const std::vector<std::vector<int32_t>> &eligible_endpoint_ids
+    ) const;
+    void validate_remote_sidecars(
+        const std::vector<TaskArgs> &args_list, const std::vector<RemoteTaskArgsSidecar> &remote_sidecars,
+        const std::vector<std::vector<int32_t>> &eligible_endpoint_ids
+    ) const;
 
     // Release one fanout reference on 'slot'.
     // If all references are released → transition to CONSUMED.

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -80,14 +80,15 @@ void Scheduler::worker_done(WorkerCompletion completion) {
                 s.group_member_states.assign(static_cast<size_t>(group_size), GroupMemberState::NOT_DISPATCHED);
                 s.group_member_outcomes.assign(static_cast<size_t>(group_size), EndpointOutcome::SKIPPED);
             }
-            if (completion.group_index < 0 || completion.group_index >= group_size) {
+            bool invalid_group_index = completion.group_index < 0 || completion.group_index >= group_size;
+            if (invalid_group_index) {
                 terminal.outcome = EndpointOutcome::ENDPOINT_FAILURE;
                 terminal.error_message = "Scheduler::worker_done: group_index " +
                                          std::to_string(completion.group_index) + " out of range for group_size " +
                                          std::to_string(group_size);
             }
 
-            int32_t index = terminal.group_index;
+            int32_t index = invalid_group_index ? -1 : terminal.group_index;
             if (index >= 0 && index < group_size) {
                 GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(index)];
                 if (is_terminal_group_state(member_state)) return;
@@ -115,7 +116,8 @@ void Scheduler::worker_done(WorkerCompletion completion) {
             if (s.group_failed) {
                 for (int32_t i = 0; i < group_size; ++i) {
                     GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(i)];
-                    if (member_state != GroupMemberState::NOT_DISPATCHED) continue;
+                    if (is_terminal_group_state(member_state)) continue;
+                    if (!invalid_group_index && member_state != GroupMemberState::NOT_DISPATCHED) continue;
                     member_state = GroupMemberState::SKIPPED;
                     s.group_member_outcomes[static_cast<size_t>(i)] = EndpointOutcome::SKIPPED;
                     s.group_terminal_count.fetch_add(1, std::memory_order_acq_rel);

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -12,10 +12,24 @@
 #include "scheduler.h"
 
 #include <stdexcept>
+#include <utility>
 
 #include "ring.h"
 #include "types.h"
 #include "worker_manager.h"
+
+namespace {
+
+bool is_failure(EndpointOutcome outcome) {
+    return outcome == EndpointOutcome::TASK_FAILURE || outcome == EndpointOutcome::ENDPOINT_FAILURE;
+}
+
+bool is_terminal_group_state(GroupMemberState state) {
+    return state == GroupMemberState::SUCCESS || state == GroupMemberState::FAILED ||
+           state == GroupMemberState::SKIPPED;
+}
+
+}  // namespace
 
 // =============================================================================
 // Scheduler
@@ -52,18 +66,86 @@ void Scheduler::stop() {
 // WorkerThread completion callback (called from WorkerThread via Manager)
 // =============================================================================
 
-void Scheduler::worker_done(TaskSlot slot) {
-    TaskSlotState &s = *cfg_.ring->slot_state(slot);
+void Scheduler::worker_done(WorkerCompletion completion) {
+    TaskSlotState &s = *cfg_.ring->slot_state(completion.task_slot);
 
     // Group aggregation: only push to completion queue when ALL workers done
     if (s.is_group()) {
-        int32_t done = s.sub_complete_count.fetch_add(1, std::memory_order_acq_rel) + 1;
-        if (done < s.group_size()) return;
+        WorkerCompletion terminal = completion;
+        bool group_terminal = false;
+        {
+            std::lock_guard<std::mutex> lk(s.group_mu);
+            const int32_t group_size = s.group_size();
+            if (s.group_member_states.size() != static_cast<size_t>(group_size)) {
+                s.group_member_states.assign(static_cast<size_t>(group_size), GroupMemberState::NOT_DISPATCHED);
+                s.group_member_outcomes.assign(static_cast<size_t>(group_size), EndpointOutcome::SKIPPED);
+            }
+            if (completion.group_index < 0 || completion.group_index >= group_size) {
+                terminal.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+                terminal.error_message = "Scheduler::worker_done: group_index " +
+                                         std::to_string(completion.group_index) + " out of range for group_size " +
+                                         std::to_string(group_size);
+            }
+
+            int32_t index = terminal.group_index;
+            if (index >= 0 && index < group_size) {
+                GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(index)];
+                if (is_terminal_group_state(member_state)) return;
+
+                if (terminal.outcome == EndpointOutcome::SUCCESS) {
+                    member_state = GroupMemberState::SUCCESS;
+                } else {
+                    member_state = GroupMemberState::FAILED;
+                    if (!s.group_failed) {
+                        s.group_first_failure_index = index;
+                        s.group_first_failure_message = terminal.error_message;
+                    }
+                    s.group_failed = true;
+                }
+                s.group_member_outcomes[static_cast<size_t>(index)] = terminal.outcome;
+                s.group_terminal_count.fetch_add(1, std::memory_order_acq_rel);
+            } else {
+                if (!s.group_failed) {
+                    s.group_first_failure_index = -1;
+                    s.group_first_failure_message = terminal.error_message;
+                }
+                s.group_failed = true;
+            }
+
+            if (s.group_failed) {
+                for (int32_t i = 0; i < group_size; ++i) {
+                    GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(i)];
+                    if (member_state != GroupMemberState::NOT_DISPATCHED) continue;
+                    member_state = GroupMemberState::SKIPPED;
+                    s.group_member_outcomes[static_cast<size_t>(i)] = EndpointOutcome::SKIPPED;
+                    s.group_terminal_count.fetch_add(1, std::memory_order_acq_rel);
+                }
+            }
+
+            if (s.group_terminal_count.load(std::memory_order_acquire) < group_size) return;
+
+            group_terminal = true;
+            if (s.group_failed) {
+                int32_t failure_index = s.group_first_failure_index;
+                terminal.group_index = failure_index;
+                terminal.outcome = EndpointOutcome::TASK_FAILURE;
+                if (failure_index >= 0 && failure_index < group_size) {
+                    EndpointOutcome member_outcome = s.group_member_outcomes[static_cast<size_t>(failure_index)];
+                    if (is_failure(member_outcome)) terminal.outcome = member_outcome;
+                }
+                terminal.error_message = s.group_first_failure_message;
+            } else {
+                terminal.outcome = EndpointOutcome::SUCCESS;
+                terminal.error_message.clear();
+            }
+        }
+        if (!group_terminal) return;
+        completion = std::move(terminal);
     }
 
     {
         std::lock_guard<std::mutex> lk(completion_mu_);
-        completion_queue_.push(slot);
+        completion_queue_.push(std::move(completion));
     }
     completion_cv_.notify_one();
 }
@@ -89,14 +171,14 @@ void Scheduler::run() {
 
         // Phase 1: drain completions
         while (true) {
-            TaskSlot slot;
+            WorkerCompletion completion;
             {
                 std::lock_guard<std::mutex> lk(completion_mu_);
                 if (completion_queue_.empty()) break;
-                slot = completion_queue_.front();
+                completion = std::move(completion_queue_.front());
                 completion_queue_.pop();
             }
-            on_task_complete(slot);
+            on_task_complete(completion);
         }
 
         // Phase 2: dispatch ready tasks
@@ -107,14 +189,14 @@ void Scheduler::run() {
             if (!cfg_.manager->any_busy()) {
                 // Final drain
                 while (true) {
-                    TaskSlot slot;
+                    WorkerCompletion completion;
                     {
                         std::lock_guard<std::mutex> lk(completion_mu_);
                         if (completion_queue_.empty()) break;
-                        slot = completion_queue_.front();
+                        completion = std::move(completion_queue_.front());
                         completion_queue_.pop();
                     }
-                    on_task_complete(slot);
+                    on_task_complete(completion);
                 }
                 dispatch_ready();
                 break;  // loop_lk released on scope exit before exiting run()
@@ -127,9 +209,16 @@ void Scheduler::run() {
 // on_task_complete / try_consume
 // =============================================================================
 
-void Scheduler::on_task_complete(TaskSlot slot) {
+void Scheduler::on_task_complete(const WorkerCompletion &completion) {
+    TaskSlot slot = completion.task_slot;
     TaskSlotState &s = *cfg_.ring->slot_state(slot);
-    s.state.store(TaskState::COMPLETED, std::memory_order_release);
+    bool failed = is_failure(completion.outcome);
+    if (failed) {
+        s.failure_message = completion.error_message;
+        s.state.store(TaskState::FAILED, std::memory_order_release);
+    } else {
+        s.state.store(TaskState::COMPLETED, std::memory_order_release);
+    }
 
     // Release fanin on downstream consumers
     std::vector<TaskSlot> consumers;
@@ -138,6 +227,10 @@ void Scheduler::on_task_complete(TaskSlot slot) {
         consumers = s.fanout_consumers;
     }
     for (TaskSlot consumer : consumers) {
+        if (failed) {
+            poison_task(consumer, completion.error_message);
+            continue;
+        }
         TaskSlotState &cs = *cfg_.ring->slot_state(consumer);
         int32_t released = cs.fanin_released.fetch_add(1, std::memory_order_acq_rel) + 1;
         if (released >= cs.fanin_count) {
@@ -166,6 +259,57 @@ void Scheduler::on_task_complete(TaskSlot slot) {
     }
 }
 
+void Scheduler::poison_task(TaskSlot slot, const std::string &root_message) {
+    TaskSlotState &s = *cfg_.ring->slot_state(slot);
+    TaskState state = s.state.load(std::memory_order_acquire);
+    if (state == TaskState::FAILED || state == TaskState::CONSUMED || state == TaskState::FREE) return;
+    if (state == TaskState::RUNNING || state == TaskState::COMPLETED) return;
+
+    s.failure_message = root_message;
+    s.state.store(TaskState::FAILED, std::memory_order_release);
+
+    if (s.is_group()) {
+        std::lock_guard<std::mutex> lk(s.group_mu);
+        const int32_t group_size = s.group_size();
+        if (s.group_member_states.size() != static_cast<size_t>(group_size)) {
+            s.group_member_states.assign(static_cast<size_t>(group_size), GroupMemberState::NOT_DISPATCHED);
+            s.group_member_outcomes.assign(static_cast<size_t>(group_size), EndpointOutcome::SKIPPED);
+        }
+        if (!s.group_failed) {
+            s.group_failed = true;
+            s.group_first_failure_index = -1;
+            s.group_first_failure_message = root_message;
+        }
+        for (int32_t i = 0; i < group_size; ++i) {
+            GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(i)];
+            if (is_terminal_group_state(member_state)) continue;
+            member_state = GroupMemberState::SKIPPED;
+            s.group_member_outcomes[static_cast<size_t>(i)] = EndpointOutcome::SKIPPED;
+            s.group_terminal_count.fetch_add(1, std::memory_order_acq_rel);
+        }
+    }
+
+    std::vector<TaskSlot> consumers;
+    {
+        std::lock_guard<std::mutex> lk(s.fanout_mu);
+        consumers = s.fanout_consumers;
+    }
+    for (TaskSlot consumer : consumers) {
+        poison_task(consumer, root_message);
+    }
+
+    try_consume(slot);
+
+    std::vector<TaskSlot> producers;
+    {
+        std::lock_guard<std::mutex> lk(s.fanout_mu);
+        producers = s.fanin_producers;
+    }
+    for (TaskSlot prod : producers) {
+        try_consume(prod);
+    }
+}
+
 void Scheduler::try_consume(TaskSlot slot) {
     TaskSlotState &s = *cfg_.ring->slot_state(slot);
     int32_t released = s.fanout_released.fetch_add(1, std::memory_order_acq_rel) + 1;
@@ -175,7 +319,8 @@ void Scheduler::try_consume(TaskSlot slot) {
         total = s.fanout_total;
     }
     if (released >= total + 1) {
-        if (s.state.load(std::memory_order_acquire) == TaskState::COMPLETED) {
+        TaskState state = s.state.load(std::memory_order_acquire);
+        if (state == TaskState::COMPLETED || state == TaskState::FAILED) {
             if (cfg_.on_consumed_cb) cfg_.on_consumed_cb(slot);
         }
     }
@@ -193,6 +338,9 @@ void Scheduler::dispatch_ready() {
         TaskSlot slot;
         while (q->try_pop(slot)) {
             TaskSlotState &s = *cfg_.ring->slot_state(slot);
+            if (s.state.load(std::memory_order_acquire) != TaskState::READY) {
+                continue;
+            }
             int N = s.group_size();  // 1 for normal tasks
 
             // Affinity-aware dispatch: pin args[i] to worker affinities[i]
@@ -205,7 +353,7 @@ void Scheduler::dispatch_ready() {
                 int8_t aff = s.get_affinity(i);
                 if (aff >= 0) {
                     auto *wt = cfg_.manager->get_worker(s.worker_type, aff);
-                    if (!wt || !wt->idle()) {
+                    if (!wt || !wt->idle() || !s.endpoint_allowed(i, wt->endpoint_id())) {
                         ok = false;
                         break;
                     }
@@ -217,7 +365,8 @@ void Scheduler::dispatch_ready() {
             if (ok) {
                 for (int i = 0; i < N; i++) {
                     if (workers[static_cast<size_t>(i)] != nullptr) continue;
-                    auto *wt = cfg_.manager->pick_idle_excluding(s.worker_type, workers);
+                    auto *wt =
+                        cfg_.manager->pick_idle_excluding_eligible(s.worker_type, workers, s.eligible_endpoints_for(i));
                     if (!wt) {
                         ok = false;
                         break;
@@ -232,7 +381,26 @@ void Scheduler::dispatch_ready() {
             }
 
             s.state.store(TaskState::RUNNING, std::memory_order_release);
+            if (s.is_group()) {
+                std::lock_guard<std::mutex> lk(s.group_mu);
+                s.group_member_states.assign(static_cast<size_t>(N), GroupMemberState::NOT_DISPATCHED);
+                s.group_member_outcomes.assign(static_cast<size_t>(N), EndpointOutcome::SKIPPED);
+                s.group_terminal_count.store(0, std::memory_order_relaxed);
+                s.group_dispatched_count.store(0, std::memory_order_relaxed);
+                s.group_failed = false;
+                s.group_first_failure_index = -1;
+                s.group_first_failure_message.clear();
+            }
             for (int i = 0; i < N; i++) {
+                if (s.is_group()) {
+                    std::lock_guard<std::mutex> lk(s.group_mu);
+                    GroupMemberState &member_state = s.group_member_states[static_cast<size_t>(i)];
+                    if (member_state != GroupMemberState::NOT_DISPATCHED || s.group_failed) {
+                        continue;
+                    }
+                    member_state = GroupMemberState::RUNNING;
+                    s.group_dispatched_count.fetch_add(1, std::memory_order_relaxed);
+                }
                 WorkerDispatch d;
                 d.task_slot = slot;
                 d.group_index = i;

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -27,8 +27,8 @@
  *     drain ready_queue → manager.pick_n_idle → dispatch
  *
  *   WorkerThread (managed by WorkerManager):
- *     loop: task_queue.pop() → worker.run(payload) →
- *           completion callback → Scheduler.worker_done(slot)
+ *     loop: task_queue.pop() → endpoint.run(dispatch) →
+ *           completion callback → Scheduler.worker_done(completion)
  */
 
 #pragma once
@@ -38,6 +38,7 @@
 #include <functional>
 #include <mutex>
 #include <queue>
+#include <string>
 #include <thread>
 
 #include "types.h"
@@ -68,8 +69,9 @@ public:
 
     bool running() const { return running_.load(std::memory_order_acquire); }
 
-    // Called by WorkerManager (from WorkerThread) after run() completes.
-    void worker_done(TaskSlot slot);
+    // Called by WorkerManager (from WorkerThread) after endpoint run() reaches
+    // a terminal outcome.
+    void worker_done(WorkerCompletion completion);
 
     // Mutex held by run() across each loop iteration's slot-touching body
     // (completion processing + dispatch). Orchestrator::drain() acquires it
@@ -82,7 +84,7 @@ private:
     std::mutex loop_mu_;
 
     // Shared completion queue (WorkerThread → Scheduler)
-    std::queue<TaskSlot> completion_queue_;
+    std::queue<WorkerCompletion> completion_queue_;
     std::mutex completion_mu_;
     std::condition_variable completion_cv_;
 
@@ -91,7 +93,8 @@ private:
     std::atomic<bool> running_{false};
 
     void run();
-    void on_task_complete(TaskSlot slot);
+    void on_task_complete(const WorkerCompletion &completion);
+    void poison_task(TaskSlot slot, const std::string &root_message);
     void try_consume(TaskSlot slot);
     void dispatch_ready();
 };

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -26,19 +26,33 @@ void TaskSlotState::reset() {
     }
     fanout_released.store(0, std::memory_order_relaxed);
     output_keys.clear();
+    eligible_endpoint_ids.clear();
     fanin_producers.clear();
+    failure_message.clear();
     worker_type = WorkerType::NEXT_LEVEL;
     callable = CallableIdentity{};
     config = CallConfig{};
     task_args.clear();
     task_args_list.clear();
     is_group_ = false;
+    remote_sidecar.clear();
+    remote_sidecars.clear();
     affinities.clear();
     // ring_idx / ring_slot_idx are deliberately NOT cleared here: Ring
     // stamps them at alloc() before the Orchestrator ever calls reset(),
     // and Ring::release() needs to read them for the FIFO advance. The
     // fields are rewritten on every alloc, so stale values never escape.
     sub_complete_count.store(0, std::memory_order_relaxed);
+    {
+        std::lock_guard<std::mutex> lk(group_mu);
+        group_member_states.clear();
+        group_member_outcomes.clear();
+        group_failed = false;
+        group_first_failure_index = -1;
+        group_first_failure_message.clear();
+    }
+    group_terminal_count.store(0, std::memory_order_relaxed);
+    group_dispatched_count.store(0, std::memory_order_relaxed);
 }
 
 // =============================================================================

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -45,17 +45,60 @@
 // TensorKey — compound key for TensorMap dependency tracking
 // =============================================================================
 
+enum class TensorAddressKind : int32_t {
+    LOCAL_HOST = 0,
+    LOCAL_CHILD = 1,
+    REMOTE_BUFFER = 2,
+    HOST_INLINE = 3,
+};
+
 struct TensorKey {
     uint64_t ptr;
     int8_t worker;  // -1 = host (globally unique), 0..N-1 = next-level worker logical id
+    TensorAddressKind address_kind{TensorAddressKind::LOCAL_HOST};
+    int32_t owner_endpoint_id{-1};
+    uint64_t buffer_id{0};
+    uint64_t generation{0};
+    uint64_t offset_begin{0};
 
-    bool operator==(const TensorKey &o) const { return ptr == o.ptr && worker == o.worker; }
+    static TensorKey local_host(uint64_t ptr) { return TensorKey{ptr, -1, TensorAddressKind::LOCAL_HOST}; }
+    static TensorKey local_child(uint64_t ptr, int8_t worker) {
+        return TensorKey{ptr, worker, TensorAddressKind::LOCAL_CHILD};
+    }
+    static TensorKey remote_buffer(
+        TensorAddressKind address_kind, int32_t owner_endpoint_id, uint64_t buffer_id, uint64_t generation,
+        uint64_t offset_begin
+    ) {
+        TensorKey key{};
+        key.ptr = 0;
+        key.worker = -1;
+        key.address_kind = address_kind;
+        key.owner_endpoint_id = owner_endpoint_id;
+        key.buffer_id = buffer_id;
+        key.generation = generation;
+        key.offset_begin = offset_begin;
+        return key;
+    }
+
+    bool operator==(const TensorKey &o) const {
+        return ptr == o.ptr && worker == o.worker && address_kind == o.address_kind &&
+               owner_endpoint_id == o.owner_endpoint_id && buffer_id == o.buffer_id && generation == o.generation &&
+               offset_begin == o.offset_begin;
+    }
 };
 
 struct TensorKeyHash {
     size_t operator()(const TensorKey &k) const {
         size_t h = std::hash<uint64_t>{}(k.ptr);
-        h ^= std::hash<int>{}(k.worker) + 0x9e3779b9 + (h << 6) + (h >> 2);
+        auto mix = [&h](size_t v) {
+            h ^= v + 0x9e3779b9 + (h << 6) + (h >> 2);
+        };
+        mix(std::hash<int>{}(k.worker));
+        mix(std::hash<int>{}(static_cast<int>(k.address_kind)));
+        mix(std::hash<int>{}(k.owner_endpoint_id));
+        mix(std::hash<uint64_t>{}(k.buffer_id));
+        mix(std::hash<uint64_t>{}(k.generation));
+        mix(std::hash<uint64_t>{}(k.offset_begin));
         return h;
     }
 };
@@ -120,7 +163,15 @@ enum class TaskState : int32_t {
     READY = 2,      // all fanins satisfied, in ready queue
     RUNNING = 3,    // dispatched to a worker
     COMPLETED = 4,  // worker finished, outputs may still be referenced
-    CONSUMED = 5,   // all references released, slot may be reused
+    FAILED = 5,     // worker failed or a producer poisoned this slot
+    CONSUMED = 6,   // all references released, slot may be reused
+};
+
+enum class EndpointOutcome : int32_t {
+    SUCCESS = 0,
+    TASK_FAILURE = 1,
+    ENDPOINT_FAILURE = 2,
+    SKIPPED = 3,
 };
 
 enum class RemoteAddressSpace : int32_t {
@@ -183,6 +234,13 @@ struct RemoteTensorDesc {
     uint64_t flags{0};
 };
 
+struct RemoteTensorRef {
+    RemoteBufferHandle handle{};
+    uint64_t offset{0};
+    std::vector<uint32_t> shape;
+    DataType dtype{DataType::FLOAT32};
+};
+
 struct RemoteTensorSidecar {
     bool present{false};
     RemoteTensorDesc desc{};
@@ -204,6 +262,21 @@ struct RemoteTaskArgsSidecar {
         tensors.clear();
         inline_payload.clear();
     }
+};
+
+enum class GroupMemberState : int32_t {
+    NOT_DISPATCHED = 0,
+    RUNNING = 1,
+    SUCCESS = 2,
+    FAILED = 3,
+    SKIPPED = 4,
+};
+
+struct WorkerCompletion {
+    TaskSlot task_slot{INVALID_SLOT};
+    int32_t group_index{0};
+    EndpointOutcome outcome{EndpointOutcome::SUCCESS};
+    std::string error_message;
 };
 
 // =============================================================================
@@ -232,6 +305,11 @@ struct TaskSlotState {
     // --- TensorMap keys registered by this task (for cleanup on CONSUMED) ---
     std::vector<TensorKey> output_keys;
 
+    // Empty outer vector means legacy/unconstrained dispatch. When present,
+    // each group member's vector is the final callable/data endpoint
+    // intersection and must be non-empty.
+    std::vector<std::vector<int32_t>> eligible_endpoint_ids;
+
     // --- Worker affinity (set by submit_next_level with worker= parameter) ---
     // Empty = unconstrained (any idle worker). Otherwise affinities[i] gives
     // the logical worker id for args[i] (-1 = unconstrained for that slot).
@@ -246,6 +324,11 @@ struct TaskSlotState {
     // When this task reaches COMPLETED, the Scheduler releases one fanout ref
     // on each producer — mirroring L2's "deferred release: walk fanin" step.
     std::vector<TaskSlot> fanin_producers;
+
+    // --- Failure state ---
+    // Root worker failures and downstream poison both land here. The
+    // WorkerManager still owns first-error-wins reporting for drain().
+    std::string failure_message;
 
     // --- Task data (stored on parent heap, lives until slot CONSUMED) ---
     WorkerType worker_type{WorkerType::NEXT_LEVEL};
@@ -262,6 +345,8 @@ struct TaskSlotState {
     TaskArgs task_args;
     std::vector<TaskArgs> task_args_list;
     bool is_group_{false};
+    RemoteTaskArgsSidecar remote_sidecar;
+    std::vector<RemoteTaskArgsSidecar> remote_sidecars;
 
     // Runtime-owned OUTPUT slabs live in the Worker's HeapRing and are
     // reclaimed implicitly by Ring::release(slot) — no per-slot
@@ -277,9 +362,43 @@ struct TaskSlotState {
 
     // --- Group bookkeeping ---
     std::atomic<int32_t> sub_complete_count{0};
+    std::mutex group_mu;
+    std::vector<GroupMemberState> group_member_states;
+    std::vector<EndpointOutcome> group_member_outcomes;
+    std::atomic<int32_t> group_terminal_count{0};
+    std::atomic<int32_t> group_dispatched_count{0};
+    bool group_failed{false};
+    int32_t group_first_failure_index{-1};
+    std::string group_first_failure_message;
 
     bool is_group() const { return is_group_; }
     int32_t group_size() const { return is_group_ ? static_cast<int32_t>(task_args_list.size()) : 1; }
+    bool has_endpoint_constraints() const { return !eligible_endpoint_ids.empty(); }
+
+    const std::vector<int32_t> &eligible_endpoints_for(int32_t i) const {
+        static const std::vector<int32_t> empty;
+        if (eligible_endpoint_ids.empty()) return empty;
+        if (i < 0 || static_cast<size_t>(i) >= eligible_endpoint_ids.size()) return empty;
+        return eligible_endpoint_ids[static_cast<size_t>(i)];
+    }
+
+    bool endpoint_allowed(int32_t i, int32_t endpoint_id) const {
+        if (eligible_endpoint_ids.empty()) return true;
+        const auto &eligible = eligible_endpoints_for(i);
+        for (int32_t id : eligible) {
+            if (id == endpoint_id) return true;
+        }
+        return false;
+    }
+
+    const RemoteTaskArgsSidecar &remote_sidecar_for(int32_t i) const {
+        static const RemoteTaskArgsSidecar empty;
+        if (is_group_) {
+            if (i < 0 || static_cast<size_t>(i) >= remote_sidecars.size()) return empty;
+            return remote_sidecars[static_cast<size_t>(i)];
+        }
+        return remote_sidecar;
+    }
 
     // Zero-copy view over the i-th worker's args (THREAD-mode dispatch).
     // `i` must be 0 for non-group slots; 0..group_size()-1 for groups.

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -78,8 +78,8 @@ void Worker::init() {
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().
-    manager_.start(&allocator_, [this](TaskSlot slot) {
-        scheduler_.worker_done(slot);
+    manager_.start(&allocator_, [this](WorkerCompletion completion) {
+        scheduler_.worker_done(completion);
     });
 
     Scheduler::Config cfg;

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -16,6 +16,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <atomic>
 #include <cerrno>
 #include <cstdio>
@@ -359,6 +360,28 @@ void WorkerManager::add_sub(void *mailbox) { sub_entries_.push_back(mailbox); }
 
 void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete) {
     if (ring == nullptr) throw std::invalid_argument("WorkerManager::start: null ring");
+
+    std::vector<int32_t> next_level_endpoint_ids;
+    next_level_endpoint_ids.reserve(next_level_entries_.size() + next_level_endpoint_entries_.size());
+    auto register_next_level_endpoint_id = [&](int32_t endpoint_id) {
+        if (endpoint_id < 0) {
+            throw std::runtime_error("WorkerManager::start: endpoint must have a stable endpoint_id");
+        }
+        if (std::find(next_level_endpoint_ids.begin(), next_level_endpoint_ids.end(), endpoint_id) !=
+            next_level_endpoint_ids.end()) {
+            throw std::runtime_error(
+                "WorkerManager::start: duplicate NEXT_LEVEL endpoint_id " + std::to_string(endpoint_id)
+            );
+        }
+        next_level_endpoint_ids.push_back(endpoint_id);
+    };
+    for (size_t i = 0; i < next_level_entries_.size(); ++i) {
+        register_next_level_endpoint_id(static_cast<int32_t>(i));
+    }
+    for (const auto &endpoint : next_level_endpoint_entries_) {
+        register_next_level_endpoint_id(endpoint->caps().endpoint_id);
+    }
+
     auto make_threads = [&](const std::vector<void *> &entries, std::vector<std::unique_ptr<WorkerThread>> &threads,
                             int32_t endpoint_offset) {
         for (size_t i = 0; i < entries.size(); ++i) {
@@ -372,9 +395,6 @@ void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete) {
     make_threads(next_level_entries_, next_level_threads_, 0);
     for (auto &endpoint : next_level_endpoint_entries_) {
         auto wt = std::make_unique<WorkerThread>();
-        if (endpoint->caps().endpoint_id < 0) {
-            throw std::runtime_error("WorkerManager::start: custom endpoint must have a stable endpoint_id");
-        }
         wt->start(ring, this, on_complete, std::move(endpoint));
         next_level_threads_.push_back(std::move(wt));
     }

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "ring.h"
@@ -54,11 +55,77 @@ std::string format_digest(const uint8_t *digest) {
 
 }  // namespace
 
+namespace {
+
+[[noreturn]] void throw_unsupported_control(const char *op_name) {
+    throw std::runtime_error(std::string(op_name) + " is not supported by this WorkerEndpoint");
+}
+
+}  // namespace
+
+uint64_t WorkerEndpoint::control_malloc(size_t) { throw_unsupported_control("control_malloc"); }
+void WorkerEndpoint::control_free(uint64_t) { throw_unsupported_control("control_free"); }
+void WorkerEndpoint::control_copy_to(uint64_t, uint64_t, size_t) { throw_unsupported_control("control_copy_to"); }
+void WorkerEndpoint::control_copy_from(uint64_t, uint64_t, size_t) { throw_unsupported_control("control_copy_from"); }
+void WorkerEndpoint::control_prepare(const uint8_t *) { throw_unsupported_control("control_prepare"); }
+void WorkerEndpoint::control_register(const char *, size_t, const uint8_t *) {
+    throw_unsupported_control("control_register");
+}
+void WorkerEndpoint::control_unregister(const uint8_t *) { throw_unsupported_control("control_unregister"); }
+void WorkerEndpoint::control_remote_prepare_register(
+    remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *, const void *, size_t
+) {
+    throw_unsupported_control("control_remote_prepare_register");
+}
+void WorkerEndpoint::control_remote_commit_register(remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *) {
+    throw_unsupported_control("control_remote_commit_register");
+}
+void WorkerEndpoint::control_remote_abort_register(remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *) {
+    throw_unsupported_control("control_remote_abort_register");
+}
+void WorkerEndpoint::control_remote_unregister(remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *) {
+    throw_unsupported_control("control_remote_unregister");
+}
+RemoteBufferHandle WorkerEndpoint::control_remote_malloc(size_t) { throw_unsupported_control("control_remote_malloc"); }
+void WorkerEndpoint::control_remote_free(const RemoteBufferHandle &) {
+    throw_unsupported_control("control_remote_free");
+}
+void WorkerEndpoint::control_remote_copy_to(const RemoteBufferHandle &, uint64_t, const void *, size_t) {
+    throw_unsupported_control("control_remote_copy_to");
+}
+void WorkerEndpoint::control_remote_copy_from(void *, const RemoteBufferHandle &, uint64_t, size_t) {
+    throw_unsupported_control("control_remote_copy_from");
+}
+RemoteBufferExport
+WorkerEndpoint::control_remote_export(const RemoteBufferHandle &, uint64_t, uint64_t, uint32_t, const std::string &) {
+    throw_unsupported_control("control_remote_export");
+}
+RemoteBufferHandle WorkerEndpoint::control_remote_import(int32_t, const RemoteBufferExport &, uint32_t) {
+    throw_unsupported_control("control_remote_import");
+}
+void WorkerEndpoint::control_remote_release_import(const RemoteBufferHandle &) {
+    throw_unsupported_control("control_remote_release_import");
+}
+void WorkerEndpoint::control_generic(uint64_t, const char *, size_t, double, const uint8_t *) {
+    throw_unsupported_control("control_generic");
+}
+void WorkerEndpoint::control_alloc_domain(const char *, const char *) {
+    throw_unsupported_control("control_alloc_domain");
+}
+void WorkerEndpoint::control_release_domain(const char *) { throw_unsupported_control("control_release_domain"); }
+void WorkerEndpoint::control_comm_init(const char *) { throw_unsupported_control("control_comm_init"); }
+
 // =============================================================================
-// WorkerThread — mailbox helpers
+// LocalMailboxEndpoint — mailbox helpers
 // =============================================================================
 
-MailboxState WorkerThread::read_mailbox_state() const {
+LocalMailboxEndpoint::LocalMailboxEndpoint(int32_t endpoint_id, void *mailbox) :
+    mailbox_(mailbox) {
+    if (mailbox == nullptr) throw std::invalid_argument("LocalMailboxEndpoint: null mailbox");
+    caps_.endpoint_id = endpoint_id;
+}
+
+MailboxState LocalMailboxEndpoint::read_mailbox_state() const {
     volatile int32_t *ptr = reinterpret_cast<volatile int32_t *>(mbox() + MAILBOX_OFF_STATE);
     int32_t v;
 #if defined(__aarch64__)
@@ -72,7 +139,7 @@ MailboxState WorkerThread::read_mailbox_state() const {
     return static_cast<MailboxState>(v);
 }
 
-void WorkerThread::write_mailbox_state(MailboxState s) {
+void LocalMailboxEndpoint::write_mailbox_state(MailboxState s) {
     volatile int32_t *ptr = reinterpret_cast<volatile int32_t *>(mbox() + MAILBOX_OFF_STATE);
     int32_t v = static_cast<int32_t>(s);
 #if defined(__aarch64__)
@@ -85,18 +152,21 @@ void WorkerThread::write_mailbox_state(MailboxState s) {
 #endif
 }
 
+void LocalMailboxEndpoint::shutdown_child() { write_mailbox_state(MailboxState::SHUTDOWN); }
+
 // =============================================================================
 // WorkerThread — lifecycle
 // =============================================================================
 
 void WorkerThread::start(
-    Ring *ring, WorkerManager *manager, const std::function<void(TaskSlot)> &on_complete, void *mailbox
+    Ring *ring, WorkerManager *manager, const std::function<void(WorkerCompletion)> &on_complete,
+    std::unique_ptr<WorkerEndpoint> endpoint
 ) {
-    if (mailbox == nullptr) throw std::invalid_argument("WorkerThread::start: null mailbox");
+    if (!endpoint) throw std::invalid_argument("WorkerThread::start: null endpoint");
     ring_ = ring;
     manager_ = manager;
     on_complete_ = on_complete;
-    mailbox_ = mailbox;
+    endpoint_ = std::move(endpoint);
     shutdown_ = false;
     idle_.store(true, std::memory_order_relaxed);
     thread_ = std::thread(&WorkerThread::loop, this);
@@ -119,10 +189,15 @@ void WorkerThread::stop() {
 }
 
 void WorkerThread::shutdown_child() {
-    if (mailbox_) {
-        write_mailbox_state(MailboxState::SHUTDOWN);
-    }
+    if (endpoint_) endpoint_->shutdown_child();
 }
+
+const WorkerEndpointCaps &WorkerThread::caps() const {
+    if (!endpoint_) throw std::runtime_error("WorkerThread::caps: null endpoint");
+    return endpoint_->caps();
+}
+
+int32_t WorkerThread::endpoint_id() const { return caps().endpoint_id; }
 
 // =============================================================================
 // WorkerThread — main loop + per-mode dispatch
@@ -141,28 +216,51 @@ void WorkerThread::loop() {
             queue_.pop();
         }
 
-        TaskSlotState &s = *ring_->slot_state(d.task_slot);
-
-        // dispatch_process may throw on a non-zero ERROR from the child.
-        // An uncaught exception escaping loop() would terminate the
-        // std::thread via std::terminate — instead, capture it and let
-        // the orch thread observe it at the next submit_*/drain.
-        // on_complete_ still fires so the scheduler releases consumers
-        // and active_tasks_ eventually reaches zero; otherwise drain()
-        // would hang.
+        WorkerCompletion completion;
         try {
-            dispatch_process(s, d.group_index);
+            completion = dispatch_process(d);
+        } catch (const std::exception &e) {
+            completion.task_slot = d.task_slot;
+            completion.group_index = d.group_index;
+            completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+            completion.error_message = std::string("WorkerThread endpoint failed: ") + e.what();
         } catch (...) {
-            if (manager_) manager_->report_error(std::current_exception());
+            completion.task_slot = d.task_slot;
+            completion.group_index = d.group_index;
+            completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+            completion.error_message = "WorkerThread endpoint failed with unknown exception";
+        }
+
+        if (completion.outcome != EndpointOutcome::SUCCESS && manager_) {
+            manager_->report_error(std::make_exception_ptr(std::runtime_error(completion.error_message)));
         }
 
         idle_.store(true, std::memory_order_release);
-        on_complete_(d.task_slot);
+        on_complete_(std::move(completion));
     }
 }
 
-void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
+WorkerCompletion WorkerThread::dispatch_process(WorkerDispatch d) {
+    if (!endpoint_) throw std::runtime_error("WorkerThread::dispatch_process: null endpoint");
+    return endpoint_->run(ring_, d);
+}
+
+WorkerCompletion LocalMailboxEndpoint::run(Ring *ring, const WorkerDispatch &dispatch) {
+    if (ring == nullptr) throw std::invalid_argument("LocalMailboxEndpoint::run: null ring");
+    TaskSlotState &s = *ring->slot_state(dispatch.task_slot);
+    int32_t group_index = dispatch.group_index;
     TaskArgsView view = s.args_view(group_index);
+    if (!s.remote_sidecar_for(group_index).empty()) {
+        WorkerCompletion completion;
+        completion.task_slot = dispatch.task_slot;
+        completion.group_index = group_index;
+        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+        completion.error_message = "LocalMailboxEndpoint::run: remote task sidecar is not supported by local mailbox";
+        return completion;
+    }
+    WorkerCompletion completion;
+    completion.task_slot = dispatch.task_slot;
+    completion.group_index = group_index;
 
     // Hold mailbox_mu_ for the entire round trip (write payload + state +
     // spin-poll TASK_DONE + reset to IDLE). Any control_* request from the
@@ -170,7 +268,9 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     // mailbox; without this they would race on MAILBOX_OFF_STATE.
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     if (mailbox_control_timed_out_) {
-        throw std::runtime_error("WorkerThread::dispatch_process: mailbox has an unresolved timed-out control command");
+        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+        completion.error_message = "LocalMailboxEndpoint::run: mailbox has an unresolved timed-out control command";
+        return completion;
     }
 
     // Clear the child-writable error fields so stale bytes from a prior
@@ -189,11 +289,12 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ContinuousTensor) +
                         static_cast<size_t>(view.scalar_count) * sizeof(uint64_t);
     if (blob_bytes > MAILBOX_ARGS_CAPACITY) {
-        throw std::runtime_error(
-            "WorkerThread::dispatch_process: args blob exceeds mailbox capacity: need " + std::to_string(blob_bytes) +
+        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+        completion.error_message =
+            "LocalMailboxEndpoint::run: args blob exceeds mailbox capacity: need " + std::to_string(blob_bytes) +
             " bytes, capacity " + std::to_string(MAILBOX_ARGS_CAPACITY) +
-            " bytes, tensors=" + std::to_string(view.tensor_count) + ", scalars=" + std::to_string(view.scalar_count)
-        );
+            " bytes, tensors=" + std::to_string(view.tensor_count) + ", scalars=" + std::to_string(view.scalar_count);
+        return completion;
     }
     uint8_t *hash_dst = reinterpret_cast<uint8_t *>(mbox() + MAILBOX_OFF_TASK_CALLABLE_HASH);
     std::memcpy(hash_dst, s.callable.digest.data(), CALLABLE_HASH_DIGEST_SIZE);
@@ -231,12 +332,16 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     if (error_code != 0) {
         std::string msg = read_error_msg(mbox());
         write_mailbox_state(MailboxState::IDLE);
-        throw std::runtime_error(
-            "WorkerThread::dispatch_process: child failed (code=" + std::to_string(error_code) + "): " + msg
-        );
+        completion.outcome = EndpointOutcome::TASK_FAILURE;
+        completion.error_message =
+            "LocalMailboxEndpoint::run: child failed (endpoint=" + std::to_string(caps_.endpoint_id) +
+            ", code=" + std::to_string(error_code) + "): " + msg;
+        return completion;
     }
 
     write_mailbox_state(MailboxState::IDLE);
+    completion.outcome = EndpointOutcome::SUCCESS;
+    return completion;
 }
 
 // =============================================================================
@@ -245,19 +350,36 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
 
 void WorkerManager::add_next_level(void *mailbox) { next_level_entries_.push_back(mailbox); }
 
+void WorkerManager::add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint) {
+    if (!endpoint) throw std::invalid_argument("WorkerManager::add_next_level_endpoint: null endpoint");
+    next_level_endpoint_entries_.push_back(std::move(endpoint));
+}
+
 void WorkerManager::add_sub(void *mailbox) { sub_entries_.push_back(mailbox); }
 
 void WorkerManager::start(Ring *ring, const OnCompleteFn &on_complete) {
     if (ring == nullptr) throw std::invalid_argument("WorkerManager::start: null ring");
-    auto make_threads = [&](const std::vector<void *> &entries, std::vector<std::unique_ptr<WorkerThread>> &threads) {
-        for (void *mailbox : entries) {
+    auto make_threads = [&](const std::vector<void *> &entries, std::vector<std::unique_ptr<WorkerThread>> &threads,
+                            int32_t endpoint_offset) {
+        for (size_t i = 0; i < entries.size(); ++i) {
             auto wt = std::make_unique<WorkerThread>();
-            wt->start(ring, this, on_complete, mailbox);
+            auto endpoint =
+                std::make_unique<LocalMailboxEndpoint>(endpoint_offset + static_cast<int32_t>(i), entries[i]);
+            wt->start(ring, this, on_complete, std::move(endpoint));
             threads.push_back(std::move(wt));
         }
     };
-    make_threads(next_level_entries_, next_level_threads_);
-    make_threads(sub_entries_, sub_threads_);
+    make_threads(next_level_entries_, next_level_threads_, 0);
+    for (auto &endpoint : next_level_endpoint_entries_) {
+        auto wt = std::make_unique<WorkerThread>();
+        if (endpoint->caps().endpoint_id < 0) {
+            throw std::runtime_error("WorkerManager::start: custom endpoint must have a stable endpoint_id");
+        }
+        wt->start(ring, this, on_complete, std::move(endpoint));
+        next_level_threads_.push_back(std::move(wt));
+    }
+    next_level_endpoint_entries_.clear();
+    make_threads(sub_entries_, sub_threads_, 0);
 }
 
 void WorkerManager::report_error(std::exception_ptr e) {
@@ -322,10 +444,36 @@ WorkerThread *WorkerManager::get_worker(WorkerType type, int logical_id) const {
     return threads[static_cast<size_t>(logical_id)].get();
 }
 
+WorkerThread *WorkerManager::get_worker_by_endpoint_id(WorkerType type, int32_t endpoint_id) const {
+    auto &threads = (type == WorkerType::NEXT_LEVEL) ? next_level_threads_ : sub_threads_;
+    for (auto &wt : threads) {
+        if (wt->endpoint_id() == endpoint_id) return wt.get();
+    }
+    return nullptr;
+}
+
 WorkerThread *WorkerManager::pick_idle_excluding(WorkerType type, const std::vector<WorkerThread *> &exclude) const {
+    static const std::vector<int32_t> unconstrained;
+    return pick_idle_excluding_eligible(type, exclude, unconstrained);
+}
+
+WorkerThread *WorkerManager::pick_idle_excluding_eligible(
+    WorkerType type, const std::vector<WorkerThread *> &exclude, const std::vector<int32_t> &eligible_endpoint_ids
+) const {
     auto &threads = (type == WorkerType::NEXT_LEVEL) ? next_level_threads_ : sub_threads_;
     for (auto &wt : threads) {
         if (!wt->idle()) continue;
+        if (!eligible_endpoint_ids.empty()) {
+            bool eligible = false;
+            int32_t endpoint_id = wt->endpoint_id();
+            for (int32_t id : eligible_endpoint_ids) {
+                if (id == endpoint_id) {
+                    eligible = true;
+                    break;
+                }
+            }
+            if (!eligible) continue;
+        }
         bool excluded = false;
         for (auto *ex : exclude) {
             if (ex == wt.get()) {
@@ -339,7 +487,7 @@ WorkerThread *WorkerManager::pick_idle_excluding(WorkerType type, const std::vec
 }
 
 // =============================================================================
-// WorkerThread — memory control (orch thread, concurrent with worker thread)
+// LocalMailboxEndpoint — memory control (orch thread, concurrent with worker thread)
 // =============================================================================
 
 static void write_control_args(char *mbox, uint64_t sub_cmd, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0) {
@@ -368,7 +516,7 @@ static void write_control_digest(char *mbox, const uint8_t *digest) {
 // from the child, throws and leaves the mailbox in IDLE before unwinding
 // (so the next claim starts from a clean state). The `op_name` is used
 // only for the exception message.
-void WorkerThread::run_control_command(const char *op_name, double timeout_s) {
+void LocalMailboxEndpoint::run_control_command(const char *op_name, double timeout_s) {
     if (mailbox_control_timed_out_) {
         throw std::runtime_error(std::string(op_name) + " failed: mailbox has an unresolved timed-out control command");
     }
@@ -398,21 +546,21 @@ void WorkerThread::run_control_command(const char *op_name, double timeout_s) {
     write_mailbox_state(MailboxState::IDLE);
 }
 
-uint64_t WorkerThread::control_malloc(size_t size) {
+uint64_t LocalMailboxEndpoint::control_malloc(size_t size) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_MALLOC, static_cast<uint64_t>(size));
     run_control_command("control_malloc");
     return read_control_result(mbox());
 }
 
-void WorkerThread::control_prepare(const uint8_t *digest) {
+void LocalMailboxEndpoint::control_prepare(const uint8_t *digest) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_PREPARE);
     write_control_digest(mbox(), digest);
     run_control_command("control_prepare");
 }
 
-void WorkerThread::control_register(const char *shm_name, size_t blob_size, const uint8_t *digest) {
+void LocalMailboxEndpoint::control_register(const char *shm_name, size_t blob_size, const uint8_t *digest) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     // OFF_ERROR / OFF_ERROR_MSG are cleared by run_control_command — no
     // prelude memset needed (matches the other control_* methods).
@@ -432,18 +580,72 @@ void WorkerThread::control_register(const char *shm_name, size_t blob_size, cons
     run_control_command("control_register");
 }
 
-void WorkerThread::control_unregister(const uint8_t *digest) {
+void LocalMailboxEndpoint::control_unregister(const uint8_t *digest) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_UNREGISTER);
     write_control_digest(mbox(), digest);
     run_control_command("control_unregister");
 }
 
-void WorkerThread::control_generic(uint64_t sub_cmd, const char *shm_name, double timeout_s, const uint8_t *digest) {
+void LocalMailboxEndpoint::control_remote_prepare_register(
+    remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *, const void *, size_t
+) {
+    throw_unsupported_control("control_remote_prepare_register");
+}
+
+void LocalMailboxEndpoint::control_remote_commit_register(
+    remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *
+) {
+    throw_unsupported_control("control_remote_commit_register");
+}
+
+void LocalMailboxEndpoint::control_remote_abort_register(
+    remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *
+) {
+    throw_unsupported_control("control_remote_abort_register");
+}
+
+void LocalMailboxEndpoint::control_remote_unregister(remote_l3::RemoteRegistryTarget, CallableKind, const uint8_t *) {
+    throw_unsupported_control("control_remote_unregister");
+}
+
+RemoteBufferHandle LocalMailboxEndpoint::control_remote_malloc(size_t) {
+    throw_unsupported_control("control_remote_malloc");
+}
+
+void LocalMailboxEndpoint::control_remote_free(const RemoteBufferHandle &) {
+    throw_unsupported_control("control_remote_free");
+}
+
+void LocalMailboxEndpoint::control_remote_copy_to(const RemoteBufferHandle &, uint64_t, const void *, size_t) {
+    throw_unsupported_control("control_remote_copy_to");
+}
+
+void LocalMailboxEndpoint::control_remote_copy_from(void *, const RemoteBufferHandle &, uint64_t, size_t) {
+    throw_unsupported_control("control_remote_copy_from");
+}
+
+RemoteBufferExport LocalMailboxEndpoint::control_remote_export(
+    const RemoteBufferHandle &, uint64_t, uint64_t, uint32_t, const std::string &
+) {
+    throw_unsupported_control("control_remote_export");
+}
+
+RemoteBufferHandle LocalMailboxEndpoint::control_remote_import(int32_t, const RemoteBufferExport &, uint32_t) {
+    throw_unsupported_control("control_remote_import");
+}
+
+void LocalMailboxEndpoint::control_remote_release_import(const RemoteBufferHandle &) {
+    throw_unsupported_control("control_remote_release_import");
+}
+
+void LocalMailboxEndpoint::control_generic(
+    uint64_t sub_cmd, const char *shm_name, size_t staged_payload_size, double timeout_s, const uint8_t *digest
+) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &sub_cmd, sizeof(uint64_t));
-    uint64_t reserved = 0;
-    std::memcpy(mbox() + CTRL_OFF_ARG0, &reserved, sizeof(uint64_t));
+    uint64_t payload_size = static_cast<uint64_t>(staged_payload_size);
+    std::memcpy(mbox() + CTRL_OFF_ARG0, &payload_size, sizeof(uint64_t));
     write_control_digest(mbox(), digest);
     const char *name = shm_name ? shm_name : "";
     size_t name_len = std::strlen(name);
@@ -455,19 +657,19 @@ void WorkerThread::control_generic(uint64_t sub_cmd, const char *shm_name, doubl
     run_control_command("control_generic", timeout_s);
 }
 
-void WorkerThread::control_free(uint64_t ptr) {
+void LocalMailboxEndpoint::control_free(uint64_t ptr) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_FREE, ptr);
     run_control_command("control_free");
 }
 
-void WorkerThread::control_copy_to(uint64_t dst, uint64_t src, size_t size) {
+void LocalMailboxEndpoint::control_copy_to(uint64_t dst, uint64_t src, size_t size) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_COPY_TO, dst, src, static_cast<uint64_t>(size));
     run_control_command("control_copy_to");
 }
 
-void WorkerThread::control_copy_from(uint64_t dst, uint64_t src, size_t size) {
+void LocalMailboxEndpoint::control_copy_from(uint64_t dst, uint64_t src, size_t size) {
     std::lock_guard<std::mutex> lk(mailbox_mu_);
     write_control_args(mbox(), CTRL_COPY_FROM, dst, src, static_cast<uint64_t>(size));
     run_control_command("control_copy_from");
@@ -490,7 +692,7 @@ static void write_shm_name_pair(char *mbox, const char *request_shm_name, const 
     write_one(mbox + MAILBOX_OFF_ARGS + CTRL_SHM_NAME_BYTES, reply_shm_name);
 }
 
-void WorkerThread::control_alloc_domain(const char *request_shm_name, const char *reply_shm_name) {
+void LocalMailboxEndpoint::control_alloc_domain(const char *request_shm_name, const char *reply_shm_name) {
     if (!request_shm_name || !*request_shm_name || !reply_shm_name || !*reply_shm_name) {
         throw std::runtime_error("control_alloc_domain: request and reply shm names must be non-empty");
     }
@@ -501,7 +703,7 @@ void WorkerThread::control_alloc_domain(const char *request_shm_name, const char
     run_control_command("control_alloc_domain");
 }
 
-void WorkerThread::control_release_domain(const char *request_shm_name) {
+void LocalMailboxEndpoint::control_release_domain(const char *request_shm_name) {
     if (!request_shm_name || !*request_shm_name) {
         throw std::runtime_error("control_release_domain: request shm name must be non-empty");
     }
@@ -512,7 +714,7 @@ void WorkerThread::control_release_domain(const char *request_shm_name) {
     run_control_command("control_release_domain");
 }
 
-void WorkerThread::control_comm_init(const char *request_shm_name) {
+void LocalMailboxEndpoint::control_comm_init(const char *request_shm_name) {
     if (!request_shm_name || !*request_shm_name) {
         throw std::runtime_error("control_comm_init: request shm name must be non-empty");
     }
@@ -521,6 +723,134 @@ void WorkerThread::control_comm_init(const char *request_shm_name) {
     std::memcpy(mbox() + MAILBOX_OFF_CALLABLE, &sub_cmd, sizeof(uint64_t));
     write_shm_name_pair(mbox(), request_shm_name, "");
     run_control_command("control_comm_init");
+}
+
+uint64_t WorkerThread::control_malloc(size_t size) {
+    if (!endpoint_) throw std::runtime_error("control_malloc: null endpoint");
+    return endpoint_->control_malloc(size);
+}
+
+void WorkerThread::control_prepare(const uint8_t *digest) {
+    if (!endpoint_) throw std::runtime_error("control_prepare: null endpoint");
+    endpoint_->control_prepare(digest);
+}
+
+void WorkerThread::control_register(const char *shm_name, size_t blob_size, const uint8_t *digest) {
+    if (!endpoint_) throw std::runtime_error("control_register: null endpoint");
+    endpoint_->control_register(shm_name, blob_size, digest);
+}
+
+void WorkerThread::control_unregister(const uint8_t *digest) {
+    if (!endpoint_) throw std::runtime_error("control_unregister: null endpoint");
+    endpoint_->control_unregister(digest);
+}
+
+void WorkerThread::control_remote_prepare_register(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest,
+    const void *payload, size_t payload_size
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_prepare_register: null endpoint");
+    endpoint_->control_remote_prepare_register(target_registry, callable_kind, digest, payload, payload_size);
+}
+
+void WorkerThread::control_remote_commit_register(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_commit_register: null endpoint");
+    endpoint_->control_remote_commit_register(target_registry, callable_kind, digest);
+}
+
+void WorkerThread::control_remote_abort_register(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_abort_register: null endpoint");
+    endpoint_->control_remote_abort_register(target_registry, callable_kind, digest);
+}
+
+void WorkerThread::control_remote_unregister(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_unregister: null endpoint");
+    endpoint_->control_remote_unregister(target_registry, callable_kind, digest);
+}
+
+RemoteBufferHandle WorkerThread::control_remote_malloc(size_t size) {
+    if (!endpoint_) throw std::runtime_error("control_remote_malloc: null endpoint");
+    return endpoint_->control_remote_malloc(size);
+}
+
+void WorkerThread::control_remote_free(const RemoteBufferHandle &handle) {
+    if (!endpoint_) throw std::runtime_error("control_remote_free: null endpoint");
+    endpoint_->control_remote_free(handle);
+}
+
+void WorkerThread::control_remote_copy_to(
+    const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_copy_to: null endpoint");
+    endpoint_->control_remote_copy_to(handle, offset, src, size);
+}
+
+void WorkerThread::control_remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size) {
+    if (!endpoint_) throw std::runtime_error("control_remote_copy_from: null endpoint");
+    endpoint_->control_remote_copy_from(dst, handle, offset, size);
+}
+
+RemoteBufferExport WorkerThread::control_remote_export(
+    const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+    const std::string &transport_profile
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_export: null endpoint");
+    return endpoint_->control_remote_export(handle, offset, size, access_flags, transport_profile);
+}
+
+RemoteBufferHandle WorkerThread::control_remote_import(
+    int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+) {
+    if (!endpoint_) throw std::runtime_error("control_remote_import: null endpoint");
+    return endpoint_->control_remote_import(importer_endpoint_id, export_desc, requested_access_flags);
+}
+
+void WorkerThread::control_remote_release_import(const RemoteBufferHandle &handle) {
+    if (!endpoint_) throw std::runtime_error("control_remote_release_import: null endpoint");
+    endpoint_->control_remote_release_import(handle);
+}
+
+void WorkerThread::control_generic(
+    uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
+) {
+    if (!endpoint_) throw std::runtime_error("control_generic: null endpoint");
+    endpoint_->control_generic(sub_cmd, shm_name, payload_size, timeout_s, digest);
+}
+
+void WorkerThread::control_free(uint64_t ptr) {
+    if (!endpoint_) throw std::runtime_error("control_free: null endpoint");
+    endpoint_->control_free(ptr);
+}
+
+void WorkerThread::control_copy_to(uint64_t dst, uint64_t src, size_t size) {
+    if (!endpoint_) throw std::runtime_error("control_copy_to: null endpoint");
+    endpoint_->control_copy_to(dst, src, size);
+}
+
+void WorkerThread::control_copy_from(uint64_t dst, uint64_t src, size_t size) {
+    if (!endpoint_) throw std::runtime_error("control_copy_from: null endpoint");
+    endpoint_->control_copy_from(dst, src, size);
+}
+
+void WorkerThread::control_alloc_domain(const char *request_shm_name, const char *reply_shm_name) {
+    if (!endpoint_) throw std::runtime_error("control_alloc_domain: null endpoint");
+    endpoint_->control_alloc_domain(request_shm_name, reply_shm_name);
+}
+
+void WorkerThread::control_release_domain(const char *request_shm_name) {
+    if (!endpoint_) throw std::runtime_error("control_release_domain: null endpoint");
+    endpoint_->control_release_domain(request_shm_name);
+}
+
+void WorkerThread::control_comm_init(const char *request_shm_name) {
+    if (!endpoint_) throw std::runtime_error("control_comm_init: null endpoint");
+    endpoint_->control_comm_init(request_shm_name);
 }
 
 bool WorkerManager::any_busy() const {
@@ -663,12 +993,154 @@ ControlResult WorkerManager::control_digest_only(
         return result;
     }
     try {
-        threads[static_cast<size_t>(worker_id)]->control_generic(sub_cmd, nullptr, timeout_s, digest);
+        threads[static_cast<size_t>(worker_id)]->control_generic(sub_cmd, nullptr, 0, timeout_s, digest);
         result.ok = true;
     } catch (const std::exception &e) {
         result.error_message = strip_control_prefix(e.what(), "control_generic");
     }
     return result;
+}
+
+ControlResult WorkerManager::control_remote_prepare_register(
+    int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const void *payload,
+    size_t payload_size, const uint8_t *digest
+) {
+    ControlResult result{"NEXT_LEVEL", static_cast<int32_t>(endpoint_id), false, ""};
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, endpoint_id);
+    if (wt == nullptr) {
+        result.error_message = "invalid endpoint_id " + std::to_string(endpoint_id);
+        return result;
+    }
+    try {
+        wt->control_remote_prepare_register(target_registry, callable_kind, digest, payload, payload_size);
+        result.ok = true;
+    } catch (const std::exception &e) {
+        result.error_message = strip_control_prefix(e.what(), "control_remote_prepare_register");
+    }
+    return result;
+}
+
+ControlResult WorkerManager::control_remote_commit_register(
+    int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    ControlResult result{"NEXT_LEVEL", static_cast<int32_t>(endpoint_id), false, ""};
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, endpoint_id);
+    if (wt == nullptr) {
+        result.error_message = "invalid endpoint_id " + std::to_string(endpoint_id);
+        return result;
+    }
+    try {
+        wt->control_remote_commit_register(target_registry, callable_kind, digest);
+        result.ok = true;
+    } catch (const std::exception &e) {
+        result.error_message = strip_control_prefix(e.what(), "control_remote_commit_register");
+    }
+    return result;
+}
+
+ControlResult WorkerManager::control_remote_abort_register(
+    int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    ControlResult result{"NEXT_LEVEL", static_cast<int32_t>(endpoint_id), false, ""};
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, endpoint_id);
+    if (wt == nullptr) {
+        result.error_message = "invalid endpoint_id " + std::to_string(endpoint_id);
+        return result;
+    }
+    try {
+        wt->control_remote_abort_register(target_registry, callable_kind, digest);
+        result.ok = true;
+    } catch (const std::exception &e) {
+        result.error_message = strip_control_prefix(e.what(), "control_remote_abort_register");
+    }
+    return result;
+}
+
+ControlResult WorkerManager::control_remote_unregister(
+    int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    ControlResult result{"NEXT_LEVEL", static_cast<int32_t>(endpoint_id), false, ""};
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, endpoint_id);
+    if (wt == nullptr) {
+        result.error_message = "invalid endpoint_id " + std::to_string(endpoint_id);
+        return result;
+    }
+    try {
+        wt->control_remote_unregister(target_registry, callable_kind, digest);
+        result.ok = true;
+    } catch (const std::exception &e) {
+        result.error_message = strip_control_prefix(e.what(), "control_remote_unregister");
+    }
+    return result;
+}
+
+RemoteBufferHandle WorkerManager::control_remote_malloc(int endpoint_id, size_t size) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_remote_malloc: invalid endpoint_id " + std::to_string(endpoint_id));
+    }
+    return wt->control_remote_malloc(size);
+}
+
+void WorkerManager::control_remote_free(const RemoteBufferHandle &handle) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, handle.endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_remote_free: invalid endpoint_id " + std::to_string(handle.endpoint_id));
+    }
+    wt->control_remote_free(handle);
+}
+
+void WorkerManager::control_remote_copy_to(
+    const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size
+) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, handle.endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_remote_copy_to: invalid endpoint_id " + std::to_string(handle.endpoint_id));
+    }
+    wt->control_remote_copy_to(handle, offset, src, size);
+}
+
+void WorkerManager::control_remote_copy_from(
+    void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size
+) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, handle.endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_remote_copy_from: invalid endpoint_id " + std::to_string(handle.endpoint_id));
+    }
+    wt->control_remote_copy_from(dst, handle, offset, size);
+}
+
+RemoteBufferExport WorkerManager::control_remote_export(
+    const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+    const std::string &transport_profile
+) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, handle.owner_endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error(
+            "control_remote_export: invalid owner endpoint_id " + std::to_string(handle.owner_endpoint_id)
+        );
+    }
+    return wt->control_remote_export(handle, offset, size, access_flags, transport_profile);
+}
+
+RemoteBufferHandle WorkerManager::control_remote_import(
+    int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, importer_endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error("control_remote_import: invalid endpoint_id " + std::to_string(importer_endpoint_id));
+    }
+    return wt->control_remote_import(importer_endpoint_id, export_desc, requested_access_flags);
+}
+
+void WorkerManager::control_remote_release_import(const RemoteBufferHandle &handle) {
+    WorkerThread *wt = get_worker_by_endpoint_id(WorkerType::NEXT_LEVEL, handle.endpoint_id);
+    if (wt == nullptr) {
+        throw std::runtime_error(
+            "control_remote_release_import: invalid endpoint_id " + std::to_string(handle.endpoint_id)
+        );
+    }
+    wt->control_remote_release_import(handle);
 }
 
 std::vector<ControlResult>
@@ -771,7 +1243,9 @@ std::vector<ControlResult> WorkerManager::broadcast_control_all(
     for (size_t i = 0; i < threads.size(); ++i) {
         workers.emplace_back([&, i]() {
             try {
-                threads[i]->control_generic(sub_cmd, shm_name.empty() ? nullptr : shm_name.c_str(), timeout_s, digest);
+                threads[i]->control_generic(
+                    sub_cmd, shm_name.empty() ? nullptr : shm_name.c_str(), payload_size, timeout_s, digest
+                );
             } catch (const std::exception &e) {
                 results[i].ok = false;
                 results[i].error_message = strip_control_prefix(e.what(), "control_generic");

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -41,6 +41,7 @@
 #include <vector>
 
 #include "../task_interface/call_config.h"
+#include "remote_wire.h"
 #include "types.h"
 
 class Ring;  // forward decl — owns the slot state pool
@@ -171,6 +172,131 @@ struct ControlResult {
     std::string error_message;
 };
 
+struct WorkerDispatch;
+
+enum class WorkerEndpointKind : int32_t {
+    LOCAL_MAILBOX = 0,
+    REMOTE_L3 = 1,
+};
+
+struct WorkerEndpointCaps {
+    WorkerEndpointKind kind{WorkerEndpointKind::LOCAL_MAILBOX};
+    int32_t endpoint_id{-1};
+    bool remote{false};
+    bool supports_task_dispatch{true};
+    bool supports_control{true};
+    std::string transport{"local-mailbox"};
+};
+
+class WorkerEndpoint {
+public:
+    virtual ~WorkerEndpoint() = default;
+
+    virtual const WorkerEndpointCaps &caps() const = 0;
+    virtual WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) = 0;
+
+    virtual void shutdown_child() {}
+    virtual uint64_t control_malloc(size_t size);
+    virtual void control_free(uint64_t ptr);
+    virtual void control_copy_to(uint64_t dst, uint64_t src, size_t size);
+    virtual void control_copy_from(uint64_t dst, uint64_t src, size_t size);
+    virtual void control_prepare(const uint8_t *digest);
+    virtual void control_register(const char *shm_name, size_t blob_size, const uint8_t *digest);
+    virtual void control_unregister(const uint8_t *digest);
+    virtual void control_remote_prepare_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest,
+        const void *payload, size_t payload_size
+    );
+    virtual void control_remote_commit_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    );
+    virtual void control_remote_abort_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    );
+    virtual void control_remote_unregister(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    );
+    virtual RemoteBufferHandle control_remote_malloc(size_t size);
+    virtual void control_remote_free(const RemoteBufferHandle &handle);
+    virtual void
+    control_remote_copy_to(const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size);
+    virtual void control_remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size);
+    virtual RemoteBufferExport control_remote_export(
+        const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+        const std::string &transport_profile
+    );
+    virtual RemoteBufferHandle control_remote_import(
+        int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+    );
+    virtual void control_remote_release_import(const RemoteBufferHandle &handle);
+    virtual void control_generic(
+        uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
+    );
+    virtual void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name);
+    virtual void control_release_domain(const char *request_shm_name);
+    virtual void control_comm_init(const char *request_shm_name);
+};
+
+class LocalMailboxEndpoint : public WorkerEndpoint {
+public:
+    LocalMailboxEndpoint(int32_t endpoint_id, void *mailbox);
+
+    const WorkerEndpointCaps &caps() const override { return caps_; }
+    WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
+
+    void shutdown_child() override;
+    uint64_t control_malloc(size_t size) override;
+    void control_free(uint64_t ptr) override;
+    void control_copy_to(uint64_t dst, uint64_t src, size_t size) override;
+    void control_copy_from(uint64_t dst, uint64_t src, size_t size) override;
+    void control_prepare(const uint8_t *digest) override;
+    void control_register(const char *shm_name, size_t blob_size, const uint8_t *digest) override;
+    void control_unregister(const uint8_t *digest) override;
+    void control_remote_prepare_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest,
+        const void *payload, size_t payload_size
+    ) override;
+    void control_remote_commit_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    ) override;
+    void control_remote_abort_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    ) override;
+    void control_remote_unregister(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    ) override;
+    RemoteBufferHandle control_remote_malloc(size_t size) override;
+    void control_remote_free(const RemoteBufferHandle &handle) override;
+    void
+    control_remote_copy_to(const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size) override;
+    void control_remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size) override;
+    RemoteBufferExport control_remote_export(
+        const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+        const std::string &transport_profile
+    ) override;
+    RemoteBufferHandle control_remote_import(
+        int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+    ) override;
+    void control_remote_release_import(const RemoteBufferHandle &handle) override;
+    void control_generic(
+        uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
+    ) override;
+    void control_alloc_domain(const char *request_shm_name, const char *reply_shm_name) override;
+    void control_release_domain(const char *request_shm_name) override;
+    void control_comm_init(const char *request_shm_name) override;
+
+private:
+    WorkerEndpointCaps caps_;
+    void *mailbox_{nullptr};
+    std::mutex mailbox_mu_;
+    bool mailbox_control_timed_out_{false};
+
+    char *mbox() const { return static_cast<char *>(mailbox_); }
+    MailboxState read_mailbox_state() const;
+    void write_mailbox_state(MailboxState s);
+    void run_control_command(const char *op_name, double timeout_s = -1.0);
+};
+
 // =============================================================================
 // WorkerDispatch — per-dispatch handle handed to a WorkerThread.
 // =============================================================================
@@ -205,16 +331,22 @@ public:
     // `ring` is a borrowed pointer to the engine's slot-state pool —
     // the thread reads callable/args/config from
     // `ring->slot_state(task_slot)` on each dispatch.
-    // on_complete(slot) is called (in the WorkerThread) after each run().
+    // on_complete(completion) is called (in the WorkerThread) after each
+    // endpoint run().
     // `manager` is a borrowed pointer used to report dispatch failures
     // (exception_ptr routed out of the worker thread to the orch thread).
-    void start(Ring *ring, WorkerManager *manager, const std::function<void(TaskSlot)> &on_complete, void *mailbox);
+    void start(
+        Ring *ring, WorkerManager *manager, const std::function<void(WorkerCompletion)> &on_complete,
+        std::unique_ptr<WorkerEndpoint> endpoint
+    );
 
     // Enqueue a dispatch for the worker. Non-blocking.
     void dispatch(WorkerDispatch d);
 
     // True if the worker has no active task.
     bool idle() const { return idle_.load(std::memory_order_acquire); }
+    const WorkerEndpointCaps &caps() const;
+    int32_t endpoint_id() const;
 
     void stop();
 
@@ -247,7 +379,34 @@ public:
     // TASK_DONE before claiming the mailbox.
     void control_register(const char *shm_name, size_t blob_size, const uint8_t *digest);
     void control_unregister(const uint8_t *digest);
-    void control_generic(uint64_t sub_cmd, const char *shm_name, double timeout_s, const uint8_t *digest);
+    void control_remote_prepare_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest,
+        const void *payload, size_t payload_size
+    );
+    void control_remote_commit_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    );
+    void control_remote_abort_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    );
+    void control_remote_unregister(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    );
+    RemoteBufferHandle control_remote_malloc(size_t size);
+    void control_remote_free(const RemoteBufferHandle &handle);
+    void control_remote_copy_to(const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size);
+    void control_remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size);
+    RemoteBufferExport control_remote_export(
+        const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+        const std::string &transport_profile
+    );
+    RemoteBufferHandle control_remote_import(
+        int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+    );
+    void control_remote_release_import(const RemoteBufferHandle &handle);
+    void control_generic(
+        uint64_t sub_cmd, const char *shm_name, size_t payload_size, double timeout_s, const uint8_t *digest
+    );
 
     // Dynamic CommDomain allocate / release.  `request_shm_name` carries the
     // request payload (header + rank_ids + buffer_nbytes); for alloc the child
@@ -265,8 +424,8 @@ public:
 private:
     Ring *ring_{nullptr};
     WorkerManager *manager_{nullptr};
-    void *mailbox_{nullptr};
-    std::function<void(TaskSlot)> on_complete_;
+    std::unique_ptr<WorkerEndpoint> endpoint_;
+    std::function<void(WorkerCompletion)> on_complete_;
 
     std::thread thread_;
     std::queue<WorkerDispatch> queue_;
@@ -275,23 +434,8 @@ private:
     bool shutdown_{false};
     std::atomic<bool> idle_{true};
 
-    // Serializes parent-side mailbox access between this WorkerThread's
-    // dispatch loop and the orch-thread control_* path. Per-WorkerThread,
-    // so different workers can dispatch in parallel.
-    std::mutex mailbox_mu_;
-    bool mailbox_control_timed_out_{false};
-
     void loop();
-    void dispatch_process(TaskSlotState &s, int32_t group_index);
-
-    // Common tail for the four control_* methods. Caller writes the args
-    // region and holds `mailbox_mu_`; this helper signals the child,
-    // spin-polls CONTROL_DONE, and throws on a non-zero child error code.
-    void run_control_command(const char *op_name, double timeout_s = -1.0);
-
-    char *mbox() const { return static_cast<char *>(mailbox_); }
-    MailboxState read_mailbox_state() const;
-    void write_mailbox_state(MailboxState s);
+    WorkerCompletion dispatch_process(WorkerDispatch d);
 };
 
 // =============================================================================
@@ -300,12 +444,13 @@ private:
 
 class WorkerManager {
 public:
-    using OnCompleteFn = std::function<void(TaskSlot)>;
+    using OnCompleteFn = std::function<void(WorkerCompletion)>;
 
     // Register a worker. `mailbox` is a MAILBOX_SIZE-byte MAP_SHARED
     // region; the real worker (a `ChipWorker` for NEXT_LEVEL, a Python
     // callable for SUB) lives in the forked child.
     void add_next_level(void *mailbox);
+    void add_next_level_endpoint(std::unique_ptr<WorkerEndpoint> endpoint);
     void add_sub(void *mailbox);
 
     void start(Ring *ring, const OnCompleteFn &on_complete);
@@ -316,9 +461,13 @@ public:
 
     // Direct index into the worker pool by logical id (0-based).
     WorkerThread *get_worker(WorkerType type, int logical_id) const;
+    WorkerThread *get_worker_by_endpoint_id(WorkerType type, int32_t endpoint_id) const;
 
     // Pick one idle worker NOT in `exclude`. Returns nullptr if none available.
     WorkerThread *pick_idle_excluding(WorkerType type, const std::vector<WorkerThread *> &exclude) const;
+    WorkerThread *pick_idle_excluding_eligible(
+        WorkerType type, const std::vector<WorkerThread *> &exclude, const std::vector<int32_t> &eligible_endpoint_ids
+    ) const;
 
     bool any_busy() const;
 
@@ -336,6 +485,34 @@ public:
     void control_comm_init(int worker_id, const char *request_shm_name);
     ControlResult
     control_digest_only(WorkerType type, int worker_id, uint64_t sub_cmd, const uint8_t *digest, double timeout_s);
+    ControlResult control_remote_prepare_register(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const void *payload, size_t payload_size, const uint8_t *digest
+    );
+    ControlResult control_remote_commit_register(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const uint8_t *digest
+    );
+    ControlResult control_remote_abort_register(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const uint8_t *digest
+    );
+    ControlResult control_remote_unregister(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const uint8_t *digest
+    );
+    RemoteBufferHandle control_remote_malloc(int endpoint_id, size_t size);
+    void control_remote_free(const RemoteBufferHandle &handle);
+    void control_remote_copy_to(const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size);
+    void control_remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size);
+    RemoteBufferExport control_remote_export(
+        const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+        const std::string &transport_profile
+    );
+    RemoteBufferHandle control_remote_import(
+        int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+    );
+    void control_remote_release_import(const RemoteBufferHandle &handle);
 
     // Broadcast CTRL_REGISTER for `digest` to every NEXT_LEVEL worker in
     // parallel. Stages `blob_size` bytes from `blob_ptr` into a per-call
@@ -368,6 +545,7 @@ public:
 private:
     std::vector<void *> next_level_entries_;
     std::vector<void *> sub_entries_;
+    std::vector<std::unique_ptr<WorkerEndpoint>> next_level_endpoint_entries_;
 
     std::vector<std::unique_ptr<WorkerThread>> next_level_threads_;
     std::vector<std::unique_ptr<WorkerThread>> sub_threads_;

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -219,6 +219,96 @@ TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {
     EXPECT_EQ(tm.lookup(TensorKey{data, -1}), res.task_slot);
 }
 
+TEST_F(OrchestratorFixture, RemoteOutputSidecarSkipsLocalAutoAllocAndRegistersRemoteKey) {
+    TaskArgs args;
+    ContinuousTensor t{};
+    t.data = 0;
+    t.ndims = 1;
+    t.shapes[0] = 1024;
+    t.dtype = DataType::UINT8;
+    args.add_tensor(t, TensorArgType::OUTPUT);
+
+    RemoteTaskArgsSidecar sidecar;
+    sidecar.tensors.resize(1);
+    sidecar.tensors[0].present = true;
+    sidecar.tensors[0].desc.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    sidecar.tensors[0].desc.owner_endpoint_id = 3;
+    sidecar.tensors[0].desc.buffer_id = 9;
+    sidecar.tensors[0].desc.generation = 2;
+    sidecar.tensors[0].desc.offset = 64;
+    sidecar.tensors[0].desc.nbytes = 1024;
+
+    auto res = orch.submit_next_level(C(42), args, cfg, -1, {3}, sidecar);
+    ASSERT_NE(res.task_slot, INVALID_SLOT);
+    EXPECT_EQ(S(res.task_slot).task_args.tensor(0).data, 0u);
+
+    TensorKey key = TensorKey::remote_buffer(TensorAddressKind::REMOTE_BUFFER, 3, 9, 2, 64);
+    EXPECT_EQ(tm.lookup(key), res.task_slot);
+}
+
+TEST_F(OrchestratorFixture, RemoteBarePayloadFailsBeforeSlotCommit) {
+    TaskArgs args = single_tensor_args(0x1234, TensorArgType::INPUT);
+
+    RemoteTaskArgsSidecar sidecar;
+    sidecar.tensors.resize(1);
+
+    EXPECT_THROW({ (void)orch.submit_next_level(C(42), args, cfg, -1, {3}, sidecar); }, std::invalid_argument);
+}
+
+TEST_F(OrchestratorFixture, RemoteSidecarRejectsNonOwnerEligibleEndpointWithoutImport) {
+    TaskArgs args;
+    ContinuousTensor t{};
+    t.data = 0;
+    t.ndims = 1;
+    t.shapes[0] = 1;
+    t.dtype = DataType::UINT8;
+    args.add_tensor(t, TensorArgType::INPUT);
+
+    RemoteTaskArgsSidecar sidecar;
+    sidecar.tensors.resize(1);
+    sidecar.tensors[0].present = true;
+    sidecar.tensors[0].desc.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    sidecar.tensors[0].desc.owner_endpoint_id = 3;
+    sidecar.tensors[0].desc.buffer_id = 9;
+    sidecar.tensors[0].desc.generation = 2;
+    sidecar.tensors[0].desc.nbytes = 1;
+
+    EXPECT_THROW({ (void)orch.submit_next_level(C(42), args, cfg, -1, {3, 4}, sidecar); }, std::invalid_argument);
+}
+
+TEST_F(OrchestratorFixture, RemoteInputSidecarUsesRemoteTensorMapKey) {
+    TaskArgs output_args;
+    ContinuousTensor out{};
+    out.data = 0;
+    out.ndims = 1;
+    out.shapes[0] = 1;
+    out.dtype = DataType::UINT8;
+    output_args.add_tensor(out, TensorArgType::OUTPUT);
+
+    RemoteTaskArgsSidecar output_sidecar;
+    output_sidecar.tensors.resize(1);
+    output_sidecar.tensors[0].present = true;
+    output_sidecar.tensors[0].desc.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    output_sidecar.tensors[0].desc.owner_endpoint_id = 3;
+    output_sidecar.tensors[0].desc.buffer_id = 9;
+    output_sidecar.tensors[0].desc.generation = 2;
+    output_sidecar.tensors[0].desc.offset = 0;
+    output_sidecar.tensors[0].desc.nbytes = 1;
+    auto producer = orch.submit_next_level(C(42), output_args, cfg, -1, {3}, output_sidecar);
+    TaskSlot ready;
+    rq.try_pop(ready);
+
+    TaskArgs input_args;
+    ContinuousTensor in = out;
+    input_args.add_tensor(in, TensorArgType::INPUT);
+    auto consumer = orch.submit_next_level(C(43), input_args, cfg, -1, {3}, output_sidecar);
+
+    EXPECT_EQ(S(consumer.task_slot).state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(consumer.task_slot).fanin_count, 1);
+    ASSERT_EQ(S(consumer.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(consumer.task_slot).fanin_producers[0], producer.task_slot);
+}
+
 TEST_F(OrchestratorFixture, InoutWiresCreatorAsFanin) {
     // INOUT is the only tag that pulls in the prior writer as a fanin
     // producer -- matching L2's pto_orchestrator.cpp Step B where only

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -102,6 +102,37 @@ TEST_F(OrchestratorFixture, DependentTaskIsPending) {
     EXPECT_FALSE(rq.try_pop(extra));  // B should NOT be in ready queue
 }
 
+TEST_F(OrchestratorFixture, SubmitAfterFailedProducerPoisonsConsumer) {
+    orch.scope_begin();
+
+    auto args_a = single_tensor_args(0xD00D, TensorArgType::OUTPUT);
+    auto a = orch.submit_next_level(C(42), args_a, cfg);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+    ASSERT_EQ(ready, a.task_slot);
+
+    TaskSlotState &producer = S(a.task_slot);
+    producer.failure_message = "producer failed";
+    producer.state.store(TaskState::FAILED, std::memory_order_release);
+    producer.fanout_released.store(1, std::memory_order_release);
+
+    auto args_b = single_tensor_args(0xD00D, TensorArgType::INPUT);
+    auto b = orch.submit_next_level(C(43), args_b, cfg);
+
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::FAILED);
+    EXPECT_EQ(S(b.task_slot).failure_message, "producer failed");
+    EXPECT_EQ(S(b.task_slot).fanin_count, 0);
+    ASSERT_EQ(S(b.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(b.task_slot).fanin_producers[0], a.task_slot);
+
+    TaskSlot extra;
+    EXPECT_FALSE(rq.try_pop(extra));
+
+    orch.scope_end();
+    EXPECT_EQ(S(a.task_slot).state.load(), TaskState::CONSUMED);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::CONSUMED);
+}
+
 TEST_F(OrchestratorFixture, TensorMapTracksProducer) {
     auto args_a = single_tensor_args(0x1234, TensorArgType::OUTPUT);
     auto a = orch.submit_next_level(C(42), args_a, cfg);

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -18,7 +18,9 @@
 #include <cstring>
 #include <iterator>
 #include <mutex>
+#include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "call_config.h"
@@ -63,6 +65,8 @@ struct MockMailboxWorker {
     std::mutex run_mu;
     std::condition_variable run_cv;
     std::atomic<bool> should_complete{false};
+    int32_t next_error_code{0};
+    std::string next_error_msg;
     std::atomic<bool> is_running{false};
     std::atomic<bool> stop_flag{false};
     std::thread loop_thread;
@@ -80,7 +84,7 @@ struct MockMailboxWorker {
         // dispatch, set stop_flag and wake the parked loop so the thread
         // joins instead of leaking. The loop's TASK_READY branch always
         // publishes TASK_DONE before checking stop_flag, so any in-flight
-        // WorkerThread::dispatch_process completes its spin-poll cleanly.
+        // LocalMailboxEndpoint::run completes its spin-poll cleanly.
         stop_flag.store(true, std::memory_order_release);
         {
             std::lock_guard<std::mutex> lk(run_mu);
@@ -94,6 +98,16 @@ struct MockMailboxWorker {
 
     void complete() {
         std::lock_guard<std::mutex> lk(run_mu);
+        next_error_code = 0;
+        next_error_msg.clear();
+        should_complete.store(true, std::memory_order_release);
+        run_cv.notify_one();
+    }
+
+    void complete_with_error(std::string msg) {
+        std::lock_guard<std::mutex> lk(run_mu);
+        next_error_code = 1;
+        next_error_msg = std::move(msg);
         should_complete.store(true, std::memory_order_release);
         run_cv.notify_one();
     }
@@ -156,11 +170,23 @@ private:
                     });
                     should_complete.store(false, std::memory_order_relaxed);
                 }
+                int32_t error_code = 0;
+                std::string error_msg;
+                {
+                    std::lock_guard<std::mutex> lk(run_mu);
+                    error_code = next_error_code;
+                    error_msg = std::move(next_error_msg);
+                    next_error_code = 0;
+                    next_error_msg.clear();
+                }
                 is_running.store(false, std::memory_order_release);
 
-                int32_t zero_err = 0;
-                std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR, &zero_err, sizeof(int32_t));
+                std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR, &error_code, sizeof(int32_t));
                 std::memset(mailbox.data() + MAILBOX_OFF_ERROR_MSG, 0, MAILBOX_ERROR_MSG_SIZE);
+                if (!error_msg.empty()) {
+                    size_t n = std::min(error_msg.size(), MAILBOX_ERROR_MSG_SIZE - 1);
+                    std::memcpy(mailbox.data() + MAILBOX_OFF_ERROR_MSG, error_msg.data(), n);
+                }
                 write_state(MailboxState::TASK_DONE);
             } else if (s == MailboxState::CONTROL_REQUEST) {
                 // Acknowledge the control request so a future test using
@@ -226,12 +252,12 @@ struct SchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         allocator.init(/*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub, &manager);
 
         mock_worker.start();
         manager.add_next_level(mock_worker.mailbox_ptr());
-        manager.start(&allocator, [this](TaskSlot slot) {
-            sched.worker_done(slot);
+        manager.start(&allocator, [this](WorkerCompletion completion) {
+            sched.worker_done(std::move(completion));
         });
 
         Scheduler::Config c;
@@ -342,6 +368,28 @@ TEST_F(SchedulerFixture, ComposedKernelArgsBlobFitsMailbox) {
     wait_consumed(res.task_slot);
 }
 
+TEST_F(SchedulerFixture, FailedProducerPoisonsDependentTask) {
+    auto args_a = single_tensor_args(0xD00D, TensorArgType::OUTPUT);
+    auto a = orch.submit_next_level(C(21), args_a, cfg);
+
+    auto args_b = single_tensor_args(0xD00D, TensorArgType::INPUT);
+    auto b = orch.submit_next_level(C(22), args_b, cfg);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::PENDING);
+
+    mock_worker.wait_running();
+    ASSERT_EQ(mock_worker.dispatched_count(), 1);
+    EXPECT_EQ(mock_worker.dispatched[0].callable_hash0, 21u);
+
+    mock_worker.complete_with_error("root task boom");
+
+    wait_consumed(a.task_slot);
+    wait_consumed(b.task_slot);
+    EXPECT_TRUE(manager.has_error());
+    EXPECT_EQ(mock_worker.dispatched_count(), 1) << "poisoned consumer must not dispatch";
+    EXPECT_EQ(S(a.task_slot).state.load(), TaskState::CONSUMED);
+    EXPECT_EQ(S(b.task_slot).state.load(), TaskState::CONSUMED);
+}
+
 // ===========================================================================
 // Group task tests -- fixture with 2 MockMailboxWorkers
 // ===========================================================================
@@ -367,14 +415,14 @@ struct GroupSchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         allocator.init(/*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub, &manager);
 
         worker_a.start();
         worker_b.start();
         manager.add_next_level(worker_a.mailbox_ptr());
         manager.add_next_level(worker_b.mailbox_ptr());
-        manager.start(&allocator, [this](TaskSlot slot) {
-            sched.worker_done(slot);
+        manager.start(&allocator, [this](WorkerCompletion completion) {
+            sched.worker_done(std::move(completion));
         });
 
         Scheduler::Config c;
@@ -453,6 +501,69 @@ TEST_F(GroupSchedulerFixture, GroupCompletesOnlyWhenAllDone) {
     wait_consumed(slot);
 }
 
+TEST_F(GroupSchedulerFixture, GroupFailureWaitsForRunningMembersThenConsumes) {
+    TaskArgs a0 = single_tensor_args(0xC0, TensorArgType::OUTPUT);
+    TaskArgs a1 = single_tensor_args(0xC1, TensorArgType::OUTPUT);
+    auto res = orch.submit_next_level_group(C(42), {a0, a1}, cfg);
+    TaskSlot slot = res.task_slot;
+
+    worker_a.wait_running();
+    worker_b.wait_running();
+
+    worker_a.complete_with_error("member boom");
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(300);
+    while (!manager.has_error() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_TRUE(manager.has_error());
+    EXPECT_EQ(S(slot).state.load(), TaskState::RUNNING);
+
+    worker_b.complete();
+    wait_consumed(slot);
+    EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
+}
+
+TEST_F(GroupSchedulerFixture, EndpointEligibilityRestrictsIdleSelection) {
+    TaskArgs args = single_tensor_args(0xE0, TensorArgType::OUTPUT);
+    auto res = orch.submit_next_level(C(55), args, cfg, -1, {1});
+    TaskSlot slot = res.task_slot;
+
+    worker_b.wait_running();
+    EXPECT_FALSE(worker_a.is_running.load());
+    EXPECT_TRUE(worker_b.is_running.load());
+    EXPECT_EQ(worker_a.dispatched_count(), 0);
+    EXPECT_EQ(worker_b.dispatched_count(), 1);
+
+    worker_b.complete();
+    wait_consumed(slot);
+}
+
+TEST_F(GroupSchedulerFixture, AffinityMustBeInEligibleEndpointSet) {
+    TaskArgs args = single_tensor_args(0xE1, TensorArgType::OUTPUT);
+    EXPECT_THROW((void)orch.submit_next_level(C(56), args, cfg, 0, {1}), std::invalid_argument);
+}
+
+TEST_F(GroupSchedulerFixture, RemoteSidecarRejectsLocalEndpointEligibility) {
+    TaskArgs args;
+    ContinuousTensor tensor{};
+    tensor.data = 0;
+    tensor.ndims = 1;
+    tensor.shapes[0] = 1;
+    tensor.dtype = DataType::UINT8;
+    args.add_tensor(tensor, TensorArgType::OUTPUT);
+
+    RemoteTaskArgsSidecar sidecar;
+    sidecar.tensors.resize(1);
+    sidecar.tensors[0].present = true;
+    sidecar.tensors[0].desc.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    sidecar.tensors[0].desc.owner_endpoint_id = 7;
+    sidecar.tensors[0].desc.buffer_id = 11;
+    sidecar.tensors[0].desc.generation = 1;
+    sidecar.tensors[0].desc.nbytes = 1;
+
+    EXPECT_THROW((void)orch.submit_next_level(C(57), args, cfg, -1, {0}, sidecar), std::invalid_argument);
+}
+
 // ===========================================================================
 // Strict-4: per-worker-type ready queues (no head-of-line blocking across
 // types). Covered here with one NEXT_LEVEL worker + one SUB worker: with a
@@ -480,14 +591,14 @@ struct MixedTypeSchedulerFixture : public ::testing::Test {
 
     void SetUp() override {
         allocator.init(/*heap_bytes=*/1ULL << 20);
-        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub);
+        orch.init(&tm, &allocator, &scope, &rq_next_level, &rq_sub, &manager);
 
         next_level_worker.start();
         sub_worker.start();
         manager.add_next_level(next_level_worker.mailbox_ptr());
         manager.add_sub(sub_worker.mailbox_ptr());
-        manager.start(&allocator, [this](TaskSlot slot) {
-            sched.worker_done(slot);
+        manager.start(&allocator, [this](WorkerCompletion completion) {
+            sched.worker_done(std::move(completion));
         });
 
         Scheduler::Config c;

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -17,6 +17,7 @@
 #include <chrono>
 #include <cstring>
 #include <iterator>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -207,6 +208,30 @@ private:
     }
 };
 
+class FakeEndpoint final : public WorkerEndpoint {
+public:
+    explicit FakeEndpoint(int32_t endpoint_id) {
+        caps_.kind = WorkerEndpointKind::REMOTE_L3;
+        caps_.endpoint_id = endpoint_id;
+        caps_.remote = true;
+        caps_.transport = "test-remote";
+    }
+
+    const WorkerEndpointCaps &caps() const override { return caps_; }
+
+    WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override {
+        (void)ring;
+        WorkerCompletion completion;
+        completion.task_slot = dispatch.task_slot;
+        completion.group_index = dispatch.group_index;
+        completion.outcome = EndpointOutcome::SUCCESS;
+        return completion;
+    }
+
+private:
+    WorkerEndpointCaps caps_;
+};
+
 // ---------------------------------------------------------------------------
 // Helper: build a TaskArgs whose only tensor has the given (data, tag).
 // ---------------------------------------------------------------------------
@@ -296,6 +321,28 @@ struct SchedulerFixture : public ::testing::Test {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+TEST(WorkerManagerTest, StartRejectsDuplicateNextLevelEndpointId) {
+    alignas(8) std::array<char, MAILBOX_SIZE> mailbox{};
+    Ring allocator;
+    allocator.init(/*heap_bytes=*/0);
+    WorkerManager manager;
+
+    manager.add_next_level(mailbox.data());
+    manager.add_next_level_endpoint(std::make_unique<FakeEndpoint>(0));
+
+    bool threw = false;
+    try {
+        manager.start(&allocator, [](WorkerCompletion) {});
+    } catch (const std::runtime_error &e) {
+        threw = true;
+        EXPECT_NE(std::string(e.what()).find("duplicate NEXT_LEVEL endpoint_id 0"), std::string::npos);
+    }
+
+    manager.stop();
+    allocator.shutdown();
+    EXPECT_TRUE(threw);
+}
 
 TEST_F(SchedulerFixture, IndependentTaskDispatchedAndConsumed) {
     auto args_a = single_tensor_args(0xCAFE, TensorArgType::OUTPUT);

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -570,6 +570,29 @@ TEST_F(GroupSchedulerFixture, GroupFailureWaitsForRunningMembersThenConsumes) {
     EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
 }
 
+TEST_F(GroupSchedulerFixture, InvalidGroupIndexFailsAndConsumesGroup) {
+    TaskArgs a0 = single_tensor_args(0xD0, TensorArgType::OUTPUT);
+    TaskArgs a1 = single_tensor_args(0xD1, TensorArgType::OUTPUT);
+    auto res = orch.submit_next_level_group(C(42), {a0, a1}, cfg);
+    TaskSlot slot = res.task_slot;
+
+    worker_a.wait_running();
+    worker_b.wait_running();
+
+    WorkerCompletion bad;
+    bad.task_slot = slot;
+    bad.group_index = 99;
+    bad.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+    bad.error_message = "bad completion index";
+    sched.worker_done(std::move(bad));
+
+    wait_consumed(slot);
+    EXPECT_EQ(S(slot).state.load(), TaskState::CONSUMED);
+
+    worker_a.complete();
+    worker_b.complete();
+}
+
 TEST_F(GroupSchedulerFixture, EndpointEligibilityRestrictsIdleSelection) {
     TaskArgs args = single_tensor_args(0xE0, TensorArgType::OUTPUT);
     auto res = orch.submit_next_level(C(55), args, cfg, -1, {1});

--- a/tests/ut/py/test_task_interface.py
+++ b/tests/ut/py/test_task_interface.py
@@ -22,6 +22,7 @@ from _task_interface import (  # pyright: ignore[reportMissingImports]
     CoreCallable,
     DataType,
     TaskArgs,
+    TaskState,
     TensorArgType,
     arg_direction_name,
     get_dtype_name,
@@ -59,6 +60,13 @@ class TestDataType:
         assert DataType.UINT64.value == 8
         assert DataType.UINT16.value == 9
         assert DataType.UINT32.value == 10
+
+
+class TestTaskState:
+    def test_failed_state_is_bound(self):
+        assert TaskState.FAILED is not None
+        assert TaskState.FAILED.value == 5
+        assert TaskState.CONSUMED.value == 6
 
 
 class TestGetElementSize:


### PR DESCRIPTION
## Summary

This is PR 4 of the remote L3 worker split stack. It introduces the scheduler
and endpoint abstraction needed for remote-capable scheduling, while still
using local endpoints only.

The goal is to teach the orchestrator, scheduler, and worker manager how to
reason about endpoint eligibility, endpoint capabilities, completion outcomes,
and dependency failure propagation before a live remote endpoint exists.

  ## Relationship to PR #866 and split stack

  This PR is part of the split stack extracted from #866.

  Stack:
  - #1006: docs: add remote L3 worker contract
  - #1007: feat: add remote import callable descriptors
  - #1008: feat: add remote L3 wire codec
  - #1009: feat: add remote endpoint eligibility scheduling
  - #1010: feat: add remote L3 endpoint facade
  - #1011: feat: add remote L3 Python session runtime

  The top of the stack was verified to match the corrected `remote-l3-worker-design`
  branch content from #866, excluding empty CI retrigger commits.


## Stack position

- Base: `remote-l3-split-remote-wire`
- Head: `remote-l3-split-scheduler-eligibility`
- Previous PR: `remote-l3-split-remote-wire`
- Next PR: `remote-l3-split-cpp-remote-endpoint`

## Scope

This PR adds or updates:

- `WorkerEndpoint` interface.
- `LocalMailboxEndpoint` adapter.
- Endpoint capability metadata.
- Eligible endpoint sets for scheduled work.
- Worker affinity validation against endpoint eligibility.
- `WorkerCompletion` outcome propagation.
- Failed-task poisoning and downstream dependency failure handling.
- Remote tensor sidecars and dependency keys without a live remote session.
- C++ scheduler, orchestrator, and worker-manager tests.

## Requirements covered

This PR covers the scheduler and endpoint-abstraction requirements from the
remote L3 contract:

- The scheduler chooses only eligible idle endpoints.
- Worker affinity cannot route a task to an endpoint outside that task's
  eligible endpoint set.
- Local endpoints continue to work through an adapter rather than a special
  scheduler-only path.
- Completion outcomes carry enough information to classify success, task
  failure, and endpoint-related failure.
- Partial group failure poisons downstream dependents deterministically.
- Slot release and `drain()` behavior remain correct after both success and
  failure.
- Remote tensor sidecar metadata can participate in dependency tracking before
  remote sessions are enabled.

## Why this is separate

Remote endpoint support requires scheduler changes, but those changes should be
reviewed before introducing command lanes, nanobind bindings, or Python session
processes. This PR keeps the scheduling model testable with local endpoints.

## Important exclusions

This PR intentionally does not add:

- A live C++ `RemoteL3Endpoint`.
- Remote command-lane serialization.
- Python remote daemon or session runtime.
- Remote buffer allocation/import/release behavior.
- Hardware transport profiles.

Those are handled by later PRs.

## Verification

Targeted verification already run during the split:

- C++ orchestrator unit test: passed.
- C++ scheduler unit test: passed.
- Worker-manager coverage associated with endpoint eligibility and failure
  propagation: passed.

## Reviewer notes

The main review focus should be scheduling correctness:

- No task should be assigned to an ineligible endpoint.
- Worker affinity should narrow, not override, eligibility.
- Failure propagation should not release slots before captured references are
  safe to drop.
- `drain()` should surface failures while leaving scheduler state consistent.
