### PR TITLE
docs(args): fix stale cap literals missed by #1056

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -322,7 +322,7 @@ struct PTO2TaskPayload {
                 result.materialize_output(tensors[i]);
             }
         }
-        // Round up to cache line boundary. Both arrays are 1024B so no overrun.
+        // Round up to cache line boundary. Both arrays are 128B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -512,7 +512,7 @@ private:
             return false;
         }
         if (tensor_count_ + sizeof...(Args) > MAX_TENSOR_ARGS) {
-            set_error("Too many tensor args (exceeds MAX_TENSOR_ARGS=16)");
+            set_error("Too many tensor args (exceeds MAX_TENSOR_ARGS=32)");
             return false;
         }
         return true;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -249,7 +249,7 @@ struct PTO2TaskPayload {
                 result.materialize_output(tensors[i]);
             }
         }
-        // Round up to cache line boundary. Both arrays are 1024B so no overrun.
+        // Round up to cache line boundary. Both arrays are 128B so no overrun.
         // Eliminates branches; extra bytes within the same CL have zero additional cost.
         memcpy(scalars, args.scalars(), PTO2_ALIGN_UP(args.scalar_count() * sizeof(uint64_t), 64));
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -500,7 +500,7 @@ private:
             return false;
         }
         if (tensor_count_ + sizeof...(Args) > MAX_TENSOR_ARGS) {
-            set_error("Too many tensor args (exceeds MAX_TENSOR_ARGS=16)");
+            set_error("Too many tensor args (exceeds MAX_TENSOR_ARGS=32)");
             return false;
         }
         return true;


### PR DESCRIPTION
## What

Fixes two stale cap literals left behind by #1056 (which raised
`CORE_MAX_TENSOR_ARGS` 16→32 and lowered `CORE_MAX_SCALAR_ARGS` 32→16).
#1056 updated the scalar-limit error strings but missed:

- **`pto_types.h`** (a2a3 + a5): the tensor-limit error string still read
  `"exceeds MAX_TENSOR_ARGS=16"`. The cap is now **32** — a user who hits
  the tensor-arg cap would otherwise get a misleading message.
- **`pto_runtime2_types.h`** (a2a3 + a5): the `PTO2TaskPayload::init`
  memcpy comment said `"Both arrays are 1024B"` (dates from an old
  128-scalar cap). The scalar arrays are now `MAX_SCALAR_ARGS * 8` =
  **128B**.

Comment/string only — **no ABI or behavior change**.

## ⚠️ Stacked on #1056

These literals are only correct **on top of #1056's cap change**. On
`main`, `CORE_MAX_TENSOR_ARGS` is still 16 and the scalar arrays are 256B,
so the current text is correct there. This branch is stacked on #1056:

- **Do not merge before #1056.**
- Until #1056 merges, this PR's diff also includes #1056's commit; after
  #1056 lands, rebasing reduces it to the 4-line doc fix here.
