### PR TITLE
[WIP] feat(dfx): add l0_swimlane intra-core pipeline trace tool

### DIFF
--- a/.claude/skills/insight-trace/SKILL.md
+++ b/.claude/skills/insight-trace/SKILL.md
@@ -610,6 +610,62 @@ an AIC-only launch with `HW_BLOCK_NUM=1`, you see one `cubecore0/`
 (no `veccore/`); for AIV-only, two `veccore{0,1}/` (no `cubecore0/`).
 Drag the `simulator/` directory into MindStudio Insight.
 
+## Viewing in Perfetto (optional — trace.json targets Insight)
+
+The intended viewer is **MindStudio Insight** (drag the `simulator/`
+directory in). In that export, `trace.json` is the timeline and
+`visualize_data.bin` is a binary bundle that embeds a byte-identical copy
+of `trace.json` plus an extra instruction→source map (`Cores` /
+`Instructions` with `AscendC Inner Code`) — Insight-only; Perfetto cannot
+read the `.bin`.
+
+`trace.json` is Chrome Trace Event JSON, so Perfetto (ui.perfetto.dev)
+*opens* it, but it is not Perfetto's intended format. **Opening the raw
+`trace.json` directly in Perfetto silently loses records** — some events
+present in the file never appear on the timeline, with no warning. The file
+itself is intact (Insight shows every record); the loss is purely in
+Perfetto's preview. It manifests in two ways:
+
+1. **Instruction records are dropped from the view.** Each pipe
+   (MTE1/MTE2/CUBE/FIXP) is one track, and concurrently in-flight `ph:"X"`
+   complete events on it overlap in time. Perfetto requires complete events
+   on a track to nest strictly; partially-overlapping ones are **dropped or
+   mis-stacked**, so e.g. a double-buffered LOAD_2D burst shows fewer
+   slices in Perfetto than were actually recorded. Because nothing warns
+   you, the missing instructions are easy to overlook.
+2. **SET_FLAG appears as a long bar (mispaired records).** SET_FLAG/
+   WAIT_FLAG are encoded as `B`/`E` pairs. Perfetto pairs them with a
+   per-track LIFO stack after sorting by ts; tie/edge cases can close a
+   short SET_FLAG `B` with a later `E`, drawing a spurious long SET_FLAG.
+   (SET_FLAG is always ~0.5 ns; the genuinely long flag bars are WAIT_FLAG
+   = pipe wait time — easy to misread as SET_FLAG.)
+
+To view in Perfetto, post-process a **copy** of `trace.json` (leave the
+original intact — Insight still needs it) with two **lossless** transforms.
+Both keep every event and its `ts`/`dur`; they only change `tid` and
+re-encode `B`/`E` as `X`:
+
+- **Sub-lanes (fixes problem 1).** Per `(pid,tid)`, greedily pack each
+  duration event into the lowest lane whose previous event already ended
+  (interval partitioning), so no two events on a lane overlap. A pipe
+  `MTE1` with depth-k concurrency becomes `MTE1#0..#k`. Give every lane of
+  a split track the `#N` suffix (**including `#0`** — a bare `MTE1`
+  alongside `MTE1#1` sorts apart) and rebuild each `thread_sort_index` as
+  `base*100 + lane`, so `#0..#k` render adjacent under their parent pipe.
+  Remember the pipe tracks also carry the flag `B`/`E` pairs and `flow`
+  (`ph` `s`/`t`) arrows — re-lane *all* of them, not just `ph:"X"`, or a
+  bare track lingers.
+- **Atomic flags (fixes problem 2).** Merge each `B`/`E` pair into a single
+  `ph:"X"` slice with `ts = B.ts`, `dur = E.ts - B.ts`. With no begin/end
+  events left, Perfetto has nothing to mispair; SET_FLAG stays its true
+  ~0.5 ns and WAIT_FLAG keeps its real wait duration.
+
+After both transforms every track is strictly non-overlapping per lane and
+free of `B`/`E`, so Perfetto shows all instructions with correct flag
+durations. If a long "SET_FLAG" still shows, you are viewing the original
+`trace.json` or a stale file — Perfetto does not auto-refresh; re-open the
+post-processed copy.
+
 ## Common pitfalls (in order of how often they bite)
 
 1. **Empty OPPROF dump after a "successful" simulator run.** Almost

--- a/docs/dfx/l0-swimlane-profiling.md
+++ b/docs/dfx/l0-swimlane-profiling.md
@@ -1,0 +1,616 @@
+# L0 Swimlane Profiling — Intra-core Pipeline Trace for One Kernel
+
+## 1. Background & Motivation
+
+[L2 swimlane](l2-swimlane-profiling.md) answers *where each task ran on
+the wall clock and how the scheduler spent its loop*. It stops at the
+AICore task boundary — one task is one opaque `[start, end]` block. When
+a single kernel is slow, the next question is **why inside the core**:
+which pipe (`MTE2` GM→L1, `MTE1` L1→L0, `CUBE` matmul, `FIXP` write-back,
+`SCALAR`) is the bottleneck, and how the per-instruction issue overlaps.
+
+L0 swimlane captures exactly that — the **intra-core pipeline** of one
+`kernel_entry(args)`. It runs the kernel in isolation under `msprof op
+simulator` (the AICore camodel) and exports a MindStudio Insight
+`trace.json` whose lanes are the core's pipes, not the chip's cores. It
+deliberately **bypasses AICPU orchestration**: scheduler / tensormap /
+ringbuffer state is out of scope (that is L2's job, and needs real
+silicon). L0 is the per-pipe, per-instruction zoom that sits one level
+below an L2 task block.
+
+The hard part of an isolated replay is rebuilding the kernel's exact
+`args[]` — Tensor descriptors (shape / dtype / strides / start_offset)
+plus scalar values — which orchestration normally computes on the fly.
+Hand-authoring them is error-prone. L0 swimlane removes the guesswork:
+it captures the **real** per-task args from a [tensor
+dump](tensor-dump.md), filters them by `func_id` to pin one kernel
+unambiguously, and generates the whole replay workspace from those
+captured args — zero hand-written shapes or scalars.
+
+## 2. Overview
+
+- **Per-pipe instruction timeline** — one Insight lane per AICore pipe
+  (`MTE2` / `MTE1` / `CUBE` / `FIXP` / `SCALAR`), each carrying the
+  kernel's individual instructions with simulated `ts` / `dur`.
+- **Zero-guess args** — the kernel's real Tensor descriptors and scalars
+  come from a JSON-only `--dump-tensor 3` capture (metadata + scalar
+  values, no `.bin` payload — all reconstruction needs), joined on
+  `func_id`. No manual shape / dtype / stride / scalar authoring.
+- **Sim or onboard capture** — with a sim `--platform` (`a2a3sim` /
+  `a5sim`) the dump runs with no NPU; with an onboard `--platform`
+  (`a2a3` / `a5`) it runs on a real device. Onboard is required for
+  kernels whose sync idiom (e.g. a manual `prod.record()`) only compiles
+  for the device, not the cpu sim. Run the whole tool under one
+  `task-submit` so the onboard dump and the `msprof op simulator` collect
+  share the locked `$TASK_DEVICE` (see [§3.2](#32-run)).
+- **Two trace outputs** — a native Insight `trace.json` and an
+  auto-generated Perfetto-friendly variant (sub-laned + atomic flags;
+  see [§3.4](#34-viewing--insight-vs-perfetto)).
+
+Drive it in one line (per kernel, selected by `func_id`):
+
+```bash
+python -m simpler_setup.tools.l0_swimlane \
+    --test tests/st/<case>/test_<name>.py --func-id <N> --platform a2a3sim
+```
+
+## 3. How to Use
+
+### 3.1 Prerequisites (one-time per test case)
+
+L0 swimlane reuses the tensor-dump pipeline to recover args, so the
+target case must satisfy what the dump needs:
+
+1. **Dump records carry `func_id`.** Built into the platform code; needs
+   a `pip install --no-build-isolation -e .` so it is compiled in. See
+   [tensor-dump.md §3.3](tensor-dump.md#33-output) for the field.
+2. **The incore signatures sum to the real payload.** The dump sums the
+   `signature` tensor count of every *active* subtask in a task and requires
+   that sum to equal the payload's actual `add_input` / `add_output` count;
+   otherwise it skips that task and the kernel becomes un-replayable.
+   - **Single-task kernel:** that incore's `signature` tensor count must
+     equal its payload tensor count.
+   - **Cooperative mix pair** (the same source compiled for both `aic` and
+     `aiv`, sharing one `args[]`): declare the full tensor `signature` on
+     **exactly one** of the two incores and leave the other's **empty /
+     absent**. Both subtasks are active and address the *same* shared
+     tensors, so declaring the signature on both doubles the sum (e.g.
+     `9 + 9 = 18 != 9`) and the dump is skipped. l0_swimlane merges the pair
+     by `func_id`, so the half that carries the signature can be either one
+     (convention: the `aic` entry); every dumped tensor is then stamped with
+     that subtask's `func_id`. Example: `spmd_paged_attention` puts all 9
+     tensors on `PA_AIC` (func_id 0) and gives `PA_AIV` (func_id 1) **no**
+     `signature` — so its dump records all carry `func_id 0`, which is
+     expected, not a bug.
+3. **The case declares the `--platform` you pass.** `CASES[*].platforms`
+   must include it — a sim platform (`a2a3sim` / `a5sim`, dump runs with
+   no NPU) or an onboard one (`a2a3` / `a5`, dump runs on a real device).
+   Pick a case with shapes small enough for the camodel replay buffers;
+   device-only-sync kernels (manual `prod.record()`) compile only onboard,
+   so they need a small **onboard** case.
+4. **`name` is optional.** When `incores[*].name` is absent the tool
+   falls back to the kernel source filename for labels / paths.
+
+### 3.2 Run
+
+```bash
+# Environment (once per shell): activate the venv and source CANN.
+source .venv/bin/activate
+export ASCEND_HOME_PATH=<your CANN install>     # e.g. .../cann-9.0.0
+source "$ASCEND_HOME_PATH/set_env.sh"
+
+# Sim capture (no NPU dump) — for a kernel whose case declares a sim platform.
+python -m simpler_setup.tools.l0_swimlane \
+    --test tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py \
+    --func-id 0 --platform a2a3sim
+
+# Onboard capture — wrap the WHOLE tool in one task-submit so the dump and the
+# collect share the locked $TASK_DEVICE (no nested lock). Required for
+# device-only-sync kernels (manual prod.record()). --case pins the dump to the
+# small case when the test also has a full-size production case.
+task-submit --device auto --device-num 1 --run \
+    "python -m simpler_setup.tools.l0_swimlane \
+        --test tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py \
+        --func-id 0 --platform a2a3 --case SmallCase1"
+```
+
+The tool runs five steps internally (the "Uses NPU" column is for an onboard
+`--platform`; a sim `--platform` uses no NPU until step 5):
+
+| Step | Action | Uses NPU |
+| ---- | ------ | -------- |
+| 1 | Read the test's `CALLABLE`; resolve the kernel `source` + `core_type` by `func_id` | No |
+| 2 | Run `--dump-tensor 3` (JSON-only) → `tensor_dump.json` (or reuse one via `--dump-json`); onboard, on `$TASK_DEVICE` | Onboard only |
+| 3 | Filter the dump by `func_id`, reconstruct that task's real args, and **print the arg-slot table** (slot / kind / shape / value) for `--set-arg` | No |
+| 4 | Emit the 5-file replay workspace and smoke-build it locally | No |
+| 5 | `msprof op simulator` collect + export → `trace.json`, then auto-converts a Perfetto variant. Reuses the outer `$TASK_DEVICE`; if none, self-locks via `task-submit --device auto` | **Yes** |
+
+Step 3 prints every arg slot so you can pick a `--set-arg` target without
+reading the kernel source — names are not in the dump (only kind / shape /
+value), so cross-reference the kernel's `args:` header for those:
+
+```text
+[l0_swimlane] arg slots (override with --set-arg SLOT=VALUE):
+    slot 4  tensor  INT32    [24]          # context_lens (mix) -> --set-arg 4=512
+    slot 15 scalar  = 24                   # total_logical_blocks
+    ...
+```
+
+A scalar slot holds the value directly (`--set-arg 4=4` for a single-task
+`n_blocks`); a tensor slot holds a pointer, so `--set-arg` fills its buffer
+(`--set-arg 4=512` makes every `context_lens` element 512 →
+`n_blocks = ceil(512 / block_size)`). See [§6.2](#62---set-arg-floor-for-a-loop-count-without-distortion).
+
+### 3.3 Key flags
+
+| Flag | Meaning |
+| ---- | ------- |
+| `--test <file.py>` | SceneTest test file (required) |
+| `--func-id <N>` | Which incore kernel to replay (required). For a cooperative **mix pair** (same source, `aic`+`aiv`) either func_id is equivalent — the tool auto-detects the pair and reconstructs/replays the whole `{aic, aiv}` set regardless of which one you name (the dump records all sit under the signature-carrying half, so the merge is what makes the other id resolve). The label follows the id you pass (`PA_AIC` vs `PA_AIV`) |
+| `--platform <p>` | Dump platform → arch / compile / SoC params (default `a2a3sim`). Sim (`a2a3sim` / `a5sim`) dumps with no NPU; onboard (`a2a3` / `a5`) dumps on `$TASK_DEVICE` (wrap the tool in `task-submit`) |
+| `--device <ID>` | NPU device for an onboard dump + collect. **Auto-supplied** — `task-submit` appends `--device <id>` to the wrapped command (also `$TASK_DEVICE`); that one device threads through both steps. Sim platforms ignore it. Rarely passed by hand |
+| `--case <NAME>` | Pin the dump to one `CASES[*].name` (e.g. `SmallCase1`). Use when the test has several cases on `--platform`, so the dump targets the small one — not the full-size production case whose shapes overflow the camodel replay. Accepts `ClassName::Case` too |
+| `--task-id <hex>` | Which task instance of that `func_id` to replay (default: lowest) |
+| `--dump-json <path>` | Reuse an existing `tensor_dump.json`, skipping the dump re-run |
+| `--set-arg SLOT=VALUE` | Override an arg by `args[]` slot for the replay. Scalar slot → rewrite value; tensor slot → fill its buffer with VALUE (integer dtypes). Shrinks a loop count without distortion — scalar `n_blocks` (`--set-arg 4=4`) or the mix `context_lens` tensor (`--set-arg 4=512`). Repeatable. Default: real dump values |
+| `--spmd-block-num N` | `block_num` written into the synthesized SPMD context (slot 48). Default: the case's `block_dim`. Only matters for kernels that branch/stride on `block_num` |
+| `--debug-line` / `-g` | Compile the kernel with `-g` (and skip link strip) so the trace carries `debug_line` → Insight maps instructions to source lines. Default off |
+| `--no-collect` | Generate + smoke-build only; do not take an NPU |
+| `--max-tensor-bytes <N>` | Warn threshold for buffer size (bytes); **never truncates** — full size is always allocated for correctness |
+| `--max-time <sec>` | `task-submit` budget (default 1800) |
+
+Per-arch build parameters are fixed in the tool's `ARCH_CONFIG`:
+
+| arch | SoC (camodel) | aicore-arch (compile) | prologue macros |
+| ---- | ------------- | --------------------- | --------------- |
+| a2a3 | `dav_2201` | `dav-c220` | `__CCE_AICORE__ 220` / `PTO_NPU_ARCH_A2A3` |
+| a5 | `dav_3510` | `dav-c310` | `__CCE_AICORE__ 310` / `PTO_NPU_ARCH_A5` |
+
+### 3.4 Viewing — Insight vs Perfetto
+
+The workspace lands at
+`outputs/l0_swimlane_<TestClass>_<Case>_<platform>_<kernel>_<ts>/`, with
+**two** final traces (both self-describing names, pretty-printed):
+
+| File | Open in |
+| ---- | ------- |
+| `<label>_trace.json` | **MindStudio Insight** (a copy of the export) |
+| `<label>_trace_perfetto.json` | **Perfetto** (auto-converted, see below) |
+
+The raw export is under
+`<ws>/insight_export/OPPROF_*/simulator/` (`trace.json` +
+`visualize_data.bin` + per-core subdirs).
+
+- **Insight** — drag the `simulator/` directory in (native, correct), or
+  open `<label>_trace.json`.
+- **Perfetto** — opening the raw Insight `trace.json` directly **drops
+  task records and mis-pairs flags** (Insight packs concurrent, pipelined
+  instructions onto one track; overlapping `ph:X` events break stack
+  nesting and `B`/`E` pairing). The tool therefore emits
+  `<label>_trace_perfetto.json` after export with two **lossless**
+  transforms: concurrent instructions on a pipe are split into sub-lanes
+  (`MTE1#0..#k`, none overlapping within a lane), and each `B`/`E` flag
+  pair is merged into one `ph:X` slice. Open that file in Perfetto for a
+  correct preview. The same transform is documented in
+  [`.claude/skills/insight-trace/SKILL.md`](../../.claude/skills/insight-trace/SKILL.md);
+  here it is built into the tool.
+
+### 3.5 Kernel shapes & what to `--set-arg`
+
+l0_swimlane handles five kernel shapes. Two things vary by shape. The
+**dump platform** is whichever the test case declares: a sim platform
+(`a2a3sim`) dumps with no NPU and the collect self-locks; an onboard one
+(`a2a3`) runs the dump on the task-submit-locked device (wrap the tool in
+`task-submit`); a cooperative mix kernel whose sync only compiles for the
+device must be onboard. **Which loop count to shrink** for a fast camodel
+is a scalar `n_blocks`, a control *tensor* (`context_lens`), or nothing —
+the slot is shown in the step-3 table and `4` is the prefetch floor (see
+[§6.2](#62---set-arg-floor-for-a-loop-count-without-distortion)).
+
+| Kernel shape | Representative test · func_id | Dump platform | `--set-arg` (loop count) |
+| ------------ | ----------------------------- | ------------- | ------------------------ |
+| AIC-only single-task | `paged_attention_unroll` · 0 (QK) | `a2a3` | `4=4` — `n_blocks` **scalar** @slot 4 |
+| AIV-only single-task | `paged_attention_unroll` · 1 (SF) | `a2a3` | `5=4` — `n_blocks` **scalar** @slot 5 (slot differs from QK) |
+| SPMD AIV (non-mix) | `spmd_multiblock_aiv` · 0 (SPMD_WRITE_AIV) | `a2a3sim` | **none** — one write per block, no inner loop |
+| SPMD mix (cooperative) | `spmd_paged_attention` · 0 (PA_AIC) | `a2a3` (must) | `4=512` — `context_lens` **tensor** @slot 4 → `n_blocks=ceil(512/block_size)` |
+| Offset subtask (independent kernel packed in a mix dispatch) | `mixed_example` · 1 (ADD) | `a2a3sim` | **none** — `case1` is already small; args sit at slots **3/4/5**, not 0 |
+
+```bash
+# AIC-only (QK): n_blocks scalar @slot 4 — onboard, wrap in task-submit
+task-submit --device auto --run \
+  "python -m simpler_setup.tools.l0_swimlane --func-id 0 --platform a2a3 --case Case1 --set-arg 4=4 \
+     --test tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py"
+
+# AIV-only (SF): n_blocks scalar @slot 5
+task-submit --device auto --run \
+  "python -m simpler_setup.tools.l0_swimlane --func-id 1 --platform a2a3 --case Case1 --set-arg 5=4 \
+     --test tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py"
+
+# SPMD AIV: nothing to shrink — sim dump (no NPU), collect self-locks
+python -m simpler_setup.tools.l0_swimlane --func-id 0 --platform a2a3sim --case Case1 \
+    --test tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+
+# SPMD mix (cooperative): context_lens tensor @slot 4
+task-submit --device auto --run \
+  "python -m simpler_setup.tools.l0_swimlane --func-id 0 --platform a2a3 --case SmallCase1 --set-arg 4=512 \
+     --test tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py"
+
+# Offset subtask (mixed_example ADD): an independent AIV kernel packed as a
+# non-first mix subtask, so its args start at slot 3, not 0 (confirmed by the
+# step-3 slot table). Plain AIV — not cooperative — so it dumps on a2a3sim and
+# the collect self-locks; nothing to shrink.
+python -m simpler_setup.tools.l0_swimlane --func-id 1 --platform a2a3sim --case case1 \
+    --test tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/test_mixed_example.py
+```
+
+Always pass `--case` to pin the dump to exactly one case — the dump runs the
+whole test otherwise, which wastes time and lets an unrelated case's golden
+failure abort the run. Without `--case`, only the default (non-manual) cases
+run.
+
+A **scalar** slot holds the value directly; a **tensor** slot holds a
+pointer, so `--set-arg` fills its buffer instead. Pick the slot from the
+printed slot table — names are in the kernel's `args:` header, not the
+dump.
+
+Slots need not start at 0. An independent kernel packed as a non-first mix
+subtask reads its args at an offset — `mixed_example`'s ADD (`func_id 1`) sits
+at slots **3/4/5** because MATMUL (`func_id 0`) occupies 0/1/2 ahead of it. The
+slot table shows where; l0_swimlane places each tensor at its real slot, so
+`--set-arg` and the replay both address the offset slot, not a 0-based index.
+
+### 3.6 Reusing a dump across kernels
+
+The dump in step 2 is the slow part (a full sim run). When tracing
+several kernels from the same case, capture once and reuse:
+
+```bash
+# First kernel: runs the sim dump.
+python -m simpler_setup.tools.l0_swimlane --test <file> --func-id 0 --platform a2a3sim
+
+# Subsequent kernels: point at the manifest the first run produced.
+python -m simpler_setup.tools.l0_swimlane --test <file> --func-id 2 --platform a2a3sim \
+    --dump-json outputs/<ClassName>_<Case>_<ts>/tensor_dump/tensor_dump.json
+```
+
+The dump manifest is graph/instance-shaped for the whole case; every
+`func_id`'s args live in the one file.
+
+## 4. Capabilities
+
+What the L0 swimlane shows:
+
+- **Per-pipe occupancy.** Busy time per pipe (`MTE2` / `MTE1` / `CUBE` /
+  `FIXP` / `SCALAR`) for one kernel, so a memory-bound vs compute-bound
+  diagnosis is direct (e.g. "MTE2 spans the whole window → GM-load
+  bound").
+- **Per-instruction issue overlap.** Each instruction is a slice on its
+  pipe lane; the Perfetto sub-lane split makes concurrent issue on the
+  same pipe legible.
+- **Source-line attribution** (with `--debug-line`). Insight maps each
+  instruction back to the kernel source line.
+- **Cross-arch comparison.** The same kernel under `a2a3sim` vs `a5sim`
+  surfaces real ISA differences (see [§6](#6-findings)).
+
+What it does **not** show (use [L2 swimlane](l2-swimlane-profiling.md)):
+
+- AICPU dispatch / finish latency, scheduler phases, dependency arrows.
+- Multi-task placement across cores. L0 is one kernel, one core.
+
+## 5. How It Works
+
+L0 swimlane is **tooling-only** — there is no dedicated device-side data
+path. It composes three existing pieces: tensor dump (for args),
+`msprof op simulator` (for the pipeline trace), and the 5-file replay
+recipe from the insight-trace skill (for the isolated kernel build).
+
+### 5.1 The generated workspace (5 files)
+
+| File | Role |
+| ---- | ---- |
+| `replay_kernel.cpp` | Mix-arch wrapper that `#include`s the target kernel. AIC-only kernels include the body only under `__DAV_CUBE__` (empty stub under `__DAV_VEC__`); AIV-only is the mirror image |
+| `replay_launch.cpp` | `replay_entry<<<1, ...>>>` launcher (`HW_BLOCK_NUM = 1`, single task in isolation) |
+| `replay_host.cpp` | Builds the 128-byte Tensor descriptors from the dump's real args + fills scalars, then launches. **Auto-generated; never hand-edited** |
+| `CMakeLists.txt` | Single mix-arch `.so` (`--cce-aicore-arch=dav-cXXX`) |
+| `run_collect.sh` | `msprof op simulator` collect (`--kernel-name=replay_entry`) + export |
+
+### 5.2 Args reconstruction (the zero-guess part)
+
+`reconstruct_task_args` filters the dump records on `func_id`, groups by
+`task_id` (default: lowest), and **unions both dump stages** — inputs +
+scalars come from `before_dispatch`, outputs from `after_completion` —
+keyed by `arg_index`. Args need **not** start at slot 0 or be
+contiguous: a kernel dispatched as a non-first MIX subtask reads its
+tensors at an offset (e.g. `mixed_example`'s ADD reads `args[3..5]`, MUL
+`args[6..8]`). The replay places each tensor at its **real** `args[]`
+slot, while the descriptor array `d_tensors` is indexed 0-based — the two
+are decoupled, so an offset kernel traces correctly. For each tensor it
+emits the literal shape / strides / dtype / start_offset into
+`make_desc`, with these correctness-critical details:
+
+- **Descriptor field offsets** are pinned by the `static_assert`s in
+  `src/{arch}/runtime/tensormap_and_ringbuffer/runtime/tensor.h`
+  (`buffer.addr@0`, `buffer.size@8`, `start_offset@24`, `ndims@36`,
+  `dtype@40`, `is_contiguous@42`, `shapes@44`, `strides@72`;
+  `sizeof(Tensor) == 128`).
+- **dtype** comes from a string→enum table mirroring
+  `src/common/task_interface/data_type.h` (note `BFLOAT16 = 6`, not 5 —
+  a wrong table corrupts every bf16 descriptor).
+- **Buffer size uses the extent formula**
+  `(start_offset + 1 + Σ(shape[i]-1)*stride[i]) * elem_size`, not
+  `numel` — strided / offset views read past `numel` and would go
+  out of bounds with a `numel` allocation.
+- Replay data is **memset to 0**; only the descriptor metadata is real.
+  This is why data-dependent branches / addresses can distort while pure
+  pipeline structure stays faithful (see [§7](#7-fidelity-rules)).
+
+### 5.3 Build & collect
+
+The smoke build (no NPU) runs cmake + builds `replay_host`, then asserts
+`replay_entry` and `launch_replay` are present in
+`libreplay_kernel.so`. With `--no-collect` it stops here. Otherwise the
+collect step runs `run_collect.sh` (the camodel needs a device context),
+locates `insight_export/OPPROF_*/simulator/trace.json`, and writes the
+two viewer copies. Device selection follows the lock already held:
+
+- **Under an outer `task-submit`** (`$TASK_DEVICE` set — the onboard
+  workflow where the whole tool is wrapped so the dump and collect share
+  one lock): reuse `$TASK_DEVICE`, **no nested `task-submit`**.
+- **Standalone** (no outer lock) with `task-submit` on `PATH`: self-lock
+  via `task-submit --device auto`.
+- **No `task-submit`** at all: unlocked run with a warning (per
+  [running-onboard.md](../../.claude/rules/running-onboard.md)).
+
+### 5.4 SPMD context synthesis (single-core and mix)
+
+SPMD kernels read an execution context the orchestration builds per
+dispatch — `LocalContext{block_idx, block_num}` at args slot 48 and
+`GlobalContext{sub_block_id}` at slot 49 (`get_block_idx` /
+`get_block_num` / `get_sub_block_id`). The isolated replay has no
+orchestration, so it **synthesizes** that context host-side. None of its
+inputs need a per-test marker; they are all derived:
+
+- **is-mix** — a cooperative mix kernel is the *same* source compiled for
+  both sub-cores, so it appears as an `(aic, aiv)` incore **pair sharing
+  one source** (e.g. `paged_attention_parallel`). `load_kernel_meta`
+  detects this. Everything else — including *independent* kernels packed
+  into a mix dispatch (different sources, e.g. `mixed_example`) — takes
+  the AIC/AIV-only path.
+- **block_num / hw_block_dim** — the case's `block_dim` (the SPMD grid
+  width), read from `CASES`. Override with `--spmd-block-num`.
+- **aiv_lanes_per_block** — the arch's hardware subblockdim (2 for the
+  1C2V a2a3/a5 clusters), from `ARCH_CONFIG`.
+
+**AIC/AIV-only path** — `replay_host.cpp` *always* builds one
+`LocalContext{block_idx=0, block_num}` + `GlobalContext{sub_block_id=0}`
+and points slots 48/49 at them, then launches `<<<1>>>`. This is
+harmless for positional kernels (they ignore 48/49) and required for
+single-core SPMD kernels (e.g. `spmd_basic`, `spmd_multiblock_aiv`),
+which would otherwise dereference a null context. `block_idx=0` traces a
+representative block; `block_num = block_dim` keeps steady-state branches
+(`block_idx+1 < block_num`) on their normal path — see
+[§7](#7-fidelity-rules) for what `block_idx=0` / `block_num` do and don't
+represent.
+
+**Mix path** (auto-detected) differs in three places:
+
+- **Wrapper** — `replay_kernel.cpp` includes the kernel under *both*
+  `__DAV_CUBE__` and `__DAV_VEC__` (no empty stub), and `replay_entry`
+  takes two args rows (`aic_args`, `aiv_args`), indexing `aic_args` by
+  hardware block and `aiv_args` by AIV lane
+  (`block * subblockdim + subblockid`).
+- **Launch** — `<<<hw_block_dim>>>` (the case `block_dim`), not `<<<1>>>`.
+- **Args** — the real tensors *and* the 3 FIFO rings come from the dump
+  unchanged (the orchestration registers the rings as full-size
+  `add_output` tensors). Only the per-row slot 48/49 context is
+  synthesized, with `block_num = hw_block_dim` (the kernel uses it as the
+  stride step) and `block_idx` / `sub_block_id` derived from the row.
+
+Two dump-side requirements specific to **mix** (single-task kernels do
+not need them):
+
+- **One incore must declare the full tensor signature.** A mix task
+  shares one `args[]` across cube + vec, but the tensor dump concatenates
+  each active subtask's signature tensors and requires their sum to equal
+  the payload tensor count — so the mix kernel must declare all its
+  tensors on **one** incore's `signature` (and leave the other empty), or
+  the dump skips the whole task. (The signature is consumed only by the
+  dump; dispatch ignores it.) This is a standard `CALLABLE` field, not a
+  tool-specific marker.
+- **Reconstruction merges the whole func_id pair.** The dump assigns a
+  per-subtask func_id, so `reconstruct_task_args` gathers records across
+  *all* func_ids sharing the mix source and merges by `arg_index` — a
+  single-func_id filter would capture only one subtask's slice.
+
+Because the contexts cannot come from the dump (they are runtime
+scaffolding, not payload), the SPMD paths are **not zero-guess** for the
+context — but the constants are all derived (grid width from `block_dim`,
+lanes from the arch), so no test markers are required. The mix path
+currently assumes **1C2V** (the only binding both current chips support).
+
+## 6. Findings
+
+Measured behaviors worth knowing before you read a trace.
+
+### 6.1 The a5 camodel is much slower than a2a3 (wall-clock)
+
+Same QK kernel, `n_blocks = 4`:
+
+| Metric | a2a3 (`dav_2201`) | a5 (`dav_3510`) |
+| ------ | ----------------- | --------------- |
+| camodel wall-clock | ~3.9 min | ~7 min |
+| Total tick | 2,059,859 | 150,217 |
+| Host cost per tick | ~0.11 ms/tick | **~2.8 ms/tick (~25×)** |
+| End-to-end | ~4.4 min | ~8.3 min |
+
+The camodel is a cycle-by-cycle, whole-chip (32-core), serial software
+model. "Total tick" is **not** comparable across platforms (tick
+granularity differs); wall-clock and the simulated µs are. a5 pays ~25×
+per tick, so it is slower end-to-end even with fewer ticks. Much of the
+cost is fixed setup independent of `n_blocks`, so shrinking `n_blocks`
+helps only modestly. **Prefer a2a3 for logic validation; run a5 only
+when you specifically need the a5 pipeline.**
+
+### 6.2 `--set-arg` floor for a loop count (without distortion)
+
+QK/PV are **double-buffered prefetch** kernels: an `if (i+1 < n_blocks)`
+guards the prefetch + `pipe_barrier`.
+
+| `n_blocks` | Captures | Distortion |
+| ---------- | -------- | ---------- |
+| 1 | No prefetch (`if` never runs) | **Distorted** — double-buffering entirely lost |
+| 2 | Prefetch, single buffer phase | Slightly incomplete |
+| 3 | Ping-pong both phases + tail block | Faithful (minimum) |
+| 4 | Plus one steady-state block | Faithful, most stable |
+
+→ **Floor 3, recommend 4; `n_blocks = 1` always distorts.** Shrinking
+the loop count cuts iterations without changing per-block pipeline
+structure; it does **not** change template branches (those are decided
+by tile shape `shapes[0]`, which must stay real).
+
+**Where the loop count lives — scalar vs tensor.** How you set
+`n_blocks` depends on the kernel:
+
+- **Single-task** (`aic_qk_matmul`, `aic_pv_matmul`): `n_blocks` is a
+  **scalar** at `args[4]` → `--set-arg 4=4`.
+- **Mix paged-attention**: `n_blocks` is **derived from the
+  `context_lens` tensor** (`args[4]`), so `--set-arg` fills that buffer:
+  `--set-arg 4=512` → every `context_lens` element = 512 →
+  `n_blocks = ceil(512 / block_size)`. Dump on a golden-passing
+  `context_len` (validates wiring), then shrink the camodel loop with the
+  fill — the wiring is already proven and only timing structure is traced.
+  `--set-arg` accepts a tensor slot only for **integer** dtypes.
+
+### 6.3 a2a3 exports veccore lanes, a5 does not (camodel policy)
+
+An AIC-only kernel on a2a3 exports `cubecore0 + veccore0/1`; on a5 it
+exports **only `cubecore0`**. This is a camodel export policy difference
+confirmed by: symmetric workspaces (only forced arch/SoC/macro/include
+differ), a5 sim logs showing `block_end AIV` (the vec lanes *do*
+execute), and disassembly showing the a5 stub compiles to real code
+(200 B FUNC), not zero instructions. The a5 (`dav_3510`) camodel does
+not export cores that ran only an empty stub with no real operator work;
+a2a3 (`dav_2201`) exports even the stub. **Read `cubecore0` for AIC-only
+and `veccore` for AIV-only; a2a3's veccore on an AIC kernel is empty-stub
+noise.**
+
+### 6.4 a2a3 vs a5 instructions / timing genuinely differ (real ISA)
+
+Same QK, `n_blocks = 4`, `cubecore0`: a5 (`dav-c310`) uses newer, more
+compact instructions — `LOAD_2Dv2`, explicit `DC_PRELOAD`, `CALL` — for
+189 events vs a2a3's 326 (cube binary 228 B vs 1312 B). Per-pipe busy
+time differs accordingly: this QK is **MTE2 (GM-load) bound on a5** (load
+fills the span) while a2a3 spreads loads across MTE1 + MTE2; cube compute
+itself is tiny on both. These are **real silicon ISA differences, not
+tool bugs**. (Some markers — `CACHEMISS`, `BAR` counts — may mix real
+behavior with the §6.3 export-policy effect and are not separated.)
+
+### 6.5 Trace can truncate the last loop iteration(s) — self-check every run
+
+A known **collection-side bug** in CANN's msprof/camodel (closed-source,
+not locatable from outside): the exported instruction stream sometimes
+**ends early**, dropping the last one or few loop iterations' compute /
+write-back. Symptom: `MMAD` / `FIX_L0C_TO_DST` counts come out **less
+than `n_blocks`** while the loads (`LOAD_2Dv2` / `MOV_OUT_TO_L1`) are
+complete — the trace's last work event is a final-iteration load with no
+trailing `MMAD` / `FIX`.
+
+Observed (a5sim, QK): `n_blocks = 4` reproduced 3 `MMAD` / 3 `FIX`
+(missing one block); `n_blocks = 6` came out complete (6 / 6). It is
+**not** a fixed `n-1` rule. The sim itself runs all blocks
+(`block_end AIC`, `All task success`, no truncate messages); only the
+exported event stream is cut at the tail.
+
+**Self-check / workaround:** after each run, verify
+`MMAD == n_blocks` **and** `FIX_L0C_TO_DST == n_blocks`. If they
+disagree the tail was truncated — do **not** draw timing conclusions from
+that trace. Retry with a different `n_blocks` (6 was complete), or re-run
+the same config until one comes out whole. This is distinct from the
+§6.3 "a5 never exports certain sync events" — that is a stable
+*instruction class* omission; this is a *tail-iteration* cut.
+
+## 7. Fidelity Rules
+
+What distorts the trace, and what is safe:
+
+| Knob | Change it? | Distorts? |
+| ---- | ---------- | --------- |
+| Tile M/K/N (`q_tile` / `head_dim` / `block_size`) | **No** | Changing it distorts — alters cycle counts and switches template branches |
+| Scalar values (`scale` / offsets / `is_first` …) | Use real dump values | Wrong value → wrong branch → distorted |
+| Loop count (`n_blocks`, via `--set-arg` — scalar slot, or fill the `context_lens` tensor) | Shrinkable to ≥ 3–4 | Faithful at ≥ 3–4; `= 1` distorts (see §6.2) |
+| Data filled to 0 / `block_table = 0` | Default (memset 0) | Cache / address / data-dependent branches distort; pure pipeline structure is fine |
+| SPMD `block_idx` (slot 48) | Fixed 0 | Traces a real block 0 — representative for uniform SPMD; an edge/special-cased block 0 would show *its* path, not steady state |
+| SPMD `block_num` (slot 48) | Default `block_dim`; `--spmd-block-num` | Any value ≥ 2 keeps steady-state branches (`block_idx+1 < block_num`); only `block_num`-proportional work needs the exact value |
+| SPMD `sub_block_id` (slot 49) | Fixed 0 | Traces AIV0 (left lane); faithful when the two vec lanes are symmetric |
+| Cross-platform (a2a3 vs a5) | Set by target | Instructions / timing genuinely differ (real silicon, not a bug — see §6.4) |
+
+## 8. Limitations
+
+- **AICPU orchestration is out of scope.** L0 sees only the AICore
+  pipeline of one kernel. For dispatch / finish / scheduler / dependency
+  data use [L2 swimlane](l2-swimlane-profiling.md).
+- **Simulation clock, not silicon.** The camodel's absolute timing is a
+  model, not measured hardware. Use it for *relative* per-pipe / per-arch
+  structure, not for absolute-latency claims.
+- **Replay data is zero.** Only descriptor metadata is real; data-driven
+  control flow can diverge (see §7).
+- **Tail-truncation collection bug.** Validate `MMAD`/`FIX` counts every
+  run (see §6.5).
+- **Scope.** AIC-only / AIV-only single-task kernels — including
+  SPMD single-core kernels (slot 48/49 context synthesized) and kernels
+  reading args at an offset / non-contiguously (e.g. `mixed_example`) —
+  are automatic. **SPMD mix** kernels are auto-detected (an `(aic, aiv)`
+  incore pair sharing one source) and need only a full-signature incore
+  for the dump; the grid width and lane count are derived. The mix path
+  assumes **1C2V** (the only binding both chips support). See
+  [§5.4](#54-spmd-context-synthesis-single-core-and-mix). What
+  `block_idx=0` / `block_num` faithfully represent (and don't) is in
+  [§7](#7-fidelity-rules).
+
+## 9. FAQ / Debug Guide
+
+**`func_id=N not found`.** The tool prints the available
+`(func_id, name, core_type)` from the test's `CALLABLE.incores`. Pick one
+of those.
+
+**No dump records for the kernel.** The incore `signature` tensor count
+likely disagrees with orchestration's real `add_input`/`add_output`
+count, so the dump skipped it — see [§3.1](#31-prerequisites-one-time-per-test-case)
+and [tensor-dump.md](tensor-dump.md).
+
+**Smoke build fails on a missing symbol.** `replay_entry` /
+`launch_replay` must appear in `libreplay_kernel.so`. Check the kernel
+source compiles standalone under the arch's prologue; a wrong
+`--platform` picks the wrong `ARCH_CONFIG`.
+
+**`ASCEND_HOME_PATH is not set`.** Source CANN's `set_env.sh` first; the
+tool requires it for both the smoke build and the collect step.
+
+**Perfetto shows overlapping / missing slices.** You opened the raw
+Insight `trace.json`. Open `<label>_trace_perfetto.json` instead
+(see [§3.4](#34-viewing--insight-vs-perfetto)).
+
+**Instructions don't map to source lines in Insight.** Re-run with
+`--debug-line` / `-g` so the kernel carries `debug_line`.
+
+**`MMAD` / `FIX` count < `n_blocks`.** The export truncated the tail —
+see [§6.5](#65-trace-can-truncate-the-last-loop-iterations--self-check-every-run).
+Re-run or change `n_blocks`; do not trust the trace's timing.
+
+**The a5 run is taking forever.** Expected — the a5 camodel is ~25× per
+tick vs a2a3 (see [§6.1](#61-the-a5-camodel-is-much-slower-than-a2a3-wall-clock)).
+Prefer a2a3 unless you specifically need the a5 pipeline; shrink
+`n_blocks` with `--set-arg` for a modest speedup.
+
+## 10. Related docs
+
+- [l2-swimlane-profiling.md](l2-swimlane-profiling.md) — the
+  per-task / scheduler swimlane one level up; L0 zooms into a single L2
+  task block.
+- [tensor-dump.md](tensor-dump.md) — the `func_id`-tagged per-task arg
+  capture L0 reconstructs from.
+- [`.claude/skills/insight-trace/SKILL.md`](../../.claude/skills/insight-trace/SKILL.md)
+  — the manual 5-file `msprof op simulator` replay recipe this tool
+  automates, plus the Perfetto conversion notes.
+- [chip-level-arch.md](../chip-level-arch.md) — the AICore pipe model
+  (MTE2 / MTE1 / CUBE / FIXP / SCALAR) the lanes represent.

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -204,6 +204,7 @@ Example manifest (one input tensor captured before dispatch):
   "tensors": [
     {
       "task_id": "0x0000000200000a00",
+      "func_id": 0,
       "role": "input",
       "stage": "before_dispatch",
       "arg_index": 0,
@@ -226,6 +227,11 @@ Key fields:
 
 - `task_id` — runtime task identity. Use to correlate with swimlane / PMU
   output.
+- `func_id` — kernel function id that produced the task, so each record is
+  attributable to a specific callable (e.g. filter all records of one
+  kernel). `-1` when unknown (currently the `host_build_graph` dump path,
+  which does not thread func_id). Emitted for the
+  `tensormap_and_ringbuffer` runtime.
 - `arg_index` — payload argument index. Tensor entries use the payload
   tensor index; scalar entries use `payload.tensor_count + scalar_index`.
   When scalar lvalue selection matched multiple scalar slots, the selected

--- a/simpler_setup/tools/l0_swimlane.py
+++ b/simpler_setup/tools/l0_swimlane.py
@@ -1,0 +1,1453 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""l0_swimlane — generate an AICore intra-core swimlane trace.json for one kernel.
+
+Given a SceneTest test file + platform + a kernel func_id, this tool:
+  1. runs (or reuses) a JSON-only tensor dump (`--dump-tensor 3`) to capture the
+     kernel's real per-task arg metadata,
+  2. reconstructs that kernel's real per-task args (shapes / dtypes / strides /
+     start_offset / scalar values) by filtering the dump on func_id — zero hand
+     guessing,
+  3. generates the 5-file "intra-core replay" workspace (the msprof op simulator
+     recipe from .claude/skills/insight-trace/SKILL.md),
+  4. smoke-builds it, then runs `msprof op simulator` and exports the kernel's
+     trace.json.
+
+Usage (onboard — recommended; wrap the whole tool in one task-submit so the dump
+and the camodel collect share the locked device):
+    task-submit --device auto --run \
+        "python -m simpler_setup.tools.l0_swimlane \
+            --test tests/st/a2a3/.../test_paged_attention_unroll.py \
+            --func-id 0 --platform a2a3 --case <small case>"
+
+Both the dump (when `--platform` is onboard) and the msprof collect step need an
+NPU device context. Run the tool under a single outer task-submit: it appends
+--device <id> to this command (also exported as $TASK_DEVICE); that one device
+threads through both the dump and the collect, so neither grabs a second lock.
+With a sim `--platform` (a2a3sim/a5sim) the dump needs no NPU, and the collect
+self-locks via its own task-submit. Requires ASCEND_HOME_PATH (source CANN
+set_env.sh first).
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+
+from simpler_setup.environment import PROJECT_ROOT
+from simpler_setup.platform_info import parse_platform
+from simpler_setup.pto_isa import ensure_pto_isa_root
+
+# Dump emits dtype as an UPPERCASE string (src/common/task_interface/data_type.h
+# get_dtype_name). Map string -> (DataType raw enum value, element bytes).
+DTYPE_RAW = {
+    "FLOAT32": 0,
+    "FLOAT16": 1,
+    "INT32": 2,
+    "INT16": 3,
+    "INT8": 4,
+    "UINT8": 5,
+    "BFLOAT16": 6,
+    "INT64": 7,
+    "UINT64": 8,
+    "UINT16": 9,
+    "UINT32": 10,
+}
+DTYPE_SIZE = {
+    "FLOAT32": 4,
+    "FLOAT16": 2,
+    "INT32": 4,
+    "INT16": 2,
+    "INT8": 1,
+    "UINT8": 1,
+    "BFLOAT16": 2,
+    "INT64": 8,
+    "UINT64": 8,
+    "UINT16": 2,
+    "UINT32": 4,
+}
+
+# --set-arg tensor fill writes an integer into every element, so it only makes
+# sense for integer-typed control tensors (loop counts / indices like
+# context_lens). Filling a float/bf16 tensor with an int is almost always a
+# mistake, so it is refused.
+INTEGER_DTYPES = frozenset(
+    {
+        "INT8",
+        "INT16",
+        "INT32",
+        "INT64",
+        "UINT8",
+        "UINT16",
+        "UINT32",
+        "UINT64",
+    }
+)
+
+KARGS_SLOTS = 50  # MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32) + 2
+
+# Per-arch build parameters. soc = msprof/simulator SoC version (and the
+# $CANN/aarch64-linux/simulator/<soc>/lib path); aicore_arch = bisheng
+# --cce-aicore-arch (single mix-arch, no -cube/-vec suffix); cce / npu_arch are
+# the standalone-compile prologue macros the kernel headers expect.
+# aiv_lanes_per_block = AIV lanes per AICore cluster (the hardware subblockdim).
+# Both a2a3 and a5 are 1C2V (1 AIC + 2 AIV per cluster), so this is 2; it sizes
+# the AIV context rows in the mix replay. It is a hardware constant, not a
+# per-kernel property — hence it lives here, not in the test.
+ARCH_CONFIG = {
+    "a2a3": {
+        "soc": "dav_2201",
+        "aicore_arch": "dav-c220",
+        "cce": 220,
+        "npu_arch": "PTO_NPU_ARCH_A2A3",
+        "aiv_lanes_per_block": 2,
+    },
+    "a5": {
+        "soc": "dav_3510",
+        "aicore_arch": "dav-c310",
+        "cce": 310,
+        "npu_arch": "PTO_NPU_ARCH_A5",
+        "aiv_lanes_per_block": 2,
+    },
+}
+
+# --- SPMD context + mix detection (no per-test markers needed) --------------
+# SPMD kernels read an execution context at args slots 48/49 —
+# LocalContext{block_idx, block_num} (48) and GlobalContext{sub_block_id} (49) —
+# which the orchestration builds per dispatch. l0_swimlane runs an isolated
+# replay (no orchestration), so it SYNTHESIZES that context host-side. None of
+# its inputs need a per-test marker; they are all derived:
+#   * is-mix      — a cooperative mix kernel is the SAME source compiled for both
+#                   sub-cores, so it appears as an (aic, aiv) incore PAIR sharing
+#                   one source. Detected by load_kernel_meta; everything else
+#                   (incl. independent kernels packed into a mix dispatch, like
+#                   mixed_example) goes through the AIC/AIV-only path.
+#   * hw_block_dim / block_num — the case's `block_dim` (the SPMD grid width).
+#   * aiv_lanes_per_block      — the arch's hardware subblockdim (ARCH_CONFIG).
+# The mix path additionally needs ONE incore to declare the full tensor
+# `signature` (so the dump captures the shared args) — a standard CALLABLE
+# field, not a tool-specific one.
+
+
+# ---------------------------------------------------------------------------
+# Step 1: read kernel metadata (source path + core_type) from the test file
+# ---------------------------------------------------------------------------
+def _case_block_dim(cls, platform):
+    """SPMD grid width for the case the dump will run (first case on `platform`,
+    else any case declaring block_dim). 1 if none — a non-SPMD single block."""
+    cases = list(getattr(cls, "CASES", []))
+    ordered = [c for c in cases if platform in c.get("platforms", [])] + cases
+    for c in ordered:
+        bd = c.get("config", {}).get("block_dim")
+        if bd:
+            return int(bd)
+    return 1
+
+
+def load_kernel_meta(test_path: Path, func_id: int, platform: str):
+    spec = importlib.util.spec_from_file_location("l0_swimlane_testmod", str(test_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import test module from {test_path}")
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so @scene_test's inspect.getfile(cls) can resolve the
+    # class -> module -> file path for relative CALLABLE source resolution.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+
+    from simpler_setup import SceneTestCase  # noqa: PLC0415
+
+    classes = [
+        v
+        for v in vars(module).values()
+        if isinstance(v, type) and issubclass(v, SceneTestCase) and v is not SceneTestCase and hasattr(v, "CALLABLE")
+    ]
+    if not classes:
+        raise ValueError(f"No SceneTestCase with CALLABLE found in {test_path}")
+
+    incores = []  # (cls, inc)
+    for cls in classes:
+        for inc in cls.CALLABLE.get("incores", []):
+            incores.append((cls, inc))
+    for cls, inc in incores:
+        if inc["func_id"] == func_id:
+            # "name" is optional in CALLABLE; fall back to the kernel filename.
+            kname = inc.get("name") or Path(inc["source"]).stem
+            # Cooperative mix = the SAME source compiled for both sub-cores, so
+            # it shows up as an (aic, aiv) incore pair sharing one source. The
+            # dump concatenates the pair's tensors under per-subtask func_ids,
+            # so reconstruction merges every func_id sharing this source.
+            same_src = [i for _, i in incores if i["source"] == inc["source"]]
+            core_types = {i["core_type"] for i in same_src}
+            is_mix = "aic" in core_types and "aiv" in core_types
+            return {
+                "source": Path(inc["source"]),
+                "core_type": inc["core_type"],
+                "name": kname,
+                "class_name": cls.__name__,
+                "is_mix": is_mix,
+                "func_ids": sorted({i["func_id"] for i in same_src}),
+                "block_dim": _case_block_dim(cls, platform),
+            }
+    avail = ", ".join(f"{i['func_id']}={i.get('name') or Path(i['source']).stem}({i['core_type']})" for _, i in incores)
+    raise ValueError(f"func_id={func_id} not found. Available incores: {avail}")
+
+
+def _case_from_manifest(manifest: Path, class_name: str) -> str:
+    """Recover the case name from the dump dir `<ClassName>_<Case>_<YYYYMMDD>_<HHMMSS>`."""
+    run_dir = manifest.parent.parent.name  # tensor_dump's parent = the run dir
+    m = re.match(rf"{re.escape(class_name)}_(.+)_\d{{8}}_\d{{6}}$", run_dir)
+    return m.group(1) if m else "case"
+
+
+# ---------------------------------------------------------------------------
+# Step 2: obtain a tensor_dump.json (run the test in sim, or reuse one)
+# ---------------------------------------------------------------------------
+def get_or_run_dump(test_path: Path, platform: str, variant: str, dump_json, case=None, device=None):
+    if dump_json:
+        p = Path(dump_json)
+        if not p.is_file():
+            raise FileNotFoundError(f"--dump-json not found: {p}")
+        return p
+
+    outputs = PROJECT_ROOT / "outputs"
+    before = set(outputs.glob("*/tensor_dump")) if outputs.is_dir() else set()
+    # Level 3 (full, JSON-only): every task's tensor *metadata* (shape/dtype/
+    # strides) + scalar values, no .bin payload copy. That is exactly what arg
+    # reconstruction consumes (it never reads the payload), and it skips the
+    # device->host arena copy entirely — cheaper, and avoids the large-shape
+    # copy failing onboard.
+    cmd = [sys.executable, str(test_path), "-p", platform, "--dump-tensor", "3"]
+    # Pin the dump to one case when given, and allow that case to be `manual`
+    # (l0_swimlane tracing targets are often manual to stay out of CI). WITHOUT
+    # --case, run only the default (non-manual) cases: pulling in every manual
+    # case can dump a full-size case that overflows the camodel, or one that
+    # fails golden and aborts the dump. Pinning also avoids the reconstruction
+    # picking the wrong (newest) dump dir when several cases ran.
+    if case:
+        cmd += ["--case", case, "--manual", "include"]
+    # Onboard dump runs on a real NPU and must use the task-submit-locked device.
+    # When the whole tool is wrapped in an outer task-submit, that device reaches
+    # us via the appended --device <id> (resolved into `device` by main) — thread
+    # it into the test so the dump and the later camodel collect share the one
+    # lock instead of grabbing separate devices. Sim variants need no device.
+    if variant != "sim":
+        if device:
+            cmd += ["--device", device]
+        else:
+            print(
+                "[l0_swimlane] WARNING: onboard dump with no locked device — not "
+                "under task-submit; the dump will use the framework default "
+                "device unlocked. Wrap the whole tool in task-submit (see "
+                ".claude/rules/running-onboard.md)."
+            )
+    print(f"[l0_swimlane] running dump: {' '.join(cmd[1:])}")
+    # check=True on purpose: a golden PASS on the dump run is the free
+    # validation that func_id / signature / args are wired correctly, so the
+    # captured dump is trustworthy. A golden FAIL means the capture is suspect
+    # — never reconstruct a trace from it.
+    subprocess.run(cmd, cwd=str(PROJECT_ROOT), check=True)
+    after = set(outputs.glob("*/tensor_dump"))
+    new = sorted(after - before, key=lambda p: p.stat().st_mtime)
+    # MUST come from THIS run. Never fall back to a pre-existing tensor_dump —
+    # that would silently reconstruct args from an unrelated test's dump and
+    # produce a wrong-but-passing trace. An empty `new` means the dump was
+    # skipped (e.g. signature/payload mismatch -> "tensor dump skipped" /
+    # "No tensor dump data to export" warnings above).
+    if not new:
+        raise RuntimeError(
+            f"dump for {test_path.name} produced no NEW outputs/*/tensor_dump — the "
+            f"tensor dump was skipped (see the 'tensor dump skipped' / 'No tensor "
+            f"dump data to export' warnings above). The incore signature likely does "
+            f"not match the dispatched payload. Refusing to reuse a stale dump."
+        )
+    cand = new[-1]
+    manifest = cand / "tensor_dump.json"
+    if not manifest.is_file():
+        raise RuntimeError(f"manifest missing (dump produced no data): {manifest}")
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# Step 3: reconstruct one task's args from the dump records (filtered by func_id)
+# ---------------------------------------------------------------------------
+def reconstruct_task_args(manifest: Path, func_ids, task_id=None):
+    """Reconstruct one task's args from the dump.
+
+    `func_ids` is one func_id or a collection. For a single-subtask kernel it is
+    one id. For a MIX task the dump assigns a per-subtask func_id and CONCATENATES
+    each subtask's tensors into the shared args[] (e.g. bgemm: func_id 0 holds
+    args 0..2, func_id 1 holds args 3..4); filtering by a single func_id would
+    then miss the other subtask's slice. So mix passes the whole pair and the
+    records are merged by arg_index across them.
+    """
+    fset = {func_ids} if isinstance(func_ids, int) else set(func_ids)
+    data = json.loads(manifest.read_text())
+    recs = [t for t in data["tensors"] if t.get("func_id") in fset]
+    if not recs:
+        raise ValueError(f"no dump records for func_id in {sorted(fset)} in {manifest}")
+
+    tasks = sorted({t["task_id"] for t in recs})
+    chosen = task_id if task_id is not None else tasks[0]
+    if chosen not in set(tasks):
+        raise ValueError(f"task_id {chosen} not among func_id {sorted(fset)} tasks ({len(tasks)})")
+    trecs = [t for t in recs if t["task_id"] == chosen]
+
+    # Union both stages, keyed by arg_index (INOUT appears twice -> keep one).
+    by_arg = {}
+    for t in trecs:
+        ai = t["arg_index"]
+        if ai not in by_arg or t["stage"] == "before_dispatch":
+            by_arg[ai] = t
+
+    tensors = sorted((t for t in by_arg.values() if t["kind"] != "scalar"), key=lambda t: t["arg_index"])
+    scalars = sorted((t for t in by_arg.values() if t["kind"] == "scalar"), key=lambda t: t["arg_index"])
+    tensor_count = len(tensors)
+    # Args need NOT start at arg_index 0 or be contiguous: a kernel dispatched as
+    # a non-first MIX subtask reads its tensors at an offset (e.g. mixed_example's
+    # ADD reads args[3..5], MUL reads args[6..8]). So validate only that every arg
+    # slot is distinct and each tensor has a shape; the kernel reads args[slot],
+    # and the replay places each tensor at its real slot (decoupled from the
+    # 0-based descriptor-array index — see emit_replay_host).
+    seen = set()
+    for t in tensors:
+        if not t.get("shape"):
+            raise ValueError(f"tensor arg {t['arg_index']} has empty shape")
+        if t["arg_index"] in seen:
+            raise ValueError(f"duplicate tensor arg_index {t['arg_index']}")
+        seen.add(t["arg_index"])
+    for s in scalars:
+        if s["arg_index"] in seen:
+            raise ValueError(f"scalar arg_index {s['arg_index']} collides with a tensor slot")
+        seen.add(s["arg_index"])
+
+    args = []
+    for t in tensors:
+        dt = t["dtype"].upper()
+        shape = list(t["shape"])
+        strides = list(t.get("strides") or _row_major(shape))
+        args.append(
+            {
+                "kind": "tensor",
+                "slot": t["arg_index"],
+                "dtype": dt,
+                "shape": shape,
+                "strides": strides,
+                "start_offset": int(t.get("start_offset", 0)),
+            }
+        )
+    for s in scalars:
+        args.append({"kind": "scalar", "slot": s["arg_index"], "value": int(s["value"])})
+    return chosen, tensor_count, args
+
+
+def _row_major(shape):
+    st = [1] * len(shape)
+    acc = 1
+    for i in range(len(shape) - 1, -1, -1):
+        st[i] = acc
+        acc *= shape[i]
+    return st
+
+
+def _extent_elem(shape, strides):
+    e = 1
+    for s, stride in zip(shape, strides):
+        if s > 0:
+            e += (s - 1) * stride
+    return e
+
+
+def _is_contiguous(shape, strides, start_offset):
+    exp = 1
+    for s, stride in zip(reversed(shape), reversed(strides)):
+        if stride != exp:
+            return False
+        exp *= s
+    return start_offset == 0
+
+
+# ---------------------------------------------------------------------------
+# Step 4: code-generation for the 5 workspace files
+# ---------------------------------------------------------------------------
+def _prologue(cfg) -> str:
+    return f"""\
+#ifndef __CCE_AICORE__
+#define __CCE_AICORE__ {cfg["cce"]}
+#endif
+#include <cce_aicore_intrinsics.h>
+#ifndef {cfg["npu_arch"]}
+#define {cfg["npu_arch"]}
+#endif
+#ifndef EVENT_ID7
+#define EVENT_ID7 ((event_t)7)
+#endif
+#ifndef PIPE_FIX
+#define PIPE_FIX ((pipe_t)10)
+#endif
+"""
+
+
+def emit_replay_kernel(core_type: str, source: Path, cfg) -> str:
+    arch = "__DAV_CUBE__" if core_type == "aic" else "__DAV_VEC__"
+    other = "__DAV_VEC__" if core_type == "aic" else "__DAV_CUBE__"
+    return f"""\
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// {core_type.upper()}-only single-task kernel: include the target only under
+// {arch}. The {other} variant still emits replay_entry (so the other mix
+// symbol exists for msprof) but its body is intentionally empty.
+#if defined({arch})
+{_prologue(cfg)}#include "{source}"
+#endif
+
+extern "C" __global__ AICORE void replay_entry(__gm__ int64_t *args) {{
+#if defined({arch})
+    kernel_entry(args);
+#endif
+    // {other} variant: intentionally empty — {core_type.upper()}-only kernel.
+}}
+"""
+
+
+def emit_replay_launch() -> str:
+    return """\
+#include <stdint.h>
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+extern "C" __global__ AICORE void replay_entry(__gm__ int64_t *args);
+
+// HW_BLOCK_NUM = 1: single task in isolation.
+extern "C" void launch_replay(void *args, void *stream) {
+    replay_entry<<<1, nullptr, stream>>>((__gm__ int64_t *)args);
+}
+"""
+
+
+def _emit_tensor_alloc_descs(args):
+    """Per-tensor (alloc, desc, argrow, free) C snippets.
+
+    `ti` is the tensor's 0-based index in the descriptor array `d_tensors`;
+    `slot` is its real args[] position. These differ when the kernel reads its
+    tensors at an offset (a non-first MIX subtask, e.g. args[3..5]) — so the
+    descriptor index and the args slot are decoupled.
+    """
+    alloc, descs, argrow, frees = [], [], [], []
+    tensor_args = [a for a in args if a["kind"] == "tensor"]
+    for ti, a in enumerate(tensor_args):
+        slot = a["slot"]
+        shape, strides, dt = a["shape"], a["strides"], a["dtype"]
+        esz = DTYPE_SIZE[dt]
+        buf_bytes = (a["start_offset"] + _extent_elem(shape, strides)) * esz
+        contig = 1 if _is_contiguous(shape, strides, a["start_offset"]) else 0
+        ndims = len(shape)
+        shp = ", ".join(str(x) for x in shape)
+        strd = ", ".join(str(x) for x in strides)
+        # Default: data memset to 0 (only descriptor metadata is real). When
+        # --set-arg fills this tensor, write VALUE into every element instead —
+        # for control tensors whose CONTENT drives the kernel (e.g. paged
+        # attention reads n_blocks from the context_lens tensor). The low `esz`
+        # bytes of the int64 VALUE are copied per element (correct for any
+        # integer width, little-endian).
+        fill = a.get("fill")
+        if fill is None:
+            init = f"    ACL_CHECK(aclrtMemset(d_t{ti}, t{ti}Bytes, 0, t{ti}Bytes));"
+        else:
+            init = (
+                f"    {{\n"
+                f"        std::vector<unsigned char> hbuf{ti}(t{ti}Bytes, 0);\n"
+                f"        const int64_t fillv{ti} = {fill}LL;\n"
+                f"        for (size_t off = 0; off + {esz} <= t{ti}Bytes; off += {esz})\n"
+                f"            memcpy(hbuf{ti}.data() + off, &fillv{ti}, {esz});\n"
+                f"        ACL_CHECK(aclrtMemcpy(d_t{ti}, t{ti}Bytes, hbuf{ti}.data(), t{ti}Bytes,\n"
+                f"                              ACL_MEMCPY_HOST_TO_DEVICE));\n"
+                f"    }}"
+            )
+        alloc.append(
+            f"    void *d_t{ti} = nullptr;\n"
+            f"    const size_t t{ti}Bytes = {buf_bytes}ULL;\n"
+            f"    ACL_CHECK(aclrtMalloc(&d_t{ti}, t{ti}Bytes, ACL_MEM_MALLOC_HUGE_FIRST));\n"
+            f"{init}"
+        )
+        descs.append(
+            f"    {{\n"
+            f"        const uint32_t shp[] = {{{shp}}};\n"
+            f"        const uint32_t strd[] = {{{strd}}};\n"
+            f"        make_desc(h_tensors.data() + {ti} * 128, (uint64_t)(uintptr_t)d_t{ti},\n"
+            f"                  t{ti}Bytes, {a['start_offset']}ULL, shp, strd, {ndims}, {DTYPE_RAW[dt]}, {contig});\n"
+            f"    }}"
+        )
+        argrow.append(f"    h_args[{slot}] = (int64_t)((uintptr_t)d_tensors + (size_t){ti} * 128);")
+        frees.append(f"    aclrtFree(d_t{ti});")
+    return alloc, descs, argrow, frees
+
+
+def emit_replay_host(tensor_count: int, args, block_num: int = 1) -> str:
+    alloc, descs, argrow, free_list = _emit_tensor_alloc_descs(args)
+    for a in args:
+        if a["kind"] == "scalar":
+            argrow.append(f"    h_args[{a['slot']}] = (int64_t){a['value']}LL;  // scalar")
+    frees = "\n".join(free_list)
+
+    return f"""\
+// Auto-generated by simpler_setup.tools.l0_swimlane — do not edit by hand.
+// Builds the kernel's real args (from tensor dump) and launches replay_entry.
+#include <acl/acl.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#define ACL_CHECK(expr)                                                        \\
+    do {{                                                                       \\
+        aclError _e = (expr);                                                  \\
+        if (_e != ACL_SUCCESS) {{                                              \\
+            fprintf(stderr, "ACL error %d at %s:%d\\n", _e, __FILE__, __LINE__);\\
+            return 1;                                                          \\
+        }}                                                                     \\
+    }} while (0)
+
+// 128B Tensor descriptor — offsets pinned by static_assert in tensor.h:
+//   buffer.addr@0 buffer.size@8 start_offset@24 ndims@36 dtype@40
+//   is_contiguous@42 shapes@44 strides@72.
+static void make_desc(void *dst128, uint64_t dev_addr, uint64_t buf_bytes,
+                      uint64_t start_offset, const uint32_t *shapes,
+                      const uint32_t *strides, uint32_t ndims, uint8_t dtype_raw,
+                      uint8_t is_contig) {{
+    uint8_t b[128];
+    memset(b, 0, sizeof(b));
+    *reinterpret_cast<uint64_t *>(b + 0) = dev_addr;
+    *reinterpret_cast<uint64_t *>(b + 8) = buf_bytes;
+    *reinterpret_cast<uint64_t *>(b + 24) = start_offset;
+    *reinterpret_cast<int32_t *>(b + 32) = 0;
+    *reinterpret_cast<uint32_t *>(b + 36) = ndims;
+    b[40] = dtype_raw;
+    b[42] = is_contig;
+    for (uint32_t i = 0; i < ndims; ++i)
+        *reinterpret_cast<uint32_t *>(b + 44 + 4 * i) = shapes[i];
+    for (uint32_t i = 0; i < ndims; ++i)
+        *reinterpret_cast<uint32_t *>(b + 72 + 4 * i) = strides[i];
+    memcpy(dst128, b, sizeof(b));
+}}
+
+extern "C" void launch_replay(void *args, void *stream);
+
+int main() {{
+    const char *dev_s = getenv("ACL_DEVICE_ID");
+    int32_t device_id = dev_s ? atoi(dev_s) : 0;
+    ACL_CHECK(aclInit(nullptr));
+    ACL_CHECK(aclrtSetDevice(device_id));
+    aclrtStream stream = nullptr;
+    ACL_CHECK(aclrtCreateStream(&stream));
+
+    constexpr int kArgsSlots = {KARGS_SLOTS};
+    constexpr int kNumTensors = {tensor_count};
+
+{chr(10).join(alloc)}
+
+    std::vector<uint8_t> h_tensors((size_t)kNumTensors * 128, 0);
+{chr(10).join(descs)}
+
+    void *d_tensors = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_tensors, (size_t)kNumTensors * 128, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_tensors, (size_t)kNumTensors * 128, h_tensors.data(),
+                          (size_t)kNumTensors * 128, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    std::vector<int64_t> h_args(kArgsSlots, 0);
+{chr(10).join(argrow)}
+
+    // SPMD context at slots 48/49 — built unconditionally. Harmless for
+    // positional kernels (they ignore 48/49); required for SPMD kernels that
+    // read get_block_idx / get_block_num / get_sub_block_id, which would
+    // otherwise dereference a null context. block_idx=0 traces a representative
+    // block; block_num={block_num} (the case's block_dim) keeps steady-state
+    // branches (e.g. `block_idx+1 < block_num`) on their normal path.
+    uint8_t h_local[64] = {{0}};   // LocalContext: block_idx@0, block_num@4
+    *reinterpret_cast<int32_t *>(h_local + 0) = 0;
+    *reinterpret_cast<int32_t *>(h_local + 4) = {block_num};
+    uint8_t h_global[16] = {{0}};  // GlobalContext: sub_block_id@0 = 0
+    void *d_local = nullptr, *d_global = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_local, sizeof(h_local), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_local, sizeof(h_local), h_local, sizeof(h_local), ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMalloc(&d_global, sizeof(h_global), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_global, sizeof(h_global), h_global, sizeof(h_global), ACL_MEMCPY_HOST_TO_DEVICE));
+    h_args[48] = (int64_t)(uintptr_t)d_local;
+    h_args[49] = (int64_t)(uintptr_t)d_global;
+
+    void *d_args = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_args, kArgsSlots * sizeof(int64_t), ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_args, kArgsSlots * sizeof(int64_t), h_args.data(),
+                          kArgsSlots * sizeof(int64_t), ACL_MEMCPY_HOST_TO_DEVICE));
+
+    launch_replay(d_args, stream);
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+    printf("[replay_host] done: kNumTensors=%d\\n", kNumTensors);
+
+{frees}
+    aclrtFree(d_tensors);
+    aclrtFree(d_local);
+    aclrtFree(d_global);
+    aclrtFree(d_args);
+    aclrtDestroyStream(stream);
+    aclrtResetDevice(device_id);
+    aclFinalize();
+    return 0;
+}}
+"""
+
+
+def emit_cmakelists(arch: str, name: str, cfg, debug: bool = False) -> str:
+    # With -g, also drop the linker `-s` (strip) so the device kernel's
+    # debug_line survives -> Insight can map instructions to source lines.
+    link_opts = "-Wl,-z,relro -Wl,-z,now" if debug else "-s -Wl,-z,relro -Wl,-z,now"
+    dbg_flag = "\n    -g" if debug else ""
+    return f"""\
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_C_COMPILER bisheng)
+set(CMAKE_CXX_COMPILER bisheng)
+
+project(l0_swimlane_{name}_replay)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+if(NOT DEFINED ENV{{ASCEND_HOME_PATH}})
+    message(FATAL_ERROR "ASCEND_HOME_PATH is not set (source CANN set_env.sh first)")
+endif()
+set(ASCEND_HOME_PATH $ENV{{ASCEND_HOME_PATH}})
+set(SOC_VERSION {cfg["soc"]} CACHE STRING "Simulator SoC version")
+set(PTO_ISA_ROOT $ENV{{PTO_ISA_ROOT}} CACHE PATH "PTO ISA root")
+set(REPO_ROOT $ENV{{REPO_ROOT}} CACHE PATH "simpler repo root")
+
+add_compile_options(
+    -D_FORTIFY_SOURCE=2 -O2 -std=c++17
+    -Wno-macro-redefined -Wno-ignored-attributes
+    -fstack-protector-strong -fPIC
+)
+add_link_options({link_opts})
+
+set(CMAKE_CCE_COMPILE_OPTIONS
+    -xcce -fenable-matrix --cce-aicore-enable-tl -fPIC
+    -Xhost-start -Xhost-end
+    "SHELL:-mllvm -cce-aicore-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-function-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-record-overflow=true"
+    "SHELL:-mllvm -cce-aicore-addr-transform"
+    "SHELL:-mllvm -cce-aicore-dcci-insert-for-scalar=false"
+)
+set(CMAKE_CPP_COMPILE_OPTIONS
+    -xc++
+    "SHELL:-include stdint.h"
+    "SHELL:-include stddef.h"
+)
+
+set(COMMON_INCLUDES
+    ${{PTO_ISA_ROOT}}/include
+    ${{PTO_ISA_ROOT}}/include/pto
+    ${{REPO_ROOT}}/src/{arch}/runtime/tensormap_and_ringbuffer/runtime
+    ${{REPO_ROOT}}/src/{arch}/runtime/tensormap_and_ringbuffer/common
+    ${{REPO_ROOT}}/src/common/task_interface
+    ${{REPO_ROOT}}/src/{arch}/platform/include
+    ${{REPO_ROOT}}/simpler_setup/incore
+    ${{ASCEND_HOME_PATH}}/pkg_inc
+    ${{ASCEND_HOME_PATH}}/pkg_inc/profiling
+    ${{ASCEND_HOME_PATH}}/pkg_inc/runtime/runtime
+    ${{ASCEND_HOME_PATH}}/include
+)
+
+add_library(replay_kernel SHARED replay_kernel.cpp replay_launch.cpp)
+target_compile_options(replay_kernel PRIVATE
+    ${{CMAKE_CCE_COMPILE_OPTIONS}}
+    --cce-aicore-arch={cfg["aicore_arch"]}
+    -DREGISTER_BASE -std=c++17{dbg_flag})
+target_include_directories(replay_kernel PRIVATE ${{COMMON_INCLUDES}})
+target_link_options(replay_kernel PRIVATE --cce-fatobj-link)
+
+add_executable(replay_host replay_host.cpp)
+target_compile_options(replay_host PRIVATE ${{CMAKE_CPP_COMPILE_OPTIONS}})
+target_include_directories(replay_host PRIVATE ${{COMMON_INCLUDES}})
+target_link_directories(replay_host PUBLIC
+    ${{ASCEND_HOME_PATH}}/lib64
+    ${{ASCEND_HOME_PATH}}/aarch64-linux/simulator/${{SOC_VERSION}}/lib
+)
+target_link_libraries(replay_host PRIVATE
+    replay_kernel
+    runtime_camodel
+    stdc++ ascendcl m tiling_api platform c_sec dl nnopbase
+)
+"""
+
+
+def emit_run_collect(cfg) -> str:
+    # Plain string (bash uses ${} braces) — substitute the SoC default via token.
+    return _RUN_COLLECT_TEMPLATE.replace("__SOC_DEFAULT__", cfg["soc"])
+
+
+_RUN_COLLECT_TEMPLATE = """\
+#!/usr/bin/env bash
+set -euo pipefail
+: "${CANN_HOME:?CANN_HOME must be set}"
+: "${PTO_ISA_ROOT:?PTO_ISA_ROOT must be set}"
+: "${REPO_ROOT:?REPO_ROOT must be set}"
+
+WS="${WS:-$(dirname "$(readlink -f "$0")")}"
+SOC_VERSION="${SOC_VERSION:-__SOC_DEFAULT__}"
+DEVICE_ID="${TARGET_DEVICE_ID:-${NPU_LOCKED_DEVICE:-0}}"
+BUILD_DIR="$WS/build"
+COLLECT_DIR="$WS/msprof_collect"
+EXPORT_ROOT="$WS/insight_export"
+
+source "$CANN_HOME/set_env.sh"
+export ASCEND_HOME_PATH="$CANN_HOME"
+SIM_LIB_DIR="$CANN_HOME/aarch64-linux/simulator/$SOC_VERSION/lib"
+LD_LIBS="$BUILD_DIR:$SIM_LIB_DIR:$CANN_HOME/lib64"
+LD_LIBS="$LD_LIBS:$CANN_HOME/aarch64-linux/devlib:$CANN_HOME/devlib"
+export LD_LIBRARY_PATH="$LD_LIBS:${LD_LIBRARY_PATH:-}"
+export ACL_DEVICE_ID="$DEVICE_ID"
+mkdir -p "$BUILD_DIR" "$COLLECT_DIR" "$EXPORT_ROOT"
+
+cmake -G Ninja -S "$WS" -B "$BUILD_DIR" \\
+    -DSOC_VERSION="$SOC_VERSION" -DPTO_ISA_ROOT="$PTO_ISA_ROOT" -DREPO_ROOT="$REPO_ROOT"
+cmake --build "$BUILD_DIR" --target replay_host
+
+msprof op simulator \\
+    --application="$BUILD_DIR/replay_host" --kernel-name="replay_entry" \\
+    --launch-count=1 --soc-version="$SOC_VERSION" --timeout=120 \\
+    --output="$COLLECT_DIR/out" 2>&1 | tee "$COLLECT_DIR/msprof_collect.log"
+
+OPPROF_DIR="$(find "$COLLECT_DIR/out" -maxdepth 1 -mindepth 1 -type d -name 'OPPROF_*' | sort | tail -n 1)"
+test -n "$OPPROF_DIR"
+if [[ -d "$OPPROF_DIR/device0/tmp_dump" ]]; then
+    EXPORT_SRC="$OPPROF_DIR/device0/tmp_dump"
+else
+    EXPORT_SRC="$OPPROF_DIR/dump"
+fi
+msprof op simulator --export="$EXPORT_SRC" --output="$EXPORT_ROOT" \\
+    2>&1 | tee "$EXPORT_ROOT/msprof_export.log"
+echo "[run_collect] done. Insight artifacts under: $EXPORT_ROOT/OPPROF_*/simulator/"
+"""
+
+
+def emit_replay_kernel_mix(source: Path, cfg) -> str:
+    return f"""\
+#include <stdint.h>
+
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+// SPMD mix kernel: the SAME kernel_entry runs on BOTH sub-cores (cube does its
+// half, vec does its half; they cooperate via the GM FIFO rings). Unlike the
+// AIC-/AIV-only path there is no empty stub — include the kernel under either
+// arch.
+#if defined(__DAV_CUBE__) || defined(__DAV_VEC__)
+{_prologue(cfg)}#include "{source}"
+#endif
+
+// Two args rows: aic_args indexed by hardware block, aiv_args by AIV lane
+// (block * subblockdim + subblockid). Each row carries its own slot 48/49
+// context, built host-side.
+//
+// NOTE: this uses the HARDWARE get_subblockid() to pick the AIV row. simpler's
+// onboard runtime does not program the subblock register (it returns 0 for both
+// AIV lanes — see intrinsic.h), which is why the kernel itself reads its lane
+// from GlobalContext (slot 49) instead. Under msprof op simulator the camodel
+// is expected to return 0/1 here; if a future run shows AIV1 redoing AIV0's
+// work, the row selection (not the kernel) is the cause.
+extern "C" __global__ AICORE void replay_entry(__gm__ int64_t *aic_args,
+                                               __gm__ int64_t *aiv_args) {{
+#if defined(__DAV_CUBE__)
+    int32_t hw_idx = get_block_idx();
+    kernel_entry(aic_args + static_cast<uint64_t>(hw_idx) * {KARGS_SLOTS});
+#endif
+#if defined(__DAV_VEC__)
+    int32_t lane_idx = get_block_idx() * get_subblockdim() + get_subblockid();
+    kernel_entry(aiv_args + static_cast<uint64_t>(lane_idx) * {KARGS_SLOTS});
+#endif
+}}
+"""
+
+
+def emit_replay_launch_mix(hw_block_dim: int) -> str:
+    return f"""\
+#include <stdint.h>
+#ifndef AICORE
+#define AICORE [aicore]
+#endif
+
+extern "C" __global__ AICORE void replay_entry(__gm__ int64_t *aic_args,
+                                               __gm__ int64_t *aiv_args);
+
+// Launch the full SPMD grid: {hw_block_dim} hardware blocks (each = 1 cube + 2 vec).
+extern "C" void launch_replay(void *aic_args, void *aiv_args, void *stream) {{
+    replay_entry<<<{hw_block_dim}, nullptr, stream>>>(
+        (__gm__ int64_t *)aic_args, (__gm__ int64_t *)aiv_args);
+}}
+"""
+
+
+def emit_replay_host_mix(tensor_count: int, args, mixcfg) -> str:
+    hw = mixcfg["hw_block_dim"]
+    lanes = hw * mixcfg["aiv_lanes_per_block"]
+    alloc, descs, _argrow, free_list = _emit_tensor_alloc_descs(args)
+    tensor_args = [a for a in args if a["kind"] == "tensor"]
+    tensor_rows = "\n".join(
+        f"            row[{a['slot']}] = (int64_t)((uintptr_t)d_tensors + (size_t){ti} * 128);"
+        for ti, a in enumerate(tensor_args)
+    )
+    scalar_rows = "\n".join(
+        f"            row[{a['slot']}] = (int64_t){a['value']}LL;  // scalar" for a in args if a["kind"] == "scalar"
+    )
+    frees = "\n".join(free_list)
+
+    return f"""\
+// Auto-generated by simpler_setup.tools.l0_swimlane (mix path) — do not edit by hand.
+// SPMD mix replay: real tensors + FIFO rings come from the tensor dump; the
+// slot 48/49 SPMD contexts are synthesized here (block_idx/block_num/sub_block_id).
+#include <acl/acl.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#define ACL_CHECK(expr)                                                        \\
+    do {{                                                                       \\
+        aclError _e = (expr);                                                  \\
+        if (_e != ACL_SUCCESS) {{                                              \\
+            fprintf(stderr, "ACL error %d at %s:%d\\n", _e, __FILE__, __LINE__);\\
+            return 1;                                                          \\
+        }}                                                                     \\
+    }} while (0)
+
+// 128B Tensor descriptor — offsets pinned by static_assert in tensor.h:
+//   buffer.addr@0 buffer.size@8 start_offset@24 ndims@36 dtype@40
+//   is_contiguous@42 shapes@44 strides@72.
+static void make_desc(void *dst128, uint64_t dev_addr, uint64_t buf_bytes,
+                      uint64_t start_offset, const uint32_t *shapes,
+                      const uint32_t *strides, uint32_t ndims, uint8_t dtype_raw,
+                      uint8_t is_contig) {{
+    uint8_t b[128];
+    memset(b, 0, sizeof(b));
+    *reinterpret_cast<uint64_t *>(b + 0) = dev_addr;
+    *reinterpret_cast<uint64_t *>(b + 8) = buf_bytes;
+    *reinterpret_cast<uint64_t *>(b + 24) = start_offset;
+    *reinterpret_cast<int32_t *>(b + 32) = 0;
+    *reinterpret_cast<uint32_t *>(b + 36) = ndims;
+    b[40] = dtype_raw;
+    b[42] = is_contig;
+    for (uint32_t i = 0; i < ndims; ++i)
+        *reinterpret_cast<uint32_t *>(b + 44 + 4 * i) = shapes[i];
+    for (uint32_t i = 0; i < ndims; ++i)
+        *reinterpret_cast<uint32_t *>(b + 72 + 4 * i) = strides[i];
+    memcpy(dst128, b, sizeof(b));
+}}
+
+extern "C" void launch_replay(void *aic_args, void *aiv_args, void *stream);
+
+int main() {{
+    const char *dev_s = getenv("ACL_DEVICE_ID");
+    int32_t device_id = dev_s ? atoi(dev_s) : 0;
+    ACL_CHECK(aclInit(nullptr));
+    ACL_CHECK(aclrtSetDevice(device_id));
+    aclrtStream stream = nullptr;
+    ACL_CHECK(aclrtCreateStream(&stream));
+
+    constexpr int kArgsSlots = {KARGS_SLOTS};
+    constexpr int kNumTensors = {tensor_count};
+    constexpr int kHwBlocks = {hw};
+    constexpr int kAivLanes = {lanes};
+    // LocalContext: block_idx@0, block_num@4 (+ async_ctx, zeroed).
+    // GlobalContext: sub_block_id@0. Strides over-estimate the real sizeof;
+    // the kernel only reads the named fields, the rest stays zero. async_ctx
+    // is left zero — the traced compute path uses the FIFO rings (TPUSH/TPOP),
+    // not the async-completion slab.
+    constexpr int kLocalCtx = 64;
+    constexpr int kGlobalCtx = 16;
+    constexpr int kSubblockDim = {mixcfg["aiv_lanes_per_block"]};
+
+{chr(10).join(alloc)}
+
+    std::vector<uint8_t> h_tensors((size_t)kNumTensors * 128, 0);
+{chr(10).join(descs)}
+
+    void *d_tensors = nullptr;
+    ACL_CHECK(aclrtMalloc(&d_tensors, (size_t)kNumTensors * 128, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_tensors, (size_t)kNumTensors * 128, h_tensors.data(),
+                          (size_t)kNumTensors * 128, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    // --- slot 48/49 SPMD contexts (synthesized; not in the dump) ---
+    auto build_ctx = [&](std::vector<uint8_t> &loc, std::vector<uint8_t> &glob,
+                         int rows, bool aiv) {{
+        for (int r = 0; r < rows; ++r) {{
+            int block_idx = aiv ? (r / kSubblockDim) : r;
+            int sub_id = aiv ? (r % kSubblockDim) : 0;
+            *reinterpret_cast<int32_t *>(loc.data() + (size_t)r * kLocalCtx + 0) = block_idx;
+            *reinterpret_cast<int32_t *>(loc.data() + (size_t)r * kLocalCtx + 4) = kHwBlocks;
+            *reinterpret_cast<int32_t *>(glob.data() + (size_t)r * kGlobalCtx + 0) = sub_id;
+        }}
+    }};
+    std::vector<uint8_t> h_aic_loc((size_t)kHwBlocks * kLocalCtx, 0);
+    std::vector<uint8_t> h_aic_glob((size_t)kHwBlocks * kGlobalCtx, 0);
+    std::vector<uint8_t> h_aiv_loc((size_t)kAivLanes * kLocalCtx, 0);
+    std::vector<uint8_t> h_aiv_glob((size_t)kAivLanes * kGlobalCtx, 0);
+    build_ctx(h_aic_loc, h_aic_glob, kHwBlocks, false);
+    build_ctx(h_aiv_loc, h_aiv_glob, kAivLanes, true);
+
+    void *d_aic_loc = nullptr, *d_aic_glob = nullptr, *d_aiv_loc = nullptr, *d_aiv_glob = nullptr;
+    auto push = [&](void **d, std::vector<uint8_t> &h) {{
+        ACL_CHECK(aclrtMalloc(d, h.size(), ACL_MEM_MALLOC_HUGE_FIRST));
+        ACL_CHECK(aclrtMemcpy(*d, h.size(), h.data(), h.size(), ACL_MEMCPY_HOST_TO_DEVICE));
+        return ACL_SUCCESS;
+    }};
+    push(&d_aic_loc, h_aic_loc);
+    push(&d_aic_glob, h_aic_glob);
+    push(&d_aiv_loc, h_aiv_loc);
+    push(&d_aiv_glob, h_aiv_glob);
+
+    // --- per-row args (tensors + scalars shared; contexts per row) ---
+    auto fill = [&](std::vector<int64_t> &a, int rows, uintptr_t lbase, uintptr_t gbase) {{
+        for (int r = 0; r < rows; ++r) {{
+            int64_t *row = a.data() + (size_t)r * kArgsSlots;
+{tensor_rows}
+{scalar_rows}
+            row[48] = (int64_t)(lbase + (size_t)r * kLocalCtx);
+            row[49] = (int64_t)(gbase + (size_t)r * kGlobalCtx);
+        }}
+    }};
+    std::vector<int64_t> h_aic_args((size_t)kHwBlocks * kArgsSlots, 0);
+    std::vector<int64_t> h_aiv_args((size_t)kAivLanes * kArgsSlots, 0);
+    fill(h_aic_args, kHwBlocks, (uintptr_t)d_aic_loc, (uintptr_t)d_aic_glob);
+    fill(h_aiv_args, kAivLanes, (uintptr_t)d_aiv_loc, (uintptr_t)d_aiv_glob);
+
+    void *d_aic_args = nullptr, *d_aiv_args = nullptr;
+    const size_t aicBytes = (size_t)kHwBlocks * kArgsSlots * sizeof(int64_t);
+    const size_t aivBytes = (size_t)kAivLanes * kArgsSlots * sizeof(int64_t);
+    ACL_CHECK(aclrtMalloc(&d_aic_args, aicBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMalloc(&d_aiv_args, aivBytes, ACL_MEM_MALLOC_HUGE_FIRST));
+    ACL_CHECK(aclrtMemcpy(d_aic_args, aicBytes, h_aic_args.data(), aicBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+    ACL_CHECK(aclrtMemcpy(d_aiv_args, aivBytes, h_aiv_args.data(), aivBytes, ACL_MEMCPY_HOST_TO_DEVICE));
+
+    launch_replay(d_aic_args, d_aiv_args, stream);
+    ACL_CHECK(aclrtSynchronizeStream(stream));
+    printf("[replay_host] mix done: tensors=%d hw_blocks=%d aiv_lanes=%d\\n",
+           kNumTensors, kHwBlocks, kAivLanes);
+
+{frees}
+    aclrtFree(d_tensors);
+    aclrtFree(d_aic_loc); aclrtFree(d_aic_glob);
+    aclrtFree(d_aiv_loc); aclrtFree(d_aiv_glob);
+    aclrtFree(d_aic_args); aclrtFree(d_aiv_args);
+    aclrtDestroyStream(stream);
+    aclrtResetDevice(device_id);
+    aclFinalize();
+    return 0;
+}}
+"""
+
+
+def generate_workspace(  # noqa: PLR0913
+    ws: Path,
+    arch: str,
+    cfg,
+    core_type: str,
+    source: Path,
+    name: str,
+    tensor_count: int,
+    args,
+    max_tensor_bytes: int,
+    debug: bool = False,
+    mixcfg=None,
+    block_num: int = 1,
+):
+    ws.mkdir(parents=True, exist_ok=True)
+    # Warn (never truncate) on oversized buffers.
+    for a in args:
+        if a["kind"] == "tensor":
+            b = (a["start_offset"] + _extent_elem(a["shape"], a["strides"])) * DTYPE_SIZE[a["dtype"]]
+            if b > max_tensor_bytes:
+                print(
+                    f"[l0_swimlane] WARNING: tensor slot {a['slot']} ({a['dtype']} "
+                    f"{a['shape']}) allocates {b / 2**20:.0f} MiB (> "
+                    f"{max_tensor_bytes / 2**20:.0f} MiB threshold); allocating full "
+                    f"size for correctness."
+                )
+    if mixcfg is not None:
+        (ws / "replay_kernel.cpp").write_text(emit_replay_kernel_mix(source, cfg))
+        (ws / "replay_launch.cpp").write_text(emit_replay_launch_mix(mixcfg["hw_block_dim"]))
+        (ws / "replay_host.cpp").write_text(emit_replay_host_mix(tensor_count, args, mixcfg))
+    else:
+        (ws / "replay_kernel.cpp").write_text(emit_replay_kernel(core_type, source, cfg))
+        (ws / "replay_launch.cpp").write_text(emit_replay_launch())
+        (ws / "replay_host.cpp").write_text(emit_replay_host(tensor_count, args, block_num))
+    (ws / "CMakeLists.txt").write_text(emit_cmakelists(arch, name, cfg, debug))
+    rc = ws / "run_collect.sh"
+    rc.write_text(emit_run_collect(cfg))
+    rc.chmod(0o755)
+
+
+# ---------------------------------------------------------------------------
+# Step 5: build + collect
+# ---------------------------------------------------------------------------
+def _build_env():
+    cann = os.environ.get("ASCEND_HOME_PATH")
+    if not cann:
+        raise OSError("ASCEND_HOME_PATH is not set — source CANN set_env.sh first")
+    env = dict(os.environ)
+    env["ASCEND_HOME_PATH"] = cann
+    env["CANN_HOME"] = cann
+    env["REPO_ROOT"] = str(PROJECT_ROOT)
+    env["PTO_ISA_ROOT"] = ensure_pto_isa_root(verbose=True)
+    return env
+
+
+def smoke_build(ws: Path, env, cfg):
+    build = ws / "build"
+    build.mkdir(exist_ok=True)
+    subprocess.run(
+        [
+            "cmake",
+            "-G",
+            "Ninja",
+            "-S",
+            str(ws),
+            "-B",
+            str(build),
+            f"-DSOC_VERSION={cfg['soc']}",
+            f"-DPTO_ISA_ROOT={env['PTO_ISA_ROOT']}",
+            f"-DREPO_ROOT={env['REPO_ROOT']}",
+        ],
+        cwd=str(ws),
+        env=env,
+        check=True,
+    )
+    subprocess.run(["cmake", "--build", str(build), "--target", "replay_host"], cwd=str(ws), env=env, check=True)
+    so = build / "libreplay_kernel.so"
+    out = subprocess.run(["nm", "-D", str(so)], check=False, capture_output=True, text=True).stdout
+    syms = {line.split()[-1] for line in out.splitlines() if " T " in line}
+    for s in ("replay_entry", "launch_replay"):
+        if s not in syms:
+            raise RuntimeError(f"smoke build: missing symbol {s} in {so}")
+    print("[l0_swimlane] smoke build OK (replay_entry, launch_replay present)")
+
+
+def _to_perfetto(d):  # noqa: PLR0912
+    """In-place transform of an Insight trace into a Perfetto-friendly one.
+
+    Insight encodes each pipe as one track and packs concurrent, pipelined
+    instructions onto it; Perfetto drops overlapping `ph:X` complete events and
+    can mis-pair `B`/`E` flag events. This fixes both, losslessly (same events,
+    same ts/dur; only `tid` changes and `B`/`E` is re-encoded as `X`):
+
+      * sub-lanes: greedily pack each duration event into the lowest lane whose
+        previous event ended, so no two events on a lane overlap. A split pipe
+        `MTE1` becomes `MTE1#0..#k`.
+      * atomic flags: merge each `B`/`E` pair into one `ph:X` slice.
+      * thread_sort_index rebuilt as base*100+lane so lanes render adjacent.
+    """
+    EPS = 1e-9
+    evs = d["traceEvents"]
+    orig_sort = {(e["pid"], e["tid"]): e["args"]["sort_index"] for e in evs if e.get("name") == "thread_sort_index"}
+
+    def is_core(e):
+        return str(e.get("pid", "")).startswith("core")
+
+    # 1. Duration intervals per (pid,tid): X events + B/E pairs (matched by id).
+    intervals = defaultdict(list)
+    be = defaultdict(dict)
+    for e in evs:
+        if not is_core(e):
+            continue
+        ph = e.get("ph")
+        key = (e["pid"], e["tid"])
+        if ph == "X":
+            intervals[key].append(
+                {
+                    "ts": e["ts"],
+                    "end": e["ts"] + e.get("dur", 0.0),
+                    "name": e["name"],
+                    "args": e.get("args", {}),
+                }
+            )
+        elif ph in ("B", "E"):
+            slot = be[(e["pid"], e["tid"], e.get("id"))]
+            slot[ph] = e["ts"]
+            slot.setdefault("src", e)
+    for (pid, tid, eid), slot in be.items():
+        s = slot.get("B", slot.get("E"))
+        en = slot.get("E", slot.get("B"))
+        if s is not None and en is not None and s > en:
+            s, en = en, s
+        src = slot["src"]
+        intervals[(pid, tid)].append(
+            {
+                "ts": s,
+                "end": en,
+                "name": src["name"],
+                "args": src.get("args", {}),
+                "id": eid,
+            }
+        )
+
+    # 2. Greedy lane assignment (interval partitioning) per track.
+    max_lane = defaultdict(int)
+    be_lane = {}
+    for key, iv in intervals.items():
+        iv.sort(key=lambda t: (t["ts"], -(t["end"] - t["ts"])))
+        lane_end = []
+        for it in iv:
+            placed = None
+            for ln in range(len(lane_end)):
+                if lane_end[ln] <= it["ts"] + EPS:
+                    placed = ln
+                    break
+            if placed is None:
+                placed = len(lane_end)
+                lane_end.append(it["end"])
+            else:
+                lane_end[placed] = it["end"]
+            it["lane"] = placed
+            max_lane[key] = max(max_lane[key], placed)
+            if "id" in it:
+                be_lane[(key[0], key[1], it["id"])] = placed
+
+    def split(pid, tid):
+        return max_lane.get((pid, tid), 0) > 0
+
+    def laned(pid, tid, lane):
+        return f"{tid}#{lane}" if split(pid, tid) else tid
+
+    out = []
+    # 3. Emit every duration interval as an atomic X with its sub-lane tid.
+    for (pid, tid), iv in intervals.items():
+        for it in iv:
+            out.append(
+                {
+                    "ph": "X",
+                    "name": it["name"],
+                    "ts": it["ts"],
+                    "dur": it["end"] - it["ts"],
+                    "pid": pid,
+                    "tid": laned(pid, tid, it["lane"]),
+                    "args": it["args"],
+                }
+            )
+
+    # 4. Pass through the rest; anchor flow arrows to their id-pair's lane.
+    for e in evs:
+        ph = e.get("ph")
+        if e.get("name") == "thread_sort_index" or ph in ("X", "B", "E"):
+            continue
+        ne = dict(e)
+        if is_core(e) and ph in ("s", "t", "f") and split(e["pid"], e["tid"]):
+            ln = be_lane.get((e["pid"], e["tid"], e.get("id")), 0)
+            ne["tid"] = f"{e['tid']}#{ln}"
+        out.append(ne)
+
+    # 5. Rebuild thread_sort_index: integer, contiguous, lanes adjacent.
+    for (pid, tid), base in orig_sort.items():
+        mx = max_lane.get((pid, tid), 0)
+        if mx > 0:
+            for k in range(mx + 1):
+                out.append(
+                    {
+                        "args": {"sort_index": base * 100 + k},
+                        "name": "thread_sort_index",
+                        "ph": "M",
+                        "pid": pid,
+                        "tid": f"{tid}#{k}",
+                    }
+                )
+        else:
+            out.append(
+                {"args": {"sort_index": base * 100}, "name": "thread_sort_index", "ph": "M", "pid": pid, "tid": tid}
+            )
+
+    d["traceEvents"] = out
+    return d
+
+
+def collect(ws: Path, env, max_time: int, device=None, dest_name: str = "trace.json"):
+    if device:
+        # Already inside an outer task-submit lock (the recommended onboard
+        # workflow: wrap the whole tool so the dump and this collect share one
+        # device — `device` is the appended --device <id>). Reuse it for the
+        # camodel collect rather than nesting a second task-submit, which would
+        # grab a different device and could deadlock against the outer lock.
+        cmd = ["bash", str(ws / "run_collect.sh")]
+        env = {**env, "TARGET_DEVICE_ID": device}
+    elif shutil.which("task-submit") is not None:
+        # Standalone (no outer lock): self-lock just the collect step.
+        cmd = [
+            "task-submit",
+            "--device",
+            "auto",
+            "--max-time",
+            str(max_time),
+            "--run",
+            f"CANN_HOME={env['CANN_HOME']} PTO_ISA_ROOT={env['PTO_ISA_ROOT']} "
+            f"REPO_ROOT={env['REPO_ROOT']} TARGET_DEVICE_ID=$TASK_DEVICE "
+            f"bash {ws}/run_collect.sh",
+        ]
+    else:
+        print(
+            "[l0_swimlane] WARNING: task-submit not found; running run_collect.sh "
+            "unlocked (results may be noisy if another process shares the NPU)"
+        )
+        cmd = ["bash", str(ws / "run_collect.sh")]
+        env = {**env, "TARGET_DEVICE_ID": os.environ.get("ACL_DEVICE_ID", "0")}
+    subprocess.run(cmd, cwd=str(ws), env=env, check=True)
+
+    sims = list(ws.glob("insight_export/OPPROF_*/simulator"))
+    if not sims:
+        raise RuntimeError("no simulator/ export produced — check msprof_collect.log")
+    trace = sorted(sims, key=lambda p: p.stat().st_mtime)[-1] / "trace.json"
+    if not trace.is_file():
+        raise RuntimeError(f"trace.json missing under {trace.parent}")
+    dst = ws / dest_name
+    perfetto_dst = ws / dest_name.replace(".json", "_perfetto.json")
+    # Pretty-print the Insight copy (one record per line); the export original
+    # stays compact (Insight loads the simulator/ directory). Then emit a
+    # Perfetto-friendly version (sub-lanes + atomic flags). Fall back to a
+    # verbatim copy if the JSON can't be parsed.
+    try:
+        with open(trace) as f:
+            data = json.load(f)
+        with open(dst, "w") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        _to_perfetto(data)  # mutates data in place (after the pretty dump above)
+        with open(perfetto_dst, "w") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+    except (json.JSONDecodeError, OSError):
+        shutil.copy(trace, dst)
+        perfetto_dst = None
+    return dst, perfetto_dst
+
+
+# ---------------------------------------------------------------------------
+def apply_arg_overrides(kargs: list[dict], set_arg, ap: argparse.ArgumentParser):
+    """Apply --set-arg SLOT=VALUE overrides to reconstructed args.
+
+    A scalar slot has its value rewritten; a tensor slot has its data buffer
+    filled with VALUE (every element) instead of memset-0. Both shrink a replay
+    loop count without touching shapes: single-task kernels carry the count as a
+    scalar (n_blocks), the mix paged-attention kernel derives it from the
+    context_lens tensor's content. Only real arg slots from the dump are
+    settable; tensor fill requires an integer dtype. Increasing a scalar beyond
+    its dump value risks out-of-bounds and is warned about.
+    """
+    if not set_arg:
+        return
+    by_slot = {a["slot"]: a for a in kargs}
+    for spec in set_arg:
+        if "=" not in spec:
+            ap.error(f"--set-arg must be SLOT=VALUE (got {spec!r})")
+        slot_s, val_s = spec.split("=", 1)
+        try:
+            slot, value = int(slot_s), int(val_s)
+        except ValueError:
+            ap.error(f"--set-arg SLOT and VALUE must be integers (got {spec!r})")
+        a = by_slot.get(slot)
+        if a is None:
+            ap.error(f"--set-arg slot {slot} is not an arg of this task")
+        if a["kind"] == "scalar":
+            old = a["value"]
+            a["value"] = value
+            note = "  WARNING: larger than dump value -> buffers may be undersized" if value > old else ""
+            print(f"[l0_swimlane] overriding scalar slot {slot}: {old} -> {value}{note}")
+        else:
+            if a["dtype"] not in INTEGER_DTYPES:
+                ap.error(
+                    f"--set-arg slot {slot} is a {a['dtype']} tensor; tensor "
+                    f"fill is only supported for integer dtypes (loop-count / "
+                    f"index control tensors like context_lens)"
+                )
+            a["fill"] = value
+            print(f"[l0_swimlane] filling tensor slot {slot} ({a['dtype']} {a['shape']}) with {value} in every element")
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Generate an AICore intra-core swimlane trace.json for one kernel.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--test", required=True, help="SceneTest test file (.py)")
+    ap.add_argument("--func-id", type=int, required=True, help="incore kernel func_id")
+    ap.add_argument(
+        "--platform",
+        default="a2a3sim",
+        help="dump platform (default a2a3sim). Sim variants "
+        "(a2a3sim/a5sim) need no NPU. Onboard variants "
+        "(a2a3/a5) run the dump on a real device — wrap the "
+        "whole tool in task-submit so the dump and collect "
+        "share the locked $TASK_DEVICE. Required for kernels "
+        "whose sync idiom (e.g. manual prod.record()) only "
+        "compiles for the device, not the cpu sim.",
+    )
+    ap.add_argument(
+        "--device",
+        default=None,
+        metavar="ID",
+        help="NPU device id for an onboard dump + collect. Normally "
+        "supplied automatically — task-submit appends "
+        "--device <id> to the wrapped command; also read from "
+        "$TASK_DEVICE. Sim platforms ignore it.",
+    )
+    ap.add_argument(
+        "--case",
+        default=None,
+        metavar="NAME",
+        help="pin the dump to one CASES[*].name (e.g. SmallCase1). "
+        "Use when the test has several cases on --platform so "
+        "the dump targets the small one, not the full-size "
+        "production case (whose shapes overflow the camodel "
+        "replay). Accepts ClassName::Case too.",
+    )
+    ap.add_argument("--task-id", default=None, help="task_id hex (default: lowest)")
+    ap.add_argument(
+        "--set-arg",
+        action="append",
+        default=[],
+        metavar="SLOT=VALUE",
+        help="override an arg by args[] slot for the replay. Scalar "
+        "slot -> rewrite its value; tensor slot -> fill its data "
+        "buffer with VALUE (integer dtypes only). Use to shrink a "
+        "loop count for the camodel without distorting pipeline "
+        "structure: single-task n_blocks is a scalar "
+        "(--set-arg 4=4); mix paged-attention derives n_blocks "
+        "from the context_lens tensor (--set-arg 4=512 -> "
+        "n_blocks=ceil(512/block_size)). Only real arg slots are "
+        "settable. Repeatable. Default: real dump values.",
+    )
+    ap.add_argument(
+        "--spmd-block-num",
+        type=int,
+        default=None,
+        metavar="N",
+        help="block_num written into the synthesized SPMD LocalContext "
+        "(slot 48). Default: the case's block_dim. Only matters for "
+        "kernels that branch/stride on block_num; set the real grid "
+        "width for those. Ignored by the mix path (uses block_dim).",
+    )
+    ap.add_argument("--dump-json", default=None, help="reuse an existing tensor_dump.json")
+    ap.add_argument("--no-collect", action="store_true", help="smoke build only")
+    ap.add_argument(
+        "--debug-line",
+        "-g",
+        action="store_true",
+        help="compile the kernel with -g (and skip link strip) so the "
+        "trace carries debug_line -> Insight maps instructions to "
+        "source lines. Default off.",
+    )
+    ap.add_argument(
+        "--max-tensor-bytes", type=int, default=1 << 30, help="warn threshold for buffer size (bytes); never truncates"
+    )
+    ap.add_argument("--max-time", type=int, default=1800, help="task-submit budget (sec)")
+    args = ap.parse_args()
+
+    test_path = Path(args.test).resolve()
+    arch, variant = parse_platform(args.platform)
+    cfg = ARCH_CONFIG.get(arch)
+    if cfg is None:
+        ap.error(f"unsupported arch {arch} (from {args.platform}); supported: {', '.join(ARCH_CONFIG)}")
+
+    meta = load_kernel_meta(test_path, args.func_id, args.platform)
+    source, core_type, name = meta["source"], meta["core_type"], meta["name"]
+    class_name, is_mix, block_dim = meta["class_name"], meta["is_mix"], meta["block_dim"]
+    if core_type not in ("aic", "aiv"):
+        ap.error(f"unsupported core_type {core_type} (only aic/aiv)")
+    # Mix is auto-detected (aic+aiv incore pair sharing one source); its constants
+    # are derived — hw_block_dim from the case's block_dim, aiv lanes from the
+    # arch. AIC/AIV-only kernels (incl. independent kernels packed into a mix
+    # dispatch) take the single-args path, which synthesizes one SPMD context.
+    mixcfg = {"hw_block_dim": block_dim, "aiv_lanes_per_block": cfg["aiv_lanes_per_block"]} if is_mix else None
+    # block_num for the synthesized LocalContext: the case grid width, overridable.
+    block_num = args.spmd_block_num if args.spmd_block_num is not None else block_dim
+    mode = "mix" if is_mix else core_type
+    print(
+        f"[l0_swimlane] kernel func_id={args.func_id} name={name} mode={mode} "
+        f"block_dim={block_dim}\n              source={source}"
+    )
+
+    # task-submit hands the locked device by appending --device <id> to argv
+    # (and may also set $TASK_DEVICE). One resolved value threads through both
+    # the dump and the collect so they share the single outer lock.
+    device = args.device or os.environ.get("TASK_DEVICE")
+    manifest = get_or_run_dump(test_path, args.platform, variant, args.dump_json, args.case, device)
+    print(f"[l0_swimlane] manifest: {manifest}")
+    # Mix: merge the whole subtask pair (the dump splits tensors across their
+    # func_ids). Single kernel: just the requested func_id.
+    recon_func_ids = meta["func_ids"] if is_mix else args.func_id
+    chosen, tensor_count, kargs = reconstruct_task_args(manifest, recon_func_ids, args.task_id)
+    scalars = [a for a in kargs if a["kind"] == "scalar"]
+    print(f"[l0_swimlane] task {chosen}: {tensor_count} tensors, {len(scalars)} scalars")
+    # Full arg-slot map so the caller can pick a slot for --set-arg without
+    # cross-referencing the kernel source. Names are not in the dump (only
+    # kind/shape/value) — read the kernel's `args:` header for those.
+    print("[l0_swimlane] arg slots (override with --set-arg SLOT=VALUE):")
+    for a in sorted(kargs, key=lambda x: x["slot"]):
+        if a["kind"] == "tensor":
+            print(f"    slot {a['slot']:<2} tensor  {a['dtype']:<8} {a['shape']}")
+        else:
+            print(f"    slot {a['slot']:<2} scalar  = {a['value']}")
+    apply_arg_overrides(kargs, args.set_arg, ap)
+
+    # Self-describing label: <TestClass>_<Case>_<platform>_<kernel>, so the
+    # workspace dir and the trace.json filename say which case/kernel they are.
+    case = _case_from_manifest(manifest, class_name)
+    label = f"{class_name}_{case}_{args.platform}_{name}"
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    ws = PROJECT_ROOT / "outputs" / f"l0_swimlane_{label}_{ts}"
+    generate_workspace(
+        ws,
+        arch,
+        cfg,
+        core_type,
+        source,
+        name,
+        tensor_count,
+        kargs,
+        args.max_tensor_bytes,
+        debug=args.debug_line,
+        mixcfg=mixcfg,
+        block_num=block_num,
+    )
+    print(f"[l0_swimlane] workspace: {ws}")
+
+    env = _build_env()
+    smoke_build(ws, env, cfg)
+    if args.no_collect:
+        print(f"[l0_swimlane] --no-collect: stopping after smoke build.\n  {ws}")
+        return
+    trace, trace_perfetto = collect(ws, env, args.max_time, device, dest_name=f"{label}_trace.json")
+    print(f"[l0_swimlane] DONE. trace.json (Insight) -> {trace}")
+    if trace_perfetto:
+        print(f"[l0_swimlane]       perfetto-friendly  -> {trace_perfetto}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/a2a3/platform/include/common/tensor_dump.h
+++ b/src/a2a3/platform/include/common/tensor_dump.h
@@ -113,9 +113,10 @@ struct alignas(64) TensorDumpRecord {
     uint64_t payload_offset;  // Monotonic byte offset into thread arena
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
     uint64_t scalar_value;    // Valid when kind == TensorDumpKind::SCALAR
+    uint16_t func_id;         // Kernel function id that produced this record; 0xFFFF if unknown
     uint8_t kind;             // TensorDumpKind
     uint8_t flags;            // TENSOR_DUMP_RECORD_FLAG_*
-    uint8_t pad0[14];         // Preserve 64B cache-line layout + scalar_value + kind
+    uint8_t pad0[12];         // Preserve 64B cache-line layout + scalar_value + func_id + kind + flags
 
     // === Cache line 2 (64B) — strided view descriptor ===
     // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 = 48B.
@@ -265,6 +266,7 @@ struct TensorDumpInfo {
     uint64_t buffer_addr;
     uint64_t scalar_value;
     uint8_t kind;
+    int32_t func_id;  // Kernel function id; -1 (0xFFFF in record) if unknown
     uint8_t flags;
     uint8_t pad[14];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin

--- a/src/a5/platform/include/common/tensor_dump.h
+++ b/src/a5/platform/include/common/tensor_dump.h
@@ -117,9 +117,10 @@ struct alignas(64) TensorDumpRecord {
     uint64_t payload_offset;  // Monotonic byte offset into thread arena
     uint64_t payload_size;    // Bytes actually copied (may be < full tensor bytes)
     uint64_t scalar_value;    // Valid when kind == TensorDumpKind::SCALAR
+    uint16_t func_id;         // Kernel function id that produced this record; 0xFFFF if unknown
     uint8_t kind;             // TensorDumpKind
     uint8_t flags;            // TENSOR_DUMP_RECORD_FLAG_*
-    uint8_t pad0[14];         // Preserve 64B cache-line layout + scalar_value + kind
+    uint8_t pad0[12];         // Preserve 64B cache-line layout + scalar_value + func_id + kind + flags
 
     // === Cache line 2 (64B) — strided view descriptor ===
     // start_offset placed first for 8B alignment without padding gaps; total = 8 + 20 + 20 = 48B.
@@ -269,6 +270,7 @@ struct TensorDumpInfo {
     uint64_t buffer_addr;
     uint64_t scalar_value;
     uint8_t kind;
+    int32_t func_id;  // Kernel function id; -1 (0xFFFF in record) if unknown
     uint8_t flags;
     uint8_t pad[14];
     uint64_t start_offset;                     // 1D ELEMENT offset of the view origin

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -137,11 +137,19 @@ inline void dump_tensors_for_task(
     rmb();
 
     int32_t tensor_index = 0;
+    // Scalars are dumped once per task (outside the subtask loop below); stamp
+    // them with the first active subtask's func_id so a per-func_id filter
+    // (l0_swimlane) still finds them. For a mix task the pair is merged, so any
+    // active subtask's id works.
+    int32_t scalar_func_id = -1;
     for (int raw_subtask_id = 0; raw_subtask_id < MaxSubtaskSlots; raw_subtask_id++) {
         if (!is_subtask_active(slot_state.active_mask, raw_subtask_id)) {
             continue;
         }
         int32_t slot_idx = raw_subtask_id;
+        if (scalar_func_id < 0) {
+            scalar_func_id = slot_state.task->kernel_id[slot_idx];
+        }
         const CoreCallable &callable = *callables[slot_idx];
         for (int32_t sig_idx = 0; sig_idx < callable.sig_count(); sig_idx++) {
             ArgDirection dir = callable.sig(sig_idx);
@@ -163,6 +171,7 @@ inline void dump_tensors_for_task(
                     info.strides[d] = t.strides[d];
                 }
                 info.task_id = slot_state.task->task_id.raw;
+                info.func_id = slot_state.task->kernel_id[slot_idx];
                 info.arg_index = static_cast<uint32_t>(tensor_index);
                 info.role = role;
                 info.stage = stage;
@@ -187,6 +196,7 @@ inline void dump_tensors_for_task(
             }
             TensorDumpInfo info = {};
             info.task_id = slot_state.task->task_id.raw;
+            info.func_id = scalar_func_id;
             info.role = TensorDumpRole::INPUT;
             info.stage = stage;
             info.dtype = (has_scalar_dtypes && scalar_index < static_cast<int32_t>(dtype_scalar_count)) ?
@@ -315,6 +325,7 @@ inline void dump_tensors_for_task(
         const auto &t = tensor_info[tensor_arg_index];
         TensorDumpInfo info = {};
         info.task_id = task_id;
+        info.func_id = -1;  // host_build_graph overload: func_id not threaded here -> unknown
         info.role = role;
         info.stage = stage;
         info.dtype = static_cast<uint8_t>(t.dtype);

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -147,6 +147,7 @@ using DumpFreeCallback = profiling_common::ProfFreeCallback;
  */
 struct DumpedTensor {
     uint64_t task_id;
+    uint16_t func_id;  // Kernel function id that produced this record; 0xFFFF if unknown
     uint32_t arg_index;
     TensorDumpRole role;
     TensorDumpStage stage;

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -657,6 +657,7 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     uint32_t idx = buf->count;
     TensorDumpRecord *rec = &buf->records[idx];
     rec->task_id = info.task_id;
+    rec->func_id = static_cast<uint16_t>(info.func_id);  // -1 -> 0xFFFF (unknown)
     rec->arg_index = info.arg_index;
     rec->is_contiguous = is_contiguous ? 1 : 0;
     rec->role = static_cast<uint8_t>(info.role);

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -224,6 +224,7 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
 
         DumpedTensor dt;
         dt.task_id = rec.task_id;
+        dt.func_id = rec.func_id;
         dt.arg_index = rec.arg_index;
         dt.role = static_cast<TensorDumpRole>(rec.role);
         dt.stage = static_cast<TensorDumpStage>(rec.stage);
@@ -622,8 +623,8 @@ int TensorDumpCollector::export_dump_files() {
         first_entry = false;
 
         json << "    {\"task_id\": \"0x" << std::hex << std::setfill('0') << std::setw(16) << dt.task_id << std::dec
-             << "\"";
-        json << ", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
+             << "\", \"func_id\": " << (dt.func_id == 0xFFFF ? -1 : static_cast<int>(dt.func_id))
+             << ", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
              << "\", \"stage\": \"" << tensor_dump_stage_name(dt.stage) << "\", \"kind\": \""
              << tensor_dump_kind_name(dt.kind) << "\", \"dtype\": \"" << dtype_name << "\"";
         if (dt.kind == TensorDumpKind::SCALAR) {

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -34,7 +34,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "QK",
                 "source": "kernels/aic/aic_qk_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 1,
@@ -48,7 +48,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 3,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
@@ -35,7 +35,17 @@ class TestSpmdMultiblockAiv(SceneTestCase):
             "signature": [D.INOUT],
         },
         "incores": [
-            {"func_id": 0, "name": "SPMD_WRITE_AIV", "source": "kernels/aiv/kernel_spmd_write.cpp", "core_type": "aiv"},
+            {
+                "func_id": 0,
+                "name": "SPMD_WRITE_AIV",
+                "source": "kernels/aiv/kernel_spmd_write.cpp",
+                "core_type": "aiv",
+                # Declare the single output tensor so the tensor dump (which
+                # sums per-subtask signature tensors and matches them to the
+                # payload) captures it under func_id 0 for l0_swimlane — without
+                # it the count is 0 != payload 1 and the dump is skipped.
+                "signature": [D.INOUT],
+            },
         ],
     }
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -37,6 +37,12 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
                 "name": "PA_AIC",
                 "source": "kernels/mix/paged_attention_parallel.cpp",
                 "core_type": "aic",
+                # Declare the full 9-tensor layout here (AIV entry left empty)
+                # so the tensor dump — which sums per-subtask signature tensors
+                # and matches them to the payload — captures all args under
+                # func_id 0 for l0_swimlane. Consumed only by the dump; dispatch
+                # ignores it.
+                "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.INOUT, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 1,
@@ -74,6 +80,27 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
                 "kv_head_num": 1,
                 "head_dim": 128,
                 "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            # l0_swimlane intra-core trace target only (--case SmallCase1;
+            # manual -> not in the default onboard CI sweep). batch=24 == the
+            # orchestration's hardcoded SPMD_BLOCK_NUM, so every hw block gets
+            # one logical block (fewer stalls the AIC<->AIV handshake). Same
+            # q_tile=16 path as Case1; passes golden at context_len=8192.
+            "name": "SmallCase1",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            "params": {
+                "batch": 24,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
                 "context_len": 8192,
                 "max_model_len": 32768,
                 "dtype": "bfloat16",

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -34,7 +34,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "QK",
                 "source": "kernels/aic/aic_qk_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 1,
@@ -48,7 +48,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 3,


### PR DESCRIPTION
  Generate an AICore intra-core swimlane trace.json for a single kernel:
  read the test's CALLABLE to resolve the kernel by func_id, run a JSON-only
  tensor dump to capture the real per-task args, reconstruct them filtered by
  func_id (zero hand-guessing), emit a 5-file msprof-op-simulator replay
  workspace, and collect the camodel trace. The dump's golden PASS is the
  gate that the captured args are trustworthy.

  Handles five kernel shapes: AIC-only, AIV-only, SPMD AIV, cooperative SPMD
  mix, and offset subtasks (an independent kernel packed into a mix dispatch,
  whose args start at a non-zero slot). --set-arg shrinks a replay loop count
  (scalar n_blocks or the context_lens control tensor) without distorting the
  pipeline structure.

  Supporting changes:

  - tensor dump: stamp each record with the originating kernel's func_id (task->kernel_id[slot]) so a multi-kernel dump can be filtered per kernel; new func_id field in TensorDumpRecord/TensorDumpInfo and the collector JSON (-1 when unknown). Required by l0_swimlane's func_id reconstruction.
  - tests: declare the incore tensor signatures the dump needs (paged_attention_unroll, spmd_multiblock_aiv SPMD_WRITE_AIV, spmd_paged_attention PA_AIC full 9-tensor layout) and add a small manual SmallCase1 to spmd_paged_attention as an onboard mix trace target.
  - docs: new docs/dfx/l0-swimlane-profiling.md (usage, kernel-shape table, --set-arg loop shrinking, the cooperative-mix signature rule — declare on exactly one of the pair); tensor-dump.md documents the func_id field; insight-trace SKILL.md records the manual recipe the tool automates.