### PR TITLE
Fix: keep HCCL weak-link dependency

### DIFF
--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -160,11 +160,13 @@ endif()
 # Link against CANN runtime libraries
 # ascend_hal is dynamically loaded at runtime via dlopen in device_runner
 # when performance profiling is enabled
+# HCCL entry points are weak symbols in CANN's hccl_comm.h. Keep libhcomm
+# in DT_NEEDED even when the x86 toolchain defaults to --as-needed.
 target_link_libraries(host_runtime
     PRIVATE
         runtime
         ascendcl
-        ${HCCL_LINK_TARGETS}
+        -Wl,--push-state,--no-as-needed,${HCCL_LINK_TARGETS},--pop-state
         dl
 )
 

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -131,11 +131,13 @@ endif()
 # Link against CANN runtime libraries
 # ascend_hal is dynamically loaded at runtime via dlopen in device_runner
 # when performance profiling is enabled
+# HCCL entry points are weak symbols in CANN's hccl_comm.h. Keep libhcomm
+# in DT_NEEDED even when the x86 toolchain defaults to --as-needed.
 target_link_libraries(host_runtime
     PRIVATE
         runtime
         ascendcl
-        ${HCCL_LINK_TARGETS}
+        -Wl,--push-state,--no-as-needed,${HCCL_LINK_TARGETS},--pop-state
         dl
 )
 


### PR DESCRIPTION
## Summary
- Keep `libhcomm.so` in `DT_NEEDED` for a2a3 onboard host runtime links.
- Apply the same weak-link protection to the a5 onboard host runtime.
- Use one comma-separated `-Wl,--push-state,--no-as-needed,...,--pop-state` option so the HCCL link target stays wrapped as a single linker argument.

## Why
CANN declares `HcclGetRootInfo` and `HcclCommInitRootInfo` as weak symbols in `hccl_comm.h`. On x86 toolchains that default to `--as-needed`, `libhcomm.so` can be dropped because it only satisfies weak undefined references. Then the HCCL entry points resolve to NULL at runtime, and rank0 can segfault in `comm_init` before writing rootinfo.

Keeping `libhcomm.so` as a needed dependency fixes the weak-symbol resolution path without changing linker state for later libraries.

## Testing
- `git diff --check`
- Verified on x86 server and A2 server: the issue #1018 `comm_init` crash no longer reproduces.
- CI note: a previous `st-onboard-a5` run failed in `examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope` with `run_prepared failed with code 507000`; the HCCL allreduce distributed case had already passed in that same job, so this looks unrelated to the weak-link fix.

Fixes #1018