### PR TITLE
fix(l2_swimlane): unify func_id resolve & gate kernel names behind --enable-dep-gen

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -246,13 +246,30 @@ The output is `outputs/<case>_<ts>/merged_swimlane.json` (or your
 in. The trace contains:
 
 - **AICore View** — one swim-lane per AICore (AIC / AIV / mix
-  channel). Each task shows `func_name(t<task_id>)`; dependency
-  arrows are joined from `deps.json` when it's available — see
-  [§3.5](#35-dependency-arrows-from-dep_gen) for the workflow. No
-  `deps.json` → no arrows (the converter prints a one-line hint).
-- **AICPU View** — scheduler thread lanes with per-iteration
-  phase blocks coloured by `phase`.
-- **AICPU Scheduler** — orchestrator phase summary at the top.
+  channel) showing each task's execution window. Task labels follow
+  the deps.json-dependent rule below.
+- **AICPU View** — one lane per task showing the AICPU
+  `dispatch_time_us → finish_time_us` window (level >= 2). Tasks here
+  carry the **same labels** as the AICore View — so they share the
+  same deps.json dependency below.
+- **AICPU Scheduler** — per-iteration scheduler phase blocks
+  (`complete` / `dispatch`) coloured by `phase` (level >= 3).
+- **AICPU Orchestrator** — per-submit `orch_submit` envelope blocks
+  (level >= 4).
+
+**Task labeling (AICore View and AICPU View) depends entirely on
+whether a `deps.json` is present** (see
+[§3.5](#35-dependency-arrows-from-dep_gen)):
+
+- **With `deps.json`** — each task shows `func_name(rXtY)` (or
+  `func_<id>(rXtY)` when no name map), and dependency arrows are
+  drawn in the AICore View.
+- **Without `deps.json`** — the host never records `func_id` (it's
+  `-1` on disk), so the converter cannot tell tasks apart by
+  function. Every task in **both** views is labeled `task(rXtY)` —
+  distinguished only by id — and no arrows are drawn (the converter
+  prints a one-line hint). Re-run with `--enable-dep-gen` (or join an
+  existing `deps.json`) to recover names and arrows.
 
 When the run also emitted a device log (`device-*` file under
 `outputs/`), `swimlane_converter` resolves the nearest log by
@@ -263,9 +280,18 @@ specific overhead source.
 
 ### 3.4 Adding human-readable names
 
-Without name mapping, tasks show as `func_<id>(t<task_id>)`. To
-get readable lane labels, add a `name` field to your CALLABLE
-spec:
+Lane labels degrade in two steps:
+
+| What's available | Label | Distinguishable? |
+| ---------------- | ----- | ---------------- |
+| No `deps.json` (no `--enable-dep-gen`) | `task(rXtY)` | By id only — `func_id` is unresolved |
+| `deps.json`, no name map | `func_<id>(rXtY)` | By function id |
+| `deps.json` + name map | `QK(rXtY)` | By human name |
+
+So a readable trace needs **both** a `deps.json` (to resolve
+`func_id`; see [§3.5](#35-dependency-arrows-from-dep_gen)) **and** a
+name map. To get readable lane labels, add a `name` field to your
+CALLABLE spec:
 
 ```python
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
@@ -345,6 +371,35 @@ Use this when:
   (one `dep_gen` capture amortizes across N swimlane runs).
 - A workload is so large that the dep_gen replay validation gate
   would dominate the swimlane run time.
+
+**Low-distortion workflow (minimal capture, names recovered
+offline):** When you want the least possible perturbation — skip the
+`dep_gen` replay overhead on the measured run, and/or use a low
+swimlane perf_level (e.g. level 1, AICore timing only) — run the perf
+capture *without* `--enable-dep-gen`. The resulting trace labels every
+task `task(rXtY)` (no `func_id`, no arrows). To recover names and
+arrows afterward, take a `deps.json` from a separate `dep_gen` capture
+of the same topology, drop it next to your `l2_swimlane_records.json`
+(or point `--deps-json` at it), and re-run the converter:
+
+```bash
+# Low-overhead perf run — no dep_gen, low level.
+python test_my_case.py --platform a2a3 --enable-l2-swimlane 1
+
+# Separately (once per topology), capture the graph.
+python test_my_case.py --platform a2a3 --enable-dep-gen
+
+# Join offline: copy the deps.json in, then re-run the converter.
+cp outputs/<case_dep_ts>/deps.json outputs/<case_perf_ts>/deps.json
+python -m simpler_setup.tools.swimlane_converter \
+    outputs/<case_perf_ts>/l2_swimlane_records.json \
+    --func-names outputs/<case_perf_ts>/name_map_<case>.json
+```
+
+The converter is a pure post-processor — re-running it against the
+same raw records with a `deps.json` now present upgrades the labels
+from `task(rXtY)` to real names and adds the dependency arrows,
+without re-running the workload.
 
 When `--deps-json` is omitted **and** the converter cannot find a
 sibling `deps.json` next to `l2_swimlane_records.json`, the trace is
@@ -827,9 +882,17 @@ did not, run it manually:
 python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json
 ```
 
-**Tasks show as `func_<id>` instead of human names.** The
-CALLABLE spec lacks `"name"` fields, or
-`name_map_<case>.json` was not produced. See [profiling-name-map.md](../profiling-name-map.md).
+**All tasks show as `task(rXtY)` (undistinguished).** No `deps.json`
+was available, so the converter could not resolve `func_id` (it's
+`-1` on disk) and every lane falls back to the anonymous `task(rXtY)`
+label with no dependency arrows. Re-run with `--enable-dep-gen`, or
+drop a `deps.json` from a prior `dep_gen` capture next to the records
+and re-run the converter — see
+[§3.5](#35-dependency-arrows-from-dep_gen).
+
+**Tasks show as `func_<id>` instead of human names.** `deps.json`
+resolved the `func_id`, but the CALLABLE spec lacks `"name"` fields
+or `name_map_<case>.json` was not produced. See [profiling-name-map.md](../profiling-name-map.md).
 
 **Some tasks missing from the swimlane.** Likely dropped on device
 because the buffer pool ran out. On a2a3 check

--- a/docs/profiling-name-map.md
+++ b/docs/profiling-name-map.md
@@ -136,7 +136,11 @@ When `--enable-l2-swimlane` is used, SceneTest automatically:
 3. Passes the file to `swimlane_converter.py` via `--func-names`.
 
 No manual steps are needed.  If no `"name"` fields are defined, no
-mapping file is written and the tools fall back to default labels.
+mapping file is written and the tools fall back to default labels:
+`func_<id>(rXtY)` when a `deps.json` resolved the `func_id`, or
+`task(rXtY)` when none is available (the host emits `func_id = -1`,
+so without `deps.json` tasks cannot be told apart by function — see
+[dfx/l2-swimlane-profiling.md §3.5](dfx/l2-swimlane-profiling.md#35-dependency-arrows-from-dep_gen)).
 
 ## Tool Usage
 

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -51,6 +51,27 @@ def _func_id_to_letter(func_id):
     return str(n) + "_" + "".join(reversed(letters))
 
 
+def _task_display_name(func_id, func_id_to_name, tdisp):
+    """Build the swimlane event label for a task.
+
+    Naming, in priority order:
+      - ``func_id < 0`` (unresolved): ``task(rXtY)``. This is the no-deps.json
+        case — without a dep_gen capture the host never carries func_id, so
+        every lane is an anonymous ``task(...)`` distinguished only by id.
+      - a name mapping exists for the func_id: ``<name>(rXtY)``.
+      - otherwise: ``func_<letter>(rXtY)`` (resolved id, but no name map entry).
+    """
+    try:
+        resolved = int(func_id) >= 0
+    except (TypeError, ValueError):
+        resolved = False
+    if not resolved:
+        return f"task({tdisp})"
+    if func_id_to_name and str(func_id) in func_id_to_name:
+        return f"{func_id_to_name[str(func_id)]}({tdisp})"
+    return f"func_{_func_id_to_letter(func_id)}({tdisp})"
+
+
 def normalize_pto2_task_id_int(v):
     """Unsigned 64-bit PTO2 task id (matches host JSON / device ``task_id.raw``).
 
@@ -688,6 +709,20 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
     if verbose:
         print(f"  Unique cores: {len(unique_cores)}")
 
+    # Recover func_id for AICORE_TIMING (level=1) records, which the host
+    # emits as func_id=-1. Resolve once here against dep_gen's per-task
+    # kernel_ids[3] (picking the subslot by core_type) and write it back onto
+    # the task, so every downstream consumer — AICore View, AICPU View, and
+    # event-hints — sees the same real func_id. See
+    # resolve_func_id_from_kernel_map() for the AIV0-vs-AIV1 tie-break and the
+    # host-side contract.
+    if deps_kernel_map is not None:
+        for task in tasks:
+            if int(task["func_id"]) < 0:
+                resolved = resolve_func_id_from_kernel_map(task["task_id"], task.get("core_type"), deps_kernel_map)
+                if resolved >= 0:
+                    task["func_id"] = resolved
+
     # Step 2: Generate JSON events
     events = []
 
@@ -735,22 +770,12 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
         ts = task["start_time_us"]
         dur = task["duration_us"]
 
-        # Get function name if available. At AICORE_TIMING (level=1) the
-        # host emits func_id=-1; recover the real func_id from dep_gen's
-        # per-task kernel_ids[3] using the record's core_type to pick the
-        # active subslot. See resolve_func_id_from_kernel_map() for the
-        # AIV0-vs-AIV1 tie-break and the host-side contract.
+        # func_id is already resolved (level=1 records recovered from
+        # dep_gen's kernel_ids up front; see the pre-pass above). Without a
+        # deps.json the id stays -1 and the lane is named task(rXtY).
         func_id = task["func_id"]
-        if int(func_id) < 0 and deps_kernel_map is not None:
-            resolved = resolve_func_id_from_kernel_map(task["task_id"], task.get("core_type"), deps_kernel_map)
-            if resolved >= 0:
-                func_id = resolved
         tdisp = format_task_display(task["task_id"])
-        if func_id_to_name and str(func_id) in func_id_to_name:
-            func_name = func_id_to_name[str(func_id)]
-            task_name = f"{func_name}({tdisp})"
-        else:
-            task_name = f"func_{_func_id_to_letter(func_id)}({tdisp})"
+        task_name = _task_display_name(func_id, func_id_to_name, tdisp)
 
         # Build fanout hint string (packed ids → rXtY / tY for readability)
         # from deps.json — the device hot path no longer carries fanout.
@@ -860,14 +885,11 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0915
             tid = task_to_aicpu_tid.get((task["task_id"], task["core_id"]), core_to_tid[task["core_id"]])
             aicpu_dur = finish_us - dispatch_us
 
-            # Get function name if available
+            # Get function name if available (task(rXtY) when no deps.json
+            # resolved the func_id; see _task_display_name).
             func_id = task["func_id"]
             tdisp = format_task_display(task["task_id"])
-            if func_id_to_name and str(func_id) in func_id_to_name:
-                func_name = func_id_to_name[str(func_id)]
-                task_name = f"{func_name}({tdisp})"
-            else:
-                task_name = f"func_{_func_id_to_letter(func_id)}({tdisp})"
+            task_name = _task_display_name(func_id, func_id_to_name, tdisp)
 
             events.append(
                 {


### PR DESCRIPTION
- Hoist func_id pre-pass for AICore/AICPU/event hints, remove duplicate AICore inline resolve
- No --enable-dep-gen: generic task(r{}t{}) labels for all swimlane items
- Enable dep-gen: render real kernel names + deps from deps.json
- Low overhead path: generate raw trace first, inject deps.json and re-convert
- Sync project docs with new flag workflow
Resolve AICPU lanes stuck with func_-1 even with valid deps.json