### PR TITLE
perf(l3): remove useless exchange buffer from ring allreduce kernel

### DIFF
--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -19,9 +19,14 @@
  * input / output are per-rank host tensors passed through TaskArgs (the
  * runtime handles the H2D / D2H).  scratch is the HCCL-window buffer:
  *   [0 .. P*chunk)           P chunk slots owned by this rank
- *   [P*chunk .. (P+1)*chunk) single-chunk exchange publish area
- *   tail                     2*(P-1)*kMaxSupportedRanks int32 barrier slots
- *                            (one row per round; fresh-window zero init)
+ *   tail                     2*(P-1)*nranks int32 barrier slots (compact layout)
+ *                            (zero-initialized at kernel entry)
+ *
+ * After each per-round barrier, peers read directly from each other's
+ * chunks[] slots via CommRemotePtr — no separate exchange publish buffer.
+ * The ``pipe_barrier(PIPE_ALL)`` at the end of each RS/AG step body drains
+ * MTE pipes before ``RoundBarrier`` fires ``TNOTIFY`` (hand-written
+ * equivalent of PTOAS v0.45's automatic ``emitTNotifyMteDrain``).
  *
  * args layout (passed as ContinuousTensor arg slots — see allreduce_ring_orch.cpp):
  *   tensor(0) = input    (host-backed, framework-supplied device addr)
@@ -57,8 +62,10 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPt
 }
 
 // Per-round barrier row: used exactly once (AtomicAdd 0→1, TWAIT GE 1).
-// No explicit reset — matches mesh allreduce_kernel.cpp; zeroing races peer notify.
-AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
+// Caller drains MTE pipes before invoking this so that prior TSTORE/TLOAD
+// work is visible before TNOTIFY lands on the peer (PTOAS v0.45 equivalent).
+AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row,
+                                 int my_rank, int nranks) {
     for (int peer = 0; peer < nranks; ++peer) {
         if (peer == my_rank) {
             continue;
@@ -75,6 +82,21 @@ AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_
         pto::comm::TWAIT(sig, (int32_t)1, pto::comm::WaitCmp::GE);
     }
     pipe_barrier(PIPE_ALL);
+}
+
+// Stage-in / stage-out helper: copy one chunk-sized segment using MTE2↔MTE3.
+template <typename ShapeDyn, typename StrideDyn, typename Global, typename TileData>
+AICORE inline void CopyChunk(__gm__ float *dst, __gm__ float *src,
+                              TileData &tile,
+                              const ShapeDyn &chunkShape, const StrideDyn &chunkStride) {
+    Global srcG(src, chunkShape, chunkStride);
+    Global dstG(dst, chunkShape, chunkStride);
+    TLOAD(tile, srcG);
+    set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+    TSTORE(dstG, tile);
+    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
 }
 
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
@@ -103,10 +125,10 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     const int chunk_elems = static_cast<int>(ALLREDUCE_COUNT / static_cast<size_t>(nranks));
     __gm__ float *chunks = scratch;
-    __gm__ float *exchange = scratch + static_cast<size_t>(nranks * chunk_elems);
-    // Signal rows after float region: one row per RS/AG round (2*(P-1) rounds total).
+    // Signal rows after float region: total_rounds × nranks int32s (compact).
+    const int total_rounds = 2 * (nranks - 1);
     __gm__ int32_t *signal_base =
-        reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>((nranks + 1) * chunk_elems));
+        reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>(nranks * chunk_elems));
 
     TileData chunkTile(1, chunk_elems);
     TileData recvTile(1, chunk_elems);
@@ -116,6 +138,15 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
     StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
 
+    // Explicitly zero-initialize local signal slots — device memory is not
+    // guaranteed to be zero-initialized and stale values cause spurious TWAIT.
+    for (int r = 0; r < total_rounds; ++r) {
+        for (int peer = 0; peer < nranks; ++peer) {
+            signal_base[r * nranks + peer] = 0;
+        }
+    }
+    pipe_barrier(PIPE_ALL);
+
     // ------------------------------------------------------------------
     // Phase 1: stage-in — partition local input into P chunk slots in the
     // HCCL window so peers can TLOAD them in later ring steps.
@@ -123,14 +154,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (int chunk = 0; chunk < nranks; ++chunk) {
         __gm__ float *dst = chunks + static_cast<size_t>(chunk * chunk_elems);
         __gm__ float *src = input + static_cast<size_t>(chunk * chunk_elems);
-        Global srcG(src, chunkShape, chunkStride);
-        Global dstG(dst, chunkShape, chunkStride);
-        TLOAD(chunkTile, srcG);
-        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        TSTORE(dstG, chunkTile);
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        CopyChunk<ShapeDyn, StrideDyn, Global, TileData>(dst, src, chunkTile, chunkShape, chunkStride);
     }
     pipe_barrier(PIPE_ALL);
 
@@ -138,27 +162,12 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     // ------------------------------------------------------------------
     // Phase 2: reduce-scatter — (P-1) ring steps; rank r ends with fully
-    // reduced chunk r.  Publish to exchange, barrier, TLOAD left neighbour's
-    // chunks[] slot (not the local exchange mirror).
+    // reduced chunk r.  Barrier, then TLOAD left neighbour's chunks[] slot.
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
-        const int send_idx = (my_rank - step + nranks) % nranks;
         const int recv_add_idx = (my_rank - step - 1 + nranks) % nranks;
 
-        {
-            __gm__ float *src = chunks + static_cast<size_t>(send_idx * chunk_elems);
-            Global srcG(src, chunkShape, chunkStride);
-            Global dstG(exchange, chunkShape, chunkStride);
-            TLOAD(chunkTile, srcG);
-            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-            TSTORE(dstG, chunkTile);
-            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        }
-        pipe_barrier(PIPE_ALL);
-
-        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
+        RoundBarrier(commCtx, signal_base + round * nranks, my_rank, nranks);
         ++round;
 
         const int left = (my_rank - 1 + nranks) % nranks;
@@ -167,19 +176,24 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
             __gm__ float *remote_chunk =
                 CommRemotePtr(commCtx, chunks + static_cast<size_t>(left_send_idx * chunk_elems), left);
             Global remoteG(remote_chunk, chunkShape, chunkStride);
+            // Issue remote and local TLOADs back-to-back to overlap latency:
+            // both target different tiles (recvTile vs chunkTile).
             TLOAD(recvTile, remoteG);
             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
+            TLOAD(chunkTile, accG);
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         }
 
-        Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
-        TLOAD(chunkTile, accG);
-        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
-        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         TADD(chunkTile, chunkTile, recvTile);
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        TSTORE(accG, chunkTile);
+        {
+            Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
+            TSTORE(accG, chunkTile);
+        }
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         pipe_barrier(PIPE_ALL);
@@ -190,23 +204,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     // reduced chunks from left neighbour chunks[] after each barrier.
     // ------------------------------------------------------------------
     for (int step = 1; step < nranks; ++step) {
-        const int send_idx = (my_rank - step + 1 + nranks) % nranks;
         const int recv_idx = (my_rank - step + nranks) % nranks;
 
-        {
-            __gm__ float *src = chunks + static_cast<size_t>(send_idx * chunk_elems);
-            Global srcG(src, chunkShape, chunkStride);
-            Global dstG(exchange, chunkShape, chunkStride);
-            TLOAD(chunkTile, srcG);
-            set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-            TSTORE(dstG, chunkTile);
-            set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-            wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        }
-        pipe_barrier(PIPE_ALL);
-
-        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
+        RoundBarrier(commCtx, signal_base + round * nranks, my_rank, nranks);
         ++round;
 
         const int left = (my_rank - 1 + nranks) % nranks;
@@ -235,14 +235,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (int chunk = 0; chunk < nranks; ++chunk) {
         __gm__ float *dst = output + static_cast<size_t>(chunk * chunk_elems);
         __gm__ float *src = chunks + static_cast<size_t>(chunk * chunk_elems);
-        Global srcG(src, chunkShape, chunkStride);
-        Global dstG(dst, chunkShape, chunkStride);
-        TLOAD(chunkTile, srcG);
-        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        TSTORE(dstG, chunkTile);
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        CopyChunk<ShapeDyn, StrideDyn, Global, TileData>(dst, src, chunkTile, chunkShape, chunkStride);
     }
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -176,24 +176,19 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
             __gm__ float *remote_chunk =
                 CommRemotePtr(commCtx, chunks + static_cast<size_t>(left_send_idx * chunk_elems), left);
             Global remoteG(remote_chunk, chunkShape, chunkStride);
-            // Issue remote and local TLOADs back-to-back to overlap latency:
-            // both target different tiles (recvTile vs chunkTile).
             TLOAD(recvTile, remoteG);
             set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
-            TLOAD(chunkTile, accG);
-            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
             wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         }
 
+        Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
+        TLOAD(chunkTile, accG);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID1);
         TADD(chunkTile, chunkTile, recvTile);
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-        {
-            Global accG(chunks + static_cast<size_t>(recv_add_idx * chunk_elems), chunkShape, chunkStride);
-            TSTORE(accG, chunkTile);
-        }
+        TSTORE(accG, chunkTile);
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         pipe_barrier(PIPE_ALL);

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -65,8 +65,7 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPt
 // Relies on fresh-window zero-init (runtime guarantee) — no explicit reset.
 // Caller drains MTE pipes before invoking this so that prior TSTORE/TLOAD
 // work is visible before TNOTIFY lands on the peer (PTOAS v0.45 equivalent).
-AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row,
-                                 int my_rank, int nranks) {
+AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row, int my_rank, int nranks) {
     for (int peer = 0; peer < nranks; ++peer) {
         if (peer == my_rank) {
             continue;

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -20,7 +20,7 @@
  * runtime handles the H2D / D2H).  scratch is the HCCL-window buffer:
  *   [0 .. P*chunk)           P chunk slots owned by this rank
  *   tail                     2*(P-1)*nranks int32 barrier slots (compact layout)
- *                            (zero-initialized at kernel entry)
+ *                            (fresh-window zero init — runtime guarantee)
  *
  * After each per-round barrier, peers read directly from each other's
  * chunks[] slots via CommRemotePtr — no separate exchange publish buffer.
@@ -62,6 +62,7 @@ AICORE inline __gm__ T *CommRemotePtr(__gm__ CommContext *ctx, __gm__ T *localPt
 }
 
 // Per-round barrier row: used exactly once (AtomicAdd 0→1, TWAIT GE 1).
+// Relies on fresh-window zero-init (runtime guarantee) — no explicit reset.
 // Caller drains MTE pipes before invoking this so that prior TSTORE/TLOAD
 // work is visible before TNOTIFY lands on the peer (PTOAS v0.45 equivalent).
 AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_row,
@@ -137,15 +138,6 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     ShapeDyn chunkShape(1, 1, 1, 1, chunk_elems);
     StrideDyn chunkStride(chunk_elems, chunk_elems, chunk_elems, chunk_elems, 1);
-
-    // Explicitly zero-initialize local signal slots — device memory is not
-    // guaranteed to be zero-initialized and stale values cause spurious TWAIT.
-    for (int r = 0; r < total_rounds; ++r) {
-        for (int peer = 0; peer < nranks; ++peer) {
-            signal_base[r * nranks + peer] = 0;
-        }
-    }
-    pipe_barrier(PIPE_ALL);
 
     // ------------------------------------------------------------------
     // Phase 1: stage-in — partition local input into P chunk slots in the

--- a/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
+++ b/examples/workers/l3/allreduce_ring_distributed/kernels/aiv/allreduce_ring_kernel.cpp
@@ -19,8 +19,8 @@
  * input / output are per-rank host tensors passed through TaskArgs (the
  * runtime handles the H2D / D2H).  scratch is the HCCL-window buffer:
  *   [0 .. P*chunk)           P chunk slots owned by this rank
- *   tail                     2*(P-1)*nranks int32 barrier slots (compact layout)
- *                            (fresh-window zero init — runtime guarantee)
+ *   tail                     2*(P-1)*kMaxSupportedRanks int32 barrier slots
+ *                            (fresh-window zero init)
  *
  * After each per-round barrier, peers read directly from each other's
  * chunks[] slots via CommRemotePtr — no separate exchange publish buffer.
@@ -85,21 +85,6 @@ AICORE inline void RoundBarrier(__gm__ CommContext *ctx, __gm__ int32_t *signal_
     pipe_barrier(PIPE_ALL);
 }
 
-// Stage-in / stage-out helper: copy one chunk-sized segment using MTE2↔MTE3.
-template <typename ShapeDyn, typename StrideDyn, typename Global, typename TileData>
-AICORE inline void CopyChunk(__gm__ float *dst, __gm__ float *src,
-                              TileData &tile,
-                              const ShapeDyn &chunkShape, const StrideDyn &chunkStride) {
-    Global srcG(src, chunkShape, chunkStride);
-    Global dstG(dst, chunkShape, chunkStride);
-    TLOAD(tile, srcG);
-    set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-    wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-    TSTORE(dstG, tile);
-    set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-    wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-}
-
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
     __gm__ Tensor *input_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
     __gm__ Tensor *output_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
@@ -126,8 +111,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     const int chunk_elems = static_cast<int>(ALLREDUCE_COUNT / static_cast<size_t>(nranks));
     __gm__ float *chunks = scratch;
-    // Signal rows after float region: total_rounds × nranks int32s (compact).
-    const int total_rounds = 2 * (nranks - 1);
+    // Signal rows after float region: 2*(P-1) rounds, kMaxSupportedRanks stride.
     __gm__ int32_t *signal_base =
         reinterpret_cast<__gm__ int32_t *>(scratch + static_cast<size_t>(nranks * chunk_elems));
 
@@ -146,7 +130,14 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (int chunk = 0; chunk < nranks; ++chunk) {
         __gm__ float *dst = chunks + static_cast<size_t>(chunk * chunk_elems);
         __gm__ float *src = input + static_cast<size_t>(chunk * chunk_elems);
-        CopyChunk<ShapeDyn, StrideDyn, Global, TileData>(dst, src, chunkTile, chunkShape, chunkStride);
+        Global srcG(src, chunkShape, chunkStride);
+        Global dstG(dst, chunkShape, chunkStride);
+        TLOAD(chunkTile, srcG);
+        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, chunkTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
     }
     pipe_barrier(PIPE_ALL);
 
@@ -159,7 +150,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (int step = 1; step < nranks; ++step) {
         const int recv_add_idx = (my_rank - step - 1 + nranks) % nranks;
 
-        RoundBarrier(commCtx, signal_base + round * nranks, my_rank, nranks);
+        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
         ++round;
 
         const int left = (my_rank - 1 + nranks) % nranks;
@@ -193,7 +184,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (int step = 1; step < nranks; ++step) {
         const int recv_idx = (my_rank - step + nranks) % nranks;
 
-        RoundBarrier(commCtx, signal_base + round * nranks, my_rank, nranks);
+        RoundBarrier(commCtx, signal_base + round * kMaxSupportedRanks, my_rank, nranks);
         ++round;
 
         const int left = (my_rank - 1 + nranks) % nranks;
@@ -222,7 +213,14 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     for (int chunk = 0; chunk < nranks; ++chunk) {
         __gm__ float *dst = output + static_cast<size_t>(chunk * chunk_elems);
         __gm__ float *src = chunks + static_cast<size_t>(chunk * chunk_elems);
-        CopyChunk<ShapeDyn, StrideDyn, Global, TileData>(dst, src, chunkTile, chunkShape, chunkStride);
+        Global srcG(src, chunkShape, chunkStride);
+        Global dstG(dst, chunkShape, chunkStride);
+        TLOAD(chunkTile, srcG);
+        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+        TSTORE(dstG, chunkTile);
+        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
     }
     pipe_barrier(PIPE_ALL);
 }

--- a/examples/workers/l3/allreduce_ring_distributed/main.py
+++ b/examples/workers/l3/allreduce_ring_distributed/main.py
@@ -28,6 +28,11 @@ Compared to mesh ``allreduce_distributed/`` (O(P) full-vector remote reads per
 rank), ring moves one chunk per round.  P=4 is the primary schedule width;
 P=2 is supported for regression.
 
+Scratch layout: P equal chunk slots followed by a compact 2(P-1)×P int32
+signal matrix (per-round notify/wait barriers).  Peers read directly from
+each other's chunk slots via CommRemotePtr — no separate exchange buffer.
+Signal slots are zero-initialized at kernel entry.
+
 Run:
     python examples/workers/l3/allreduce_ring_distributed/main.py -p a2a3sim -d 0-3
 
@@ -73,19 +78,19 @@ ALLREDUCE_COUNT = 256
 DTYPE_NBYTES = 4  # float32
 K_MAX_SUPPORTED_RANKS = 16
 CHUNK_MAX = ALLREDUCE_COUNT // 2  # largest chunk (P=2)
-# Float region: (nranks+1)*chunk at runtime; SCRATCH_NBYTES sized for max chunk.
-SCRATCH_FLOAT_ELEMS_MAX = (K_MAX_SUPPORTED_RANKS + 1) * CHUNK_MAX
+# Float region: P*chunk at runtime; SCRATCH_NBYTES sized for max chunk (no exchange).
+SCRATCH_FLOAT_ELEMS_MAX = K_MAX_SUPPORTED_RANKS * CHUNK_MAX
 # Signal tail: one int32 row per RS/AG round (2*(P-1) rounds), bounded by kMaxSupportedRanks.
 SIGNAL_TAIL_NBYTES = 2 * (K_MAX_SUPPORTED_RANKS - 1) * K_MAX_SUPPORTED_RANKS * DTYPE_NBYTES
 SCRATCH_NBYTES = SCRATCH_FLOAT_ELEMS_MAX * DTYPE_NBYTES + SIGNAL_TAIL_NBYTES
 
 
 def scratch_float_elems(nranks: int) -> int:
-    """Float slots in the HCCL window for this rank count: P chunk slots + 1 exchange."""
+    """Float slots in the HCCL window for this rank count: P equal chunk slots."""
     if ALLREDUCE_COUNT % nranks != 0:
         raise ValueError(f"ALLREDUCE_COUNT={ALLREDUCE_COUNT} must divide nranks={nranks}")
     chunk = ALLREDUCE_COUNT // nranks
-    return (nranks + 1) * chunk
+    return nranks * chunk
 
 
 def parse_device_range(spec: str) -> list[int]:

--- a/examples/workers/l3/allreduce_ring_distributed/main.py
+++ b/examples/workers/l3/allreduce_ring_distributed/main.py
@@ -28,10 +28,9 @@ Compared to mesh ``allreduce_distributed/`` (O(P) full-vector remote reads per
 rank), ring moves one chunk per round.  P=4 is the primary schedule width;
 P=2 is supported for regression.
 
-Scratch layout: P equal chunk slots followed by a compact 2(P-1)×P int32
-signal matrix (per-round notify/wait barriers).  Peers read directly from
+Scratch layout: P equal chunk slots followed by a 2(P-1)×kMax signal
+matrix (per-round notify/wait barriers).  Peers read directly from
 each other's chunk slots via CommRemotePtr — no separate exchange buffer.
-Signal slots rely on fresh-window zero-init (runtime guarantee).
 
 Run:
     python examples/workers/l3/allreduce_ring_distributed/main.py -p a2a3sim -d 0-3

--- a/examples/workers/l3/allreduce_ring_distributed/main.py
+++ b/examples/workers/l3/allreduce_ring_distributed/main.py
@@ -28,7 +28,7 @@ Compared to mesh ``allreduce_distributed/`` (O(P) full-vector remote reads per
 rank), ring moves one chunk per round.  P=4 is the primary schedule width;
 P=2 is supported for regression.
 
-Scratch layout: P equal chunk slots followed by a 2(P-1)×kMax signal
+Scratch layout: P equal chunk slots followed by a 2(P-1) x kMax signal
 matrix (per-round notify/wait barriers).  Peers read directly from
 each other's chunk slots via CommRemotePtr — no separate exchange buffer.
 

--- a/examples/workers/l3/allreduce_ring_distributed/main.py
+++ b/examples/workers/l3/allreduce_ring_distributed/main.py
@@ -31,7 +31,7 @@ P=2 is supported for regression.
 Scratch layout: P equal chunk slots followed by a compact 2(P-1)×P int32
 signal matrix (per-round notify/wait barriers).  Peers read directly from
 each other's chunk slots via CommRemotePtr — no separate exchange buffer.
-Signal slots are zero-initialized at kernel entry.
+Signal slots rely on fresh-window zero-init (runtime guarantee).
 
 Run:
     python examples/workers/l3/allreduce_ring_distributed/main.py -p a2a3sim -d 0-3


### PR DESCRIPTION
## Summary

Remove the never-read `exchange` publish buffer from the ring allreduce AIV kernel. The kernel wrote a send chunk to a local `exchange` slot before each per-round barrier, but peers **always** read directly from each other's `chunks[]` slots via `CommRemotePtr` — the `exchange` was written to but never consumed. Pure dead-code removal; the RS+AG schedule, signal layout, and golden are unchanged.

## What changed

| File | Change |
|------|--------|
| `kernels/aiv/allreduce_ring_kernel.cpp` | Remove `exchange` variable, both RS+AG publish blocks (TLOAD→TSTORE→pipe_barrier), dead `send_idx` computation |
| `main.py` | `scratch_float_elems()`: `(P+1)*chunk` → `P*chunk` (saves 512 B for P=2); update docstring |

## Why

The exchange buffer was an artifact from the original PR #975 design where peers were expected to read from each other's `exchange` slot. That design was changed during review (commit `690efbcf`) — peers read `chunks[]` directly — but the exchange publish code and its memory allocation were never cleaned up.