### PR TITLE
test: skip two failing a2a3 cases from CI (sdma_async_completion_demo + spmd_paged_attention_highperf)

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -189,6 +189,11 @@ def run(
         worker.close()
 
 
+@pytest.mark.skip(
+    reason="onboard a2a3 SDMA STARS completion path broken "
+    "(aclnnShmemSdmaStarsQueryGetWorkspaceSize failed); disabled from CI "
+    "pending fix, see hw-native-sys/simpler#1067"
+)
 @pytest.mark.platforms(["a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
@@ -170,6 +170,10 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
     CASES = [
         {
             "name": "b1_h32_kv8_s128_bs128_fp16",
+            # Disabled from CI: regression on main (passed at 17fa04aa, fails at
+            # 19b2c0be) — sim scheduler stall (rc=-100 TIMEOUT_EXIT) and onboard
+            # golden mismatch. Tracked in hw-native-sys/simpler#1070.
+            "manual": True,
             "platforms": ["a2a3sim", "a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {


### PR DESCRIPTION
Disable two failing a2a3 scene tests from CI so the pipeline stays green while each is tracked separately. Both are mitigations only — neither fixes a root cause.

## 1. sdma_async_completion_demo (onboard a2a3) — #1067

`examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py` is a standalone pytest function (no `CASES`), so it is disabled with `@pytest.mark.skip`.

The SDMA STARS completion query into CANN (`aclnnShmemSdmaStarsQueryGetWorkspaceSize`) fails, so `TGET_ASYNC` never delivers the peer window into `out` and the golden check fails:

```
[SDMA] Created 40 STARS streams OK
[SDMA] aclnnShmemSdmaStarsQueryGetWorkspaceSize failed
E       AssertionError: assert 1 == 0
```

It only matches the onboard a2a3 run, so the skip affects no sim pipeline.

## 2. spmd_paged_attention_highperf b1 case (sim + onboard a2a3) — #1070

`tests/st/.../spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py` is a `SceneTestCase`, so the failing case `b1_h32_kv8_s128_bs128_fp16` is disabled the idiomatic way — `"manual": True` (CI runs `--manual exclude`, so it is skipped on both a2a3sim and a2a3 while staying runnable via `--manual only`).

This is a **regression on `main`**: the case passed at `17fa04aa` (2026-06-11) and fails at HEAD `19b2c0be`. On a2a3sim the scheduler stalls (`rc=-100`, `TIMEOUT_EXIT`); on onboard a2a3 the `out` golden mismatches and poisons the device. Unrelated to this PR's diff.

## Re-enabling

Each tracking issue stays open until its root cause is fixed; the fix PR must remove the corresponding `@pytest.mark.skip` / `"manual": True` and confirm the test passes.