### PR TITLE
feat(dump): add JSON-only tensor-dump level (FULL_JSON_ONLY)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -154,7 +154,8 @@ def pytest_addoption(parser):
         type=int,
         default=0,
         help="Dump per-task tensor I/O at runtime. Level: 0=off, 1=partial (only "
-        "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks).",
+        "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks), "
+        "3=full_json_only (all tasks, JSON metadata only, no .bin payload).",
     )
     parser.addoption(
         "--enable-dep-gen",

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -49,6 +49,14 @@ python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor 2
 | `0` (or flag absent) | off — zero overhead |
 | `1` (bare `--dump-tensor`) | **partial** — only tasks marked with `Arg::dump(...)` (see §3.2) |
 | `2` (`--dump-tensor 2`) | **full** — every task's tensor inputs and outputs |
+| `3` (`--dump-tensor 3`) | **full, JSON only** — every task's metadata (shape, dtype, strides, scalar values) to `tensor_dump.json`; no payload captured, no `.bin` file |
+
+Level 3 exists for consumers that need only the per-task tensor *structure*,
+not the element data — e.g. feeding the manifest into tooling. The AICPU
+skips the arena payload copy entirely (treating every tensor like a scalar
+for payload purposes), so it incurs none of full mode's device→host
+bandwidth or arena pressure, and the manifest's `bin_file` is `null` with
+every `bin_size` at `0`.
 
 ```bash
 # Standalone runner
@@ -60,18 +68,19 @@ pytest tests/st/<case> --platform a5sim --dump-tensor 2
 pytest examples/a5/host_build_graph/vector_example --platform a5sim --dump-tensor 2
 ```
 
-The level sets `CallConfig::enable_dump_tensor` (0/1/2). The host then
+The level sets `CallConfig::enable_dump_tensor` (0/1/2/3). The host then
 allocates dump storage, publishes its base address through
 `kernel_args.dump_data_base`, and sets `PROFILING_FLAG_DUMP_TENSOR`
-(levels 1 and 2) in each worker handshake's `enable_profiling_flag` for
-the enable/disable decision. The **partial-vs-full** distinction is
-carried as a `DumpTensorLevel` in the dump shared-memory header
+(levels 1, 2, and 3) in each worker handshake's `enable_profiling_flag` for
+the enable/disable decision. The **partial / full / full-json-only**
+distinction is carried as a `DumpTensorLevel` in the dump shared-memory header
 (`DumpDataHeader::dump_tensor_level`, host-written before launch) rather
 than in the profiling-flag bitmask. The on-device AICPU reads the storage base
 via `set_platform_dump_base()`, the enable bit via
-`set_dump_tensor_enabled(GET_PROFILING_FLAG(...))`, and latches selective
-mode in `dump_tensor_init()` from the header level (`PARTIAL` →
-selective). Because the level is decided host-side **before any task is
+`set_dump_tensor_enabled(GET_PROFILING_FLAG(...))`, and latches the mode
+in `dump_tensor_init()` from the header level (`PARTIAL` → selective,
+`FULL_JSON_ONLY` → metadata-only, payload copy suppressed). Because the
+level is decided host-side **before any task is
 dispatched**, it is latched up front — there is no dependence on task
 submission order. AICore executors read the same `PROFILING_FLAG_DUMP_TENSOR`
 bit to insert a `pipe_barrier(PIPE_ALL)` before FIN when dump is on, so
@@ -123,7 +132,8 @@ Partial vs full is chosen by the **dump level** (§3.1), latched host-side
 before any dispatch — not inferred from the markers, so it never depends
 on task submission order. At level 1, tasks without a marker are skipped
 and marked tasks dump only their selected arguments. At level 2, the
-markers are ignored and every task's tensors are dumped. With no
+markers are ignored and every task's tensors are dumped. At level 3, every
+task's tensors are dumped as metadata only (no payload, no `.bin`). With no
 `--dump-tensor` (level 0) dump is off entirely.
 
 If you run at level 1 but place no `dump(...)` markers anywhere, the
@@ -151,7 +161,9 @@ same `tensor_dump/` directory.
 #### `tensor_dump.json` — Unified manifest
 
 `tensor_dump.json` is the manifest; its `bin_file` field points at
-the sibling binary payload.
+the sibling binary payload. At level 3 (full, JSON only) no payload is
+captured: `bin_file` is `null`, no `.bin` is written, and every entry's
+`bin_size` is `0`.
 
 Example manifest (one input tensor captured before dispatch):
 
@@ -304,7 +316,7 @@ DumpDataHeader                                  (host init, AICPU reads)
 ├── num_dump_threads
 ├── records_per_buffer
 ├── magic = 0x44554D50 ("DUMP")
-└── dump_tensor_level  (DumpTensorLevel: 0=off, 1=partial, 2=full; AICPU latches in dump_tensor_init)
+└── dump_tensor_level  (DumpTensorLevel: 0=off, 1=partial, 2=full, 3=full_json_only; AICPU latches in dump_tensor_init)
 
 DumpBufferState[num_dump_threads]               (per-thread)
 ├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -603,15 +603,16 @@ NB_MODULE(_task_interface, m) {
             [](const CallConfig &c) {
                 return c.enable_dump_tensor;
             },
-            // Accept either an int dump level (0=off, 1=partial, 2=full) or a
-            // Python bool. `True` maps to level 1 (partial) — the default when
-            // --dump-tensor is passed without a value; `False` maps to 0.
+            // Accept either an int dump level (0=off, 1=partial, 2=full,
+            // 3=full_json_only) or a Python bool. `True` maps to level 1
+            // (partial) — the default when --dump-tensor is passed without a
+            // value; `False` maps to 0.
             [](CallConfig &c, nb::object v) {
                 if (PyBool_Check(v.ptr())) {
                     c.enable_dump_tensor = nb::cast<bool>(v) ? 1 : 0;
                 } else {
                     int level = nb::cast<int>(v);
-                    c.enable_dump_tensor = (level < 0) ? 0 : (level > 2) ? 2 : level;
+                    c.enable_dump_tensor = (level < 0) ? 0 : (level > 3) ? 3 : level;
                 }
             }
         )

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -96,7 +96,7 @@ def tensor_filename(t: dict) -> str:
     return f"task_{t['task_id']}_{stage_str}_{role_str}{t['arg_index']}.txt"
 
 
-def write_tensor(tensor: dict, bin_path: Path, out):
+def write_tensor(tensor: dict, bin_path: Path | None, out):
     t = tensor
     out.write(f"# task_id: {t['task_id']}\n")
     out.write(f"# role: {t['role']}\n")
@@ -119,6 +119,12 @@ def write_tensor(tensor: dict, bin_path: Path, out):
         out.write("# (no data)\n")
         return
 
+    # bin_size > 0 implies a payload was captured, so bin_path is set
+    # (full_json_only dumps have bin_size == 0 everywhere and never reach here).
+    # Guard explicitly rather than assert so a corrupt manifest fails loudly
+    # even under python -O.
+    if bin_path is None:
+        raise ValueError("bin_path is None but bin_size > 0 (corrupt manifest?)")
     data = read_tensor_data(bin_path, t["bin_offset"], bin_size)
     shape = t["shape"]
     numel = 1
@@ -163,7 +169,7 @@ def write_tensor(tensor: dict, bin_path: Path, out):
         out.write(f"[{idx_str}] {s}\n")
 
 
-def export_tensor(tensor: dict, bin_path: Path, dump_dir: Path):
+def export_tensor(tensor: dict, bin_path: Path | None, dump_dir: Path):
     txt_dir = dump_dir / "txt"
     txt_dir.mkdir(exist_ok=True)
     fname = tensor_filename(tensor)
@@ -268,7 +274,10 @@ def main():
     with open(manifest_path) as f:
         manifest = json.load(f)
 
-    bin_path = dump_dir / manifest.get("bin_file", "tensors.bin")
+    # full_json_only dumps (level 3) carry no payload: bin_file is null and
+    # there is no .bin to export from — listing metadata still works.
+    bin_name = manifest.get("bin_file", "tensors.bin")
+    bin_path = (dump_dir / bin_name) if bin_name else None
     tensors = manifest["tensors"]
 
     filtered = _apply_filters(tensors, args)

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -224,9 +224,10 @@ struct DumpReadyQueueEntry {
 // Tensor-dump level. Carried in DumpDataHeader so the
 // AICPU latches the mode in dump_tensor_init() before any task is dispatched.
 enum class DumpTensorLevel : uint32_t {
-    OFF = 0,      // no dump
-    PARTIAL = 1,  // only tasks marked with Arg::dump(...)
-    FULL = 2,     // every task's tensor I/O
+    OFF = 0,             // no dump
+    PARTIAL = 1,         // only tasks marked with Arg::dump(...)
+    FULL = 2,            // every task's tensor I/O (JSON manifest + BIN payload)
+    FULL_JSON_ONLY = 3,  // every task's metadata to JSON; no payload capture, no BIN
 };
 
 struct DumpDataHeader {
@@ -240,7 +241,7 @@ struct DumpDataHeader {
     uint32_t records_per_buffer;
     uint64_t arena_size_per_thread;
     uint32_t magic;
-    uint32_t dump_tensor_level;  // DumpTensorLevel: 0=off, 1=partial, 2=full
+    uint32_t dump_tensor_level;  // DumpTensorLevel: 0=off, 1=partial, 2=full, 3=full_json_only
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -228,9 +228,10 @@ struct DumpReadyQueueEntry {
 // Tensor-dump level. Carried in DumpDataHeader so the
 // AICPU latches the mode in dump_tensor_init() before any task is dispatched.
 enum class DumpTensorLevel : uint32_t {
-    OFF = 0,      // no dump
-    PARTIAL = 1,  // only tasks marked with Arg::dump(...)
-    FULL = 2,     // every task's tensor I/O
+    OFF = 0,             // no dump
+    PARTIAL = 1,         // only tasks marked with Arg::dump(...)
+    FULL = 2,            // every task's tensor I/O (JSON manifest + BIN payload)
+    FULL_JSON_ONLY = 3,  // every task's metadata to JSON; no payload capture, no BIN
 };
 
 struct DumpDataHeader {
@@ -244,7 +245,7 @@ struct DumpDataHeader {
     uint32_t records_per_buffer;
     uint64_t arena_size_per_thread;
     uint32_t magic;
-    uint32_t dump_tensor_level;  // DumpTensorLevel: 0=off, 1=partial, 2=full
+    uint32_t dump_tensor_level;  // DumpTensorLevel: 0=off, 1=partial, 2=full, 3=full_json_only
 } __attribute__((aligned(64)));
 
 // =============================================================================

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -72,7 +72,6 @@ void set_dump_tensor_enabled(bool enable);
  * @return true if tensor dump is enabled
  */
 bool is_dump_tensor_enabled();
-void set_dump_tensor_selective_mode(bool enable);
 bool is_dump_tensor_selective_mode();
 void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask);
 TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id);

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -200,8 +200,10 @@ public:
      * @param user_data         Opaque pointer forwarded to callbacks
      * @param output_prefix     Per-task directory; tensor_dump/ subdir lands here
      * @param dump_tensor_level OFF / PARTIAL (only Arg::dump()-marked tasks) /
-     *                          FULL. Written to DumpDataHeader so the AICPU
-     *                          latches the mode before any dispatch.
+     *                          FULL / FULL_JSON_ONLY (every task's metadata to
+     *                          JSON, no payload or .bin). Written to
+     *                          DumpDataHeader so the AICPU latches the mode
+     *                          before any dispatch.
      * @return 0 on success, error code on failure
      */
     int initialize(
@@ -298,6 +300,9 @@ private:
     std::condition_variable write_cv_;
     std::queue<DumpedTensor> write_queue_;
     std::atomic<bool> writer_done_{false};
+
+    // Resolved dump level; FULL_JSON_ONLY suppresses the .bin file entirely.
+    DumpTensorLevel dump_tensor_level_{DumpTensorLevel::OFF};
 
     // Output directory and single binary file
     std::filesystem::path run_dir_;

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -54,7 +54,10 @@ extern "C" void set_platform_dump_base(uint64_t dump_data_base) { g_platform_dum
 extern "C" uint64_t get_platform_dump_base() { return g_platform_dump_base; }
 
 static bool g_enable_dump_tensor = false;
-static bool g_dump_tensor_selective_mode = false;
+// Dump level latched from the header in dump_tensor_init(). The selective
+// (PARTIAL) and json-only (FULL_JSON_ONLY) modes are derived from it rather
+// than tracked as separate flags — mirrors g_l2_swimlane_level.
+static DumpTensorLevel g_dump_tensor_level = DumpTensorLevel::OFF;
 struct DumpTaskMaskEntry {
     uint64_t task_id;
     TensorDumpArgMask mask;
@@ -91,15 +94,13 @@ static void clear_dump_mask_table() {
 
 extern "C" void set_dump_tensor_enabled(bool enable) {
     g_enable_dump_tensor = enable;
-    g_dump_tensor_selective_mode = false;
+    g_dump_tensor_level = DumpTensorLevel::OFF;
     clear_dump_mask_table();
 }
 
 extern "C" bool is_dump_tensor_enabled() { return g_enable_dump_tensor; }
 
-extern "C" void set_dump_tensor_selective_mode(bool enable) { g_dump_tensor_selective_mode = enable; }
-
-extern "C" bool is_dump_tensor_selective_mode() { return g_dump_tensor_selective_mode; }
+extern "C" bool is_dump_tensor_selective_mode() { return g_dump_tensor_level == DumpTensorLevel::PARTIAL; }
 
 extern "C" void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask) {
     if (mask == TENSOR_DUMP_ARG_MASK_NONE) {
@@ -439,11 +440,10 @@ void dump_tensor_init(int num_dump_threads) {
 
     s_dump_header = get_dump_header(dump_base);
 
-    // Latch dump mode from the host-written header before any task is dumped.
-    // PARTIAL → selective (only Arg::dump()-marked tasks); FULL → every task.
-    set_dump_tensor_selective_mode(
-        static_cast<DumpTensorLevel>(s_dump_header->dump_tensor_level) == DumpTensorLevel::PARTIAL
-    );
+    // Latch dump level from the host-written header before any task is dumped.
+    // PARTIAL → selective (only Arg::dump()-marked tasks); FULL → every task;
+    // FULL_JSON_ONLY → every task, metadata only (no payload copied into arena).
+    g_dump_tensor_level = static_cast<DumpTensorLevel>(s_dump_header->dump_tensor_level);
 
     LOG_INFO_V0("Initializing tensor dump for %d threads", num_dump_threads);
 
@@ -517,7 +517,9 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     bool is_contiguous = tensor_dump_is_contiguous(info);
     bool is_scalar = static_cast<TensorDumpKind>(info.kind) == TensorDumpKind::SCALAR;
 
-    if (is_scalar) {
+    if (is_scalar || g_dump_tensor_level == DumpTensorLevel::FULL_JSON_ONLY) {
+        // JSON-only level captures full metadata but no payload, so the
+        // record carries shape/dtype/strides with payload_size == 0.
         copy_bytes = 0;
     } else if (bytes > state->arena_size) {
         // Tensor larger than entire arena — copy a partial sample

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -56,6 +56,7 @@ int TensorDumpCollector::initialize(
 
     num_dump_threads_ = num_dump_threads;
     output_prefix_ = output_prefix;
+    dump_tensor_level_ = dump_tensor_level;
 
     // Stash the memory context on the base up-front so alloc_paired_buffer
     // (which reads alloc_cb_/register_cb_/free_cb_/device_id_)
@@ -171,7 +172,12 @@ void TensorDumpCollector::start_writer_thread_once() {
     std::string base_name = "tensor_dump";
     run_dir_ = std::filesystem::path(output_prefix_) / base_name;
     std::filesystem::create_directories(run_dir_);
-    bin_file_.open(run_dir_ / (base_name + ".bin"), std::ios::binary);
+    // FULL_JSON_ONLY captures no payload (device sets payload_size == 0), so
+    // there is nothing to stream — skip the .bin file rather than leaving a
+    // 0-byte artifact next to the manifest.
+    if (dump_tensor_level_ != DumpTensorLevel::FULL_JSON_ONLY) {
+        bin_file_.open(run_dir_ / (base_name + ".bin"), std::ios::binary);
+    }
     next_bin_offset_ = 0;
 
     writer_done_.store(false);
@@ -470,7 +476,9 @@ int TensorDumpCollector::export_dump_files() {
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
 
-        bin_file_.close();
+        if (bin_file_.is_open()) {
+            bin_file_.close();
+        }
 
         auto elapsed_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - run_start_time_)
@@ -538,7 +546,11 @@ int TensorDumpCollector::export_dump_files() {
     json << "  \"truncated_tensors\": " << total_truncated_count_ << ",\n";
     json << "  \"dropped_records\": " << total_dropped_record_count_ << ",\n";
     json << "  \"dropped_overwrite\": " << total_overwrite_count_ << ",\n";
-    json << "  \"bin_file\": \"" << base_name << ".bin\",\n";
+    if (dump_tensor_level_ == DumpTensorLevel::FULL_JSON_ONLY) {
+        json << "  \"bin_file\": null,\n";
+    } else {
+        json << "  \"bin_file\": \"" << base_name << ".bin\",\n";
+    }
     json << "  \"tensors\": [\n";
 
     bool first_entry = true;

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
@@ -111,12 +111,18 @@ class TestTensorDump(SceneTestCase):
         with manifest.open() as f:
             data = json.load(f)
         bin_name = data.get("bin_file")
-        assert bin_name, f"manifest missing bin_file field: {data}"
-        bin_path = dump_dir / bin_name
-        assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
         tensors = data.get("tensors", [])
         assert tensors, f"tensor_dump.json has no entries: {data}"
-        assert bin_path.stat().st_size > 0, "tensor_dump.bin is empty"
+        if level == 3:
+            # full_json_only: metadata only, no payload and no .bin file.
+            assert bin_name is None, f"level 3 manifest should have bin_file=null: {data}"
+            assert not (dump_dir / "tensor_dump.bin").exists(), "level 3 must not write tensor_dump.bin"
+            assert all(t.get("bin_size") == 0 for t in tensors), tensors
+        else:
+            assert bin_name, f"manifest missing bin_file field: {data}"
+            bin_path = dump_dir / bin_name
+            assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
+            assert bin_path.stat().st_size > 0, "tensor_dump.bin is empty"
 
         # Unified manifest (#792): tensors and scalar args share one
         # tensor_dump.json keyed by a "kind" field; no separate args files.
@@ -144,7 +150,7 @@ class TestTensorDump(SceneTestCase):
             # Selective mode also confines scalar-arg dumps to the marked tasks.
             assert {t["task_id"] for t in scalar_entries} <= task_ids, scalar_entries
         else:
-            # Full (level 2): markers ignored — every one of the 5 tasks is dumped.
+            # Full (level 2 or 3): markers ignored — every one of the 5 tasks is dumped.
             assert len(task_ids) >= 5, f"full dump should cover all 5 tasks, got {sorted(task_ids)}"
 
         # ---- Tool smoke: dump_viewer ----

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -43,12 +43,15 @@ class TestCallConfig:
         assert config.enable_l2_swimlane == 2
         config.enable_l2_swimlane = False
         assert config.enable_l2_swimlane == 0
-        # enable_dump_tensor is likewise a level (0=off, 1=partial, 2=full):
-        # `True` maps to level 1 (partial), explicit ints select the level.
+        # enable_dump_tensor is likewise a level (0=off, 1=partial, 2=full,
+        # 3=full_json_only): `True` maps to level 1 (partial), explicit ints
+        # select the level.
         config.enable_dump_tensor = True
         assert config.enable_dump_tensor == 1
         config.enable_dump_tensor = 2
         assert config.enable_dump_tensor == 2
+        config.enable_dump_tensor = 3
+        assert config.enable_dump_tensor == 3
         config.enable_dump_tensor = False
         assert config.enable_dump_tensor == 0
 


### PR DESCRIPTION
## What

Adds a new **JSON-only** tensor-dump level (`3` / `DumpTensorLevel::FULL_JSON_ONLY`)
alongside the existing `0=off`, `1=partial`, `2=full`. At level 3 every task's
tensor/scalar **metadata** is written to `tensor_dump/tensor_dump.json`, but **no
payload is captured and no `.bin` file is produced**.

Until now the level only controlled *which tasks* were captured — JSON and BIN were
always emitted together. Level 3 is for consumers that need only the per-task tensor
**structure** (`task_id`, `role`, `stage`, `arg_index`, `dtype`, `shape`, `strides`,
`is_contiguous`, scalar `value`), not the element data.

## How

- `DumpTensorLevel::FULL_JSON_ONLY = 3` added to both the a5 and a2a3 headers.
- The AICPU now latches the **full level enum** (`g_dump_tensor_level`) from the dump
  header and derives the selective (`PARTIAL`) and json-only (`FULL_JSON_ONLY`) modes
  from it, instead of tracking a separate `g_dump_tensor_selective_mode` bool — this
  matches the existing `g_l2_swimlane_level` pattern. At level 3 the arena payload
  copy is skipped (each tensor is treated like a scalar for payload purposes), so
  there is **no device→host payload traffic and no arena pressure**.
- The host collector skips the `.bin` file entirely and writes `"bin_file": null`
  with every entry's `"bin_size": 0`.
- nanobind `enable_dump_tensor` accepts level 3; `dump_viewer.py` tolerates a null
  `bin_file` (lists metadata, exports `# (no data)`); `--dump-tensor` help and
  `docs/dfx/tensor-dump.md` document the new level.

## Cost

At level 3 the device does no payload copy and the host writes no `.bin`, so it
avoids full mode's device→host bandwidth, arena pressure (no truncation/overwrite
anomalies on large runs), and disk cost — only the JSON manifest is produced.

## Testing

- `tests/ut/py/test_chip_worker.py` — `enable_dump_tensor` round-trips level 3.
- `tests/st/.../dfx/tensor_dump/test_tensor_dump.py` — level-3 path asserts
  `bin_file` is null, no `.bin` is written, and every `bin_size` is 0; the
  `dump_viewer` smoke step still passes.
- Incremental build + unit tests green locally.

Closes #1020
