### PR TITLE
Update: raise CORE_MAX_TENSOR_ARGS to 32, lower scalars to 16

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -325,12 +325,12 @@ slots that overlay normal record slots in the buffer.
 | Submit `explicit_dep_count` | Chain shape | Per-submit slots used |
 | --------------------------- | ----------- | --------------------- |
 | `0 ≤ dc ≤ 64` | base only — fast path, no chain bookkeeping | 1 |
-| `65 ≤ dc ≤ 390` | base (64 deps) + 1 overflow (up to 326 deps) | 2 |
-| `391 ≤ dc ≤ 716` | base + 2 overflow | 3 |
-| general | base + `⌈(dc − 64) / 326⌉` overflow | `1 + ⌈(dc − 64) / 326⌉` |
+| `65 ≤ dc ≤ 646` | base (64 deps) + 1 overflow (up to 582 deps) | 2 |
+| `647 ≤ dc ≤ 1228` | base + 2 overflow | 3 |
+| general | base + `⌈(dc − 64) / 582⌉` overflow | `1 + ⌈(dc − 64) / 582⌉` |
 
-**Wire format.** An overflow record reinterprets the same 2624-byte slot
-as `{ task_id (8) + flags (4) + dep_count (2) + _reserved (2) + deps[326] }` —
+**Wire format.** An overflow record reinterprets the same 4672-byte slot
+as `{ task_id (8) + flags (4) + dep_count (2) + _reserved (2) + deps[582] }` —
 no tensor blobs (those live on the base record). Replay distinguishes
 the two views by `flags & DEP_GEN_FLAG_OVERFLOW`. Chain records always
 share the base's `task_id`, and the last one sets
@@ -347,7 +347,7 @@ base via `task_id`.
 
 **Truncation tail.** A submit whose chain exceeds the buffer's slot
 budget (`PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32` slots → roughly
-`64 + 31 × 326 = 10170` deps max in the best case) is logged via
+`64 + 31 × 582 = 18106` deps max in the best case) is logged via
 `LOG_ERROR` and truncated to the largest dc that fits. Runtime
 correctness is unaffected — `Arg::set_dependencies` keeps the full dep
 list; only the dep_gen replay graph loses the tail.
@@ -358,7 +358,7 @@ list; only the dep_gen replay graph loses the tail.
 
 | Layer | File | Role |
 | ----- | ---- | ---- |
-| Shared-mem layout | `src/{a2a3,a5}/platform/include/common/dep_gen.h` | `DepGenRecord` (2624 B base, cache-line aligned, ≤64 inline explicit_deps) + `DepGenOverflowRecord` chain view (≤326 deps per slot) + SPSC ring + per-thread ready queue. Byte-identical layout across platforms. |
+| Shared-mem layout | `src/{a2a3,a5}/platform/include/common/dep_gen.h` | `DepGenRecord` (4672 B base, cache-line aligned, ≤64 inline explicit_deps) + `DepGenOverflowRecord` chain view (≤582 deps per slot) + SPSC ring + per-thread ready queue. Byte-identical layout across platforms. |
 | AICPU writer | `src/{a2a3,a5}/platform/{include,shared}/aicpu/dep_gen_collector_aicpu.{h,cpp}` | Single-instance write path; weak-fallback exported to host build. a5 reuses the a2a3 source verbatim — the writer accesses its own device-side view of shared memory, independent of how host↔device transport is implemented. |
 | Host collector | `src/{a2a3,a5}/platform/{include/host,shared/host}/dep_gen_collector.{h,cpp}` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector. On a5 (no SVM) it uses the base `alloc_paired_buffer`, which malloc's a host shadow + `copy_to_device`'s it and registers it via `add_malloc_shadow` so teardown can free it; `reconcile_counters` explicitly `copy_from_device`'s the BufferState before reading, and `finalize` lets `BufferPoolManager::clear_mappings()` release all shadows as the single source of truth. |
 | Capture call site | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. **a2a3 only:** the schema additionally carries `kernel_id[3] = {aic, aiv0, aiv1}` so the swimlane post-processor can resolve `task_id → kernel` from `deps.json` at level=1 where the AICore record is the sole device-side identity source. Inactive subslots stay at `INVALID_KERNEL_ID = -1`. |

--- a/src/a2a3/platform/include/common/dep_gen.h
+++ b/src/a2a3/platform/include/common/dep_gen.h
@@ -93,11 +93,11 @@ enum DepGenRecordFlags : uint32_t {
  * Layout:
  *   - task_id, flags, counts, explicit_deps, arg_types, kernel_id in the first
  *     cache lines
- *   - tensors[] (16 × 128 B opaque blobs) at the tail; covers ~64% of the entry
+ *   - tensors[] (32 × 128 B opaque blobs) at the tail; covers ~88% of the entry
  *
- * Total size: 8 + 4 + 4 + 64*8 + 16 + 12 (kernel_id) + 20 (pad) + 16*128
- *           = 2624 bytes.
- * Aligned to 64 B → 2624 B (already a multiple of 64). kernel_id + _pad0
+ * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (pad) + 32*128
+ *           = 4672 bytes.
+ * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + _pad0
  * together pad tensors[] up to offset 576 = 9 * 64 so each 128-byte tensor
  * blob covers exactly two cache lines instead of straddling three.
  */
@@ -109,11 +109,11 @@ struct DepGenRecord {
     uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // PTO2TaskId::raw, length = explicit_dep_count
     uint8_t arg_types[CORE_MAX_TENSOR_ARGS];            // TensorArgType, length = tensor_count
     int32_t kernel_id[3];  // per-subslot kernel id (AIC, AIV0, AIV1); INVALID_KERNEL_ID = -1
-    uint8_t _pad0[20];     // align tensors[] to 64 B (offset 576)
+    uint8_t _pad0[4];      // align tensors[] to 64 B (offset 576)
     uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(DepGenRecord) == 2624, "DepGenRecord size changed — update header comment + docs/dfx/dep_gen.md");
+static_assert(sizeof(DepGenRecord) == 4672, "DepGenRecord size changed — update header comment + docs/dfx/dep_gen.md");
 static_assert(sizeof(DepGenRecord) % 64 == 0, "DepGenRecord must be cache-line aligned");
 static_assert(offsetof(DepGenRecord, tensors) % 64 == 0, "DepGenRecord::tensors[] must start on a cache-line boundary");
 static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors offset changed — update header comment");
@@ -127,9 +127,9 @@ static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors off
  * DepGenOverflowRecord exactly overlays a DepGenRecord slot in the buffer.
  *
  * Layout: 16-byte header (task_id + flags + dep_count + _reserved) + deps[].
- * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 326 entries.
+ * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 582 entries.
  */
-constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 326;
+constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 582;
 
 /**
  * Reinterpret-view of a DepGenRecord slot when flags & DEP_GEN_FLAG_OVERFLOW.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -97,7 +97,7 @@ static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
 /**
  * Args[] suffix indices for context pointers.
- * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32).
+ * Derived from MAX_TENSOR_ARGS(32) + MAX_SCALAR_ARGS(16).
  * Users should not depend on these values; use the Get* functions below.
  */
 static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 48;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -555,7 +555,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         // `explicit_dep_count` / `over->dep_count` originate from device
         // shared memory and are bounded by the writer to the array sizes, but
         // we clamp on read too so a corrupted record never drives an OOB read
-        // off the end of rec.explicit_deps[64] / over->deps[326].
+        // off the end of rec.explicit_deps[64] / over->deps[582].
         const uint64_t *deps_data;
         int32_t dc;
         if (rec.flags & DEP_GEN_FLAG_HAS_OVERFLOW) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -39,7 +39,7 @@
 #include "intrinsic.h"
 #include "pto_types.h"
 
-/** Max dispatch arguments: 32 scalars + up to 16 tensor pointers + ext params */
+/** Max dispatch arguments: 16 scalars + up to 32 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS
 #define PTO2_DISPATCH_MAX_ARGS (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + PTO2_EXT_PARAMS_COUNT)
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -243,14 +243,14 @@ struct PTO2TaskPayload {
     int32_t fanin_spill_start{0};   // Linear start index in fanin spill pool (0 = no spill)
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
-    // === Cache lines 9-40 (2048B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 9-72 (4096B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 41-44 (256B) — scalars ===
+    // === Cache lines 73-74 (128B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
-    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 256, "scalar region must be 256B (4 cache lines)");
+    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
 
     /**
      * Initialize payload: copy tensors, store scalars.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -335,15 +335,15 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
         if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         (add_scalar_one(std::forward<Args>(args)), ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
-        if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -361,8 +361,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
     void add_scalars_i32(const int32_t *values, int count) {
-        if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -395,12 +395,12 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      * Useful when multiple tasks share the same scalar data (e.g., block indices).
      */
     void copy_scalars_from(const Arg &src, int src_offset, int count) {
-        if (src_offset + count > src.scalar_count_) {
+        if (count < 0 || src_offset + count > src.scalar_count_) {
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;
         }
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));

--- a/src/a5/platform/include/common/dep_gen.h
+++ b/src/a5/platform/include/common/dep_gen.h
@@ -93,11 +93,11 @@ enum DepGenRecordFlags : uint32_t {
  * Layout:
  *   - task_id, flags, counts, explicit_deps, arg_types, kernel_id in the first
  *     cache lines
- *   - tensors[] (16 × 128 B opaque blobs) at the tail; covers ~64% of the entry
+ *   - tensors[] (32 × 128 B opaque blobs) at the tail; covers ~88% of the entry
  *
- * Total size: 8 + 4 + 4 + 64*8 + 16 + 12 (kernel_id) + 20 (pad) + 16*128
- *           = 2624 bytes.
- * Aligned to 64 B → 2624 B (already a multiple of 64). kernel_id + _pad0
+ * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (pad) + 32*128
+ *           = 4672 bytes.
+ * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + _pad0
  * together pad tensors[] up to offset 576 = 9 * 64 so each 128-byte tensor
  * blob covers exactly two cache lines instead of straddling three.
  */
@@ -109,11 +109,11 @@ struct DepGenRecord {
     uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // PTO2TaskId::raw, length = explicit_dep_count
     uint8_t arg_types[CORE_MAX_TENSOR_ARGS];            // TensorArgType, length = tensor_count
     int32_t kernel_id[3];  // per-subslot kernel id (AIC, AIV0, AIV1); INVALID_KERNEL_ID = -1
-    uint8_t _pad0[20];     // align tensors[] to 64 B (offset 576)
+    uint8_t _pad0[4];      // align tensors[] to 64 B (offset 576)
     uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
 } __attribute__((aligned(64)));
 
-static_assert(sizeof(DepGenRecord) == 2624, "DepGenRecord size changed — update header comment + docs/dfx/dep_gen.md");
+static_assert(sizeof(DepGenRecord) == 4672, "DepGenRecord size changed — update header comment + docs/dfx/dep_gen.md");
 static_assert(sizeof(DepGenRecord) % 64 == 0, "DepGenRecord must be cache-line aligned");
 static_assert(offsetof(DepGenRecord, tensors) % 64 == 0, "DepGenRecord::tensors[] must start on a cache-line boundary");
 static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors offset changed — update header comment");
@@ -127,9 +127,9 @@ static_assert(offsetof(DepGenRecord, tensors) == 576, "DepGenRecord::tensors off
  * DepGenOverflowRecord exactly overlays a DepGenRecord slot in the buffer.
  *
  * Layout: 16-byte header (task_id + flags + dep_count + _reserved) + deps[].
- * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 326 entries.
+ * deps[] occupies (sizeof(DepGenRecord) - 16) / sizeof(uint64_t) = 582 entries.
  */
-constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 326;
+constexpr int DEP_GEN_OVERFLOW_DEPS_PER_RECORD = 582;
 
 /**
  * Reinterpret-view of a DepGenRecord slot when flags & DEP_GEN_FLAG_OVERFLOW.

--- a/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/common/intrinsic.h
@@ -97,7 +97,7 @@ static constexpr int32_t PTO2_EXT_PARAMS_COUNT = 2;
 
 /**
  * Args[] suffix indices for context pointers.
- * Derived from MAX_TENSOR_ARGS(16) + MAX_SCALAR_ARGS(32).
+ * Derived from MAX_TENSOR_ARGS(32) + MAX_SCALAR_ARGS(16).
  * Users should not depend on these values; use the Get* functions below.
  */
 static constexpr int32_t SPMD_LOCAL_CONTEXT_INDEX = 48;

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -555,7 +555,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         // `explicit_dep_count` / `over->dep_count` originate from device
         // shared memory and are bounded by the writer to the array sizes, but
         // we clamp on read too so a corrupted record never drives an OOB read
-        // off the end of rec.explicit_deps[64] / over->deps[326].
+        // off the end of rec.explicit_deps[64] / over->deps[582].
         const uint64_t *deps_data;
         int32_t dc;
         if (rec.flags & DEP_GEN_FLAG_HAS_OVERFLOW) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -39,7 +39,7 @@
 #include "intrinsic.h"
 #include "pto_types.h"
 
-/** Max dispatch arguments: 32 scalars + up to 16 tensor pointers + ext params */
+/** Max dispatch arguments: 16 scalars + up to 32 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS
 #define PTO2_DISPATCH_MAX_ARGS (MAX_TENSOR_ARGS + MAX_SCALAR_ARGS + PTO2_EXT_PARAMS_COUNT)
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -243,14 +243,14 @@ struct PTO2TaskPayload {
     int32_t fanin_spill_start{0};   // Linear start index in fanin spill pool (0 = no spill)
     PTO2FaninPool *fanin_spill_pool{nullptr};
     PTO2TaskSlotState *fanin_inline_slot_states[PTO2_FANIN_INLINE_CAP];
-    // === Cache lines 9-40 (2048B) — tensors (alignas(64) forces alignment) ===
+    // === Cache lines 9-72 (4096B) — tensors (alignas(64) forces alignment) ===
     Tensor tensors[MAX_TENSOR_ARGS];
-    // === Cache lines 41-44 (256B) — scalars ===
+    // === Cache lines 73-74 (128B) — scalars ===
     uint64_t scalars[MAX_SCALAR_ARGS];
 
     // Layout verification (size checks that don't need offsetof).
     static_assert(sizeof(Tensor) == 128, "Tensor must be 2 cache lines");
-    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 256, "scalar region must be 256B (4 cache lines)");
+    static_assert(MAX_SCALAR_ARGS * sizeof(uint64_t) == 128, "scalar region must be 128B (2 cache lines)");
 
     /**
      * Initialize payload: copy tensors, store scalars.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -333,15 +333,15 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
         if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         (add_scalar_one(std::forward<Args>(args)), ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
-        if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -359,8 +359,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
     void add_scalars_i32(const int32_t *values, int count) {
-        if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -393,12 +393,12 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      * Useful when multiple tasks share the same scalar data (e.g., block indices).
      */
     void copy_scalars_from(const Arg &src, int src_offset, int count) {
-        if (src_offset + count > src.scalar_count_) {
+        if (count < 0 || src_offset + count > src.scalar_count_) {
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;
         }
         if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
+            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -26,13 +26,13 @@ enum class ArgDirection : int32_t {
     INOUT = 3,
 };
 
-inline constexpr int CORE_MAX_TENSOR_ARGS = 16;
+inline constexpr int CORE_MAX_TENSOR_ARGS = 32;
 // Chip-level entry-tensor cap. Sizes ChipCallable::signature_[] and
 // ChipStorageTaskArgs::tensors_[], both of which cross the host->device wire
 // as fixed POD — raising this is an additive ABI change (existing callers
 // still fit; transient storage grows by 64 * sizeof(ContinuousTensor)).
 inline constexpr int CHIP_MAX_TENSOR_ARGS = 128;
-inline constexpr int CORE_MAX_SCALAR_ARGS = 32;
+inline constexpr int CORE_MAX_SCALAR_ARGS = 16;
 inline constexpr int CHIP_MAX_SCALAR_ARGS = 128;
 inline constexpr uint32_t CALLABLE_ALIGN = 64;
 


### PR DESCRIPTION
## Summary

Double the per-core kernel **tensor-arg** capacity (16 → 32). The most
tensor-hungry in-tree kernel (`spmd_paged_attention_highperf`) already uses
**15** in-core tensors — only one slot of headroom under the old cap.

To keep this cost-free on the dispatch hot path, lower
`CORE_MAX_SCALAR_ARGS` 32 → 16 so the **tensor + scalar sum stays 48**.
That keeps `PTO2DispatchPayload` at **512 B** and the SPMD context indices
at **48/49**, so per-dispatch latency is unchanged. Repo-wide max in-core
scalar usage is **8** (`spmd_paged_attention`), well under the new 16 cap.

### Changes
- `arg_direction.h`: `CORE_MAX_TENSOR_ARGS` 16→32, `CORE_MAX_SCALAR_ARGS` 32→16
- `DepGenRecord` (tensor-driven): size 2624→4672, `_pad0` 20→4,
  `DEP_GEN_OVERFLOW_DEPS_PER_RECORD` 326→582; `docs/dfx/dep_gen.md` updated
- `PTO2TaskPayload`: tensors region 2048→4096 B, scalar-region guard
  256→128 B; stale cache-line layout comments corrected
- `pto_types.h`: scalar-limit error strings 32→16
- `intrinsic.h` / `pto2_dispatch_payload.h`: comment-only (SPMD indices and
  payload size return to their original 48/49 and 512 B since the sum is 48)

### Cost note
The `PTO2TaskPayload` tensor region doubles (cold-path, per task slot:
+1920 B net). This is the only real footprint cost and is driven purely by
the tensor cap, independent of the scalar rebalance.

## Testing
- [x] a2a3 + a5 build (all static_asserts pass)
- [x] Simulation tests pass (`vector_example`, `scalar_data`)
- [x] Hardware A/B (a2a3, NPU 10, interleaved, spmd excluded): perf-neutral.
      On `qwen3_14b_decode` Device +0.3% (within noise); micro-kernels show
      ≤ ~3% on the smallest dispatch-bound case only.