### PR TITLE
removing the -Werror flag in development mode

### DIFF
--- a/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
@@ -63,9 +63,9 @@ message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
 message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
 
-option(WERROR "Treat compiler warnings as errors" OFF)
-if(DEFINED ENV{CI})
-    set(WERROR ON)
+option(WERROR "Treat compiler warnings as errors" ON)
+if(DEFINED ENV{SIMPLER_DISABLE_WARNINGS_AS_ERRORS})
+    set(WERROR OFF)
 endif()
 
 # Compile options (common to both C and C++)

--- a/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
@@ -63,6 +63,11 @@ message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
 message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
 
+option(WERROR "Treat compiler warnings as errors" OFF)
+if(DEFINED ENV{CI})
+    set(WERROR ON)
+endif()
+
 # Compile options (common to both C and C++)
 target_compile_options(aicpu_kernel
     PRIVATE
@@ -71,6 +76,7 @@ target_compile_options(aicpu_kernel
         -rdynamic
         -O3
         -fPIC
+        $<$<BOOL:${WERROR}>:-Werror>
         -Wno-error=variadic-macros
         -fno-common
         -g

--- a/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/aicpu/CMakeLists.txt
@@ -71,7 +71,6 @@ target_compile_options(aicpu_kernel
         -rdynamic
         -O3
         -fPIC
-        -Werror
         -Wno-error=variadic-macros
         -fno-common
         -g

--- a/src/a2a3/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicpu/CMakeLists.txt
@@ -70,11 +70,17 @@ endif()
 # Create shared library (host-compatible for dlopen)
 add_library(aicpu_kernel SHARED ${AICPU_SOURCES})
 
+option(WERROR "Treat compiler warnings as errors" OFF)
+if(DEFINED ENV{CI})
+    set(WERROR ON)
+endif()
+
 # Compile options (host g++/gcc)
 target_compile_options(aicpu_kernel
     PRIVATE
         -Wall
         -Wextra
+        $<$<BOOL:${WERROR}>:-Werror>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=class-memaccess>
         -fPIC
         -O3

--- a/src/a2a3/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicpu/CMakeLists.txt
@@ -70,9 +70,9 @@ endif()
 # Create shared library (host-compatible for dlopen)
 add_library(aicpu_kernel SHARED ${AICPU_SOURCES})
 
-option(WERROR "Treat compiler warnings as errors" OFF)
-if(DEFINED ENV{CI})
-    set(WERROR ON)
+option(WERROR "Treat compiler warnings as errors" ON)
+if(DEFINED ENV{SIMPLER_DISABLE_WARNINGS_AS_ERRORS})
+    set(WERROR OFF)
 endif()
 
 # Compile options (host g++/gcc)

--- a/src/a2a3/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a2a3/platform/sim/aicpu/CMakeLists.txt
@@ -75,7 +75,6 @@ target_compile_options(aicpu_kernel
     PRIVATE
         -Wall
         -Wextra
-        -Werror
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=class-memaccess>
         -fPIC
         -O3

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -63,9 +63,9 @@ message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
 message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
 
-option(WERROR "Treat compiler warnings as errors" OFF)
-if(DEFINED ENV{CI})
-    set(WERROR ON)
+option(WERROR "Treat compiler warnings as errors" ON)
+if(DEFINED ENV{SIMPLER_DISABLE_WARNINGS_AS_ERRORS})
+    set(WERROR OFF)
 endif()
 
 # Compile options (common to both C and C++)

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -63,6 +63,11 @@ message(STATUS "AICpu kernel: ${NUM_AICPU_KERNEL_SOURCES} source files")
 message(VERBOSE "AICpu kernel sources: ${AICPU_KERNEL_SOURCES}")
 add_library(aicpu_kernel SHARED ${AICPU_KERNEL_SOURCES})
 
+option(WERROR "Treat compiler warnings as errors" OFF)
+if(DEFINED ENV{CI})
+    set(WERROR ON)
+endif()
+
 # Compile options (common to both C and C++)
 target_compile_options(aicpu_kernel
     PRIVATE
@@ -71,6 +76,7 @@ target_compile_options(aicpu_kernel
         -rdynamic
         -O3
         -fPIC
+        $<$<BOOL:${WERROR}>:-Werror>
         -Wno-error=variadic-macros
         -fno-common
         -g

--- a/src/a5/platform/onboard/aicpu/CMakeLists.txt
+++ b/src/a5/platform/onboard/aicpu/CMakeLists.txt
@@ -71,7 +71,6 @@ target_compile_options(aicpu_kernel
         -rdynamic
         -O3
         -fPIC
-        -Werror
         -Wno-error=variadic-macros
         -fno-common
         -g

--- a/src/a5/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a5/platform/sim/aicpu/CMakeLists.txt
@@ -68,11 +68,17 @@ endif()
 # Create shared library (host-compatible for dlopen)
 add_library(aicpu_kernel SHARED ${AICPU_SOURCES})
 
+option(WERROR "Treat compiler warnings as errors" OFF)
+if(DEFINED ENV{CI})
+    set(WERROR ON)
+endif()
+
 # Compile options (host g++/gcc)
 target_compile_options(aicpu_kernel
     PRIVATE
         -Wall
         -Wextra
+        $<$<BOOL:${WERROR}>:-Werror>
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=class-memaccess>
         -fPIC
         -O3

--- a/src/a5/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a5/platform/sim/aicpu/CMakeLists.txt
@@ -73,7 +73,6 @@ target_compile_options(aicpu_kernel
     PRIVATE
         -Wall
         -Wextra
-        -Werror
         $<$<CXX_COMPILER_ID:GNU>:-Wno-error=class-memaccess>
         -fPIC
         -O3

--- a/src/a5/platform/sim/aicpu/CMakeLists.txt
+++ b/src/a5/platform/sim/aicpu/CMakeLists.txt
@@ -68,9 +68,9 @@ endif()
 # Create shared library (host-compatible for dlopen)
 add_library(aicpu_kernel SHARED ${AICPU_SOURCES})
 
-option(WERROR "Treat compiler warnings as errors" OFF)
-if(DEFINED ENV{CI})
-    set(WERROR ON)
+option(WERROR "Treat compiler warnings as errors" ON)
+if(DEFINED ENV{SIMPLER_DISABLE_WARNINGS_AS_ERRORS})
+    set(WERROR OFF)
 endif()
 
 # Compile options (host g++/gcc)


### PR DESCRIPTION
general recommendation: 
"Warnings as Errors" should not be enforced during development, only at CI

reason: 
Many times, one comments out lines of code for debugging -- having to also remove or "[[maybe_unused]]" function arguments or variables that remain unused wastes a lot of time.

What has been done:
The `-Werror` flag will only be added for the CI. Locally, it will not be triggered automatically. 
One can do so manually: `cmake -DWERROR=ON ...`