### PR TITLE
Fix: scheduler timeout per platform variant (sim 5s, onboard 2s)

### DIFF
--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -877,9 +877,9 @@ ordering — the three budgets are tuned so the **AICPU detects the
 hang first**, dumps, and only then the hardware/host timeouts fire:
 
 ```text
-SCHEDULER_TIMEOUT_MS (2 s)  <  PLATFORM_OP_EXECUTE_TIMEOUT_US (3 s)  <  PLATFORM_STREAM_SYNC_TIMEOUT_MS (4 s)
-   AICPU declares hang,          STARS reaps the AICore op            host stream sync gives up
-   flushes + dumps in-flight     and poisons the context              and surfaces the error
+SCHEDULER_TIMEOUT_MS (2 s, onboard)  <  PLATFORM_OP_EXECUTE_TIMEOUT_US (3 s)  <  PLATFORM_STREAM_SYNC_TIMEOUT_MS (4 s)
+   AICPU declares hang,                   STARS reaps the AICore op              host stream sync gives up
+   flushes + dumps in-flight              and poisons the context                and surfaces the error
 ```
 
 - **Device-side graceful flush (primary).** At 2 s of no progress
@@ -909,9 +909,11 @@ This ordering is load-bearing: if the timeouts were inverted (STARS
 reaping before the AICPU's budget, as in earlier versions), the
 device-side dump would never run on a real AICore hang and you would
 only recover what was already in the buffer. The chain lives in
-`scheduler_types.h` (`SCHEDULER_TIMEOUT_MS`) and `platform_config.h`
-(`PLATFORM_OP_EXECUTE_TIMEOUT_US` / `PLATFORM_STREAM_SYNC_TIMEOUT_MS`),
-along with the `#897` distributed-skew trade-off.
+`spin_hint.h` (`PLATFORM_SCHEDULER_TIMEOUT_MS`, surfaced as
+`SCHEDULER_TIMEOUT_MS` — 2 s onboard, 5 s in sim where there is no STARS to
+race) and `platform_config.h` (`PLATFORM_OP_EXECUTE_TIMEOUT_US` /
+`PLATFORM_STREAM_SYNC_TIMEOUT_MS`), along with the `#897` distributed-skew
+trade-off.
 
 ## 9. Related docs
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -43,7 +43,7 @@ Each sub-level macro requires `PTO2_PROFILING=1`:
 
 - Debug/diagnostic logs (always present)
 - Progress tracking (`PTO2 progress: completed=...`)
-- Stall detection and dump (triggered only after `MAX_IDLE_ITERATIONS` idle loops)
+- Stall detection and dump (triggered after the `SCHEDULER_TIMEOUT_MS` wall-clock no-progress budget)
 - Deadlock/livelock detection (`diagnose_stuck_state`, called on stall)
 
 **What's NOT compiled:**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -44,15 +44,17 @@
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS;  // platform-defined cap (sim vs onboard)
-constexpr int32_t STALL_LOG_INTERVAL =
-    MAX_IDLE_ITERATIONS * 6 / 10;                     // derived: ~one stall diagnostic halfway to timeout
+// Periodic cadence (in idle iterations) for emitting the per-thread STALL
+// diagnostic while no progress is being made. Purely an observability knob,
+// independent of the wall-clock timeout below: small enough to fire a few times
+// before the budget expires, large enough not to flood device_log.
+constexpr int32_t STALL_LOG_INTERVAL = 480000;
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 
 // Wall-clock budget for declaring "no progress = scheduler timeout". Replaces
-// the per-thread iteration-count cap for the fatal-latch decision; the
-// iteration cap still drives the STALL diagnostic cadence (which is per-thread
-// observability and benefits from running at the thread's own pace).
+// the per-thread iteration-count cap that once lived here as MAX_IDLE_ITERATIONS
+// for the fatal-latch decision; STALL_LOG_INTERVAL above keeps the per-thread
+// diagnostic cadence.
 //
 // Using wall-clock here is load-bearing for distributed runs: with per-thread
 // iteration counts, a pure-idle thread spinning ~115 ns/iter hits the cap in
@@ -61,14 +63,14 @@ constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator erro
 // kills the slower-but-correct poller mid-poll — see the distributed
 // startup-skew scenario in issue #897.
 //
-// The value is set *below* the STARS AICore op-execution timeout
-// (PLATFORM_OP_EXECUTE_TIMEOUT_US, 3 s) on purpose: the AICPU must detect a hang
-// and flush its diagnostics (tensor dump, in-flight partial output) before STARS
-// reaps the op and poisons the context. Chain: this < op-exec < host stream-sync
-// (platform_config.h). Trade-off: 2 s is shorter than the worst distributed-init
-// / HCCL skew #897 sized 5 s for, so a slow distributed startup can false-latch;
-// if that bites, raise this together with the op-exec / stream-sync timeouts.
-constexpr int32_t SCHEDULER_TIMEOUT_MS = 2000;  // 2 s; < op-exec so the AICPU dumps before STARS reaps
+// The budget is platform-defined (PLATFORM_SCHEDULER_TIMEOUT_MS in spin_hint.h)
+// because the safe value differs per variant: onboard trims it to 2 s so the
+// AICPU detects a hang and flushes its diagnostics (tensor dump, in-flight
+// partial output) before STARS reaps the op and poisons the context (chain:
+// this < op-exec < host stream-sync, platform_config.h); sim has no STARS to
+// race and keeps the full 5 s #897 headroom. See spin_hint.h for the per-variant
+// rationale.
+constexpr int32_t SCHEDULER_TIMEOUT_MS = PLATFORM_SCHEDULER_TIMEOUT_MS;
 constexpr uint64_t SCHEDULER_TIMEOUT_CYCLES =
     static_cast<uint64_t>(SCHEDULER_TIMEOUT_MS) * (PLATFORM_PROF_SYS_CNT_FREQ / 1000);
 constexpr int32_t STALL_DUMP_READY_MAX = 8;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/profiling_levels.md
@@ -43,7 +43,7 @@ Each sub-level macro requires `PTO2_PROFILING=1`:
 
 - Debug/diagnostic logs (always present)
 - Progress tracking (`PTO2 progress: completed=...`)
-- Stall detection and dump (triggered only after `MAX_IDLE_ITERATIONS` idle loops)
+- Stall detection and dump (triggered after the `SCHEDULER_TIMEOUT_MS` wall-clock no-progress budget)
 - Deadlock/livelock detection (`diagnose_stuck_state`, called on stall)
 
 **What's NOT compiled:**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -45,15 +45,17 @@
 
 constexpr int32_t MAX_AICPU_THREADS = PLATFORM_MAX_AICPU_THREADS;
 
-constexpr int32_t MAX_IDLE_ITERATIONS = PLATFORM_MAX_IDLE_ITERATIONS;  // platform-defined cap (sim vs onboard)
-constexpr int32_t STALL_LOG_INTERVAL =
-    MAX_IDLE_ITERATIONS * 6 / 10;                     // derived: ~one stall diagnostic halfway to timeout
+// Periodic cadence (in idle iterations) for emitting the per-thread STALL
+// diagnostic while no progress is being made. Purely an observability knob,
+// independent of the wall-clock timeout below: small enough to fire a few times
+// before the budget expires, large enough not to flood device_log.
+constexpr int32_t STALL_LOG_INTERVAL = 480000;
 constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator error every N idle iters
 
 // Wall-clock budget for declaring "no progress = scheduler timeout". Replaces
-// the per-thread iteration-count cap for the fatal-latch decision; the
-// iteration cap still drives the STALL diagnostic cadence (which is per-thread
-// observability and benefits from running at the thread's own pace).
+// the per-thread iteration-count cap that once lived here as MAX_IDLE_ITERATIONS
+// for the fatal-latch decision; STALL_LOG_INTERVAL above keeps the per-thread
+// diagnostic cadence.
 //
 // Using wall-clock here is load-bearing for distributed runs: with per-thread
 // iteration counts, a pure-idle thread spinning ~115 ns/iter hits the cap in
@@ -62,14 +64,14 @@ constexpr int32_t FATAL_ERROR_CHECK_INTERVAL = 1024;  // Check orchestrator erro
 // kills the slower-but-correct poller mid-poll — see the distributed
 // startup-skew scenario in issue #897.
 //
-// The value is set *below* the STARS AICore op-execution timeout
-// (PLATFORM_OP_EXECUTE_TIMEOUT_US, 3 s) on purpose: the AICPU must detect a hang
-// and flush its diagnostics (tensor dump, in-flight partial output) before STARS
-// reaps the op and poisons the context. Chain: this < op-exec < host stream-sync
-// (platform_config.h). Trade-off: 2 s is shorter than the worst distributed-init
-// / HCCL skew #897 sized 5 s for, so a slow distributed startup can false-latch;
-// if that bites, raise this together with the op-exec / stream-sync timeouts.
-constexpr int32_t SCHEDULER_TIMEOUT_MS = 2000;  // 2 s; < op-exec so the AICPU dumps before STARS reaps
+// The budget is platform-defined (PLATFORM_SCHEDULER_TIMEOUT_MS in spin_hint.h)
+// because the safe value differs per variant: onboard trims it to 2 s so the
+// AICPU detects a hang and flushes its diagnostics (tensor dump, in-flight
+// partial output) before STARS reaps the op and poisons the context (chain:
+// this < op-exec < host stream-sync, platform_config.h); sim has no STARS to
+// race and keeps the full 5 s #897 headroom. See spin_hint.h for the per-variant
+// rationale.
+constexpr int32_t SCHEDULER_TIMEOUT_MS = PLATFORM_SCHEDULER_TIMEOUT_MS;
 constexpr uint64_t SCHEDULER_TIMEOUT_CYCLES =
     static_cast<uint64_t>(SCHEDULER_TIMEOUT_MS) * (PLATFORM_PROF_SYS_CNT_FREQ / 1000);
 constexpr int32_t STALL_DUMP_READY_MAX = 8;

--- a/src/common/platform/onboard/aicpu/spin_hint.h
+++ b/src/common/platform/onboard/aicpu/spin_hint.h
@@ -23,10 +23,17 @@
 
 #define SPIN_WAIT_HINT() ((void)0)
 
-// Consecutive idle scheduler iterations (no task progress) before the dispatch
-// loop aborts with PTO2_ERROR_SCHEDULER_TIMEOUT. On real hardware each idle
-// iteration is a cheap no-op spin, so this bounds a genuine deadlock. The
-// runtime consumes it as MAX_IDLE_ITERATIONS (see scheduler_types.h).
-constexpr int32_t PLATFORM_MAX_IDLE_ITERATIONS = 800000;
+// Wall-clock budget (ms) of no task progress before the dispatch loop aborts
+// with PTO2_ERROR_SCHEDULER_TIMEOUT. On real hardware this must sit *below* the
+// STARS AICore op-execution timeout (PLATFORM_OP_EXECUTE_TIMEOUT_US, 3 s) so the
+// AICPU detects the hang and flushes its diagnostics (tensor dump, in-flight
+// partial output) before STARS reaps the op and poisons the context. Chain:
+// this < op-exec < host stream-sync (platform_config.h). Trade-off: 2 s is
+// shorter than the worst distributed-init / HCCL skew #897 sized 5 s for, so a
+// slow distributed startup can false-latch; if that bites, raise this together
+// with the op-exec / stream-sync timeouts. The sim build keeps the full 5 s (no
+// STARS to race). The runtime consumes it as SCHEDULER_TIMEOUT_MS (see
+// scheduler_types.h).
+constexpr int32_t PLATFORM_SCHEDULER_TIMEOUT_MS = 2000;
 
 #endif  // PLATFORM_A2A3_AICPU_SPIN_HINT_H_

--- a/src/common/platform/sim/aicpu/spin_hint.h
+++ b/src/common/platform/sim/aicpu/spin_hint.h
@@ -15,15 +15,15 @@
  * In simulation, all AICPU scheduler threads share a small number of host CPU
  * cores with AICore threads. Without explicit yielding, idle scheduler threads
  * in tight polling loops starve the AICore thread executing the actual kernel,
- * causing iteration-based timeouts (MAX_IDLE_ITERATIONS) before the kernel can
- * complete — especially on resource-constrained CI runners (e.g., 2 cores
- * running 13+ threads).
+ * causing premature scheduler timeouts before the kernel can complete —
+ * especially on resource-constrained CI runners (e.g., 2 cores running 13+
+ * threads).
  *
  * Two mitigations live here. The CPU hint (pause/yield) plus sched_yield() let
  * the OS scheduler give time slices to threads doing real work, and
- * PLATFORM_MAX_IDLE_ITERATIONS below raises the idle cap well above the onboard
- * value so a slow CPU-sim task (e.g. matmul-heavy kernels) making real progress
- * is not mistaken for a deadlock.
+ * PLATFORM_SCHEDULER_TIMEOUT_MS below keeps the no-progress budget generous so a
+ * slow CPU-sim task (e.g. matmul-heavy kernels) making real progress is not
+ * mistaken for a deadlock.
  */
 
 #ifndef PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_
@@ -48,13 +48,14 @@
 #define SPIN_WAIT_HINT() sched_yield()
 #endif
 
-// Consecutive idle scheduler iterations (no task progress) before the dispatch
-// loop aborts with PTO2_ERROR_SCHEDULER_TIMEOUT. CPU sim accumulates idle
-// iterations far faster than real kernel progress, so the cap is raised well
-// above the onboard value to avoid false timeouts on slow (e.g. matmul-heavy)
-// kernels. Set to 10x the onboard cap as a conservative bump; raise further if
-// a slow kernel still false-times-out. The runtime consumes it as
-// MAX_IDLE_ITERATIONS (see scheduler_types.h).
-constexpr int32_t PLATFORM_MAX_IDLE_ITERATIONS = 8000000;
+// Wall-clock budget (ms) of no task progress before the dispatch loop aborts
+// with PTO2_ERROR_SCHEDULER_TIMEOUT. Unlike onboard there is no STARS
+// op-execution timeout to race here, so this keeps the full #897 distributed-init
+// / HCCL-skew headroom (the onboard build trims its copy to 2 s to dump before
+// STARS reaps). A generous budget also avoids false timeouts when an
+// oversubscribed CPU-sim kernel (e.g. matmul-heavy) makes real but slow
+// progress; raise further if a slow kernel still false-times-out. The runtime
+// consumes it as SCHEDULER_TIMEOUT_MS (see scheduler_types.h).
+constexpr int32_t PLATFORM_SCHEDULER_TIMEOUT_MS = 5000;
 
 #endif  // PLATFORM_A2A3SIM_AICPU_SPIN_HINT_H_

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
@@ -170,11 +170,9 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
     CASES = [
         {
             "name": "b1_h32_kv8_s128_bs128_fp16",
-            # Disabled from CI: regression on main (passed at 17fa04aa, fails at
-            # 19b2c0be) — sim scheduler stall (rc=-100 TIMEOUT_EXIT) and onboard
-            # golden mismatch. Tracked in hw-native-sys/simpler#1070.
-            "manual": True,
-            "platforms": ["a2a3sim", "a2a3"],
+            # onboard a2a3 stays out pending the
+            # separate 'out' golden mismatch (hw-native-sys/simpler#1070).
+            "platforms": ["a2a3sim"],
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {
                 "batch": 1,


### PR DESCRIPTION
## Summary

Commit f0454712 (#1035) lowered `SCHEDULER_TIMEOUT_MS` to 2 s so the
**onboard** AICPU detects a hang and flushes its diagnostics before STARS
reaps the op (chain: scheduler 2 s < op-exec 3 s < stream-sync 4 s). But
that constant is shared by the **sim** build, which has no STARS to race
and relied on the 5 s `#897` distributed-init / HCCL-skew headroom — so the
change silently cut sim's no-progress budget to 2 s.

This sources the budget **per platform variant** from the already-split
aicpu `spin_hint.h`, which is resolved by the aicpu include path — so **no
new macro or compile flag** is introduced:

- `PLATFORM_SCHEDULER_TIMEOUT_MS` = **2 s onboard**, **5 s sim**
- `SCHEDULER_TIMEOUT_MS` in `scheduler_types.h` now reads the platform value
- Retire `PLATFORM_MAX_IDLE_ITERATIONS` (the old iteration-based timeout
  cap). It only still fed the STALL-diagnostic log cadence, so
  `STALL_LOG_INTERVAL` becomes a standalone iteration constant (`480000`,
  the prior onboard cadence). Deriving it from the wall-clock budget was
  rejected: the gate compares against `idle_iterations`, not cycles, and
  `cycles * 6/10` overflows `int32` on a5 sim.
- Docs (`tensor-dump.md`, `profiling_levels.md`) updated to match.

## Testing
- Compile-checked the per-variant resolution: onboard `spin_hint.h` →
  `PLATFORM_SCHEDULER_TIMEOUT_MS == 2000`, sim → `5000` (g++ `-fsyntax-only`
  against each variant's include dir).
- [ ] Simulation tests (CI)
- [ ] Hardware tests (CI)

Relates to #1035