### PR TITLE
Support: enhance weekly-changelog skill (inventory, zh, Why/How)

### DIFF
--- a/.claude/skills/weekly-changelog/SKILL.md
+++ b/.claude/skills/weekly-changelog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: weekly-changelog
-description: Summarize user-facing changes merged in the current Friday-anchored week (most recent Friday up through yesterday) in the simpler repo into a markdown changelog with before/after code examples. Use when the user asks for a weekly changelog, weekly summary, or weekly external changes report.
+description: Summarize user-facing changes merged in the current Friday-anchored week (most recent Friday up through yesterday) in the simpler repo into a markdown changelog with before/after code examples. Also emits a full all-PR inventory (WEEKLY_ALL_PRS) and Chinese (_zh) translations of both docs. Use when the user asks for a weekly changelog, weekly summary, or weekly external changes report.
 ---
 
 # Weekly Changelog
@@ -9,13 +9,24 @@ Generate a focused, example-driven changelog of **user-facing** changes merged
 in the **current Friday-anchored window**: from the most recent Friday strictly
 before today, up through **yesterday**. The team's release cadence runs
 Friday→Thursday, so on Friday morning this yields the just-ended Fri→Thu week;
-mid-week it yields a partial-week running report. Write the output to
-`WEEKLY_CHANGES_<YYYY-MM-DD>.md` in the project root, where the date is the
-**Friday** that started the window.
+mid-week it yields a partial-week running report.
 
-**Output language.** The rendered report is **English** — same convention
-as the rest of the repo. PR titles, identifiers, file paths, and code
-snippets stay in their original form (they already are English).
+This skill produces **four files** in the project root, all keyed to the
+**Friday** that started the window (`$START` from §1):
+
+| File | What | Built in |
+| ---- | ---- | -------- |
+| `WEEKLY_CHANGES_<Friday>.md` | Curated, user-facing changelog (filtered) | §4 |
+| `WEEKLY_ALL_PRS_<Friday>.md` | Full inventory of **every** PR in the window | §6 |
+| `WEEKLY_CHANGES_<Friday>_zh.md` | Chinese translation of the changelog | §7c |
+| `WEEKLY_ALL_PRS_<Friday>_zh.md` | Chinese translation of the inventory | §7c |
+
+**Output language.** The two canonical docs are authored in **English** (repo
+convention / English-only lint). The Chinese `_zh.md` files are a **post-hoc
+translation pass** over the finished English docs (§7c) — write English first,
+then translate; translation drift is acceptable. In every file, PR titles,
+identifiers, file paths, code/diff blocks, and shell commands stay in their
+original English — only prose is translated.
 
 ## 1. Compute the week range
 
@@ -78,6 +89,23 @@ gh pr view <num> --json title,body -q '.title + "\n" + .body'
 gh pr diff <num>
 ```
 
+**Pass C — data for the full inventory (§6).** The curated changelog needs
+only kept-PR bodies. The full inventory additionally needs, for **every** PR
+in the window: a 1-3 line description (so fetch the *skipped* PRs' bodies too —
+trivial ones can be summarized from the title) and a size stat. Batch the
+sizes in one GraphQL call (one alias per PR, same shape as Pass A):
+
+```bash
+gh api graphql -F owner=<owner> -F name=<repo> -f query='
+query($owner: String!, $name: String!) {
+  repository(owner: $owner, name: $name) {
+    pr<N>: pullRequest(number: <N>) { number additions deletions changedFiles }
+    # ... one alias per PR in the window
+  }
+}'
+# render each as `+<additions>/-<deletions>, <changedFiles>f`
+```
+
 ## 3. Keep / skip rules (user-facing test)
 
 A change is **user-facing** if a user writing `examples/...` or
@@ -106,6 +134,14 @@ else is internal.
 - Runtime behavior users will observe (new timeouts, validation errors,
   diagnostics, env vars, CLI flags)
 - New examples, new test entry points, new tools
+- **DFX / diagnostic tooling the user runs** — a tensor-dump level, a
+  profiling flag, a new channel/field in a report (`scope_stats`), a new
+  track/arrow in a trace (`swimlane`), or corrected report output is
+  user-facing *when it adds or changes something the user observes while
+  running the tool* (a new `--flag`, a new level, a new resource channel,
+  a value that was previously wrong/unreadable). A pure internal refactor of
+  the same tool with **no observable change** (e.g. gating a counter that was
+  already free, renaming an internal field) stays internal.
 
 For each kept PR, decide which bucket it lands in:
 
@@ -133,7 +169,8 @@ explicit "stacked on #NNN" / "follow-up to #NNN" language in the body.
 Every run assumes the project has no prior weekly report — render the full
 structure below, do not "match prior reports." The skeleton is shown using
 four-backtick fences so that the inner triple-backtick example blocks
-render literally. Use the headings literally — no translation step.
+render literally. Use the headings literally in the English doc — translation,
+if any, happens only in the `_zh.md` pass (§7c).
 
 ````markdown
 # simpler weekly external changes (YYYY-MM-DD ~ YYYY-MM-DD)
@@ -147,7 +184,15 @@ comparisons; see each PR for details.
 
 ### N. <short title> — [#NNN](https://github.com/.../pull/NNN)
 
-<one-line motivation>
+**Why:** <the problem this change solves — what broke, was missing, or forced a
+migration without it. Give enough context to feel the pain: what the user hit,
+under what condition, and why it mattered. When there is more than one distinct
+problem, enumerate them `1.` / `2.` so the How can answer each by number.>
+
+**How:** <how this change resolves the Why — in the SAME order and numbering:
+point 1 here answers problem 1 above. Name the concrete mechanism (new
+argument, changed default, added validation, new contract), not just "it is
+fixed". One clause per Why point.>
 
 ```diff
 - <old code>
@@ -162,11 +207,20 @@ comparisons; see each PR for details.
 
 ### N. <feature name> — [#NNN](https://github.com/.../pull/NNN)
 
+**Why:** <the problem this feature solves — what was impossible, broken, or
+costly before it. Give enough context to feel the gap: what the user could not
+do, or paid for, without it. Enumerate `1.` / `2.` when several drivers
+motivate the feature.>
+
+**How:** <how the feature closes the Why — in the SAME order and numbering: the
+surface the user calls plus what it does underneath, mapped back to the problem
+each part removes. One clause per Why point.>
+
 ```<lang>
 <minimum callable example: Python API / orch C++ / shell command>
 ```
 
-<necessary supplement, 1-3 lines>
+<necessary supplement / constraints, 1-3 lines>
 
 ---
 
@@ -183,38 +237,107 @@ comparisons; see each PR for details.
   block from a real example file in the repo (`examples/...` or
   `tests/...`). Pull the snippet directly from the PR diff — do not
   paraphrase.
-- **Concise prose.** One sentence of "why" is the cap.
-- **Bug-fix rows are user-symptom only.** Each row in section III must
-  describe what a user would have *observed* before the fix — a log line,
-  an error code, a wrong output, a hang. **Do not** describe the internal
-  cause ("missing finalize call", "wrong header order"). If you cannot
-  phrase the user symptom in one line, the PR is internal and belongs in
-  the excluded list, not in section III.
+- **Motivation is mandatory for features and interface changes.** Every entry
+  in §I and §II opens with a `**Why:**` that names the concrete problem the
+  change solves — a dropped capability, an error code, a perf cost, a missing
+  surface. Give enough context that a reader feels the problem: what was hit,
+  under what condition, and why it mattered — not a single terse clause. 2-5
+  lines, grounded in the PR body; do not skip it and do not pad it to filler.
+  If you cannot name a concrete problem, re-check whether the PR is actually
+  user-facing (it may belong in the excluded list).
+- **Why and How pair one-to-one.** §I and §II entries follow `**Why:**` with a
+  `**How:**` that explains how the change resolves it, lining up point-for-point
+  with the Why. If Why enumerates `1.` / `2.`, How answers `1.` / `2.` in the
+  same order; if Why is a single problem, How is a single matching answer. How
+  names the concrete mechanism — the new argument, the changed default, the
+  validation added, the contract introduced — so the reader can trace each
+  problem to its fix. Do not bury the solution in the caveat line or leave it
+  implicit in the diff: the diff shows *what* the code is now, the How says
+  *why that resolves the Why*.
+- **Concise elsewhere.** Outside `**Why:**` / `**How:**`, keep each supplement
+  to 1-3 lines.
+- **Bug-fix rows are user-symptom only.** Each §III row is one line, takes no
+  `**Why:**`, and describes what a user would have *observed* before the fix —
+  a log line, an error code, a wrong output, a hang — **not** the internal
+  cause ("missing finalize call", "wrong header order"). If you cannot phrase
+  the user symptom in one line, the PR is internal and belongs in the excluded
+  list, not §III.
 
-## 6. Output
+## 6. Full-PR inventory document
 
-### 6a. The md file
+Alongside the curated changelog, produce a **full inventory** —
+`WEEKLY_ALL_PRS_<Friday>.md` — listing **every** PR merged in the window,
+internal and user-facing alike. This is the "what did simpler change this
+week, in total" view; the curated changelog is the filtered subset.
 
-Write the file to `<repo_root>/WEEKLY_CHANGES_<Friday>.md` where `<Friday>`
-is the Friday that started the window — i.e. `$START` from section 1, NOT
-the end date. The same Friday-anchored filename is reused throughout the
-Fri→Thu cycle so mid-week re-runs overwrite in place and the file grows
-into a complete weekly report by the time the cycle closes. Overwrite if
-it already exists.
+Group PRs by **subsystem / theme** (e.g. Platform/AICore, Device recovery,
+Scheduler/Runtime, Performance, DFX, Remote-L3, Examples, Build·CI, Docs —
+derive the actual themes from the window's PRs; do not hardcode this list).
+Lead with a scannable overview table, then one detail entry per PR. Mark a PR
+`✓` in the `User-visible` column iff it also appears in the curated changelog,
+so the two docs stay cross-referenced (and update the `✓` if the user later
+moves a PR in or out of the curated set).
 
-The md file contains **only** the three sections from §4 (Interface
-changes / New features / User-visible bug fixes). Do **not** write the
-excluded-PR list, the window range, or any meta commentary into the md —
-those belong in the chat reply, not the file.
+````markdown
+# simpler — all merged PRs (YYYY-MM-DD ~ YYYY-MM-DD)
 
-### 6b. The chat reply
+Full inventory of every PR merged in the window (internal + user-facing).
+`User-visible` ✓ = also in the curated `WEEKLY_CHANGES_<Friday>.md`.
+Size = `+added/-deleted, N files`.
 
-Separately, report back to the user in the chat reply (not in the md):
+## Overview
 
-- the file path
-- the window range (`$START` ~ `$END`, noting partial-week if `$END` is
-  not yet a Thursday)
-- counts: N interface changes / N new features / N bug fixes
+| PR | Title | Category | User-visible |
+| --- | --- | --- | :---: |
+| [#NNN](url) | <short title> | <theme> | ✓ |
+| [#NNN](url) | <short title> | <theme> | — |
+
+Total N PRs; M user-visible (#NNN #NNN ...).
+
+## <Theme>
+
+### [#NNN](url) <title> · `+A/-D, Nf` · ✓
+
+<1-3 lines: what changed + why / observable effect; note a2a3/a5 scope if it differs>
+````
+
+## 7. Output & Chinese translation
+
+### 7a. Curated changelog (English)
+
+Write `<repo_root>/WEEKLY_CHANGES_<Friday>.md` where `<Friday>` is `$START`
+from §1 (NOT the end date). The Friday-anchored filename is reused all cycle,
+so mid-week re-runs overwrite in place and the file grows into the full weekly
+report by cycle close. Contains **only** the three §4 sections — no excluded
+list, no window range, no meta commentary (those go in the chat reply, §7d).
+
+### 7b. Full inventory (English)
+
+Write `<repo_root>/WEEKLY_ALL_PRS_<Friday>.md` per §6 — every PR, overview
+table + per-theme detail. Same Friday-anchored, overwrite-in-place rule.
+
+### 7c. Chinese translations
+
+After **both** English docs are final, translate each into a `_zh.md`
+companion in the same directory:
+
+- `WEEKLY_CHANGES_<Friday>.md`  → `WEEKLY_CHANGES_<Friday>_zh.md`
+- `WEEKLY_ALL_PRS_<Friday>.md`  → `WEEKLY_ALL_PRS_<Friday>_zh.md`
+
+Translate **prose only**, per the Output-language rule in the intro
+(identifiers, paths, code/diff, commands, table keys stay English; drift is
+fine; author *from* the English, never from scratch). The `_zh.md` files are
+local-only and need not pass the repo's English-only lint.
+
+### 7d. Chat reply
+
+Report back in the chat reply (not in any md):
+
+- the four file paths
+- the window range (`$START` ~ `$END`, noting partial-week if `$END` is not
+  yet a Thursday)
+- counts: N interface changes / N new features / N bug fixes (curated), and
+  total PRs / user-visible count (inventory)
 - the excluded PR numbers, **aggregated by category** so the user can scan
   them at a glance instead of reading a flat list:
 


### PR DESCRIPTION
## Summary

Enhancements to the `weekly-changelog` skill (`.claude/skills/weekly-changelog/SKILL.md`), docs-only:

- **Full-PR inventory doc** (`WEEKLY_ALL_PRS_<Friday>.md`) — groups every merged PR in the window by subsystem and cross-references the curated changelog via a `User-visible` column (§6).
- **Chinese translation pass** — emits `_zh.md` companions for both English docs as a post-hoc, prose-only translation (§7c). English remains the canonical, lint-passing source.
- **Pass C data collection** — batches per-PR size stats and skipped-PR descriptions needed by the inventory (§2).
- **Broader user-facing rule** — DFX / diagnostic tooling the user runs (a new flag, level, report channel, or corrected output) now counts as user-facing; pure internal refactors of the same tool stay excluded (§3).
- **Why/How one-to-one pairing** — §I/§II entries now pair each `**Why:**` (the problem, enumerated when multiple) with a `**How:**` that resolves it point-for-point with the concrete mechanism, so the solution is no longer brief or buried in the diff/caveats (§4, §5).

## Testing

- [x] Docs-only change — no code paths affected; pre-commit hooks (markdownlint, check-english-only, check-headers) pass.