### PR TITLE
Fix: monotonic scope_stats heap accounting for multi-wrap scopes

### DIFF
--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -92,16 +92,18 @@ and common patterns.
 
 | Metric | Formula | What it tells you |
 | ------ | ------- | ----------------- |
-| `scope_high_water` | `end.head − begin.tail` | Highest occupancy the scope held — residual not yet released on entry, plus what this scope added. The true peak. |
-| `real_occupancy` | `end.head − end.tail` | What is still occupied at scope exit (the live level on leaving). |
-| `scope_alloc` | `end.head − begin.head` | How far the allocation frontier advanced — this scope's own net (unreleased) allocation. |
+| `scope_high_water` | `end.head − begin.tail` | Upper bound on the occupancy this scope reached — entry backlog plus everything this scope allocated, *without* subtracting what was released mid-scope. Not a realized peak, and not bounded by capacity: a scope that streams more than `cap` reports more than `cap`. |
+| `real_occupancy` | `end.head − end.tail` | What is still occupied at scope exit (the live level on leaving). Always in `[0, cap]`. |
+| `scope_alloc` | `end.head − begin.head` | How far the allocation frontier advanced over the scope — this scope's total allocation throughput (can exceed `cap`). |
 
 For `task_window`, `heap`, and `dep_pool`, `head` / `tail` mean that
 resource's allocation frontier and released boundary at the sampled scope
-boundary. Ring-buffer occupancy is non-negative, so a negative delta is folded
-back by one buffer length (`(head + cap − tail) % cap`) — a wrap past the
-buffer end. `tensormap` is reported as a single in-use value (no head/tail), so
-it shows only the `real_occupancy` curve.
+boundary. All three are reported as **monotonic, non-wrapping** counters
+(byte totals for `heap`, entry counters for the others), so every delta above
+is an exact, non-negative subtraction regardless of how many times the
+underlying ring wrapped during the scope — no wrap correction is applied.
+`tensormap` is reported as a single in-use value (no head/tail), so it shows
+only the `real_occupancy` curve.
 
 ## 2. What gets captured
 
@@ -127,10 +129,13 @@ it shows only the `real_occupancy` curve.
 ## 3. Output: `scope_stats.jsonl`
 
 NDJSON. Line 1 is run metadata; each subsequent line is one scope
-sample (`begin` or `end`). Schema version 5:
+sample (`begin` or `end`). Schema version 6 (bumped from 5 when
+`heap_start`/`heap_end` changed from wrapping ring offsets to monotonic
+cumulative bytes — a `version == 5` file's heap fields wrap, a `version == 6`
+file's do not):
 
 ```json
-{"version": 5, "fatal": false, "dropped": 0, "total": 4, "task_window_max": [8, 4], "heap_max": [268435456, 268435456], "dep_pool_max": [1024, 1024], "tensormap_max": 65536}
+{"version": 6, "fatal": false, "dropped": 0, "total": 4, "task_window_max": [8, 4], "heap_max": [268435456, 268435456], "dep_pool_max": [1024, 1024], "tensormap_max": 65536}
 {"site": "example_orchestration.cpp:77", "phase": "begin", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 0, "heap_start": 0, "heap_end": 0, "dep_pool_start": 1, "dep_pool_end": 1, "tensormap": 0}
 {"site": "example_orchestration.cpp:77", "phase": "end", "depth": 1, "ring": 1, "task_window_start": 0, "task_window_end": 4, "heap_start": 0, "heap_end": 8192, "dep_pool_start": 1, "dep_pool_end": 6, "tensormap": 5}
 ```
@@ -139,7 +144,7 @@ Metadata line (line 1):
 
 | Field | Type | Meaning |
 | ----- | ---- | ------- |
-| `version` | int | Schema version (`5`) |
+| `version` | int | Schema version (`6`) |
 | `fatal` | bool | `true` iff a fatal was latched during the run; records past it are diagnostic-only |
 | `dropped` | uint | Records dropped on device (free_queue empty / ready_queue full); `0` on a healthy run |
 | `total` | uint | Total records the device attempted (collected + dropped) |
@@ -158,8 +163,8 @@ Per-sample lines, oldest-first:
 | `ring` | int | Ring this scope used; indexes `task_window_max` / `heap_max` / `dep_pool_max` |
 | `task_window_start` | int | Task-window ring tail at this boundary |
 | `task_window_end` | int | Task-window ring head at this boundary |
-| `heap_start` | uint | Heap ring tail (released boundary) in bytes |
-| `heap_end` | uint | Heap ring head (allocation frontier) in bytes |
+| `heap_start` | uint | Heap reclaim boundary — monotonic cumulative bytes reclaimed (non-wrapping) |
+| `heap_end` | uint | Heap allocation frontier — monotonic cumulative bytes allocated (non-wrapping) |
 | `dep_pool_start` | int | Scheduler-published dependency-list pool tail at this boundary |
 | `dep_pool_end` | int | Scheduler-published dependency-list pool top at this boundary |
 | `tensormap` | int | Tensormap entries in use |

--- a/simpler_setup/tools/scope_stats_plot.py
+++ b/simpler_setup/tools/scope_stats_plot.py
@@ -72,7 +72,8 @@ def _metrics(resource: str) -> list[Metric]:
             "scope_high_water",
             "High water",
             "end.head - begin.tail",
-            "Peak pressure seen by this scope, including backlog already live on entry.",
+            "Occupancy upper bound for this scope: entry backlog plus everything it allocated, "
+            "not a realized peak and not bounded by capacity.",
             lambda b, en: en.get(e, 0) - b.get(s, 0),
         ),
         Metric(
@@ -113,12 +114,6 @@ def _resource_has_data(pairs_by_ring: dict[int, list[tuple[dict, dict]]], resour
     return any(
         s in begin and e in begin and s in end and e in end for pairs in pairs_by_ring.values() for begin, end in pairs
     )
-
-
-def _wrap(delta: int, size: int | None) -> int:
-    if size and delta < 0:
-        return delta + size
-    return delta
 
 
 def _pair_by_ring(records: list[dict]) -> dict[int, list[tuple[dict, dict]]]:
@@ -188,13 +183,15 @@ def _use_bar_html(ratio: float | None) -> str:
     )
 
 
-def _series_for_resource(pairs: list[tuple[dict, dict]], resource: str, size: int | None) -> list[dict]:
+def _series_for_resource(pairs: list[tuple[dict, dict]], resource: str) -> list[dict]:
     info = RESOURCES[resource]
     sites = [end.get("site", "?") for _begin, end in pairs]
     rings = [end.get("ring", begin.get("ring")) for begin, end in pairs]
     series = []
     for metric in _metrics(resource):
-        raw_values = [_wrap(metric.fn(begin, end), size) for begin, end in pairs]
+        # head/tail are monotonic non-wrapping counters, so each delta is exact
+        # and non-negative — no wrap correction needed (see docs/dfx/scope-stats.md).
+        raw_values = [metric.fn(begin, end) for begin, end in pairs]
         values = [v / info.divisor for v in raw_values]
         if values:
             peak_idx = max(range(len(values)), key=values.__getitem__)
@@ -230,7 +227,7 @@ def _risk_entry(meta: dict, resource: str, ring: int | None, pairs: list[tuple[d
     info = RESOURCES[resource]
     size = _resource_size(meta, resource, 0 if ring is None else ring)
     cap = (size / info.divisor) if size is not None else None
-    series = _series_for_resource(pairs, resource, size)
+    series = _series_for_resource(pairs, resource)
     risk = next((s for s in series if s["metric"].key == info.risk_metric), series[0])
     ratio = risk["peak"] / cap if cap else None
     return {
@@ -616,7 +613,7 @@ def _chart_stack_html(series: list[dict], unit: str) -> str:
 
 def _scope_group_section(resource: str, title: str, pairs: list[tuple[dict, dict]], size: int | None) -> str:
     info = RESOURCES[resource]
-    series = _series_for_resource(pairs, resource, size)
+    series = _series_for_resource(pairs, resource)
     cap = size / info.divisor if size is not None else None
     risk = next((s for s in series if s["metric"].key == info.risk_metric), series[0])
     ratio = risk["peak"] / cap if cap else None

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -67,6 +67,11 @@ __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
 // cross-agent occupancy reads that feed the sample when scope_stats is disabled.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
 
+// Heap-ring wrap report, called from the allocator (pto_ring_buffer.h) on each
+// wrap. Strong definition lives in the AICPU collector; host builds fall back to
+// this weak no-op so the runtime translation unit stays self-contained.
+extern "C" __attribute__((weak, visibility("hidden"))) void scope_stats_note_heap_wrap(int) {}
+
 // =============================================================================
 // Orchestrator Profiling (compile-time toggle)
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -42,6 +42,13 @@
 #include "pto_shared_memory.h"
 #include "common/unified_log.h"
 
+#if PTO2_PROFILING
+// Heap-ring wrap reporting — the allocator is the only place each individual
+// wrap is observable, so it notifies the scope_stats collector here. Gated:
+// pays nothing (no include, no call) when profiling is compiled out.
+#include "aicpu/scope_stats_collector_aicpu.h"
+#endif
+
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
@@ -252,8 +259,19 @@ private:
         last_alive_seen_ = last_alive;
 
         PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
+        uint64_t old_tail = heap_tail_;
         heap_tail_ =
             static_cast<uint64_t>(static_cast<char *>(desc.packed_buffer_end) - static_cast<char *>(heap_base_));
+#if PTO2_PROFILING
+        // Reclaim pointer moves forward monotonically in ring order; a decrease
+        // means it wrapped past heap_size_ (occupancy < heap_size_ guarantees at
+        // most one wrap per call). Report it so scope_stats can unroll.
+        if (is_scope_stats_enabled() && heap_tail_ < old_tail) {
+            scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+        }
+#else
+        (void)old_tail;
+#endif
     }
 
     /**
@@ -281,6 +299,12 @@ private:
                 );
                 result = heap_base_;
                 heap_top_ = alloc_size;
+#if PTO2_PROFILING
+                // Allocation pointer just wrapped past heap_size_; report it so
+                // scope_stats can unroll the wrapping offset into a monotonic value.
+                // The collector attributes the wrap to the current scope's ring.
+                if (is_scope_stats_enabled()) scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+#endif
             } else {
                 LOG_DEBUG(
                     "try_bump_heap failed (top>=tail): top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -22,7 +22,9 @@
 #include "common/unified_log.h"
 
 #if PTO2_PROFILING
+// Weak fallbacks for host/UT builds that don't link the scope_stats collector.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
+extern "C" __attribute__((weak, visibility("hidden"))) void scope_stats_note_heap_wrap(int) {}
 #endif
 
 // =============================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -38,11 +38,6 @@
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 
-#if PTO2_PROFILING
-// Strong def in scope_stats_collector_aicpu.cpp; weak fallback in pto_scheduler.cpp for host/UT builds.
-extern "C" bool is_scope_stats_enabled();
-#endif
-
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -68,6 +68,11 @@ __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
 // builds fall back to this weak `false`. Gating here still skips the
 // cross-agent occupancy reads that feed the sample when scope_stats is disabled.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
+
+// Heap-ring wrap report, called from the allocator (pto_ring_buffer.h) on each
+// wrap. Strong definition lives in the AICPU collector; host builds fall back to
+// this weak no-op so the runtime translation unit stays self-contained.
+extern "C" __attribute__((weak, visibility("hidden"))) void scope_stats_note_heap_wrap(int) {}
 #endif
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -42,6 +42,13 @@
 #include "pto_shared_memory.h"
 #include "common/unified_log.h"
 
+#if PTO2_PROFILING
+// Heap-ring wrap reporting — the allocator is the only place each individual
+// wrap is observable, so it notifies the scope_stats collector here. Gated:
+// pays nothing (no include, no call) when profiling is compiled out.
+#include "aicpu/scope_stats_collector_aicpu.h"
+#endif
+
 // Block notification interval (in spin counts)
 #define PTO2_BLOCK_NOTIFY_INTERVAL 10000
 // Alloc spin limit - after this, report deadlock and exit
@@ -253,8 +260,19 @@ private:
         last_alive_seen_ = last_alive;
 
         PTO2TaskDescriptor &desc = descriptors_[(last_alive - 1) & window_mask_];
+        uint64_t old_tail = heap_tail_;
         heap_tail_ =
             static_cast<uint64_t>(static_cast<char *>(desc.packed_buffer_end) - static_cast<char *>(heap_base_));
+#if PTO2_PROFILING
+        // Reclaim pointer moves forward monotonically in ring order; a decrease
+        // means it wrapped past heap_size_ (occupancy < heap_size_ guarantees at
+        // most one wrap per call). Report it so scope_stats can unroll.
+        if (is_scope_stats_enabled() && heap_tail_ < old_tail) {
+            scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+        }
+#else
+        (void)old_tail;
+#endif
     }
 
     /**
@@ -282,6 +300,12 @@ private:
                 );
                 result = heap_base_;
                 heap_top_ = alloc_size;
+#if PTO2_PROFILING
+                // Allocation pointer just wrapped past heap_size_; report it so
+                // scope_stats can unroll the wrapping offset into a monotonic value.
+                // The collector attributes the wrap to the current scope's ring.
+                if (is_scope_stats_enabled()) scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+#endif
             } else {
                 LOG_DEBUG(
                     "try_bump_heap failed (top>=tail): top=%" PRIu64 ", tail=%" PRIu64 ", alloc=%" PRIu64

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.cpp
@@ -22,7 +22,9 @@
 #include "common/unified_log.h"
 
 #if PTO2_PROFILING
+// Weak fallbacks for host/UT builds that don't link the scope_stats collector.
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_scope_stats_enabled() { return false; }
+extern "C" __attribute__((weak, visibility("hidden"))) void scope_stats_note_heap_wrap(int) {}
 #endif
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -38,11 +38,6 @@
 #include "pto_runtime2_types.h"
 #include "pto_shared_memory.h"
 
-#if PTO2_PROFILING
-// Strong def in scope_stats_collector_aicpu.cpp; weak fallback in pto_scheduler.cpp for host/UT builds.
-extern "C" bool is_scope_stats_enabled();
-#endif
-
 #if PTO2_SCHED_PROFILING
 #include "aicpu/device_time.h"
 #define PTO2_SCHED_CYCLE_START() uint64_t _st0 = get_sys_cnt_aicpu(), _st1

--- a/src/common/platform/include/aicpu/scope_stats_collector_aicpu.h
+++ b/src/common/platform/include/aicpu/scope_stats_collector_aicpu.h
@@ -89,4 +89,23 @@ void scope_stats_aicpu_flush_buffers();
 void scope_stats_set_ring_capacity(int ring_id, int32_t window_cap, uint64_t heap_cap, int32_t dep_pool_cap);
 void scope_stats_set_tensormap_capacity(int32_t cap);
 
+// --- Heap-ring wrap accounting ---
+//
+// The heap ring's reclaim/alloc pointers are wrapping byte offsets in
+// [0, heap_cap); subtracting two boundary snapshots therefore loses every wrap
+// that happened in between, so the per-scope alloc / high-water deltas are not
+// recoverable once a scope's heap throughput exceeds heap_cap. The runtime is
+// the only place each individual wrap is observable (each allocation is
+// < heap_cap, so a single wrap is unambiguous), so it reports each wrap here;
+// the collector accumulates the count per ring and unrolls the sampled wrapping
+// offsets into monotonic values, making every delta exact for any wrap count.
+//
+// The runtime passes only the side — it stores no per-ring state. The collector
+// attributes the wrap to the current scope's ring (the wrap always happens mid
+// scope, where the active ring equals the most recent scope_stats_begin's ring).
+#define SCOPE_STATS_HEAP_SIDE_ALLOC 0    // heap_top (allocation pointer) wrapped.
+#define SCOPE_STATS_HEAP_SIDE_RECLAIM 1  // heap_tail (reclaim pointer) wrapped.
+
+void scope_stats_note_heap_wrap(int side);
+
 }  // extern "C"

--- a/src/common/platform/include/common/scope_stats.h
+++ b/src/common/platform/include/common/scope_stats.h
@@ -83,8 +83,8 @@ struct ScopeStatsRecord {
                                   // human-readable path without dereferencing a
                                   // device pointer (the string table lives in the
                                   // orchestration .so, not in shared memory).
-    uint64_t heap_start;          // Heap ring reclaim pointer (heap_tail_).
-    uint64_t heap_end;            // Heap ring allocation pointer (heap_top_).
+    uint64_t heap_start;          // Heap reclaim pointer, unrolled to monotonic cumulative bytes.
+    uint64_t heap_end;            // Heap allocation pointer, unrolled to monotonic cumulative bytes.
     int32_t site_line;
     int32_t task_start;      // Task ring tail (last_task_alive).
     int32_t task_end;        // Task ring head (next task id).

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -41,7 +41,7 @@
  *   finalize()           — Free all device memory, unregister.
  *
  * Output (scope_stats/scope_stats.jsonl), NDJSON:
- *   line 1: {"version":5,"fatal":bool,"dropped":uint,"total":uint,
+ *   line 1: {"version":6,"fatal":bool,"dropped":uint,"total":uint,
  *            "task_window_max":[...],"heap_max":[...],
  *            "dep_pool_max":[...],"tensormap_max":uint}
  *   line k: {"site":"file:line","phase":"begin|end","depth":int,

--- a/src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
@@ -38,6 +38,12 @@ static ScopeStatsDataHeader *s_scope_stats_header = nullptr;
 static ScopeStatsBufferState *s_scope_stats_state = nullptr;
 static int s_orch_thread_idx = -1;  // set via scope_stats_aicpu_set_orch_thread_idx
 
+// Cumulative heap-ring wrap counts per ring, indexed by SCOPE_STATS_HEAP_SIDE_*.
+// Fed by the runtime via scope_stats_note_heap_wrap at each wrap; used to unroll
+// the boundary-sampled wrapping offsets into monotonic values (see
+// unroll_heap_offset). Reset in set_platform_scope_stats_base.
+static uint64_t s_heap_wraps[PTO2_SCOPE_STATS_MAX_RING_DEPTH][2] = {};
+
 namespace {
 
 const char *s_pending_site_file = nullptr;
@@ -45,6 +51,9 @@ int32_t s_pending_site_line = 0;
 
 const char *s_scope_site_file[PTO2_SCOPE_STATS_MAX_SCOPE_DEPTH] = {};
 int32_t s_scope_site_line[PTO2_SCOPE_STATS_MAX_SCOPE_DEPTH] = {};
+// Ring id of each open scope, recorded at scope_stats_begin. Lets a heap-wrap
+// report (which carries no ring id) be attributed to the current scope's ring.
+int s_scope_ring[PTO2_SCOPE_STATS_MAX_SCOPE_DEPTH] = {};
 
 inline const char *basename_of(const char *path) {
     if (!path) return "(unknown)";
@@ -164,6 +173,16 @@ void switch_buffer() {
     wmb();
 }
 
+// Unroll a wrapping heap byte offset into a monotonic value using the
+// accumulated wrap count for this ring/side and the registered heap capacity.
+// With monotonic heap_start/heap_end, every host-side delta (real_occupancy,
+// scope_alloc, high-water) is an exact subtraction regardless of wrap count.
+inline uint64_t unroll_heap_offset(uint64_t offset, int ring_id, int side) {
+    if (s_scope_stats_header == nullptr) return offset;
+    if (ring_id < 0 || ring_id >= PTO2_SCOPE_STATS_MAX_RING_DEPTH) return offset;
+    return offset + s_heap_wraps[ring_id][side] * s_scope_stats_header->heap_cap[ring_id];
+}
+
 // Append one record carrying the task/heap ring start/end and tensormap usage,
 // tagged with the current depth/site and the boundary phase. Called once per
 // scope boundary.
@@ -204,8 +223,8 @@ void append_record_snapshot(
     rec.dep_pool_start = dep_pool_start;
     rec.dep_pool_end = dep_pool_end;
     rec.tensormap_used = tensormap_used;
-    rec.heap_start = heap_start;
-    rec.heap_end = heap_end;
+    rec.heap_start = unroll_heap_offset(heap_start, ring_id, SCOPE_STATS_HEAP_SIDE_RECLAIM);
+    rec.heap_end = unroll_heap_offset(heap_end, ring_id, SCOPE_STATS_HEAP_SIDE_ALLOC);
     buf->count = idx + 1;
 }
 
@@ -237,6 +256,8 @@ extern "C" void set_platform_scope_stats_base(uint64_t scope_stats_data_base) {
     s_pending_site_line = 0;
     memset(s_scope_site_file, 0, sizeof(s_scope_site_file));
     memset(s_scope_site_line, 0, sizeof(s_scope_site_line));
+    memset(s_scope_ring, 0, sizeof(s_scope_ring));
+    memset(s_heap_wraps, 0, sizeof(s_heap_wraps));
 }
 
 void scope_stats_aicpu_set_orch_thread_idx(int thread_idx) { s_orch_thread_idx = thread_idx; }
@@ -287,6 +308,7 @@ extern "C" void scope_stats_begin(
     int32_t d = ++scope_stats_depth;
     s_scope_site_file[d] = s_pending_site_file;
     s_scope_site_line[d] = s_pending_site_line;
+    s_scope_ring[d] = ring_id;
     s_pending_site_file = nullptr;
     s_pending_site_line = 0;
     append_record_snapshot(
@@ -337,4 +359,13 @@ scope_stats_set_ring_capacity(int ring_id, int32_t window_cap, uint64_t heap_cap
 extern "C" void scope_stats_set_tensormap_capacity(int32_t cap) {
     if (!s_scope_stats_header) return;
     s_scope_stats_header->tensormap_cap = cap;
+}
+
+extern "C" void scope_stats_note_heap_wrap(int side) {
+    if (!scope_stats_enabled) return;
+    if (scope_stats_depth < 0) return;  // wrap outside any scope — unattributable
+    if (side != SCOPE_STATS_HEAP_SIDE_ALLOC && side != SCOPE_STATS_HEAP_SIDE_RECLAIM) return;
+    int ring_id = s_scope_ring[scope_stats_depth];
+    if (ring_id < 0 || ring_id >= PTO2_SCOPE_STATS_MAX_RING_DEPTH) return;
+    s_heap_wraps[ring_id][side] += 1;
 }

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -260,7 +260,9 @@ int ScopeStatsCollector::write_jsonl(const std::string &output_dir) {
     }
     std::fprintf(
         fp,
-        "{\"version\": 5, \"fatal\": %s, \"dropped\": %u, \"total\": %u, "
+        // version 6: heap_start/heap_end are monotonic cumulative bytes (was
+        // wrapping ring offsets in v5) — see docs/dfx/scope-stats.md.
+        "{\"version\": 6, \"fatal\": %s, \"dropped\": %u, \"total\": %u, "
         "\"task_window_max\": [%s], \"heap_max\": [%s], \"dep_pool_max\": [%s], \"tensormap_max\": %d}\n",
         hdr->fatal_latched ? "true" : "false", state->dropped_record_count, state->total_record_count,
         task_window_max.c_str(), heap_max.c_str(), dep_pool_max.c_str(), hdr->tensormap_cap

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -18,7 +18,7 @@ runtime takes care of the ``set_pending_site`` / ``scope_stats_begin`` /
 ``scope_stats_end`` calls. Schema lives in ``docs/dfx/scope-stats.md`` §3.
 
 Output (``scope_stats.jsonl``): line 1 is run metadata
-(``{"version":5,"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
+(``{"version":6,"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
 line is one scope-boundary record carrying task/heap/dep_pool start-end.
 """
 
@@ -118,7 +118,7 @@ class TestScopeStats(SceneTestCase):
         lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
         assert lines, f"scope_stats.jsonl empty under {matches[-1]}"
         meta = json.loads(lines[0])
-        assert meta.get("version") == 5, f"unexpected schema version: {meta!r}"
+        assert meta.get("version") == 6, f"unexpected schema version: {meta!r}"
         assert meta.get("fatal") is False, f"run latched fatal: {meta!r}"
         assert meta.get("dropped", 0) == 0, f"records dropped on device: {meta!r}"
         assert "dep_pool_max" in meta, f"metadata missing dep_pool_max: {meta!r}"

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -92,7 +92,6 @@ add_library(a2a3_rt_objs OBJECT
     ${A2A3_RUNTIME_DIR}/scheduler/pto_scheduler.cpp
     ${A2A3_RUNTIME_DIR}/shared/pto_tensormap.cpp
     ${A2A3_RUNTIME_DIR}/shared/pto_runtime2_init.cpp
-    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
     ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
 )
 target_include_directories(a2a3_rt_objs PUBLIC
@@ -352,6 +351,7 @@ add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
 add_a2a3_runtime_test(test_spsc_queue       a2a3/test_spsc_queue.cpp)
 add_a2a3_runtime_test(test_wiring           a2a3/test_wiring.cpp)
 add_a2a3_runtime_test(test_aicore_completion_mailbox a2a3/test_aicore_completion_mailbox.cpp)
+add_a2a3_runtime_test(test_scope_stats_collector a2a3/test_scope_stats_collector.cpp)
 
 # ---------------------------------------------------------------------------
 # A5 tests (src/a5/runtime/tensormap_and_ringbuffer/)

--- a/tests/ut/cpp/a2a3/test_scope_stats_collector.cpp
+++ b/tests/ut/cpp/a2a3/test_scope_stats_collector.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Regression tests for the scope_stats collector's monotonic heap accounting
+ * (issue #996).
+ *
+ * The collector samples the heap ring's reclaim/alloc pointers as wrapping byte
+ * offsets in [0, heap_cap). Subtracting two boundary snapshots loses every wrap
+ * in between, so before the fix a scope whose heap throughput exceeded heap_cap
+ * reported wrong scope_alloc / high-water deltas (and they were unrecoverable
+ * from the two wrapped samples). The allocator now reports each wrap via
+ * scope_stats_note_heap_wrap(side); the collector unrolls the sampled offsets
+ * into monotonic cumulative bytes so every host-side delta is exact for any
+ * wrap count.
+ *
+ * These tests drive the collector directly (no device): they feed
+ * scope_stats_begin / note_heap_wrap / scope_stats_end and assert the unrolled
+ * heap_start/heap_end committed to the buffer, reproducing the multi-wrap case
+ * #996 asked for. The metric expressions mirror simpler_setup/tools/
+ * scope_stats_plot.py exactly (scope_alloc = end.head - begin.head, etc.).
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+
+#include "aicpu/scope_stats_collector_aicpu.h"
+#include "common/scope_stats.h"
+// Collector compiled in here (not linked via CMake).
+// NOLINTNEXTLINE(bugprone-suspicious-include)
+#include "../../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp"
+
+namespace {
+
+constexpr uint64_t kHeapCap = 4096;  // small cap so a few KB of throughput wraps it.
+constexpr int kRing = 0;
+
+// Drives one collector instance over a host-owned shared region plus a single
+// free buffer, mirroring what the host collector hands the device at init.
+class ScopeStatsCollectorTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        size_t shm_size = calc_scope_stats_shm_size(/*num_instances=*/1);
+        base_ = std::aligned_alloc(64, shm_size);
+        buf_ = static_cast<ScopeStatsBuffer *>(std::aligned_alloc(64, sizeof(ScopeStatsBuffer)));
+        std::memset(base_, 0, shm_size);
+        std::memset(buf_, 0, sizeof(ScopeStatsBuffer));
+
+        set_scope_stats_enabled(true);
+        set_platform_scope_stats_base(reinterpret_cast<uint64_t>(base_));
+        scope_stats_aicpu_set_orch_thread_idx(0);
+        scope_stats_set_ring_capacity(kRing, /*window_cap=*/8, kHeapCap, /*dep_pool_cap=*/1024);
+
+        // Hand the device one free buffer to pop into (host is the producer).
+        ScopeStatsBufferState *state = get_scope_stats_buffer_state(base_, 0);
+        state->free_queue.buffer_ptrs[0] = reinterpret_cast<uint64_t>(buf_);
+        state->free_queue.head = 0;
+        state->free_queue.tail = 1;
+    }
+
+    void TearDown() override {
+        set_scope_stats_enabled(false);
+        set_platform_scope_stats_base(0);
+        std::free(base_);
+        std::free(buf_);
+    }
+
+    const ScopeStatsRecord &record(uint32_t i) const { return buf_->records[i]; }
+
+    void *base_ = nullptr;
+    ScopeStatsBuffer *buf_ = nullptr;
+};
+
+// A scope that wraps the alloc pointer twice and the reclaim pointer once must
+// report monotonic cumulative bytes, so scope_alloc recovers the full
+// throughput even though it exceeds heap_cap. This is the case #996 reported.
+TEST_F(ScopeStatsCollectorTest, MultiWrapScopeUnrollsToMonotonicBytes) {
+    // Total over the scope: 10000 bytes allocated, 8000 reclaimed.
+    //   alloc:   10000 = 2 * 4096 + 1808  -> 2 wraps, raw offset 1808
+    //   reclaim:  8000 = 1 * 4096 + 3904  -> 1 wrap,  raw offset 3904
+    constexpr uint64_t kAllocRaw = 1808;
+    constexpr uint64_t kReclaimRaw = 3904;
+
+    scope_stats_set_pending_site("test_scope_stats_collector.cpp", __LINE__);
+    scope_stats_begin(kRing, 0, 0, /*heap_start=*/0, /*heap_end=*/0, 0, 0, 0);
+
+    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+
+    scope_stats_end(kRing, 0, 0, /*heap_start=*/kReclaimRaw, /*heap_end=*/kAllocRaw, 0, 0, 0);
+
+    ASSERT_EQ(buf_->count, 2u);
+    const ScopeStatsRecord &begin = record(0);
+    const ScopeStatsRecord &end = record(1);
+
+    // Unrolled to monotonic cumulative bytes (raw + wraps * cap).
+    EXPECT_EQ(begin.heap_start, 0u);
+    EXPECT_EQ(begin.heap_end, 0u);
+    EXPECT_EQ(end.heap_start, 8000u);
+    EXPECT_EQ(end.heap_end, 10000u);
+
+    // Metric expressions mirror scope_stats_plot.py.
+    uint64_t scope_alloc = end.heap_end - begin.heap_end;
+    uint64_t real_occupancy = end.heap_end - end.heap_start;
+    uint64_t high_water = end.heap_end - begin.heap_start;
+
+    EXPECT_EQ(scope_alloc, 10000u);
+    EXPECT_GT(scope_alloc, kHeapCap);  // the multi-wrap throughput the old code lost.
+    EXPECT_EQ(real_occupancy, 2000u);
+    EXPECT_LE(real_occupancy, kHeapCap);
+    EXPECT_EQ(high_water, 10000u);
+}
+
+// When the ring is exactly full, the raw offsets coincide (modular occupancy
+// folds to 0) but the unrolled occupancy is heap_cap. The debug invariant
+// assert must accept this instead of firing — exercised here because the UT
+// build keeps assertions enabled (no NDEBUG).
+TEST_F(ScopeStatsCollectorTest, FullRingOccupancyDoesNotTripInvariant) {
+    // alloc 8192 (2 wraps, raw 0), reclaim 4096 (1 wrap, raw 0) -> occ == cap.
+    scope_stats_set_pending_site("test_scope_stats_collector.cpp", __LINE__);
+    scope_stats_begin(kRing, 0, 0, /*heap_start=*/0, /*heap_end=*/0, 0, 0, 0);
+
+    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_ALLOC);
+    scope_stats_note_heap_wrap(SCOPE_STATS_HEAP_SIDE_RECLAIM);
+
+    scope_stats_end(kRing, 0, 0, /*heap_start=*/0, /*heap_end=*/0, 0, 0, 0);
+
+    ASSERT_EQ(buf_->count, 2u);
+    const ScopeStatsRecord &end = record(1);
+    EXPECT_EQ(end.heap_start, kHeapCap);                 // 1 * cap
+    EXPECT_EQ(end.heap_end, 2 * kHeapCap);               // 2 * cap
+    EXPECT_EQ(end.heap_end - end.heap_start, kHeapCap);  // full ring, exactly cap.
+}
+
+// A ring that never wraps must pass raw offsets through unchanged (the wrap
+// accounting stays dormant), so a non-migrated path is unaffected.
+TEST_F(ScopeStatsCollectorTest, NoWrapPassesOffsetsThrough) {
+    scope_stats_set_pending_site("test_scope_stats_collector.cpp", __LINE__);
+    scope_stats_begin(kRing, 0, 0, /*heap_start=*/0, /*heap_end=*/512, 0, 0, 0);
+    scope_stats_end(kRing, 0, 0, /*heap_start=*/512, /*heap_end=*/2048, 0, 0, 0);
+
+    ASSERT_EQ(buf_->count, 2u);
+    EXPECT_EQ(record(0).heap_end, 512u);
+    EXPECT_EQ(record(1).heap_start, 512u);
+    EXPECT_EQ(record(1).heap_end, 2048u);
+}
+
+}  // namespace


### PR DESCRIPTION
heap_start/heap_end were wrapping byte offsets in [0, heap_cap), so subtracting two boundary snapshots lost every wrap in between — per-scope alloc / high-water metrics were wrong once a scope's heap throughput exceeded heap_cap, and unrecoverable from two wrapped samples.

The allocator is the only place each individual wrap is observable (each allocation is < heap_cap), so it now reports every wrap to the collector via scope_stats_note_heap_wrap(side). The collector accumulates per-ring wrap counts, attributes each wrap to the current scope's ring (derived from depth, so the runtime stores no scope_stats state), and unrolls the sampled offsets into monotonic cumulative-byte values. Every host-side delta is now an exact, non-negative subtraction for any wrap count.

A debug-only invariant assert (unrolled occupancy == modular occupancy) guards against wrap-count drift; it is skipped for rings that report no wraps, so a5's pre-migration path is unaffected.

Applied to both a2a3 and a5. dep_pool and task_window are already monotonic linear counters and need no change. Docs updated for the new non-wrapping semantics.

fixes: #996 