### PR TITLE
Fix: direction-aware host<->device tensor staging (#1047)

### DIFF
--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -135,11 +135,10 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    // PTO2 static-arena hooks. The host_build_graph runtime does not currently
-    // use these — the fields exist only so the platform layer's
-    // pto_runtime_c_api.cpp can populate the same HostApi struct regardless of
-    // which runtime variant it is built against. Unset for this variant; do
-    // not call.
+    // Device-side memset (zero-init pure OUTPUT buffers in lieu of an H2D
+    // copy-in). Unused by host_build_graph; present only so the platform
+    // layer can populate the same HostApi shape regardless of runtime variant.
+    int (*device_memset)(void *dev_ptr, int value, size_t size);
     // PTO2 static-arena hooks. The host_build_graph runtime does not currently
     // use these — the fields exist only so the platform layer's
     // pto_runtime_c_api.cpp can populate the same HostApi struct regardless of

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -15,12 +15,14 @@
  * Supports device orchestration where AICPU thread 3 runs the orchestrator.
  *
  * init_runtime_impl:
- *   - Converts host tensor pointers to device pointers (all tensors copied both directions)
+ *   - Converts host tensor pointers to device pointers (all inputs copied H2D;
+ *     only OUTPUT/INOUT tensors are copied back D2H)
  *   - Copies orchestration SO to device memory
  *   - Sets up runtime state for device orchestration
  *
  * validate_runtime_impl:
- *   - Copies recorded tensors back from device to host
+ *   - Copies OUTPUT/INOUT tensors back from device to host (read-only inputs
+ *     are skipped)
  *   - Frees device memory
  */
 
@@ -161,9 +163,8 @@ prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const 
  * @return 0 on success, -1 on failure
  */
 extern "C" int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
-    const ArgDirection * /*signature*/, int /*sig_count*/, uint64_t ring_task_window, uint64_t ring_heap,
-    uint64_t ring_dep_pool
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -209,13 +210,32 @@ extern "C" int bind_callable_to_runtime_impl(
             return -1;
         }
 
-        int rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+        // Pure write-only OUTPUT buffers carry no meaningful host content, so
+        // the H2D copy-in is wasted. Zero them on-device instead (cheap HBM
+        // memset, no PCIe) so any region the kernel leaves unwritten reads as 0
+        // rather than pooled-allocator garbage. INOUT (read-before-write)
+        // and IN keep the H2D copy. Falls back to copy_to_device if a backend
+        // did not wire device_memset.
+        bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
+        int rc;
+        if (is_pure_output && runtime->host_api.device_memset != nullptr) {
+            rc = runtime->host_api.device_memset(dev_ptr, 0, size);
+        } else {
+            rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+        }
         if (rc != 0) {
-            LOG_ERROR("Failed to copy tensor %d to device", i);
+            LOG_ERROR("Failed to stage tensor %d to device", i);
             runtime->host_api.device_free(dev_ptr);
             return -1;
         }
-        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size});
+        // Read-only INPUT tensors are never written by the kernel, so there is
+        // no point copying them back D2H at the end. Index the signature
+        // by the orch tensor index `i` (child_memory tensors are skipped above
+        // but do not consume a separate signature slot — scalars follow the
+        // tensor entries). Anything not provably IN keeps the safe default of
+        // copying back.
+        bool needs_copy_back = !(signature != nullptr && i < sig_count && signature[i] == ArgDirection::IN);
+        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size, needs_copy_back});
         LOG_INFO_V0("  Tensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         t.data = reinterpret_cast<uint64_t>(dev_ptr);
@@ -450,6 +470,14 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
             // If host pointer is null, this is a device-only allocation (no copy-back)
             if (pair.host_ptr == nullptr) {
                 LOG_INFO_V0("Tensor %d: device-only allocation (no copy-back)", i);
+                continue;
+            }
+
+            // Read-only INPUT tensors were uploaded H2D but the kernel never
+            // wrote them — copying them back (potentially ~GB) is pure waste.
+            // They are still device_free'd in the cleanup loop below.
+            if (!pair.needs_copy_back) {
+                LOG_INFO_V0("Tensor %d: read-only input, skipping copy-back", i);
                 continue;
             }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -108,6 +108,10 @@ struct TensorPair {
     void *host_ptr;
     void *dev_ptr;
     size_t size;
+    // false for read-only INPUT tensors: they are never written by the kernel,
+    // so the end-of-run D2H copy-back is skipped. OUTPUT/INOUT/unknown
+    // keep the safe default of copying back.
+    bool needs_copy_back = true;
 };
 
 /**
@@ -119,6 +123,11 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Set a device buffer to a byte value (device-side, no PCIe). Used to
+    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
+    // null on backends that don't wire it; callers must fall back to
+    // copy_to_device.
+    int (*device_memset)(void *dev_ptr, int value, size_t size);
     // Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2 shared
     // memory, trb prebuilt runtime arena) as three independent device
     // allocations. `runtime_arena_size == 0` skips the third region (hbg

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -141,6 +141,10 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Device-side memset (zero-init pure OUTPUT buffers in lieu of an H2D
+    // copy-in). Unused by host_build_graph; present only so the platform
+    // layer can populate the same HostApi shape regardless of runtime variant.
+    int (*device_memset)(void *dev_ptr, int value, size_t size);
     // PTO2 static-arena hooks. The host_build_graph runtime does not currently
     // use these — the fields exist only so the platform layer's
     // pto_runtime_c_api.cpp can populate the same HostApi struct regardless of

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -15,12 +15,14 @@
  * Supports device orchestration where AICPU thread 3 runs the orchestrator.
  *
  * init_runtime_impl:
- *   - Converts host tensor pointers to device pointers (all tensors copied both directions)
+ *   - Converts host tensor pointers to device pointers (all inputs copied H2D;
+ *     only OUTPUT/INOUT tensors are copied back D2H)
  *   - Copies orchestration SO to device memory
  *   - Sets up runtime state for device orchestration
  *
  * validate_runtime_impl:
- *   - Copies recorded tensors back from device to host
+ *   - Copies OUTPUT/INOUT tensors back from device to host (read-only inputs
+ *     are skipped)
  *   - Frees device memory
  */
 
@@ -161,9 +163,8 @@ prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const 
  * @return 0 on success, -1 on failure
  */
 extern "C" int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
-    const ArgDirection * /*signature*/, int /*sig_count*/, uint64_t ring_task_window, uint64_t ring_heap,
-    uint64_t ring_dep_pool
+    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
+    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -209,13 +210,32 @@ extern "C" int bind_callable_to_runtime_impl(
             return -1;
         }
 
-        int rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+        // Pure write-only OUTPUT buffers carry no meaningful host content, so
+        // the H2D copy-in is wasted. Zero them on-device instead (cheap HBM
+        // memset, no PCIe) so any region the kernel leaves unwritten reads as 0
+        // rather than pooled-allocator garbage. INOUT (read-before-write)
+        // and IN keep the H2D copy. Falls back to copy_to_device if a backend
+        // did not wire device_memset.
+        bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
+        int rc;
+        if (is_pure_output && runtime->host_api.device_memset != nullptr) {
+            rc = runtime->host_api.device_memset(dev_ptr, 0, size);
+        } else {
+            rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+        }
         if (rc != 0) {
-            LOG_ERROR("Failed to copy tensor %d to device", i);
+            LOG_ERROR("Failed to stage tensor %d to device", i);
             runtime->host_api.device_free(dev_ptr);
             return -1;
         }
-        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size});
+        // Read-only INPUT tensors are never written by the kernel, so there is
+        // no point copying them back D2H at the end. Index the signature
+        // by the orch tensor index `i` (child_memory tensors are skipped above
+        // but do not consume a separate signature slot — scalars follow the
+        // tensor entries). Anything not provably IN keeps the safe default of
+        // copying back.
+        bool needs_copy_back = !(signature != nullptr && i < sig_count && signature[i] == ArgDirection::IN);
+        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size, needs_copy_back});
         LOG_INFO_V0("  Tensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         t.data = reinterpret_cast<uint64_t>(dev_ptr);
@@ -450,6 +470,14 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
             // If host pointer is null, this is a device-only allocation (no copy-back)
             if (pair.host_ptr == nullptr) {
                 LOG_INFO_V0("Tensor %d: device-only allocation (no copy-back)", i);
+                continue;
+            }
+
+            // Read-only INPUT tensors were uploaded H2D but the kernel never
+            // wrote them — copying them back (potentially ~GB) is pure waste.
+            // They are still device_free'd in the cleanup loop below.
+            if (!pair.needs_copy_back) {
+                LOG_INFO_V0("Tensor %d: read-only input, skipping copy-back", i);
                 continue;
             }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -116,6 +116,10 @@ struct TensorPair {
     void *host_ptr;
     void *dev_ptr;
     size_t size;
+    // false for read-only INPUT tensors: they are never written by the kernel,
+    // so the end-of-run D2H copy-back is skipped. OUTPUT/INOUT/unknown
+    // keep the safe default of copying back.
+    bool needs_copy_back = true;
 };
 
 /**
@@ -127,6 +131,11 @@ struct HostApi {
     void (*device_free)(void *dev_ptr);
     int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
     int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Set a device buffer to a byte value (device-side, no PCIe). Used to
+    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
+    // null on backends that don't wire it; callers must fall back to
+    // copy_to_device.
+    int (*device_memset)(void *dev_ptr, int value, size_t size);
     // Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2 shared
     // memory, trb prebuilt runtime arena) as three independent device
     // allocations. `runtime_arena_size == 0` skips the third region (hbg

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -106,6 +106,15 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
+static int device_memset(void *dev_ptr, int value, size_t size) {
+    if (dev_ptr == NULL) return -1;
+    try {
+        return current_runner()->device_memset(dev_ptr, value, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
 static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
         return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
@@ -359,6 +368,7 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
+        r->host_api.device_memset = device_memset;
         r->host_api.setup_static_arena = setup_static_arena_wrapper;
         r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
         r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
@@ -369,8 +379,9 @@ int run_prepared(
         // returned host_orch_func_ptr is non-null only on the hbg path and is
         // handed straight into bind_callable_to_runtime_impl below. signature
         // is the cached ChipCallable signature_[]; it's plumbed end-to-end for
-        // per-tensor direction decisions in runtime_maker but is currently
-        // unconsumed on both runtimes — see bind_callable_to_runtime_impl.
+        // per-tensor direction decisions in runtime_maker. trb consumes it to
+        // skip the D2H copy-back of read-only INPUT tensors; hbg still
+        // ignores it — see bind_callable_to_runtime_impl.
         auto bind_result = runner->bind_callable_to_runtime(*r, callable_id);
         if (bind_result.rc != 0) {
             return bind_result.rc;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -67,6 +67,10 @@ int DeviceRunnerBase::copy_from_device(void *host_ptr, const void *dev_ptr, std:
     return rtMemcpy(host_ptr, bytes, dev_ptr, bytes, RT_MEMCPY_DEVICE_TO_HOST);
 }
 
+int DeviceRunnerBase::device_memset(void *dev_ptr, int value, std::size_t bytes) {
+    return aclrtMemset(dev_ptr, bytes, value, bytes);
+}
+
 void *DeviceRunnerBase::acquire_pooled_gm_heap() {
     if (!gm_heap_arena_.is_committed()) return nullptr;
     return gm_heap_arena_.base();

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -86,6 +86,7 @@ public:
     void free_tensor(void *dev_ptr);
     int copy_to_device(void *dev_ptr, const void *host_ptr, std::size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, std::size_t bytes);
+    int device_memset(void *dev_ptr, int value, std::size_t bytes);
 
     /**
      * Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -101,6 +101,15 @@ static int copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
     }
 }
 
+static int device_memset(void *dev_ptr, int value, size_t size) {
+    if (dev_ptr == NULL) return -1;
+    try {
+        return current_runner()->device_memset(dev_ptr, value, size);
+    } catch (...) {
+        return -1;
+    }
+}
+
 static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
         return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
@@ -318,6 +327,7 @@ int run_prepared(
         r->host_api.device_free = device_free;
         r->host_api.copy_to_device = copy_to_device;
         r->host_api.copy_from_device = copy_from_device;
+        r->host_api.device_memset = device_memset;
         r->host_api.setup_static_arena = setup_static_arena_wrapper;
         r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
         r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -196,6 +196,11 @@ int SimDeviceRunnerBase::copy_from_device(void *host_ptr, const void *dev_ptr, s
     return 0;
 }
 
+int SimDeviceRunnerBase::device_memset(void *dev_ptr, int value, size_t bytes) {
+    std::memset(dev_ptr, value, bytes);
+    return 0;
+}
+
 int SimDeviceRunnerBase::prepare_orch_so(Runtime &runtime) {
     const int32_t cid = runtime.get_active_callable_id();
     if (cid < 0) {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -83,6 +83,7 @@ public:
     void free_tensor(void *dev_ptr);
     int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
+    int device_memset(void *dev_ptr, int value, size_t bytes);
 
     int register_callable(
         int32_t callable_id, const void *orch_so_data, size_t orch_so_size, const char *func_name,


### PR DESCRIPTION
## What

The orchestration entry (`bind_callable_to_runtime_impl` / `validate_runtime_impl`, trb runtime) copied **every** non-`child_memory` tensor in **both** directions, ignoring per-arg direction. This consumes the already-plumbed `ChipCallable` signature to stage each tensor by its `ArgDirection`:

- **Read-only `INPUT`** tensors are never written by the kernel → skip the end-of-run **D2H copy-back** (the dominant waste; e.g. paged_attention `key_cache` + `value_cache` ≈ 1 GB/run).
- **Pure `OUTPUT`** tensors carry no meaningful host content → skip the **H2D copy-in** and zero them on-device (new `HostApi::device_memset` → `aclrtMemset` onboard / `std::memset` sim) so unwritten regions read as 0 rather than pooled-allocator garbage.
- `INOUT` and anything not provably `IN`/`OUT` keep the safe both-directions default; a null `device_memset` falls back to `copy_to_device`.

Each `TensorPair` is tagged with `needs_copy_back`; `validate_runtime_impl` skips D2H for those. Mirrored across **a2a3** and **a5** (trb); the hbg `HostApi` gains the same field for ABI-shape parity.

Closes #1047.

## Measured impact (a2a3 hardware, device 8)

`paged_attention_unroll` Case1 via an L2-worker timing harness, 2 warmup + 10 measured rounds (median):

| metric | pre-fix | post-fix | delta |
| --- | ---: | ---: | ---: |
| **host_wall** | 78471 us | **35876 us** | **−54.3%** |
| device_wall | 2788 us | 2763 us | ~0 (noise) |
| golden `max\|out−ref\|` | 1.10e-4 ✅ | 1.04e-4 ✅ | PASS |

`host_wall` more than halves while `device_wall` (pure on-NPU time) is flat — the saving is host-side copy only. The ~42.6 ms removed ≈ the D2H of ~1075 MB read-only inputs. The OUTPUT H2D skip is within noise here (paged_attention's output is ~2 MB); it pays off for output-heavy workloads.

## Test

- a2a3 hardware: golden PASS pre- and post-fix (read-only inputs are bit-identical before/after a correct run; pure outputs are fully written by this kernel).
- a2a3 + a5 fix hunks are byte-identical (mirror parity verified). Relies on full CI to validate the OUTPUT-zeroing semantic change across all examples — any tensor relying on a non-zero host OUTPUT init must be tagged `INOUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)