### PR TITLE
Add: selective scalar tensor dump

### DIFF
--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -49,9 +49,9 @@ python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor 2
 | Level | Meaning |
 | ----- | ------- |
 | `0` (or flag absent) | off — zero overhead |
-| `1` (bare `--dump-tensor`) | **partial** — only tasks marked with `Arg::dump(...)` (see §3.2) |
-| `2` (`--dump-tensor 2`) | **full** — every task's tensor inputs and outputs |
-| `3` (`--dump-tensor 3`) | **full, JSON only** — every task's metadata (shape, dtype, strides, scalar values) to `tensor_dump.json`; no payload captured, no `.bin` file |
+| `1` (bare `--dump-tensor`) | **partial** — only args marked with `Arg::dump(...)` (see §3.2) |
+| `2` (`--dump-tensor 2`) | **full** — every task's tensor inputs/outputs and scalar args |
+| `3` (`--dump-tensor 3`) | **full, JSON only** — every task's tensor/scalar metadata (shape, dtype, strides, scalar values) to `tensor_dump.json`; no payload captured, no `.bin` file |
 
 Level 3 exists for consumers that need only the per-task tensor *structure*,
 not the element data — e.g. feeding the manifest into tooling. The AICPU
@@ -88,10 +88,11 @@ submission order. AICore executors read the same `PROFILING_FLAG_DUMP_TENSOR`
 bit to insert a `pipe_barrier(PIPE_ALL)` before FIN when dump is on, so
 `AFTER_COMPLETION` snapshots see the kernel's final writes.
 
-### 3.2 Partial Dump — Select Specific Tasks / Tensors
+### 3.2 Partial Dump — Select Specific Args
 
 Partial dump (level 1) captures only the tasks whose `Arg` is marked
-with `dump(...)`; every unmarked task is skipped. Mark the arguments on
+with `dump(...)`; every unmarked task is skipped. Within a marked task,
+only the selected tensor/scalar args are recorded. Mark the arguments on
 the relevant `Arg` before submission:
 
 ```cpp
@@ -99,34 +100,47 @@ Arg args;
 args.add_input(x);
 args.add_input(y);
 args.add_output(z);
-args.dump(x, y, z);
+float scale = 1.0f;
+args.add_scalar(scale);
+args.dump(x, z, scale);
 rt_submit_aiv_task(FUNC_ADD, args);
 ```
 
-`dump(...)` selects tensor arguments from the current `Arg`; it does not
-execute a dump immediately. The selected tensors must already belong to
-that `Arg`. The runtime uses the argument direction already provided by
-`add_input()`, `add_output()`, or `add_inout()` to decide when each
-selected tensor is captured:
+`dump(...)` selects arguments from the current `Arg`; it does not execute
+a dump immediately. The selected tensors and scalar lvalues must already
+belong to that `Arg`. Scalar selection is by the lvalue passed to
+`add_scalar(...)`, not by scalar value. Temporaries such as
+`args.dump(1.0f)` are rejected because they do not identify a previously
+added scalar slot. If the same scalar lvalue is added more than once,
+`dump(lvalue)` selects the first matching scalar arg and marks that scalar
+entry with `arg_index_ambiguous: true` in `tensor_dump.json`; use distinct
+local variables when you need to select a later duplicate.
+
+The runtime uses the tensor direction already provided by `add_input()`,
+`add_output()`, or `add_inout()` to decide when each selected tensor is
+captured:
 
 - input tensors are dumped before dispatch.
 - output tensors are dumped after completion.
 - inout tensors follow the existing inout dump behavior.
+- scalar args are dumped before dispatch.
 
 Selective dump comes at two granularities, both expressed with the same
 `dump(...)` marker:
 
-- **Tensor granularity** — `dump(x, y, z)` selects specific tensor
-  arguments of the task (the example above).
+- **Arg granularity** — `dump(x, z, scale)` selects specific tensor and
+  scalar arguments of the task (the example above).
 - **Task granularity** — `dump()` with no arguments selects the whole
-  task (every tensor argument on the `Arg`), without enumerating them:
+  task (every tensor and scalar argument on the `Arg`), without
+  enumerating them:
 
   ```cpp
   Arg args;
   args.add_input(x);
   args.add_input(y);
   args.add_output(z);
-  args.dump();        // whole task: every tensor arg on this Arg
+  args.add_scalar(scale);
+  args.dump();        // whole task: every tensor/scalar arg on this Arg
   rt_submit_aiv_task(FUNC_ADD, args);
   ```
 
@@ -134,8 +148,9 @@ Partial vs full is chosen by the **dump level** (§3.1), latched host-side
 before any dispatch — not inferred from the markers, so it never depends
 on task submission order. At level 1, tasks without a marker are skipped
 and marked tasks dump only their selected arguments. At level 2, the
-markers are ignored and every task's tensors are dumped. At level 3, every
-task's tensors are dumped as metadata only (no payload, no `.bin`). With no
+markers are ignored and every task's tensors/scalars are dumped. At level
+3, every task's tensors/scalars are dumped as metadata only (no payload,
+no `.bin`). With no
 `--dump-tensor` (level 0) dump is off entirely.
 
 If you run at level 1 but place no `dump(...)` markers anywhere, the
@@ -211,8 +226,10 @@ Key fields:
 
 - `task_id` — runtime task identity. Use to correlate with swimlane / PMU
   output.
-- `arg_index` — position in the formal callable signature. For scalar
-  entries this equals `payload.tensor_count + scalar_index`.
+- `arg_index` — payload argument index. Tensor entries use the payload
+  tensor index; scalar entries use `payload.tensor_count + scalar_index`.
+  When scalar lvalue selection matched multiple scalar slots, the selected
+  first-match scalar entry carries `arg_index_ambiguous: true`.
 - `role` / `stage` — `input` / `output` / `inout`, captured
   `before_dispatch` / `after_completion`.
 - `kind` — `tensor` for arena-backed payloads, `scalar` for

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -79,13 +79,15 @@ enum class TensorDumpKind : uint8_t {
 using TensorDumpArgMask = uint64_t;
 
 // Bitmask stored in the platform-owned mask pool when orchestration selects
-// specific task tensor arguments for dump. Bit N corresponds to tensors[N].
+// specific task tensor/scalar arguments for dump. Bit N corresponds to the
+// payload arg index: tensors first, then scalars.
 // Zero preserves legacy "dump all tasks" behavior unless selective mode is enabled.
 constexpr TensorDumpArgMask TENSOR_DUMP_ARG_MASK_NONE = 0;
 constexpr uint32_t TENSOR_DUMP_ARG_MASK_BITS = 64;
 constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_RINGS = PTO2_MAX_RING_DEPTH;
 constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_SLOTS = PTO2_TASK_WINDOW_SIZE;
 constexpr uint32_t TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK = TENSOR_DUMP_MASK_POOL_MAX_SLOTS - 1;
+constexpr uint8_t TENSOR_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
 
 // =============================================================================
 // TensorDumpRecord - Single Tensor Dump Entry (128B = 2 cache lines)
@@ -112,7 +114,8 @@ struct alignas(64) TensorDumpRecord {
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
     uint64_t scalar_value;    // Valid when kind == TensorDumpKind::SCALAR
     uint8_t kind;             // TensorDumpKind
-    uint8_t pad0[15];         // Preserve 64B cache-line layout + scalar_value + kind
+    uint8_t flags;            // TENSOR_DUMP_RECORD_FLAG_*
+    uint8_t pad0[14];         // Preserve 64B cache-line layout + scalar_value + kind
 
     // === Cache line 2 (64B) — strided view descriptor ===
     // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 = 48B.
@@ -225,9 +228,9 @@ struct DumpReadyQueueEntry {
 // AICPU latches the mode in dump_tensor_init() before any task is dispatched.
 enum class DumpTensorLevel : uint32_t {
     OFF = 0,             // no dump
-    PARTIAL = 1,         // only tasks marked with Arg::dump(...)
-    FULL = 2,            // every task's tensor I/O (JSON manifest + BIN payload)
-    FULL_JSON_ONLY = 3,  // every task's metadata to JSON; no payload capture, no BIN
+    PARTIAL = 1,         // only args marked with Arg::dump(...)
+    FULL = 2,            // every task's tensor/scalar I/O (JSON manifest + BIN payload)
+    FULL_JSON_ONLY = 3,  // every task's tensor/scalar metadata to JSON; no BIN
 };
 
 struct DumpDataHeader {
@@ -262,7 +265,8 @@ struct TensorDumpInfo {
     uint64_t buffer_addr;
     uint64_t scalar_value;
     uint8_t kind;
-    uint8_t pad[15];
+    uint8_t flags;
+    uint8_t pad[14];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -670,10 +670,12 @@ static TaskOutputTensors submit_task_common(
         }
         // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
         // (host-decided before any dispatch), so it is race-free regardless of
-        // submission order. Here we only record each marked task's arg mask, which
-        // selective collection consults.
+        // submission order. Here we only record each marked task's arg mask and
+        // metadata flags, which selective collection consults.
         if (args.tensor_dump_arg_mask() != 0) {
-            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+            set_dump_tensor_task_mask(
+                task_id.raw, args.tensor_dump_arg_mask(), args.tensor_dump_arg_index_ambiguous_mask()
+            );
         }
     }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -28,6 +28,9 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <type_traits>
+#include <utility>
+
 #if defined(__aarch64__)
 #include <arm_neon.h>
 #endif
@@ -37,6 +40,10 @@
 #include "task_args.h"
 #include "tensor.h"
 #include "tensor_arg.h"
+
+#ifndef PTO2_PROFILING
+#define PTO2_PROFILING 1
+#endif
 
 // Task arguments — alias the common CORE_MAX_* constants (single source of
 // truth in src/common/task_interface/arg_direction.h, transitively included
@@ -177,14 +184,22 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
 
+    void clear() {
+        TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
+#if PTO2_PROFILING
+        dump_arg_mask_ = 0;
+        dump_arg_index_ambiguous_mask_ = 0;
+        clear_scalar_sources();
+        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
+#endif
+        explicit_deps_ = nullptr;
+        explicit_dep_count_ = 0;
+    }
+
     void reset() {
         clear();
         has_error = false;
         error_msg = nullptr;
-        tensor_dump_arg_mask_ = 0;
-        explicit_deps_ = nullptr;
-        explicit_dep_count_ = 0;
-        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
     }
 
     void set_error(const char *msg) {
@@ -196,23 +211,32 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     template <typename... Args>
     void dump(Args &&...args) {
+#if PTO2_PROFILING
         static_assert(
             (std::is_lvalue_reference_v<Args> && ...),
-            "dump: temporaries are not allowed — pass tensors already added to this Arg"
+            "dump: temporaries are not allowed — pass tensors/scalars already added to this Arg"
         );
         static_assert(
-            ((std::is_same_v<std::decay_t<Args>, Tensor> || std::is_same_v<std::decay_t<Args>, TensorCreateInfo>) &&
-             ...),
-            "dump: all arguments must be Tensor or TensorCreateInfo"
+            (is_supported_dump_arg_v<Args> && ...),
+            "dump: all arguments must be Tensor, TensorCreateInfo, or scalar lvalues"
         );
         if constexpr (sizeof...(Args) == 0) {
-            mark_all_tensor_dump_arg();
+            mark_all_dump_args();
         } else {
-            (mark_tensor_dump_arg(args), ...);
+            (mark_dump_arg(args), ...);
         }
+#else
+        ((void)args, ...);
+#endif
     }
 
-    uint64_t tensor_dump_arg_mask() const { return tensor_dump_arg_mask_; }
+#if PTO2_PROFILING
+    uint64_t tensor_dump_arg_mask() const { return dump_arg_mask_; }
+    uint64_t tensor_dump_arg_index_ambiguous_mask() const { return dump_arg_index_ambiguous_mask_; }
+#else
+    uint64_t tensor_dump_arg_mask() const { return 0; }
+    uint64_t tensor_dump_arg_index_ambiguous_mask() const { return 0; }
+#endif
 
     template <typename... Args>
     void add_input(Args &&...args) {
@@ -307,16 +331,14 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      *   args.add_scalar(3.14f, int32_t(42), 7u);     // mixed batch
      */
     template <typename... Args>
-    void add_scalar(Args... args) {
+    void add_scalar(Args &&...args) {
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
         if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
-        ((scalars_[scalar_count_] = to_u64(args),
-          scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<Args>>>(), ++scalar_count_),
-         ...);
+        (add_scalar_one(std::forward<Args>(args)), ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
@@ -325,6 +347,10 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
+#if PTO2_PROFILING
+        memset(&scalar_dtypes_[scalar_count_], 0, count * sizeof(uint8_t));
+        clear_scalar_sources(scalar_count_, count);
+#endif
         scalar_count_ += count;
     }
 
@@ -357,6 +383,10 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             dst[i] = static_cast<uint64_t>(static_cast<uint32_t>(values[i]));
         }
 #endif
+#if PTO2_PROFILING
+        memset(&scalar_dtypes_[scalar_count_], 0, count * sizeof(uint8_t));
+        clear_scalar_sources(scalar_count_, count);
+#endif
         scalar_count_ += count;
     }
 
@@ -374,50 +404,123 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
+#if PTO2_PROFILING
         memcpy(&scalar_dtypes_[scalar_count_], &src.scalar_dtypes_[src_offset], count * sizeof(uint8_t));
+        clear_scalar_sources(scalar_count_, count);
+#endif
         scalar_count_ += count;
     }
 
+#if PTO2_PROFILING
     const uint8_t *scalar_dtypes() const { return scalar_dtypes_; }
+#else
+    const uint8_t *scalar_dtypes() const { return nullptr; }
+#endif
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
-    static_assert(MAX_TENSOR_ARGS <= 64, "tensor dump arg mask assumes at most 64 tensor arguments");
-    uint64_t tensor_dump_arg_mask_{0};
+#if PTO2_PROFILING
+    static_assert(MAX_TENSOR_ARGS + MAX_SCALAR_ARGS <= 64, "dump arg mask assumes at most 64 arguments");
+    uint64_t dump_arg_mask_{0};
+    uint64_t dump_arg_index_ambiguous_mask_{0};
+    uintptr_t scalar_source_ptrs_[MAX_SCALAR_ARGS]{};
+#endif
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+#if PTO2_PROFILING
     uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
-    // No-arg dump(): mark every tensor arg already added to this Arg.
-    void mark_all_tensor_dump_arg() {
-        if (tensor_count_ == 0) {
-            set_error("dump: no tensor arguments added to this Arg");
-            return;
-        }
-        for (int32_t i = 0; i < tensor_count_; i++) {
-            tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+    template <typename T>
+    static constexpr bool is_supported_dump_arg_v =
+        std::is_same_v<std::decay_t<T>, Tensor> || std::is_same_v<std::decay_t<T>, TensorCreateInfo> ||
+        is_supported_scalar_arg_v<T>;
+
+    void mark_arg_index(int32_t index) { dump_arg_mask_ |= (uint64_t{1} << index); }
+    void mark_arg_index_ambiguous(int32_t index) { dump_arg_index_ambiguous_mask_ |= (uint64_t{1} << index); }
+
+    void clear_scalar_sources() { clear_scalar_sources(0, MAX_SCALAR_ARGS); }
+
+    void clear_scalar_sources(int32_t start, int32_t count) {
+        for (int32_t i = 0; i < count; i++) {
+            scalar_source_ptrs_[start + i] = 0;
         }
     }
 
-    void mark_tensor_dump_arg(const Tensor &tensor) {
+#endif
+
+    template <typename T>
+    void add_scalar_one(T &&value) {
+        scalars_[scalar_count_] = to_u64(value);
+#if PTO2_PROFILING
+        scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<T>>>();
+        if constexpr (std::is_lvalue_reference_v<T>) {
+            scalar_source_ptrs_[scalar_count_] = reinterpret_cast<uintptr_t>(&value);
+        } else {
+            scalar_source_ptrs_[scalar_count_] = 0;
+        }
+#endif
+        scalar_count_++;
+    }
+
+#if PTO2_PROFILING
+    // No-arg dump(): mark every arg already added to this Arg.
+    void mark_all_dump_args() {
+        if (tensor_count_ == 0 && scalar_count_ == 0) {
+            set_error("dump: no arguments added to this Arg");
+            return;
+        }
+        for (int32_t i = 0; i < tensor_count_; i++) {
+            mark_arg_index(i);
+        }
+        for (int32_t i = 0; i < scalar_count_; i++) {
+            mark_arg_index(tensor_count_ + i);
+        }
+    }
+
+    void mark_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].ptr == &tensor) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                mark_arg_index(i);
                 return;
             }
         }
         set_error("dump: tensor is not part of this Arg");
     }
 
-    void mark_tensor_dump_arg(const TensorCreateInfo &create_info) {
+    void mark_dump_arg(const TensorCreateInfo &create_info) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].create_info == &create_info) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                mark_arg_index(i);
                 return;
             }
         }
         set_error("dump: TensorCreateInfo is not part of this Arg");
     }
+
+    template <typename T>
+    std::enable_if_t<is_supported_scalar_arg_v<T>, void> mark_dump_arg(const T &scalar) {
+        uintptr_t ptr = reinterpret_cast<uintptr_t>(&scalar);
+        int32_t first_match = -1;
+        int32_t match_count = 0;
+        for (int32_t i = 0; i < scalar_count_; i++) {
+            if (scalar_source_ptrs_[i] == ptr) {
+                if (first_match < 0) {
+                    first_match = i;
+                }
+                match_count++;
+            }
+        }
+        if (first_match >= 0) {
+            int32_t arg_index = tensor_count_ + first_match;
+            mark_arg_index(arg_index);
+            if (match_count > 1) {
+                mark_arg_index_ambiguous(arg_index);
+            }
+            return;
+        }
+        set_error("dump: scalar is not part of this Arg");
+    }
+#endif
 
     template <bool is_output, typename... Args>
     bool check_add_tensor_valid(Args &&...) {

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -83,13 +83,15 @@ enum class TensorDumpKind : uint8_t {
 using TensorDumpArgMask = uint64_t;
 
 // Bitmask stored in the platform-owned mask pool when orchestration selects
-// specific task tensor arguments for dump. Bit N corresponds to tensors[N].
+// specific task tensor/scalar arguments for dump. Bit N corresponds to the
+// payload arg index: tensors first, then scalars.
 // Zero preserves legacy "dump all tasks" behavior unless selective mode is enabled.
 constexpr TensorDumpArgMask TENSOR_DUMP_ARG_MASK_NONE = 0;
 constexpr uint32_t TENSOR_DUMP_ARG_MASK_BITS = 64;
 constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_RINGS = PTO2_MAX_RING_DEPTH;
 constexpr uint32_t TENSOR_DUMP_MASK_POOL_MAX_SLOTS = PTO2_TASK_WINDOW_SIZE;
 constexpr uint32_t TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK = TENSOR_DUMP_MASK_POOL_MAX_SLOTS - 1;
+constexpr uint8_t TENSOR_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS = 1u << 0;
 
 // =============================================================================
 // TensorDumpRecord - Single Tensor Dump Entry (128B = 2 cache lines)
@@ -116,7 +118,8 @@ struct alignas(64) TensorDumpRecord {
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
     uint64_t scalar_value;    // Valid when kind == TensorDumpKind::SCALAR
     uint8_t kind;             // TensorDumpKind
-    uint8_t pad0[15];         // Preserve 64B cache-line layout + scalar_value + kind
+    uint8_t flags;            // TENSOR_DUMP_RECORD_FLAG_*
+    uint8_t pad0[14];         // Preserve 64B cache-line layout + scalar_value + kind
 
     // === Cache line 2 (64B) — strided view descriptor ===
     // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 = 48B.
@@ -229,9 +232,9 @@ struct DumpReadyQueueEntry {
 // AICPU latches the mode in dump_tensor_init() before any task is dispatched.
 enum class DumpTensorLevel : uint32_t {
     OFF = 0,             // no dump
-    PARTIAL = 1,         // only tasks marked with Arg::dump(...)
-    FULL = 2,            // every task's tensor I/O (JSON manifest + BIN payload)
-    FULL_JSON_ONLY = 3,  // every task's metadata to JSON; no payload capture, no BIN
+    PARTIAL = 1,         // only args marked with Arg::dump(...)
+    FULL = 2,            // every task's tensor/scalar I/O (JSON manifest + BIN payload)
+    FULL_JSON_ONLY = 3,  // every task's tensor/scalar metadata to JSON; no BIN
 };
 
 struct DumpDataHeader {
@@ -266,7 +269,8 @@ struct TensorDumpInfo {
     uint64_t buffer_addr;
     uint64_t scalar_value;
     uint8_t kind;
-    uint8_t pad[15];
+    uint8_t flags;
+    uint8_t pad[14];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin
     uint32_t shapes[PLATFORM_DUMP_MAX_DIMS];   // Current view shape
     uint32_t strides[PLATFORM_DUMP_MAX_DIMS];  // Element stride per dimension (strictly > 0, type-enforced)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -666,10 +666,12 @@ static TaskOutputTensors submit_task_common(
         }
         // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
         // (host-decided before any dispatch), so it is race-free regardless of
-        // submission order. Here we only record each marked task's arg mask, which
-        // selective collection consults.
+        // submission order. Here we only record each marked task's arg mask and
+        // metadata flags, which selective collection consults.
         if (args.tensor_dump_arg_mask() != 0) {
-            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+            set_dump_tensor_task_mask(
+                task_id.raw, args.tensor_dump_arg_mask(), args.tensor_dump_arg_index_ambiguous_mask()
+            );
         }
     }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -28,17 +28,22 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <type_traits>
+#include <utility>
+
 #if defined(__aarch64__)
 #include <arm_neon.h>
 #endif
-
-#include <utility>
 
 #include "data_type.h"
 #include "pto_submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
 #include "tensor_arg.h"
+
+#ifndef PTO2_PROFILING
+#define PTO2_PROFILING 1
+#endif
 
 // Task arguments — alias the common CORE_MAX_* constants (single source of
 // truth in src/common/task_interface/arg_direction.h, transitively included
@@ -179,10 +184,14 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     void clear() {
         TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
-        tensor_dump_arg_mask_ = 0;
+#if PTO2_PROFILING
+        dump_arg_mask_ = 0;
+        dump_arg_index_ambiguous_mask_ = 0;
+        clear_scalar_sources();
+        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
+#endif
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
-        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
     }
 
     void reset() {
@@ -200,23 +209,32 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     template <typename... Args>
     void dump(Args &&...args) {
+#if PTO2_PROFILING
         static_assert(
             (std::is_lvalue_reference_v<Args> && ...),
-            "dump: temporaries are not allowed — pass tensors already added to this Arg"
+            "dump: temporaries are not allowed — pass tensors/scalars already added to this Arg"
         );
         static_assert(
-            ((std::is_same_v<std::decay_t<Args>, Tensor> || std::is_same_v<std::decay_t<Args>, TensorCreateInfo>) &&
-             ...),
-            "dump: all arguments must be Tensor or TensorCreateInfo"
+            (is_supported_dump_arg_v<Args> && ...),
+            "dump: all arguments must be Tensor, TensorCreateInfo, or scalar lvalues"
         );
         if constexpr (sizeof...(Args) == 0) {
-            mark_all_tensor_dump_arg();
+            mark_all_dump_args();
         } else {
-            (mark_tensor_dump_arg(args), ...);
+            (mark_dump_arg(args), ...);
         }
+#else
+        ((void)args, ...);
+#endif
     }
 
-    uint64_t tensor_dump_arg_mask() const { return tensor_dump_arg_mask_; }
+#if PTO2_PROFILING
+    uint64_t tensor_dump_arg_mask() const { return dump_arg_mask_; }
+    uint64_t tensor_dump_arg_index_ambiguous_mask() const { return dump_arg_index_ambiguous_mask_; }
+#else
+    uint64_t tensor_dump_arg_mask() const { return 0; }
+    uint64_t tensor_dump_arg_index_ambiguous_mask() const { return 0; }
+#endif
 
     template <typename... Args>
     void add_input(Args &&...args) {
@@ -311,16 +329,14 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      *   args.add_scalar(3.14f, int32_t(42), 7u);     // mixed batch
      */
     template <typename... Args>
-    void add_scalar(Args... args) {
+    void add_scalar(Args &&...args) {
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
         if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
-        ((scalars_[scalar_count_] = to_u64(args),
-          scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<Args>>>(), ++scalar_count_),
-         ...);
+        (add_scalar_one(std::forward<Args>(args)), ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
@@ -329,6 +345,10 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
+#if PTO2_PROFILING
+        memset(&scalar_dtypes_[scalar_count_], 0, count * sizeof(uint8_t));
+        clear_scalar_sources(scalar_count_, count);
+#endif
         scalar_count_ += count;
     }
 
@@ -361,6 +381,10 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             dst[i] = static_cast<uint64_t>(static_cast<uint32_t>(values[i]));
         }
 #endif
+#if PTO2_PROFILING
+        memset(&scalar_dtypes_[scalar_count_], 0, count * sizeof(uint8_t));
+        clear_scalar_sources(scalar_count_, count);
+#endif
         scalar_count_ += count;
     }
 
@@ -378,50 +402,123 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
+#if PTO2_PROFILING
         memcpy(&scalar_dtypes_[scalar_count_], &src.scalar_dtypes_[src_offset], count * sizeof(uint8_t));
+        clear_scalar_sources(scalar_count_, count);
+#endif
         scalar_count_ += count;
     }
 
+#if PTO2_PROFILING
     const uint8_t *scalar_dtypes() const { return scalar_dtypes_; }
+#else
+    const uint8_t *scalar_dtypes() const { return nullptr; }
+#endif
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
-    static_assert(MAX_TENSOR_ARGS <= 64, "tensor dump arg mask assumes at most 64 tensor arguments");
-    uint64_t tensor_dump_arg_mask_{0};
+#if PTO2_PROFILING
+    static_assert(MAX_TENSOR_ARGS + MAX_SCALAR_ARGS <= 64, "dump arg mask assumes at most 64 arguments");
+    uint64_t dump_arg_mask_{0};
+    uint64_t dump_arg_index_ambiguous_mask_{0};
+    uintptr_t scalar_source_ptrs_[MAX_SCALAR_ARGS]{};
+#endif
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+#if PTO2_PROFILING
     uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
-    // No-arg dump(): mark every tensor arg already added to this Arg.
-    void mark_all_tensor_dump_arg() {
-        if (tensor_count_ == 0) {
-            set_error("dump: no tensor arguments added to this Arg");
-            return;
-        }
-        for (int32_t i = 0; i < tensor_count_; i++) {
-            tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+    template <typename T>
+    static constexpr bool is_supported_dump_arg_v =
+        std::is_same_v<std::decay_t<T>, Tensor> || std::is_same_v<std::decay_t<T>, TensorCreateInfo> ||
+        is_supported_scalar_arg_v<T>;
+
+    void mark_arg_index(int32_t index) { dump_arg_mask_ |= (uint64_t{1} << index); }
+    void mark_arg_index_ambiguous(int32_t index) { dump_arg_index_ambiguous_mask_ |= (uint64_t{1} << index); }
+
+    void clear_scalar_sources() { clear_scalar_sources(0, MAX_SCALAR_ARGS); }
+
+    void clear_scalar_sources(int32_t start, int32_t count) {
+        for (int32_t i = 0; i < count; i++) {
+            scalar_source_ptrs_[start + i] = 0;
         }
     }
 
-    void mark_tensor_dump_arg(const Tensor &tensor) {
+#endif
+
+    template <typename T>
+    void add_scalar_one(T &&value) {
+        scalars_[scalar_count_] = to_u64(value);
+#if PTO2_PROFILING
+        scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<T>>>();
+        if constexpr (std::is_lvalue_reference_v<T>) {
+            scalar_source_ptrs_[scalar_count_] = reinterpret_cast<uintptr_t>(&value);
+        } else {
+            scalar_source_ptrs_[scalar_count_] = 0;
+        }
+#endif
+        scalar_count_++;
+    }
+
+#if PTO2_PROFILING
+    // No-arg dump(): mark every arg already added to this Arg.
+    void mark_all_dump_args() {
+        if (tensor_count_ == 0 && scalar_count_ == 0) {
+            set_error("dump: no arguments added to this Arg");
+            return;
+        }
+        for (int32_t i = 0; i < tensor_count_; i++) {
+            mark_arg_index(i);
+        }
+        for (int32_t i = 0; i < scalar_count_; i++) {
+            mark_arg_index(tensor_count_ + i);
+        }
+    }
+
+    void mark_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].ptr == &tensor) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                mark_arg_index(i);
                 return;
             }
         }
         set_error("dump: tensor is not part of this Arg");
     }
 
-    void mark_tensor_dump_arg(const TensorCreateInfo &create_info) {
+    void mark_dump_arg(const TensorCreateInfo &create_info) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].create_info == &create_info) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                mark_arg_index(i);
                 return;
             }
         }
         set_error("dump: TensorCreateInfo is not part of this Arg");
     }
+
+    template <typename T>
+    std::enable_if_t<is_supported_scalar_arg_v<T>, void> mark_dump_arg(const T &scalar) {
+        uintptr_t ptr = reinterpret_cast<uintptr_t>(&scalar);
+        int32_t first_match = -1;
+        int32_t match_count = 0;
+        for (int32_t i = 0; i < scalar_count_; i++) {
+            if (scalar_source_ptrs_[i] == ptr) {
+                if (first_match < 0) {
+                    first_match = i;
+                }
+                match_count++;
+            }
+        }
+        if (first_match >= 0) {
+            int32_t arg_index = tensor_count_ + first_match;
+            mark_arg_index(arg_index);
+            if (match_count > 1) {
+                mark_arg_index_ambiguous(arg_index);
+            }
+            return;
+        }
+        set_error("dump: scalar is not part of this Arg");
+    }
+#endif
 
     template <bool is_output, typename... Args>
     bool check_add_tensor_valid(Args &&...) {

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -73,8 +73,8 @@ void set_dump_tensor_enabled(bool enable);
  */
 bool is_dump_tensor_enabled();
 bool is_dump_tensor_selective_mode();
-void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask);
-TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id);
+void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask, TensorDumpArgMask flags);
+void get_dump_tensor_task_masks(uint64_t task_id, TensorDumpArgMask *mask, TensorDumpArgMask *flags);
 void set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes);
 bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes);
 
@@ -87,7 +87,8 @@ bool get_tensor_dump_role_from_direction(ArgDirection dir, TensorDumpRole *role)
 int32_t count_callable_tensor_args(const CoreCallable &callable);
 bool should_dump_tensor_at_stage(TensorDumpRole role, TensorDumpStage stage);
 bool should_dump_task(TensorDumpArgMask arg_mask);
-bool should_dump_tensor_arg(TensorDumpArgMask arg_mask, int32_t arg_index);
+bool should_dump_arg(TensorDumpArgMask arg_mask, int32_t arg_index);
+bool has_dump_arg_flag(TensorDumpArgMask arg_mask, int32_t arg_index);
 bool try_log_tensor_dump_layout_mismatch();
 int dump_tensor_record(int thread_idx, const TensorDumpInfo &info);
 
@@ -98,8 +99,9 @@ inline void dump_tensors_for_task(
 ) {
     const auto &pl = *slot_state.payload;
     TensorDumpArgMask dump_arg_mask = TENSOR_DUMP_ARG_MASK_NONE;
+    TensorDumpArgMask dump_arg_flags = TENSOR_DUMP_ARG_MASK_NONE;
     if (is_dump_tensor_selective_mode()) {
-        dump_arg_mask = get_dump_tensor_task_mask(slot_state.task->task_id.raw);
+        get_dump_tensor_task_masks(slot_state.task->task_id.raw, &dump_arg_mask, &dump_arg_flags);
     }
     if (!should_dump_task(dump_arg_mask)) {
         return;
@@ -134,7 +136,6 @@ inline void dump_tensors_for_task(
 
     rmb();
 
-    int32_t arg_index = 0;
     int32_t tensor_index = 0;
     for (int raw_subtask_id = 0; raw_subtask_id < MaxSubtaskSlots; raw_subtask_id++) {
         if (!is_subtask_active(slot_state.active_mask, raw_subtask_id)) {
@@ -145,13 +146,11 @@ inline void dump_tensors_for_task(
         for (int32_t sig_idx = 0; sig_idx < callable.sig_count(); sig_idx++) {
             ArgDirection dir = callable.sig(sig_idx);
             if (dir == ArgDirection::SCALAR) {
-                arg_index++;
                 continue;
             }
             TensorDumpRole role;
             bool dump_tensor = get_tensor_dump_role_from_direction(dir, &role) &&
-                               should_dump_tensor_at_stage(role, stage) &&
-                               should_dump_tensor_arg(dump_arg_mask, tensor_index);
+                               should_dump_tensor_at_stage(role, stage) && should_dump_arg(dump_arg_mask, tensor_index);
             if (dump_tensor) {
                 const auto &t = pl.tensors[tensor_index];
                 TensorDumpInfo info = {};
@@ -164,23 +163,28 @@ inline void dump_tensors_for_task(
                     info.strides[d] = t.strides[d];
                 }
                 info.task_id = slot_state.task->task_id.raw;
-                info.arg_index = static_cast<uint32_t>(arg_index);
+                info.arg_index = static_cast<uint32_t>(tensor_index);
                 info.role = role;
                 info.stage = stage;
                 info.kind = static_cast<uint8_t>(TensorDumpKind::TENSOR);
                 dump_tensor_record(thread_idx, info);
             }
-            arg_index++;
             tensor_index++;
         }
     }
 
+    // Scalars are stored once in the task payload; keep them out of the
+    // subtask loop to avoid duplicate records for mixed-subtask tasks.
     if (stage == TensorDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
         uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS] = {};
         uint32_t dtype_scalar_count = 0;
         bool has_scalar_dtypes =
             get_dump_tensor_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
         for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
+            int32_t scalar_arg_index = pl.tensor_count + scalar_index;
+            if (!should_dump_arg(dump_arg_mask, scalar_arg_index)) {
+                continue;
+            }
             TensorDumpInfo info = {};
             info.task_id = slot_state.task->task_id.raw;
             info.role = TensorDumpRole::INPUT;
@@ -189,9 +193,12 @@ inline void dump_tensors_for_task(
                              scalar_dtypes[scalar_index] :
                              static_cast<uint8_t>(DataType::UINT64);
             info.ndims = 0;
-            info.arg_index = static_cast<uint32_t>(pl.tensor_count + scalar_index);
+            info.arg_index = static_cast<uint32_t>(scalar_arg_index);
             info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
             info.scalar_value = pl.scalars[scalar_index];
+            if (has_dump_arg_flag(dump_arg_flags, scalar_arg_index)) {
+                info.flags = TENSOR_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS;
+            }
             dump_tensor_record(thread_idx, info);
         }
     }

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -152,6 +152,7 @@ struct DumpedTensor {
     TensorDumpStage stage;
     uint8_t dtype;
     uint8_t ndims;
+    uint8_t flags;
     TensorDumpKind kind;
     uint64_t scalar_value;
     uint64_t start_offset;                     // 1D element offset of the view origin
@@ -199,7 +200,7 @@ public:
      * @param free_cb           Memory free callback
      * @param user_data         Opaque pointer forwarded to callbacks
      * @param output_prefix     Per-task directory; tensor_dump/ subdir lands here
-     * @param dump_tensor_level OFF / PARTIAL (only Arg::dump()-marked tasks) /
+     * @param dump_tensor_level OFF / PARTIAL (only Arg::dump()-marked args) /
      *                          FULL / FULL_JSON_ONLY (every task's metadata to
      *                          JSON, no payload or .bin). Written to
      *                          DumpDataHeader so the AICPU latches the mode

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -61,6 +61,7 @@ static DumpTensorLevel g_dump_tensor_level = DumpTensorLevel::OFF;
 struct DumpTaskMaskEntry {
     uint64_t task_id;
     TensorDumpArgMask mask;
+    TensorDumpArgMask flags;
 };
 struct DumpTaskScalarDtypeEntry {
     uint64_t task_id;
@@ -84,6 +85,7 @@ static bool ensure_dump_mask_table() {
     for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
         g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
         g_dump_mask_table[i].mask = TENSOR_DUMP_ARG_MASK_NONE;
+        g_dump_mask_table[i].flags = TENSOR_DUMP_ARG_MASK_NONE;
     }
     return true;
 }
@@ -112,6 +114,7 @@ static void clear_dump_mask_table() {
         for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
             g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
             g_dump_mask_table[i].mask = TENSOR_DUMP_ARG_MASK_NONE;
+            g_dump_mask_table[i].flags = TENSOR_DUMP_ARG_MASK_NONE;
         }
     }
     if (g_dump_scalar_dtype_table != nullptr) {
@@ -195,7 +198,7 @@ extern "C" bool is_dump_tensor_enabled() { return g_enable_dump_tensor; }
 
 extern "C" bool is_dump_tensor_selective_mode() { return g_dump_tensor_level == DumpTensorLevel::PARTIAL; }
 
-extern "C" void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask) {
+extern "C" void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask, TensorDumpArgMask flags) {
     if (mask == TENSOR_DUMP_ARG_MASK_NONE) {
         return;
     }
@@ -213,32 +216,44 @@ extern "C" void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask ma
         if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID || entry.task_id == task_id) {
             entry.task_id = task_id;
             entry.mask = mask;
+            entry.flags = flags;
             return;
         }
     }
     LOG_ERROR("tensor dump selective mask table is full");
 }
 
-extern "C" TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id) {
+extern "C" void get_dump_tensor_task_masks(uint64_t task_id, TensorDumpArgMask *mask, TensorDumpArgMask *flags) {
+    if (mask != nullptr) {
+        *mask = TENSOR_DUMP_ARG_MASK_NONE;
+    }
+    if (flags != nullptr) {
+        *flags = TENSOR_DUMP_ARG_MASK_NONE;
+    }
     if (g_dump_mask_table == nullptr) {
-        return TENSOR_DUMP_ARG_MASK_NONE;
+        return;
     }
     uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
     if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
-        return TENSOR_DUMP_ARG_MASK_NONE;
+        return;
     }
     uint32_t slot = static_cast<uint32_t>(task_id) & TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK;
     uint32_t idx = (ring_id * TENSOR_DUMP_MASK_POOL_MAX_SLOTS + slot) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
         const DumpTaskMaskEntry &entry = g_dump_mask_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
         if (entry.task_id == task_id) {
-            return entry.mask;
+            if (mask != nullptr) {
+                *mask = entry.mask;
+            }
+            if (flags != nullptr) {
+                *flags = entry.flags;
+            }
+            return;
         }
         if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID) {
-            return TENSOR_DUMP_ARG_MASK_NONE;
+            return;
         }
     }
-    return TENSOR_DUMP_ARG_MASK_NONE;
 }
 
 bool get_tensor_dump_role_from_direction(ArgDirection dir, TensorDumpRole *role) {
@@ -287,10 +302,15 @@ bool should_dump_task(TensorDumpArgMask arg_mask) {
     return arg_mask != TENSOR_DUMP_ARG_MASK_NONE;
 }
 
-bool should_dump_tensor_arg(TensorDumpArgMask arg_mask, int32_t arg_index) {
+bool should_dump_arg(TensorDumpArgMask arg_mask, int32_t arg_index) {
     if (!is_dump_tensor_selective_mode()) {
         return true;
     }
+    if (arg_index < 0 || arg_index >= static_cast<int32_t>(TENSOR_DUMP_ARG_MASK_BITS)) return false;
+    return (arg_mask & (TensorDumpArgMask{1} << arg_index)) != 0;
+}
+
+bool has_dump_arg_flag(TensorDumpArgMask arg_mask, int32_t arg_index) {
     if (arg_index < 0 || arg_index >= static_cast<int32_t>(TENSOR_DUMP_ARG_MASK_BITS)) return false;
     return (arg_mask & (TensorDumpArgMask{1} << arg_index)) != 0;
 }
@@ -534,7 +554,7 @@ void dump_tensor_init(int num_dump_threads) {
     s_dump_header = get_dump_header(dump_base);
 
     // Latch dump level from the host-written header before any task is dumped.
-    // PARTIAL → selective (only Arg::dump()-marked tasks); FULL → every task;
+    // PARTIAL → selective (only Arg::dump()-marked args); FULL → every task;
     // FULL_JSON_ONLY → every task, metadata only (no payload copied into arena).
     g_dump_tensor_level = static_cast<DumpTensorLevel>(s_dump_header->dump_tensor_level);
 
@@ -648,6 +668,7 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     rec->payload_size = copy_bytes;
     rec->scalar_value = is_scalar ? info.scalar_value : 0;
     rec->kind = info.kind;
+    rec->flags = info.flags;
     rec->start_offset = info.start_offset;
     for (int d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
         rec->shapes[d] = info.shapes[d];

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -229,6 +229,7 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         dt.stage = static_cast<TensorDumpStage>(rec.stage);
         dt.dtype = rec.dtype;
         dt.ndims = rec.ndims;
+        dt.flags = rec.flags;
         dt.kind = static_cast<TensorDumpKind>(rec.kind);
         dt.scalar_value = rec.scalar_value;
         dt.is_contiguous = (rec.is_contiguous != 0);
@@ -624,12 +625,15 @@ int TensorDumpCollector::export_dump_files() {
              << "\"";
         json << ", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
              << "\", \"stage\": \"" << tensor_dump_stage_name(dt.stage) << "\", \"kind\": \""
-             << tensor_dump_kind_name(dt.kind) << "\", \"dtype\": \"" << dtype_name
-             << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false") << ", \"shape\": " << shape_str
-             << ", \"strides\": " << strides_str << ", \"start_offset\": " << dt.start_offset
-             << ", \"numel\": " << numel;
+             << tensor_dump_kind_name(dt.kind) << "\", \"dtype\": \"" << dtype_name << "\"";
         if (dt.kind == TensorDumpKind::SCALAR) {
             write_scalar_json_value(json, dt);
+        }
+        json << ", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false") << ", \"shape\": " << shape_str
+             << ", \"strides\": " << strides_str << ", \"start_offset\": " << dt.start_offset
+             << ", \"numel\": " << numel;
+        if ((dt.flags & TENSOR_DUMP_RECORD_FLAG_ARG_INDEX_AMBIGUOUS) != 0) {
+            json << ", \"arg_index_ambiguous\": true";
         }
         json << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
              << ", \"truncated\": " << (dt.truncated ? "true" : "false")

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -43,16 +43,24 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         Arg params_t1;
         params_t1.add_input(c);
         params_t1.add_output(inter_ci);
-        params_t1.add_scalar(1.0f);
-        params_t1.add_scalar(3u);
+        float t1_addend = 1.0f;
+        uint32_t t1_count = 3u;
+        params_t1.add_scalar(t1_addend, t1_count);
+        // Partial dump, task granularity: no-arg dump() selects every tensor
+        // and scalar arg on this Arg.
+        params_t1.dump();
         TaskOutputTensors outs_t1 = rt_submit_aiv_task(1, params_t1);
         const Tensor &d = outs_t1.get_ref(0);
 
         Arg params_t2;
         params_t2.add_input(c);
         params_t2.add_output(inter_ci);
-        params_t2.add_scalar(2.0f);
-        params_t2.add_scalar(3u);
+        float t2_addend = 2.0f;
+        uint32_t t2_count = 3u;
+        params_t2.add_scalar(t2_addend, t2_count);
+        // Scalar-only selection: t2_count has the same value as t1_count
+        // but is left unmarked, so only t2_addend should be dumped.
+        params_t2.dump(t2_addend);
         TaskOutputTensors outs_t2 = rt_submit_aiv_task(1, params_t2);
         const Tensor &e = outs_t2.get_ref(0);
 
@@ -60,10 +68,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t3.add_input(d);
         params_t3.add_input(e);
         params_t3.add_output(inter_ci);
-        params_t3.add_scalar(3u);
-        // Partial dump, tensor granularity: select specific tensors of this task
-        // (input d + the output; input e is left unmarked).
-        params_t3.dump(d, inter_ci);
+        uint32_t t3_count = 3u;
+        params_t3.add_scalar(t3_count, t3_count);
+        // Mixed selection: input d + the output + one scalar. The scalar lvalue
+        // is added twice, so dump(t3_count) selects the first matching scalar
+        // arg and marks its JSON arg_index as ambiguous. Input e is left
+        // unmarked.
+        params_t3.dump(d, inter_ci, t3_count);
         TaskOutputTensors outs_t3 = rt_submit_aiv_task(2, params_t3);
         const Tensor &g = outs_t3.get_ref(0);
 
@@ -71,8 +82,8 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);
-        // Partial dump, task granularity: no-arg dump() selects the whole task
-        // (every tensor arg on this Arg).
+        // Tensor-only task granularity: no-arg dump() still selects every
+        // tensor arg on this Arg.
         params_t4.dump();
         rt_submit_aiv_task(0, params_t4);
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
@@ -34,14 +34,16 @@ KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_
 class TestTensorDump(SceneTestCase):
     """tensor_dump capture smoke, level-aware on the ``--dump-tensor`` level.
 
-    Uses ``partial_dump_orch`` (5 tasks; two carry ``dump(...)`` markers) so a
+    Uses ``partial_dump_orch`` (5 tasks; four carry ``dump(...)`` markers) so a
     single orchestration exercises both modes:
 
-    - ``--dump-tensor 1`` (partial): only the two marked tasks are captured —
-      task ``0x..02`` via ``dump(d, inter_ci)`` (tensor granularity: args 0+2,
-      input ``e`` excluded), task ``0x..03`` via no-arg ``dump()`` (task
-      granularity: all three args). Mode is latched host-side before dispatch,
-      so it is race-free regardless of submission order.
+    - ``--dump-tensor 1`` (partial): only marked args are captured — task
+      ``0x..00`` via no-arg ``dump()`` (all tensor + scalar args), task
+      ``0x..01`` via ``dump(t2_addend)`` (scalar-only), task ``0x..02`` via
+      ``dump(d, inter_ci, t3_count)`` (mixed tensor + scalar, input ``e``
+      excluded), and task ``0x..03`` via no-arg ``dump()`` (all tensor args).
+      Mode is latched host-side before dispatch, so it is race-free regardless
+      of submission order.
     - ``--dump-tensor 2`` (full): markers are ignored, every task is dumped.
 
     The dump level comes straight from the CLI ``--dump-tensor`` value
@@ -138,17 +140,36 @@ class TestTensorDump(SceneTestCase):
         tensor_entries = [t for t in tensors if t.get("kind") == "tensor"]
         task_ids = {t["task_id"] for t in tensor_entries}
         if level == 1:
-            # Partial: only the two dump()-marked tasks, race-free (host-latched).
-            assert len(tensor_entries) == 5, f"partial expected 5 tensor entries, got {len(tensor_entries)}"
-            assert task_ids == {"0x0000000100000002", "0x0000000100000003"}
-            # Tensor granularity: dump(d, inter_ci) captured args 0 + 2, not arg 1 (e).
+            # Partial: only the selected tensor/scalar args, race-free (host-latched).
+            assert len(tensor_entries) == 7, f"partial expected 7 tensor entries, got {len(tensor_entries)}"
+            assert task_ids == {
+                "0x0000000100000000",
+                "0x0000000100000002",
+                "0x0000000100000003",
+            }
+            # Task granularity: dump() captured all tensor args on task 0.
+            t00 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000000")
+            assert t00 == [0, 1]
+            # Mixed granularity: dump(d, inter_ci, t3_count) captured tensor args
+            # 0 + 2, not arg 1 (e).
             t02 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000002")
             assert t02 == [0, 2]
-            # Task granularity: dump() captured all three tensor args.
+            # Tensor-only task granularity: dump() captured all three tensor args.
             t03 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000003")
             assert t03 == [0, 1, 2]
-            # Selective mode also confines scalar-arg dumps to the marked tasks.
-            assert {t["task_id"] for t in scalar_entries} <= task_ids, scalar_entries
+            scalar_by_task = {
+                task_id: sorted(t["arg_index"] for t in scalar_entries if t["task_id"] == task_id)
+                for task_id in {t["task_id"] for t in scalar_entries}
+            }
+            assert scalar_by_task == {
+                "0x0000000100000000": [2, 3],
+                "0x0000000100000001": [2],
+                "0x0000000100000002": [3],
+            }
+            ambiguous_scalars = [
+                (t["task_id"], t["arg_index"]) for t in scalar_entries if t.get("arg_index_ambiguous", False)
+            ]
+            assert ambiguous_scalars == [("0x0000000100000002", 3)]
         else:
             # Full (level 2 or 3): markers ignored — every one of the 5 tasks is dumped.
             assert len(task_ids) >= 5, f"full dump should cover all 5 tasks, got {sorted(task_ids)}"

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -95,6 +95,8 @@ TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const Arg &) {
     return TaskOutputTensors{};
 }
 
+TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const Arg &) { return TaskOutputTensors{}; }
+
 const PTO2RuntimeOps kFakeOps = {
     .submit_task = fake_submit,
     .scope_begin = fake_scope_begin,
@@ -109,6 +111,8 @@ const PTO2RuntimeOps kFakeOps = {
     .get_tensor_data = fake_get_tensor_data,
     .set_tensor_data = fake_set_tensor_data,
     .alloc_tensors = fake_alloc_tensors,
+    .submit_dummy_task = fake_submit_dummy,
+    .scope_set_site = nullptr,
 };
 
 class RuntimeBindingGuard {

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -89,6 +89,8 @@ TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const Arg &) {
     return TaskOutputTensors{};
 }
 
+TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const Arg &) { return TaskOutputTensors{}; }
+
 const PTO2RuntimeOps kFakeOps = {
     .submit_task = fake_submit,
     .scope_begin = fake_scope_begin,
@@ -103,6 +105,8 @@ const PTO2RuntimeOps kFakeOps = {
     .get_tensor_data = fake_get_tensor_data,
     .set_tensor_data = fake_set_tensor_data,
     .alloc_tensors = fake_alloc_tensors,
+    .submit_dummy_task = fake_submit_dummy,
+    .scope_set_site = nullptr,
 };
 
 class RuntimeBindingGuard {


### PR DESCRIPTION
## Summary
- Extend `Arg::dump(...)` so partial dump can select scalar lvalues together with tensors.
- Use one tensor/scalar arg mask for AICPU filtering and dump scalars once per task.
- Update tensor dump docs and ST coverage for task, scalar-only, and mixed selection.

## Testing
- `git diff --check`
- `git diff --cached --check`
- `g++ -std=c++17 -fsyntax-only ... src/a2a3/.../pto_orchestrator.cpp`
- `g++ -std=c++17 -fsyntax-only ... src/a5/.../pto_orchestrator.cpp`
- `python3 -m py_compile tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py`
- Not run: full runtime rebuild / ST. `npu-smi info` timed out locally, and the known local a2a3sim libstdc++ ABI issue blocks the tensor-dump ST.

Fixes #1026