### PR TITLE
Fix: a5 AICPU affinity gate must degrade, not crash, when topology probe fails

### DIFF
--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -124,21 +124,22 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // exec_idx via platform_aicpu_affinity_thread_idx() — the executor
     // reads it to assign sched/orch role.
     //
-    // If the host probe didn't populate the gate inputs (allowed_count or
-    // launch_count is 0) the gate would unconditionally drop every thread
-    // and we'd silently return success without ever calling aicpu_execute.
-    // That's a host-side bug; fail loud so it surfaces instead of
-    // producing nothing at runtime.
+    // Empty gate inputs (allowed_count or launch_count == 0) mean the host
+    // disabled the gate: either the single-thread init path (no gate needed)
+    // or a SKU whose topology probe is unsupported, where device_runner.cpp
+    // degrades to unpinned launch. Run all threads with no filtering — the
+    // executor falls back to arrival-order role assignment
+    // (platform_aicpu_affinity_thread_idx() returns -1 → thread_idx_++).
+    // This is the pre-#963 behavior; the gate is a perf optimization, not a
+    // correctness requirement.
     if (runtime->aicpu_allowed_cpu_count <= 0 || runtime->aicpu_launch_count <= 0) {
-        LOG_ERROR(
-            "AICPU affinity inputs missing: allowed_cpu_count=%d launch_count=%d (host probe must run before exec)",
+        LOG_INFO_V0(
+            "AICPU affinity gate disabled (allowed_cpu_count=%d launch_count=%d); running unpinned",
             runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
         );
-        return -1;
-    }
-    if (!platform_aicpu_affinity_gate_filter(
-            runtime->aicpu_allowed_cpus, runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
-        )) {
+    } else if (!platform_aicpu_affinity_gate_filter(
+                   runtime->aicpu_allowed_cpus, runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+               )) {
         LOG_INFO_V0("Thread dropped by filter affinity gate");
         return 0;
     }

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -205,44 +205,56 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         const int32_t n_sched = (launch_aicpu_num > 1) ? (launch_aicpu_num - n_orch) : 0;
         runtime.aicpu_allowed_cpu_count = 0;
         if (n_sched > 0) {
+            // The affinity gate is a performance optimization (ready-queue
+            // locality), not a correctness requirement. On a5 SKUs/drivers
+            // whose CPU_TOPO query is unsupported the probe fails
+            // (halGetDeviceInfoByBuff rc=65534 / dsmi_get_device_info rc=27).
+            // Degrade to the pre-#963 behavior — leave aicpu_allowed_cpu_count
+            // and aicpu_launch_count at 0, which the device kernel reads as
+            // "gate disabled": no CPU pinning, launch the caller-requested
+            // thread count, roles assigned by arrival order. Do NOT fail the
+            // run — only probe-incapable hardware reaches here, and CANN still
+            // schedules the AICPU threads correctly without the gate.
             if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
-                LOG_ERROR("AICPU topology probe failed; affinity gate will drop all threads");
-                return -1;
-            }
-            if (!pto::a5::compute_allowed_cpus(user_cpus, n_sched, n_orch, allowed)) {
+                LOG_WARN(
+                    "AICPU topology probe failed; disabling affinity gate "
+                    "(no CPU pinning, launching %d AICPU threads unpinned)", launch_aicpu_num
+                );
+            } else if (!pto::a5::compute_allowed_cpus(user_cpus, n_sched, n_orch, allowed)) {
                 LOG_ERROR(
                     "AICPU topology has %zu user cpus, cannot fit %d sched + %d orch", user_cpus.size(), n_sched, n_orch
                 );
                 return -1;
+            } else {
+                const size_t cap = sizeof(runtime.aicpu_allowed_cpus) / sizeof(runtime.aicpu_allowed_cpus[0]);
+                if (allowed.size() > cap) {
+                    LOG_ERROR("compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
+                    return -1;
+                }
+                for (size_t i = 0; i < allowed.size(); ++i)
+                    runtime.aicpu_allowed_cpus[i] = allowed[i];
+                runtime.aicpu_allowed_cpu_count = static_cast<int32_t>(allowed.size());
+                // Launch one AICPU thread per OCCUPY-visible user cpu so CANN
+                // spreads exactly across the user pool — over-subscription on a
+                // SKU with fewer user cpus than the compile-time bound deadlocks
+                // the production AICPU kernel. Capped by the compile-time array
+                // sizing in case the SKU exceeds expectation.
+                int32_t launch_n = static_cast<int32_t>(user_cpus.size());
+                if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
+                    launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+                }
+                runtime.aicpu_launch_count = launch_n;
+                std::string dump;
+                for (size_t i = 0; i < allowed.size(); ++i) {
+                    if (i) dump += ", ";
+                    dump += std::to_string(allowed[i]);
+                    if (i + 1 == allowed.size()) dump += "(orch)";
+                }
+                LOG_INFO_V0(
+                    "AICPU ALLOWED_CPUS = [%s] (n_sched=%d, n_orch=%d, launch=%d, user_cpus=%zu)", dump.c_str(), n_sched,
+                    n_orch, launch_n, user_cpus.size()
+                );
             }
-            const size_t cap = sizeof(runtime.aicpu_allowed_cpus) / sizeof(runtime.aicpu_allowed_cpus[0]);
-            if (allowed.size() > cap) {
-                LOG_ERROR("compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
-                return -1;
-            }
-            for (size_t i = 0; i < allowed.size(); ++i)
-                runtime.aicpu_allowed_cpus[i] = allowed[i];
-            runtime.aicpu_allowed_cpu_count = static_cast<int32_t>(allowed.size());
-            // Launch one AICPU thread per OCCUPY-visible user cpu so CANN
-            // spreads exactly across the user pool — over-subscription on a
-            // SKU with fewer user cpus than the compile-time bound deadlocks
-            // the production AICPU kernel. Capped by the compile-time array
-            // sizing in case the SKU exceeds expectation.
-            int32_t launch_n = static_cast<int32_t>(user_cpus.size());
-            if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
-                launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
-            }
-            runtime.aicpu_launch_count = launch_n;
-            std::string dump;
-            for (size_t i = 0; i < allowed.size(); ++i) {
-                if (i) dump += ", ";
-                dump += std::to_string(allowed[i]);
-                if (i + 1 == allowed.size()) dump += "(orch)";
-            }
-            LOG_INFO_V0(
-                "AICPU ALLOWED_CPUS = [%s] (n_sched=%d, n_orch=%d, launch=%d, user_cpus=%zu)", dump.c_str(), n_sched,
-                n_orch, launch_n, user_cpus.size()
-            );
         }
     }
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -203,7 +203,14 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         std::vector<int32_t> allowed;
         const int32_t n_orch = 1;
         const int32_t n_sched = (launch_aicpu_num > 1) ? (launch_aicpu_num - n_orch) : 0;
+        // Default to the gate-disabled state; only a successful probe below
+        // sets these positive. Resetting both (not just allowed_cpu_count)
+        // matters when a Runtime is reused across launches — a stale positive
+        // aicpu_launch_count would otherwise survive into the probe-failure /
+        // single-thread fallback and override the requested launch count at
+        // the aicpu_launch_n computation below.
         runtime.aicpu_allowed_cpu_count = 0;
+        runtime.aicpu_launch_count = 0;
         if (n_sched > 0) {
             // The affinity gate is a performance optimization (ready-queue
             // locality), not a correctness requirement. On a5 SKUs/drivers
@@ -218,7 +225,8 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
             if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
                 LOG_WARN(
                     "AICPU topology probe failed; disabling affinity gate "
-                    "(no CPU pinning, launching %d AICPU threads unpinned)", launch_aicpu_num
+                    "(no CPU pinning, launching %d AICPU threads unpinned)",
+                    launch_aicpu_num
                 );
             } else if (!pto::a5::compute_allowed_cpus(user_cpus, n_sched, n_orch, allowed)) {
                 LOG_ERROR(
@@ -251,8 +259,8 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
                     if (i + 1 == allowed.size()) dump += "(orch)";
                 }
                 LOG_INFO_V0(
-                    "AICPU ALLOWED_CPUS = [%s] (n_sched=%d, n_orch=%d, launch=%d, user_cpus=%zu)", dump.c_str(), n_sched,
-                    n_orch, launch_n, user_cpus.size()
+                    "AICPU ALLOWED_CPUS = [%s] (n_sched=%d, n_orch=%d, launch=%d, user_cpus=%zu)", dump.c_str(),
+                    n_sched, n_orch, launch_n, user_cpus.size()
                 );
             }
         }


### PR DESCRIPTION
## Problem (bug)

The filter-style AICPU affinity gate added in #963 turns an a5-onboard run into a hard crash (`run_prepared failed with code -1`) on any SKU/driver whose `CPU_TOPO` query is unsupported.

Two independent hard-fail points:
- `device_runner.cpp` returns `-1` the moment `probe_aicpu_topology()` fails — on the affected driver both probe paths fail: `halGetDeviceInfoByBuff(CPU_TOPO) rc=65534` and `dsmi_get_device_info(CPU_TOPO) rc=27`.
- `kernel.cpp` independently returns `-1` when the gate inputs (`aicpu_allowed_cpu_count` / `aicpu_launch_count`) are empty.

#963 was only validated on one SKU (Ascend950PR, `OCCUPY=0x1f8`). The daily **a5 onboard CI runner is a different SKU** whose driver cannot answer `CPU_TOPO`, so **every test that launches >1 AICPU thread crashes**. This is what the current daily a5 CI is hitting (5 failures: `test_tile_assemble` vec / loop_col_broadcast / double_loop_broadcast, `test_qwen3_decode_scope3_mixed[a5]`, `test_dyn_orch_paged_attention[a5]`).

The existing investigation note `docs/investigations/2026-06-a5-aicpu-filter-gate-scenario-b-validation.md` only considered Scenario B (probe succeeds but CANN dispatch ⊊ OCCUPY) — it never covered the probe **itself** failing on a different SKU.

## Root cause

The affinity gate is a **performance optimization** (ready-queue locality), not a correctness requirement. When the topology cannot be read, the runtime should degrade to the pre-#963 behavior (no CPU pinning, launch the caller-requested thread count, roles by arrival order), not fail the workload.

## Fix

- **`device_runner.cpp`**: on probe failure, `LOG_WARN` and leave `aicpu_allowed_cpu_count` / `aicpu_launch_count` at `0` (the "gate disabled" state) instead of `return -1`. `compute_allowed_cpus` / cap-overflow remain fatal — they only fire *after* a successful probe.
- **`kernel.cpp`**: treat empty gate inputs as "gate disabled, run unpinned" rather than a fatal host bug. The executor already falls back to arrival-order role assignment when `platform_aicpu_affinity_thread_idx()` returns `-1` (`thread_idx_++`).

SKUs where the probe works are unaffected — the gate runs exactly as before.

## Verification

On an a5 onboard runner (device 1, via `task-submit`), all 5 daily-CI failures now **pass**; the probe failure emits a single `WARN` and the run proceeds:

```
test_tile_assemble_vec ............................ PASSED
test_tile_assemble_loop_col_broadcast ............. PASSED
test_tile_assemble_double_loop_broadcast .......... PASSED
test_qwen3_decode_scope3_mixed[a5] ................ PASSED
test_dyn_orch_paged_attention[2-16-128-128-256-1024-a5] ... PASSED
```

Happy to add a short `docs/investigations/` entry documenting the probe-failure degradation path if maintainers prefer.