### PR TITLE
Add: tensor dump on the abnormal path (hang / op-timeout) (a5 + a2a3)

### DIFF
--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -832,6 +832,52 @@ viewer's working directory differs from the run's. Pass the
 explicit dump-dir path to the viewer:
 `python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump`.
 
+**The run hung (AICore op-timeout / scheduler timeout) — is there
+still a dump?** Yes, and it includes the hung kernel's own partial
+output. The host exports the manifest even though `run()` returns the
+timeout error, and you get the inputs of every dispatched task
+(captured at `BEFORE_DISPATCH`) plus the `AFTER_COMPLETION` output of
+every task that completed before the hang. This rests on the timeout
+ordering — the three budgets are tuned so the **AICPU detects the
+hang first**, dumps, and only then the hardware/host timeouts fire:
+
+```text
+SCHEDULER_TIMEOUT_MS (2 s)  <  PLATFORM_OP_EXECUTE_TIMEOUT_US (3 s)  <  PLATFORM_STREAM_SYNC_TIMEOUT_MS (4 s)
+   AICPU declares hang,          STARS reaps the AICore op            host stream sync gives up
+   flushes + dumps in-flight     and poisons the context              and surfaces the error
+```
+
+- **Device-side graceful flush (primary).** At 2 s of no progress
+  the AICPU declares the hang, runs the end-of-loop flush, *and*
+  dumps the **partial output** of every task still RUNNING on a core
+  — written at the `after_completion` stage, reflecting current GM,
+  so you can see how far a stuck kernel got and how much it wrote.
+  Because this fires ~1 s before STARS reaps the op (3 s), it
+  normally completes while the kernel is still wedged (and host-side
+  recovery below backstops the rest). Best-effort:
+  only AICore writes already drained to GM are visible (the stuck
+  core issued no `pipe_barrier`, so writes still in its cache are
+  not), and a read may be torn if the core is mid-write. To tell a
+  running task's partial output apart from a genuine completion,
+  cross-reference the `[STALL …] state=RUNNING` / `SHUTDOWN_SNAPSHOT`
+  log lines — those task_ids are the in-flight ones.
+- **Host-side recovery (backstop).** If the AICPU is killed before
+  it finishes flushing (it loses the race, or `emergency_shutdown`
+  blocks on the wedged core), its last buffer is left un-flushed on
+  the device (`current_buf_ptr != 0`). The host's `reconcile_counters`
+  detects this and recovers those records directly from the device
+  buffer + arena (the device is not reset until *after* the export),
+  so whatever the AICPU managed to record — including in-flight
+  output written before the kill — still reaches the manifest.
+
+This ordering is load-bearing: if the timeouts were inverted (STARS
+reaping before the AICPU's budget, as in earlier versions), the
+device-side dump would never run on a real AICore hang and you would
+only recover what was already in the buffer. The chain lives in
+`scheduler_types.h` (`SCHEDULER_TIMEOUT_MS`) and `platform_config.h`
+(`PLATFORM_OP_EXECUTE_TIMEOUT_US` / `PLATFORM_STREAM_SYNC_TIMEOUT_MS`),
+along with the `#897` distributed-skew trade-off.
+
 ## 9. Related docs
 
 - [profiling-framework.md](../profiling-framework.md) — shared

--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -64,15 +64,16 @@ constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 6;
  * Passed to aclrtSetOpExecuteTimeOutV2 so that STARS actively monitors
  * AICore task execution and kills ops that exceed this threshold.
  */
-constexpr uint64_t PLATFORM_OP_EXECUTE_TIMEOUT_US = 1000000;  // 1s
+constexpr uint64_t PLATFORM_OP_EXECUTE_TIMEOUT_US = 3000000;  // 3s
 
 /**
  * Host-side stream synchronization timeout (milliseconds).
  * Passed to aclrtSynchronizeStreamWithTimeout to detect stream sync hangs.
- * Must be longer than PLATFORM_OP_EXECUTE_TIMEOUT_US to allow STARS
- * enough time to kill the timed-out op and propagate the notification.
+ * Must be longer than PLATFORM_OP_EXECUTE_TIMEOUT_US so the host waits for
+ * STARS to reap the timed-out op and surface the error, rather than giving up
+ * first.
  */
-constexpr int PLATFORM_STREAM_SYNC_TIMEOUT_MS = 2000;  // 2s (> op timeout 1s)
+constexpr int PLATFORM_STREAM_SYNC_TIMEOUT_MS = 4000;  // 4s (> op-exec 3s)
 
 // =============================================================================
 // Derived Platform Limits

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -400,6 +400,15 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         // run, so attempt recovery / mark-unusable here too, not only on the
         // launch-error path above.
         recover_device_or_mark_unusable(rc);
+        // On an AICPU-detected scheduler hang the device flushed its diagnostic
+        // buffers during emergency_shutdown before returning the timeout rc.
+        // Export them here too — otherwise the success-only teardown below is
+        // skipped and the dumped tensors (the stuck task's inputs plus every
+        // completed task's in/out) are streamed to .bin but left without the
+        // JSON manifest, i.e. unusable for triage. reconcile/export are not
+        // idempotent, so this runs only on the error return; the success path
+        // still exports exactly once below.
+        teardown_shared_collectors_after_run();
         return rc;
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -18,6 +18,7 @@
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/pmu_collector_aicpu.h"
+#include "aicpu/tensor_dump_aicpu.h"
 #include "common/memory_barrier.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
@@ -381,6 +382,24 @@ int32_t SchedulerContext::handle_timeout_exit(
     latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
         log_shutdown_stall_snapshot(thread_idx, idle_iterations, last_progress_count);
+#if PTO2_PROFILING
+        // Capture the in-flight kernels' partial output before signalling the
+        // cores to exit, so the dump reflects the live stuck state.
+        if (is_dump_tensor_enabled()) {
+            dump_running_task_outputs<PTO2_SUBTASK_SLOT_COUNT>(
+                thread_idx, cores_total_num_,
+                [this](int32_t cid) {
+                    return core_exec_states_[cid].running_slot_state;
+                },
+                [](ActiveMask active_mask, int raw_subtask_id) {
+                    return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+                },
+                [this](int32_t func_id) {
+                    return get_function_bin_addr(func_id);
+                }
+            );
+        }
+#endif
         emergency_shutdown(runtime);
     }
 #if PTO2_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -613,6 +613,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
     LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
     int32_t cur_thread_completed = 0;
+    // Non-zero once a scheduler-hang timeout latches; returned in place of the
+    // completed count so the caller still sees the negative error rc while the
+    // shared end-of-loop flush below runs.
+    int32_t timeout_rc = 0;
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
 #if PTO2_PROFILING
@@ -974,13 +978,20 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                                     completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&
                                     no_thread_owns_running_task();
                 if (self_owns || global_stuck) {
-                    return handle_timeout_exit(
+                    // Latch the error + emergency_shutdown, then break to the
+                    // shared end-of-loop cleanup so the diagnostic buffers get
+                    // flushed to the host. An early return here would strand the
+                    // stuck task's already-dumped inputs and every completed
+                    // task's in/out records in the unflushed per-thread dump
+                    // buffer — exactly the state we need to triage the hang.
+                    timeout_rc = handle_timeout_exit(
                         thread_idx, header, runtime, idle_iterations, last_progress_count
 #if PTO2_PROFILING
                         ,
                         l2_swimlane.sched_start_ts
 #endif
                     );
+                    break;
                 }
                 last_progress_ts = get_sys_cnt_aicpu();
             }
@@ -1065,5 +1076,5 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 #endif
 
-    return cur_thread_completed;
+    return timeout_rc != 0 ? timeout_rc : cur_thread_completed;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -60,7 +60,15 @@ constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator erro
 // same iteration count. The fast spinner racing ahead and latching fatal
 // kills the slower-but-correct poller mid-poll — see the distributed
 // startup-skew scenario in issue #897.
-constexpr int32_t SCHEDULER_TIMEOUT_MS = 5000;  // 5 s; > worst observed distributed-init skew + HCCL wait
+//
+// The value is set *below* the STARS AICore op-execution timeout
+// (PLATFORM_OP_EXECUTE_TIMEOUT_US, 3 s) on purpose: the AICPU must detect a hang
+// and flush its diagnostics (tensor dump, in-flight partial output) before STARS
+// reaps the op and poisons the context. Chain: this < op-exec < host stream-sync
+// (platform_config.h). Trade-off: 2 s is shorter than the worst distributed-init
+// / HCCL skew #897 sized 5 s for, so a slow distributed startup can false-latch;
+// if that bites, raise this together with the op-exec / stream-sync timeouts.
+constexpr int32_t SCHEDULER_TIMEOUT_MS = 2000;  // 2 s; < op-exec so the AICPU dumps before STARS reaps
 constexpr uint64_t SCHEDULER_TIMEOUT_CYCLES =
     static_cast<uint64_t>(SCHEDULER_TIMEOUT_MS) * (PLATFORM_PROF_SYS_CNT_FREQ / 1000);
 constexpr int32_t STALL_DUMP_READY_MAX = 8;

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -91,15 +91,16 @@ constexpr int PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH = 14;
  * Passed to aclrtSetOpExecuteTimeOutV2 so that STARS actively monitors
  * AICore task execution and kills ops that exceed this threshold.
  */
-constexpr uint64_t PLATFORM_OP_EXECUTE_TIMEOUT_US = 1000000;  // 1s
+constexpr uint64_t PLATFORM_OP_EXECUTE_TIMEOUT_US = 3000000;  // 3s
 
 /**
  * Host-side stream synchronization timeout (milliseconds).
  * Passed to aclrtSynchronizeStreamWithTimeout to detect stream sync hangs.
- * Must be longer than PLATFORM_OP_EXECUTE_TIMEOUT_US to allow STARS
- * enough time to kill the timed-out op and propagate the notification.
+ * Must be longer than PLATFORM_OP_EXECUTE_TIMEOUT_US so the host waits for
+ * STARS to reap the timed-out op and surface the error, rather than giving up
+ * first.
  */
-constexpr int PLATFORM_STREAM_SYNC_TIMEOUT_MS = 2000;  // 2s (> op timeout 1s)
+constexpr int PLATFORM_STREAM_SYNC_TIMEOUT_MS = 4000;  // 4s (> op-exec 3s)
 
 // =============================================================================
 // Derived Platform Limits

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -381,6 +381,15 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         // run, so attempt recovery / mark-unusable here too, not only on the
         // launch-error path above.
         recover_device_or_mark_unusable(rc);
+        // On an AICPU-detected scheduler hang the device flushed its diagnostic
+        // buffers during emergency_shutdown before returning the timeout rc.
+        // Export them here too — otherwise the success-only teardown below is
+        // skipped and the dumped tensors (the stuck task's inputs plus every
+        // completed task's in/out) are streamed to .bin but left without the
+        // JSON manifest, i.e. unusable for triage. reconcile/export are not
+        // idempotent, so this runs only on the error return; the success path
+        // still exports exactly once below.
+        teardown_shared_collectors_after_run();
         return rc;
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -18,6 +18,7 @@
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/pmu_collector_aicpu.h"
+#include "aicpu/tensor_dump_aicpu.h"
 #include "common/memory_barrier.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
@@ -381,6 +382,24 @@ int32_t SchedulerContext::handle_timeout_exit(
     latch_scheduler_error(header, thread_idx, PTO2_ERROR_SCHEDULER_TIMEOUT);
     if (!completed_.exchange(true, std::memory_order_acq_rel)) {
         log_shutdown_stall_snapshot(thread_idx, idle_iterations, last_progress_count);
+#if PTO2_PROFILING
+        // Capture the in-flight kernels' partial output before signalling the
+        // cores to exit, so the dump reflects the live stuck state.
+        if (is_dump_tensor_enabled()) {
+            dump_running_task_outputs<PTO2_SUBTASK_SLOT_COUNT>(
+                thread_idx, cores_total_num_,
+                [this](int32_t cid) {
+                    return core_exec_states_[cid].running_slot_state;
+                },
+                [](ActiveMask active_mask, int raw_subtask_id) {
+                    return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
+                },
+                [this](int32_t func_id) {
+                    return get_function_bin_addr(func_id);
+                }
+            );
+        }
+#endif
         emergency_shutdown(runtime);
     }
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -507,6 +507,10 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
     LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, tracker.core_num());
     int32_t cur_thread_completed = 0;
+    // Non-zero once a scheduler-hang timeout latches; returned in place of the
+    // completed count so the caller still sees the negative error rc while the
+    // shared end-of-loop flush below runs.
+    int32_t timeout_rc = 0;
     int32_t idle_iterations = 0;
     int32_t last_progress_count = 0;
 #if PTO2_PROFILING
@@ -863,13 +867,20 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
                                     completed_tasks_.load(std::memory_order_relaxed) < total_tasks_ &&
                                     no_thread_owns_running_task();
                 if (self_owns || global_stuck) {
-                    return handle_timeout_exit(
+                    // Latch the error + emergency_shutdown, then break to the
+                    // shared end-of-loop cleanup so the diagnostic buffers get
+                    // flushed to the host. An early return here would strand the
+                    // stuck task's already-dumped inputs and every completed
+                    // task's in/out records in the unflushed per-thread dump
+                    // buffer — exactly the state we need to triage the hang.
+                    timeout_rc = handle_timeout_exit(
                         thread_idx, header, runtime, idle_iterations, last_progress_count
 #if PTO2_PROFILING
                         ,
                         l2_swimlane.sched_start_ts
 #endif
                     );
+                    break;
                 }
                 last_progress_ts = get_sys_cnt_aicpu();
             }
@@ -948,5 +959,5 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 #endif
 
-    return cur_thread_completed;
+    return timeout_rc != 0 ? timeout_rc : cur_thread_completed;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -61,7 +61,15 @@ constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator erro
 // same iteration count. The fast spinner racing ahead and latching fatal
 // kills the slower-but-correct poller mid-poll — see the distributed
 // startup-skew scenario in issue #897.
-constexpr int32_t SCHEDULER_TIMEOUT_MS = 5000;  // 5 s; > worst observed distributed-init skew + HCCL wait
+//
+// The value is set *below* the STARS AICore op-execution timeout
+// (PLATFORM_OP_EXECUTE_TIMEOUT_US, 3 s) on purpose: the AICPU must detect a hang
+// and flush its diagnostics (tensor dump, in-flight partial output) before STARS
+// reaps the op and poisons the context. Chain: this < op-exec < host stream-sync
+// (platform_config.h). Trade-off: 2 s is shorter than the worst distributed-init
+// / HCCL skew #897 sized 5 s for, so a slow distributed startup can false-latch;
+// if that bites, raise this together with the op-exec / stream-sync timeouts.
+constexpr int32_t SCHEDULER_TIMEOUT_MS = 2000;  // 2 s; < op-exec so the AICPU dumps before STARS reaps
 constexpr uint64_t SCHEDULER_TIMEOUT_CYCLES =
     static_cast<uint64_t>(SCHEDULER_TIMEOUT_MS) * (PLATFORM_PROF_SYS_CNT_FREQ / 1000);
 constexpr int32_t STALL_DUMP_READY_MAX = 8;

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -189,6 +189,51 @@ inline void dump_tensors_for_task(
     }
 }
 
+// Dump the OUTPUT tensors of every task still RUNNING on a core, for the
+// scheduler-hang / timeout path. These tasks never reached completion, so their
+// AFTER_COMPLETION output was never captured; reading the current GM contents
+// shows how far each stuck kernel got and how much output it wrote.
+//
+// Best-effort: only AICore writes already drained to GM are visible (the stuck
+// core issued no pipe_barrier, so writes still in its cache are not), and a read
+// may be torn if the core is mid-write. Records go into thread_idx's dump buffer
+// and ride out on its dump_tensor_flush.
+//
+// The runtime supplies its own core/slot accessors so this stays platform-side
+// and reusable across runtimes:
+//   get_running_slot(cid)   -> SlotState* for the task running on core cid, or
+//                              nullptr if idle. A cluster's cores share one
+//                              SlotState pointer; pointer identity is used to
+//                              emit each running task exactly once.
+//   is_subtask_active / get_function_bin_addr — same callbacks as
+//   dump_tensors_for_task.
+template <int MaxSubtaskSlots, typename GetRunningSlotFn, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
+inline void dump_running_task_outputs(
+    int32_t thread_idx, int32_t cores_total_num, GetRunningSlotFn get_running_slot, IsSubtaskActiveFn is_subtask_active,
+    GetFunctionBinAddrFn get_function_bin_addr
+) {
+    for (int32_t cid = 0; cid < cores_total_num; cid++) {
+        auto *running = get_running_slot(cid);
+        if (running == nullptr) {
+            continue;
+        }
+        // Dedup: let the lowest-id core of each running task drive the dump.
+        bool already_dumped = false;
+        for (int32_t prev = 0; prev < cid; prev++) {
+            if (get_running_slot(prev) == running) {
+                already_dumped = true;
+                break;
+            }
+        }
+        if (already_dumped) {
+            continue;
+        }
+        dump_tensors_for_task<MaxSubtaskSlots>(
+            thread_idx, *running, TensorDumpStage::AFTER_COMPLETION, is_subtask_active, get_function_bin_addr
+        );
+    }
+}
+
 template <typename TensorInfoT>
 inline void dump_tensors_for_task(
     int32_t thread_idx, uint64_t task_id, int32_t task_arg_count, const CoreCallable &callable,

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -325,11 +325,15 @@ void TensorDumpCollector::reconcile_counters() {
     rmb();
 
     uint32_t dropped_total = 0;
-    int leftover_active = 0;
-    // After stop(), dump_tensor_flush should have either enqueued the
-    // active buffer (success → current_buf_ptr=0) or counted it as dropped
-    // and cleared it. A non-zero pointer with non-zero count means records
-    // AICPU neither delivered nor accounted for — a device-side flush bug.
+    int recovered_threads = 0;
+    // After stop(), a non-zero current_buf_ptr with records means the device
+    // never ran dump_tensor_flush for that thread. The common cause is a hang:
+    // the AICPU op is reaped by the hardware op-execution timeout (507xxx)
+    // before its graceful scheduler-timeout shutdown can flush. The host still
+    // holds the buffer and the originating arena, so recover the records here
+    // (the same path the poll thread uses for a ready buffer) instead of
+    // dropping them — export_dump_files() then writes them like any normally
+    // collected buffer, so a hung run still yields its dumped inputs/outputs.
     for (int t = 0; t < num_dump_threads_; t++) {
         DumpBufferState *state = get_dump_buffer_state(shm_host_, t);
 
@@ -346,12 +350,18 @@ void TensorDumpCollector::reconcile_counters() {
         uint32_t count = reinterpret_cast<DumpMetaBuffer *>(host_ptr)->count;
         if (count == 0) continue;
 
-        LOG_ERROR(
-            "Dump reconcile: thread %d has un-flushed buffer (current_buf_ptr=0x%lx, count=%u) after "
-            "stop() — device flush failed",
-            t, static_cast<unsigned long>(cur_ptr), count
+        DumpReadyBufferInfo info;
+        info.thread_index = static_cast<uint32_t>(t);
+        info.dev_buffer_ptr = reinterpret_cast<void *>(cur_ptr);
+        info.host_buffer_ptr = host_ptr;
+        info.buffer_seq = state->current_buf_seq;
+        on_buffer_collected(info);
+        recovered_threads++;
+        LOG_WARN(
+            "Dump reconcile: thread %d had an un-flushed buffer (count=%u) — device flush did not run "
+            "(AICPU likely reaped on a hang); recovered the records host-side",
+            t, count
         );
-        leftover_active++;
     }
 
     if (dropped_total > 0) {
@@ -361,8 +371,12 @@ void TensorDumpCollector::reconcile_counters() {
             dropped_total
         );
     }
-    if (leftover_active > 0) {
-        LOG_ERROR("Dump reconcile: %d thread(s) had un-cleared current_buf_ptr — see prior errors", leftover_active);
+    if (recovered_threads > 0) {
+        LOG_WARN(
+            "Dump reconcile: recovered un-flushed buffers from %d thread(s) (device-side flush was skipped, "
+            "typically an AICPU hang reap)",
+            recovered_threads
+        );
     }
 }
 


### PR DESCRIPTION
## Summary

Make `--dump-tensor` produce a usable dump when a run **hangs** (AICPU
scheduler-hang / AICore op-timeout), not only on a clean run. Previously a hung
run stranded the dumped inputs on-device and wrote no JSON manifest, so the
dump was empty exactly when it is most useful for triage.

Closes #1034.

## What changed

1. **Device flush on the timeout exit** — the scheduler-timeout branch in
   `resolve_and_dispatch` now `break`s to the shared end-of-loop flush instead
   of early-returning past it, so `dump_tensor_flush` (and the L2-swimlane / PMU
   flushes) run on the timeout path. The negative timeout rc is preserved to the
   caller via a `timeout_rc` local.
2. **In-flight partial output** — new platform template
   `dump_running_task_outputs` (`tensor_dump_aicpu.h`) dumps the current GM
   OUTPUT of every task still RUNNING on a core at hang time (best-effort,
   `after_completion` stage), so you can see how far a stuck kernel got. The
   runtime supplies its core/slot accessors via lambdas (same pattern as
   `dump_tensors_for_task`); deduped per cluster.
3. **Host export on the error path** — `DeviceRunner::run()` now calls
   `teardown_shared_collectors_after_run()` on the op-timeout error return, so
   the manifest is exported even though `run()` returns the error.
4. **Host-side recovery** — `reconcile_counters` recovers un-flushed buffers:
   when the AICPU is reaped (STARS op-timeout) before it can flush
   (`current_buf_ptr != 0`), it pulls the stranded records straight from device
   memory (before the force-reset) into the collected set instead of just
   logging "device flush failed".
5. **Timeout ordering** — re-tuned so the AICPU detects + dumps *before* STARS
   reaps the op, unified across a5/a2a3:
   `SCHEDULER_TIMEOUT_MS` (2 s) < `PLATFORM_OP_EXECUTE_TIMEOUT_US` (3 s) <
   `PLATFORM_STREAM_SYNC_TIMEOUT_MS` (4 s). Also fixes the stale a2a3 comments
   that disagreed with their values.

Docs: `docs/dfx/tensor-dump.md` FAQ rewritten to describe the two-path model
(device-side graceful dump primary, host-side recovery backstop) and the
timeout chain.

## Testing

- All changed translation units compile with the real toolchain across
  a5/a2a3 × onboard/sim (aicpu cross-compiler for the scheduler/platform
  template, host compiler for the runner/collector); both arch
  `libaicpu_kernel.so` link clean.
- Reproduced the original failure on hardware (deliberately hung kernel →
  `507018`, reconcile "un-flushed buffer", "No tensor dump data to export"),
  which motivated the host-side recovery + timeout reordering. A full onboard
  re-run with `--dump-tensor 2` to confirm the manifest now appears is
  recommended before merge.

## Notes

- The longer op-exec / stream-sync budgets raise worst-case hang-recovery
  latency (~1 s → ~4 s); acceptable for the diagnostic value, and the 2 s
  scheduler budget is below the `#897` distributed-init/HCCL floor (documented
  trade-off in `scheduler_types.h`).
- If `aclrtSetOpExecuteTimeOutV2` clamps the requested 3 s op-exec timeout
  (check its requested-vs-actual log), the ordering must be re-verified.