### PR TITLE
Fix: fanin producer dedup lookup cost

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -217,13 +217,32 @@ void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, c
     va_end(args);
 }
 
+static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
+    uint32_t next = orch->fanin_seen_current_epoch + 1;
+    if (next == 0) {
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            memset(
+                orch->fanin_seen_epoch[r], 0,
+                static_cast<size_t>(orch->sm_header->rings[r].task_window_size) * sizeof(uint32_t)
+            );
+        }
+        next = 1;
+    }
+    orch->fanin_seen_current_epoch = next;
+    return next;
+}
+
 struct PTO2FaninBuilder {
-    PTO2FaninBuilder(PTO2FaninPool &spill_pool) :
+    PTO2FaninBuilder(PTO2OrchestratorState *orch, PTO2FaninPool &spill_pool, uint32_t seen_epoch) :
         count(0),
         spill_start(0),
+        orch(orch),
+        seen_epoch(seen_epoch),
         spill_pool(spill_pool) {}
     int32_t count{0};
     int32_t spill_start{0};
+    PTO2OrchestratorState *orch{nullptr};
+    uint32_t seen_epoch{0};
     PTO2FaninPool &spill_pool;
     PTO2TaskSlotState *inline_slots[PTO2_FANIN_INLINE_CAP];
 
@@ -232,26 +251,25 @@ struct PTO2FaninBuilder {
         return for_each_fanin_storage(inline_slots, count, spill_start, spill_pool, static_cast<Fn &&>(fn));
     }
 
-    bool contains(PTO2TaskSlotState *prod_state) const {
-        bool found = false;
-        for_each([&](PTO2TaskSlotState *slot_state) {
-            if (slot_state == prod_state) {
-                found = true;
-                return false;
-            }
-            return true;
-        });
-        if (found) {
+    bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
+        if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
+            return false;
+        }
+        uint32_t *seen = orch->fanin_seen_epoch[prod_ring];
+        uint32_t slot = static_cast<uint32_t>(prod_slot);
+        if (seen[slot] == seen_epoch) {
             return true;
         }
+        seen[slot] = seen_epoch;
         return false;
     }
 };
 
 static bool append_fanin_or_fail(
-    PTO2OrchestratorState *orch, PTO2TaskSlotState *prod_state, PTO2FaninBuilder *fanin_builder, uint8_t ring_id
+    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
+    PTO2FaninBuilder *fanin_builder, uint8_t ring_id
 ) {
-    if (fanin_builder->contains(prod_state)) {
+    if (fanin_builder->mark_seen(prod_ring, prod_slot)) {
         return true;
     }
 
@@ -574,7 +592,7 @@ static TaskOutputTensors submit_task_common(
         );
     }
 
-    PTO2FaninBuilder fanin_builder(orch->rings[ring_id].fanin_pool);
+    PTO2FaninBuilder fanin_builder(orch, orch->rings[ring_id].fanin_pool, next_fanin_seen_epoch(orch));
 
     CYCLE_COUNT_LAP(g_orch_alloc_cycle);
 
@@ -601,14 +619,16 @@ static TaskOutputTensors submit_task_common(
             );
             return result;
         }
-        PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];
+        uint8_t dep_ring_id = dep_task_id.ring();
+        PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_ring_id];
         int32_t dep_local_task_id = static_cast<int32_t>(dep_task_id.local());
         int32_t dep_last_task_alive = dep_ring.fc.last_task_alive.load(std::memory_order_acquire);
         if (dep_local_task_id < dep_last_task_alive) {
             continue;
         }
-        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_task_id(dep_local_task_id);
-        if (!append_fanin_or_fail(orch, producer_slot_state, &fanin_builder, ring_id)) {
+        int32_t dep_slot = dep_ring.get_slot_by_task_id(dep_local_task_id);
+        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
+        if (!append_fanin_or_fail(orch, dep_ring_id, dep_slot, producer_slot_state, &fanin_builder, ring_id)) {
             return result;
         }
     }
@@ -620,9 +640,11 @@ static TaskOutputTensors submit_task_common(
     };
 
     auto runtime_emit = [&](PTO2TaskId producer_task_id) -> bool {
-        PTO2TaskSlotState *prod_state =
-            &orch->sm_header->rings[producer_task_id.ring()].get_slot_state_by_task_id(producer_task_id.local());
-        return append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id);
+        uint8_t prod_ring = producer_task_id.ring();
+        PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->rings[prod_ring];
+        int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
+        PTO2TaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
+        return append_fanin_or_fail(orch, prod_ring, prod_slot, prod_state, &fanin_builder, ring_id);
     };
 
     if (!compute_task_fanin(dep_inputs, orch->tensor_map, orch->in_manual_scope(), runtime_emit)) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -45,6 +45,7 @@
  */
 struct PTO2OrchestratorLayout {
     size_t off_fanin_pool[PTO2_MAX_RING_DEPTH];
+    size_t off_fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
     size_t off_scope_tasks;
     size_t off_scope_begins;
     PTO2TensorMapLayout tensor_map;
@@ -68,6 +69,8 @@ struct PTO2OrchestratorState {
 
     // === PER-RING RESOURCES ===
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
+    uint32_t *fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
+    uint32_t fanin_seen_current_epoch{1};
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;  // Producer lookup

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -95,17 +95,23 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;
 
+    int32_t get_slot_by_task_id(int32_t local_task_id) { return local_task_id & task_window_mask; }
+
     PTO2TaskDescriptor &get_task_by_slot(int32_t slot) { return task_descriptors[slot]; }
 
-    PTO2TaskDescriptor &get_task_by_task_id(int32_t local_id) { return task_descriptors[local_id & task_window_mask]; }
+    PTO2TaskDescriptor &get_task_by_task_id(int32_t local_id) {
+        return task_descriptors[get_slot_by_task_id(local_id)];
+    }
 
     PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
 
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[local_id & task_window_mask]; }
+    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) { return slot_states[local_id & task_window_mask]; }
+    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
+        return slot_states[get_slot_by_task_id(local_id)];
+    }
 };
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -200,6 +200,11 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
         const size_t fanin_pool_bytes =
             PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         layout.off_fanin_pool[r] = arena.reserve(fanin_pool_bytes, PTO2_ALIGN_SIZE);
+
+        always_assert(task_window_sizes[r] > 0 && (task_window_sizes[r] & (task_window_sizes[r] - 1)) == 0);
+        const size_t seen_epoch_bytes =
+            PTO2_ALIGN_UP(static_cast<size_t>(task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
+        layout.off_fanin_seen_epoch[r] = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
     }
     layout.off_scope_tasks = arena.reserve(
         static_cast<size_t>(layout.scope_tasks_cap) * sizeof(PTO2TaskSlotState *), alignof(PTO2TaskSlotState *)
@@ -245,6 +250,13 @@ bool PTO2OrchestratorState::init_data_from_layout(
         auto *fanin_entries = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
         memset(fanin_entries, 0, fanin_pool_bytes);
         orch->rings[r].fanin_pool.init(fanin_entries, layout.dep_pool_capacity, orch_err);
+
+        const size_t seen_epoch_bytes = PTO2_ALIGN_UP(
+            static_cast<size_t>(layout.tensor_map.task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE
+        );
+        auto *seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
+        memset(seen_epoch, 0, seen_epoch_bytes);
+        orch->fanin_seen_epoch[r] = seen_epoch;
     }
 
     if (!orch->tensor_map.init_data_from_layout(layout.tensor_map, arena)) {
@@ -266,6 +278,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
     auto *orch = this;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
+        orch->fanin_seen_epoch[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
     }
     orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
     orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
@@ -278,6 +291,7 @@ void PTO2OrchestratorState::destroy() {
     orch->tensor_map.destroy();
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = nullptr;
+        orch->fanin_seen_epoch[r] = nullptr;
     }
     orch->scope_tasks = nullptr;
     orch->scope_begins = nullptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -212,13 +212,32 @@ void PTO2OrchestratorState::report_fatal(int32_t error_code, const char *func, c
     va_end(args);
 }
 
+static uint32_t next_fanin_seen_epoch(PTO2OrchestratorState *orch) {
+    uint32_t next = orch->fanin_seen_current_epoch + 1;
+    if (next == 0) {
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            memset(
+                orch->fanin_seen_epoch[r], 0,
+                static_cast<size_t>(orch->sm_header->rings[r].task_window_size) * sizeof(uint32_t)
+            );
+        }
+        next = 1;
+    }
+    orch->fanin_seen_current_epoch = next;
+    return next;
+}
+
 struct PTO2FaninBuilder {
-    PTO2FaninBuilder(PTO2FaninPool &spill_pool) :
+    PTO2FaninBuilder(PTO2OrchestratorState *orch, PTO2FaninPool &spill_pool, uint32_t seen_epoch) :
         count(0),
         spill_start(0),
+        orch(orch),
+        seen_epoch(seen_epoch),
         spill_pool(spill_pool) {}
     int32_t count{0};
     int32_t spill_start{0};
+    PTO2OrchestratorState *orch{nullptr};
+    uint32_t seen_epoch{0};
     PTO2FaninPool &spill_pool;
     PTO2TaskSlotState *inline_slots[PTO2_FANIN_INLINE_CAP];
 
@@ -227,26 +246,25 @@ struct PTO2FaninBuilder {
         return for_each_fanin_storage(inline_slots, count, spill_start, spill_pool, static_cast<Fn &&>(fn));
     }
 
-    bool contains(PTO2TaskSlotState *prod_state) const {
-        bool found = false;
-        for_each([&](PTO2TaskSlotState *slot_state) {
-            if (slot_state == prod_state) {
-                found = true;
-                return false;
-            }
-            return true;
-        });
-        if (found) {
+    bool mark_seen(uint8_t prod_ring, int32_t prod_slot) {
+        if (prod_ring >= PTO2_MAX_RING_DEPTH || prod_slot < 0) {
+            return false;
+        }
+        uint32_t *seen = orch->fanin_seen_epoch[prod_ring];
+        uint32_t slot = static_cast<uint32_t>(prod_slot);
+        if (seen[slot] == seen_epoch) {
             return true;
         }
+        seen[slot] = seen_epoch;
         return false;
     }
 };
 
 static bool append_fanin_or_fail(
-    PTO2OrchestratorState *orch, PTO2TaskSlotState *prod_state, PTO2FaninBuilder *fanin_builder, uint8_t ring_id
+    PTO2OrchestratorState *orch, uint8_t prod_ring, int32_t prod_slot, PTO2TaskSlotState *prod_state,
+    PTO2FaninBuilder *fanin_builder, uint8_t ring_id
 ) {
-    if (fanin_builder->contains(prod_state)) {
+    if (fanin_builder->mark_seen(prod_ring, prod_slot)) {
         return true;
     }
 
@@ -570,7 +588,7 @@ static TaskOutputTensors submit_task_common(
         );
     }
 
-    PTO2FaninBuilder fanin_builder(orch->rings[ring_id].fanin_pool);
+    PTO2FaninBuilder fanin_builder(orch, orch->rings[ring_id].fanin_pool, next_fanin_seen_epoch(orch));
 
     CYCLE_COUNT_LAP(g_orch_alloc_cycle);
 
@@ -597,14 +615,16 @@ static TaskOutputTensors submit_task_common(
             );
             return result;
         }
-        PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_task_id.ring()];
+        uint8_t dep_ring_id = dep_task_id.ring();
+        PTO2SharedMemoryRingHeader &dep_ring = orch->sm_header->rings[dep_ring_id];
         int32_t dep_local_task_id = static_cast<int32_t>(dep_task_id.local());
         int32_t dep_last_task_alive = dep_ring.fc.last_task_alive.load(std::memory_order_acquire);
         if (dep_local_task_id < dep_last_task_alive) {
             continue;
         }
-        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_task_id(dep_local_task_id);
-        if (!append_fanin_or_fail(orch, producer_slot_state, &fanin_builder, ring_id)) {
+        int32_t dep_slot = dep_ring.get_slot_by_task_id(dep_local_task_id);
+        PTO2TaskSlotState *producer_slot_state = &dep_ring.get_slot_state_by_slot(dep_slot);
+        if (!append_fanin_or_fail(orch, dep_ring_id, dep_slot, producer_slot_state, &fanin_builder, ring_id)) {
             return result;
         }
     }
@@ -616,9 +636,11 @@ static TaskOutputTensors submit_task_common(
     };
 
     auto runtime_emit = [&](PTO2TaskId producer_task_id) -> bool {
-        PTO2TaskSlotState *prod_state =
-            &orch->sm_header->rings[producer_task_id.ring()].get_slot_state_by_task_id(producer_task_id.local());
-        return append_fanin_or_fail(orch, prod_state, &fanin_builder, ring_id);
+        uint8_t prod_ring = producer_task_id.ring();
+        PTO2SharedMemoryRingHeader &producer_ring = orch->sm_header->rings[prod_ring];
+        int32_t prod_slot = producer_ring.get_slot_by_task_id(static_cast<int32_t>(producer_task_id.local()));
+        PTO2TaskSlotState *prod_state = &producer_ring.get_slot_state_by_slot(prod_slot);
+        return append_fanin_or_fail(orch, prod_ring, prod_slot, prod_state, &fanin_builder, ring_id);
     };
 
     if (!compute_task_fanin(dep_inputs, orch->tensor_map, orch->in_manual_scope(), runtime_emit)) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -44,6 +44,7 @@
  */
 struct PTO2OrchestratorLayout {
     size_t off_fanin_pool[PTO2_MAX_RING_DEPTH];
+    size_t off_fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
     size_t off_scope_tasks;
     size_t off_scope_begins;
     PTO2TensorMapLayout tensor_map;
@@ -67,6 +68,8 @@ struct PTO2OrchestratorState {
 
     // === PER-RING RESOURCES ===
     PTO2RingSet rings[PTO2_MAX_RING_DEPTH];
+    uint32_t *fanin_seen_epoch[PTO2_MAX_RING_DEPTH];
+    uint32_t fanin_seen_current_epoch{1};
 
     // === TENSOR MAP (Private) ===
     PTO2TensorMap tensor_map;  // Producer lookup

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -95,17 +95,23 @@ struct alignas(64) PTO2SharedMemoryRingHeader {
     PTO2TaskPayload *task_payloads;
     PTO2TaskSlotState *slot_states;
 
+    int32_t get_slot_by_task_id(int32_t local_task_id) { return local_task_id & task_window_mask; }
+
     PTO2TaskDescriptor &get_task_by_slot(int32_t slot) { return task_descriptors[slot]; }
 
-    PTO2TaskDescriptor &get_task_by_task_id(int32_t local_id) { return task_descriptors[local_id & task_window_mask]; }
+    PTO2TaskDescriptor &get_task_by_task_id(int32_t local_id) {
+        return task_descriptors[get_slot_by_task_id(local_id)];
+    }
 
     PTO2TaskPayload &get_payload_by_slot(int32_t slot) { return task_payloads[slot]; }
 
-    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[local_id & task_window_mask]; }
+    PTO2TaskPayload &get_payload_by_task_id(int32_t local_id) { return task_payloads[get_slot_by_task_id(local_id)]; }
 
     PTO2TaskSlotState &get_slot_state_by_slot(int32_t slot) { return slot_states[slot]; }
 
-    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) { return slot_states[local_id & task_window_mask]; }
+    PTO2TaskSlotState &get_slot_state_by_task_id(int32_t local_id) {
+        return slot_states[get_slot_by_task_id(local_id)];
+    }
 };
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -200,6 +200,11 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
         const size_t fanin_pool_bytes =
             PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         layout.off_fanin_pool[r] = arena.reserve(fanin_pool_bytes, PTO2_ALIGN_SIZE);
+
+        always_assert(task_window_sizes[r] > 0 && (task_window_sizes[r] & (task_window_sizes[r] - 1)) == 0);
+        const size_t seen_epoch_bytes =
+            PTO2_ALIGN_UP(static_cast<size_t>(task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
+        layout.off_fanin_seen_epoch[r] = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
     }
     layout.off_scope_tasks = arena.reserve(
         static_cast<size_t>(layout.scope_tasks_cap) * sizeof(PTO2TaskSlotState *), alignof(PTO2TaskSlotState *)
@@ -245,6 +250,13 @@ bool PTO2OrchestratorState::init_data_from_layout(
         auto *fanin_entries = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
         memset(fanin_entries, 0, fanin_pool_bytes);
         orch->rings[r].fanin_pool.init(fanin_entries, layout.dep_pool_capacity, orch_err);
+
+        const size_t seen_epoch_bytes = PTO2_ALIGN_UP(
+            static_cast<size_t>(layout.tensor_map.task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE
+        );
+        auto *seen_epoch = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
+        memset(seen_epoch, 0, seen_epoch_bytes);
+        orch->fanin_seen_epoch[r] = seen_epoch;
     }
 
     if (!orch->tensor_map.init_data_from_layout(layout.tensor_map, arena)) {
@@ -266,6 +278,7 @@ void PTO2OrchestratorState::wire_arena_pointers(
     auto *orch = this;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
+        orch->fanin_seen_epoch[r] = static_cast<uint32_t *>(arena.region_ptr(layout.off_fanin_seen_epoch[r]));
     }
     orch->tensor_map.wire_arena_pointers(layout.tensor_map, arena);
     orch->scope_tasks = static_cast<PTO2TaskSlotState **>(arena.region_ptr(layout.off_scope_tasks));
@@ -278,6 +291,7 @@ void PTO2OrchestratorState::destroy() {
     orch->tensor_map.destroy();
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         orch->rings[r].fanin_pool.base = nullptr;
+        orch->fanin_seen_epoch[r] = nullptr;
     }
     orch->scope_tasks = nullptr;
     orch->scope_begins = nullptr;

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <unordered_set>
 
 #include "worker_manager.h"
 
@@ -510,16 +511,22 @@ void Orchestrator::infer_deps(
     const std::vector<RemoteTaskArgsSidecar> &remote_sidecars, std::vector<TaskSlot> &producers,
     std::vector<TensorKey> &output_keys
 ) {
+    std::unordered_set<TaskSlot> producer_seen;
+    size_t tensor_count_hint = 0;
+    for (const TaskArgs &args : args_list) {
+        tensor_count_hint += static_cast<size_t>(args.tensor_count());
+    }
+    producer_seen.reserve(tensor_count_hint);
+
     auto add_unique_producer = [&](TaskSlot p) {
         // Group submits walk many TaskArgs under one slot: if two entries in
         // the same group tag the same buffer (e.g. both OUTPUT 0xCAFE), the
         // second-pass lookup would return the slot that the first pass just
         // inserted — a self-loop. Skip it.
         if (p == slot) return;
-        for (TaskSlot existing : producers) {
-            if (existing == p) return;
+        if (producer_seen.insert(p).second) {
+            producers.push_back(p);
         }
-        producers.push_back(p);
     };
 
     // Tag-driven dependency inference — mirrors L2

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/aic/kernel_write_const_visible.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/aic/kernel_write_const_visible.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#ifndef __aicore__
+#define __aicore__ [aicore]  // NOLINT(whitespace/braces)
+#endif
+
+#include "intrinsic.h"
+
+#ifdef PTO_CPUSTUB_HPP
+#define dcci(...) \
+    do {          \
+    } while (0)
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+
+extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    // Keep the swimlane bars visible. Lookup-only timing uses dummy tasks, so
+    // this spin does not affect the fanin lookup cost measurement.
+    volatile uint32_t spin = 0;
+    for (uint32_t i = 0; i < 4096; i++) {
+        spin += i;
+    }
+
+    out[0] = 42.0f;
+    if (spin == 0xffffffffu) {
+        out[0] = 43.0f;
+    }
+    dcci(&out[0], SINGLE_CACHE_LINE, CACHELINE_OUT);
+}

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+/**
+ * Explicit 64x64 fanin DAG validation scene.
+ *
+ * Args layout:
+ *   tensor[0]: producer outputs, split into disjoint producer slices
+ *   tensor[1]: consumer outputs, split into disjoint consumer slices
+ *   scalar[0]: producer_count
+ *   scalar[1]: consumer_count
+ *   scalar[2]: use_real_kernels
+ *
+ * The scene submits producer_count independent producers, then consumer_count
+ * independent consumers where every consumer explicitly depends on every
+ * producer. Real-kernel mode writes disjoint tensor slices so tensormap
+ * auto-deps do not add producer chains or consumer chains.
+ *
+ * When use_real_kernels is false, the same dependency shape is submitted with
+ * dummy tasks to isolate orchestrator fanin lookup cost.
+ */
+
+#include <cstdint>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+static constexpr int32_t MAX_PRODUCERS = 64;
+static constexpr int32_t MAX_CONSUMERS = 64;
+static constexpr uint32_t SLOT_ELEMS = 16;
+
+#define FUNC_WRITE_CONST 0
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+    (void)orch_args;  // NOLINT(readability/casting)
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 5,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+    Tensor producer_outputs = from_tensor_arg(orch_args.tensor(0));
+    Tensor consumer_outputs = from_tensor_arg(orch_args.tensor(1));
+    int32_t producer_count = static_cast<int32_t>(orch_args.scalar(0));
+    int32_t consumer_count = static_cast<int32_t>(orch_args.scalar(1));
+    bool use_real_kernels = orch_args.scalar(2) != 0;
+    if (producer_count < 1 || producer_count > MAX_PRODUCERS || consumer_count < 1 || consumer_count > MAX_CONSUMERS) {
+        rt_report_fatal(
+            PTO2_ERROR_INVALID_ARGS,
+            "producer_count=%d consumer_count=%d exceed supported range producers=[1, %d] consumers=[1, %d]",
+            producer_count, consumer_count, MAX_PRODUCERS, MAX_CONSUMERS
+        );
+        return;
+    }
+
+    PTO2TaskId producer_ids[MAX_PRODUCERS];
+    uint32_t slot_shape[1] = {SLOT_ELEMS};
+    for (int32_t i = 0; i < producer_count; i++) {
+        Arg args;
+        if (use_real_kernels) {
+            uint32_t offset[1] = {static_cast<uint32_t>(i) * SLOT_ELEMS};
+            Tensor producer_out = producer_outputs.view(slot_shape, offset);
+            args.add_inout(producer_out);
+            producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
+        } else {
+            producer_ids[i] = rt_submit_dummy_task(args).task_id();
+        }
+    }
+
+    for (int32_t c = 0; c < consumer_count; c++) {
+        Arg args;
+        args.set_dependencies(producer_ids, static_cast<uint32_t>(producer_count));
+        if (use_real_kernels) {
+            uint32_t offset[1] = {static_cast<uint32_t>(c) * SLOT_ELEMS};
+            Tensor consumer_out = consumer_outputs.view(slot_shape, offset);
+            args.add_inout(consumer_out);
+            rt_submit_aic_task(FUNC_WRITE_CONST, args);
+        } else {
+            rt_submit_dummy_task(args);
+        }
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""fanin_lookup_perf: validate a 64x64 explicit fanin DAG.
+
+The orchestration submits 64 independent producers and 64 independent
+consumers. Each consumer explicitly depends on all 64 producers. The real
+kernel case uses disjoint tensor slices so tensormap auto-deps do not add
+producer chains or consumer chains.
+"""
+
+import ctypes
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import Scalar, SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestFaninLookupPerf(SceneTestCase):
+    """Validate a wide 64-producer/64-consumer explicit fanin DAG."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/fanin_lookup_perf_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.INOUT, D.INOUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "WRITE_CONST",
+                "source": "kernels/aic/kernel_write_const_visible.cpp",
+                "core_type": "aic",
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "LookupOnlyProducers64Consumers64",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 0},
+        },
+        {
+            "name": "SwimlaneProducers64Consumers64",
+            "platforms": ["a2a3sim", "a2a3"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            "params": {"producer_count": 64, "consumer_count": 64, "use_real_kernels": 1},
+        },
+    ]
+
+    def generate_args(self, params):
+        slot_elems = 16
+        producer_count = int(params["producer_count"])
+        consumer_count = int(params["consumer_count"])
+        return TaskArgsBuilder(
+            Tensor("producer_out", torch.full((producer_count * slot_elems,), -1.0, dtype=torch.float32)),
+            Tensor("consumer_out", torch.full((consumer_count * slot_elems,), -1.0, dtype=torch.float32)),
+            Scalar("producer_count", ctypes.c_int64(producer_count)),
+            Scalar("consumer_count", ctypes.c_int64(consumer_count)),
+            Scalar("use_real_kernels", ctypes.c_int64(int(params["use_real_kernels"]))),
+        )
+
+    def compute_golden(self, args, params):
+        if not params["use_real_kernels"]:
+            return
+        slot_elems = 16
+        for i in range(int(params["producer_count"])):
+            args.producer_out[i * slot_elems] = 42.0
+        for c in range(int(params["consumer_count"])):
+            args.consumer_out[c * slot_elems] = 42.0
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -118,6 +118,27 @@ function(add_a2a3_runtime_test name src)
     set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
 endfunction()
 
+function(add_a2a3_orchestrator_runtime_test name src)
+    add_executable(${name}
+        ${src}
+        ${A2A3_RUNTIME_DIR}/pto_orchestrator.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime
+    )
+    target_link_libraries(${name} PRIVATE
+        a2a3_rt_objs
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
+endfunction()
+
 # ---------------------------------------------------------------------------
 # Distributed runtime sources under test, bundled into an OBJECT library so
 # they compile once and link into every hierarchical test.
@@ -229,6 +250,27 @@ target_include_directories(a5_rt_objs PUBLIC
 function(add_a5_runtime_test name src)
     add_executable(${name} ${src})
     target_include_directories(${name} PRIVATE ${GTEST_INCLUDE_DIRS})
+    target_link_libraries(${name} PRIVATE
+        a5_rt_objs
+        ${GTEST_MAIN_LIB}
+        ${GTEST_LIB}
+        pthread
+    )
+    add_test(NAME ${name} COMMAND ${name})
+    set_tests_properties(${name} PROPERTIES LABELS "no_hardware")
+endfunction()
+
+function(add_a5_orchestrator_runtime_test name src)
+    add_executable(${name}
+        ${src}
+        ${A5_RUNTIME_DIR}/pto_orchestrator.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/scope_stats_collector_aicpu.cpp
+        ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+    )
+    target_include_directories(${name} PRIVATE
+        ${GTEST_INCLUDE_DIRS}
+        ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime
+    )
     target_link_libraries(${name} PRIVATE
         a5_rt_objs
         ${GTEST_MAIN_LIB}
@@ -371,6 +413,7 @@ add_a2a3_runtime_test(test_ready_queue      a2a3/test_ready_queue.cpp)
 add_a2a3_runtime_test(test_shared_memory    a2a3/test_shared_memory.cpp)
 add_a2a3_runtime_test(test_a2a3_tensormap   a2a3/test_tensormap.cpp)
 add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
+add_a2a3_orchestrator_runtime_test(test_a2a3_orchestrator_fanin a2a3/test_orchestrator_fanin.cpp)
 add_a2a3_runtime_test(test_spsc_queue       a2a3/test_spsc_queue.cpp)
 add_a2a3_runtime_test(test_wiring           a2a3/test_wiring.cpp)
 add_a2a3_runtime_test(test_aicore_completion_mailbox a2a3/test_aicore_completion_mailbox.cpp)
@@ -393,6 +436,7 @@ add_a5_runtime_test(test_a5_ready_queue      a5/test_ready_queue.cpp)
 add_a5_runtime_test(test_a5_shared_memory    a5/test_shared_memory.cpp)
 add_a5_runtime_test(test_a5_tensormap        a5/test_tensormap.cpp)
 add_a5_runtime_test(test_a5_fanin_pool       a5/test_fanin_pool.cpp)
+add_a5_orchestrator_runtime_test(test_a5_orchestrator_fanin a5/test_orchestrator_fanin.cpp)
 add_a5_runtime_test(test_a5_spsc_queue       a5/test_spsc_queue.cpp)
 add_a5_runtime_test(test_a5_wiring           a5/test_wiring.cpp)
 add_a5_runtime_test(test_a5_aicore_completion_mailbox a5/test_aicore_completion_mailbox.cpp)

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "utils/device_arena.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+
+class OrchestratorFaninTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2OrchestratorState orch{};
+    PTO2SchedulerState sched{};
+    PTO2OrchestratorLayout orch_layout{};
+    PTO2SchedulerLayout sched_layout{};
+    std::vector<char> gm_heap;
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+
+        int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            task_window_sizes[r] = static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE);
+        }
+
+        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, task_window_sizes);
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(orch.init_data_from_layout(
+            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE
+        ));
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+    }
+
+    void TearDown() override {
+        orch.destroy();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+};
+
+TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
+    orch.begin_scope();
+
+    Arg producer_args;
+    TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
+    ASSERT_TRUE(producer.task_id().is_valid());
+
+    PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
+    Arg consumer_args;
+    consumer_args.set_dependencies(deps, 2);
+    TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
+    ASSERT_TRUE(consumer.task_id().is_valid());
+
+    auto &producer_slot =
+        sm_handle->header->rings[producer.task_id().ring()].get_slot_state_by_task_id(producer.task_id().local());
+    auto &consumer_slot =
+        sm_handle->header->rings[consumer.task_id().ring()].get_slot_state_by_task_id(consumer.task_id().local());
+
+    ASSERT_NE(consumer_slot.payload, nullptr);
+    EXPECT_EQ(consumer_slot.payload->fanin_actual_count, 1);
+    EXPECT_EQ(consumer_slot.payload->fanin_inline_slot_states[0], &producer_slot);
+    EXPECT_EQ(producer_slot.fanout_count, 2);
+}

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <vector>
+
+#include "utils/device_arena.h"
+#include "pto_orchestrator.h"
+#include "pto_shared_memory.h"
+
+class OrchestratorFaninTest : public ::testing::Test {
+protected:
+    DeviceArena sm_arena;
+    DeviceArena runtime_arena;
+    PTO2SharedMemoryHandle *sm_handle = nullptr;
+    PTO2OrchestratorState orch{};
+    PTO2SchedulerState sched{};
+    PTO2OrchestratorLayout orch_layout{};
+    PTO2SchedulerLayout sched_layout{};
+    std::vector<char> gm_heap;
+
+    void SetUp() override {
+        sm_handle = PTO2SharedMemoryHandle::create_and_init_default(sm_arena);
+        ASSERT_NE(sm_handle, nullptr);
+        gm_heap.resize(4096 * PTO2_MAX_RING_DEPTH);
+
+        int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            task_window_sizes[r] = static_cast<int32_t>(PTO2_TASK_WINDOW_SIZE);
+        }
+
+        orch_layout = PTO2OrchestratorState::reserve_layout(runtime_arena, task_window_sizes);
+        sched_layout = PTO2SchedulerState::reserve_layout(runtime_arena);
+        ASSERT_NE(runtime_arena.commit(), nullptr);
+
+        ASSERT_TRUE(orch.init_data_from_layout(
+            orch_layout, runtime_arena, sm_handle->sm_base, gm_heap.data(), 4096, PTO2_TASK_WINDOW_SIZE
+        ));
+        ASSERT_TRUE(sched.init_data_from_layout(sched_layout, runtime_arena, sm_handle->sm_base));
+        sched.wire_arena_pointers(sched_layout, runtime_arena);
+        orch.wire_arena_pointers(orch_layout, runtime_arena, &sched);
+    }
+
+    void TearDown() override {
+        orch.destroy();
+        sched.destroy();
+        runtime_arena.release();
+        sm_arena.release();
+    }
+};
+
+TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
+    orch.begin_scope();
+
+    Arg producer_args;
+    TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
+    ASSERT_TRUE(producer.task_id().is_valid());
+
+    PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
+    Arg consumer_args;
+    consumer_args.set_dependencies(deps, 2);
+    TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
+    ASSERT_TRUE(consumer.task_id().is_valid());
+
+    auto &producer_slot =
+        sm_handle->header->rings[producer.task_id().ring()].get_slot_state_by_task_id(producer.task_id().local());
+    auto &consumer_slot =
+        sm_handle->header->rings[consumer.task_id().ring()].get_slot_state_by_task_id(consumer.task_id().local());
+
+    ASSERT_NE(consumer_slot.payload, nullptr);
+    EXPECT_EQ(consumer_slot.payload->fanin_actual_count, 1);
+    EXPECT_EQ(consumer_slot.payload->fanin_inline_slot_states[0], &producer_slot);
+    EXPECT_EQ(producer_slot.fanout_count, 2);
+}

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -102,6 +102,23 @@ TEST_F(OrchestratorFixture, DependentTaskIsPending) {
     EXPECT_FALSE(rq.try_pop(extra));  // B should NOT be in ready queue
 }
 
+TEST_F(OrchestratorFixture, GroupDuplicateInputsKeepOneProducer) {
+    auto producer_args = single_tensor_args(0xBEEF, TensorArgType::OUTPUT);
+    auto producer = orch.submit_next_level(C(42), producer_args, cfg);
+    TaskSlot ready;
+    ASSERT_TRUE(rq.try_pop(ready));
+    ASSERT_EQ(ready, producer.task_slot);
+
+    TaskArgs input0 = single_tensor_args(0xBEEF, TensorArgType::INPUT);
+    TaskArgs input1 = single_tensor_args(0xBEEF, TensorArgType::INPUT);
+    auto consumer = orch.submit_next_level_group(C(43), {input0, input1}, cfg);
+
+    EXPECT_EQ(S(consumer.task_slot).state.load(), TaskState::PENDING);
+    EXPECT_EQ(S(consumer.task_slot).fanin_count, 1);
+    ASSERT_EQ(S(consumer.task_slot).fanin_producers.size(), 1u);
+    EXPECT_EQ(S(consumer.task_slot).fanin_producers[0], producer.task_slot);
+}
+
 TEST_F(OrchestratorFixture, SubmitAfterFailedProducerPoisonsConsumer) {
     orch.scope_begin();
 


### PR DESCRIPTION
## Summary
- Replace linear fanin producer dedup checks with per-ring epoch markers in a2a3/a5 runtime fanin building.
- Deduplicate producers in the common hierarchical infer_deps path with a set.
- Add runtime C++ UT coverage for duplicate explicit producers entering fanin only once on both a2a3 and a5.

Fixes #1013

## Tests
- Remote a2a3/a5 orchestrator fanin UT binaries: passed
- Remote C++ UT: `ctest --test-dir tests/ut/cpp/build-oldabi --output-on-failure` -> 41/41 passed
- Earlier remote Python no-hardware UT: 391 passed, 10 deselected
- Earlier a2a3 hardware scene smokes: vector_example, test_l3_dependency.py, test_l3_group.py passed

## Notes
- Full hardware UT still has pre-existing HCCL/domain failures in comm allocation/lifecycle paths (507899/507018 class), not in the fanin dedup path.

## Latest update
- Added `PTO2SharedMemoryRingHeader::get_slot_by_task_id(int32_t local_task_id)` following the review-comment naming/writing style, and made the by-task-id accessors reuse it.
- Changed `append_fanin_or_fail` / `mark_seen` call sites to pass producer ring + slot, with slot coming from the ring-header interface instead of open-coded arithmetic.
- Local checks: `git diff --check` passed, and `rg` confirmed no old helper-call signatures or `task_slot_from_*` helper names remain.
- Local Windows/MSVC C++ UT build was attempted but cannot compile this repo's Linux/GCC-specific C++ paths (`sys/mman.h`, `dlfcn.h`, `setenv`, `__builtin_*` intrinsics), so the fanin UTs were not runnable in this local environment after the latest amend.