### PR TITLE
Fix: size hierarchical worker mailbox to hold largest TaskArgs blob

### DIFF
--- a/docs/remote-l3-worker-design.md
+++ b/docs/remote-l3-worker-design.md
@@ -25,7 +25,7 @@ design: remote L3 callable routing should use `hashid` identities and
 target-private execution slots instead of cross-worker integer routing.
 
 The current implementation uses pre-forked local child processes and a
-4096-byte shared-memory mailbox. That model depends on copy-on-write callable
+fixed-size (`MAILBOX_SIZE`-byte) shared-memory mailbox. That model depends on copy-on-write callable
 registries, identical virtual addresses for `MAP_SHARED` regions, and
 parent-visible child PIDs. None of those assumptions holds across hosts.
 
@@ -37,7 +37,7 @@ not the production daemon/HCOMM backends.
 Implemented:
 
 - `WorkerEndpoint` with `LocalMailboxEndpoint` and `RemoteL3Endpoint`.
-  `LocalMailboxEndpoint` keeps the existing 4096-byte mailbox local-only.
+  `LocalMailboxEndpoint` keeps the existing fixed-size mailbox local-only.
   `RemoteL3Endpoint` encodes versioned TASK frames through a
   `RemoteL3Transport` interface and waits for matching COMPLETION frames.
 - Explicit endpoint outcomes: success, task failure, endpoint failure, and
@@ -549,7 +549,7 @@ requirements.
 
 ## Protocol
 
-Do not reuse the raw 4096-byte mailbox format across hosts. It has no version
+Do not reuse the raw fixed-size mailbox format across hosts. It has no version
 field, no sequence number, and assumes shared virtual memory.
 
 Remote endpoints use a versioned frame protocol with `HELLO`, `TASK`,

--- a/docs/remote-l3-worker-design/buffers-and-transports.md
+++ b/docs/remote-l3-worker-design/buffers-and-transports.md
@@ -128,7 +128,7 @@ and imported simulation handles.
 Endpoint rules:
 
 - `LocalMailboxEndpoint` rejects non-empty sidecars. It cannot encode remote
-  descriptors into the local 4096-byte mailbox, and its child processes expect
+  descriptors into the local fixed-size mailbox, and its child processes expect
   `ContinuousTensor.data` to be a local host/shm pointer or a local child-memory
   pointer.
 - `RemoteL3Endpoint` requires a sidecar for every tensor payload that crosses

--- a/docs/remote-l3-worker-design/protocol.md
+++ b/docs/remote-l3-worker-design/protocol.md
@@ -12,7 +12,7 @@ by host pointers.
 
 ## Frames
 
-Remote transport must not reuse the raw 4096-byte mailbox format. Define a
+Remote transport must not reuse the raw fixed-size mailbox format. Define a
 versioned frame header:
 
 ```text

--- a/docs/sim_multi_device_isolation.md
+++ b/docs/sim_multi_device_isolation.md
@@ -20,7 +20,7 @@ Main process (Scheduler)
                                                 ← isolated globals
 ```
 
-Communication uses a 4096-byte shared-memory mailbox per chip — the same layout used for SUB-type workers. The parent copies `ChipStorageTaskArgs` into the mailbox; the child copies it to heap before calling `run_runtime` (sim runtime requires heap-backed args, not mmap-backed).
+Communication uses a fixed-size (`MAILBOX_SIZE`-byte) shared-memory mailbox per chip — the same layout used for SUB-type workers. The parent copies `ChipStorageTaskArgs` into the mailbox; the child copies it to heap before calling `run_runtime` (sim runtime requires heap-backed args, not mmap-backed).
 
 ## Why Not Fix the Globals
 

--- a/docs/worker-manager.md
+++ b/docs/worker-manager.md
@@ -17,7 +17,7 @@ SUB) in its own address space.
 The remote L3 design keeps this local fork/shm path behind
 `LocalMailboxEndpoint` and reserves the same `WorkerEndpoint` boundary for a
 framed `RemoteL3Endpoint` for cross-host NEXT_LEVEL children. A remote endpoint
-is not another child loop that polls the 4096-byte mailbox; it uses the
+is not another child loop that polls the `MAILBOX_SIZE`-byte mailbox; it uses the
 contracts in
 [remote-l3-worker-design.md](remote-l3-worker-design.md).
 The current code includes that `RemoteL3Endpoint` boundary, a socket-backed

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -189,7 +189,11 @@ void WorkerThread::dispatch_process(TaskSlotState &s, int32_t group_index) {
     size_t blob_bytes = TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(view.tensor_count) * sizeof(ContinuousTensor) +
                         static_cast<size_t>(view.scalar_count) * sizeof(uint64_t);
     if (blob_bytes > MAILBOX_ARGS_CAPACITY) {
-        throw std::runtime_error("WorkerThread::dispatch_process: args blob exceeds mailbox capacity");
+        throw std::runtime_error(
+            "WorkerThread::dispatch_process: args blob exceeds mailbox capacity: need " + std::to_string(blob_bytes) +
+            " bytes, capacity " + std::to_string(MAILBOX_ARGS_CAPACITY) +
+            " bytes, tensors=" + std::to_string(view.tensor_count) + ", scalars=" + std::to_string(view.scalar_count)
+        );
     }
     uint8_t *hash_dst = reinterpret_cast<uint8_t *>(mbox() + MAILBOX_OFF_TASK_CALLABLE_HASH);
     std::memcpy(hash_dst, s.callable.digest.data(), CALLABLE_HASH_DIGEST_SIZE);

--- a/src/common/hierarchical/worker_manager.h
+++ b/src/common/hierarchical/worker_manager.h
@@ -70,7 +70,11 @@ enum class MailboxState : int32_t {
     INIT_DONE = 6,
 };
 
-static constexpr size_t MAILBOX_SIZE = 4096;
+// Sized so the args region can hold any TaskArgs the runtime itself accepts
+// (CHIP_MAX_TENSOR_ARGS tensors + CHIP_MAX_SCALAR_ARGS scalars; see the
+// static_assert after MAILBOX_ARGS_CAPACITY). 4096 was too tight for composed
+// child kernels with many tensor args (issue #1024).
+static constexpr size_t MAILBOX_SIZE = 16384;
 
 // Error message region lives at the mailbox tail. 256 B of headroom is
 // enough for `<ExceptionType>: <short message>` produced by the child-side
@@ -107,6 +111,12 @@ static constexpr ptrdiff_t MAILBOX_OFF_CONTROL_CALLABLE_HASH =
     MAILBOX_OFF_ARGS + static_cast<ptrdiff_t>(CTRL_SHM_NAME_BYTES);
 static constexpr size_t MAILBOX_ARGS_CAPACITY =
     MAILBOX_SIZE - static_cast<size_t>(MAILBOX_OFF_TASK_ARGS_BLOB) - MAILBOX_ERROR_MSG_SIZE;
+static_assert(
+    MAILBOX_ARGS_CAPACITY >= TASK_ARGS_BLOB_HEADER_SIZE +
+                                 static_cast<size_t>(CHIP_MAX_TENSOR_ARGS) * sizeof(ContinuousTensor) +
+                                 static_cast<size_t>(CHIP_MAX_SCALAR_ARGS) * sizeof(uint64_t),
+    "mailbox args region must hold the largest TaskArgs blob the runtime accepts (issue #1024)"
+);
 
 // Control sub-commands (written at MAILBOX_OFF_CALLABLE when state == CONTROL_*)
 static constexpr uint64_t CTRL_MALLOC = 0;

--- a/tests/ut/cpp/hierarchical/test_scheduler.cpp
+++ b/tests/ut/cpp/hierarchical/test_scheduler.cpp
@@ -309,6 +309,39 @@ TEST_F(SchedulerFixture, DependentTaskDispatchedAfterProducerCompletes) {
     (void)a;
 }
 
+// Issue #1024: composed child kernels can carry far more tensor args than a
+// top-level entry (repro: 76 tensors + 2 scalars = 3064-byte blob). The
+// mailbox must hold any blob the runtime itself accepts, i.e. up to
+// CHIP_MAX_TENSOR_ARGS / CHIP_MAX_SCALAR_ARGS.
+TEST_F(SchedulerFixture, ComposedKernelArgsBlobFitsMailbox) {
+    constexpr size_t max_blob = TASK_ARGS_BLOB_HEADER_SIZE +
+                                static_cast<size_t>(CHIP_MAX_TENSOR_ARGS) * sizeof(ContinuousTensor) +
+                                static_cast<size_t>(CHIP_MAX_SCALAR_ARGS) * sizeof(uint64_t);
+    EXPECT_GE(MAILBOX_ARGS_CAPACITY, max_blob);
+
+    TaskArgs args;
+    for (int i = 0; i < 76; ++i) {
+        ContinuousTensor t{};
+        t.data = 0x1000u + static_cast<uint64_t>(i) * 0x100u;
+        t.ndims = 1;
+        t.shapes[0] = 1;
+        t.dtype = DataType::UINT8;
+        args.add_tensor(t, TensorArgType::OUTPUT);
+    }
+    args.add_scalar(1);
+    args.add_scalar(2);
+
+    auto res = orch.submit_next_level(C(76), args, cfg);
+
+    mock_worker.wait_running();
+    ASSERT_GE(mock_worker.dispatched_count(), 1)
+        << "dispatch never reached the child: args blob exceeds mailbox capacity";
+    EXPECT_EQ(mock_worker.dispatched[0].callable_hash0, 76u);
+
+    mock_worker.complete();
+    wait_consumed(res.task_slot);
+}
+
 // ===========================================================================
 // Group task tests -- fixture with 2 MockMailboxWorkers
 // ===========================================================================


### PR DESCRIPTION
## Summary

Fixes #1024.

A hierarchical worker dispatch failed with `WorkerThread::dispatch_process: args blob exceeds mailbox capacity` when a host orchestration called a child kernel with many tensor arguments. The 4096-byte mailbox also stores `CallConfig` and the 256-byte child error region, leaving only 2768 bytes for the TaskArgs blob — but a composed child kernel (76 tensors + 2 scalars) serializes to 3064 bytes, so a valid nested dispatch was rejected even though each descriptor is compact.

- Raise `MAILBOX_SIZE` 4096 → 16384 so the args region holds any blob the runtime itself accepts (`CHIP_MAX_TENSOR_ARGS` + `CHIP_MAX_SCALAR_ARGS`).
- Add a `static_assert` tying `MAILBOX_ARGS_CAPACITY` to those limits, so the mailbox can never again be sized below a submittable TaskArgs blob.
- Enrich the overflow error with `need <bytes>, capacity <bytes>, tensors=<T>, scalars=<S>` for diagnosability if the limit is ever hit again.
- Update docs that quoted the old fixed 4096-byte mailbox size.

## Testing

- [x] C++ unit tests pass — new regression `SchedulerFixture.ComposedKernelArgsBlobFitsMailbox` fails against the old 4096-byte mailbox and passes after the bump; full `tests/ut/cpp` suite (38 tests) green.
- [x] Python unit tests pass (`pytest tests/ut`, 363 passed / 2 skipped) after rebuilding the nanobind module so the exported `MAILBOX_SIZE` reflects 16384.
- [x] Hierarchical L3 scene tests pass on `a2a3sim` (`test_l3_dependency`, `test_l3_group`).
- [ ] Hardware tests (not run in this environment).