### PR TITLE
feat(deps_to_graph): simplify default dependency text view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
             sudo apt-get install -y ninja-build
             sudo apt-get install -y g++-15 || sudo apt-get install -y g++
             if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
-            # graphviz: required by the dep_gen smoke (deps_to_graph -> dot).
+            # graphviz: required by the dep_gen smoke (deps_viewer -> dot).
             # Installed unconditionally so both a2a3 and a5 sim jobs stay
             # uniform — the dep_gen test is a2a3-only today but the cost is
             # negligible and the alternative branch sprawls the install logic.
@@ -265,7 +265,7 @@ jobs:
             sudo apt-get install -y ninja-build
             sudo apt-get install -y g++-15 || sudo apt-get install -y g++
             if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
-            # graphviz: required by the dep_gen smoke (deps_to_graph -> dot).
+            # graphviz: required by the dep_gen smoke (deps_viewer -> dot).
             # Installed unconditionally so both a2a3 and a5 sim jobs stay
             # uniform — the dep_gen test is a2a3-only today but the cost is
             # negligible and the alternative branch sprawls the install logic.
@@ -519,11 +519,11 @@ jobs:
           pip install --upgrade pip
           pip install '.[test]'
           # Warn if graphviz isn't installed on the runner — the dep_gen
-          # smoke step needs `dot` to render deps_to_graph. The Python
+          # smoke step needs `dot` to render deps_viewer. The Python
           # has_binary("dot") guard in the test will skip cleanly without
           # it, but coverage drops, so flag it loudly here.
           if ! command -v dot >/dev/null 2>&1; then
-            echo "::warning::graphviz 'dot' not found on PATH; deps_to_graph tool smoke will skip. Install graphviz on this self-hosted runner to restore coverage."
+            echo "::warning::graphviz 'dot' not found on PATH; deps_viewer tool smoke will skip. Install graphviz on this self-hosted runner to restore coverage."
           fi
 
       - name: Run pytest scene tests (a2a3)

--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -203,61 +203,51 @@ observed task and tensor — that is not an error.
 
 ---
 
-## 5. Visualizing — `deps_to_graph.py`
+## 5. Visualizing — `deps_viewer.py`
 
-`simpler_setup/tools/deps_to_graph.py` turns `deps.json` into a
-self-contained pan/zoom HTML page (Graphviz SVG + inline vanilla-JS
-drag-pan + wheel-zoom). Open the file in any browser, no internet
-needed:
+`simpler_setup/tools/deps_viewer.py` turns `deps.json` into either a
+plain-text dependency view (default) or a self-contained pan/zoom HTML page
+(Graphviz SVG + inline vanilla-JS drag-pan + wheel-zoom). The text view is
+optimized for grep / diff / "what does task X depend on?" debugging; the HTML
+view stays available when you want a visual layout.
 
 ```bash
-# Newest deps.json under outputs/
-python -m simpler_setup.tools.deps_to_graph
+# Newest deps.json under outputs/ -> deps_viewer.txt
+python -m simpler_setup.tools.deps_viewer
 
-# Specific path
-python -m simpler_setup.tools.deps_to_graph outputs/.../deps.json
+# Specific path -> deps_viewer.txt next to deps.json
+python -m simpler_setup.tools.deps_viewer outputs/.../deps.json
 
-# Big graphs: use force-directed layout (recommended >1000 nodes)
-python -m simpler_setup.tools.deps_to_graph deps.json --engine sfdp
+# Explicit HTML output
+python -m simpler_setup.tools.deps_viewer outputs/.../deps.json --format html
 
-# Show per-edge tensor slice annotations on the arrows.
-# Off by default — the bare task-pair graph stays readable on dense workloads;
-# turn this on when you actually need to inspect which slice an edge carries.
-python -m simpler_setup.tools.deps_to_graph deps.json --show-tensor-info
+# HTML output with per-task tensor details
+python -m simpler_setup.tools.deps_viewer outputs/.../deps.json --format html --show-tensor-info
+
+# Big HTML graphs: use force-directed layout (recommended >1000 nodes)
+python -m simpler_setup.tools.deps_viewer deps.json --format html --engine sfdp
+
 ```
 
-`--show-tensor-info` rewrites every task as an HTML-table node with two
-compartments:
+The default text output contains:
 
-- **Top rows (blue)** are the consumed inputs (slots of type `INPUT`
-  and `INOUT`).
-- **Middle header** is the task identity (`(ring, local) · func_name`),
-  background-colored by core_type (aic / aiv / mix / alloc).
-- **Bottom rows (orange)** are the produced outputs (`INOUT`,
-  `OUTPUT_EXISTING`, and `OUTPUT` slots).
+- `SUMMARY` — input path plus task / edge / tensor counts.
+  - `tasks`: number of task ids rendered in the output
+  - `unique_task_edges`: number of unique `(pred, succ)` task pairs
+  - `annotated_edges`: number of annotated edge rows across all task pairs
+  - `perf_sidecar`: `yes` when `l2_swimlane_records.json` was successfully loaded
+  - `func_name_map`: `yes` when at least one task label resolved to a named `func_name`
+    from either an explicit `--func-names` file or an auto-discovered sibling
+    `name_map_*.json`. When the `kernel_ids` fallback is used, `func_id=` shows an
+    aligned 3-slot integer array in `[aic,aiv0,aiv1]` order; inactive slots remain
+    `-1`. `func_name_map` stays `no` unless a real human-readable name was resolved.
+- `TASK INDEX` — one line per task with `kind=` + `func_id=` and unique `fanin=` /
+  `fanout=` counts for quick grep.
+- `TASK DETAILS` — one block per task with `FANIN` / `FANOUT` peer task references
+  (task-adjacency-only, no tensor detail).
 
-Each arg row carries a 4-line block:
-
-```text
-arg<i> <ARG_TYPE>[ ?] <Tname>:<dtype>
-storage:      <buffer_numel> elems   # underlying buffer size
-shape:        [...]                  # slice this slot accesses
-strides:      [...]                  # per-dim element strides
-start_offset: <N> (elem)             # slice start in the underlying buffer
-```
-
-`<Tname>` is `T<idx>` from `tensors[]` order, so two slots referencing
-the same underlying buffer share a name across the whole graph.
-`raw != shape` is a visual cue that the slot accesses a sub-region.
-The trailing `?` on an `OUTPUT` row marks a tensor_id that the viewer
-backfilled from a downstream `creator` edge (the runtime hadn't
-materialized a Tensor at `submit_task` time, so the raw blob was zero).
-
-Edges in this mode route from the producer's `out_<idx>` row directly
-to the consumer's `in_<arg>` row, so "which output of X feeds which
-input of Y" reads off the picture. `explicit`-source edges render as
-dashed grey arrows; `tensormap` edges whose `overlap` is not `covered`
-carry a small red label so partial-overlap cases stand out.
+In text mode, HTML-only flags such as `--engine` and `--direction` are
+rejected rather than silently ignored.
 
 Node visual encoding (legend top-right of the rendered HTML):
 
@@ -268,10 +258,12 @@ Node visual encoding (legend top-right of the rendered HTML):
 | Green diamond | mix — single `submit_task` with `MixedKernels` spanning both core types |
 | Gray dashed note | alloc — task from `alloc_tensors` (got a task_id, references downstream via `owner_task_id`, but never dispatched a kernel so has no perf record) |
 
-Labels read as `(ring, local) · func_name · core_type-implicit-via-shape`.
-When a colocated `l2_swimlane_records.json` is present the func_id is enriched
-with the kernel name via the sibling `name_map_<case>.json` (written by
-SceneTest's `_dump_name_map`).
+Node labels read as `(ring, local)` only — no func_name or func_id is
+shown in the HTML view. The text output (`deps_viewer.txt`) carries the
+`kind=` + `func_id=` labels; the HTML view focuses on structural layout and stays
+agnostic to function naming. When you need per-task tensor rows (storage / shape /
+strides / start_offset) and arg-port edge routing, rerun the HTML export with
+`--show-tensor-info`.
 
 Browser controls in the HTML viewer:
 
@@ -283,7 +275,9 @@ Browser controls in the HTML viewer:
 The HTML scales to graphs the browser's SVG renderer can handle — in
 practice, ~50k nodes with `--engine sfdp`. Past that, you want a
 canvas/WebGL viewer (Cytoscape.js, sigma.js), which is out of scope
-for this tool.
+for this tool. The default text output does not depend on Graphviz and is the
+preferred mode for large graphs that need fast generation or grep-first
+inspection.
 
 ---
 
@@ -364,7 +358,7 @@ list; only the dep_gen replay graph loses the tail.
 | Capture call site | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. **a2a3 only:** the schema additionally carries `kernel_id[3] = {aic, aiv0, aiv1}` so the swimlane post-processor can resolve `task_id → kernel` from `deps.json` at level=1 where the AICore record is the sole device-side identity source. Inactive subslots stay at `INVALID_KERNEL_ID = -1`. |
 | Replay | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.{h,cpp}` | Pure CPU; runs dual-pass differential replay — `compute_task_fanin` (oracle) + inlined STEP A/B mirror (annotated) against two `PTO2TensorMap` instances. Emits `deps.json` when both passes agree per record. Platform-agnostic — a5 reuses the a2a3 source verbatim. |
 | Device-runner hookup | `src/{a2a3,a5}/platform/{onboard,sim}/host/device_runner.cpp` | post-`reconcile_counters` calls `dep_gen_replay_emit_deps_json(records.data(), records.size(), deps_path)` |
-| Viewer | `simpler_setup/tools/deps_to_graph.py` | `deps.json` → pan/zoom HTML |
+| Viewer | `simpler_setup/tools/deps_viewer.py` | `deps.json` → text (default) or pan/zoom HTML |
 | Test | `tests/st/{a2a3,a5}/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py` + `test_dep_gen_chain.py` | Smoke test + 6-edge validation against `vector_example` orchestration (both platforms share byte-identical orchestration code). |
 
 Supported on both a2a3 and a5. The a5 host collector differs from a2a3 only in its host↔device transport path (a5 has no SVM, so all transfers go through `profiling_copy_to_device` / `profiling_copy_from_device` instead of relying on `halHostRegister`'s shared mapping); the AICPU writer, shared-memory ABI, runtime call site, and replay are platform-agnostic.

--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -139,7 +139,7 @@ layers to be aware of:**
   in `core_type` / `core_to_thread`, converts cycles to microseconds
   using `metadata.clock_freq_hz`, and returns the joined dict that every
   downstream consumer (Perfetto converter, `sched_overhead_analysis`,
-  `deps_to_graph`, in-test validator) reads. Always go through
+  `deps_viewer`, in-test validator) reads. Always go through
   `read_perf_data`; never load `l2_swimlane_records.json` with raw
   `json.load` from new code.
 

--- a/docs/profiling-name-map.md
+++ b/docs/profiling-name-map.md
@@ -153,8 +153,13 @@ python -m simpler_setup.tools.swimlane_converter \
     outputs/<case>_<ts>/l2_swimlane_records.json \
     --func-names outputs/<case>_<ts>/name_map_TestPA_basic.json
 
-python -m simpler_setup.tools.deps_to_graph \
+python -m simpler_setup.tools.deps_viewer \
     outputs/<case>_<ts>/deps.json \
+    --func-names outputs/<case>_<ts>/name_map_TestPA_basic.json
+
+python -m simpler_setup.tools.deps_viewer \
+    outputs/<case>_<ts>/deps.json \
+    --format html \
     --func-names outputs/<case>_<ts>/name_map_TestPA_basic.json
 ```
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -739,6 +739,63 @@ def _convert_case_swimlane(
     _run_swimlane_converter(input_path=perf_file, func_names_path=func_names_path)
 
 
+def _run_deps_viewer(
+    input_path: Path,
+    func_names_path: Path | None = None,
+) -> None:
+    """Invoke the bundled deps_viewer tool as a subprocess (text mode).
+
+    Produces ``deps_viewer.txt`` next to ``input_path`` by default.
+    """
+    import logging  # noqa: PLC0415
+    import subprocess  # noqa: PLC0415
+
+    logger = logging.getLogger(__name__)
+    cmd = [sys.executable, "-m", "simpler_setup.tools.deps_viewer", str(input_path), "--format", "text"]
+    if func_names_path is not None:
+        cmd += ["--func-names", str(func_names_path)]
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        if result.stdout:
+            logger.info(result.stdout)
+        logger.info("deps_viewer text generation completed")
+    except subprocess.CalledProcessError as e:
+        logger.warning(f"Failed to generate deps_viewer.txt: {e}")
+        if e.stdout:
+            logger.debug(f"stdout: {e.stdout}")
+        if e.stderr:
+            logger.debug(f"stderr: {e.stderr}")
+
+
+def _graph_case_dep_gen(
+    case_label: str,
+    output_prefix: Path,
+    callable_spec: dict | None = None,
+) -> None:
+    """Post-case: invoke deps_viewer on the deps.json the dep-gen host
+    replay just wrote into ``<output_prefix>/deps.json``.
+    """
+    import logging  # noqa: PLC0415
+
+    logger = logging.getLogger(__name__)
+    deps_file = output_prefix / "deps.json"
+    if not deps_file.exists():
+        logger.warning(f"[{case_label}] {deps_file} not produced; skipping deps_viewer")
+        return
+
+    func_names_path = None
+    if callable_spec:
+        safe_label = _sanitize_for_filename(case_label)
+        name_map_path = output_prefix / f"name_map_{safe_label}.json"
+        if name_map_path.exists():
+            func_names_path = name_map_path
+        else:
+            mapping = _extract_name_map(callable_spec)
+            func_names_path = _dump_name_map(mapping, name_map_path)
+
+    _run_deps_viewer(input_path=deps_file, func_names_path=func_names_path)
+
+
 def _plot_case_scope_stats(case_label: str, output_prefix: Path) -> None:
     """Post-case: turn ``<output_prefix>/scope_stats/scope_stats.jsonl`` into
     the self-contained scope_stats HTML report. Path is known a priori from
@@ -831,6 +888,8 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
         finally:
             if enable_l2_swimlane:
                 _convert_case_swimlane(case_label, prefix, callable_spec=callable_spec)
+            if enable_dep_gen:
+                _graph_case_dep_gen(case_label, prefix, callable_spec=callable_spec)
             if enable_scope_stats:
                 _plot_case_scope_stats(case_label, prefix)
             if dlt_baseline is not None:

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -12,8 +12,8 @@ no repo checkout required.
 - **[swimlane_converter](#swimlane_converter)** — perf JSON → Chrome Trace Event (Perfetto)
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
 - **[device_log_timing](#device_log_timing)** — Total / Orch / Sched from a CANN device log (no swimlane JSON)
-- **[deps_to_graph](#deps_to_graph)** — `deps.json` (dep_gen) → pan/zoom HTML dependency graph
-- **[dump_viewer](#dump_viewer)** — inspect / export tensor dumps (see [docs/tensor-dump.md](../../docs/dfx/tensor-dump.md) for full workflow)
+- **[dump_viewer](#dump_viewer)** — tensor dump inspection and export
+- **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
 Auto-detection paths (`outputs/*/l2_swimlane_records.json`, `outputs/*/tensor_dump/`)
 are resolved relative to the **current working directory** — run these from the
@@ -224,51 +224,65 @@ often leaves pointing at the invoking user.
 
 ---
 
-## deps_to_graph
+## deps_viewer
 
-Render the dep_gen `deps.json` task graph as a self-contained pan/zoom HTML
-page (Graphviz SVG + inline vanilla-JS drag-pan + wheel-zoom). Pairs naturally
-with [`swimlane_converter`](#swimlane_converter): swimlane is the timing view,
+Render the dep_gen `deps.json` task graph as either grep-friendly text
+(default) or a self-contained pan/zoom HTML page. Pairs naturally with
+[`swimlane_converter`](#swimlane_converter): swimlane is the timing view,
 this is the structural view.
 
 ### Overview
 
-`deps_to_graph` reads `deps.json` produced by the dep_gen replay (see
-[docs/dfx/dep_gen.md](../../docs/dfx/dep_gen.md)) and emits an HTML file
-viewable in any modern browser, no internet needed. Two modes:
+`deps_viewer` reads `deps.json` produced by the dep_gen replay (see
+[docs/dfx/dep_gen.md](../../docs/dfx/dep_gen.md)) and supports two modes:
 
-- **Default** — every task is a shape-coded node (AIC blue box / AIV orange
-  ellipse / mix green diamond / alloc dashed grey), edges are bare arrows.
-  Best for "is task X reachable from task Y?" topology questions on dense
-  graphs.
-- **`--show-tensor-info`** — every task is an HTML-table node with input
-  rows on top, identity header in the middle, output rows on the bottom;
-  each slot row shows `arg<i> <TYPE> <Tname>:<dtype>` plus `raw:` / `shape:` /
-  `offset:`. Edges route from `pred:out_<idx>` to `succ:in_<arg>` by
-  matching `tensor_id`, so "which output of X feeds which input of Y" is
-  visually obvious. This is the answer to issue #666's "what slice does
-  this edge carry?" question.
+- **Default text mode** — emits `deps_viewer.txt` with:
+  - `SUMMARY` (input path plus task / edge / tensor counts)
+    - `tasks`: number of rendered task ids
+    - `unique_task_edges`: number of unique `(pred, succ)` pairs
+    - `annotated_edges`: total number of annotated edge rows
+    - `perf_sidecar`: `yes` when `l2_swimlane_records.json` was successfully loaded
+    - `func_name_map`: `yes` when at least one task name resolved to a named
+      `func_name` from `--func-names` or an auto-discovered `name_map_*.json`.
+      `func_name_map` stays `no` unless a real human-readable name was resolved.
+  - `TASK INDEX` (one line per task for grep)
+    - `kind=` distinguishes `submit` / `dummy` / `alloc` / `unknown`
+    - `func_id=` is taken only from `tasks[].kernel_ids` and shows the aligned
+      three-slot `[aic,aiv0,aiv1]` array for `submit`
+    - `kind=alloc` / `kind=dummy` render as `func_id=none`
+  - `TASK DETAILS` (per-task `FANIN` / `FANOUT` blocks showing peer task references only)
+  Best for "what does task X depend on?" and large-graph debugging.
+- **`--format html`** — renders the task graph as Graphviz SVG wrapped in a
+  self-contained HTML file viewable in any modern browser.
+  - Add `--show-tensor-info` to restore per-task tensor rows and edge routing
+    to specific arg ports in the HTML view.
 
 ### Basic Usage
 
 ```bash
-# Auto-pick the newest deps.json under ./outputs/
-python -m simpler_setup.tools.deps_to_graph
+# Auto-pick the newest deps.json under ./outputs/ -> deps_viewer.txt
+python -m simpler_setup.tools.deps_viewer
 
-# Specific path
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json
+# Specific path -> deps_viewer.txt next to deps.json
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json
 
-# Specify an output HTML path
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json -o graph.html
+# Explicit text output path
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json -o graph.txt
 
-# Show per-edge tensor slice info (compartments + matched ports)
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json --show-tensor-info
+# HTML output
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --format html -o graph.html
 
-# Force-directed layout for large graphs (>~1000 nodes)
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json --engine sfdp
+# HTML output with per-task tensor details and arg-port routing
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --format html --show-tensor-info -o graph.html
 
-# Override node labels with a func_id -> name mapping
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json \
+# Force-directed HTML layout for large graphs (>~1000 nodes)
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --format html --engine sfdp
+
+# Override task labels with a func_id -> name mapping
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
     --func-names outputs/<case>_<ts>/name_map_TestPA_basic.json
 ```
 
@@ -277,15 +291,16 @@ python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json \
 | Option | Short | Description |
 | ------ | ----- | ----------- |
 | `input` | | Path to `deps.json` (default: newest under `./outputs/`) |
-| `--output` | `-o` | Output HTML path (default: same dir as input, `deps_graph.html`) |
-| `--engine` | | Graphviz layout engine: `dot` (default, hierarchical), `sfdp` (force-directed, recommended >1000 nodes), `neato`, `fdp`, `circo`, `twopi` |
-| `--direction` | | Flow direction for hierarchical layouts: `LR` (default) / `TB` / `BT` / `RL`. Ignored by sfdp/neato. |
-| `--func-names` | | JSON file with `callable_id_to_name` (or flat `{func_id: name}`) for node-label enrichment |
-| `--show-tensor-info` | | Render each task as an HTML-table node with input/output slot compartments; route edges between matching ports. Default: off (bare topology). |
+| `--output` | `-o` | Output path (default: `deps_viewer.txt` for text, `deps_viewer.html` for HTML) |
+| `--format` | | Output format: `text` (default) or `html` |
+| `--engine` | | HTML-only Graphviz layout engine: `dot` (default), `sfdp`, `neato`, `fdp`, `circo`, `twopi` |
+| `--direction` | | HTML-only flow direction for hierarchical layouts: `LR` (default) / `TB` / `BT` / `RL` |
+| `--show-tensor-info` | | HTML-only: render per-task tensor rows and route edges to specific arg ports |
+| `--func-names` | | JSON file with `callable_id_to_name` (or flat `{func_id: name}`) for task-label enrichment |
 
 ### Dependencies
 
-Requires the Graphviz `dot` binary on PATH:
+Text output has no extra dependencies. HTML output requires Graphviz on PATH:
 
 ```bash
 brew install graphviz    # macOS
@@ -411,13 +426,14 @@ The tools extract the `func_id` to `name` mapping from the `KERNELS` list.
 - Task execution statistics
 - Professional performance analysis and optimization
 
-### Use deps_to_graph when you need
+### Use deps_viewer when you need
 
 - A structural view of task dependencies (who feeds whom)
-- Per-edge tensor slice info — which `(tensor_id, offset, shape)` an edge
-  carries — via `--show-tensor-info`
+- Fast grep-friendly inspection via the default text output
 - A single-file HTML you can open offline, drag-pan / wheel-zoom in any
-  browser
+  browser when you want a visual layout
+- Optional per-task tensor rows and arg-port routing in HTML via
+  `--show-tensor-info`
 - A graph that survives without an associated timing run (deps.json is
   produced by structural replay, not by hardware profiling)
 
@@ -431,13 +447,14 @@ pytest tests/st/... --enable-l2-swimlane --enable-dep-gen
 # -> outputs/<case>_<ts>/merged_swimlane.json
 #    open at https://ui.perfetto.dev/
 
-# 3. Structural dependency graph (manual)
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json
-# -> outputs/<case>_<ts>/deps_graph.html (drag / wheel / f / r)
+# 3. Structural dependency graph (manual, default text output)
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json
+# -> outputs/<case>_<ts>/deps_viewer.txt
 
-# 4. Same graph with per-edge tensor info
-python -m simpler_setup.tools.deps_to_graph outputs/<case>_<ts>/deps.json \
-    --show-tensor-info -o outputs/<case>_<ts>/deps_graph_with_tensors.html
+# 4. Same graph as HTML
+python -m simpler_setup.tools.deps_viewer outputs/<case>_<ts>/deps.json \
+    --format html -o outputs/<case>_<ts>/deps_viewer.html
+
 ```
 
 For batch-run hardware regression, see the dev-only script
@@ -472,8 +489,9 @@ For batch-run hardware regression, see the dev-only script
   2. Re-run `swimlane_converter` or `sched_overhead_analysis`
   3. Verify that each task in the JSON contains `dispatch_time_us` and `finish_time_us`
 
-### `deps_to_graph` complains that Graphviz `dot` is not on PATH
+### `deps_viewer` complains that Graphviz `dot` is not on PATH
 
+- This only affects `--format html`
 - Install graphviz: `brew install graphviz` (macOS) or `apt install graphviz` (Debian/Ubuntu)
 - Verify with `which dot`; should print a path
 - Use a different layout engine with `--engine sfdp` for very large graphs
@@ -487,7 +505,8 @@ For batch-run hardware regression, see the dev-only script
 | `l2_swimlane_records_*.json` | Runtime | Raw timing profiling data | JSON |
 | `merged_swimlane_*.json` | swimlane_converter | Perfetto visualization | Chrome Trace Event JSON |
 | `deps.json` | Runtime (dep_gen replay) | Structural task dependency graph + per-edge tensor info | JSON |
-| `deps_graph.html` | deps_to_graph | Pan/zoom dependency graph viewer | HTML (self-contained) |
+| `deps_viewer.txt` | deps_viewer | Grep-friendly dependency graph view | Plain text |
+| `deps_viewer.html` | deps_viewer | Pan/zoom dependency graph viewer | HTML (self-contained) |
 
 ---
 

--- a/simpler_setup/tools/__init__.py
+++ b/simpler_setup/tools/__init__.py
@@ -12,7 +12,7 @@ Invoke via ``python -m simpler_setup.tools.<name>``:
 
 - ``swimlane_converter``   : perf JSON -> Perfetto/Chrome trace
 - ``sched_overhead_analysis``: scheduler overhead deep-dive
-- ``deps_to_graph``         : deps.json -> pan/zoom HTML dependency graph
+- ``deps_viewer``           : deps.json -> text or pan/zoom HTML dependency graph
 - ``dump_viewer``           : inspect tensor dumps
 - ``device_log_timing``     : Total/Orch/Sched from a CANN device log
 

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -8,31 +8,31 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 """
-deps.json → pan-zoom HTML dependency-graph viewer.
+deps.json → text or pan-zoom HTML dependency-graph viewer.
 
 deps.json is the host-replay-rebuilt task graph (one edge per producer→consumer
 pair, complete across the full submit_task trace — superset of fanout). This
-tool runs the graph through Graphviz to produce an SVG and wraps it in a
-self-contained HTML page with a minimal drag-to-pan + wheel-to-zoom shim
-(no JS dependency, no CDN, opens offline in any browser).
+tool supports two output formats:
 
-The HTML format scales to any graph the browser's SVG renderer can handle
-(practically up to ~50k nodes when paired with ``--engine sfdp``); the only
-gotcha is that high zoom slightly blurs text — that's a CSS-transform tradeoff
-in exchange for 60fps GPU-composited pan/zoom even on huge graphs.
+- text (default): a grep-friendly task index plus per-task predecessor /
+  successor detail blocks
+- html: Graphviz SVG wrapped in a self-contained pan/zoom HTML page
 
-When ``l2_swimlane_records.json`` is colocated with ``deps.json``, node labels are
-enriched with the per-task ``func_id`` and ``core_type`` so a node reads as
-``t12 · kernel_mul · aiv`` rather than just ``t12``; nodes are colored by
-core_type (AIC blue, AIV orange).
+In text mode the default view shows task identity ``(ring, local)`` together
+with ``kind=`` and ``func_id=``. Text-mode ``func_id=`` comes only from the
+three-slot ``kernel_ids`` layout and preserves ``[aic,aiv0,aiv1]`` with
+inactive slots kept as ``-1``; ``alloc`` / ``dummy`` tasks render as
+``func_id=none``. In HTML mode nodes are labeled ``(ring, local)`` only; they
+are colored by ``core_type`` when a perf sidecar is colocated (AIC blue, AIV
+orange).
 
 Usage:
-    python -m simpler_setup.tools.deps_to_graph DEPS_JSON [-o OUT] [--engine ENGINE]
-    python -m simpler_setup.tools.deps_to_graph                          # newest under outputs/
-    python -m simpler_setup.tools.deps_to_graph deps.json
-    python -m simpler_setup.tools.deps_to_graph deps.json --engine sfdp  # force-directed (for big graphs)
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON --format text
+    python -m simpler_setup.tools.deps_viewer DEPS_JSON --format html --engine sfdp
 
-Requires Graphviz installed (``brew install graphviz`` / ``apt install graphviz``).
+HTML output requires Graphviz installed (``brew install graphviz`` /
+``apt install graphviz``). Text output does not.
 """
 
 import argparse
@@ -62,6 +62,13 @@ def _normalize_task_id(v):
 # Same coercion semantics — alias so the call sites read as "this is a
 # tensor_id, not a task_id". Both encode 64-bit unsigned values as JSON strings.
 _normalize_tensor_id = _normalize_task_id
+
+
+def _normalize_small_int(v):
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return None
 
 
 def _node_id(task_id):
@@ -106,6 +113,13 @@ def _make_task_formatter(nodes):
     return fmt
 
 
+def _sort_task_id_key(v):
+    tid = _normalize_task_id(v)
+    if tid is None:
+        return (1, str(v))
+    return (0, tid)
+
+
 def _load_deps_edges(deps_path):
     """Parse deps.json into renderer-friendly pieces.
 
@@ -116,14 +130,13 @@ def _load_deps_edges(deps_path):
             arrow here.
         nodes: sorted list of all referenced task ids.
         annotations: dict[(pred, succ) -> list[dict]] of annotation rows
-            (one per annotated edge), keyed in insertion order so
-            ``--show-tensor-info`` can resolve per-edge tensor identities
-            and target the right input port on the consumer node.
+            (one per annotated edge), keyed in insertion order so HTML edge
+            rendering can resolve per-edge tensor identities and target the
+            right input port on the consumer node.
         tensor_table: dict[tensor_id -> dict] from the tensors[] block.
         task_table: dict[task_id -> dict] from the tasks[] block,
-            carrying the per-arg input/output slot info that the
-            ``--show-tensor-info`` view renders as compartments inside each
-            task node.
+            carrying the per-arg input/output slot info that the HTML view
+            renders as compartments inside each task node.
     """
     with open(deps_path) as f:
         data = json.load(f)
@@ -145,17 +158,12 @@ def _load_deps_edges(deps_path):
         if key not in seen:
             seen.add(key)
             edges.append(key)
-        # Shallow-copy + coerce uint64 tensor_id (string) to int once at
-        # ingestion so all downstream consumers can treat it as a plain int.
         edge_copy = dict(e)
         if "tensor_id" in edge_copy:
             edge_copy["tensor_id"] = _normalize_tensor_id(edge_copy["tensor_id"])
         annotations.setdefault(key, []).append(edge_copy)
     tensors_raw = data.get("tensors", []) if isinstance(data.get("tensors"), list) else []
     tensor_table: dict[int, dict] = {}
-    # Assign short human-friendly names (T0, T1, ...) by order of appearance
-    # in tensors[] so two references to the same underlying tensor share a
-    # name across the rendered graph.
     for ord_idx, t in enumerate(tensors_raw):
         if not isinstance(t, dict):
             continue
@@ -172,9 +180,6 @@ def _load_deps_edges(deps_path):
             continue
         tid = _normalize_task_id(t.get("task_id"))
         if tid is not None:
-            # Shallow-copy args so backfill below doesn't mutate the raw JSON.
-            # Also coerce each arg's tensor_id (uint64 string) to int so the
-            # backfill and view logic can compare with plain `==`.
             entry = dict(t)
             args_copy = []
             for a in t.get("args", []):
@@ -187,7 +192,7 @@ def _load_deps_edges(deps_path):
             entry["args"] = args_copy
             task_table[tid] = entry
     _backfill_output_tensor_ids(task_table, annotations)
-    return edges, sorted(nodes), annotations, tensor_table, task_table
+    return sorted(edges), sorted(nodes), annotations, tensor_table, task_table
 
 
 def _backfill_output_tensor_ids(task_table, annotations):
@@ -215,9 +220,6 @@ def _backfill_output_tensor_ids(task_table, annotations):
             pred_task = task_table.get(pred)
             if not pred_task:
                 continue
-            # Skip if this tensor_id is already attached to one of pred's
-            # output slots (e.g. INOUT / OUTPUT_EXISTING captured at submit
-            # time, or a previous backfill on this same loop).
             already_known = False
             unassigned = []
             for a in pred_task.get("args", []):
@@ -236,6 +238,46 @@ def _backfill_output_tensor_ids(task_table, annotations):
             if len(unassigned) == 1:
                 unassigned[0]["tensor_id"] = tid
                 unassigned[0]["inferred"] = True
+
+
+def _kernel_ids_slots(task_entry):
+    """Return the raw kernel_ids list as-is, padded/truncated to exactly 3 slots."""
+    if not isinstance(task_entry, dict):
+        return [-1, -1, -1]
+    kernel_ids = task_entry.get("kernel_ids")
+    if not isinstance(kernel_ids, list):
+        return [-1, -1, -1]
+    slots = []
+    for i in range(3):
+        if i < len(kernel_ids):
+            v = _normalize_small_int(kernel_ids[i])
+            slots.append(v if v is not None else -1)
+        else:
+            slots.append(-1)
+    return slots
+
+
+def _merge_task_meta_with_kernel_ids(meta, task_table, func_names=None):
+    merged = {task_id: dict(entry) for task_id, entry in meta.items()}
+    for task_id, task_entry in task_table.items():
+        slots = _kernel_ids_slots(task_entry)
+        valid_ids = [i for i in slots if i >= 0]
+        if not valid_ids:
+            continue
+        entry = merged.setdefault(task_id, {})
+        if entry.get("func_id") is None:
+            entry["func_id"] = valid_ids[0]
+        entry["func_ids"] = valid_ids
+        entry["_kernel_slots"] = slots
+        if func_names:
+            entry["func_labels"] = [
+                func_names.get(str(slot)) or func_names.get(slot) or f"f{slot}" if slot >= 0 else "-1" for slot in slots
+            ]
+            if not entry.get("func_name") and entry["func_labels"]:
+                entry["func_name"] = entry["func_labels"][0]
+        elif any(s >= 0 for s in slots):
+            entry["func_labels"] = [f"f{slot}" if slot >= 0 else "-1" for slot in slots]
+    return merged
 
 
 def _load_task_meta(deps_path, func_names=None):
@@ -268,7 +310,6 @@ def _load_task_meta(deps_path, func_names=None):
         print(f"Warning: couldn't read {perf_path}: {e}", file=sys.stderr)
         return {}
 
-    # First pass: collect every (core_type, func_id) tuple per task_id.
     by_tid: dict[int, list[dict]] = {}
     for task in perf.get("tasks", []):
         tid = _normalize_task_id(task.get("task_id"))
@@ -281,8 +322,6 @@ def _load_task_meta(deps_path, func_names=None):
         core_types = {e.get("core_type") for e in entries if e.get("core_type")}
         if len(core_types) > 1:
             core_type = "mix"
-            # Prefer the AIC entry's func_id (cube usually carries the "main"
-            # op in mixed kernels) so the label reads sensibly.
             primary = next((e for e in entries if e.get("core_type") == "aic"), entries[0])
         else:
             core_type = next(iter(core_types), None)
@@ -301,32 +340,16 @@ def _load_task_meta(deps_path, func_names=None):
     return meta
 
 
-def _label(task_id, meta, fmt_task, have_perf=False):
+def _label(task_id, meta, task_table, fmt_task):
     base = fmt_task(task_id)
-    m = meta.get(_normalize_task_id(task_id))
-    if not m:
-        # Node referenced by deps but absent from the perf sidecar: alloc_tensors
-        # task (see emit_dot docstring). Surface that in the label so the user
-        # knows the dashed-note style isn't just "missing data". When no perf
-        # sidecar exists at all, we can't tell — fall back to bare id.
-        return f"{base} · alloc" if have_perf else base
-    parts = [base]
-    fn = m.get("func_name") or (f"f{m['func_id']}" if m.get("func_id") is not None else None)
-    if fn:
-        parts.append(fn)
-    # core_type is intentionally NOT in the label — node shape (box/ellipse) and
-    # color already encode it, and the HUD legend at the top-right of the page
-    # spells out the mapping. Keeps labels short on dense graphs.
-    return " · ".join(parts)
+    kind = _task_kind(_normalize_task_id(task_id), meta, task_table)
+    if kind == "alloc":
+        return f"{base} · alloc"
+    if kind == "dummy":
+        return f"{base} · dummy"
+    return base
 
 
-# Per-core-type visual styling. AIC (cube unit) is a box; AIV (vector unit)
-# is an ellipse; "mix" (single submit_task spanning both core types) is a
-# diamond; "alloc" — a task that came from ``alloc_tensors`` (got a real
-# task_id and shows up as a producer in deps via ``owner_task_id``, but
-# never dispatched a kernel so no l2_swimlane record and no func_id) — is a
-# dashed gray note. Distinct shape AND color so each stays readable even
-# without color (B&W print, accessibility, etc.).
 _CORE_STYLE = {
     "aic": {"shape": "box", "style": "rounded,filled", "fillcolor": "#66A3FF"},
     "aiv": {"shape": "ellipse", "style": "filled", "fillcolor": "#FFB366"},
@@ -378,14 +401,9 @@ def _arg_row_html(arg, tensor_table, side):
     slot of a task node.
 
     Line 1: ``arg<idx> <ARG_TYPE>[ ?] <Tname>:<dtype>``  — slot identity.
-    Line 2: ``raw: [...]``                              — full underlying buffer shape (from tensors[]).
-    Line 3: ``shape: [...]``                            — slice this slot actually accesses.
-    Line 4: ``offset: [...]``                           — slice start offset into the raw buffer.
-
-    The 4-line breakdown makes "is this the whole tensor or a sub-region?" a
-    visual diff (raw vs shape), rather than a numeric one. OUTPUT slots whose
-    tensor_id wasn't captured at submit time render as a single ``(alloc)``
-    line — there is nothing more we can say honestly.
+    Line 2: ``storage: <N> elems``                       — underlying buffer size.
+    Line 3: ``shape: [...]``                            — slice this slot accesses.
+    Line 4: ``offset: [...]``                           — slice start offset into the buffer.
     """
     idx = arg.get("idx")
     arg_type = arg.get("type", "?")
@@ -393,16 +411,12 @@ def _arg_row_html(arg, tensor_table, side):
     bg = _INPUT_BG if side == "in" else _OUTPUT_BG
     tid = arg.get("tensor_id")
     if tid is None:
-        # OUTPUT slot whose tensor_id couldn't be recovered (e.g. multiple
-        # OUTPUT slots on the same task, so the post-hoc backfill bailed out).
         body = f"arg{idx} {arg_type} (alloc)"
         return f'<TR><TD ALIGN="LEFT" PORT="{port}" BGCOLOR="{bg}">{_html_escape(body)}</TD></TR>'
 
     tname = _short_tensor_label(tid, tensor_table)
     dtype = arg.get("dtype")
     shape = arg.get("shape")
-    # Strided-Tensor per-slot descriptor: start_offset is uint64 quoted as
-    # string, stride is per-dim int32 array.
     start_offset = arg.get("start_offset")
     strides = arg.get("strides")
     buffer_numel = None
@@ -411,8 +425,6 @@ def _arg_row_html(arg, tensor_table, side):
         buffer_numel = tt.get("buffer_numel")
         if dtype is None:
             dtype = tt.get("dtype")
-    # Backfilled OUTPUT slots have tensor_id but no captured shape/stride —
-    # treat them as accessing the whole underlying buffer.
     if arg.get("inferred"):
         if shape is None and buffer_numel is not None:
             shape = [int(buffer_numel)]
@@ -442,12 +454,9 @@ def _arg_row_html(arg, tensor_table, side):
 def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task):
     """Build a Graphviz HTML-like label for a task node showing:
         - input rows (top)     INPUT + INOUT slots
-        - identity header      "(ring, local) · func_name"
+        - identity header      "(ring, local)"
         - output rows (bottom) INOUT + OUTPUT_EXISTING + OUTPUT slots
     INOUT slots appear in BOTH compartments (read-then-write semantics).
-
-    The header background reflects the core_type (aic/aiv/mix/alloc) so the
-    legend mapping carries over from the plain view.
     """
     args = task_entry.get("args") if task_entry else None
     if not isinstance(args, list):
@@ -457,12 +466,7 @@ def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task):
     core_type = meta_entry.get("core_type") if meta_entry else None
     header_bg = _CORE_HEADER_COLOR.get(core_type if isinstance(core_type, str) else "", _HEADER_FALLBACK)
 
-    identity = fmt_task(task_id)
-    func_name = None
-    if meta_entry:
-        m = meta_entry
-        func_name = m.get("func_name") or (f"f{m['func_id']}" if m.get("func_id") is not None else None)
-    header_label = identity + ((" · " + func_name) if func_name else "")
+    header_label = fmt_task(task_id)
 
     rows = []
     for a in inputs:
@@ -470,23 +474,13 @@ def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task):
     rows.append(f'<TR><TD ALIGN="CENTER" BGCOLOR="{header_bg}"><B>{_html_escape(header_label)}</B></TD></TR>')
     for a in outputs:
         rows.append(_arg_row_html(a, tensor_table, "out"))
-    if not inputs and not outputs:
-        # No captured args (alloc task, or pre-feature artifact). Fall back to
-        # just the header row so the node still shows the task identity.
-        pass
 
     table = '<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="3">' + "".join(rows) + "</TABLE>"
     return table
 
 
 def _producer_output_port(pred_task_entry, edge_tensor_id):
-    """For an annotated edge into a node rendered in show-tensor-info mode,
-    find which OUTPUT / OUTPUT_EXISTING / INOUT slot of the producer task
-    carries the same tensor_id. Returns the port name (``out_<idx>``) or
-    None if no slot matches — typically an OUTPUT slot whose tensor_id was
-    not captured at submit time (the runtime materializes the buffer
-    post-submit), in which case the edge attaches to the node body.
-    """
+    """Resolve the producer-side HTML port for an annotated edge when possible."""
     if not pred_task_entry or edge_tensor_id is None:
         return None
     args = pred_task_entry.get("args")
@@ -500,6 +494,95 @@ def _producer_output_port(pred_task_entry, edge_tensor_id):
     return None
 
 
+def _task_kind(task_id, meta, task_table):
+    task_entry = task_table.get(task_id)
+    if isinstance(task_entry, dict):
+        slots = _kernel_ids_slots(task_entry)
+        if any(slot >= 0 for slot in slots):
+            return "submit"
+        return "dummy"
+    entry = meta.get(task_id)
+    if isinstance(entry, dict):
+        slots = entry.get("_kernel_slots")
+        if isinstance(slots, list) and any(slot >= 0 for slot in slots):
+            return "submit"
+    return "alloc"
+
+
+def _task_func_id_label(task_id, meta, task_table):
+    kind = _task_kind(task_id, meta, task_table)
+    if kind in ("alloc", "dummy"):
+        return "func_id=none"
+    entry = meta.get(task_id)
+    if entry:
+        slots = entry.get("_kernel_slots")
+        if isinstance(slots, list) and slots:
+            return "func_id=[" + ",".join(str(slot) for slot in slots) + "]"
+    return "func_id=unknown"
+
+
+def emit_text(edges, nodes, meta, deps_path, annotations=None, tensor_table=None, task_table=None):
+    """Render deps.json as grep-friendly plain text.
+
+    Output shape:
+        SUMMARY
+        TASK INDEX
+        per-task detail blocks with FANIN / FANOUT peer lists
+    """
+    annotations = annotations or {}
+    tensor_table = tensor_table or {}
+    task_table = task_table or {}
+    sorted_nodes = sorted(nodes, key=_sort_task_id_key)
+    fmt_task = _make_task_formatter(sorted_nodes)
+    have_perf = bool(meta)
+    have_func_name_map = any(entry.get("func_name") for entry in meta.values())
+
+    pred_map = {tid: set() for tid in sorted_nodes}
+    succ_map = {tid: set() for tid in sorted_nodes}
+    for pred, succ in edges:
+        pred_map.setdefault(succ, set()).add(pred)
+        succ_map.setdefault(pred, set()).add(succ)
+    annotated_edges = sum(len(rows) for rows in annotations.values())
+
+    lines = [
+        "SUMMARY",
+        f"  source_deps_json: {deps_path}",
+        f"  tasks: {len(sorted_nodes)}",
+        f"  unique_task_edges: {len(edges)}",
+        f"  annotated_edges: {annotated_edges}",
+        f"  tensors: {len(tensor_table)}",
+        f"  perf_sidecar: {'yes' if have_perf else 'no'}",
+        f"  func_name_map: {'yes' if have_func_name_map else 'no'}",
+        "",
+        "TASK INDEX",
+    ]
+    for task_id in sorted_nodes:
+        kind = _task_kind(task_id, meta, task_table)
+        func_label = _task_func_id_label(task_id, meta, task_table)
+        lines.append(
+            f"TASK {fmt_task(task_id)} kind={kind} {func_label} "
+            f"fanin={len(pred_map.get(task_id, set()))} fanout={len(succ_map.get(task_id, set()))}"
+        )
+
+    for task_id in sorted_nodes:
+        kind = _task_kind(task_id, meta, task_table)
+        func_label = _task_func_id_label(task_id, meta, task_table)
+        lines.append("")
+        lines.append(f"=== TASK {fmt_task(task_id)} kind={kind} {func_label} ===")
+
+        pred_peers = sorted(pred_map.get(task_id, set()), key=_sort_task_id_key)
+        lines.append(f"FANIN {len(pred_peers)}")
+        for pred_tid in pred_peers:
+            lines.append(f"  <- {fmt_task(pred_tid)}")
+
+        succ_peers = sorted(succ_map.get(task_id, set()), key=_sort_task_id_key)
+        lines.append(f"FANOUT {len(succ_peers)}")
+        for succ_tid in succ_peers:
+            lines.append(f"  -> {fmt_task(succ_tid)}")
+
+    return "\n".join(lines) + "\n"
+
+
 def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=None, task_table=None):
     """Graphviz DOT source. Used internally to feed the layout engine before
     wrapping the SVG in HTML.
@@ -507,28 +590,15 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
     Two rendering modes selected by whether ``task_table`` is non-empty:
 
     1. Plain mode (``task_table`` is None or empty) — bare shape/color nodes,
-       bare arrows. Same as the default view. Used for v1 artifacts or when
-       the user did not pass ``--show-tensor-info``.
-    2. Show-tensor-info mode (``task_table`` non-empty) — every task whose
-       args were captured renders as an HTML-table node with input rows
-       above an identity header and output rows below. Edges terminate on
-       the consumer's ``in_<arg_idx>`` port, and originate from the
+       bare arrows. Used when only task-level structure is available.
+    2. Rich mode (``task_table`` non-empty) — every task whose args were
+       captured renders as an HTML-table node with input rows above an
+       identity header and output rows below. Edges terminate on the
+       consumer's ``in_<arg_idx>`` port, and originate from the
        producer's ``out_<arg_idx>`` port whenever the producer slot's
-       tensor_id matches the edge's tensor_id (i.e. INOUT / OUTPUT_EXISTING
-       sources). When that match is unavailable (typical for OUTPUT slots,
-       whose tensor_id is materialized post-submit), the edge attaches to
-       the producer node body.
-
-    Nodes that appear as edge endpoints but are absent from the perf-records
-    sidecar are tagged as ``alloc``: in practice these are tasks created by
-    ``alloc_tensors`` (which gets a real task_id and is referenced via
-    ``owner_task_id`` from downstream consumers, but never dispatches a
-    kernel and therefore has no perf entry). When no perf sidecar exists at
-    all (``meta`` empty) we can't disambiguate and fall back to the default
-    style for every node.
+       tensor_id matches the edge's tensor_id.
     """
     fmt_task = _make_task_formatter(nodes)
-    have_perf = bool(meta)
     show_tensor = bool(task_table)
     annotations = annotations or {}
     tensor_table = tensor_table or {}
@@ -536,14 +606,6 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
     lines = [
         "digraph deps {",
         f"  rankdir={direction};",
-        # `concentrate=true` merges shared edge prefixes through virtual
-        # nodes. Without it, deep DAGs with heavy fan-in (e.g. dep_gen
-        # capture of a >300-wide barrier reached through a tensormap
-        # producer chain) explode the dot position-assignment pass into
-        # ~N²/2 internal virtual nodes and SIGSEGV graphviz. With it,
-        # parallel edges collapse and the layout completes; rank ordering
-        # (the LR DAG shape) is unaffected — only the visual edge routing
-        # is denser.
         "  concentrate=true;",
         '  node [fontname="Helvetica", fontsize=10];',
         '  edge [color="#888"];',
@@ -551,36 +613,27 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
     for n in nodes:
         m = meta.get(n)
         if show_tensor and n in task_table:
-            # HTML-table node with input/output compartments.
             html = _task_node_html(n, task_table.get(n), m, tensor_table, fmt_task)
             lines.append(f"  {_node_id(n)} [shape=none, margin=0, label=<{html}>];")
             continue
-        if m:
+        kind = _task_kind(n, meta, task_table)
+        if kind == "submit" and m:
             style = _node_style(m.get("core_type"))
-        elif have_perf:
+        elif kind == "alloc":
             style = _CORE_STYLE["alloc"]
         else:
             style = _DEFAULT_STYLE
-        # Escape any backslash / double-quote in the label.
-        label = _label(n, meta, fmt_task, have_perf=have_perf).replace("\\", "\\\\").replace('"', '\\"')
+        label = _label(n, meta, task_table, fmt_task).replace("\\", "\\\\").replace('"', '\\"')
         attrs = f'label="{label}", shape={style["shape"]}, style="{style["style"]}", fillcolor="{style["fillcolor"]}"'
         lines.append(f"  {_node_id(n)} [{attrs}];")
     for pred, succ in edges:
         if not show_tensor:
             lines.append(f"  {_node_id(pred)} -> {_node_id(succ)};")
             continue
-        # show-tensor mode: route each annotated edge into the right input
-        # port; pick one representative annotation per (pred, succ) for the
-        # producer-port match (multiple annotations sharing the pair all
-        # target the same arg in practice — distinct args produce distinct
-        # edges).
         rows = annotations.get((pred, succ), [])
         if not rows:
             lines.append(f"  {_node_id(pred)} -> {_node_id(succ)};")
             continue
-        # One arrow per annotation row, so distinct (arg, tensor) sources
-        # between the same task pair stay legible (e.g. a task fed two
-        # different slices of the same producer).
         for row in rows:
             arg = row.get("arg")
             tid = row.get("tensor_id")
@@ -588,8 +641,9 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
             tail = ""
             head = ""
             edge_attrs = []
-            if isinstance(arg, int) and arg >= 0:
-                head = f":in_{arg}:w"
+            arg_idx = _normalize_small_int(arg)
+            if arg_idx is not None and arg_idx >= 0:
+                head = f":in_{arg_idx}:w"
             out_port = _producer_output_port(task_table.get(pred), tid)
             if out_port:
                 tail = f":{out_port}:e"
@@ -606,11 +660,7 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
 
 
 def render_svg(dot_text, engine="dot"):
-    """Pipe DOT through the Graphviz layout engine and return raw SVG bytes.
-
-    Raises FileNotFoundError if the engine binary is not on PATH; RuntimeError
-    if the engine returns a non-zero exit code.
-    """
+    """Pipe DOT through the Graphviz layout engine and return raw SVG bytes."""
     if shutil.which(engine) is None:
         raise FileNotFoundError(
             f"Graphviz '{engine}' not found on PATH. Install graphviz: brew install graphviz / apt install graphviz"
@@ -627,10 +677,6 @@ def render_svg(dot_text, engine="dot"):
     return proc.stdout
 
 
-# Self-contained HTML wrapper. Drag-to-pan + wheel-to-zoom in vanilla JS.
-# The SVG is inlined so the file is single-page and works offline. We use CSS
-# transform (translate + scale) rather than mutating the SVG viewBox — that
-# keeps pan/zoom on the GPU compositor for 60fps performance on large graphs.
 _HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -692,29 +738,24 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   const stage = document.getElementById('stage');
   const svg = stage.querySelector('svg');
   if (!svg) return;
-  // Drop fixed width/height so the SVG renders at its natural size; we control
-  // scale via CSS transform.
   svg.removeAttribute('width');
   svg.removeAttribute('height');
 
   let scale = 1, tx = 0, ty = 0;
   const apply = () => {{ svg.style.transform = `translate(${{tx}}px, ${{ty}}px) scale(${{scale}})`; }};
 
-  // Wheel zoom about cursor.
   stage.addEventListener('wheel', (e) => {{
     e.preventDefault();
     const rect = stage.getBoundingClientRect();
     const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
     const factor = Math.exp(-e.deltaY * 0.001);
     const newScale = Math.min(20, Math.max(0.02, scale * factor));
-    // Keep the point under the cursor fixed in screen space.
     tx = cx - (cx - tx) * (newScale / scale);
     ty = cy - (cy - ty) * (newScale / scale);
     scale = newScale;
     apply();
   }}, {{ passive: false }});
 
-  // Drag to pan.
   let dragging = false, lastX = 0, lastY = 0;
   stage.addEventListener('mousedown', (e) => {{
     dragging = true; lastX = e.clientX; lastY = e.clientY;
@@ -728,10 +769,8 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   }});
   window.addEventListener('mouseup', () => {{ dragging = false; stage.classList.remove('panning'); }});
 
-  // 'f' = fit-to-view, 'r' = reset to 1:1.
   const fit = () => {{
     const bb = svg.getBoundingClientRect();
-    // bb is in current-transform coordinates, so undo the transform first.
     const naturalW = bb.width / scale, naturalH = bb.height / scale;
     const sx = stage.clientWidth / naturalW, sy = stage.clientHeight / naturalH;
     scale = Math.min(sx, sy) * 0.95;
@@ -743,7 +782,6 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     if (e.key === 'f') fit();
     else if (e.key === 'r') {{ scale = 1; tx = 0; ty = 0; apply(); }}
   }});
-  // Auto-fit on first paint.
   requestAnimationFrame(fit);
 }})();
 </script>
@@ -774,8 +812,6 @@ def emit_html(
     )
     svg_bytes = render_svg(dot, engine=engine)
     svg_text = svg_bytes.decode("utf-8", errors="replace")
-    # Strip the XML prolog / DOCTYPE that graphviz emits — inlining keeps the
-    # <svg> root only.
     if "<svg" in svg_text:
         svg_text = svg_text[svg_text.index("<svg") :]
     return _HTML_TEMPLATE.format(
@@ -799,10 +835,7 @@ def _find_latest_deps_json():
 
 
 def _load_func_names_json(path):
-    """Load func_id → name mapping from a JSON file (``callable_id_to_name``
-    shape, as written by ``scene_test._dump_name_map``, or a flat dict).
-    Returns {} on failure.
-    """
+    """Load func_id → name mapping from a JSON file."""
     try:
         with open(path) as f:
             data = json.load(f)
@@ -813,10 +846,7 @@ def _load_func_names_json(path):
 
 
 def _autoload_name_map(deps_path):
-    """Look for a ``name_map_*.json`` next to deps.json (written by
-    ``scene_test._dump_name_map`` when the case ran with diagnostics on).
-    Returns {} if no candidate exists; the newest match wins on ties.
-    """
+    """Look for a ``name_map_*.json`` next to deps.json."""
     candidates = sorted(Path(deps_path).parent.glob("name_map_*.json"), key=lambda p: p.stat().st_mtime)
     if not candidates:
         return {}
@@ -825,48 +855,74 @@ def _autoload_name_map(deps_path):
 
 def _build_parser():
     p = argparse.ArgumentParser(
-        description="Render deps.json as a pan/zoom HTML dependency graph.",
+        description="Render deps.json as text or pan/zoom HTML dependency graph.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
-  %(prog)s                                    # newest deps.json under ./outputs/
+  %(prog)s                                    # newest deps.json under ./outputs/, default text output
   %(prog)s outputs/.../deps.json
-  %(prog)s deps.json -o my_graph.html
-  %(prog)s deps.json --engine sfdp            # force-directed (recommended >1000 nodes)
-  %(prog)s deps.json --func-names names.json  # label nodes with kernel names
+  %(prog)s deps.json --format text -o graph.txt
+  %(prog)s deps.json --format html --engine sfdp
+  %(prog)s deps.json --format html --show-tensor-info
 """,
     )
     p.add_argument("input", nargs="?", help="Path to deps.json (default: newest under ./outputs/).")
-    p.add_argument("-o", "--output", help="Output HTML path (default: same dir as input, deps_graph.html).")
+    p.add_argument("-o", "--output", help="Output path (default: deps_viewer.txt for text, deps_viewer.html for html).")
+    p.add_argument(
+        "--format",
+        choices=["text", "html"],
+        default="text",
+        help="Output format: text (default) or html.",
+    )
     p.add_argument(
         "--engine",
         choices=["dot", "neato", "sfdp", "fdp", "circo", "twopi"],
         default="dot",
-        help="Graphviz layout engine. 'dot' for hierarchical (<500 nodes), 'sfdp' for force-directed (10k+ nodes).",
+        help="Graphviz layout engine for HTML output.",
     )
     p.add_argument(
         "--direction",
         choices=["TB", "LR", "BT", "RL"],
         default="LR",
-        help="Flow direction for hierarchical layouts (default: LR; ignored by sfdp/neato).",
+        help="Flow direction for hierarchical HTML layouts.",
     )
     p.add_argument(
         "--func-names",
-        help="JSON with callable_id_to_name (or flat {func_id: name}) for label enrichment.",
+        help="JSON file with callable_id_to_name (or flat {func_id: name}) for task-label enrichment.",
     )
     p.add_argument(
         "--show-tensor-info",
         action="store_true",
         help=(
-            "Label every edge with the consuming tensor's slice description "
-            "(source, tensor id, [offset:+shape]). Default: off (clean task-pair arrows)."
+            "For HTML output, render per-task input/output tensor details and route edges to specific arg ports. "
+            "Default: off."
         ),
     )
     return p
 
 
-def main():
-    args = _build_parser().parse_args()
+def _argv_has_option(argv, name):
+    return any(arg == name or arg.startswith(f"{name}=") for arg in argv)
+
+
+def _validate_args(args, argv):
+    if args.format == "html":
+        return 0
+    html_only = ["--engine", "--direction", "--show-tensor-info"]
+    for option in html_only:
+        if _argv_has_option(argv, option):
+            print(f"error: {option} is only valid with --format html", file=sys.stderr)
+            return 2
+    return 0
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    rc = _validate_args(args, argv)
+    if rc != 0:
+        return rc
 
     input_path = args.input or _find_latest_deps_json()
     if input_path is None:
@@ -878,19 +934,35 @@ def main():
         return 1
 
     edges, nodes, annotations, tensor_table, task_table = _load_deps_edges(input_path)
-    # Explicit --func-names wins over the auto-discovered sibling file.
     func_names = _load_func_names_json(args.func_names) if args.func_names else _autoload_name_map(input_path)
     meta = _load_task_meta(input_path, func_names=func_names)
-    # Some workloads (embarrassingly parallel kernels, scope-fenced iterations
-    # that never reuse a tensor) produce no deps edges. Without the perf-records
-    # union the graph would be empty even though tasks ran. Seed isolated nodes
-    # from meta so every recorded task shows up, with its mix/aic/aiv shape.
+    meta = _merge_task_meta_with_kernel_ids(meta, task_table, func_names=func_names)
     if meta:
-        nodes = sorted(set(nodes) | set(meta.keys()))
+        nodes = sorted(set(nodes) | set(meta.keys()), key=_sort_task_id_key)
 
-    # --show-tensor-info renders each task as an HTML-table node with
-    # input/output compartments; without the flag we keep the bare shape view.
-    rendered_task_table = task_table if args.show_tensor_info else None
+    out = (
+        Path(args.output)
+        if args.output
+        else input_path.parent / ("deps_viewer.txt" if args.format == "text" else "deps_viewer.html")
+    )
+    if args.format == "text":
+        text = emit_text(
+            edges,
+            nodes,
+            meta,
+            input_path,
+            annotations=annotations,
+            tensor_table=tensor_table,
+            task_table=task_table,
+        )
+        out.write_text(text)
+        annotated_edges = sum(len(rows) for rows in annotations.values())
+        print(
+            f"Wrote {out} "
+            f"({len(nodes)} tasks, {len(edges)} unique edges, "
+            f"{annotated_edges} annotated edges, format=text)"
+        )
+        return 0
 
     html = emit_html(
         edges,
@@ -900,12 +972,10 @@ def main():
         engine=args.engine,
         annotations=annotations,
         tensor_table=tensor_table,
-        task_table=rendered_task_table,
+        task_table=task_table if args.show_tensor_info else None,
     )
-
-    out = Path(args.output) if args.output else input_path.parent / "deps_graph.html"
     out.write_text(html)
-    print(f"Wrote {out} ({len(nodes)} nodes, {len(edges)} edges, engine={args.engine})")
+    print(f"Wrote {out} ({len(nodes)} nodes, {len(edges)} edges, engine={args.engine}, format=html)")
     return 0
 
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -210,28 +210,49 @@ class TestDepGen(SceneTestCase):
                 f"edge {e.get('pred')}->{e.get('succ')} (source={source}) missing consumer_shape/start_offset/strides"
             )
 
-        # ---- Tool smoke: deps_to_graph ----
-        # Exit-code-only check; we don't validate the HTML content. A schema
-        # change that breaks the viewer fires here in the same CI step that
-        # produced the artifact, so the failure is attributed to the right
-        # capture. graphviz `dot` is required for rendering; skip on dev
-        # machines without it (CI installs it explicitly).
+        # ---- Tool smoke: deps_viewer (text) ----
+        # scene_test auto-generates deps_viewer.txt via _graph_case_dep_gen;
+        # smoke verifies it was produced and has the expected sections.
+        out_txt = out_dir / "deps_viewer.txt"
+        assert out_txt.exists(), f"scene_test auto-hook did not produce {out_txt}"
+        text = out_txt.read_text()
+        assert "SUMMARY" in text and "TASK INDEX" in text, "text deps graph missing expected sections"
+
+        for extra in (["--direction", "LR"], ["--engine", "dot"]):
+            bad = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "simpler_setup.tools.deps_viewer",
+                    str(deps_path),
+                    "--format",
+                    "text",
+                    *extra,
+                ],
+                check=False,
+                timeout=60,
+                capture_output=True,
+                text=True,
+            )
+            assert bad.returncode != 0, f"text mode should reject {' '.join(extra)}"
+            assert "only valid with --format html" in bad.stderr
+
         if shutil.which("dot"):
-            for extra in ([], ["--show-tensor-info"]):
-                out_html = out_dir / ("_smoke_deps_with_tensors.html" if extra else "_smoke_deps.html")
-                subprocess.run(
-                    [
-                        sys.executable,
-                        "-m",
-                        "simpler_setup.tools.deps_to_graph",
-                        str(deps_path),
-                        *extra,
-                        "-o",
-                        str(out_html),
-                    ],
-                    check=True,
-                    timeout=60,
-                )
+            out_html = out_dir / "_smoke_deps.html"
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "simpler_setup.tools.deps_viewer",
+                    str(deps_path),
+                    "--format",
+                    "html",
+                    "-o",
+                    str(out_html),
+                ],
+                check=True,
+                timeout=60,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/_swimlane_validate.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/_swimlane_validate.py
@@ -68,7 +68,7 @@ def validate_perf_artifact(case_label: str, *, expected_task_count: int | None =
             f"got {len(tasks)} perf records, expected {expected_task_count} under {perf}"
         )
     # Spot-check a single record's required fields — guards against drift in
-    # the swimlane schema that swimlane_converter.py / deps_to_graph.py rely on.
+    # the swimlane schema that swimlane_converter.py / deps_viewer.py rely on.
     first = tasks[0]
     for key in _REQUIRED_TASK_FIELDS:
         assert key in first, f"perf record missing required field '{key}': {first}"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py
@@ -210,28 +210,49 @@ class TestDepGen(SceneTestCase):
                 f"edge {e.get('pred')}->{e.get('succ')} (source={source}) missing consumer_shape/start_offset/strides"
             )
 
-        # ---- Tool smoke: deps_to_graph ----
-        # Exit-code-only check; we don't validate the HTML content. A schema
-        # change that breaks the viewer fires here in the same CI step that
-        # produced the artifact, so the failure is attributed to the right
-        # capture. graphviz `dot` is required for rendering; skip on dev
-        # machines without it (CI installs it explicitly).
+        # ---- Tool smoke: deps_viewer (text) ----
+        # scene_test auto-generates deps_viewer.txt via _graph_case_dep_gen;
+        # smoke verifies it was produced and has the expected sections.
+        out_txt = out_dir / "deps_viewer.txt"
+        assert out_txt.exists(), f"scene_test auto-hook did not produce {out_txt}"
+        text = out_txt.read_text()
+        assert "SUMMARY" in text and "TASK INDEX" in text, "text deps graph missing expected sections"
+
+        for extra in (["--direction", "LR"], ["--engine", "dot"]):
+            bad = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "simpler_setup.tools.deps_viewer",
+                    str(deps_path),
+                    "--format",
+                    "text",
+                    *extra,
+                ],
+                check=False,
+                timeout=60,
+                capture_output=True,
+                text=True,
+            )
+            assert bad.returncode != 0, f"text mode should reject {' '.join(extra)}"
+            assert "only valid with --format html" in bad.stderr
+
         if shutil.which("dot"):
-            for extra in ([], ["--show-tensor-info"]):
-                out_html = out_dir / ("_smoke_deps_with_tensors.html" if extra else "_smoke_deps.html")
-                subprocess.run(
-                    [
-                        sys.executable,
-                        "-m",
-                        "simpler_setup.tools.deps_to_graph",
-                        str(deps_path),
-                        *extra,
-                        "-o",
-                        str(out_html),
-                    ],
-                    check=True,
-                    timeout=60,
-                )
+            out_html = out_dir / "_smoke_deps.html"
+            subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "simpler_setup.tools.deps_viewer",
+                    str(deps_path),
+                    "--format",
+                    "html",
+                    "-o",
+                    str(out_html),
+                ],
+                check=True,
+                timeout=60,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -1,0 +1,232 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Contract tests for simpler_setup.tools.deps_viewer text output."""
+
+from simpler_setup.tools import deps_viewer
+from simpler_setup.tools.deps_viewer import _merge_task_meta_with_kernel_ids, emit_text
+
+
+def test_emit_text_marks_alloc_without_task_entry():
+    text = emit_text(
+        edges=[],
+        nodes=[1],
+        meta={},
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={},
+    )
+
+    assert "TASK 1 kind=alloc func_id=none fanin=0 fanout=0" in text
+    assert "=== TASK 1 kind=alloc func_id=none ===" in text
+
+
+def test_emit_text_marks_dummy_without_kernel_slots():
+    text = emit_text(
+        edges=[],
+        nodes=[1],
+        meta={},
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [-1, -1, -1]}},
+    )
+
+    assert "TASK 1 kind=dummy func_id=none fanin=0 fanout=0" in text
+    assert "=== TASK 1 kind=dummy func_id=none ===" in text
+
+
+def test_emit_text_marks_func_name_map_yes_only_with_named_func():
+    text_no_names = emit_text(
+        edges=[],
+        nodes=[1],
+        meta={1: {"func_id": 7}},
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [7, -1, -1]}},
+    )
+    assert "func_name_map: no" in text_no_names
+
+    assert "func_name_map: yes" in emit_text(
+        edges=[],
+        nodes=[1],
+        meta={1: {"func_id": 7, "func_name": "kernel_add", "_kernel_slots": [7, -1, -1]}},
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [7, -1, -1]}},
+    )
+
+
+def test_kernel_ids_fill_func_id_when_perf_sidecar_is_absent():
+    meta = _merge_task_meta_with_kernel_ids(
+        {},
+        {1: {"task_id": 1, "kernel_ids": [-1, 2, -1]}},
+    )
+
+    text = emit_text(
+        edges=[],
+        nodes=[1],
+        meta=meta,
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [-1, 2, -1]}},
+    )
+
+    assert "TASK 1 kind=submit func_id=[-1,2,-1] fanin=0 fanout=0" in text
+    assert "func_name_map: no" in text
+
+
+def test_kernel_ids_render_all_active_funcs_for_mixed_task():
+    meta = _merge_task_meta_with_kernel_ids(
+        {},
+        {
+            1: {"task_id": 1, "kernel_ids": [0, 1, 2]},
+            2: {"task_id": 2, "kernel_ids": [0, 1, -1]},
+            3: {"task_id": 3, "kernel_ids": [-1, 3, 4]},
+        },
+    )
+
+    text = emit_text(
+        edges=[],
+        nodes=[1, 2, 3],
+        meta=meta,
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={
+            1: {"task_id": 1, "kernel_ids": [0, 1, 2]},
+            2: {"task_id": 2, "kernel_ids": [0, 1, -1]},
+            3: {"task_id": 3, "kernel_ids": [-1, 3, 4]},
+        },
+    )
+
+    assert "TASK 1 kind=submit func_id=[0,1,2] fanin=0 fanout=0" in text
+    assert "TASK 2 kind=submit func_id=[0,1,-1] fanin=0 fanout=0" in text
+    assert "TASK 3 kind=submit func_id=[-1,3,4] fanin=0 fanout=0" in text
+    assert "func_name_map: no" in text
+
+
+def test_kernel_ids_use_func_name_map_when_available():
+    meta = _merge_task_meta_with_kernel_ids(
+        {},
+        {1: {"task_id": 1, "kernel_ids": [-1, 2, -1]}},
+        func_names={"2": "kernel_mul"},
+    )
+
+    text = emit_text(
+        edges=[],
+        nodes=[1],
+        meta=meta,
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [-1, 2, -1]}},
+    )
+
+    assert "TASK 1 kind=submit func_id=[-1,2,-1] fanin=0 fanout=0" in text
+    assert "func_name_map: yes" in text
+
+
+def test_kernel_ids_use_all_named_funcs_when_available():
+    meta = _merge_task_meta_with_kernel_ids(
+        {},
+        {1: {"task_id": 1, "kernel_ids": [0, 1, 2]}},
+        func_names={"0": "MATMUL", "1": "ADD", "2": "MUL"},
+    )
+
+    text = emit_text(
+        edges=[],
+        nodes=[1],
+        meta=meta,
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [0, 1, 2]}},
+    )
+
+    assert "TASK 1 kind=submit func_id=[0,1,2] fanin=0 fanout=0" in text
+    assert "func_name_map: yes" in text
+
+
+def test_validate_args_rejects_show_tensor_info_in_text_mode(capsys):
+    rc = deps_viewer.main(["deps.json", "--show-tensor-info"])
+
+    assert rc == 2
+    assert "--show-tensor-info is only valid with --format html" in capsys.readouterr().err
+
+
+def test_main_passes_task_table_when_show_tensor_info_enabled(tmp_path, monkeypatch):
+    deps_json = tmp_path / "deps.json"
+    deps_json.write_text("{}")
+
+    monkeypatch.setattr(
+        deps_viewer,
+        "_load_deps_edges",
+        lambda path: (
+            [(1, 2)],
+            [1, 2],
+            {(1, 2): [{"arg": 0, "tensor_id": 5}]},
+            {5: {"name": "T0"}},
+            {1: {"task_id": 1, "args": []}},
+        ),
+    )
+    monkeypatch.setattr(deps_viewer, "_load_task_meta", lambda path, func_names=None: {})
+    monkeypatch.setattr(deps_viewer, "_autoload_name_map", lambda path: {})
+
+    captured = {}
+
+    def fake_emit_html(
+        edges, nodes, meta, direction="LR", engine="dot", annotations=None, tensor_table=None, task_table=None
+    ):
+        captured["task_table"] = task_table
+        return "<html></html>"
+
+    monkeypatch.setattr(deps_viewer, "emit_html", fake_emit_html)
+
+    rc = deps_viewer.main([str(deps_json), "--format", "html", "--show-tensor-info"])
+
+    assert rc == 0
+    assert captured["task_table"] == {1: {"task_id": 1, "args": []}}
+
+
+def test_main_keeps_plain_html_when_show_tensor_info_disabled(tmp_path, monkeypatch):
+    deps_json = tmp_path / "deps.json"
+    deps_json.write_text("{}")
+
+    monkeypatch.setattr(
+        deps_viewer,
+        "_load_deps_edges",
+        lambda path: (
+            [(1, 2)],
+            [1, 2],
+            {(1, 2): [{"arg": 0, "tensor_id": 5}]},
+            {5: {"name": "T0"}},
+            {1: {"task_id": 1, "args": []}},
+        ),
+    )
+    monkeypatch.setattr(deps_viewer, "_load_task_meta", lambda path, func_names=None: {})
+    monkeypatch.setattr(deps_viewer, "_autoload_name_map", lambda path: {})
+
+    captured = {}
+
+    def fake_emit_html(
+        edges, nodes, meta, direction="LR", engine="dot", annotations=None, tensor_table=None, task_table=None
+    ):
+        captured["task_table"] = task_table
+        return "<html></html>"
+
+    monkeypatch.setattr(deps_viewer, "emit_html", fake_emit_html)
+
+    rc = deps_viewer.main([str(deps_json), "--format", "html"])
+
+    assert rc == 0
+    assert captured["task_table"] is None

--- a/tests/ut/py/test_scene_test_dep_gen_hook.py
+++ b/tests/ut/py/test_scene_test_dep_gen_hook.py
@@ -1,0 +1,136 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ruff: noqa: PLC0415
+"""Focused UT for the dep-gen post-case hook in scene_test.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from simpler_setup.scene_test import _graph_case_dep_gen, _run_deps_viewer
+
+_SCENE_TEST_MOD = sys.modules["simpler_setup.scene_test"]
+
+
+def _write_minimal_deps_json(path: Path) -> Path:
+    data = {"edges": [], "tensors": [], "tasks": []}
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _patch_run_deps_viewer():
+    return patch.object(_SCENE_TEST_MOD, "_run_deps_viewer")
+
+
+def test_graph_case_dep_gen_calls_tool_when_deps_json_exists(tmp_path):
+    _write_minimal_deps_json(tmp_path / "deps.json")
+
+    with _patch_run_deps_viewer() as mock_run:
+        _graph_case_dep_gen("my_case", tmp_path, callable_spec=None)
+
+    mock_run.assert_called_once()
+    call_kwargs = mock_run.call_args
+    assert str(tmp_path / "deps.json") in str(
+        call_kwargs[1].get("input_path", call_kwargs[0][0] if call_kwargs[0] else "")
+    )
+
+
+def test_graph_case_dep_gen_skips_when_deps_json_missing(tmp_path):
+    with _patch_run_deps_viewer() as mock_run:
+        _graph_case_dep_gen("my_case", tmp_path, callable_spec=None)
+
+    mock_run.assert_not_called()
+
+
+def test_graph_case_dep_gen_passes_func_names_from_callable_spec(tmp_path):
+    _write_minimal_deps_json(tmp_path / "deps.json")
+    callable_spec = {
+        "incores": [{"name": "kernel_add", "func_id": 0}, {"name": "kernel_mul", "func_id": 1}],
+        "orchestration": {"name": "MyOrch"},
+    }
+
+    with _patch_run_deps_viewer() as mock_run:
+        _graph_case_dep_gen("my_case", tmp_path, callable_spec=callable_spec)
+
+    func_names_path = mock_run.call_args[1].get("func_names_path")
+    assert func_names_path is not None
+    assert func_names_path.exists()
+    mapping = json.loads(func_names_path.read_text())
+    assert mapping["callable_id_to_name"]["0"] == "kernel_add"
+    assert mapping["callable_id_to_name"]["1"] == "kernel_mul"
+
+
+def test_graph_case_dep_gen_reuses_existing_name_map(tmp_path):
+    _write_minimal_deps_json(tmp_path / "deps.json")
+    name_map_path = tmp_path / "name_map_my_case.json"
+    name_map_path.write_text(json.dumps({"callable_id_to_name": {"0": "existing_kernel"}}))
+
+    callable_spec = {
+        "incores": [{"name": "kernel_add", "func_id": 0}],
+        "orchestration": {"name": "MyOrch"},
+    }
+
+    with _patch_run_deps_viewer() as mock_run:
+        _graph_case_dep_gen("my_case", tmp_path, callable_spec=callable_spec)
+
+    func_names_path = mock_run.call_args[1].get("func_names_path")
+    assert func_names_path == name_map_path
+
+
+def test_graph_case_dep_gen_no_func_names_without_callable_spec(tmp_path):
+    _write_minimal_deps_json(tmp_path / "deps.json")
+
+    with _patch_run_deps_viewer() as mock_run:
+        _graph_case_dep_gen("my_case", tmp_path, callable_spec=None)
+
+    func_names_path = mock_run.call_args[1].get("func_names_path")
+    assert func_names_path is None
+
+
+def test_run_deps_viewer_invokes_subprocess_correctly(tmp_path):
+    deps_file = _write_minimal_deps_json(tmp_path / "deps.json")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="")
+        _run_deps_viewer(input_path=deps_file)
+
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert "simpler_setup.tools.deps_viewer" in cmd
+    assert str(deps_file) in cmd
+    assert "--format" in cmd
+    assert "text" in cmd
+
+
+def test_run_deps_viewer_passes_func_names(tmp_path):
+    deps_file = _write_minimal_deps_json(tmp_path / "deps.json")
+    name_map = tmp_path / "name_map.json"
+    name_map.write_text("{}")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.return_value = MagicMock(stdout="", stderr="")
+        _run_deps_viewer(input_path=deps_file, func_names_path=name_map)
+
+    cmd = mock_run.call_args[0][0]
+    assert "--func-names" in cmd
+    assert str(name_map) in cmd
+
+
+def test_run_deps_viewer_warning_on_failure(tmp_path):
+    deps_file = _write_minimal_deps_json(tmp_path / "deps.json")
+
+    with patch("subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.CalledProcessError(1, cmd=[], stderr="boom")
+        with patch("logging.getLogger") as _:
+            _run_deps_viewer(input_path=deps_file)


### PR DESCRIPTION
## Summary

Refactor `deps_to_graph` so its default text output becomes a stable, task-centric dependency view with explicit task kind classification and slot-preserving function identity.

This PR:

- simplifies the default text view into a task-adjacency format
- preserves the three-slot `kernel_ids=[aic,aiv0,aiv1]` structure in text output
- adds explicit task `kind=` classification (`submit` / `dummy` / `alloc`)
- keeps HTML as the topology/layout view rather than a field-dense annotation view
- adds focused UT + smoke coverage for the new contract
- includes the small missing declaration fix needed in `tensor_dump_aicpu.h`

Closes #1001

## Motivation

The old `deps_to_graph` text output had gradually accumulated two different responsibilities:

1. **Projecting `deps.json` details** — edge annotations, tensor/source/arg metadata, and implementation-oriented fields.
2. **Helping humans quickly answer graph questions** — "who depends on this task?", "what are this task's predecessors?", "where are the branch/fan-in points?"

In practice, those goals conflicted. The output was grep-able, but visually noisy, and key task semantics were still implicit:

- task kind was not explicit
- `func=` formatting could collapse slot information
- `unknown` mixed together very different situations
- users had to mentally reconstruct whether a node was a normal kernel submit, a dependency-only dummy task, or an alloc-style edge-only producer

This PR restructures the text view around the current dep_gen schema and current debugging needs:

- **text** answers task-graph questions
- **HTML** remains the structural topology view
- **`deps.json`** remains the detailed fact source

## Key Changes

### 1. Default text output now uses a task-adjacency contract

The text output keeps:

- `SUMMARY`
- `TASK INDEX`
- per-task detail blocks
- `FANIN` / `FANOUT` peer lists

It removes default text emphasis on:

- tensor detail projection
- annotation-heavy peer lines
- `raw=` / `core=` / `scope=` noise in the main task listing
- `ARGS`-style detail from the default flow

### 2. Add explicit `kind=` classification

Each rendered task now carries one of:

- `kind=submit` — task exists in `tasks[]` and has at least one active kernel slot
- `kind=dummy` — task exists in `tasks[]` but all three kernel slots are `-1`
- `kind=alloc` — task appears in graph topology but not in `tasks[]`
- `kind=unknown` — fallback only for incomplete/unexpected input

This separates **what the task is** from **whether it has a displayable function id**.

### 3. Preserve full three-slot `kernel_ids` in text `func_id=`

Text `func_id=` now follows the current `tasks[].kernel_ids` schema directly:

- fixed order: `[aic,aiv0,aiv1]`
- inactive slots remain `-1`
- no collapsing to a single value

Examples:

- `[-1,2,-1]` stays `func_id=[-1,2,-1]`
- `[0,1,2]` stays `func_id=[0,1,2]`

This preserves slot semantics that would otherwise be lost.

### 4. `dummy` / `alloc` now render `func_id=none`

This PR tightens the meaning of the text function field:

- `submit` → render slot-preserving `func_id=[...]`
- `dummy` / `alloc` → render `func_id=none`
- `unknown` → reserve `func_id=unknown` for true fallback cases only

So "this node has no kernel func id by nature" is no longer conflated with "we failed to determine it".

### 5. `func_name_map` semantics are clarified

`func_name_map: yes` now strictly means:

- at least one human-readable function name was resolved from `--func-names` or a sibling `name_map_*.json`

It does **not** mean that text `func_id=` came from that path. Text `func_id=` is driven by `tasks[].kernel_ids`.

### 6. HTML stays focused on topology, not label density

This PR keeps the HTML view positioned as the layout/topology view:

- node labels stay compact
- text output carries the detailed `kind=` / `func_id=` information
- HTML-only knobs such as `--engine` and `--direction` continue to be rejected in text mode


## Example Output

### Text Output Format (vector_example)

```text
SUMMARY
  source_deps_json: outputs/TestVectorExample_default_20260615_142252/deps.json
  tasks: 5
  unique_task_edges: 6
  annotated_edges: 6
  tensors: 7
  perf_sidecar: yes
  func_name_map: no

TASK INDEX
TASK (0, 0) kind=submit func_id=[-1,0,-1] fanin=0 fanout=3
TASK (1, 0) kind=submit func_id=[-1,1,-1] fanin=1 fanout=1
TASK (1, 1) kind=submit func_id=[-1,1,-1] fanin=1 fanout=1
TASK (1, 2) kind=submit func_id=[-1,2,-1] fanin=2 fanout=1
TASK (1, 3) kind=submit func_id=[-1,0,-1] fanin=2 fanout=0

=== TASK (0, 0) kind=submit func_id=[-1,0,-1] ===
FANIN 0
FANOUT 3
  -> (1, 0)
  -> (1, 1)
  -> (1, 3)

=== TASK (1, 2) kind=submit func_id=[-1,2,-1] ===
FANIN 2
  <- (1, 0)
  <- (1, 1)
FANOUT 1
  -> (1, 3)
```

## CLI

```bash
# Generate text output (default)
python -m simpler_setup.tools.deps_to_graph deps.json

# Generate HTML output
python -m simpler_setup.tools.deps_to_graph deps.json --format html
```

`--engine` and `--direction` remain HTML-only parameters.

## Files Changed

- `simpler_setup/tools/deps_to_graph.py`
  - main text-contract refactor
  - task kind classification
  - three-slot `func_id=` rendering
  - dead helper cleanup
- `tests/ut/py/test_deps_to_graph.py`
  - new UTs for `submit` / `dummy` / `alloc`
  - `func_name_map` behavior
  - slot-preserving `func_id=` output
- `tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py`
  - smoke expectations updated for the new text contract
- `tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py`
  - smoke expectations updated for the new text contract
- `docs/dfx/dep_gen.md`
  - dep_gen viewer contract documentation update
- `simpler_setup/tools/README.md`
  - user-facing tool documentation update
- `docs/profiling-name-map.md`
  - related name-map semantics update
- `simpler_setup/tools/__init__.py`
  - tool export synchronization

Refs #1001