### PR TITLE
feat: add remote l3 endpoint facade

### DIFF
--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -22,6 +22,8 @@ set(HIERARCHICAL_SOURCES
     ${HIERARCHICAL_SRC}/tensormap.cpp
     ${HIERARCHICAL_SRC}/ring.cpp
     ${HIERARCHICAL_SRC}/scope.cpp
+    ${HIERARCHICAL_SRC}/remote_wire.cpp
+    ${HIERARCHICAL_SRC}/remote_endpoint.cpp
     ${HIERARCHICAL_SRC}/orchestrator.cpp
     ${HIERARCHICAL_SRC}/worker_manager.cpp
     ${HIERARCHICAL_SRC}/scheduler.cpp

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <vector>
 
 #include "ring.h"
 #include "orchestrator.h"
@@ -43,13 +44,21 @@ namespace nb = nanobind;
 inline CallableKind parse_callable_kind(const std::string &kind) {
     if (kind == "CHIP_CALLABLE") return CallableKind::CHIP_CALLABLE;
     if (kind == "PYTHON_SERIALIZED") return CallableKind::PYTHON_SERIALIZED;
+    if (kind == "PYTHON_IMPORT") return CallableKind::PYTHON_IMPORT;
     throw std::invalid_argument("CALLABLE_KIND_UNSUPPORTED: " + kind);
 }
 
 inline TargetNamespace parse_target_namespace(const std::string &target_namespace) {
     if (target_namespace == "LOCAL_CHIP") return TargetNamespace::LOCAL_CHIP;
     if (target_namespace == "LOCAL_PYTHON") return TargetNamespace::LOCAL_PYTHON;
+    if (target_namespace == "REMOTE_TASK_DISPATCHER") return TargetNamespace::REMOTE_TASK_DISPATCHER;
     throw std::invalid_argument("unsupported callable target namespace: " + target_namespace);
+}
+
+inline remote_l3::RemoteRegistryTarget parse_remote_registry_target(const std::string &target_registry) {
+    if (target_registry == "REMOTE_TASK_DISPATCHER") return remote_l3::RemoteRegistryTarget::REMOTE_TASK_DISPATCHER;
+    if (target_registry == "INNER_L3_WORKER") return remote_l3::RemoteRegistryTarget::INNER_L3_WORKER;
+    throw std::invalid_argument("unsupported remote registry target: " + target_registry);
 }
 
 inline CallableIdentity
@@ -84,6 +93,80 @@ inline std::string bytes_from_digest_arg(nb::object digest) {
         throw std::invalid_argument("callable digest must be exactly 32 bytes");
     }
     return out;
+}
+
+inline std::vector<uint8_t> bytes_to_u8_vector(nb::handle obj, const char *field_name) {
+    Py_buffer view;
+    if (PyObject_GetBuffer(obj.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
+        throw nb::python_error();
+    }
+    if (view.len < 0) {
+        PyBuffer_Release(&view);
+        throw std::invalid_argument(std::string(field_name) + " must not have negative length");
+    }
+    auto *begin = static_cast<const uint8_t *>(view.buf);
+    std::vector<uint8_t> out(begin, begin + static_cast<size_t>(view.len));
+    PyBuffer_Release(&view);
+    return out;
+}
+
+inline RemoteAddressSpace parse_remote_address_space(nb::handle value) {
+    int v = nb::cast<int>(value);
+    switch (v) {
+    case static_cast<int>(RemoteAddressSpace::HOST_INLINE):
+        return RemoteAddressSpace::HOST_INLINE;
+    case static_cast<int>(RemoteAddressSpace::REMOTE_DEVICE):
+        return RemoteAddressSpace::REMOTE_DEVICE;
+    case static_cast<int>(RemoteAddressSpace::REMOTE_WINDOW):
+        return RemoteAddressSpace::REMOTE_WINDOW;
+    case static_cast<int>(RemoteAddressSpace::UB_LDST):
+        return RemoteAddressSpace::UB_LDST;
+    default:
+        throw std::invalid_argument("unknown RemoteAddressSpace value: " + std::to_string(v));
+    }
+}
+
+inline RemoteTensorSidecar parse_remote_tensor_sidecar(nb::handle obj) {
+    RemoteTensorSidecar sidecar{};
+    if (obj.is_none()) return sidecar;
+
+    sidecar.present = nb::cast<bool>(obj.attr("present"));
+    if (!sidecar.present) return sidecar;
+
+    nb::object desc = obj.attr("desc");
+    sidecar.desc.address_space = parse_remote_address_space(desc.attr("address_space"));
+    sidecar.desc.owner_endpoint_id = nb::cast<int32_t>(desc.attr("owner_endpoint_id"));
+    sidecar.desc.buffer_id = nb::cast<uint64_t>(desc.attr("buffer_id"));
+    sidecar.desc.offset = nb::cast<uint64_t>(desc.attr("offset"));
+    sidecar.desc.nbytes = nb::cast<uint64_t>(desc.attr("nbytes"));
+    sidecar.desc.remote_addr = nb::cast<uint64_t>(desc.attr("remote_addr"));
+    sidecar.desc.rkey_or_token = nb::cast<uint64_t>(desc.attr("rkey_or_token"));
+    sidecar.desc.generation = nb::cast<uint64_t>(desc.attr("generation"));
+    sidecar.desc.inline_payload_offset = nb::cast<uint64_t>(desc.attr("inline_payload_offset"));
+    sidecar.desc.inline_payload_len = nb::cast<uint64_t>(desc.attr("inline_payload_len"));
+    sidecar.desc.flags = nb::cast<uint64_t>(desc.attr("flags"));
+    return sidecar;
+}
+
+inline RemoteTaskArgsSidecar parse_remote_task_args_sidecar(nb::handle obj) {
+    RemoteTaskArgsSidecar sidecar{};
+    if (obj.is_none()) return sidecar;
+
+    nb::object tensors_obj = obj.attr("tensors");
+    for (nb::handle item : nb::borrow<nb::iterable>(tensors_obj)) {
+        sidecar.tensors.push_back(parse_remote_tensor_sidecar(item));
+    }
+    sidecar.inline_payload = bytes_to_u8_vector(obj.attr("inline_payload"), "remote sidecar inline_payload");
+    return sidecar;
+}
+
+inline std::vector<RemoteTaskArgsSidecar> parse_remote_task_args_sidecars(nb::handle obj) {
+    std::vector<RemoteTaskArgsSidecar> sidecars;
+    if (obj.is_none()) return sidecars;
+    for (nb::handle item : nb::borrow<nb::iterable>(obj)) {
+        sidecars.push_back(parse_remote_task_args_sidecar(item));
+    }
+    return sidecars;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,24 +231,33 @@ inline void bind_worker(nb::module_ &m) {
         .def(
             "submit_next_level",
             [](Orchestrator &self, nb::bytes digest, const std::string &kind, const std::string &target_namespace,
-               const TaskArgs &args, const CallConfig &config, int8_t worker) {
-                self.submit_next_level(make_callable_identity(digest, kind, target_namespace), args, config, worker);
+               const TaskArgs &args, const CallConfig &config, int8_t worker,
+               const std::vector<int32_t> &eligible_endpoint_ids, nb::object remote_sidecar) {
+                self.submit_next_level(
+                    make_callable_identity(digest, kind, target_namespace), args, config, worker, eligible_endpoint_ids,
+                    parse_remote_task_args_sidecar(remote_sidecar)
+                );
             },
             nb::arg("digest"), nb::arg("kind"), nb::arg("target_namespace"), nb::arg("args"), nb::arg("config"),
-            nb::arg("worker") = int8_t(-1),
+            nb::arg("worker") = int8_t(-1), nb::arg("eligible_endpoint_ids") = std::vector<int32_t>{},
+            nb::arg("remote_sidecar") = nb::none(),
             "Submit a NEXT_LEVEL task by registered callable digest. "
             "worker= pins to a specific next-level worker (-1 = any)."
         )
         .def(
             "submit_next_level_group",
             [](Orchestrator &self, nb::bytes digest, const std::string &kind, const std::string &target_namespace,
-               const std::vector<TaskArgs> &args_list, const CallConfig &config, const std::vector<int8_t> &workers) {
+               const std::vector<TaskArgs> &args_list, const CallConfig &config, const std::vector<int8_t> &workers,
+               const std::vector<std::vector<int32_t>> &eligible_endpoint_ids, nb::object remote_sidecars) {
                 self.submit_next_level_group(
-                    make_callable_identity(digest, kind, target_namespace), args_list, config, workers
+                    make_callable_identity(digest, kind, target_namespace), args_list, config, workers,
+                    eligible_endpoint_ids, parse_remote_task_args_sidecars(remote_sidecars)
                 );
             },
             nb::arg("digest"), nb::arg("kind"), nb::arg("target_namespace"), nb::arg("args_list"), nb::arg("config"),
             nb::arg("workers") = std::vector<int8_t>{},
+            nb::arg("eligible_endpoint_ids") = std::vector<std::vector<int32_t>>{},
+            nb::arg("remote_sidecars") = nb::none(),
             "Submit a group of NEXT_LEVEL tasks by registered callable digest. "
             "workers= per-args affinity (empty = any)."
         )
@@ -270,6 +362,20 @@ inline void bind_worker(nb::module_ &m) {
             "MAILBOX_SIZE-byte MAP_SHARED region; the child process loop is "
             "Python-managed (fork + _sub_worker_loop)."
         )
+        .def(
+            "add_remote_l3_socket",
+            [](Worker &self, int32_t endpoint_id, uint64_t session_id, const std::string &transport_name,
+               const std::string &host, uint16_t port, const std::string &health_host, uint16_t health_port,
+               double timeout_s) {
+                nb::gil_scoped_release release;
+                self.add_remote_l3_socket(
+                    endpoint_id, session_id, transport_name, host, port, health_host, health_port, timeout_s
+                );
+            },
+            nb::arg("endpoint_id"), nb::arg("session_id"), nb::arg("transport_name"), nb::arg("host"), nb::arg("port"),
+            nb::arg("health_host"), nb::arg("health_port"), nb::arg("timeout_s") = 30.0,
+            "Register a REMOTE_L3 endpoint after the session reports HELLO READY."
+        )
 
         .def("init", &Worker::init, "Start the Scheduler thread.")
         .def("close", &Worker::close, "Stop the Scheduler thread.")
@@ -321,6 +427,207 @@ inline void bind_worker(nb::module_ &m) {
             nb::arg("timeout_s") = nb::none(),
             "Drive one selected worker through a digest-only CONTROL_REQUEST. "
             "Used by registration cleanup after partial broadcast failures."
+        )
+        .def(
+            "remote_prepare_register",
+            [](Worker &self, int endpoint_id, const std::string &target_registry, const std::string &kind,
+               nb::object payload, nb::object digest) {
+                std::string payload_bytes;
+                if (!payload.is_none()) {
+                    Py_buffer view;
+                    if (PyObject_GetBuffer(payload.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
+                        throw nb::python_error();
+                    }
+                    payload_bytes.assign(static_cast<const char *>(view.buf), static_cast<size_t>(view.len));
+                    PyBuffer_Release(&view);
+                }
+                std::string digest_bytes = bytes_from_digest_arg(digest);
+                nb::gil_scoped_release release;
+                return self.remote_prepare_register(
+                    endpoint_id, parse_remote_registry_target(target_registry), parse_callable_kind(kind),
+                    payload_bytes.data(), payload_bytes.size(), reinterpret_cast<const uint8_t *>(digest_bytes.data())
+                );
+            },
+            nb::arg("endpoint_id"), nb::arg("target_registry"), nb::arg("kind"), nb::arg("payload"), nb::arg("digest"),
+            "Send PREPARE_REGISTER_CALLABLE to one remote endpoint."
+        )
+        .def(
+            "remote_commit_register",
+            [](Worker &self, int endpoint_id, const std::string &target_registry, const std::string &kind,
+               nb::object digest) {
+                std::string digest_bytes = bytes_from_digest_arg(digest);
+                nb::gil_scoped_release release;
+                return self.remote_commit_register(
+                    endpoint_id, parse_remote_registry_target(target_registry), parse_callable_kind(kind),
+                    reinterpret_cast<const uint8_t *>(digest_bytes.data())
+                );
+            },
+            nb::arg("endpoint_id"), nb::arg("target_registry"), nb::arg("kind"), nb::arg("digest"),
+            "Send COMMIT_REGISTER_CALLABLE to one remote endpoint."
+        )
+        .def(
+            "remote_abort_register",
+            [](Worker &self, int endpoint_id, const std::string &target_registry, const std::string &kind,
+               nb::object digest) {
+                std::string digest_bytes = bytes_from_digest_arg(digest);
+                nb::gil_scoped_release release;
+                return self.remote_abort_register(
+                    endpoint_id, parse_remote_registry_target(target_registry), parse_callable_kind(kind),
+                    reinterpret_cast<const uint8_t *>(digest_bytes.data())
+                );
+            },
+            nb::arg("endpoint_id"), nb::arg("target_registry"), nb::arg("kind"), nb::arg("digest"),
+            "Send ABORT_REGISTER_CALLABLE to one remote endpoint."
+        )
+        .def(
+            "remote_unregister",
+            [](Worker &self, int endpoint_id, const std::string &target_registry, const std::string &kind,
+               nb::object digest) {
+                std::string digest_bytes = bytes_from_digest_arg(digest);
+                nb::gil_scoped_release release;
+                return self.remote_unregister(
+                    endpoint_id, parse_remote_registry_target(target_registry), parse_callable_kind(kind),
+                    reinterpret_cast<const uint8_t *>(digest_bytes.data())
+                );
+            },
+            nb::arg("endpoint_id"), nb::arg("target_registry"), nb::arg("kind"), nb::arg("digest"),
+            "Send UNREGISTER_CALLABLE to one remote endpoint."
+        )
+        .def(
+            "remote_malloc",
+            [](Worker &self, int endpoint_id, size_t size) {
+                RemoteBufferHandle h;
+                {
+                    nb::gil_scoped_release release;
+                    h = self.remote_malloc(endpoint_id, size);
+                }
+                return nb::make_tuple(
+                    h.endpoint_id, h.buffer_id, h.generation, static_cast<int32_t>(h.address_space), h.nbytes,
+                    h.remote_addr, h.rkey_or_token, h.ub_ldst_va
+                );
+            },
+            nb::arg("endpoint_id"), nb::arg("size"), "Allocate a remote buffer and return handle fields."
+        )
+        .def(
+            "remote_free",
+            [](Worker &self, int endpoint_id, uint64_t buffer_id, uint64_t generation) {
+                RemoteBufferHandle h;
+                h.endpoint_id = endpoint_id;
+                h.buffer_id = buffer_id;
+                h.generation = generation;
+                nb::gil_scoped_release release;
+                self.remote_free(h);
+            },
+            nb::arg("endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), "Free a remote buffer."
+        )
+        .def(
+            "remote_copy_to",
+            [](Worker &self, int endpoint_id, uint64_t buffer_id, uint64_t generation, uint64_t offset, uint64_t src,
+               size_t size) {
+                RemoteBufferHandle h;
+                h.endpoint_id = endpoint_id;
+                h.buffer_id = buffer_id;
+                h.generation = generation;
+                nb::gil_scoped_release release;
+                self.remote_copy_to(h, offset, reinterpret_cast<const void *>(src), size);
+            },
+            nb::arg("endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), nb::arg("offset"), nb::arg("src"),
+            nb::arg("size"), "Copy host bytes into a remote buffer."
+        )
+        .def(
+            "remote_copy_from",
+            [](Worker &self, uint64_t dst, int endpoint_id, uint64_t buffer_id, uint64_t generation, uint64_t offset,
+               size_t size) {
+                RemoteBufferHandle h;
+                h.endpoint_id = endpoint_id;
+                h.buffer_id = buffer_id;
+                h.generation = generation;
+                nb::gil_scoped_release release;
+                self.remote_copy_from(reinterpret_cast<void *>(dst), h, offset, size);
+            },
+            nb::arg("dst"), nb::arg("endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), nb::arg("offset"),
+            nb::arg("size"), "Copy remote buffer bytes into host memory."
+        )
+        .def(
+            "remote_export",
+            [](Worker &self, int owner_endpoint_id, uint64_t buffer_id, uint64_t generation, uint64_t handle_offset,
+               uint64_t offset, uint64_t size, uint32_t access_flags, const std::string &transport_profile) {
+                RemoteBufferHandle h;
+                h.endpoint_id = owner_endpoint_id;
+                h.owner_endpoint_id = owner_endpoint_id;
+                h.buffer_id = buffer_id;
+                h.generation = generation;
+                h.offset = handle_offset;
+                RemoteBufferExport e;
+                {
+                    nb::gil_scoped_release release;
+                    e = self.remote_export(h, offset, size, access_flags, transport_profile);
+                }
+                return nb::make_tuple(
+                    e.owner_endpoint_id, e.buffer_id, e.generation, static_cast<int32_t>(e.address_space), e.offset,
+                    e.nbytes, e.export_id, e.remote_addr, e.rkey_or_token, e.ub_ldst_va, e.access_flags,
+                    e.transport_profile,
+                    nb::bytes(
+                        reinterpret_cast<const char *>(e.transport_descriptor.data()), e.transport_descriptor.size()
+                    )
+                );
+            },
+            nb::arg("owner_endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), nb::arg("handle_offset"),
+            nb::arg("offset"), nb::arg("size"), nb::arg("access_flags"), nb::arg("transport_profile"),
+            "Export a remote buffer range and return export descriptor fields."
+        )
+        .def(
+            "remote_import",
+            [](Worker &self, int importer_endpoint_id, int owner_endpoint_id, uint64_t buffer_id, uint64_t generation,
+               int address_space, uint64_t offset, uint64_t size, uint64_t export_id, uint64_t remote_addr,
+               uint64_t rkey_or_token, uint64_t ub_ldst_va, uint32_t access_flags, const std::string &transport_profile,
+               nb::object transport_descriptor, uint32_t requested_access_flags) {
+                RemoteBufferExport e;
+                e.owner_endpoint_id = owner_endpoint_id;
+                e.buffer_id = buffer_id;
+                e.generation = generation;
+                e.address_space = parse_remote_address_space(nb::int_(address_space));
+                e.offset = offset;
+                e.nbytes = size;
+                e.export_id = export_id;
+                e.remote_addr = remote_addr;
+                e.rkey_or_token = rkey_or_token;
+                e.ub_ldst_va = ub_ldst_va;
+                e.access_flags = access_flags;
+                e.transport_profile = transport_profile;
+                e.transport_descriptor = bytes_to_u8_vector(transport_descriptor, "transport_descriptor");
+                RemoteBufferHandle h;
+                {
+                    nb::gil_scoped_release release;
+                    h = self.remote_import(importer_endpoint_id, e, requested_access_flags);
+                }
+                return nb::make_tuple(
+                    h.endpoint_id, h.owner_endpoint_id, h.buffer_id, h.generation, h.import_id,
+                    static_cast<int32_t>(h.address_space), h.nbytes, h.offset, h.remote_addr, h.rkey_or_token,
+                    h.ub_ldst_va, h.access_flags
+                );
+            },
+            nb::arg("importer_endpoint_id"), nb::arg("owner_endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"),
+            nb::arg("address_space"), nb::arg("offset"), nb::arg("size"), nb::arg("export_id"), nb::arg("remote_addr"),
+            nb::arg("rkey_or_token"), nb::arg("ub_ldst_va"), nb::arg("access_flags"), nb::arg("transport_profile"),
+            nb::arg("transport_descriptor"), nb::arg("requested_access_flags"),
+            "Import a remote buffer export into an endpoint."
+        )
+        .def(
+            "remote_release_import",
+            [](Worker &self, int importer_endpoint_id, int owner_endpoint_id, uint64_t buffer_id, uint64_t generation,
+               uint64_t import_id) {
+                RemoteBufferHandle h;
+                h.endpoint_id = importer_endpoint_id;
+                h.owner_endpoint_id = owner_endpoint_id;
+                h.buffer_id = buffer_id;
+                h.generation = generation;
+                h.import_id = import_id;
+                nb::gil_scoped_release release;
+                self.remote_release_import(h);
+            },
+            nb::arg("importer_endpoint_id"), nb::arg("owner_endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"),
+            nb::arg("import_id"), "Release an imported remote buffer mapping."
         )
         .def(
             "broadcast_unregister_all",

--- a/python/bindings/worker_bind.h
+++ b/python/bindings/worker_bind.h
@@ -30,6 +30,7 @@
 
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -40,6 +41,52 @@
 #include "worker_manager.h"
 
 namespace nb = nanobind;
+
+class PyBufferView {
+public:
+    explicit PyBufferView(nb::handle obj) {
+        if (PyObject_GetBuffer(obj.ptr(), &view_, PyBUF_CONTIG_RO) != 0) {
+            throw nb::python_error();
+        }
+    }
+
+    ~PyBufferView() { PyBuffer_Release(&view_); }
+
+    PyBufferView(const PyBufferView &) = delete;
+    PyBufferView &operator=(const PyBufferView &) = delete;
+
+    const void *data() const { return view_.buf; }
+    Py_ssize_t size() const { return view_.len; }
+
+private:
+    Py_buffer view_{};
+};
+
+inline uint64_t checked_remote_range_end(const char *op_name, uint64_t base, uint64_t offset, uint64_t size) {
+    uint64_t max = std::numeric_limits<uint64_t>::max();
+    if (offset > max - size || base > max - offset - size) {
+        throw std::invalid_argument(std::string(op_name) + ": remote buffer range overflows");
+    }
+    return base + offset + size;
+}
+
+inline uint64_t
+validated_handle_nbytes(uint64_t nbytes, const char *op_name, uint64_t base, uint64_t offset, uint64_t size) {
+    uint64_t minimum = checked_remote_range_end(op_name, base, offset, size);
+    if (nbytes < minimum) {
+        throw std::invalid_argument(std::string(op_name) + ": handle_nbytes is smaller than requested range");
+    }
+    return nbytes;
+}
+
+inline std::string buffer_to_string(nb::handle obj, const char *field_name) {
+    PyBufferView view(obj);
+    if (view.size() < 0) {
+        throw std::invalid_argument(std::string(field_name) + " must not have negative length");
+    }
+    if (view.size() == 0) return {};
+    return std::string(static_cast<const char *>(view.data()), static_cast<size_t>(view.size()));
+}
 
 inline CallableKind parse_callable_kind(const std::string &kind) {
     if (kind == "CHIP_CALLABLE") return CallableKind::CHIP_CALLABLE;
@@ -63,32 +110,19 @@ inline remote_l3::RemoteRegistryTarget parse_remote_registry_target(const std::s
 
 inline CallableIdentity
 make_callable_identity(nb::bytes digest, const std::string &kind, const std::string &target_namespace) {
-    Py_buffer view;
-    if (PyObject_GetBuffer(digest.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
-        throw nb::python_error();
-    }
-    auto release = [&]() {
-        PyBuffer_Release(&view);
-    };
-    if (static_cast<size_t>(view.len) != CALLABLE_HASH_DIGEST_SIZE) {
-        release();
+    PyBufferView view(digest);
+    if (view.size() != static_cast<Py_ssize_t>(CALLABLE_HASH_DIGEST_SIZE)) {
         throw std::invalid_argument("callable digest must be exactly 32 bytes");
     }
     CallableIdentity out;
-    std::memcpy(out.digest.data(), view.buf, CALLABLE_HASH_DIGEST_SIZE);
-    release();
+    std::memcpy(out.digest.data(), view.data(), CALLABLE_HASH_DIGEST_SIZE);
     out.kind = parse_callable_kind(kind);
     out.target_namespace = parse_target_namespace(target_namespace);
     return out;
 }
 
 inline std::string bytes_from_digest_arg(nb::object digest) {
-    Py_buffer view;
-    if (PyObject_GetBuffer(digest.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
-        throw nb::python_error();
-    }
-    std::string out(static_cast<const char *>(view.buf), static_cast<size_t>(view.len));
-    PyBuffer_Release(&view);
+    std::string out = buffer_to_string(digest, "callable digest");
     if (out.size() != CALLABLE_HASH_DIGEST_SIZE) {
         throw std::invalid_argument("callable digest must be exactly 32 bytes");
     }
@@ -96,18 +130,13 @@ inline std::string bytes_from_digest_arg(nb::object digest) {
 }
 
 inline std::vector<uint8_t> bytes_to_u8_vector(nb::handle obj, const char *field_name) {
-    Py_buffer view;
-    if (PyObject_GetBuffer(obj.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
-        throw nb::python_error();
-    }
-    if (view.len < 0) {
-        PyBuffer_Release(&view);
+    PyBufferView view(obj);
+    if (view.size() < 0) {
         throw std::invalid_argument(std::string(field_name) + " must not have negative length");
     }
-    auto *begin = static_cast<const uint8_t *>(view.buf);
-    std::vector<uint8_t> out(begin, begin + static_cast<size_t>(view.len));
-    PyBuffer_Release(&view);
-    return out;
+    if (view.size() == 0) return {};
+    auto *begin = static_cast<const uint8_t *>(view.data());
+    return std::vector<uint8_t>(begin, begin + static_cast<size_t>(view.size()));
 }
 
 inline RemoteAddressSpace parse_remote_address_space(nb::handle value) {
@@ -434,12 +463,7 @@ inline void bind_worker(nb::module_ &m) {
                nb::object payload, nb::object digest) {
                 std::string payload_bytes;
                 if (!payload.is_none()) {
-                    Py_buffer view;
-                    if (PyObject_GetBuffer(payload.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
-                        throw nb::python_error();
-                    }
-                    payload_bytes.assign(static_cast<const char *>(view.buf), static_cast<size_t>(view.len));
-                    PyBuffer_Release(&view);
+                    payload_bytes = buffer_to_string(payload, "payload");
                 }
                 std::string digest_bytes = bytes_from_digest_arg(digest);
                 nb::gil_scoped_release release;
@@ -523,41 +547,45 @@ inline void bind_worker(nb::module_ &m) {
         .def(
             "remote_copy_to",
             [](Worker &self, int endpoint_id, uint64_t buffer_id, uint64_t generation, uint64_t offset, uint64_t src,
-               size_t size) {
+               size_t size, uint64_t handle_nbytes) {
                 RemoteBufferHandle h;
                 h.endpoint_id = endpoint_id;
                 h.buffer_id = buffer_id;
                 h.generation = generation;
+                h.nbytes = validated_handle_nbytes(handle_nbytes, "remote_copy_to", 0, offset, size);
                 nb::gil_scoped_release release;
                 self.remote_copy_to(h, offset, reinterpret_cast<const void *>(src), size);
             },
             nb::arg("endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), nb::arg("offset"), nb::arg("src"),
-            nb::arg("size"), "Copy host bytes into a remote buffer."
+            nb::arg("size"), nb::arg("handle_nbytes"), "Copy host bytes into a remote buffer."
         )
         .def(
             "remote_copy_from",
             [](Worker &self, uint64_t dst, int endpoint_id, uint64_t buffer_id, uint64_t generation, uint64_t offset,
-               size_t size) {
+               size_t size, uint64_t handle_nbytes) {
                 RemoteBufferHandle h;
                 h.endpoint_id = endpoint_id;
                 h.buffer_id = buffer_id;
                 h.generation = generation;
+                h.nbytes = validated_handle_nbytes(handle_nbytes, "remote_copy_from", 0, offset, size);
                 nb::gil_scoped_release release;
                 self.remote_copy_from(reinterpret_cast<void *>(dst), h, offset, size);
             },
             nb::arg("dst"), nb::arg("endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), nb::arg("offset"),
-            nb::arg("size"), "Copy remote buffer bytes into host memory."
+            nb::arg("size"), nb::arg("handle_nbytes"), "Copy remote buffer bytes into host memory."
         )
         .def(
             "remote_export",
             [](Worker &self, int owner_endpoint_id, uint64_t buffer_id, uint64_t generation, uint64_t handle_offset,
-               uint64_t offset, uint64_t size, uint32_t access_flags, const std::string &transport_profile) {
+               uint64_t offset, uint64_t size, uint32_t access_flags, const std::string &transport_profile,
+               uint64_t handle_nbytes) {
                 RemoteBufferHandle h;
                 h.endpoint_id = owner_endpoint_id;
                 h.owner_endpoint_id = owner_endpoint_id;
                 h.buffer_id = buffer_id;
                 h.generation = generation;
                 h.offset = handle_offset;
+                h.nbytes = validated_handle_nbytes(handle_nbytes, "remote_export", handle_offset, offset, size);
                 RemoteBufferExport e;
                 {
                     nb::gil_scoped_release release;
@@ -574,7 +602,7 @@ inline void bind_worker(nb::module_ &m) {
             },
             nb::arg("owner_endpoint_id"), nb::arg("buffer_id"), nb::arg("generation"), nb::arg("handle_offset"),
             nb::arg("offset"), nb::arg("size"), nb::arg("access_flags"), nb::arg("transport_profile"),
-            "Export a remote buffer range and return export descriptor fields."
+            nb::arg("handle_nbytes"), "Export a remote buffer range and return export descriptor fields."
         )
         .def(
             "remote_import",
@@ -648,12 +676,7 @@ inline void bind_worker(nb::module_ &m) {
                 const void *payload_ptr = nullptr;
                 size_t payload_size = 0;
                 if (!payload.is_none()) {
-                    Py_buffer view;
-                    if (PyObject_GetBuffer(payload.ptr(), &view, PyBUF_CONTIG_RO) != 0) {
-                        throw nb::python_error();
-                    }
-                    payload_bytes.assign(static_cast<const char *>(view.buf), static_cast<size_t>(view.len));
-                    PyBuffer_Release(&view);
+                    payload_bytes = buffer_to_string(payload, "payload");
                     payload_ptr = payload_bytes.data();
                     payload_size = payload_bytes.size();
                 }

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -414,9 +414,9 @@ void RemoteL3SocketTransport::start_health_monitor(uint64_t session_id, int32_t 
         auto read_exact = [&](uint8_t *data, size_t size) -> bool {
             size_t off = 0;
             auto deadline =
-                std::chrono::steady_clock::now() +
-                std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<double>(timeout_s)
-                );
+                std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                                       std::chrono::duration<double>(timeout_s)
+                                                   );
             while (off < size) {
                 if (health_stop_.load(std::memory_order_acquire)) return false;
                 auto now = std::chrono::steady_clock::now();

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -1,0 +1,721 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "remote_endpoint.h"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <cerrno>
+#include <cstdint>
+#include <array>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+#include "ring.h"
+
+namespace {
+
+uint32_t read_le_u32(const uint8_t *data) {
+    return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
+           (static_cast<uint32_t>(data[2]) << 16) | (static_cast<uint32_t>(data[3]) << 24);
+}
+
+std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> digest_array(const uint8_t *digest) {
+    if (digest == nullptr) throw std::invalid_argument("RemoteL3Endpoint: null callable digest");
+    std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> out{};
+    std::memcpy(out.data(), digest, out.size());
+    return out;
+}
+
+void put_u32(std::vector<uint8_t> &out, uint32_t v) {
+    for (int i = 0; i < 4; ++i)
+        out.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xffU));
+}
+
+void put_i32(std::vector<uint8_t> &out, int32_t v) { put_u32(out, static_cast<uint32_t>(v)); }
+
+void put_u64(std::vector<uint8_t> &out, uint64_t v) {
+    for (int i = 0; i < 8; ++i)
+        out.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xffU));
+}
+
+uint64_t get_u64(const std::vector<uint8_t> &data, size_t &offset) {
+    if (offset > data.size() || data.size() - offset < 8) {
+        throw std::runtime_error("RemoteL3Endpoint: truncated uint64 result");
+    }
+    uint64_t v = 0;
+    for (int i = 0; i < 8; ++i)
+        v |= static_cast<uint64_t>(data[offset++]) << (8 * i);
+    return v;
+}
+
+int32_t get_i32(const std::vector<uint8_t> &data, size_t &offset) {
+    if (offset > data.size() || data.size() - offset < 4) {
+        throw std::runtime_error("RemoteL3Endpoint: truncated int32 result");
+    }
+    uint32_t v = 0;
+    for (int i = 0; i < 4; ++i)
+        v |= static_cast<uint32_t>(data[offset++]) << (8 * i);
+    return static_cast<int32_t>(v);
+}
+
+timeval timeout_to_timeval(double timeout_s) {
+    if (timeout_s <= 0.0) throw std::invalid_argument("RemoteL3SocketTransport: timeout must be positive");
+    timeval tv{};
+    tv.tv_sec = static_cast<long>(timeout_s);
+    tv.tv_usec = static_cast<long>((timeout_s - static_cast<double>(tv.tv_sec)) * 1000000.0);
+    return tv;
+}
+
+int connect_tcp_socket(const std::string &host, uint16_t port, const std::string &label) {
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    addrinfo *results = nullptr;
+    std::string port_s = std::to_string(port);
+    int rc = getaddrinfo(host.c_str(), port_s.c_str(), &hints, &results);
+    if (rc != 0) {
+        throw std::runtime_error(label + ": getaddrinfo failed for " + host + ":" + port_s + ": " + gai_strerror(rc));
+    }
+
+    int fd = -1;
+    int last_errno = 0;
+    for (addrinfo *ai = results; ai != nullptr; ai = ai->ai_next) {
+        int candidate = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+        if (candidate < 0) {
+            last_errno = errno;
+            continue;
+        }
+        if (::connect(candidate, ai->ai_addr, ai->ai_addrlen) == 0) {
+            fd = candidate;
+            break;
+        }
+        last_errno = errno;
+        ::close(candidate);
+    }
+    freeaddrinfo(results);
+    if (fd < 0) {
+        throw std::runtime_error(
+            label + ": connect failed to " + host + ":" + port_s + ": " + std::strerror(last_errno)
+        );
+    }
+    return fd;
+}
+
+}  // namespace
+
+RemoteL3SocketTransport::RemoteL3SocketTransport(
+    std::string host, uint16_t port, std::string health_host, uint16_t health_port, double timeout_s
+) :
+    host_(std::move(host)),
+    port_(port),
+    health_host_(std::move(health_host)),
+    health_port_(health_port),
+    timeout_s_(timeout_s) {
+    if (host_.empty()) throw std::invalid_argument("RemoteL3SocketTransport: host must be non-empty");
+    if (port_ == 0) throw std::invalid_argument("RemoteL3SocketTransport: port must be non-zero");
+    if (health_host_.empty()) throw std::invalid_argument("RemoteL3SocketTransport: health host must be non-empty");
+    if (health_port_ == 0) throw std::invalid_argument("RemoteL3SocketTransport: health port must be non-zero");
+    if (timeout_s_ <= 0.0) throw std::invalid_argument("RemoteL3SocketTransport: timeout must be positive");
+    connect_socket();
+}
+
+RemoteL3SocketTransport::~RemoteL3SocketTransport() { close_socket(); }
+
+void RemoteL3SocketTransport::connect_socket() {
+    fd_ = connect_tcp_socket(host_, port_, "RemoteL3SocketTransport(command)");
+}
+
+void RemoteL3SocketTransport::close_socket() {
+    stop_health_monitor();
+    if (fd_ >= 0) {
+        ::shutdown(fd_, SHUT_RDWR);
+        ::close(fd_);
+        fd_ = -1;
+    }
+}
+
+void RemoteL3SocketTransport::mark_health_failed(const std::string &message) {
+    bool expected = false;
+    if (health_failed_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        std::lock_guard<std::mutex> lk(health_mu_);
+        health_error_ = message;
+    }
+}
+
+void RemoteL3SocketTransport::check_health() {
+    if (!health_failed_.load(std::memory_order_acquire)) return;
+    std::string message;
+    {
+        std::lock_guard<std::mutex> lk(health_mu_);
+        message = health_error_;
+    }
+    throw std::runtime_error("RemoteL3SocketTransport: health lane failed: " + message);
+}
+
+void RemoteL3SocketTransport::start_health_monitor(uint64_t session_id, int32_t endpoint_id) {
+    if (health_thread_.joinable()) return;
+    health_fd_ = connect_tcp_socket(health_host_, health_port_, "RemoteL3SocketTransport(health)");
+    health_stop_.store(false, std::memory_order_release);
+    health_failed_.store(false, std::memory_order_release);
+    {
+        std::lock_guard<std::mutex> lk(health_mu_);
+        health_error_.clear();
+    }
+    int fd = health_fd_;
+    double timeout_s = timeout_s_;
+    health_thread_ = std::thread([this, fd, session_id, endpoint_id, timeout_s]() {
+        auto read_exact = [&](uint8_t *data, size_t size) -> bool {
+            size_t off = 0;
+            auto deadline =
+                std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+                                                       std::chrono::duration<double>(timeout_s)
+                                                   );
+            while (off < size) {
+                if (health_stop_.load(std::memory_order_acquire)) return false;
+                auto now = std::chrono::steady_clock::now();
+                if (now >= deadline) throw std::runtime_error("timed out waiting for HEALTH frame");
+                double remaining = std::chrono::duration<double>(deadline - now).count();
+                timeval tv = timeout_to_timeval(std::min(0.2, remaining));
+                fd_set rfds;
+                FD_ZERO(&rfds);
+                FD_SET(fd, &rfds);
+                int rc = ::select(fd + 1, &rfds, nullptr, nullptr, &tv);
+                if (rc == 0) continue;
+                if (rc < 0) {
+                    if (errno == EINTR) continue;
+                    throw std::runtime_error(std::string("select failed: ") + std::strerror(errno));
+                }
+                ssize_t n = ::recv(fd, data + off, size - off, 0);
+                if (n < 0) {
+                    if (errno == EINTR) continue;
+                    throw std::runtime_error(std::string("recv failed: ") + std::strerror(errno));
+                }
+                if (n == 0) throw std::runtime_error("health socket closed");
+                off += static_cast<size_t>(n);
+            }
+            return true;
+        };
+
+        try {
+            static constexpr size_t HEADER_BYTES = 40;
+            while (!health_stop_.load(std::memory_order_acquire)) {
+                std::vector<uint8_t> frame(HEADER_BYTES);
+                if (!read_exact(frame.data(), HEADER_BYTES)) return;
+                uint32_t payload_bytes = read_le_u32(frame.data() + 32);
+                if (payload_bytes > remote_l3::MAX_FRAME_PAYLOAD_BYTES) {
+                    throw std::runtime_error("HEALTH payload exceeds maximum");
+                }
+                frame.resize(HEADER_BYTES + payload_bytes);
+                if (payload_bytes != 0 && !read_exact(frame.data() + HEADER_BYTES, payload_bytes)) return;
+                auto decoded = remote_l3::decode_frame(frame);
+                if (decoded.header.frame_type != remote_l3::FrameType::HEALTH) {
+                    throw std::runtime_error("non-HEALTH frame on health lane");
+                }
+                if (decoded.header.session_id != session_id || decoded.header.endpoint_id != endpoint_id) {
+                    throw std::runtime_error("HEALTH session or endpoint mismatch");
+                }
+            }
+        } catch (const std::exception &e) {
+            if (!health_stop_.load(std::memory_order_acquire)) mark_health_failed(e.what());
+        }
+    });
+}
+
+void RemoteL3SocketTransport::stop_health_monitor() {
+    health_stop_.store(true, std::memory_order_release);
+    if (health_fd_ >= 0) {
+        ::shutdown(health_fd_, SHUT_RDWR);
+    }
+    if (health_thread_.joinable()) {
+        health_thread_.join();
+    }
+    if (health_fd_ >= 0) {
+        ::close(health_fd_);
+        health_fd_ = -1;
+    }
+}
+
+void RemoteL3SocketTransport::wait_readable() {
+    auto deadline =
+        std::chrono::steady_clock::now() +
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<double>(timeout_s_));
+    while (true) {
+        check_health();
+        auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) throw std::runtime_error("RemoteL3SocketTransport: timed out waiting for frame");
+        double remaining = std::chrono::duration<double>(deadline - now).count();
+        timeval tv = timeout_to_timeval(std::min(0.2, remaining));
+        fd_set rfds;
+        FD_ZERO(&rfds);
+        FD_SET(fd_, &rfds);
+        int rc = ::select(fd_ + 1, &rfds, nullptr, nullptr, &tv);
+        if (rc > 0) return;
+        if (rc < 0) {
+            if (errno == EINTR) continue;
+            throw std::runtime_error(
+                std::string("RemoteL3SocketTransport: select(read) failed: ") + std::strerror(errno)
+            );
+        }
+    }
+}
+
+void RemoteL3SocketTransport::wait_writable() {
+    auto deadline =
+        std::chrono::steady_clock::now() +
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<double>(timeout_s_));
+    while (true) {
+        check_health();
+        auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) throw std::runtime_error("RemoteL3SocketTransport: timed out writing frame");
+        double remaining = std::chrono::duration<double>(deadline - now).count();
+        timeval tv = timeout_to_timeval(std::min(0.2, remaining));
+        fd_set wfds;
+        FD_ZERO(&wfds);
+        FD_SET(fd_, &wfds);
+        int rc = ::select(fd_ + 1, nullptr, &wfds, nullptr, &tv);
+        if (rc > 0) return;
+        if (rc < 0) {
+            if (errno == EINTR) continue;
+            throw std::runtime_error(
+                std::string("RemoteL3SocketTransport: select(write) failed: ") + std::strerror(errno)
+            );
+        }
+    }
+}
+
+void RemoteL3SocketTransport::write_all(const uint8_t *data, size_t size) {
+    size_t off = 0;
+    while (off < size) {
+        wait_writable();
+        ssize_t n = ::send(fd_, data + off, size - off, 0);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            throw std::runtime_error(std::string("RemoteL3SocketTransport: send failed: ") + std::strerror(errno));
+        }
+        if (n == 0) throw std::runtime_error("RemoteL3SocketTransport: socket closed while writing");
+        off += static_cast<size_t>(n);
+    }
+}
+
+std::vector<uint8_t> RemoteL3SocketTransport::read_frame() {
+    static constexpr size_t HEADER_BYTES = 40;
+    std::vector<uint8_t> frame(HEADER_BYTES);
+    size_t off = 0;
+    while (off < HEADER_BYTES) {
+        wait_readable();
+        ssize_t n = ::recv(fd_, frame.data() + off, HEADER_BYTES - off, 0);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            throw std::runtime_error(
+                std::string("RemoteL3SocketTransport: recv header failed: ") + std::strerror(errno)
+            );
+        }
+        if (n == 0) throw std::runtime_error("RemoteL3SocketTransport: socket closed while reading header");
+        off += static_cast<size_t>(n);
+    }
+    uint32_t payload_bytes = read_le_u32(frame.data() + 32);
+    if (payload_bytes > remote_l3::MAX_FRAME_PAYLOAD_BYTES) {
+        throw std::runtime_error("RemoteL3SocketTransport: frame payload exceeds maximum");
+    }
+    frame.resize(HEADER_BYTES + payload_bytes);
+    off = HEADER_BYTES;
+    while (off < frame.size()) {
+        wait_readable();
+        ssize_t n = ::recv(fd_, frame.data() + off, frame.size() - off, 0);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            throw std::runtime_error(
+                std::string("RemoteL3SocketTransport: recv payload failed: ") + std::strerror(errno)
+            );
+        }
+        if (n == 0) throw std::runtime_error("RemoteL3SocketTransport: socket closed while reading payload");
+        off += static_cast<size_t>(n);
+    }
+    return frame;
+}
+
+void RemoteL3SocketTransport::expect_hello_ready(
+    uint64_t session_id, int32_t endpoint_id, const std::string &comm_profile
+) {
+    auto frame = remote_l3::decode_frame(read_frame());
+    if (frame.header.frame_type != remote_l3::FrameType::HELLO) {
+        throw std::runtime_error("RemoteL3SocketTransport: expected HELLO frame");
+    }
+    auto hello = remote_l3::decode_hello(frame.payload.data(), frame.payload.size());
+    if (hello.session_id != session_id || hello.endpoint_id != endpoint_id) {
+        throw std::runtime_error("RemoteL3SocketTransport: HELLO session or endpoint mismatch");
+    }
+    if (hello.ready_state != remote_l3::ReadyState::READY) {
+        throw std::runtime_error("RemoteL3SocketTransport: HELLO did not report READY");
+    }
+    if (hello.comm_profile != comm_profile) {
+        throw std::runtime_error("RemoteL3SocketTransport: HELLO comm profile mismatch");
+    }
+    start_health_monitor(session_id, endpoint_id);
+}
+
+void RemoteL3SocketTransport::submit_frame(const std::vector<uint8_t> &frame) {
+    if (fd_ < 0) throw std::runtime_error("RemoteL3SocketTransport: socket is closed");
+    write_all(frame.data(), frame.size());
+}
+
+std::vector<uint8_t> RemoteL3SocketTransport::wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) {
+    auto frame_bytes = read_frame();
+    auto frame = remote_l3::decode_frame(frame_bytes);
+    if (frame.header.frame_type != frame_type || frame.header.sequence != sequence) {
+        throw std::runtime_error("RemoteL3SocketTransport: reply frame type or sequence mismatch");
+    }
+    return frame_bytes;
+}
+
+void RemoteL3SocketTransport::shutdown() { close_socket(); }
+
+RemoteL3Endpoint::RemoteL3Endpoint(
+    int32_t endpoint_id, uint64_t session_id, std::string transport_name, std::unique_ptr<RemoteL3Transport> transport
+) :
+    session_id_(session_id),
+    transport_(std::move(transport)) {
+    if (endpoint_id < 0) throw std::invalid_argument("RemoteL3Endpoint: endpoint_id must be non-negative");
+    if (session_id == 0) throw std::invalid_argument("RemoteL3Endpoint: session_id must be non-zero");
+    if (!transport_) throw std::invalid_argument("RemoteL3Endpoint: null transport");
+    caps_.kind = WorkerEndpointKind::REMOTE_L3;
+    caps_.endpoint_id = endpoint_id;
+    caps_.remote = true;
+    caps_.supports_task_dispatch = true;
+    caps_.supports_control = true;
+    caps_.transport = std::move(transport_name);
+}
+
+remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotState &slot, int32_t group_index) const {
+    remote_l3::TaskPayloadWire payload;
+    payload.callable_digest = slot.callable.digest;
+    payload.config = slot.config;
+
+    TaskArgsView view = slot.args_view(group_index);
+    const RemoteTaskArgsSidecar &sidecar = slot.remote_sidecar_for(group_index);
+    if (!sidecar.tensors.empty() && sidecar.tensors.size() != static_cast<size_t>(view.tensor_count)) {
+        throw std::runtime_error("RemoteL3Endpoint::run: remote sidecar tensor count does not match TaskArgs");
+    }
+    payload.args.inline_payload = sidecar.inline_payload;
+    payload.args.tensor_metadata.reserve(static_cast<size_t>(view.tensor_count));
+    payload.args.remote_desc.reserve(static_cast<size_t>(view.tensor_count));
+
+    for (int32_t i = 0; i < view.tensor_count; ++i) {
+        ContinuousTensor tensor = view.tensors[i];
+        RemoteTensorSidecar tensor_sidecar{};
+        if (!sidecar.tensors.empty()) tensor_sidecar = sidecar.tensors[static_cast<size_t>(i)];
+        if (tensor.data != 0 && !tensor_sidecar.present) {
+            throw std::runtime_error("RemoteL3Endpoint::run: bare host pointer submitted without remote sidecar");
+        }
+        if (tensor.is_child_memory() && !tensor_sidecar.present) {
+            throw std::runtime_error("RemoteL3Endpoint::run: child-memory tensor submitted without remote sidecar");
+        }
+        if (!tensor_sidecar.present && tensor.nbytes() != 0) {
+            throw std::runtime_error("RemoteL3Endpoint::run: tensor payload submitted without remote sidecar");
+        }
+        tensor.data = 0;
+        payload.args.tensor_metadata.push_back(tensor);
+        payload.args.remote_desc.push_back(tensor_sidecar);
+    }
+    payload.args.scalars.reserve(static_cast<size_t>(view.scalar_count));
+    for (int32_t i = 0; i < view.scalar_count; ++i)
+        payload.args.scalars.push_back(view.scalars[i]);
+    return payload;
+}
+
+WorkerCompletion RemoteL3Endpoint::run(Ring *ring, const WorkerDispatch &dispatch) {
+    if (ring == nullptr) throw std::invalid_argument("RemoteL3Endpoint::run: null ring");
+    TaskSlotState &slot = *ring->slot_state(dispatch.task_slot);
+
+    WorkerCompletion completion;
+    completion.task_slot = dispatch.task_slot;
+    completion.group_index = dispatch.group_index;
+
+    uint64_t sequence = 0;
+    std::unique_lock<std::mutex> command_lk(command_mu_);
+    try {
+        sequence = command_lane_.begin_command();
+        auto payload = remote_l3::encode_task_payload(build_task_payload(slot, dispatch.group_index));
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::TASK;
+        header.session_id = session_id_;
+        header.endpoint_id = caps_.endpoint_id;
+        header.sequence = sequence;
+        transport_->submit_frame(remote_l3::encode_frame(header, payload));
+
+        auto reply_bytes = transport_->wait_for_reply(remote_l3::FrameType::COMPLETION, sequence);
+        auto reply = remote_l3::decode_frame(reply_bytes);
+        if (reply.header.frame_type != remote_l3::FrameType::COMPLETION) {
+            throw std::runtime_error("RemoteL3Endpoint::run: expected COMPLETION reply");
+        }
+        if (reply.header.session_id != session_id_ || reply.header.endpoint_id != caps_.endpoint_id) {
+            throw std::runtime_error("RemoteL3Endpoint::run: completion session or endpoint mismatch");
+        }
+        auto decoded = remote_l3::decode_completion(reply.payload.data(), reply.payload.size(), sequence);
+        command_lane_.finish_reply(sequence);
+
+        if (decoded.error_code == 0) {
+            completion.outcome = EndpointOutcome::SUCCESS;
+        } else {
+            completion.outcome = EndpointOutcome::TASK_FAILURE;
+            completion.error_message = decoded.error_message;
+        }
+    } catch (const std::exception &e) {
+        if (sequence != 0 && command_lane_.in_flight()) {
+            try {
+                command_lane_.finish_reply(sequence);
+            } catch (...) {}
+        }
+        completion.outcome = EndpointOutcome::ENDPOINT_FAILURE;
+        completion.error_message =
+            std::string("RemoteL3Endpoint::run(endpoint=") + std::to_string(caps_.endpoint_id) + "): " + e.what();
+    }
+    return completion;
+}
+
+remote_l3::ControlReplyPayload
+RemoteL3Endpoint::run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes) {
+    std::unique_lock<std::mutex> command_lk(command_mu_);
+    uint64_t sequence = 0;
+    try {
+        sequence = command_lane_.begin_command();
+        remote_l3::ControlPayload control;
+        control.control_name = control_name;
+        control.control_version = 1;
+        control.command_bytes = command_bytes;
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::CONTROL;
+        header.session_id = session_id_;
+        header.endpoint_id = caps_.endpoint_id;
+        header.sequence = sequence;
+        transport_->submit_frame(remote_l3::encode_frame(header, remote_l3::encode_control(control)));
+
+        auto reply_bytes = transport_->wait_for_reply(remote_l3::FrameType::CONTROL_REPLY, sequence);
+        auto reply = remote_l3::decode_frame(reply_bytes);
+        if (reply.header.session_id != session_id_ || reply.header.endpoint_id != caps_.endpoint_id) {
+            throw std::runtime_error("RemoteL3Endpoint::control: reply session or endpoint mismatch");
+        }
+        auto decoded =
+            remote_l3::decode_control_reply(reply.payload.data(), reply.payload.size(), sequence, control_name, 1);
+        command_lane_.finish_reply(sequence);
+        if (decoded.error_code != 0) {
+            throw std::runtime_error(decoded.error_message);
+        }
+        return decoded;
+    } catch (...) {
+        if (sequence != 0 && command_lane_.in_flight()) {
+            try {
+                command_lane_.finish_reply(sequence);
+            } catch (...) {}
+        }
+        throw;
+    }
+}
+
+void RemoteL3Endpoint::control_remote_prepare_register(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest,
+    const void *payload, size_t payload_size
+) {
+    if (payload == nullptr && payload_size != 0) {
+        throw std::invalid_argument("RemoteL3Endpoint::control_remote_prepare_register: null payload");
+    }
+    std::vector<uint8_t> bytes;
+    const auto *payload_bytes = static_cast<const uint8_t *>(payload);
+    if (payload_size > 0) bytes.assign(payload_bytes, payload_bytes + payload_size);
+    run_control(
+        remote_l3::ControlName::PREPARE_REGISTER_CALLABLE,
+        remote_l3::encode_register_callable_command(target_registry, callable_kind, digest_array(digest), 1, bytes)
+    );
+}
+
+void RemoteL3Endpoint::control_prepare(const uint8_t *digest) {
+    run_control(
+        remote_l3::ControlName::PREPARE_CALLABLE,
+        remote_l3::encode_digest_callable_command(
+            remote_l3::RemoteRegistryTarget::REMOTE_TASK_DISPATCHER, CallableKind::PYTHON_IMPORT, digest_array(digest)
+        )
+    );
+}
+
+void RemoteL3Endpoint::control_remote_commit_register(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    run_control(
+        remote_l3::ControlName::COMMIT_REGISTER_CALLABLE,
+        remote_l3::encode_digest_callable_command(target_registry, callable_kind, digest_array(digest))
+    );
+}
+
+void RemoteL3Endpoint::control_remote_abort_register(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    run_control(
+        remote_l3::ControlName::ABORT_REGISTER_CALLABLE,
+        remote_l3::encode_digest_callable_command(target_registry, callable_kind, digest_array(digest))
+    );
+}
+
+void RemoteL3Endpoint::control_remote_unregister(
+    remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+) {
+    run_control(
+        remote_l3::ControlName::UNREGISTER_CALLABLE,
+        remote_l3::encode_digest_callable_command(target_registry, callable_kind, digest_array(digest))
+    );
+}
+
+RemoteBufferHandle RemoteL3Endpoint::control_remote_malloc(size_t size) {
+    std::vector<uint8_t> command;
+    put_u64(command, static_cast<uint64_t>(size));
+    auto reply = run_control(remote_l3::ControlName::ALLOC_REMOTE_BUFFER, command);
+    size_t offset = 0;
+    RemoteBufferHandle handle;
+    handle.endpoint_id = get_i32(reply.result_bytes, offset);
+    handle.owner_endpoint_id = handle.endpoint_id;
+    handle.buffer_id = get_u64(reply.result_bytes, offset);
+    handle.generation = get_u64(reply.result_bytes, offset);
+    handle.import_id = 0;
+    handle.address_space = static_cast<RemoteAddressSpace>(get_i32(reply.result_bytes, offset));
+    handle.nbytes = get_u64(reply.result_bytes, offset);
+    handle.offset = 0;
+    handle.remote_addr = get_u64(reply.result_bytes, offset);
+    handle.rkey_or_token = get_u64(reply.result_bytes, offset);
+    handle.ub_ldst_va = get_u64(reply.result_bytes, offset);
+    handle.access_flags = remote_l3::REMOTE_BUFFER_ACCESS_READ_WRITE;
+    if (handle.endpoint_id != caps_.endpoint_id) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: endpoint mismatch in result");
+    }
+    if (offset != reply.result_bytes.size()) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: trailing bytes in result");
+    }
+    return handle;
+}
+
+void RemoteL3Endpoint::control_remote_free(const RemoteBufferHandle &handle) {
+    std::vector<uint8_t> command;
+    put_i32(command, handle.endpoint_id);
+    put_u64(command, handle.buffer_id);
+    put_u64(command, handle.generation);
+    run_control(remote_l3::ControlName::FREE_REMOTE_BUFFER, command);
+}
+
+void RemoteL3Endpoint::control_remote_copy_to(
+    const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size
+) {
+    if (src == nullptr && size != 0) throw std::invalid_argument("control_remote_copy_to: null src");
+    std::vector<uint8_t> command;
+    put_i32(command, handle.endpoint_id);
+    put_u64(command, handle.buffer_id);
+    put_u64(command, handle.generation);
+    put_u64(command, offset);
+    put_u64(command, static_cast<uint64_t>(size));
+    const auto *bytes = static_cast<const uint8_t *>(src);
+    if (size > 0) command.insert(command.end(), bytes, bytes + size);
+    run_control(remote_l3::ControlName::COPY_TO_REMOTE, command);
+}
+
+void RemoteL3Endpoint::control_remote_copy_from(
+    void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size
+) {
+    if (dst == nullptr && size != 0) throw std::invalid_argument("control_remote_copy_from: null dst");
+    std::vector<uint8_t> command;
+    put_i32(command, handle.endpoint_id);
+    put_u64(command, handle.buffer_id);
+    put_u64(command, handle.generation);
+    put_u64(command, offset);
+    put_u64(command, static_cast<uint64_t>(size));
+    auto reply = run_control(remote_l3::ControlName::COPY_FROM_REMOTE, command);
+    if (reply.result_bytes.size() != size) {
+        throw std::runtime_error("control_remote_copy_from: result size mismatch");
+    }
+    if (size > 0) std::memcpy(dst, reply.result_bytes.data(), size);
+}
+
+RemoteBufferExport RemoteL3Endpoint::control_remote_export(
+    const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+    const std::string &transport_profile
+) {
+    const int32_t owner_endpoint_id = handle.owner_endpoint_id >= 0 ? handle.owner_endpoint_id : handle.endpoint_id;
+    if (owner_endpoint_id != caps_.endpoint_id) {
+        throw std::invalid_argument("RemoteL3Endpoint::control_remote_export: endpoint is not the owner");
+    }
+    remote_l3::ExportBufferRequest request;
+    request.owner_endpoint_id = owner_endpoint_id;
+    request.buffer_id = handle.buffer_id;
+    request.generation = handle.generation;
+    request.offset = handle.offset + offset;
+    request.nbytes = size;
+    request.access_flags = access_flags;
+    request.transport_profile = transport_profile;
+    auto reply = run_control(remote_l3::ControlName::EXPORT_BUFFER, remote_l3::encode_export_buffer_request(request));
+    auto result = remote_l3::decode_export_buffer_result(reply.result_bytes.data(), reply.result_bytes.size());
+    if (result.owner_endpoint_id != owner_endpoint_id) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_export: owner endpoint mismatch in result");
+    }
+    return result;
+}
+
+RemoteBufferHandle RemoteL3Endpoint::control_remote_import(
+    int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+) {
+    if (importer_endpoint_id != caps_.endpoint_id) {
+        throw std::invalid_argument("RemoteL3Endpoint::control_remote_import: endpoint is not the importer");
+    }
+    remote_l3::ImportBufferRequest request;
+    request.importer_endpoint_id = importer_endpoint_id;
+    request.requested_access_flags = requested_access_flags;
+    request.export_desc = export_desc;
+    auto reply = run_control(remote_l3::ControlName::IMPORT_BUFFER, remote_l3::encode_import_buffer_request(request));
+    auto handle = remote_l3::decode_import_buffer_result(reply.result_bytes.data(), reply.result_bytes.size());
+    if (handle.endpoint_id != importer_endpoint_id) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_import: importer endpoint mismatch in result");
+    }
+    return handle;
+}
+
+void RemoteL3Endpoint::control_remote_release_import(const RemoteBufferHandle &handle) {
+    if (handle.endpoint_id != caps_.endpoint_id) {
+        throw std::invalid_argument("RemoteL3Endpoint::control_remote_release_import: endpoint is not the importer");
+    }
+    remote_l3::ReleaseImportRequest request;
+    request.importer_endpoint_id = handle.endpoint_id;
+    request.owner_endpoint_id = handle.owner_endpoint_id;
+    request.buffer_id = handle.buffer_id;
+    request.generation = handle.generation;
+    request.import_id = handle.import_id;
+    run_control(remote_l3::ControlName::RELEASE_IMPORT, remote_l3::encode_release_import_request(request));
+}
+
+void RemoteL3Endpoint::shutdown_child() {
+    if (!transport_) return;
+    try {
+        std::lock_guard<std::mutex> command_lk(command_mu_);
+        uint64_t sequence = command_lane_.begin_command();
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::SHUTDOWN;
+        header.session_id = session_id_;
+        header.endpoint_id = caps_.endpoint_id;
+        header.sequence = sequence;
+        transport_->submit_frame(remote_l3::encode_frame(header, {}));
+        command_lane_.finish_reply(sequence);
+        transport_->shutdown();
+    } catch (...) {}
+}

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -12,18 +12,20 @@
 #include "remote_endpoint.h"
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <netdb.h>
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <array>
 #include <atomic>
+#include <cerrno>
 #include <chrono>
 #include <cstring>
-#include <cerrno>
 #include <cstdint>
-#include <array>
+#include <future>
 #include <stdexcept>
 #include <thread>
 #include <utility>
@@ -31,6 +33,22 @@
 #include "ring.h"
 
 namespace {
+
+using Deadline = std::chrono::steady_clock::time_point;
+
+struct TcpAddress {
+    int family{AF_UNSPEC};
+    int socktype{SOCK_STREAM};
+    int protocol{0};
+    sockaddr_storage addr{};
+    socklen_t addrlen{0};
+};
+
+struct ResolveTcpResult {
+    int error_code{0};
+    std::string error_message;
+    std::vector<TcpAddress> addresses;
+};
 
 uint32_t read_le_u32(const uint8_t *data) {
     return static_cast<uint32_t>(data[0]) | (static_cast<uint32_t>(data[1]) << 8) |
@@ -76,6 +94,12 @@ int32_t get_i32(const std::vector<uint8_t> &data, size_t &offset) {
     return static_cast<int32_t>(v);
 }
 
+double remaining_seconds(Deadline deadline, const std::string &message) {
+    auto now = std::chrono::steady_clock::now();
+    if (now >= deadline) throw std::runtime_error(message);
+    return std::chrono::duration<double>(deadline - now).count();
+}
+
 timeval timeout_to_timeval(double timeout_s) {
     if (timeout_s <= 0.0) throw std::invalid_argument("RemoteL3SocketTransport: timeout must be positive");
     timeval tv{};
@@ -84,39 +108,204 @@ timeval timeout_to_timeval(double timeout_s) {
     return tv;
 }
 
-int connect_tcp_socket(const std::string &host, uint16_t port, const std::string &label) {
+ResolveTcpResult resolve_tcp_addresses(const std::string &host, const std::string &port_s) {
     addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     addrinfo *results = nullptr;
-    std::string port_s = std::to_string(port);
+
+    ResolveTcpResult result;
     int rc = getaddrinfo(host.c_str(), port_s.c_str(), &hints, &results);
     if (rc != 0) {
-        throw std::runtime_error(label + ": getaddrinfo failed for " + host + ":" + port_s + ": " + gai_strerror(rc));
+        result.error_code = rc;
+        result.error_message = gai_strerror(rc);
+        return result;
     }
+    for (addrinfo *ai = results; ai != nullptr; ai = ai->ai_next) {
+        if (ai->ai_addrlen > sizeof(sockaddr_storage)) continue;
+        TcpAddress addr;
+        addr.family = ai->ai_family;
+        addr.socktype = ai->ai_socktype;
+        addr.protocol = ai->ai_protocol;
+        addr.addrlen = static_cast<socklen_t>(ai->ai_addrlen);
+        std::memcpy(&addr.addr, ai->ai_addr, ai->ai_addrlen);
+        result.addresses.push_back(addr);
+    }
+    freeaddrinfo(results);
+    return result;
+}
 
+std::vector<TcpAddress> resolve_tcp_addresses_with_timeout(
+    const std::string &host, const std::string &port_s, const std::string &label, Deadline deadline
+) {
+    auto promise = std::make_shared<std::promise<ResolveTcpResult>>();
+    std::future<ResolveTcpResult> future = promise->get_future();
+    std::thread([promise, host, port_s]() {
+        try {
+            promise->set_value(resolve_tcp_addresses(host, port_s));
+        } catch (...) {
+            promise->set_exception(std::current_exception());
+        }
+    }).detach();
+
+    double remaining = remaining_seconds(deadline, label + ": timed out resolving address");
+    if (future.wait_for(std::chrono::duration<double>(remaining)) != std::future_status::ready) {
+        throw std::runtime_error(label + ": timed out resolving address");
+    }
+    ResolveTcpResult result = future.get();
+    if (result.error_code != 0) {
+        throw std::runtime_error(
+            label + ": getaddrinfo failed for " + host + ":" + port_s + ": " + result.error_message
+        );
+    }
+    if (result.addresses.empty()) {
+        throw std::runtime_error(label + ": no TCP address found for " + host + ":" + port_s);
+    }
+    return result.addresses;
+}
+
+void configure_socket_no_sigpipe(int fd, const std::string &label) {
+#if defined(SO_NOSIGPIPE)
+    int one = 1;
+    if (::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one)) != 0) {
+        throw std::runtime_error(label + ": setsockopt(SO_NOSIGPIPE) failed: " + std::strerror(errno));
+    }
+#else
+    (void)fd;
+    (void)label;
+#endif
+}
+
+ssize_t send_no_sigpipe(int fd, const uint8_t *data, size_t size) {
+#if defined(MSG_NOSIGNAL)
+    return ::send(fd, data, size, MSG_NOSIGNAL);
+#else
+    return ::send(fd, data, size, 0);
+#endif
+}
+
+void restore_socket_flags(int fd, int flags, const std::string &label) {
+    if (::fcntl(fd, F_SETFL, flags) != 0) {
+        throw std::runtime_error(label + ": fcntl(F_SETFL) failed: " + std::strerror(errno));
+    }
+}
+
+int wait_for_connect(int fd, Deadline deadline, const std::string &label) {
+    while (true) {
+        double remaining = remaining_seconds(deadline, label + ": connect timed out");
+        timeval tv = timeout_to_timeval(std::min(0.2, remaining));
+        fd_set wfds;
+        FD_ZERO(&wfds);
+        FD_SET(fd, &wfds);
+        int rc = ::select(fd + 1, nullptr, &wfds, nullptr, &tv);
+        if (rc == 0) continue;
+        if (rc < 0) {
+            if (errno == EINTR) continue;
+            return errno;
+        }
+        int socket_error = 0;
+        socklen_t len = sizeof(socket_error);
+        if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &socket_error, &len) != 0) {
+            return errno;
+        }
+        return socket_error;
+    }
+}
+
+int connect_tcp_socket(const std::string &host, uint16_t port, const std::string &label, double timeout_s) {
+    Deadline deadline =
+        std::chrono::steady_clock::now() +
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<double>(timeout_s));
+    std::string port_s = std::to_string(port);
+    std::vector<TcpAddress> addresses = resolve_tcp_addresses_with_timeout(host, port_s, label, deadline);
     int fd = -1;
     int last_errno = 0;
-    for (addrinfo *ai = results; ai != nullptr; ai = ai->ai_next) {
-        int candidate = ::socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    for (const TcpAddress &addr : addresses) {
+        (void)remaining_seconds(deadline, label + ": connect timed out");
+        int candidate = ::socket(addr.family, addr.socktype, addr.protocol);
         if (candidate < 0) {
             last_errno = errno;
             continue;
         }
-        if (::connect(candidate, ai->ai_addr, ai->ai_addrlen) == 0) {
-            fd = candidate;
-            break;
+        try {
+            configure_socket_no_sigpipe(candidate, label);
+            int flags = ::fcntl(candidate, F_GETFL, 0);
+            if (flags < 0) {
+                last_errno = errno;
+                ::close(candidate);
+                continue;
+            }
+            if (::fcntl(candidate, F_SETFL, flags | O_NONBLOCK) != 0) {
+                last_errno = errno;
+                ::close(candidate);
+                continue;
+            }
+            int rc = ::connect(candidate, reinterpret_cast<const sockaddr *>(&addr.addr), addr.addrlen);
+            if (rc == 0) {
+                restore_socket_flags(candidate, flags, label);
+                fd = candidate;
+                break;
+            }
+            if (errno != EINPROGRESS) {
+                last_errno = errno;
+                ::close(candidate);
+                continue;
+            }
+            int connect_error = wait_for_connect(candidate, deadline, label);
+            if (connect_error == 0) {
+                restore_socket_flags(candidate, flags, label);
+                fd = candidate;
+                break;
+            }
+            last_errno = connect_error;
+            ::close(candidate);
+        } catch (...) {
+            ::close(candidate);
+            throw;
         }
-        last_errno = errno;
-        ::close(candidate);
     }
-    freeaddrinfo(results);
     if (fd < 0) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            throw std::runtime_error(label + ": connect timed out to " + host + ":" + port_s);
+        }
         throw std::runtime_error(
             label + ": connect failed to " + host + ":" + port_s + ": " + std::strerror(last_errno)
         );
     }
     return fd;
+}
+
+RemoteAddressSpace decode_remote_address_space(int32_t raw, const char *field_name) {
+    switch (static_cast<RemoteAddressSpace>(raw)) {
+    case RemoteAddressSpace::HOST_INLINE:
+    case RemoteAddressSpace::REMOTE_DEVICE:
+    case RemoteAddressSpace::REMOTE_WINDOW:
+    case RemoteAddressSpace::UB_LDST:
+        return static_cast<RemoteAddressSpace>(raw);
+    default:
+        throw std::runtime_error(std::string("RemoteL3Endpoint: unknown ") + field_name);
+    }
+}
+
+void validate_owner_buffer_handle(const RemoteBufferHandle &handle, size_t requested_size) {
+    if (handle.buffer_id == 0) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: buffer_id must be non-zero");
+    }
+    if (handle.generation == 0) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: generation must be non-zero");
+    }
+    if (handle.import_id != 0) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: import_id must be zero");
+    }
+    if (handle.address_space != RemoteAddressSpace::REMOTE_DEVICE) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: owner allocation must be REMOTE_DEVICE");
+    }
+    if (handle.nbytes == 0 || handle.nbytes != static_cast<uint64_t>(requested_size)) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: result size mismatch");
+    }
+    if (handle.offset != 0) {
+        throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: owner allocation offset must be zero");
+    }
 }
 
 }  // namespace
@@ -140,7 +329,7 @@ RemoteL3SocketTransport::RemoteL3SocketTransport(
 RemoteL3SocketTransport::~RemoteL3SocketTransport() { close_socket(); }
 
 void RemoteL3SocketTransport::connect_socket() {
-    fd_ = connect_tcp_socket(host_, port_, "RemoteL3SocketTransport(command)");
+    fd_ = connect_tcp_socket(host_, port_, "RemoteL3SocketTransport(command)", timeout_s_);
 }
 
 void RemoteL3SocketTransport::close_socket() {
@@ -172,7 +361,7 @@ void RemoteL3SocketTransport::check_health() {
 
 void RemoteL3SocketTransport::start_health_monitor(uint64_t session_id, int32_t endpoint_id) {
     if (health_thread_.joinable()) return;
-    health_fd_ = connect_tcp_socket(health_host_, health_port_, "RemoteL3SocketTransport(health)");
+    health_fd_ = connect_tcp_socket(health_host_, health_port_, "RemoteL3SocketTransport(health)", timeout_s_);
     health_stop_.store(false, std::memory_order_release);
     health_failed_.store(false, std::memory_order_release);
     {
@@ -185,9 +374,9 @@ void RemoteL3SocketTransport::start_health_monitor(uint64_t session_id, int32_t 
         auto read_exact = [&](uint8_t *data, size_t size) -> bool {
             size_t off = 0;
             auto deadline =
-                std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-                                                       std::chrono::duration<double>(timeout_s)
-                                                   );
+                std::chrono::steady_clock::now() +
+                std::chrono::duration_cast<std::chrono::steady_clock::duration>(std::chrono::duration<double>(timeout_s)
+                );
             while (off < size) {
                 if (health_stop_.load(std::memory_order_acquire)) return false;
                 auto now = std::chrono::steady_clock::now();
@@ -305,7 +494,7 @@ void RemoteL3SocketTransport::write_all(const uint8_t *data, size_t size) {
     size_t off = 0;
     while (off < size) {
         wait_writable();
-        ssize_t n = ::send(fd_, data + off, size - off, 0);
+        ssize_t n = send_no_sigpipe(fd_, data + off, size - off);
         if (n < 0) {
             if (errno == EINTR) continue;
             throw std::runtime_error(std::string("RemoteL3SocketTransport: send failed: ") + std::strerror(errno));
@@ -583,6 +772,7 @@ void RemoteL3Endpoint::control_remote_unregister(
 }
 
 RemoteBufferHandle RemoteL3Endpoint::control_remote_malloc(size_t size) {
+    if (size == 0) throw std::invalid_argument("RemoteL3Endpoint::control_remote_malloc: size must be non-zero");
     std::vector<uint8_t> command;
     put_u64(command, static_cast<uint64_t>(size));
     auto reply = run_control(remote_l3::ControlName::ALLOC_REMOTE_BUFFER, command);
@@ -593,7 +783,8 @@ RemoteBufferHandle RemoteL3Endpoint::control_remote_malloc(size_t size) {
     handle.buffer_id = get_u64(reply.result_bytes, offset);
     handle.generation = get_u64(reply.result_bytes, offset);
     handle.import_id = 0;
-    handle.address_space = static_cast<RemoteAddressSpace>(get_i32(reply.result_bytes, offset));
+    handle.address_space =
+        decode_remote_address_space(get_i32(reply.result_bytes, offset), "ALLOC_REMOTE_BUFFER address_space");
     handle.nbytes = get_u64(reply.result_bytes, offset);
     handle.offset = 0;
     handle.remote_addr = get_u64(reply.result_bytes, offset);
@@ -606,6 +797,7 @@ RemoteBufferHandle RemoteL3Endpoint::control_remote_malloc(size_t size) {
     if (offset != reply.result_bytes.size()) {
         throw std::runtime_error("RemoteL3Endpoint::control_remote_malloc: trailing bytes in result");
     }
+    validate_owner_buffer_handle(handle, size);
     return handle;
 }
 

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -14,7 +14,7 @@
 #include <arpa/inet.h>
 #include <fcntl.h>
 #include <netdb.h>
-#include <sys/select.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -100,12 +100,10 @@ double remaining_seconds(Deadline deadline, const std::string &message) {
     return std::chrono::duration<double>(deadline - now).count();
 }
 
-timeval timeout_to_timeval(double timeout_s) {
+int timeout_to_poll_ms(double timeout_s) {
     if (timeout_s <= 0.0) throw std::invalid_argument("RemoteL3SocketTransport: timeout must be positive");
-    timeval tv{};
-    tv.tv_sec = static_cast<long>(timeout_s);
-    tv.tv_usec = static_cast<long>((timeout_s - static_cast<double>(tv.tv_sec)) * 1000000.0);
-    return tv;
+    int timeout_ms = static_cast<int>(timeout_s * 1000.0);
+    return timeout_ms > 0 ? timeout_ms : 1;
 }
 
 ResolveTcpResult resolve_tcp_addresses(const std::string &host, const std::string &port_s) {
@@ -190,25 +188,68 @@ void restore_socket_flags(int fd, int flags, const std::string &label) {
     }
 }
 
-int wait_for_connect(int fd, Deadline deadline, const std::string &label) {
+short poll_socket(
+    int fd, short events, Deadline deadline, const std::string &timeout_message, const std::string &poll_error_context
+) {
     while (true) {
-        double remaining = remaining_seconds(deadline, label + ": connect timed out");
-        timeval tv = timeout_to_timeval(std::min(0.2, remaining));
-        fd_set wfds;
-        FD_ZERO(&wfds);
-        FD_SET(fd, &wfds);
-        int rc = ::select(fd + 1, nullptr, &wfds, nullptr, &tv);
+        double remaining = remaining_seconds(deadline, timeout_message);
+        pollfd pfd{};
+        pfd.fd = fd;
+        pfd.events = events;
+        int rc = ::poll(&pfd, 1, timeout_to_poll_ms(std::min(0.2, remaining)));
         if (rc == 0) continue;
         if (rc < 0) {
             if (errno == EINTR) continue;
-            return errno;
+            throw std::runtime_error(poll_error_context + ": " + std::strerror(errno));
         }
+        if ((pfd.revents & POLLNVAL) != 0) {
+            throw std::runtime_error(poll_error_context + ": invalid file descriptor");
+        }
+        if ((pfd.revents & (events | POLLERR | POLLHUP)) != 0) {
+            return pfd.revents;
+        }
+    }
+}
+
+int wait_for_connect(int fd, Deadline deadline, const std::string &label) {
+    while (true) {
+        short revents =
+            poll_socket(fd, POLLOUT, deadline, label + ": connect timed out", label + ": poll(connect) failed");
         int socket_error = 0;
         socklen_t len = sizeof(socket_error);
         if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &socket_error, &len) != 0) {
             return errno;
         }
+        if (socket_error == 0 && (revents & (POLLERR | POLLHUP)) != 0) {
+            return ECONNRESET;
+        }
         return socket_error;
+    }
+}
+
+void validate_remote_buffer_relative_range(
+    const char *op_name, const RemoteBufferHandle &handle, uint64_t offset, uint64_t size
+) {
+    if (handle.nbytes == 0) {
+        throw std::invalid_argument(std::string(op_name) + ": handle size must be non-zero");
+    }
+    if (offset > handle.nbytes || size > handle.nbytes - offset) {
+        throw std::out_of_range(std::string(op_name) + ": range exceeds remote buffer");
+    }
+}
+
+void validate_remote_buffer_export_range(
+    const char *op_name, const RemoteBufferHandle &handle, uint64_t offset, uint64_t size
+) {
+    if (handle.nbytes == 0) {
+        throw std::invalid_argument(std::string(op_name) + ": handle size must be non-zero");
+    }
+    if (handle.offset > handle.nbytes) {
+        throw std::invalid_argument(std::string(op_name) + ": handle offset exceeds size");
+    }
+    uint64_t available = handle.nbytes - handle.offset;
+    if (offset > available || size > available - offset) {
+        throw std::out_of_range(std::string(op_name) + ": range exceeds remote buffer");
     }
 }
 
@@ -342,11 +383,10 @@ void RemoteL3SocketTransport::close_socket() {
 }
 
 void RemoteL3SocketTransport::mark_health_failed(const std::string &message) {
-    bool expected = false;
-    if (health_failed_.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
-        std::lock_guard<std::mutex> lk(health_mu_);
-        health_error_ = message;
-    }
+    std::lock_guard<std::mutex> lk(health_mu_);
+    if (health_failed_.load(std::memory_order_acquire)) return;
+    health_error_ = message;
+    health_failed_.store(true, std::memory_order_release);
 }
 
 void RemoteL3SocketTransport::check_health() {
@@ -381,17 +421,7 @@ void RemoteL3SocketTransport::start_health_monitor(uint64_t session_id, int32_t 
                 if (health_stop_.load(std::memory_order_acquire)) return false;
                 auto now = std::chrono::steady_clock::now();
                 if (now >= deadline) throw std::runtime_error("timed out waiting for HEALTH frame");
-                double remaining = std::chrono::duration<double>(deadline - now).count();
-                timeval tv = timeout_to_timeval(std::min(0.2, remaining));
-                fd_set rfds;
-                FD_ZERO(&rfds);
-                FD_SET(fd, &rfds);
-                int rc = ::select(fd + 1, &rfds, nullptr, nullptr, &tv);
-                if (rc == 0) continue;
-                if (rc < 0) {
-                    if (errno == EINTR) continue;
-                    throw std::runtime_error(std::string("select failed: ") + std::strerror(errno));
-                }
+                (void)poll_socket(fd, POLLIN, deadline, "timed out waiting for HEALTH frame", "poll failed");
                 ssize_t n = ::recv(fd, data + off, size - off, 0);
                 if (n < 0) {
                     if (errno == EINTR) continue;
@@ -450,19 +480,11 @@ void RemoteL3SocketTransport::wait_readable() {
         check_health();
         auto now = std::chrono::steady_clock::now();
         if (now >= deadline) throw std::runtime_error("RemoteL3SocketTransport: timed out waiting for frame");
-        double remaining = std::chrono::duration<double>(deadline - now).count();
-        timeval tv = timeout_to_timeval(std::min(0.2, remaining));
-        fd_set rfds;
-        FD_ZERO(&rfds);
-        FD_SET(fd_, &rfds);
-        int rc = ::select(fd_ + 1, &rfds, nullptr, nullptr, &tv);
-        if (rc > 0) return;
-        if (rc < 0) {
-            if (errno == EINTR) continue;
-            throw std::runtime_error(
-                std::string("RemoteL3SocketTransport: select(read) failed: ") + std::strerror(errno)
-            );
-        }
+        (void)poll_socket(
+            fd_, POLLIN, deadline, "RemoteL3SocketTransport: timed out waiting for frame",
+            "RemoteL3SocketTransport: poll(read) failed"
+        );
+        return;
     }
 }
 
@@ -474,19 +496,11 @@ void RemoteL3SocketTransport::wait_writable() {
         check_health();
         auto now = std::chrono::steady_clock::now();
         if (now >= deadline) throw std::runtime_error("RemoteL3SocketTransport: timed out writing frame");
-        double remaining = std::chrono::duration<double>(deadline - now).count();
-        timeval tv = timeout_to_timeval(std::min(0.2, remaining));
-        fd_set wfds;
-        FD_ZERO(&wfds);
-        FD_SET(fd_, &wfds);
-        int rc = ::select(fd_ + 1, nullptr, &wfds, nullptr, &tv);
-        if (rc > 0) return;
-        if (rc < 0) {
-            if (errno == EINTR) continue;
-            throw std::runtime_error(
-                std::string("RemoteL3SocketTransport: select(write) failed: ") + std::strerror(errno)
-            );
-        }
+        (void)poll_socket(
+            fd_, POLLOUT, deadline, "RemoteL3SocketTransport: timed out writing frame",
+            "RemoteL3SocketTransport: poll(write) failed"
+        );
+        return;
     }
 }
 
@@ -813,6 +827,7 @@ void RemoteL3Endpoint::control_remote_copy_to(
     const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size
 ) {
     if (src == nullptr && size != 0) throw std::invalid_argument("control_remote_copy_to: null src");
+    validate_remote_buffer_relative_range("control_remote_copy_to", handle, offset, static_cast<uint64_t>(size));
     std::vector<uint8_t> command;
     put_i32(command, handle.endpoint_id);
     put_u64(command, handle.buffer_id);
@@ -828,6 +843,7 @@ void RemoteL3Endpoint::control_remote_copy_from(
     void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size
 ) {
     if (dst == nullptr && size != 0) throw std::invalid_argument("control_remote_copy_from: null dst");
+    validate_remote_buffer_relative_range("control_remote_copy_from", handle, offset, static_cast<uint64_t>(size));
     std::vector<uint8_t> command;
     put_i32(command, handle.endpoint_id);
     put_u64(command, handle.buffer_id);
@@ -845,6 +861,7 @@ RemoteBufferExport RemoteL3Endpoint::control_remote_export(
     const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
     const std::string &transport_profile
 ) {
+    validate_remote_buffer_export_range("RemoteL3Endpoint::control_remote_export", handle, offset, size);
     const int32_t owner_endpoint_id = handle.owner_endpoint_id >= 0 ? handle.owner_endpoint_id : handle.endpoint_id;
     if (owner_endpoint_id != caps_.endpoint_id) {
         throw std::invalid_argument("RemoteL3Endpoint::control_remote_export: endpoint is not the owner");

--- a/src/common/hierarchical/remote_endpoint.h
+++ b/src/common/hierarchical/remote_endpoint.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "remote_wire.h"
+#include "worker_manager.h"
+
+class RemoteL3Transport {
+public:
+    virtual ~RemoteL3Transport() = default;
+    virtual void submit_frame(const std::vector<uint8_t> &frame) = 0;
+    virtual std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) = 0;
+    virtual void shutdown() {}
+};
+
+class RemoteL3SocketTransport : public RemoteL3Transport {
+public:
+    RemoteL3SocketTransport(
+        std::string host, uint16_t port, std::string health_host, uint16_t health_port, double timeout_s
+    );
+    ~RemoteL3SocketTransport() override;
+
+    void expect_hello_ready(uint64_t session_id, int32_t endpoint_id, const std::string &comm_profile);
+    void submit_frame(const std::vector<uint8_t> &frame) override;
+    std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) override;
+    void shutdown() override;
+
+private:
+    std::string host_;
+    uint16_t port_{0};
+    std::string health_host_;
+    uint16_t health_port_{0};
+    double timeout_s_{30.0};
+    int fd_{-1};
+    int health_fd_{-1};
+    std::thread health_thread_;
+    std::atomic<bool> health_stop_{false};
+    std::atomic<bool> health_failed_{false};
+    std::mutex health_mu_;
+    std::string health_error_;
+
+    void connect_socket();
+    void close_socket();
+    void start_health_monitor(uint64_t session_id, int32_t endpoint_id);
+    void stop_health_monitor();
+    void mark_health_failed(const std::string &message);
+    void check_health();
+    void wait_readable();
+    void wait_writable();
+    void write_all(const uint8_t *data, size_t size);
+    std::vector<uint8_t> read_frame();
+};
+
+class RemoteL3Endpoint : public WorkerEndpoint {
+public:
+    RemoteL3Endpoint(
+        int32_t endpoint_id, uint64_t session_id, std::string transport_name,
+        std::unique_ptr<RemoteL3Transport> transport
+    );
+
+    const WorkerEndpointCaps &caps() const override { return caps_; }
+    WorkerCompletion run(Ring *ring, const WorkerDispatch &dispatch) override;
+    void shutdown_child() override;
+    void control_prepare(const uint8_t *digest) override;
+    void control_remote_prepare_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest,
+        const void *payload, size_t payload_size
+    ) override;
+    void control_remote_commit_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    ) override;
+    void control_remote_abort_register(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    ) override;
+    void control_remote_unregister(
+        remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind, const uint8_t *digest
+    ) override;
+    RemoteBufferHandle control_remote_malloc(size_t size) override;
+    void control_remote_free(const RemoteBufferHandle &handle) override;
+    void
+    control_remote_copy_to(const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size) override;
+    void control_remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size) override;
+    RemoteBufferExport control_remote_export(
+        const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+        const std::string &transport_profile
+    ) override;
+    RemoteBufferHandle control_remote_import(
+        int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+    ) override;
+    void control_remote_release_import(const RemoteBufferHandle &handle) override;
+
+private:
+    WorkerEndpointCaps caps_;
+    uint64_t session_id_{0};
+    std::unique_ptr<RemoteL3Transport> transport_;
+    remote_l3::OrderedCommandLane command_lane_;
+    std::mutex command_mu_;
+
+    remote_l3::TaskPayloadWire build_task_payload(const TaskSlotState &slot, int32_t group_index) const;
+    remote_l3::ControlReplyPayload
+    run_control(remote_l3::ControlName control_name, const std::vector<uint8_t> &command_bytes);
+};

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -14,6 +14,9 @@
 #include <cstdlib>
 #include <mutex>
 #include <stdexcept>
+#include <utility>
+
+#include "remote_endpoint.h"
 
 // ---------------------------------------------------------------------------
 // Fork hygiene
@@ -71,6 +74,18 @@ void Worker::add_worker(WorkerType type, void *mailbox) {
     else manager_.add_sub(mailbox);
 }
 
+void Worker::add_remote_l3_socket(
+    int32_t endpoint_id, uint64_t session_id, const std::string &transport_name, const std::string &host, uint16_t port,
+    const std::string &health_host, uint16_t health_port, double timeout_s
+) {
+    if (initialized_) throw std::runtime_error("Worker: add_remote_l3_socket after init");
+    auto transport = std::make_unique<RemoteL3SocketTransport>(host, port, health_host, health_port, timeout_s);
+    transport->expect_hello_ready(session_id, endpoint_id, transport_name);
+    manager_.add_next_level_endpoint(
+        std::make_unique<RemoteL3Endpoint>(endpoint_id, session_id, transport_name, std::move(transport))
+    );
+}
+
 void Worker::init() {
     if (initialized_) throw std::runtime_error("Worker: already initialized");
 
@@ -79,7 +94,7 @@ void Worker::init() {
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().
     manager_.start(&allocator_, [this](WorkerCompletion completion) {
-        scheduler_.worker_done(completion);
+        scheduler_.worker_done(std::move(completion));
     });
 
     Scheduler::Config cfg;

--- a/src/common/hierarchical/worker.h
+++ b/src/common/hierarchical/worker.h
@@ -76,6 +76,13 @@ public:
     // child and consumes the mailbox via the Python child loop.
     void add_worker(WorkerType type, void *mailbox);
 
+    // Register a REMOTE_L3 endpoint only after its session runner completed
+    // prestart and reported HELLO READY on the command lane.
+    void add_remote_l3_socket(
+        int32_t endpoint_id, uint64_t session_id, const std::string &transport_name, const std::string &host,
+        uint16_t port, const std::string &health_host, uint16_t health_port, double timeout_s
+    );
+
     // Start the scheduler thread. Must be called AFTER the parent has forked
     // any child workers — init() spins up threads in the parent that would
     // otherwise be accidentally inherited across fork.
@@ -110,6 +117,54 @@ public:
     control_digest_only(WorkerType type, int worker_id, uint64_t sub_cmd, const uint8_t *digest, double timeout_s) {
         return manager_.control_digest_only(type, worker_id, sub_cmd, digest, timeout_s);
     }
+    ControlResult remote_prepare_register(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const void *payload, size_t payload_size, const uint8_t *digest
+    ) {
+        return manager_.control_remote_prepare_register(
+            endpoint_id, target_registry, callable_kind, payload, payload_size, digest
+        );
+    }
+    ControlResult remote_commit_register(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const uint8_t *digest
+    ) {
+        return manager_.control_remote_commit_register(endpoint_id, target_registry, callable_kind, digest);
+    }
+    ControlResult remote_abort_register(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const uint8_t *digest
+    ) {
+        return manager_.control_remote_abort_register(endpoint_id, target_registry, callable_kind, digest);
+    }
+    ControlResult remote_unregister(
+        int endpoint_id, remote_l3::RemoteRegistryTarget target_registry, CallableKind callable_kind,
+        const uint8_t *digest
+    ) {
+        return manager_.control_remote_unregister(endpoint_id, target_registry, callable_kind, digest);
+    }
+    RemoteBufferHandle remote_malloc(int endpoint_id, size_t size) {
+        return manager_.control_remote_malloc(endpoint_id, size);
+    }
+    void remote_free(const RemoteBufferHandle &handle) { manager_.control_remote_free(handle); }
+    void remote_copy_to(const RemoteBufferHandle &handle, uint64_t offset, const void *src, size_t size) {
+        manager_.control_remote_copy_to(handle, offset, src, size);
+    }
+    void remote_copy_from(void *dst, const RemoteBufferHandle &handle, uint64_t offset, size_t size) {
+        manager_.control_remote_copy_from(dst, handle, offset, size);
+    }
+    RemoteBufferExport remote_export(
+        const RemoteBufferHandle &handle, uint64_t offset, uint64_t size, uint32_t access_flags,
+        const std::string &transport_profile
+    ) {
+        return manager_.control_remote_export(handle, offset, size, access_flags, transport_profile);
+    }
+    RemoteBufferHandle remote_import(
+        int32_t importer_endpoint_id, const RemoteBufferExport &export_desc, uint32_t requested_access_flags
+    ) {
+        return manager_.control_remote_import(importer_endpoint_id, export_desc, requested_access_flags);
+    }
+    void remote_release_import(const RemoteBufferHandle &handle) { manager_.control_remote_release_import(handle); }
 
     // Broadcast CTRL_REGISTER / CTRL_UNREGISTER for a ChipCallable digest to
     // every NEXT_LEVEL child in parallel. `blob_ptr`/`blob_size` describe

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -132,6 +132,7 @@ add_library(hierarchical_objs OBJECT
     ${HIERARCHICAL_SRC_DIR}/ring.cpp
     ${HIERARCHICAL_SRC_DIR}/scope.cpp
     ${HIERARCHICAL_SRC_DIR}/remote_wire.cpp
+    ${HIERARCHICAL_SRC_DIR}/remote_endpoint.cpp
     ${HIERARCHICAL_SRC_DIR}/orchestrator.cpp
     ${HIERARCHICAL_SRC_DIR}/worker_manager.cpp
     ${HIERARCHICAL_SRC_DIR}/scheduler.cpp
@@ -281,6 +282,7 @@ add_hierarchical_test(test_scope      hierarchical/test_scope.cpp)
 add_hierarchical_test(test_orchestrator hierarchical/test_orchestrator.cpp)
 add_hierarchical_test(test_scheduler  hierarchical/test_scheduler.cpp)
 add_hierarchical_test(test_remote_wire hierarchical/test_remote_wire.cpp)
+add_hierarchical_test(test_remote_endpoint hierarchical/test_remote_endpoint.cpp)
 
 # ---------------------------------------------------------------------------
 # Types / task_interface tests (src/common/task_interface/)

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "remote_endpoint.h"
+#include "ring.h"
+
+namespace {
+
+class FakeRemoteTransport : public RemoteL3Transport {
+public:
+    int32_t next_error_code{0};
+    std::string next_error_message;
+    std::vector<uint8_t> last_frame;
+    remote_l3::ControlName last_control_name{remote_l3::ControlName::PREPARE_CALLABLE};
+    remote_l3::RemoteRegistryTarget last_target_registry{remote_l3::RemoteRegistryTarget::REMOTE_TASK_DISPATCHER};
+    CallableKind last_callable_kind{CallableKind::PYTHON_IMPORT};
+
+    void submit_frame(const std::vector<uint8_t> &frame) override { last_frame = frame; }
+
+    std::vector<uint8_t> wait_for_reply(remote_l3::FrameType frame_type, uint64_t sequence) override {
+        auto submitted = remote_l3::decode_frame(last_frame);
+        EXPECT_EQ(submitted.header.sequence, sequence);
+        if (submitted.header.frame_type == remote_l3::FrameType::CONTROL) {
+            EXPECT_EQ(frame_type, remote_l3::FrameType::CONTROL_REPLY);
+            auto control = remote_l3::decode_control(submitted.payload.data(), submitted.payload.size());
+            last_control_name = control.control_name;
+            if (control.control_name == remote_l3::ControlName::PREPARE_REGISTER_CALLABLE) {
+                EXPECT_GE(control.command_bytes.size(), 8u);
+                uint32_t raw_target = static_cast<uint32_t>(control.command_bytes[0]) |
+                                      (static_cast<uint32_t>(control.command_bytes[1]) << 8) |
+                                      (static_cast<uint32_t>(control.command_bytes[2]) << 16) |
+                                      (static_cast<uint32_t>(control.command_bytes[3]) << 24);
+                uint32_t raw_kind = static_cast<uint32_t>(control.command_bytes[4]) |
+                                    (static_cast<uint32_t>(control.command_bytes[5]) << 8) |
+                                    (static_cast<uint32_t>(control.command_bytes[6]) << 16) |
+                                    (static_cast<uint32_t>(control.command_bytes[7]) << 24);
+                last_target_registry = static_cast<remote_l3::RemoteRegistryTarget>(raw_target);
+                last_callable_kind = static_cast<CallableKind>(static_cast<int32_t>(raw_kind));
+            }
+            remote_l3::ControlReplyPayload payload;
+            payload.sequence = sequence;
+            payload.control_name = control.control_name;
+            payload.control_version = control.control_version;
+            remote_l3::FrameHeader header;
+            header.frame_type = remote_l3::FrameType::CONTROL_REPLY;
+            header.session_id = submitted.header.session_id;
+            header.endpoint_id = submitted.header.endpoint_id;
+            header.sequence = sequence;
+            return remote_l3::encode_frame(header, remote_l3::encode_control_reply(payload));
+        }
+
+        EXPECT_EQ(frame_type, remote_l3::FrameType::COMPLETION);
+        auto task = remote_l3::decode_task_payload(submitted.payload.data(), submitted.payload.size());
+        EXPECT_EQ(task.callable_digest[0], 0x5A);
+
+        remote_l3::CompletionPayload payload;
+        payload.sequence = sequence;
+        payload.error_code = next_error_code;
+        payload.error_message = next_error_message;
+        remote_l3::FrameHeader header;
+        header.frame_type = remote_l3::FrameType::COMPLETION;
+        header.session_id = submitted.header.session_id;
+        header.endpoint_id = submitted.header.endpoint_id;
+        header.sequence = sequence;
+        return remote_l3::encode_frame(header, remote_l3::encode_completion(payload));
+    }
+};
+
+TaskSlot make_slot(Ring &ring, const TaskArgs &args) {
+    AllocResult ar = ring.alloc(0, 0);
+    if (ar.slot == INVALID_SLOT) throw std::runtime_error("alloc failed");
+    TaskSlotState &s = *ring.slot_state(ar.slot);
+    s.reset();
+    s.callable.digest.fill(0x5A);
+    s.worker_type = WorkerType::NEXT_LEVEL;
+    s.task_args = args;
+    s.is_group_ = false;
+    s.state.store(TaskState::RUNNING);
+    return ar.slot;
+}
+
+TaskArgs scalar_args() {
+    TaskArgs args;
+    args.add_scalar(7);
+    return args;
+}
+
+TaskArgs bare_pointer_args() {
+    TaskArgs args;
+    ContinuousTensor tensor{};
+    tensor.data = 0x1234;
+    tensor.ndims = 1;
+    tensor.shapes[0] = 1;
+    tensor.dtype = DataType::UINT8;
+    args.add_tensor(tensor, TensorArgType::INPUT);
+    return args;
+}
+
+}  // namespace
+
+TEST(RemoteEndpoint, SuccessCompletionMapsToSuccess) {
+    Ring ring;
+    ring.init(1ULL << 20);
+    TaskSlot slot = make_slot(ring, scalar_args());
+
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+
+    WorkerDispatch dispatch;
+    dispatch.task_slot = slot;
+    WorkerCompletion completion = endpoint.run(&ring, dispatch);
+
+    EXPECT_EQ(completion.outcome, EndpointOutcome::SUCCESS);
+    EXPECT_FALSE(transport->last_frame.empty());
+    ring.shutdown();
+}
+
+TEST(RemoteEndpoint, RemoteTaskErrorMapsToTaskFailure) {
+    Ring ring;
+    ring.init(1ULL << 20);
+    TaskSlot slot = make_slot(ring, scalar_args());
+
+    auto *transport = new FakeRemoteTransport();
+    transport->next_error_code = 1;
+    transport->next_error_message = "remote orch failed";
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+
+    WorkerDispatch dispatch;
+    dispatch.task_slot = slot;
+    WorkerCompletion completion = endpoint.run(&ring, dispatch);
+
+    EXPECT_EQ(completion.outcome, EndpointOutcome::TASK_FAILURE);
+    EXPECT_EQ(completion.error_message, "remote orch failed");
+    ring.shutdown();
+}
+
+TEST(RemoteEndpoint, ControlPrepareUsesTypedPrepareCallableFrame) {
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+    std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> digest{};
+    digest.fill(0x7B);
+
+    endpoint.control_prepare(digest.data());
+
+    EXPECT_EQ(transport->last_control_name, remote_l3::ControlName::PREPARE_CALLABLE);
+}
+
+TEST(RemoteEndpoint, RemoteRegisterPrepareCarriesRequestedRegistryTarget) {
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+    std::array<uint8_t, CALLABLE_HASH_DIGEST_SIZE> digest{};
+    digest.fill(0x7B);
+    std::vector<uint8_t> payload{'x'};
+
+    endpoint.control_remote_prepare_register(
+        remote_l3::RemoteRegistryTarget::INNER_L3_WORKER, CallableKind::CHIP_CALLABLE, digest.data(), payload.data(),
+        payload.size()
+    );
+
+    EXPECT_EQ(transport->last_control_name, remote_l3::ControlName::PREPARE_REGISTER_CALLABLE);
+    EXPECT_EQ(transport->last_target_registry, remote_l3::RemoteRegistryTarget::INNER_L3_WORKER);
+    EXPECT_EQ(transport->last_callable_kind, CallableKind::CHIP_CALLABLE);
+}
+
+TEST(RemoteEndpoint, BareHostPointerWithoutSidecarIsEndpointFailure) {
+    Ring ring;
+    ring.init(1ULL << 20);
+    TaskSlot slot = make_slot(ring, bare_pointer_args());
+
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+
+    WorkerDispatch dispatch;
+    dispatch.task_slot = slot;
+    WorkerCompletion completion = endpoint.run(&ring, dispatch);
+
+    EXPECT_EQ(completion.outcome, EndpointOutcome::ENDPOINT_FAILURE);
+    EXPECT_NE(completion.error_message.find("bare host pointer"), std::string::npos);
+    EXPECT_TRUE(transport->last_frame.empty());
+    ring.shutdown();
+}

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -11,8 +11,19 @@
 
 #include <gtest/gtest.h>
 
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <csignal>
+#include <chrono>
+#include <cstring>
 #include <memory>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -21,10 +32,96 @@
 
 namespace {
 
+volatile sig_atomic_t g_sigpipe_count = 0;
+
+void count_sigpipe(int) { ++g_sigpipe_count; }
+
+class ScopedSigpipeCounter {
+public:
+    ScopedSigpipeCounter() {
+        struct sigaction action {};
+        action.sa_handler = count_sigpipe;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = 0;
+        if (sigaction(SIGPIPE, &action, &old_action_) != 0) {
+            throw std::runtime_error(std::string("sigaction failed: ") + std::strerror(errno));
+        }
+        g_sigpipe_count = 0;
+    }
+
+    ~ScopedSigpipeCounter() { (void)sigaction(SIGPIPE, &old_action_, nullptr); }
+
+    ScopedSigpipeCounter(const ScopedSigpipeCounter &) = delete;
+    ScopedSigpipeCounter &operator=(const ScopedSigpipeCounter &) = delete;
+
+private:
+    struct sigaction old_action_ {};
+};
+
+void append_i32(std::vector<uint8_t> &out, int32_t v) {
+    uint32_t raw = static_cast<uint32_t>(v);
+    for (int i = 0; i < 4; ++i)
+        out.push_back(static_cast<uint8_t>((raw >> (8 * i)) & 0xffU));
+}
+
+void append_u64(std::vector<uint8_t> &out, uint64_t v) {
+    for (int i = 0; i < 8; ++i)
+        out.push_back(static_cast<uint8_t>((v >> (8 * i)) & 0xffU));
+}
+
+std::vector<uint8_t>
+malloc_result(int32_t endpoint_id, uint64_t buffer_id, uint64_t generation, int32_t address_space, uint64_t nbytes) {
+    std::vector<uint8_t> out;
+    append_i32(out, endpoint_id);
+    append_u64(out, buffer_id);
+    append_u64(out, generation);
+    append_i32(out, address_space);
+    append_u64(out, nbytes);
+    append_u64(out, 0x1000);
+    append_u64(out, 0x2000);
+    append_u64(out, 0x3000);
+    return out;
+}
+
+uint16_t start_closing_server(std::thread &server_thread) {
+    int listener = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (listener < 0) throw std::runtime_error(std::string("socket failed: ") + std::strerror(errno));
+    int one = 1;
+    (void)::setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    if (::bind(listener, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+        int err = errno;
+        ::close(listener);
+        throw std::runtime_error(std::string("bind failed: ") + std::strerror(err));
+    }
+    if (::listen(listener, 1) != 0) {
+        int err = errno;
+        ::close(listener);
+        throw std::runtime_error(std::string("listen failed: ") + std::strerror(err));
+    }
+    socklen_t len = sizeof(addr);
+    if (::getsockname(listener, reinterpret_cast<sockaddr *>(&addr), &len) != 0) {
+        int err = errno;
+        ::close(listener);
+        throw std::runtime_error(std::string("getsockname failed: ") + std::strerror(err));
+    }
+    server_thread = std::thread([listener]() {
+        int fd = ::accept(listener, nullptr, nullptr);
+        if (fd >= 0) ::close(fd);
+        ::close(listener);
+    });
+    return ntohs(addr.sin_port);
+}
+
 class FakeRemoteTransport : public RemoteL3Transport {
 public:
     int32_t next_error_code{0};
     std::string next_error_message;
+    std::vector<uint8_t> next_control_result_bytes;
     std::vector<uint8_t> last_frame;
     remote_l3::ControlName last_control_name{remote_l3::ControlName::PREPARE_CALLABLE};
     remote_l3::RemoteRegistryTarget last_target_registry{remote_l3::RemoteRegistryTarget::REMOTE_TASK_DISPATCHER};
@@ -56,6 +153,7 @@ public:
             payload.sequence = sequence;
             payload.control_name = control.control_name;
             payload.control_version = control.control_version;
+            payload.result_bytes = next_control_result_bytes;
             remote_l3::FrameHeader header;
             header.frame_type = remote_l3::FrameType::CONTROL_REPLY;
             header.session_id = submitted.header.session_id;
@@ -175,6 +273,70 @@ TEST(RemoteEndpoint, RemoteRegisterPrepareCarriesRequestedRegistryTarget) {
     EXPECT_EQ(transport->last_control_name, remote_l3::ControlName::PREPARE_REGISTER_CALLABLE);
     EXPECT_EQ(transport->last_target_registry, remote_l3::RemoteRegistryTarget::INNER_L3_WORKER);
     EXPECT_EQ(transport->last_callable_kind, CallableKind::CHIP_CALLABLE);
+}
+
+TEST(RemoteEndpoint, RemoteMallocAcceptsValidOwnerHandle) {
+    auto *transport = new FakeRemoteTransport();
+    transport->next_control_result_bytes =
+        malloc_result(3, 9, 2, static_cast<int32_t>(RemoteAddressSpace::REMOTE_DEVICE), 64);
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+
+    RemoteBufferHandle handle = endpoint.control_remote_malloc(64);
+
+    EXPECT_EQ(handle.endpoint_id, 3);
+    EXPECT_EQ(handle.owner_endpoint_id, 3);
+    EXPECT_EQ(handle.buffer_id, 9u);
+    EXPECT_EQ(handle.generation, 2u);
+    EXPECT_EQ(handle.import_id, 0u);
+    EXPECT_EQ(handle.address_space, RemoteAddressSpace::REMOTE_DEVICE);
+    EXPECT_EQ(handle.nbytes, 64u);
+}
+
+TEST(RemoteEndpoint, RemoteMallocRejectsInvalidOwnerHandle) {
+    auto expect_reject = [](std::vector<uint8_t> result_bytes, size_t requested_size) {
+        auto *transport = new FakeRemoteTransport();
+        transport->next_control_result_bytes = std::move(result_bytes);
+        RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+        EXPECT_THROW((void)endpoint.control_remote_malloc(requested_size), std::runtime_error);
+    };
+
+    EXPECT_THROW(
+        {
+            auto *transport = new FakeRemoteTransport();
+            RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+            (void)endpoint.control_remote_malloc(0);
+        },
+        std::invalid_argument
+    );
+    expect_reject(malloc_result(3, 0, 2, static_cast<int32_t>(RemoteAddressSpace::REMOTE_DEVICE), 64), 64);
+    expect_reject(malloc_result(3, 9, 0, static_cast<int32_t>(RemoteAddressSpace::REMOTE_DEVICE), 64), 64);
+    expect_reject(malloc_result(3, 9, 2, static_cast<int32_t>(RemoteAddressSpace::HOST_INLINE), 64), 64);
+    expect_reject(malloc_result(3, 9, 2, 99, 64), 64);
+    expect_reject(malloc_result(3, 9, 2, static_cast<int32_t>(RemoteAddressSpace::REMOTE_DEVICE), 32), 64);
+}
+
+TEST(RemoteSocketTransport, ClosedPeerWriteDoesNotRaiseSigpipe) {
+    std::thread server_thread;
+    uint16_t port = start_closing_server(server_thread);
+    RemoteL3SocketTransport transport("127.0.0.1", port, "127.0.0.1", 1, 1.0);
+    server_thread.join();
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    ScopedSigpipeCounter sigpipe_counter;
+    std::vector<uint8_t> frame(4096, 0x5A);
+    bool saw_error = false;
+    for (int i = 0; i < 3; ++i) {
+        try {
+            transport.submit_frame(frame);
+        } catch (const std::runtime_error &) {
+            saw_error = true;
+            break;
+        }
+    }
+
+    EXPECT_TRUE(saw_error);
+    EXPECT_EQ(g_sigpipe_count, 0);
+    transport.shutdown();
 }
 
 TEST(RemoteEndpoint, BareHostPointerWithoutSidecarIsEndpointFailure) {

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -39,7 +39,7 @@ void count_sigpipe(int) { ++g_sigpipe_count; }
 class ScopedSigpipeCounter {
 public:
     ScopedSigpipeCounter() {
-        struct sigaction action {};
+        struct sigaction action{};
         action.sa_handler = count_sigpipe;
         sigemptyset(&action.sa_mask);
         action.sa_flags = 0;
@@ -55,7 +55,7 @@ public:
     ScopedSigpipeCounter &operator=(const ScopedSigpipeCounter &) = delete;
 
 private:
-    struct sigaction old_action_ {};
+    struct sigaction old_action_{};
 };
 
 void append_i32(std::vector<uint8_t> &out, int32_t v) {
@@ -111,7 +111,13 @@ uint16_t start_closing_server(std::thread &server_thread) {
     }
     server_thread = std::thread([listener]() {
         int fd = ::accept(listener, nullptr, nullptr);
-        if (fd >= 0) ::close(fd);
+        if (fd >= 0) {
+            struct linger rst{};
+            rst.l_onoff = 1;
+            rst.l_linger = 0;
+            (void)::setsockopt(fd, SOL_SOCKET, SO_LINGER, &rst, sizeof(rst));
+            ::close(fd);
+        }
         ::close(listener);
     });
     return ntohs(addr.sin_port);

--- a/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
+++ b/tests/ut/cpp/hierarchical/test_remote_endpoint.cpp
@@ -137,7 +137,10 @@ public:
             auto control = remote_l3::decode_control(submitted.payload.data(), submitted.payload.size());
             last_control_name = control.control_name;
             if (control.control_name == remote_l3::ControlName::PREPARE_REGISTER_CALLABLE) {
-                EXPECT_GE(control.command_bytes.size(), 8u);
+                if (control.command_bytes.size() < 8u) {
+                    ADD_FAILURE() << "PREPARE_REGISTER_CALLABLE command is truncated";
+                    return {};
+                }
                 uint32_t raw_target = static_cast<uint32_t>(control.command_bytes[0]) |
                                       (static_cast<uint32_t>(control.command_bytes[1]) << 8) |
                                       (static_cast<uint32_t>(control.command_bytes[2]) << 16) |
@@ -313,6 +316,35 @@ TEST(RemoteEndpoint, RemoteMallocRejectsInvalidOwnerHandle) {
     expect_reject(malloc_result(3, 9, 2, static_cast<int32_t>(RemoteAddressSpace::HOST_INLINE), 64), 64);
     expect_reject(malloc_result(3, 9, 2, 99, 64), 64);
     expect_reject(malloc_result(3, 9, 2, static_cast<int32_t>(RemoteAddressSpace::REMOTE_DEVICE), 32), 64);
+}
+
+TEST(RemoteEndpoint, RemoteBufferControlsRejectOutOfRangeSlices) {
+    auto *transport = new FakeRemoteTransport();
+    RemoteL3Endpoint endpoint(3, 99, "fake", std::unique_ptr<RemoteL3Transport>(transport));
+    RemoteBufferHandle handle;
+    handle.endpoint_id = 3;
+    handle.owner_endpoint_id = 3;
+    handle.buffer_id = 9;
+    handle.generation = 2;
+    handle.address_space = RemoteAddressSpace::REMOTE_DEVICE;
+    handle.nbytes = 64;
+    handle.offset = 0;
+    std::array<uint8_t, 8> bytes{};
+
+    EXPECT_THROW(endpoint.control_remote_copy_to(handle, 64, bytes.data(), 1), std::out_of_range);
+    EXPECT_THROW(endpoint.control_remote_copy_from(bytes.data(), handle, 63, 2), std::out_of_range);
+    EXPECT_THROW(
+        endpoint.control_remote_export(handle, 64, 1, remote_l3::REMOTE_BUFFER_ACCESS_READ, "tcp"), std::out_of_range
+    );
+
+    handle.offset = 16;
+    EXPECT_THROW(
+        endpoint.control_remote_export(handle, 48, 1, remote_l3::REMOTE_BUFFER_ACCESS_READ, "tcp"), std::out_of_range
+    );
+
+    handle.offset = 0;
+    handle.nbytes = 0;
+    EXPECT_THROW(endpoint.control_remote_copy_to(handle, 0, bytes.data(), 1), std::invalid_argument);
 }
 
 TEST(RemoteSocketTransport, ClosedPeerWriteDoesNotRaiseSigpipe) {


### PR DESCRIPTION
## Summary

This is PR 5 of the remote L3 worker split stack. It adds the C++
`RemoteL3Endpoint` facade, endpoint-level command handling, and nanobind
exposure needed by the later Python remote session runtime.

This PR makes the C++ side capable of representing a remote endpoint and
driving remote control operations, but it does not yet add the Python daemon or
simulation session runtime.

  ## Relationship to PR #866 and split stack

  This PR is part of the split stack extracted from #866.

  Stack:
  - #1006: docs: add remote L3 worker contract
  - #1007: feat: add remote import callable descriptors
  - #1008: feat: add remote L3 wire codec
  - #1009: feat: add remote endpoint eligibility scheduling
  - #1010: feat: add remote L3 endpoint facade
  - #1011: feat: add remote L3 Python session runtime

  The top of the stack was verified to match the corrected `remote-l3-worker-design`
  branch content from #866, excluding empty CI retrigger commits.


## Stack position

- Base: `remote-l3-split-scheduler-eligibility`
- Head: `remote-l3-split-cpp-remote-endpoint`
- Previous PR: `remote-l3-split-scheduler-eligibility`
- Next PR: `remote-l3-split-python-runtime`

## Scope

This PR adds or updates:

- C++ `RemoteL3Endpoint`.
- Transport-neutral command-lane facade.
- Endpoint-level remote control methods.
- Control and completion sequence matching.
- Health/error surfacing while endpoint commands wait.
- Nanobind exposure for remote endpoint controls.
- Nanobind exposure for remote buffer descriptors.
- Build wiring for the C++ remote endpoint and remote wire implementation.
- Endpoint-level C++ unit tests and binding smoke coverage.

## Requirements covered

This PR covers the C++ endpoint and binding requirements from the remote L3
contract:

- Per-endpoint command serialization is enforced.
- CONTROL and CONTROL_REPLY messages are matched by sequence number.
- Completion replies are matched to the correct submitted task.
- Health failure can surface while a command-lane operation is waiting.
- Endpoint failure and task failure are classified separately.
- Remote buffer descriptors are exposed to Python without enabling the full
  Python session runtime yet.
- Nanobind code does not construct Python return values while the GIL is
  released.

## Why this is separate

The Python remote runtime depends on a C++ endpoint facade, but the endpoint
itself has concurrency, command sequencing, health, and binding risks that
should be reviewed independently. Splitting it here keeps those risks visible
before session lifecycle and daemon behavior are introduced.

## Important exclusions

This PR intentionally does not add:

- `simpler-remote-worker`.
- `simpler-remote-l3-session`.
- Python `RemoteCallable`, `RemoteBufferHandle`, `RemoteTensorRef`, or
  `RemoteTaskArgs` integration.
- Simulation remote buffer lifecycle.
- Hardware HCOMM profiles.
- Remote CommDomain support.

Those are handled by PR 6 or future work.

## Verification

Targeted verification already run during the split:

- C++ remote endpoint unit test: passed.
- C++ remote wire unit test: passed.
- Editable build/install smoke after binding build wiring: passed.
- `_task_interface` import smoke for remote endpoint and remote wire binding
  exposure: passed.

## Reviewer notes

Please pay close attention to command-lane ordering, sequence-number matching,
health failure surfacing, and GIL boundaries. These are the highest-risk parts
of this PR because later Python session code relies on them for deterministic
remote endpoint behavior.
