### PR TITLE
Fix: recover unflushed scope stats records

### DIFF
--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -300,6 +300,8 @@ ScopeStatsCollector                platform scope_stats_collector_aicpu.cpp
       │                         │         └─ emit record, append to buffer;
   stop() (drain + join)         └──────────── push full buffer to ready_queue
   reconcile_counters()               orch exit: flush remaining buffers
+    recover current_buf_ptr
+    if abnormal exit left one
   write_jsonl()
 ```
 

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -472,6 +472,8 @@ poll thread that drains the L2 hand-off queue into
 │ stop()                   │               │   log per-thread stats   │
 │   join mgmt → join poll  │               └──────────────────────────┘
 │ reconcile_counters()     │
+│   recover leftovers      │
+│   + dropped accounting   │
 │                          │
 │ export_dump_files()      │
 │   → <output_prefix>/     │
@@ -494,10 +496,8 @@ rtStreamSynchronize              ← wait for kernel completion
 stop()                           ← join mgmt (its final-drain pass into L2
                                    has poll as the consumer), then signal
                                    poll and join it
-reconcile_counters()             ← passive sanity check + dropped accounting
-                                   (host never recovers from
-                                   current_buf_ptr — device flush is the
-                                   sole data path)
+reconcile_counters()             ← recover leftover current buffers
+                                   + dropped accounting
 export_dump_files()
 ```
 
@@ -583,7 +583,7 @@ the buffer's records.
 │ stop()                   │               │                          │
 │   join mgmt + poll       │               │                          │
 │ reconcile_counters()     │               │                          │
-│   sanity-check leftovers │               │                          │
+│   recover leftovers      │               │                          │
 │   + dropped accounting   │               │                          │
 │ export_dump_files()      │               │                          │
 │   → <output_prefix>/     │               │                          │
@@ -601,7 +601,8 @@ dump_collector_.start(thread_factory)   ← mgmt + poll threads
 launch AICPU / AICore
 rtStreamSynchronize
 dump_collector_.stop()                  ← join mgmt + poll, drain final batch
-dump_collector_.reconcile_counters()    ← sanity-check + dropped accounting
+dump_collector_.reconcile_counters()    ← recover leftover current buffers
+                                          + dropped accounting
 dump_collector_.export_dump_files()
 dump_collector_.finalize()
 ```
@@ -615,11 +616,10 @@ with `DumpModule`. The only a5-specific glue is the 5-callback
 `MemoryOps`, the per-tick shm mirror, and the on-demand arena copy
 inside `on_buffer_collected`.
 
-a5's per-thread AICPU flush (`dump_tensor_flush`) is the only data
-path on the records side — host never reads from `current_buf_ptr`
-to recover records. `reconcile_counters` is purely passive: it logs
-an error if any `current_buf_ptr` is non-zero with a non-empty buffer
-(a device-flush bug), then accumulates each thread's
+a5 normally relies on per-thread AICPU flush (`dump_tensor_flush`) to move
+the current buffer into the ready queue. If a hang/op-timeout reaps AICPU
+before that flush runs, `reconcile_counters` recovers a non-empty
+`current_buf_ptr` host-side before export, then accumulates each thread's
 `dropped_record_count` for the final anomaly report.
 
 ### 5.6 a2a3 vs a5 at a glance
@@ -634,7 +634,7 @@ an error if any `current_buf_ptr` is non-zero with a non-empty buffer
 | Host transport | `halHostRegister` shared memory | host-shadow `malloc` + per-tick `rtMemcpy`/`memcpy` |
 | `MemoryOps` callbacks | 3 (`alloc`, `reg`, `free_`) | 5 (+ `copy_to_device`, `copy_from_device`) |
 | Arena access | direct via SVM | `copy_from_device` inside `on_buffer_collected` |
-| `reconcile_counters` | passive sanity check + dropped accounting | identical |
+| `reconcile_counters` | recover leftover current buffers + dropped accounting | identical |
 | Lifecycle | `initialize` → `start` → `stop` → `reconcile_counters` → `export_dump_files` → `finalize` | identical |
 
 ## 6. Overhead

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -1,7 +1,7 @@
 # Profiling Framework
 
-Shared host-side infrastructure that the PMU, L2Swimlane, and TensorDump
-collectors are built on. The framework headers live in
+Shared host-side infrastructure that the PMU, L2Swimlane, TensorDump, and
+ScopeStats collectors are built on. The framework headers live in
 [`src/common/platform/include/host/`](../src/common/platform/include/host/)
 and are consumed verbatim by both a2a3 and a5 collectors (PR #944
 unified the previously-divergent per-arch copies into one set). This page
@@ -11,7 +11,8 @@ the collectors themselves still carry.
 The per-collector pages
 ([pmu-profiling.md](dfx/pmu-profiling.md),
 [l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md),
-[tensor-dump.md](dfx/tensor-dump.md))
+[tensor-dump.md](dfx/tensor-dump.md),
+[scope-stats.md](dfx/scope-stats.md))
 describe the data each subsystem collects and how it enables it on-device.
 
 ## 1. Why a shared framework
@@ -343,14 +344,14 @@ changes capture that:
    the same for any remaining mappings (per-state buffers and the shm
    region itself).
 
-Each collector's `reconcile_counters` is purely passive — same shape as
-a2a3. It pulls the post-`stop()` `BufferState`s, logs an error if any
-`current_buf_ptr` still references a non-empty buffer (a device flush
-bug, since AICPU is the only writer that can clear it), and runs the
-three-bucket cross-check
-`collected_on_host + dropped + mismatch == device_total` against
-device-side counters per pool. Host never reads from `current_buf_ptr`
-to recover records — recovering would mask AICPU flush bugs.
+Most collectors keep `reconcile_counters` passive — same shape as a2a3. It
+pulls the post-`stop()` `BufferState`s, logs an error if any
+`current_buf_ptr` still references a non-empty buffer (a device flush bug,
+since AICPU is the only writer that can clear it), and runs the collector's
+counter cross-check/accounting against device-side counters. TensorDump and
+ScopeStats are the recovery-oriented exceptions: on abnormal exit they may
+recover a non-empty `current_buf_ptr` host-side before export, so already
+recorded dump metadata or scope samples still reach the output files.
 
 ### 8.1 Profiling state lives on `KernelArgs`, not `Handshake`
 

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -34,8 +34,9 @@
  *   start(tf)            — Inherited: launches mgmt + poll threads.
  *   [device execution]
  *   stop()               — Inherited: drain queues, join threads.
- *   reconcile_counters() — current_buf_ptr cleared by flush + collected ==
- *                          total - dropped cross-check.
+ *   reconcile_counters() — Recover any un-flushed current buffer left by an
+ *                          abnormal exit, then cross-check collected ==
+ *                          total - dropped.
  *   write_jsonl()        — Emit scope_stats/scope_stats.jsonl
  *                          (meta line + one record/line).
  *   finalize()           — Free all device memory, unregister.
@@ -153,8 +154,9 @@ public:
     // Poll-thread hook: append the buffer's records to the in-memory vector.
     void on_buffer_collected(const ScopeStatsReadyBufferInfo &info);
 
-    // After stop(): warn on drops / un-flushed buffer and cross-check
-    // collected == total - dropped. Returns true iff the run is clean.
+    // After stop(): recover a non-empty current buffer left by abnormal exit,
+    // warn on drops, and cross-check collected == total - dropped. Returns
+    // true iff the run is clean.
     bool reconcile_counters();
 
     // Render the collected records to
@@ -180,6 +182,8 @@ private:
     std::vector<ScopeStatsRecord> records_;
     std::mutex records_mutex_;
     uint64_t total_collected_ = 0;
+    uint64_t recovered_current_buf_ = 0;
+    uint64_t recovered_current_total_ = 0;
 
     ScopeStatsDataHeader *scope_stats_header() const { return get_scope_stats_header(shm_host_); }
     ScopeStatsBufferState *scope_stats_state(int idx = 0) const { return get_scope_stats_buffer_state(shm_host_, idx); }

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -228,11 +228,9 @@ public:
     int export_dump_files();
 
     /**
-     * After stop(), perform purely-passive accounting:
-     *   - LOG_ERROR any non-zero DumpBufferState::current_buf_ptr with
-     *     records (device flush should always succeed-or-bump-dropped, so
-     *     a non-empty leftover indicates an AICPU flush bug — host does
-     *     NOT recover, to avoid masking the bug).
+     * After stop():
+     *   - Recover records from any non-empty DumpBufferState::current_buf_ptr
+     *     left behind by abnormal exit before device-side flush ran.
      *   - Accumulate device-side dropped_record_count into
      *     total_dropped_record_count_ for the final anomaly report.
      * Must be called after stop().

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -37,7 +37,6 @@
 #include <cstring>
 #include <filesystem>
 #include <system_error>
-#include <unordered_set>
 
 #include "common/memory_barrier.h"
 #include "common/unified_log.h"
@@ -65,6 +64,8 @@ int ScopeStatsCollector::init(
     num_threads_ = num_threads;
     total_collected_ = 0;
     records_.clear();
+    recovered_current_buf_ = 0;
+    recovered_current_total_ = 0;
     execution_complete_.store(false, std::memory_order_release);
 
     // Stash callbacks on the base up-front so alloc_paired_buffer sees
@@ -175,6 +176,9 @@ bool ScopeStatsCollector::reconcile_counters() {
     bool clean = true;
 
     ScopeStatsBufferState *state = scope_stats_state(0);
+    uint64_t total_device = state->total_record_count;
+    uint64_t dropped_device = state->dropped_record_count;
+
     uint64_t buf_dev = state->current_buf_ptr;
     if (buf_dev != 0) {
         void *host_ptr = manager_.resolve_host_ptr(reinterpret_cast<void *>(buf_dev));
@@ -182,17 +186,32 @@ bool ScopeStatsCollector::reconcile_counters() {
             profiling_copy_from_device(host_ptr, reinterpret_cast<void *>(buf_dev), sizeof(ScopeStatsBuffer));
             uint32_t count = reinterpret_cast<const ScopeStatsBuffer *>(host_ptr)->count;
             if (count != 0) {
-                LOG_ERROR(
-                    "scope_stats reconcile: un-flushed buffer (current_buf_ptr=0x%lx, count=%u) — device flush failed",
-                    static_cast<unsigned long>(buf_dev), count
-                );
+                if (recovered_current_buf_ != buf_dev || recovered_current_total_ != total_device) {
+                    append_buffer_records(host_ptr);
+                    recovered_current_buf_ = buf_dev;
+                    recovered_current_total_ = total_device;
+                    LOG_WARN(
+                        "scope_stats reconcile: recovered un-flushed buffer "
+                        "(current_buf_ptr=0x%lx, count=%u) host-side; device flush did not run",
+                        static_cast<unsigned long>(buf_dev), count
+                    );
+                } else {
+                    LOG_WARN(
+                        "scope_stats reconcile: un-flushed buffer "
+                        "(current_buf_ptr=0x%lx, count=%u) was already recovered host-side",
+                        static_cast<unsigned long>(buf_dev), count
+                    );
+                }
                 clean = false;
             }
+        } else {
+            LOG_ERROR(
+                "scope_stats reconcile: un-flushed buffer current_buf_ptr=0x%lx has no host mapping",
+                static_cast<unsigned long>(buf_dev)
+            );
+            clean = false;
         }
     }
-
-    uint64_t total_device = state->total_record_count;
-    uint64_t dropped_device = state->dropped_record_count;
 
     if (dropped_device > 0) {
         LOG_WARN(
@@ -312,6 +331,8 @@ void ScopeStatsCollector::finalize(ScopeStatsUnregisterCallback unregister_cb, c
         records_.clear();
         records_.shrink_to_fit();
     }
+    recovered_current_buf_ = 0;
+    recovered_current_total_ = 0;
 
     auto release_dev = [&](void *p) {
         release_one_buffer(p, unregister_cb, free_cb);

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -320,7 +320,7 @@ void TensorDumpCollector::on_buffer_collected(const DumpReadyBufferInfo &info) {
 }
 
 // ---------------------------------------------------------------------------
-// reconcile_counters: passive sanity-check + dropped accounting
+// reconcile_counters: recover un-flushed current buffers + dropped accounting
 // ---------------------------------------------------------------------------
 
 void TensorDumpCollector::reconcile_counters() {

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -315,6 +315,27 @@ add_common_utils_test(test_elf_build_id common/test_elf_build_id.cpp)
 add_common_utils_test(test_runtime_orch_so common/test_runtime_orch_so.cpp)
 add_common_utils_test(test_device_arena common/test_device_arena.cpp)
 
+add_executable(test_scope_stats_collector
+    common/test_scope_stats_collector.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/scope_stats_collector.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/sim/host/profiling_copy.cpp
+    ${CMAKE_SOURCE_DIR}/stubs/test_stubs.cpp
+)
+target_include_directories(test_scope_stats_collector PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_scope_stats_collector PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_scope_stats_collector COMMAND test_scope_stats_collector)
+set_tests_properties(test_scope_stats_collector PROPERTIES LABELS "no_hardware")
+
 # Per-callable_id orch SO file naming regression (see rtStreamSynchronize
 # 507018 root cause). Compiles the a2a3 onboard `create_orch_so_file`
 # against the test source so it runs on no-hw runners too.

--- a/tests/ut/cpp/common/test_scope_stats_collector.cpp
+++ b/tests/ut/cpp/common/test_scope_stats_collector.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "host/scope_stats_collector.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <unistd.h>
+
+namespace {
+
+void *test_alloc(size_t size) { return std::calloc(1, size); }
+
+int test_free(void *ptr) {
+    std::free(ptr);
+    return 0;
+}
+
+void fill_record(ScopeStatsRecord &rec, const char *site, int line, int16_t phase) {
+    std::memset(&rec, 0, sizeof(rec));
+    std::snprintf(rec.site_file_basename, sizeof(rec.site_file_basename), "%s", site);
+    rec.site_line = line;
+    rec.phase = phase;
+    rec.depth = 1;
+    rec.ring_id = 1;
+    rec.task_start = 10;
+    rec.task_end = 14;
+    rec.heap_start = 1024;
+    rec.heap_end = 4096;
+    rec.dep_pool_start = 2;
+    rec.dep_pool_end = 5;
+    rec.tensormap_used = 7;
+}
+
+std::string read_file(const std::filesystem::path &path) {
+    std::ifstream in(path);
+    return std::string((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+TEST(ScopeStatsCollectorTest, ReconcileRecoversUnflushedCurrentBuffer) {
+    ScopeStatsCollector collector;
+    ASSERT_EQ(collector.init(1, test_alloc, nullptr, test_free, 0), 0);
+
+    auto *header = get_scope_stats_header(collector.get_scope_stats_shm_device_ptr());
+    auto *state = get_scope_stats_buffer_state(collector.get_scope_stats_shm_device_ptr(), 0);
+    ASSERT_EQ(header->num_instances, 1u);
+
+    const uint32_t head = state->free_queue.head;
+    const uint32_t tail = state->free_queue.tail;
+    ASSERT_LT(head, tail);
+
+    uint64_t buf_dev = state->free_queue.buffer_ptrs[head % PLATFORM_SCOPE_STATS_SLOT_COUNT];
+    ASSERT_NE(buf_dev, 0u);
+    state->free_queue.head = head + 1;
+    state->current_buf_ptr = buf_dev;
+    state->current_buf_seq = 7;
+    state->total_record_count = 2;
+
+    auto *buf = reinterpret_cast<ScopeStatsBuffer *>(buf_dev);
+    buf->count = 2;
+    fill_record(buf->records[0], "recover.cpp", 123, SCOPE_STATS_PHASE_BEGIN);
+    fill_record(buf->records[1], "recover.cpp", 123, SCOPE_STATS_PHASE_END);
+
+    EXPECT_FALSE(collector.reconcile_counters());
+    EXPECT_EQ(collector.total_collected(), 2u);
+
+    std::filesystem::path out_dir = std::filesystem::temp_directory_path() /
+                                    ("scope_stats_collector_test_" + std::to_string(::getpid()) + "_recover");
+    std::filesystem::remove_all(out_dir);
+    ASSERT_EQ(collector.write_jsonl(out_dir.string()), 0);
+
+    std::string jsonl = read_file(out_dir / "scope_stats" / "scope_stats.jsonl");
+    ASSERT_FALSE(jsonl.empty());
+    EXPECT_NE(jsonl.find("\"total\": 2"), std::string::npos);
+    EXPECT_NE(jsonl.find("\"site\": \"recover.cpp:123\""), std::string::npos);
+    EXPECT_NE(jsonl.find("\"phase\": \"begin\""), std::string::npos);
+    EXPECT_NE(jsonl.find("\"phase\": \"end\""), std::string::npos);
+
+    // A second reconcile on the same un-flushed pointer should not append the
+    // same buffer again.
+    EXPECT_FALSE(collector.reconcile_counters());
+    EXPECT_EQ(collector.total_collected(), 2u);
+
+    // A later abnormal run may reuse the same current_buf_ptr. A changed
+    // device total means this is a new in-flight buffer snapshot, not the
+    // duplicate reconcile above.
+    state->total_record_count = 3;
+    buf->count = 1;
+    fill_record(buf->records[0], "recover_again.cpp", 456, SCOPE_STATS_PHASE_BEGIN);
+    EXPECT_FALSE(collector.reconcile_counters());
+    EXPECT_EQ(collector.total_collected(), 3u);
+
+    std::filesystem::remove_all(out_dir);
+    collector.finalize(nullptr, test_free);
+}


### PR DESCRIPTION
## Summary
- Recover non-empty scope_stats current buffers during host reconcile so abnormal exits can still export already-recorded records.
- Track the recovered current buffer pointer to avoid duplicate appends if reconcile runs more than once.
- Add C++ unit coverage for the unflushed current-buffer path and update profiling docs/comments to reflect recovery behavior.

## Testing
- conda run -n zm_pypto pre-commit run --show-diff-on-failure
- Manual abnormal-run repro generated scope_stats JSONL/HTML from a hung paged_attention_unroll case.

Fixes #1038