### PR TITLE
Launch AICore before AICPU Run (a5+a2a3): first-launch latency + op-timeout defense

### DIFF
--- a/docs/hardware/chip-architecture.md
+++ b/docs/hardware/chip-architecture.md
@@ -54,6 +54,21 @@ A chip may comprise one or more dies, and may present to the host as
 one or more device IDs (the die ↔ device-id mapping is chip-specific —
 see `src/{a2a3,a5}/docs/`).
 
+**GM is "shared" only within one `device_id`** — shared across that device's
+AICPU and AICore tiers. It is **exclusive per `device_id`**, never shared across
+device IDs. The die↔device mapping differs by arch but does not change this:
+
+- **a5**: one `device_id` owns the chip's dies/clusters, managed as one unit by
+  the AICPU; one orch runs per `device_id` (an invariant). There is no
+  "two-die concurrency" inside a device.
+- **a2a3**: a card presents two `device_id`s; they are independent.
+
+So multiple device IDs (e.g. pytest xdist `gw0`/`gw1`, or `--device 2-3`) run on
+**independent HBM with no cross-device contention**. A per-device OOM comes from
+that device's own workload, not from an "adjacent die". (The chip-shared
+contention model was removed in PR #990 — see
+`.claude/rules/running-onboard.md`.)
+
 ## Identifying which chip generation you have
 
 CANN ships per-SoC platform configs under

--- a/docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md
+++ b/docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md
@@ -1,0 +1,146 @@
+# PagedAttentionUnrollManualScope intermittent 207001: an op-timeout-window issue fixed by #1035; a5 launch reorder kept as latency + defense-in-depth
+
+**Date**: 2026-06-16
+**Verdict**: #1019 itself is fixed by #1035 (op-execute timeout 1 s → 3 s,
+landed for an unrelated tensor-dump feature) — no code change is *needed* to
+close #1019. Separately, the a5 launch reorder (AICore before the AICPU Run
+task) **is kept** as a first-launch latency optimization (~1.4 s → ~0.4 ms,
+measured) and op-timeout-family defense-in-depth — it removes the slow launch
+that trips the timeout, rather than only widening the window. a2a3 mirrors the
+same reorder to keep the two arches symmetric; it is **unverified on a2a3
+silicon** (a5-only dev box), relying on CI.
+
+## Question
+
+Issue #1019: `TestPagedAttentionUnrollManualScope` on a5 intermittently
+(~30 % on a poisoned device) fails with `207001`, whose CANN string is
+"ACL_ERROR_RT_MEMORY_ALLOCATION / host memory has been exhausted" — which
+reads like HBM OOM. It is filed as "op-timeout family, #1016". The intuition
+that sends you down the wrong path: the error string says memory, and the
+test does paged-attention with sizeable KV buffers, so it looks like a
+sizing/leak/OOM bug.
+
+## What was tried
+
+- **Confirmed not OOM**: an HBM probe showed 122 GB free at the failing
+  launch. `207001` = `RT_ERROR_MODULE_NEW` aliased to
+  `ACL_ERROR_RT_MEMORY_ALLOCATION` with a hardcoded misleading string
+  (`errcode_manage.cc:243`) — a *null module object*, not host OOM.
+- **Same-device A/B on launch order** (host-side submit timing instrumented
+  around `rtKernelLaunchWithHandleV2`): with the AICPU Run task launched
+  before the AICore (the original order), the first AICore submit blocked
+  0.95–11.5 s; launched after, ≤424 µs. On a poisoned device: OLD order
+  5/14 pytests failed, NEW order 0/80 launches. This *looked* like proof the
+  order is the root cause.
+- **CANN runtime source trace** (gitcode `cann/runtime`): chased several
+  candidate mechanisms for the multi-second block — per-device task-id pool
+  back-pressure (`task.cc` `TryAgainAlloc`, 1000×10 ms), lazy device-side
+  module load (`Module::Load` = HBM `DevMemAlloc` + H2D `MemCopySync`). None
+  was confirmed; each failed a sanity check (e.g. a single spinning AICPU
+  task holds one task-id, nowhere near pool exhaustion).
+- **Full st-onboard-a5 suite, 6× on 2 cards** with the OLD-order build:
+  0 reproductions. Single-example loops the same day: ~60–80 launches,
+  0 reproductions. The bug would not reproduce on a healthy device at all.
+- **Bisect** (the step that actually answered it): the branch's merge-base
+  was afb5c5a9 (#1016, op-timeout **1 s**); current upstream is post-#1035
+  (op-timeout **3 s**). On the *current* code, reverting only the #1035
+  timeout values to 1 s/2 s (keeping the OLD launch order) reproduced the
+  op-timeout wedge **on the same clean device** the 3 s build never failed
+  on.
+
+## Result
+
+- OLD launch order makes the **first** AICore launch slow — measured ~1.2–1.6 s
+  median, up to 11.5 s worst case on an already-poisoned device. It is a
+  *latency* effect of submitting the AICore right after the AICPU Run task
+  starts spinning in `handshake_all_cores()`. The slow path is the lazy
+  device-side binary load inside `rtKernelLaunchWithHandleV2`
+  (`Module::Load` = HBM `DevMemAlloc` + H2D `MemCopySync`).
+- **Spin poll-frequency is NOT the cause** (throttle experiment, inconclusive):
+  the handshake spin on `aicore_regs_ready` is a no-op `SPIN_WAIT_HINT()` =
+  a tight GM-hammer loop. Inserting a busy delay between polls gave a
+  non-monotonic, within-noise result — median first-launch submit 1.46 s (no
+  throttle) → 1.10 s (200k-iter delay) → 1.40 s (4M-iter delay), n=8 each with
+  heavily overlapping spreads. If the spin's GM traffic were the cause, more
+  throttle would help monotonically; it didn't. So reducing the poll rate does
+  not reliably change the launch time — the cause is **not** the spin's polling
+  frequency. The actual internal cause of the ~1.4 s OLD-order slow launch
+  remains unpinned (it is not isolable from outside CANN).
+- **What IS robust**: NEW order (AICore launched before the AICPU Run task, so
+  no AICPU is running during the binary load) submits in **~0.4 ms** vs OLD
+  order's **~1.4 s** median — a ~1.4 s first-launch difference, far outside the
+  noise. Whatever the internal cause, having the AICPU Run task already
+  launched is what makes the first AICore launch slow, and the reorder removes
+  it entirely.
+- With op-timeout **1 s** (pre-#1035): that ~1.9 s launch exceeds the
+  threshold → STARS reaps the op → op-timeout cascade. Surfaces as `207001`
+  (null module, when the reap lands during module creation) or `507046`/
+  `507000` (stream-sync timeout) — same family, different reap point.
+  Reproduced **1/15** on a clean device.
+- With op-timeout **3 s** (post-#1035): the same ~1.9 s launch fits inside
+  the window and completes → no cascade. **0/~40** on the same device.
+- #1035 ("tensor dump on the abnormal path", closes #1034) raised
+  `PLATFORM_OP_EXECUTE_TIMEOUT_US` 1 s → 3 s and
+  `PLATFORM_STREAM_SYNC_TIMEOUT_MS` 2 s → 4 s as a side effect of ordering
+  the timeout chain (SCHEDULER 2 s < OP_EXEC 3 s < STREAM_SYNC 4 s). Nobody
+  connected it to #1019.
+- A launch-order reorder (AICore before AICPU Run) removes the slow launch
+  entirely (NEW order submits in ~0.4 ms). It is **kept on a5** — not as the
+  #1019 fix, but as a latency + defense-in-depth measure (below).
+
+## Disposition: #1035 fixes #1019; the a5 reorder is kept on its own merits
+
+**#1019 itself needs no code change** — #1035 already prevents the failure on
+current `main` by widening the op-timeout window past the slow launch. The bug
+is "fixed by #1035; verify and close". Labelling a reorder as *the* #1019 fix
+would overclaim a root cause we never pinned (the ~1.4 s contention) and
+duplicate a fix that already landed; the cascade is additionally *recovered*
+in-process by #1016's force-reset and *contained* by #1005.
+
+**The a5 reorder is nonetheless kept**, justified independently of #1019:
+
+- *Latency*: it removes a robust, large first-launch cost (~1.4 s → ~0.4 ms,
+  measured, far outside noise) on every fresh worker's first AICore launch.
+  Zero functional risk — the handshake is launch-order-independent (NEW order
+  passes the full suite).
+- *Defense-in-depth*: the slow launch is what trips the op-execute timeout.
+  #1035 widened the window; the reorder removes the slow launch itself, so the
+  wedge cannot return if the timeout is later tightened or a slower device
+  pushes the launch past it.
+
+**a2a3 mirrors the same reorder** to keep the two arches symmetric (one launch
+order, not split per-arch). a2a3 has the same Init→`core_type`-publish→Run→AICore
+structure as a5, and the a5 reorder keeps AICore after Init and before Run
+(verified), so the mirror is the same logical change. It is **unverified on
+a2a3 silicon** (a5-only dev box) — relying on CI; the ~1.4 s slow-launch was
+only measured on a5.
+
+## When to reconsider
+
+- If `PLATFORM_OP_EXECUTE_TIMEOUT_US` is ever lowered back toward the slow
+  first-launch latency (~2 s), #1019 returns — the reorder (AICore-first) is
+  then the correct fix, and the ~1.9 s OLD-order first-launch latency is the
+  number to design against.
+- If first-run latency on a5 becomes a measured concern, the AICore-first
+  reorder is a free ~1.9 s win on the first launch (handshake is
+  launch-order-independent), independent of #1019.
+- The still-open part: *why* the OLD-order first launch takes ~1.4 s (it is not
+  the spin poll frequency — throttling didn't help). CANN's per-stage
+  timestamps (`DumpTimeStampPart1`, gated by the `TEMP_PERFORMANCE` build macro
+  — needs a CANN rebuild) on an OLD-order run would show whether it is in
+  `MemCopySync`/`DevMemAlloc` (the binary load) or the task-submit path.
+
+## References
+
+- Issue #1019 (open), #1034 / PR #1035 (the timeout retune), #1016
+  (force-reset recovery), #1005 (cascade containment).
+- `src/a5/platform/include/common/platform_config.h` —
+  `PLATFORM_OP_EXECUTE_TIMEOUT_US`, `PLATFORM_STREAM_SYNC_TIMEOUT_MS`.
+- CANN runtime (gitcode `cann/runtime`): `common/errcode_manage.cc:243`
+  (207001 alias), `launch/aix_stars.cc`, `kernel/module.cc`.
+- Related: [`2026-06-a5-aicore-op-timeout-cascade.md`](2026-06-a5-aicore-op-timeout-cascade.md)
+  (same op-timeout family, recovery side).
+- Rule: [`.claude/rules/discipline.md`](../../.claude/rules/discipline.md)
+  §"bug fixes start with a failing repro" and the rebase-before-testing
+  guidance — testing on the pre-#1035 base is exactly what made this look
+  like an unfixed bug.

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -84,6 +84,7 @@ that ...".
 
 Newest first.
 
+- [2026-06 — PA-unroll 207001: an op-timeout-window issue fixed by #1035, not a launch-order bug](2026-06-pa-unroll-207001-optimeout-window.md)
 - [2026-06 — Cross-task batched publish: hoist wmb across distinct tasks in one pop](2026-06-cross-task-batched-publish.md) — also carries the root cause + fix for the `spmd_sync_start_stress` 507018 drain-barrier hang
 - [2026-06 — AICore first-task cold-start: pre-warm dispatch path](2026-06-aicore-cold-start-warmup.md)
 - [2026-06 — a5 AICore op-timeout poisons the shared L2 worker (cascade)](2026-06-a5-aicore-op-timeout-cascade.md)

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -374,20 +374,36 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
 
+    // Launch the AICore worker BEFORE the AICPU Run task — mirrors the a5 path
+    // so the two arches stay symmetric. First-launch latency optimization +
+    // op-timeout-family defense-in-depth: with the AICPU Run task launched first
+    // it occupies the device (spinning in the handshake), and the first AICore
+    // launch — which lazily loads the kernel binary onto the device inside
+    // rtKernelLaunchWithHandleV2 — is slow; launching AICore first does that load
+    // on an idle device. The handshake is launch-order-independent. The ~1.4 s
+    // slow-launch / 207001 wedge was measured on a5; this mirror is UNVERIFIED on
+    // a2a3 silicon (the dev box is a5-only), relying on CI. See
+    // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
+    LOG_INFO_V0("=== launch_aicore_kernel ===");
+    // Launch AICore kernel (pass device copy of KernelArgs)
+    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
+    if (rc != 0) {
+        LOG_ERROR("launch_aicore_kernel failed: %d", rc);
+        recover_device_or_mark_unusable(rc);
+        return rc;
+    }
+
     LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
     rc = launch_aicpu_kernel(
         stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
     );
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
-        return rc;
-    }
-
-    LOG_INFO_V0("=== launch_aicore_kernel ===");
-    // Launch AICore kernel (pass device copy of KernelArgs)
-    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
-    if (rc != 0) {
-        LOG_ERROR("launch_aicore_kernel failed: %d", rc);
+        // The AICore worker was already launched above and is now spinning in
+        // the handshake waiting for this AICPU Run task. If the Run launch
+        // fails, that AICore is orphaned and will spin to the op-timeout,
+        // poisoning the device — so recover/mark-unusable here (matches the
+        // launch_aicore failure path).
         recover_device_or_mark_unusable(rc);
         return rc;
     }

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -345,6 +345,35 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
 
+    // Launch the AICore worker BEFORE the AICPU Run task. This is a first-launch
+    // latency optimization, not a correctness requirement (the handshake is
+    // launch-order-independent). When the AICPU Run task is launched first it
+    // immediately occupies the device (spinning in handshake_all_cores), and the
+    // first AICore launch — which lazily loads the kernel binary onto the device
+    // inside rtKernelLaunchWithHandleV2 — then takes ~1.4 s instead of ~0.4 ms
+    // (measured a5; the exact device-side contention is not pinned, see the
+    // investigation doc). Submitting the AICore first does that load on an idle
+    // device, then the AICPU spins and finds the AICore already up.
+    //
+    // Defense-in-depth for the op-timeout family (#1019): that ~1.4 s slow launch
+    // is what trips the op-execute timeout when it is tight. #1035 widened the
+    // timeout 1 s -> 3 s so the slow launch no longer wedges, but this ordering
+    // removes the slow launch itself, so the wedge cannot return if the timeout
+    // is ever tightened or a slower device pushes the launch past it. See
+    // docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md.
+    LOG_INFO_V0("=== launch_aicore_kernel ===");
+    rc = kernel_args_.init_device_kernel_args(mem_alloc_);
+    if (rc != 0) {
+        LOG_ERROR("init_device_kernel_args failed: %d", rc);
+        return rc;
+    }
+    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
+    if (rc != 0) {
+        LOG_ERROR("launch_aicore_kernel failed: %d", rc);
+        recover_device_or_mark_unusable(rc);
+        return rc;
+    }
+
     LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
     // launch_count = popcount(OCCUPY) from the topology probe — one thread
     // per user-schedulable cpu_id. The filter gate barriers exactly this
@@ -357,18 +386,11 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
-        return rc;
-    }
-
-    LOG_INFO_V0("=== launch_aicore_kernel ===");
-    rc = kernel_args_.init_device_kernel_args(mem_alloc_);
-    if (rc != 0) {
-        LOG_ERROR("init_device_kernel_args failed: %d", rc);
-        return rc;
-    }
-    rc = launch_aicore_kernel(stream_aicore_, kernel_args_.device_k_args_);
-    if (rc != 0) {
-        LOG_ERROR("launch_aicore_kernel failed: %d", rc);
+        // The AICore worker was already launched above and is now spinning in
+        // the handshake waiting for this AICPU Run task. If the Run launch
+        // fails, that AICore is orphaned and will spin to the op-timeout,
+        // poisoning the device — so recover/mark-unusable here (matches the
+        // launch_aicore failure path).
         recover_device_or_mark_unusable(rc);
         return rc;
     }

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -374,7 +374,7 @@ add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
 add_a2a3_runtime_test(test_spsc_queue       a2a3/test_spsc_queue.cpp)
 add_a2a3_runtime_test(test_wiring           a2a3/test_wiring.cpp)
 add_a2a3_runtime_test(test_aicore_completion_mailbox a2a3/test_aicore_completion_mailbox.cpp)
-add_a2a3_runtime_test(test_scope_stats_collector a2a3/test_scope_stats_collector.cpp)
+add_a2a3_runtime_test(test_a2a3_scope_stats_collector a2a3/test_scope_stats_collector.cpp)
 
 # ---------------------------------------------------------------------------
 # A5 tests (src/a5/runtime/tensormap_and_ringbuffer/)


### PR DESCRIPTION
## Summary

`#1019` (`TestPagedAttentionUnrollManualScope` intermittent `207001`) is
**already fixed upstream by #1035** — which raised the AICore op-execute
timeout 1 s → 3 s (a side effect of its tensor-dump-on-hang feature). **No code
change is needed to close #1019 itself.** This PR keeps a separately-justified
launch reorder and lands the investigation write-up.

> Earlier revisions of this PR described it as the #1019 root-cause fix
> (various "module-load / task-submit contention" mechanisms). Those were
> wrong — see the investigation doc. The bisect below is what actually
> explains #1019.

## The reorder (a5 + a2a3) — kept on its own merits, not as the #1019 fix

Launch the AICore worker **before** the AICPU Run task (same order on both
arches — the launch order is not split per-arch).

- **First-launch latency**: with the AICPU Run task launched first it occupies
  the device (spinning in `handshake_all_cores`), and the first AICore launch —
  which lazily loads the kernel binary onto the device inside
  `rtKernelLaunchWithHandleV2` — then takes **~1.4 s vs ~0.4 ms** (measured a5,
  robust, far outside noise). Launching AICore first does that load on an idle
  device. Zero functional risk: the handshake is launch-order-independent.
- **Defense-in-depth**: that ~1.4 s slow launch is what trips the op-execute
  timeout (the #1019 family). #1035 widened the *window*; this removes the slow
  *launch*, so the wedge cannot return if the timeout is later tightened or a
  device runs slower.

## How #1019 was actually explained (bisect)

| | OLD order, **1 s** timeout (pre-#1035) | OLD order, **3 s** timeout (post-#1035) |
| --- | --- | --- |
| repro on a clean device | **1/15** (op-timeout cascade: 207001 / 507046) | **0/~40** |

Only the timeout differs. The ~1.4 s slow launch exceeds the old 1 s op-timeout
→ STARS reaps the op → cascade; it fits inside the new 3 s → no failure. The
branch "stopped failing" simply because rebasing onto upstream pulled in #1035.
A spin-throttle experiment **ruled out** the handshake poll frequency as the
cause; the exact internal cause of the ~1.4 s stays unpinned but no longer
matters. Full trail in
`docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md`.

## Changes

- `src/{a5,a2a3}/platform/onboard/host/device_runner.cpp`: reorder.
- `docs/investigations/2026-06-pa-unroll-207001-optimeout-window.md` (+ index).
- `docs/hardware/chip-architecture.md`: GM is exclusive per `device_id`.

## Testing

- [x] a5 hardware: reorder builds + runs clean (5/5 sanity on the rebased base;
  earlier ~39/39).
- [ ] a2a3 hardware: mirror builds clean but is **unverified on a2a3 silicon**
  (dev box is a5-only) — relying on CI.

Refs #1019 (root cause is #1035; this PR is latency + defense-in-depth, not the
fix).