### PR TITLE
Rename dump tensor surface to dump args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,7 @@ jobs:
         run: |
           pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --dump-tensor --clone-protocol https
+            --dump-args --clone-protocol https
 
   st-sim-a5:
     needs: detect-changes
@@ -562,7 +562,7 @@ jobs:
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --dump-tensor --clone-protocol ssh
+            --dump-args --clone-protocol ssh
 
 
   # ---------- Detect platform-specific changes (runs on GitHub server) ----------

--- a/conftest.py
+++ b/conftest.py
@@ -148,12 +148,12 @@ def pytest_addoption(parser):
         "1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases",
     )
     parser.addoption(
-        "--dump-tensor",
+        "--dump-args",
         nargs="?",
         const=1,
         type=int,
         default=0,
-        help="Dump per-task tensor I/O at runtime. Level: 0=off, 1=partial (only "
+        help="Dump per-task args at runtime. Level: 0=off, 1=partial (only "
         "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks), "
         "3=full_json_only (all tasks, JSON metadata only, no .bin payload).",
     )

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -1,4 +1,4 @@
-# Tensor Dump — Per-task Tensor Capture
+# Args Dump — Per-task Argument Capture
 
 ## 1. Background & Motivation
 
@@ -8,7 +8,7 @@ the symptom shows up two tasks downstream, the suspect tensor is
 gone, and re-running with `printf` distorts the timing that triggered
 the bug in the first place.
 
-Tensor Dump captures per-task tensor inputs and outputs during kernel
+Args Dump captures per-task tensor and scalar inputs and outputs during kernel
 execution and writes them to disk for offline inspection. The host
 pre-allocates the recording buffers, AICPU writes records during
 execution, and the host exports a JSON manifest plus a binary payload.
@@ -23,12 +23,12 @@ saw, without the timing distortion of inline printing.
 - **Logical shape preserved.** Records carry dtype, shape,
   `strides`, `start_offset`, and `is_contiguous` so logical views are
   reconstructable.
-- **Manifest + binary payload.** `--dump-tensor` writes a JSON
+- **Manifest + binary payload.** `--dump-args` writes a JSON
   manifest plus one `.bin` payload per run; tensor entries carry
   `bin_offset` / `bin_size`, while scalar entries stay manifest-only.
 - **Unified scalar args.** Scalar values are emitted as
   `kind: scalar`, `stage: before_dispatch`, zero-dim records in
-  `tensor_dump.json`; there is no separate args-only manifest. Their
+  `args_dump.json`; there is no separate args-only manifest. Their
   final `dtype` is registered at submit time in a dump-only per-task side table
   and resolved by AICPU when writing each scalar dump record.
 - **Cross-architecture.** Same flags and on-disk layout family on
@@ -37,21 +37,21 @@ saw, without the timing distortion of inline printing.
 Enable in one line (`2` = full dump, every task):
 
 ```bash
-python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor 2
+python tests/st/<case>/test_<name>.py -p a5sim --dump-args 2
 ```
 
 ## 3. How to Use
 
-### 3.1 Enable Tensor Dump
+### 3.1 Enable Args Dump
 
-`--dump-tensor` takes an optional **level**:
+`--dump-args` takes an optional **level**:
 
 | Level | Meaning |
 | ----- | ------- |
 | `0` (or flag absent) | off — zero overhead |
-| `1` (bare `--dump-tensor`) | **partial** — only tasks marked with `Arg::dump(...)` (see §3.2) |
-| `2` (`--dump-tensor 2`) | **full** — every task's tensor inputs and outputs |
-| `3` (`--dump-tensor 3`) | **full, JSON only** — every task's metadata (shape, dtype, strides, scalar values) to `tensor_dump.json`; no payload captured, no `.bin` file |
+| `1` (bare `--dump-args`) | **partial** — only tasks marked with `Arg::dump(...)` (see §3.2) |
+| `2` (`--dump-args 2`) | **full** — every task's tensor inputs and outputs |
+| `3` (`--dump-args 3`) | **full, JSON only** — every task's metadata (shape, dtype, strides, scalar values) to `args_dump.json`; no payload captured, no `.bin` file |
 
 Level 3 exists for consumers that need only the per-task tensor *structure*,
 not the element data — e.g. feeding the manifest into tooling. The AICPU
@@ -62,12 +62,12 @@ every `bin_size` at `0`.
 
 ```bash
 # Standalone runner
-python tests/st/<case>/test_<name>.py -p a5sim --dump-tensor 2     # full
-python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --dump-tensor   # partial (level 1)
+python tests/st/<case>/test_<name>.py -p a5sim --dump-args 2     # full
+python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --dump-args   # partial (level 1)
 
 # pytest
-pytest tests/st/<case> --platform a5sim --dump-tensor 2
-pytest examples/a5/host_build_graph/vector_example --platform a5sim --dump-tensor 2
+pytest tests/st/<case> --platform a5sim --dump-args 2
+pytest examples/a5/host_build_graph/vector_example --platform a5sim --dump-args 2
 ```
 
 The level sets `CallConfig::enable_dump_tensor` (0/1/2/3). The host then
@@ -79,8 +79,8 @@ distinction is carried as a `DumpTensorLevel` in the dump shared-memory header
 (`DumpDataHeader::dump_tensor_level`, host-written before launch) rather
 than in the profiling-flag bitmask. The on-device AICPU reads the storage base
 via `set_platform_dump_base()`, the enable bit via
-`set_dump_tensor_enabled(GET_PROFILING_FLAG(...))`, and latches the mode
-in `dump_tensor_init()` from the header level (`PARTIAL` → selective,
+`set_dump_args_enabled(GET_PROFILING_FLAG(...))`, and latches the mode
+in `dump_args_init()` from the header level (`PARTIAL` → selective,
 `FULL_JSON_ONLY` → metadata-only, payload copy suppressed). Because the
 level is decided host-side **before any task is
 dispatched**, it is latched up front — there is no dependence on task
@@ -136,11 +136,11 @@ on task submission order. At level 1, tasks without a marker are skipped
 and marked tasks dump only their selected arguments. At level 2, the
 markers are ignored and every task's tensors are dumped. At level 3, every
 task's tensors are dumped as metadata only (no payload, no `.bin`). With no
-`--dump-tensor` (level 0) dump is off entirely.
+`--dump-args` (level 0) dump is off entirely.
 
 If you run at level 1 but place no `dump(...)` markers anywhere, the
 manifest is empty — that is the deliberate "only what I marked" contract.
-Use `--dump-tensor 2` when you want everything.
+Use `--dump-args 2` when you want everything.
 
 ### 3.3 Output
 
@@ -151,18 +151,18 @@ The dump artifacts land under the per-task output prefix
 
 ```text
 <output_prefix>/
-└── tensor_dump/
-    ├── tensor_dump.json  # unified tensor/scalar manifest (`--dump-tensor`)
-    └── tensor_dump.bin   # raw tensor payload (`--dump-tensor`)
+└── args_dump/
+    ├── args_dump.json  # unified tensor/scalar manifest (`--dump-args`)
+    └── args.bin   # raw tensor payload (`--dump-args`)
 ```
 
 Filenames are fixed (no per-file timestamp) — the directory is the
-per-task uniqueness boundary. `--dump-tensor` emits both files in the
-same `tensor_dump/` directory.
+per-task uniqueness boundary. `--dump-args` emits both files in the
+same `args_dump/` directory.
 
-#### `tensor_dump.json` — Unified manifest
+#### `args_dump.json` — Unified manifest
 
-`tensor_dump.json` is the manifest; its `bin_file` field points at
+`args_dump.json` is the manifest; its `bin_file` field points at
 the sibling binary payload. At level 3 (full, JSON only) no payload is
 captured: `bin_file` is `null`, no `.bin` is written, and every entry's
 `bin_size` is `0`.
@@ -171,22 +171,22 @@ Example manifest (one input tensor captured before dispatch):
 
 ```json
 {
-  "run_dir": "tensor_dump",
+  "run_dir": "args_dump",
   "bin_format": {
     "type": "logical_contiguous",
     "byte_order": "little_endian"
   },
-  "total_tensors": 1,
+  "total_args": 1,
   "before_dispatch": 1,
   "after_completion": 0,
-  "input_tensors": 1,
-  "output_tensors": 0,
-  "inout_tensors": 0,
-  "truncated_tensors": 0,
+  "input_args": 1,
+  "output_args": 0,
+  "inout_args": 0,
+  "truncated_args": 0,
   "dropped_records": 0,
   "dropped_overwrite": 0,
-  "bin_file": "tensor_dump.bin",
-  "tensors": [
+  "bin_file": "args.bin",
+  "args": [
     {
       "task_id": "0x0000000200000a00",
       "role": "input",
@@ -222,7 +222,7 @@ Key fields:
   `is_contiguous` — logical view geometry. Tensor `bin_size` is
   `numel × elem_size` of the *logical* view, gathered if
   non-contiguous; scalar entries have `bin_size = 0`.
-- `bin_offset` — byte offset into `tensor_dump.bin` where the
+- `bin_offset` — byte offset into `args.bin` where the
   payload starts.
 - `truncated` / `overwritten` — set when the tensor exceeded arena
   size or was overwritten by a later task; see §7.
@@ -231,22 +231,22 @@ Key fields:
 
 ### 3.3 Inspect with `dump_viewer`
 
-The viewer auto-picks the latest `outputs/*/tensor_dump` directory
-when invoked without arguments. It loads `tensor_dump.json` and
+The viewer auto-picks the latest `outputs/*/args_dump` directory
+when invoked without arguments. It loads `args_dump.json` and
 uses its `bin_file` field to find the payload:
 
 ```bash
-# List every dumped tensor in the latest run
+# List every dumped arg in the latest run
 python -m simpler_setup.tools.dump_viewer
 
-# Filter and save matching tensors to human-readable .txt files
+# Filter and save matching args to human-readable .txt files
 python -m simpler_setup.tools.dump_viewer --stage before --role input --export
 
 # Export one specific entry by its manifest index
 python -m simpler_setup.tools.dump_viewer --index 42
 
 # Pin to a specific dump directory
-python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump \
+python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/args_dump \
     --task 0x0000000200000a00 --export
 ```
 
@@ -277,13 +277,13 @@ int t1 = add_task_with_tensor_info(
 ```
 
 Full template:
-[`tests/st/a5/host_build_graph/dump_tensor_example`](../tests/st/a5/host_build_graph/dump_tensor_example/)
+[`tests/st/a5/host_build_graph/dump_tensor`](../tests/st/a5/host_build_graph/dump_tensor/)
 (and the `a2a3` mirror at
-`tests/st/a2a3/host_build_graph/dump_tensor_example`).
+`tests/st/a2a3/host_build_graph/dump_tensor`).
 
 ## 4. Capabilities
 
-What you can read out of `tensor_dump.json` + `tensor_dump.bin`:
+What you can read out of `args_dump.json` + `args.bin`:
 
 - **Per-task input snapshots** (`role: input`, `stage:
   before_dispatch`) — what each kernel was given.
@@ -319,7 +319,7 @@ DumpDataHeader                                  (host init, AICPU reads)
 ├── num_dump_threads
 ├── records_per_buffer
 ├── magic = 0x44554D50 ("DUMP")
-└── dump_tensor_level  (DumpTensorLevel: 0=off, 1=partial, 2=full, 3=full_json_only; AICPU latches in dump_tensor_init)
+└── dump_tensor_level  (DumpTensorLevel: 0=off, 1=partial, 2=full, 3=full_json_only; AICPU latches in dump_args_init)
 
 DumpBufferState[num_dump_threads]               (per-thread)
 ├── free_queue {buffer_ptrs[SLOT_COUNT], head, tail}
@@ -344,7 +344,7 @@ These structs are binary-identical between a2a3 and a5
 `set_platform_dump_base()`. Dump enablement is propagated
 separately via the umbrella bitmask `KernelArgs::enable_profiling_flag`
 (`bit0 = PROFILING_FLAG_DUMP_TENSOR`); the AICPU kernel entry calls
-`set_dump_tensor_enabled()` with the decoded bit, so device-side
+`set_dump_args_enabled()` with the decoded bit, so device-side
 code does not infer "dump enabled" from `dump_data_base != 0`.
 
 Each record is fixed at 128 B (two cache lines) — see
@@ -354,7 +354,7 @@ Each record is fixed at 128 B (two cache lines) — see
 ### 5.2 Where dump calls are wired in
 
 Each runtime's scheduler dispatch code calls
-`dump_tensors_for_task` at two points in the per-task state machine
+`dump_args_for_task` at two points in the per-task state machine
 (for `tensormap_and_ringbuffer`, this is in
 `runtime/scheduler/scheduler_completion.cpp` and
 `runtime/scheduler/scheduler_dispatch.cpp`):
@@ -362,24 +362,24 @@ Each runtime's scheduler dispatch code calls
 ```text
 ┌──────────────────────────────────────┐
 │ per-task dispatch:                   │
-│   if enable_dump_tensor {            │
-│     dump_tensors_for_task(           │
+│   if enable_dump_args {              │
+│     dump_args_for_task(              │
 │         BEFORE_DISPATCH);            │
 │   }                                  │
 │   dispatch(task);                    │
 │   wait FIN;                          │
-│   if enable_dump_tensor {            │
-│     dump_tensors_for_task(           │
+│   if enable_dump_args {              │
+│     dump_args_for_task(              │
 │         AFTER_COMPLETION);           │
 │   }                                  │
 │   retire(task);                      │
 └──────────────────────────────────────┘
 ```
 
-`dump_tensors_for_task` walks the formal callable signature for
+`dump_args_for_task` walks the formal callable signature for
 non-scalar tensor slots, matches each tensor slot to a
 `TensorDumpInfo` (dtype + shape + strides + start offset + device
-address), and calls `dump_tensor_record` for slots that match the
+address), and calls `dump_arg_record` for slots that match the
 current stage. Scalar values are dumped separately from the flat
 payload `scalars[]`; their dtype table is registered at submit time
 and emitted as a dump-only metadata record at `BEFORE_DISPATCH`.
@@ -407,7 +407,7 @@ on `TensorInfo` (see
   - `add_task_with_tensor_info()` (single-call convenience wrapper)
 
   See
-  [`dump_tensor_orch.cpp`](../tests/st/a5/host_build_graph/dump_tensor_example/kernels/orchestration/dump_tensor_orch.cpp)
+  [`dump_tensor_orch.cpp`](../tests/st/a5/host_build_graph/dump_tensor/kernels/orchestration/dump_tensor_orch.cpp)
   for both styles in one file.
 - **`tensormap_and_ringbuffer`** — runtime layer fills `TensorInfo`
   from `PTO2TaskPayload::tensors[]` directly. The ring buffer
@@ -416,7 +416,7 @@ on `TensorInfo` (see
 
 When metadata is missing or inconsistent, the task is skipped for
 dump and a single `LOG_WARN` is emitted (guarded by
-`try_log_tensor_dump_layout_mismatch` to avoid log flooding);
+`try_log_dump_args_layout_mismatch` to avoid log flooding);
 normal execution continues.
 
 ### 5.4 a2a3 — shared-memory streaming
@@ -435,32 +435,32 @@ poll thread that drains the L2 hand-off queue into
 ┌──────────────────────────┐               ┌──────────────────────────┐
 │ TensorDumpCollector      │               │ AICPU thread             │
 │                          │               │                          │
-│ initialize()             │  alloc +      │ dump_tensor_init()       │
+│ initialize()             │  alloc +      │ dump_args_init()         │
 │   rtMalloc + halRegister │──register────>│   read DumpDataHeader    │
 │   build DumpDataHeader   │              │   cache per-thread ptrs  │
 │                          │               │                          │
 │ start()                  │               │ per-task run loop:       │
 │   ┌────────────────────┐ │               │   BEFORE_DISPATCH        │
-│   │ mgmt thread        │ │               │     dump_tensor_record() │
+│   │ mgmt thread        │ │               │     dump_arg_record()    │
 │   │ (BufferPool driver)│ │ SPSC ready    │     → write to arena     │
 │   │   poll ready queue │<┼──queues──────<│     → append record      │
 │   │   recycle buffers  │─┼──free queue──>│     → push to ready_q    │
 │   └────────────────────┘ │               │   dispatch kernel        │
 │   ┌────────────────────┐ │               │   wait FIN               │
 │   │ poll thread        │ │               │   AFTER_COMPLETION       │
-│   │   reads arena via  │ │ shared mem    │     dump_tensor_record() │
+│   │   reads arena via  │ │ shared mem    │     dump_arg_record()    │
 │   │   host mapping     │<┼──mapping─────<│                          │
 │   └────────────────────┘ │               │                          │
-│                          │               │ dump_tensor_flush()      │
+│                          │               │ dump_args_flush()        │
 │ stop()                   │               │   log per-thread stats   │
 │   join mgmt → join poll  │               └──────────────────────────┘
 │ reconcile_counters()     │
 │                          │
 │ export_dump_files()      │
 │   → <output_prefix>/     │
-│     tensor_dump/         │
-│       tensor_dump.json   │
-│       tensor_dump.bin    │
+│     args_dump/           │
+│       args_dump.json     │
+│       args.bin           │
 └──────────────────────────┘
 ```
 
@@ -531,22 +531,22 @@ the buffer's records.
 │ TensorDumpCollector      │               │ AICPU thread             │
 │   : ProfilerBase<...>    │               │                          │
 │                          │               │                          │
-│ initialize()             │  alloc + reg  │ dump_tensor_init()       │
+│ initialize()             │  alloc + reg  │ dump_args_init()         │
 │   rtMalloc shm           │──+ shadow────>│   read DumpDataHeader    │
 │   per-thread arenas      │   memset 0    │   cache per-thread ptrs  │
 │   per-thread             │   + push 0s   │                          │
 │   DumpMetaBuffers        │               │ per-task run loop:       │
 │   register_mapping(s)    │               │   BEFORE_DISPATCH        │
-│                          │               │     dump_tensor_record() │
+│                          │               │     dump_arg_record()    │
 │ start(thread_factory)    │               │   dispatch kernel        │
 │   mgmt_thread starts     │               │   wait FIN               │
 │   poll_thread starts     │               │   AFTER_COMPLETION       │
-│                          │               │     dump_tensor_record() │
+│                          │               │     dump_arg_record()    │
 │ mgmt every 10us tick:    │               │   if buffer full:        │
 │   copy_from_device(shm)  │<──memcpy─────<│     push ready entry,    │
 │   for each ready entry:  │               │     pop next from free_q │
 │     copy buf from device │<──memcpy─────<│                          │
-│     resolve host ptr     │               │ dump_tensor_flush():     │
+│     resolve host ptr     │               │ dump_args_flush():       │
 │     push to L2 ready_q   │               │   push remaining buffers │
 │   advance queue_heads,   │               │   to ready_q             │
 │     refill free_queues   │               │                          │
@@ -555,7 +555,7 @@ the buffer's records.
 │     field                │               │                          │
 │                          │               │                          │
 │ poll thread:             │               │                          │
-│   wait_pop_ready          │               │                          │
+│   wait_pop_ready         │               │                          │
 │   on_buffer_collected →  │               │                          │
 │     copy arena slice     │<──memcpy─────<│                          │
 │     extract DumpedTensors│               │                          │
@@ -570,7 +570,7 @@ the buffer's records.
 │   + dropped accounting   │               │                          │
 │ export_dump_files()      │               │                          │
 │   → <output_prefix>/     │               │                          │
-│     tensor_dump/...      │               │                          │
+│     args_dump/...        │               │                          │
 └──────────────────────────┘               └──────────────────────────┘
 ```
 
@@ -598,7 +598,7 @@ with `DumpModule`. The only a5-specific glue is the 5-callback
 `MemoryOps`, the per-tick shm mirror, and the on-demand arena copy
 inside `on_buffer_collected`.
 
-a5's per-thread AICPU flush (`dump_tensor_flush`) is the only data
+a5's per-thread AICPU flush (`dump_args_flush`) is the only data
 path on the records side — host never reads from `current_buf_ptr`
 to recover records. `reconcile_counters` is purely passive: it logs
 an error if any `current_buf_ptr` is non-zero with a non-empty buffer
@@ -622,12 +622,12 @@ an error if any `current_buf_ptr` is non-zero with a non-empty buffer
 
 ## 6. Overhead
 
-Tensor Dump is opt-in and zero-overhead when disabled — without
-`--dump-tensor` the host does not allocate dump storage and AICPU /
+Args Dump is opt-in and zero-overhead when disabled — without
+`--dump-args` the host does not allocate dump storage and AICPU /
 AICore skip the dump-specific code paths. The `pipe_barrier(PIPE_ALL)`
 before FIN is also gated on the same handshake bit.
 
-With `--dump-tensor`, AICPU records full `BEFORE_DISPATCH` /
+With `--dump-args`, AICPU records full `BEFORE_DISPATCH` /
 `AFTER_COMPLETION` tensor payloads plus manifest-only
 `BEFORE_DISPATCH` scalar args. The per-task overhead is dominated by:
 
@@ -648,7 +648,7 @@ device.
 ## 7. Limitations
 
 Three failure modes exist when dump buffers run out of space. All
-three surface in the JSON manifest plus the `dump_tensor_flush`
+three surface in the JSON manifest plus the `dump_args_flush`
 log line so users can detect and diagnose them.
 
 ### 7.1 Truncation (`truncated = true`)
@@ -733,7 +733,7 @@ full and no replacement buffer is available.
 
 **a5 mechanism (simple):** each thread has a single `DumpBuffer`
 with `capacity = RECORDS_PER_BUFFER` (default 256). When `count >=
-capacity`, subsequent `dump_tensor_record()` calls increment
+capacity`, subsequent `dump_arg_record()` calls increment
 `dropped_count` and return immediately — no metadata, no payload
 is stored for that tensor.
 
@@ -763,7 +763,7 @@ cur_buf.count = 0          ← reset and reuse
 dropped_record_count += N  ← tracks total lost records
 ```
 
-The same fallback applies during `dump_tensor_flush()` at end of
+The same fallback applies during `dump_args_flush()` at end of
 execution if the ready queue is full.
 
 **Effect:** `dropped_records` in the manifest summary shows how
@@ -802,21 +802,21 @@ Per-thread arena =
 
 ## 8. FAQ / Debug Guide
 
-**No `tensor_dump/` directory in the output.** Check that
-`--dump-tensor` was passed; without it (level 0) the host does not
+**No `args_dump/` directory in the output.** Check that
+`--dump-args` was passed; without it (level 0) the host does not
 allocate dump storage. Verify the run wrote to the expected
 `<output_prefix>` and that the kernel actually executed (a kernel
 that exits early before any task dispatch produces an empty
 manifest).
 
-**`tensor_dump/` exists but the manifest captured nothing.** You are
-most likely at the default partial level (`--dump-tensor` = level 1)
+**`args_dump/` exists but the manifest captured nothing.** You are
+most likely at the default partial level (`--dump-args` = level 1)
 with no `Arg::dump(...)` markers in the orchestration, so every task is
-skipped. Add markers (§3.2), or pass `--dump-tensor 2` for a full dump.
+skipped. Add markers (§3.2), or pass `--dump-args 2` for a full dump.
 
 **Manifest has tasks but `tensors[]` is empty.** AICPU received a
 task whose `TensorInfo` was missing or inconsistent. Look for a
-`LOG_WARN` from `try_log_tensor_dump_layout_mismatch` — it
+`LOG_WARN` from `try_log_dump_args_layout_mismatch` — it
 identifies the first mismatched task, then is suppressed to avoid
 log flooding. For `host_build_graph`, ensure
 `set_tensor_info_to_task` (or
@@ -829,7 +829,7 @@ If you see it, verify the executor saw `PROFILING_FLAG_DUMP_TENSOR`
 set in the handshake (a missing handshake bit silently disables
 the barrier).
 
-**`truncated_tensors > 0` in summary.** A tensor exceeded the
+**`truncated_args > 0` in summary.** A tensor exceeded the
 per-thread arena (default 128 MiB). Bump
 `PLATFORM_DUMP_AVG_TENSOR_BYTES` to extend the arena and rerun.
 
@@ -844,11 +844,11 @@ On a5 raise `PLATFORM_DUMP_RECORDS_PER_BUFFER`; on a2a3 raise
 `PLATFORM_DUMP_BUFFERS_PER_THREAD` and/or
 `PLATFORM_DUMP_READYQUEUE_SIZE`.
 
-**Viewer reports "no `outputs/*/tensor_dump` directory found".**
+**Viewer reports "no `outputs/*/args_dump` directory found".**
 Either the run did not produce one (see first question), or the
 viewer's working directory differs from the run's. Pass the
 explicit dump-dir path to the viewer:
-`python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump`.
+`python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/args_dump`.
 
 ## 9. Related docs
 

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -26,9 +26,11 @@ saw, without the timing distortion of inline printing.
 - **Manifest + binary payload.** `--dump-tensor` writes a JSON
   manifest plus one `.bin` payload per run; tensor entries carry
   `bin_offset` / `bin_size`, while scalar entries stay manifest-only.
-- **Unified scalar args.** Scalar callable slots are emitted as
+- **Unified scalar args.** Scalar values are emitted as
   `kind: scalar`, `stage: before_dispatch`, zero-dim records in
-  `tensor_dump.json`; there is no separate args-only manifest.
+  `tensor_dump.json`; there is no separate args-only manifest. Their
+  final `dtype` is registered at submit time in a dump-only per-task side table
+  and resolved by AICPU when writing each scalar dump record.
 - **Cross-architecture.** Same flags and on-disk layout family on
   `a2a3` and `a5`. Both runtimes are wired through.
 
@@ -274,8 +276,9 @@ What you can read out of `tensor_dump.json` + `tensor_dump.bin`:
 - **Per-task input snapshots** (`role: input`, `stage:
   before_dispatch`) — what each kernel was given.
 - **Per-dispatch scalar args** (`kind: scalar`, `stage:
-  before_dispatch`) — the raw callable-slot scalar values AICPU
-  handed to the kernel.
+  before_dispatch`) — the raw per-task scalar-slot values AICPU
+  handed to the kernel, tagged with the dump-only dtype captured at
+  submit time.
 - **Per-task output snapshots** (`role: output`, `stage:
   after_completion`) — what each kernel produced. The barrier
   ensures these reflect the kernel's final writes.
@@ -284,8 +287,8 @@ What you can read out of `tensor_dump.json` + `tensor_dump.bin`:
 - **Logical view reconstruction** — `shape` / `strides` /
   `start_offset` / `is_contiguous` plus the gathered
   logical-contiguous payload.
-- **Per-task identity** — `task_id` / `subtask_id` / `func_id`
-  correlates dump entries with swimlane and PMU rows.
+- **Per-task identity** — `task_id`, `stage`, `role`, and `arg_index`
+  identify each dumped argument within a task.
 - **Loss accounting** — `truncated` / `overwritten` per-record
   flags, plus aggregate `dropped_records` / `dropped_overwrite` in
   the summary.
@@ -361,10 +364,13 @@ Each runtime's scheduler dispatch code calls
 └──────────────────────────────────────┘
 ```
 
-`dump_tensors_for_task` walks the formal callable signature,
-matches each non-scalar slot to a `TensorDumpInfo` (dtype + shape +
-strides + start offset + device address), and calls
-`dump_tensor_record` for slots that match the current stage.
+`dump_tensors_for_task` walks the formal callable signature for
+non-scalar tensor slots, matches each tensor slot to a
+`TensorDumpInfo` (dtype + shape + strides + start offset + device
+address), and calls `dump_tensor_record` for slots that match the
+current stage. Scalar values are dumped separately from the flat
+payload `scalars[]`; their dtype table is registered at submit time
+and emitted as a dump-only metadata record at `BEFORE_DISPATCH`.
 
 When dump is enabled, AICore executors also issue
 `pipe_barrier(PIPE_ALL)` after kernel execution and before writing

--- a/docs/profiling-framework.md
+++ b/docs/profiling-framework.md
@@ -361,7 +361,7 @@ per-core ring/reg addresses travel through `KernelArgs`:
 
 | `KernelArgs` field | Producer | Consumer |
 | ------------------ | -------- | -------- |
-| `enable_profiling_flag` (bitmask) | host (DeviceRunner) | AICPU `kernel.cpp` → `set_l2_swimlane_enabled` / `set_pmu_enabled` / `set_dump_tensor_enabled`; AICore `KERNEL_ENTRY` → `set_aicore_profiling_flag` |
+| `enable_profiling_flag` (bitmask) | host (DeviceRunner) | AICPU `kernel.cpp` → `set_l2_swimlane_enabled` / `set_pmu_enabled` / `set_dump_args_enabled`; AICore `KERNEL_ENTRY` → `set_aicore_profiling_flag` |
 | `aicore_l2_swimlane_ring_addrs` (table) | host (`L2SwimlaneCollector::initialize`) | AICore `KERNEL_ENTRY` indexes `table[block_idx]` → `set_aicore_l2_swimlane_ring` |
 | `aicore_pmu_ring_addrs` (table) | host (`PmuCollector::init`) | AICore `KERNEL_ENTRY` → `set_aicore_pmu_ring` |
 | `regs` (per-physical-core register-base table) | host (already required for AICPU MMIO) | AICore `KERNEL_ENTRY` resolves `regs[get_physical_core_id()]` → `set_aicore_pmu_reg_base`; AICore `aicore_execute` caches the value at Phase-3 |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,9 +45,9 @@ python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example
 python examples/a2a3/tensormap_and_ringbuffer/vector_example/test_vector_example.py \
     -p a2a3 --enable-l2-swimlane
 
-# Tensor dump
+# Args dump
 python tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/test_alternating_matmul_add.py \
-    -p a2a3 -d 11 --dump-tensor
+    -p a2a3 -d 11 --dump-args
 ```
 
 ## Test Organization
@@ -69,7 +69,7 @@ If a module is pure C++ with no Python binding, test in **ut-cpp** (`tests/ut/cp
 
 Scene tests support advanced CLI options for benchmarking, profiling, and runtime control. These work identically in both pytest and standalone mode.
 
-> "Profiling" is the umbrella for three parallel diagnostics sub-features: `--enable-l2-swimlane` (L2 swimlane), `--dump-tensor` (unified tensor/scalar dump), and `--enable-pmu` (PMU CSV). They are independent and can be combined.
+> "Profiling" is the umbrella for three parallel diagnostics sub-features: `--enable-l2-swimlane` (L2 swimlane), `--dump-args` (unified tensor/scalar dump), and `--enable-pmu` (PMU CSV). They are independent and can be combined.
 
 ### pytest
 
@@ -87,7 +87,7 @@ pytest --platform a2a3sim --log-level debug                        # verbose C++
 python test_xxx.py -p a2a3sim                                    # default: 1 round + golden
 python test_xxx.py -p a2a3 -d 0 --rounds 100 --skip-golden       # benchmark mode
 python test_xxx.py -p a2a3 --enable-l2-swimlane                         # L2 swimlane (first round)
-python test_xxx.py -p a2a3 --dump-tensor                         # dump unified tensor/scalar artifacts
+python test_xxx.py -p a2a3 --dump-args                         # dump unified tensor/scalar artifacts
 python test_xxx.py -p a2a3 --enable-pmu 4                        # PMU CSV (MEMORY)
 python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ logging
 ```
@@ -105,7 +105,7 @@ python test_xxx.py -p a2a3sim --log-level debug                  # verbose C++ l
 | `--manual` | | `exclude` | `exclude`/`include`/`only` for manual cases |
 | `--skip-golden` | | false | Skip golden comparison (for benchmarking) |
 | `--enable-l2-swimlane [PERF_LEVEL]` | | `0` | Enable L2 swimlane collection on first round only. The flag takes an integer perf_level 0–4 (bare = 4); see [docs/dfx/l2-swimlane-profiling.md](dfx/l2-swimlane-profiling.md#31-enable-l2-swimlane) for the level table. Each test case gets its own `outputs/<case>_<ts>/` directory under which `l2_swimlane_records.json` lands; parallel runs never collide. |
-| `--dump-tensor` | | false | Dump tensors plus scalar args into unified runtime artifacts |
+| `--dump-args` | | false | Dump tensors plus scalar args into unified runtime artifacts |
 | `--enable-pmu [EVENT_TYPE]` | | `0` | Enable a2a3 PMU CSV collection. Bare flag selects `PIPE_UTILIZATION` (`2`); pass an event type such as `4` for `MEMORY`. |
 | `--exitfirst` | `-x` | false | Stop on first failing test (fail-fast, primarily for CI) |
 | `--log-level LEVEL` | | `v5` | Simpler logger threshold. Accepts `debug` / `V0..V9` / `info` / `warn` / `error` / `null` (case-insensitive). pytest's own CLI validator does `int(getattr(logging, level.upper(), level))`, so the V tiers and `NUL`/`NULL` are exposed as attributes on the `logging` module via `setattr` (registration in `conftest.py` runs before pytest's option machinery). `logging.addLevelName` is also called so `%(levelname)s` formatters print `V3` instead of `Level 18`, but it is not what makes the CLI parser accept the value. The "simpler" Python logger is the single source of truth; the value is snapshotted into the platform SO at `Worker.init()` time (not per `Worker.run()`) and pushed to host `HostLogger`, runner state, and (onboard) CANN `dlog_setlevel`. AICPU receives it via `KernelArgs.log_info_v`. Changing the Python logger level after `Worker.init()` does not retroactively affect that worker. See [Log levels](#log-levels). |
@@ -211,7 +211,7 @@ Worked examples:
 | `--rounds` | both | **(none)** | pytest-xdist already uses `-n` for worker count. Standalone originally had `-n` for `--rounds`, creating a letter-level collision whenever a user switched between pytest (`-n 8` = 8 workers) and standalone (`-n 8` = 8 rounds). Removed in [#574](https://github.com/hw-native-sys/simpler/pull/574); do not reintroduce. |
 | `--max-parallel` | both | **(none)** | `-j` would be the natural make-style short, but pytest reserves all lowercase single letters (`parser.addoption` rejects lowercase shorts). Standalone mirrors this to keep both CLIs identical — no short in either, always spell out `--max-parallel`. |
 | `--runtime` / `--level` | both | **(none)** | Internal child-mode markers; users rarely type them. No short keeps them distinctive. |
-| `--skip-golden`, `--enable-l2-swimlane`, `--dump-tensor`, `--enable-pmu`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
+| `--skip-golden`, `--enable-l2-swimlane`, `--dump-args`, `--enable-pmu`, `--manual`, `--case`, `--log-level` | both | **(none)** | Low-frequency; long form reads better in scripts and docs. Not worth reserving letters. |
 
 Practical guidance when adding a new CLI option:
 
@@ -319,7 +319,7 @@ A single file can declare both L2 and L3 classes; they're grouped by `(runtime, 
 Each test case sets its own `CallConfig.output_prefix` (chosen by `scene_test.py::_build_output_prefix` as `outputs/<ClassName>_<case>_<YYYYMMDD_HHMMSS>/`). The C++ runtime writes all diagnostic artifacts under that prefix with fixed filenames:
 
 - `outputs/<case>_<ts>/l2_swimlane_records.json` — swimlane (`--enable-l2-swimlane`)
-- `outputs/<case>_<ts>/tensor_dump/` — tensor dump (`--dump-tensor`)
+- `outputs/<case>_<ts>/args_dump/` — args dump (`--dump-args`)
 - `outputs/<case>_<ts>/pmu.csv` — PMU counters (`--enable-pmu`)
 
 Because each case gets its own directory, parallel runs (xdist workers, L3 case fanout, L2 device fanout) can never collide on filename — there is no per-file timestamp, no env-var scoping, and no post-run flatten step. `CallConfig::validate()` throws if any diagnostic flag is enabled but `output_prefix` is empty; `scene_test.py::run_class_cases` always fills it from the case label.

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -558,7 +558,7 @@ def _build_output_prefix(case_label: str) -> Path:
     """Per-case directory for diagnostic artifacts.
 
     Each case gets its own ``outputs/<case_label>_<timestamp>/`` directory; the
-    runtime writes ``l2_swimlane_records.json``, ``tensor_dump/``, and ``pmu.csv``
+    runtime writes ``l2_swimlane_records.json``, ``args_dump/``, and ``pmu.csv``
     under that root with fixed filenames. Two cases of the same name run in
     the same second is not a contemplated scenario (parallel xdist runs differ
     by class+method).
@@ -675,7 +675,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     rounds,
     skip_golden,
     enable_l2_swimlane,
-    enable_dump_tensor,
+    enable_dump_args,
     enable_pmu,
     enable_dep_gen,
     enable_scope_stats,
@@ -688,7 +688,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
     """
     cls_name = type(cls_inst).__name__
     callable_spec = getattr(type(cls_inst), "CALLABLE", None)
-    diagnostics_on = enable_l2_swimlane or enable_dump_tensor or enable_pmu or enable_dep_gen or enable_scope_stats
+    diagnostics_on = enable_l2_swimlane or enable_dump_args or enable_pmu or enable_dep_gen or enable_scope_stats
     for case in cases:
         case_label = f"{cls_name}_{case['name']}"
         # Per-case directory the runtime writes into. Required (non-empty) when
@@ -706,7 +706,7 @@ def run_class_cases(  # noqa: PLR0913 -- shared layer-5 entry; kwargs mirror CLI
                 rounds=rounds,
                 skip_golden=skip_golden,
                 enable_l2_swimlane=enable_l2_swimlane,
-                enable_dump_tensor=enable_dump_tensor,
+                enable_dump_args=enable_dump_args,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
@@ -881,7 +881,7 @@ class SceneTestCase:
         self,
         config_dict,
         enable_l2_swimlane=0,
-        enable_dump_tensor=False,
+        enable_dump_args=False,
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
@@ -898,7 +898,7 @@ class SceneTestCase:
         config.block_dim = config_dict.get("block_dim", 0)
         config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 3)
         config.enable_l2_swimlane = enable_l2_swimlane
-        config.enable_dump_tensor = enable_dump_tensor
+        config.enable_dump_tensor = enable_dump_args
         config.enable_pmu = enable_pmu  # 0=disabled, >0=enabled with event type
         config.enable_dep_gen = enable_dep_gen
         config.enable_scope_stats = enable_scope_stats
@@ -935,7 +935,7 @@ class SceneTestCase:
         rounds=1,
         skip_golden=False,
         enable_l2_swimlane=0,
-        enable_dump_tensor=False,
+        enable_dump_args=False,
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
@@ -949,7 +949,7 @@ class SceneTestCase:
                 rounds=rounds,
                 skip_golden=skip_golden,
                 enable_l2_swimlane=enable_l2_swimlane,
-                enable_dump_tensor=enable_dump_tensor,
+                enable_dump_args=enable_dump_args,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
@@ -964,7 +964,7 @@ class SceneTestCase:
                 rounds=rounds,
                 skip_golden=skip_golden,
                 enable_l2_swimlane=enable_l2_swimlane,
-                enable_dump_tensor=enable_dump_tensor,
+                enable_dump_args=enable_dump_args,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
@@ -979,7 +979,7 @@ class SceneTestCase:
         rounds=1,
         skip_golden=False,
         enable_l2_swimlane=0,
-        enable_dump_tensor=False,
+        enable_dump_args=False,
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
@@ -1027,7 +1027,7 @@ class SceneTestCase:
             config = self._build_config(
                 config_dict,
                 enable_l2_swimlane=enable_l2_swimlane,
-                enable_dump_tensor=enable_dump_tensor,
+                enable_dump_args=enable_dump_args,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
@@ -1054,7 +1054,7 @@ class SceneTestCase:
         rounds=1,
         skip_golden=False,
         enable_l2_swimlane=0,
-        enable_dump_tensor=False,
+        enable_dump_args=False,
         enable_pmu=0,
         enable_dep_gen=False,
         enable_scope_stats=False,
@@ -1109,7 +1109,7 @@ class SceneTestCase:
             config = self._build_config(
                 config_dict,
                 enable_l2_swimlane=enable_l2_swimlane,
-                enable_dump_tensor=enable_dump_tensor,
+                enable_dump_args=enable_dump_args,
                 enable_pmu=enable_pmu,
                 enable_dep_gen=enable_dep_gen,
                 enable_scope_stats=enable_scope_stats,
@@ -1163,7 +1163,7 @@ class SceneTestCase:
         rounds = request.config.getoption("--rounds", default=1)
         skip_golden = request.config.getoption("--skip-golden", default=False)
         enable_l2_swimlane = request.config.getoption("--enable-l2-swimlane", default=0)
-        enable_dump_tensor = request.config.getoption("--dump-tensor", default=0)
+        enable_dump_args = request.config.getoption("--dump-args", default=0)
         enable_pmu = request.config.getoption("--enable-pmu", default=0)
         enable_dep_gen = self._effective_enable_dep_gen(request, warn=True)
         enable_scope_stats = request.config.getoption("--enable-scope-stats", default=False)
@@ -1171,9 +1171,9 @@ class SceneTestCase:
             if enable_l2_swimlane:
                 logger.warning("Profiling disabled: --rounds > 1")
                 enable_l2_swimlane = 0
-            if enable_dump_tensor:
-                logger.warning("Dump tensor disabled: --rounds > 1")
-                enable_dump_tensor = 0
+            if enable_dump_args:
+                logger.warning("Dump args disabled: --rounds > 1")
+                enable_dump_args = 0
             if enable_pmu:
                 logger.warning("PMU disabled: --rounds > 1")
                 enable_pmu = 0
@@ -1217,7 +1217,7 @@ class SceneTestCase:
             rounds=rounds,
             skip_golden=skip_golden,
             enable_l2_swimlane=enable_l2_swimlane,
-            enable_dump_tensor=enable_dump_tensor,
+            enable_dump_args=enable_dump_args,
             enable_pmu=enable_pmu,
             enable_dep_gen=enable_dep_gen,
             enable_scope_stats=enable_scope_stats,
@@ -1282,12 +1282,12 @@ class SceneTestCase:
             "1=AICore timing, 2=+dispatch/fanout, 3=+sched phases, 4=+orch phases",
         )
         parser.add_argument(
-            "--dump-tensor",
+            "--dump-args",
             nargs="?",
             const=1,
             type=int,
             default=0,
-            help="Dump per-task tensor I/O at runtime. Level: 0=off, 1=partial (only "
+            help="Dump per-task args at runtime. Level: 0=off, 1=partial (only "
             "tasks marked via Arg::dump(...), default when given without a value), 2=full (all tasks).",
         )
         parser.add_argument(
@@ -1522,7 +1522,7 @@ class SceneTestCase:
                                 rounds=args.rounds,
                                 skip_golden=args.skip_golden,
                                 enable_l2_swimlane=args.enable_l2_swimlane,
-                                enable_dump_tensor=args.dump_tensor,
+                                enable_dump_args=args.dump_args,
                                 enable_pmu=args.enable_pmu,
                                 enable_dep_gen=args.enable_dep_gen,
                                 enable_scope_stats=args.enable_scope_stats,
@@ -1563,8 +1563,8 @@ def _dispatch_test_phases_standalone(module_name, selected_by_cls, args):  # noq
         common.append("--skip-golden")
     if args.enable_l2_swimlane:
         common += ["--enable-l2-swimlane", str(args.enable_l2_swimlane)]
-    if args.dump_tensor:
-        common.append("--dump-tensor")
+    if args.dump_args:
+        common.append("--dump-args")
     if args.enable_dep_gen:
         common.append("--enable-dep-gen")
     if args.enable_scope_stats:

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -1,6 +1,6 @@
 # Profiling & Debug Tools (shipped in the wheel)
 
-End-user CLIs for analyzing PTO Runtime profiling data and tensor dumps.
+End-user CLIs for analyzing PTO Runtime profiling data and args dumps.
 All are invokable as Python modules once the `simpler` wheel is installed —
 no repo checkout required.
 
@@ -12,9 +12,9 @@ no repo checkout required.
 - **[swimlane_converter](#swimlane_converter)** — perf JSON → Chrome Trace Event (Perfetto)
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
 - **[deps_to_graph](#deps_to_graph)** — `deps.json` (dep_gen) → pan/zoom HTML dependency graph
-- **[dump_viewer](#dump_viewer)** — inspect / export tensor dumps (see [docs/tensor-dump.md](../../docs/dfx/tensor-dump.md) for full workflow)
+- **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/tensor-dump.md](../../docs/dfx/tensor-dump.md) for full workflow)
 
-Auto-detection paths (`outputs/*/l2_swimlane_records.json`, `outputs/*/tensor_dump/`)
+Auto-detection paths (`outputs/*/l2_swimlane_records.json`, `outputs/*/args_dump/`)
 are resolved relative to the **current working directory** — run these from the
 directory that holds your `outputs/`. Each test case writes into its own
 `outputs/<case>_<ts>/` directory; the tools auto-pick the latest by mtime.
@@ -253,24 +253,24 @@ at view time.
 
 ## dump_viewer
 
-Inspect and export tensors captured by the runtime tensor-dump feature.
+Inspect and export args captured by the runtime args-dump feature.
 See [docs/tensor-dump.md](../../docs/dfx/tensor-dump.md) for the full capture workflow;
 this section only documents CLI invocation.
 
 ### Basic Usage
 
 ```bash
-# List all tensors (auto-picks latest outputs/tensor_dump_* dir)
+# List all args (auto-picks latest outputs/*/args_dump dir)
 python -m simpler_setup.tools.dump_viewer
 
-# Filter by stage/role/func_id
-python -m simpler_setup.tools.dump_viewer --func 3 --stage before --role input
+# Filter by task/stage/role
+python -m simpler_setup.tools.dump_viewer --task 0x0000000200000a00 --stage before --role input
 
 # Export the current selection to txt
-python -m simpler_setup.tools.dump_viewer --func 3 --stage before --role input --export
+python -m simpler_setup.tools.dump_viewer --task 0x0000000200000a00 --stage before --role input --export
 
-# Export a specific tensor by index (always exports)
-python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump/ --index 42
+# Export a specific arg by index (always exports)
+python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/args_dump/ --index 42
 ```
 
 ---

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -7,7 +7,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Tensor dump viewer — extract tensors from tensors.bin to txt files.
+"""Args dump viewer — extract args from args.bin to txt files.
 
 Filters (freely combinable):
     --task   Filter by task_id (hex, e.g. 0x0000000200000a00)
@@ -15,24 +15,24 @@ Filters (freely combinable):
     --role   Filter by role (input / output / inout)
     --arg    Filter by arg_index (int)
 
-With no filters: lists all tensors.
-With filters: lists matching tensors. Add --export to save them to txt.
+With no filters: lists all args.
+With filters: lists matching args. Add --export to save them to txt.
 
 Usage:
-    # List all tensors (auto-picks latest outputs/*/tensor_dump dir under ./outputs/)
+    # List all args (auto-picks latest outputs/*/args_dump dir under ./outputs/)
     python -m simpler_setup.tools.dump_viewer
 
-    # List all tensors in a specific dump dir
-    python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump/
+    # List all args in a specific dump dir
+    python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/args_dump/
 
     # List before-dispatch inputs of task_id 0x... (latest dir)
     python -m simpler_setup.tools.dump_viewer --task 0x0000000200000a00 --stage before --role input
 
     # Export them to txt
-    python -m simpler_setup.tools.dump_viewer outputs/<case>/tensor_dump/ --stage before --export
+    python -m simpler_setup.tools.dump_viewer outputs/<case>/args_dump/ --stage before --export
 
-    # Export a specific tensor by index
-    python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/tensor_dump/ --index 42 --export
+    # Export a specific arg by index
+    python -m simpler_setup.tools.dump_viewer outputs/<case>_<ts>/args_dump/ --index 42 --export
 """
 
 from __future__ import annotations
@@ -63,7 +63,7 @@ def bfloat16_to_float32(raw: int) -> float:
     return struct.unpack("f", struct.pack("I", raw << 16))[0]
 
 
-def read_tensor_data(bin_path: Path, offset: int, size: int) -> bytes:
+def read_arg_data(bin_path: Path, offset: int, size: int) -> bytes:
     with open(bin_path, "rb") as f:
         f.seek(offset)
         return f.read(size)
@@ -91,65 +91,60 @@ def format_element(val, dtype: str) -> str:
     return str(val)
 
 
-def tensor_filename(t: dict) -> str:
+def arg_filename(arg: dict) -> str:
     stage_map = {"before_dispatch": "before", "after_completion": "after"}
     role_map = {"input": "in", "output": "out", "inout": "inout"}
-    stage_str = stage_map.get(t["stage"], t["stage"])
-    role_str = role_map.get(t["role"], t["role"])
-    return f"task_{t['task_id']}_{stage_str}_{role_str}{t['arg_index']}.txt"
+    stage_str = stage_map.get(arg["stage"], arg["stage"])
+    role_str = role_map.get(arg["role"], arg["role"])
+    return f"task_{arg['task_id']}_{stage_str}_{role_str}{arg['arg_index']}.txt"
 
 
-def write_tensor(tensor: dict, bin_path: Path | None, out):
-    t = tensor
-    out.write(f"# task_id: {t['task_id']}\n")
-    out.write(f"# role: {t['role']}\n")
-    out.write(f"# stage: {t['stage']}\n")
-    out.write(f"# arg_index: {t['arg_index']}\n")
-    out.write(f"# dtype: {t['dtype']}\n")
-    out.write(f"# kind: {t.get('kind', 'tensor')}\n")
-    out.write(f"# is_contiguous: {t['is_contiguous']}\n")
-    out.write(f"# shape: {t['shape']}\n")
-    out.write(f"# strides: {t['strides']}\n")
-    out.write(f"# start_offset: {t['start_offset']}\n")
+def write_arg(arg: dict, bin_path: Path | None, out):
+    out.write(f"# task_id: {arg['task_id']}\n")
+    out.write(f"# role: {arg['role']}\n")
+    out.write(f"# stage: {arg['stage']}\n")
+    out.write(f"# arg_index: {arg['arg_index']}\n")
+    out.write(f"# dtype: {arg['dtype']}\n")
+    out.write(f"# kind: {arg.get('kind', 'tensor')}\n")
+    out.write(f"# is_contiguous: {arg['is_contiguous']}\n")
+    out.write(f"# shape: {arg['shape']}\n")
+    out.write(f"# strides: {arg['strides']}\n")
+    out.write(f"# start_offset: {arg['start_offset']}\n")
 
-    if t.get("overwritten"):
+    if arg.get("overwritten"):
         out.write("# DATA OVERWRITTEN (host too slow)\n")
         return
-    if t.get("truncated"):
+    if arg.get("truncated"):
         out.write("# DATA TRUNCATED (tensor too large for arena)\n")
 
-    if t.get("kind") == "scalar":
-        val = t.get("value")
-        if t.get("dtype", "").upper() == "BOOL":
+    if arg.get("kind") == "scalar":
+        val = arg.get("value")
+        if arg.get("dtype", "").upper() == "BOOL":
             val = "true" if val else "false"
         out.write(f"# value: {val}\n")
         return
 
-    bin_size = t.get("bin_size", 0)
+    bin_size = arg.get("bin_size", 0)
     if bin_size == 0:
         out.write("# (no data)\n")
         return
 
-    # bin_size > 0 implies a payload was captured, so bin_path is set
-    # (full_json_only dumps have bin_size == 0 everywhere and never reach here).
-    # Guard explicitly rather than assert so a corrupt manifest fails loudly
-    # even under python -O.
     if bin_path is None:
         raise ValueError("bin_path is None but bin_size > 0 (corrupt manifest?)")
-    data = read_tensor_data(bin_path, t["bin_offset"], bin_size)
-    shape = t["shape"]
+    data = read_arg_data(bin_path, arg["bin_offset"], bin_size)
+    shape = arg["shape"]
     numel = 1
     for d in shape:
         numel *= d
     if numel == 0:
         numel = 1
 
-    _, elem_sz = DTYPE_INFO.get(t["dtype"].lower(), (None, 1))
+    _, elem_sz = DTYPE_INFO.get(arg["dtype"].lower(), (None, 1))
     max_from_bytes = len(data) // elem_sz
     numel = min(numel, max_from_bytes)
 
-    elements = decode_elements(data, t["dtype"], numel)
-    formatted = [format_element(v, t["dtype"]) for v in elements]
+    elements = decode_elements(data, arg["dtype"], numel)
+    formatted = [format_element(v, arg["dtype"]) for v in elements]
 
     out.write("\n# Overview:\n")
     col_width = max(len(s) for s in formatted) if formatted else 1
@@ -180,13 +175,13 @@ def write_tensor(tensor: dict, bin_path: Path | None, out):
         out.write(f"[{idx_str}] {s}\n")
 
 
-def export_tensor(tensor: dict, bin_path: Path | None, dump_dir: Path):
+def export_arg(arg: dict, bin_path: Path | None, dump_dir: Path):
     txt_dir = dump_dir / "txt"
     txt_dir.mkdir(exist_ok=True)
-    fname = tensor_filename(tensor)
+    fname = arg_filename(arg)
     txt_path = txt_dir / fname
     with open(txt_path, "w") as f:
-        write_tensor(tensor, bin_path, f)
+        write_arg(arg, bin_path, f)
     return txt_path
 
 
@@ -194,7 +189,7 @@ def collect_valid_values(tensors: list, field: str) -> list:
     return sorted(set(str(t[field]) for t in tensors))
 
 
-def list_tensors(tensors: list):
+def list_args(tensors: list):
     print(
         f"{'idx':>6}  {'task_id':>18}  {'stage':>7}  {'role':>5}"
         f"  {'arg':>3}  {'dtype':>8}  {'shape':<20}  {'bytes':>10}"
@@ -211,10 +206,10 @@ def list_tensors(tensors: list):
 def _resolve_dump_dir(dump_dir_arg: str | None) -> Path:
     if dump_dir_arg is not None:
         return Path(dump_dir_arg)
-    # Tests/runtime now write tensor_dump under outputs/<case>/tensor_dump/.
-    candidates = sorted(Path("outputs").glob("*/tensor_dump"), key=lambda p: p.stat().st_mtime)
+    # Tests/runtime now write args_dump under outputs/<case>/args_dump/.
+    candidates = sorted(Path("outputs").glob("*/args_dump"), key=lambda p: p.stat().st_mtime)
     if not candidates:
-        print("Error: no outputs/*/tensor_dump directory found", file=sys.stderr)
+        print("Error: no outputs/*/args_dump directory found", file=sys.stderr)
         sys.exit(1)
     print(f"Using latest dump directory: {candidates[-1]}")
     return candidates[-1]
@@ -259,27 +254,27 @@ def _apply_filters(tensors: list, args: argparse.Namespace) -> list:
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Tensor dump viewer — extract tensors from tensors.bin to txt files",
+        description="Args dump viewer — extract args from args.bin to txt files",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "dump_dir",
         nargs="?",
         default=None,
-        help="Path to outputs/<case>_<ts>/tensor_dump directory (default: latest outputs/*/tensor_dump dir)",
+        help="Path to outputs/<case>_<ts>/args_dump directory (default: latest outputs/*/args_dump dir)",
     )
     parser.add_argument("--task", "-t", help="Filter by task_id (e.g. 0x0000000200000a00)")
     parser.add_argument("--stage", "-s", help="Filter by stage (before / after)")
     parser.add_argument("--role", "-r", help="Filter by role (input / output / inout)")
     parser.add_argument("--arg", "-a", type=int, help="Filter by arg_index")
-    parser.add_argument("--index", "-i", type=int, help="Select tensor by index in manifest")
-    parser.add_argument("--export", "-e", action="store_true", help="Export filtered tensors to txt")
+    parser.add_argument("--index", "-i", type=int, help="Select arg by index in manifest")
+    parser.add_argument("--export", "-e", action="store_true", help="Export filtered args to txt")
     args = parser.parse_args()
 
     dump_dir = _resolve_dump_dir(args.dump_dir)
-    manifest_path = dump_dir / "tensor_dump.json"
+    manifest_path = dump_dir / "args_dump.json"
     if not manifest_path.exists():
-        print(f"Error: tensor_dump.json not found in {dump_dir}", file=sys.stderr)
+        print(f"Error: args_dump.json not found in {dump_dir}", file=sys.stderr)
         sys.exit(1)
 
     with open(manifest_path) as f:
@@ -287,37 +282,37 @@ def main():
 
     # full_json_only dumps (level 3) carry no payload: bin_file is null and
     # there is no .bin to export from — listing metadata still works.
-    bin_name = manifest.get("bin_file", "tensors.bin")
+    bin_name = manifest.get("bin_file", "args.bin")
     bin_path = (dump_dir / bin_name) if bin_name else None
-    tensors = manifest["tensors"]
+    args_data = manifest.get("args", manifest.get("tensors", []))
 
-    filtered = _apply_filters(tensors, args)
+    filtered = _apply_filters(args_data, args)
 
     # --- Select by index ---
     if args.index is not None:
-        if args.index < 0 or args.index >= len(tensors):
-            print(f"Error: --index {args.index} out of range (0-{len(tensors) - 1})", file=sys.stderr)
+        if args.index < 0 or args.index >= len(args_data):
+            print(f"Error: --index {args.index} out of range (0-{len(args_data) - 1})", file=sys.stderr)
             sys.exit(1)
-        filtered = [tensors[args.index]]
+        filtered = [args_data[args.index]]
         args.export = True  # --index always exports
 
     if not filtered:
-        print("No tensors match the given filters.", file=sys.stderr)
+        print("No args match the given filters.", file=sys.stderr)
         sys.exit(1)
 
     # --- Export or list ---
     has_filters = any([args.task, args.stage, args.role, args.arg is not None])
 
     if args.export or args.index is not None:
-        for t in filtered:
-            txt_path = export_tensor(t, bin_path, dump_dir)
+        for arg in filtered:
+            txt_path = export_arg(arg, bin_path, dump_dir)
             print(f"Saved: {txt_path}")
-        print(f"\nExported {len(filtered)} tensor(s) to {dump_dir / 'txt/'}")
+        print(f"\nExported {len(filtered)} arg(s) to {dump_dir / 'txt/'}")
     else:
         if has_filters:
-            print(f"Filtered: {len(filtered)}/{len(tensors)} tensors")
-            print(f"Add --export to save these tensors to {dump_dir / 'txt/'}\n")
-        list_tensors(filtered)
+            print(f"Filtered: {len(filtered)}/{len(args_data)} args")
+            print(f"Add --export to save these args to {dump_dir / 'txt/'}\n")
+        list_args(filtered)
 
 
 if __name__ == "__main__":

--- a/simpler_setup/tools/dump_viewer.py
+++ b/simpler_setup/tools/dump_viewer.py
@@ -51,8 +51,11 @@ DTYPE_INFO = {
     "int64": ("q", 8),
     "uint64": ("Q", 8),
     "int16": ("h", 2),
+    "uint16": ("H", 2),
     "int8": ("b", 1),
     "uint8": ("B", 1),
+    "uint32": ("I", 4),
+    "bool": ("?", 1),
 }
 
 
@@ -103,6 +106,7 @@ def write_tensor(tensor: dict, bin_path: Path, out):
     out.write(f"# stage: {t['stage']}\n")
     out.write(f"# arg_index: {t['arg_index']}\n")
     out.write(f"# dtype: {t['dtype']}\n")
+    out.write(f"# kind: {t.get('kind', 'tensor')}\n")
     out.write(f"# is_contiguous: {t['is_contiguous']}\n")
     out.write(f"# shape: {t['shape']}\n")
     out.write(f"# strides: {t['strides']}\n")
@@ -113,6 +117,13 @@ def write_tensor(tensor: dict, bin_path: Path, out):
         return
     if t.get("truncated"):
         out.write("# DATA TRUNCATED (tensor too large for arena)\n")
+
+    if t.get("kind") == "scalar":
+        val = t.get("value")
+        if t.get("dtype", "").upper() == "BOOL":
+            val = "true" if val else "false"
+        out.write(f"# value: {val}\n")
+        return
 
     bin_size = t.get("bin_size", 0)
     if bin_size == 0:

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -108,7 +108,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // Device ordinal for per-device orchestration-SO naming in the executor.
     set_orch_device_id(static_cast<int>(k_args->device_id));
     set_platform_dump_base(k_args->dump_data_base);
-    set_dump_tensor_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_dump_args_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_swimlane_base(k_args->l2_swimlane_data_base);
     set_platform_l2_swimlane_aicore_rotation_table(k_args->l2_swimlane_aicore_rotation_table);
     set_l2_swimlane_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -87,7 +87,7 @@ int DeviceRunner::ensure_binaries_loaded() {
         if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_))) return -1;
         if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_))) return -1;
         if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_))) return -1;
-        if (!load_sym("set_dump_tensor_enabled", reinterpret_cast<void **>(&set_dump_tensor_enabled_func_))) return -1;
+        if (!load_sym("set_dump_args_enabled", reinterpret_cast<void **>(&set_dump_args_enabled_func_))) return -1;
         if (!load_sym("set_platform_l2_swimlane_base", reinterpret_cast<void **>(&set_platform_l2_swimlane_base_func_)))
             return -1;
         if (!load_sym(
@@ -382,7 +382,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     LOG_INFO_V0("Allocated simulated PMU registers: %d cores x 0x%x bytes", num_aicore, SIM_REG_BLOCK_SIZE);
 
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
-        set_platform_dump_base_func_ == nullptr || set_dump_tensor_enabled_func_ == nullptr ||
+        set_platform_dump_base_func_ == nullptr || set_dump_args_enabled_func_ == nullptr ||
         set_platform_pmu_base_func_ == nullptr || set_platform_pmu_reg_addrs_func_ == nullptr ||
         set_pmu_enabled_func_ == nullptr || set_platform_dep_gen_base_func_ == nullptr ||
         set_dep_gen_enabled_func_ == nullptr || set_scope_stats_enabled_func_ == nullptr ||
@@ -393,7 +393,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_dump_tensor_enabled_func_(enable_dump_tensor_);
+    set_dump_args_enabled_func_(enable_dump_tensor_);
     set_platform_l2_swimlane_base_func_(kernel_args_.l2_swimlane_data_base);
     set_platform_l2_swimlane_aicore_rotation_table_func_(kernel_args_.l2_swimlane_aicore_rotation_table);
     set_l2_swimlane_enabled_func_(enable_l2_swimlane_);
@@ -553,7 +553,7 @@ void DeviceRunner::unload_executor_binaries() {
         aicpu_execute_func_ = nullptr;
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
-        set_dump_tensor_enabled_func_ = nullptr;
+        set_dump_args_enabled_func_ = nullptr;
         set_platform_l2_swimlane_base_func_ = nullptr;
         set_platform_l2_swimlane_aicore_rotation_table_func_ = nullptr;
         set_l2_swimlane_enabled_func_ = nullptr;

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -57,7 +57,7 @@ private:
     void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t, uint32_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
-    void (*set_dump_tensor_enabled_func_)(bool){nullptr};
+    void (*set_dump_args_enabled_func_)(bool){nullptr};
     void (*set_platform_l2_swimlane_base_func_)(uint64_t){nullptr};
     void (*set_platform_l2_swimlane_aicore_rotation_table_func_)(uint64_t){nullptr};
     void (*set_l2_swimlane_enabled_func_)(bool){nullptr};

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -178,7 +178,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
     }
 
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
+    if (is_dump_args_enabled()) {
         uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
         if (callable_addr != 0) {
             const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
@@ -187,7 +187,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
             uint64_t tensor_buffer_addrs[RUNTIME_MAX_ARGS] = {};
             int tensor_buffer_count =
                 collect_task_tensor_buffer_addrs(runtime, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
-            dump_tensors_for_task(
+            dump_args_for_task(
                 thread_idx, static_cast<uint64_t>(task->task_id), task->num_args, *callable, tensor_info,
                 tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::AFTER_COMPLETION
             );
@@ -256,7 +256,7 @@ inline bool AicpuExecutor::try_dispatch_task(
     );
 
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
+    if (is_dump_args_enabled()) {
         Task *task = runtime.get_task(task_id);
         if (task != nullptr) {
             uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
@@ -267,7 +267,7 @@ inline bool AicpuExecutor::try_dispatch_task(
                 uint64_t tensor_buffer_addrs[RUNTIME_MAX_ARGS] = {};
                 int tensor_buffer_count =
                     collect_task_tensor_buffer_addrs(runtime, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
-                dump_tensors_for_task(
+                dump_args_for_task(
                     thread_idx, static_cast<uint64_t>(task_id), task->num_args, *callable, tensor_info,
                     tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::BEFORE_DISPATCH
                 );
@@ -368,8 +368,8 @@ int AicpuExecutor::init(Runtime *runtime) {
         dispatch_timestamps_[i] = 0;
     }
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_init(aicpu_thread_num_);
+    if (is_dump_args_enabled()) {
+        dump_args_init(aicpu_thread_num_);
     }
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
@@ -1102,8 +1102,8 @@ int AicpuExecutor::run(Runtime *runtime) {
     if (is_pmu_enabled()) {
         pmu_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_flush(thread_idx);
+    if (is_dump_args_enabled()) {
+        dump_args_flush(thread_idx);
     }
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -36,10 +36,9 @@
 #include "pto_types.h"
 #include "tensor.h"
 
-extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
-
 #if PTO2_PROFILING
 #include "aicpu/scope_stats_collector_aicpu.h"
+#include "aicpu/tensor_dump_aicpu.h"
 #endif
 
 // Verify the captured Tensor blob size in DepGenRecord matches the runtime
@@ -648,12 +647,19 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
-    // (host-decided before any dispatch), so it is race-free regardless of
-    // submission order. Here we only record each marked task's arg mask, which
-    // selective collection consults.
-    if (args.tensor_dump_arg_mask() != 0) {
-        set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+    if (is_dump_tensor_enabled()) {
+        if (args.scalar_count() > 0) {
+            set_dump_tensor_task_scalar_dtypes(
+                task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
+            );
+        }
+        // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+        // (host-decided before any dispatch), so it is race-free regardless of
+        // submission order. Here we only record each marked task's arg mask, which
+        // selective collection consults.
+        if (args.tensor_dump_arg_mask() != 0) {
+            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+        }
     }
 #endif
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -662,18 +662,18 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
+    if (is_dump_args_enabled()) {
         if (args.scalar_count() > 0) {
-            set_dump_tensor_task_scalar_dtypes(
+            set_dump_args_task_scalar_dtypes(
                 task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
             );
         }
-        // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+        // Selective vs full dump is latched at dump_args_init from DumpDataHeader
         // (host-decided before any dispatch), so it is race-free regardless of
         // submission order. Here we only record each marked task's arg mask, which
         // selective collection consults.
-        if (args.tensor_dump_arg_mask() != 0) {
-            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+        if (args.dump_arg_mask() != 0) {
+            set_dump_args_task_mask(task_id.raw, args.dump_arg_mask());
         }
     }
 #endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -181,7 +181,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         clear();
         has_error = false;
         error_msg = nullptr;
-        tensor_dump_arg_mask_ = 0;
+        dump_arg_mask_ = 0;
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
         memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
@@ -206,13 +206,13 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             "dump: all arguments must be Tensor or TensorCreateInfo"
         );
         if constexpr (sizeof...(Args) == 0) {
-            mark_all_tensor_dump_arg();
+            mark_all_dump_args();
         } else {
-            (mark_tensor_dump_arg(args), ...);
+            (mark_dump_arg(args), ...);
         }
     }
 
-    uint64_t tensor_dump_arg_mask() const { return tensor_dump_arg_mask_; }
+    uint64_t dump_arg_mask() const { return dump_arg_mask_; }
 
     template <typename... Args>
     void add_input(Args &&...args) {
@@ -382,37 +382,37 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
-    static_assert(MAX_TENSOR_ARGS <= 64, "tensor dump arg mask assumes at most 64 tensor arguments");
-    uint64_t tensor_dump_arg_mask_{0};
+    static_assert(MAX_TENSOR_ARGS <= 64, "dump arg mask assumes at most 64 tensor arguments");
+    uint64_t dump_arg_mask_{0};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
     uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
     // No-arg dump(): mark every tensor arg already added to this Arg.
-    void mark_all_tensor_dump_arg() {
+    void mark_all_dump_args() {
         if (tensor_count_ == 0) {
             set_error("dump: no tensor arguments added to this Arg");
             return;
         }
         for (int32_t i = 0; i < tensor_count_; i++) {
-            tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+            dump_arg_mask_ |= (uint64_t{1} << i);
         }
     }
 
-    void mark_tensor_dump_arg(const Tensor &tensor) {
+    void mark_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].ptr == &tensor) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                dump_arg_mask_ |= (uint64_t{1} << i);
                 return;
             }
         }
         set_error("dump: tensor is not part of this Arg");
     }
 
-    void mark_tensor_dump_arg(const TensorCreateInfo &create_info) {
+    void mark_dump_arg(const TensorCreateInfo &create_info) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].create_info == &create_info) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                dump_arg_mask_ |= (uint64_t{1} << i);
                 return;
             }
         }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -32,6 +32,7 @@
 #include <arm_neon.h>
 #endif
 
+#include "data_type.h"
 #include "pto_submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
@@ -183,6 +184,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         tensor_dump_arg_mask_ = 0;
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
+        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
     }
 
     void set_error(const char *msg) {
@@ -312,7 +314,9 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
-        ((scalars_[scalar_count_++] = to_u64(args)), ...);
+        ((scalars_[scalar_count_] = to_u64(args),
+          scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<Args>>>(), ++scalar_count_),
+         ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
@@ -370,8 +374,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
+        memcpy(&scalar_dtypes_[scalar_count_], &src.scalar_dtypes_[src_offset], count * sizeof(uint8_t));
         scalar_count_ += count;
     }
+
+    const uint8_t *scalar_dtypes() const { return scalar_dtypes_; }
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
@@ -379,6 +386,7 @@ private:
     uint64_t tensor_dump_arg_mask_{0};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+    uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
     // No-arg dump(): mark every tensor arg already added to this Arg.
     void mark_all_tensor_dump_arg() {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -851,7 +851,7 @@ int32_t SchedulerContext::init(
         l2_swimlane_aicpu_init(runtime->worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
-            // Sched-phase pool count: matches the dump_tensor_init branch in
+            // Sched-phase pool count: matches the dump_args_init branch in
             // scheduler_dispatch.cpp. sched_thread_num_ <= 0 means "use all
             // AICPU threads as scheduler threads" (see assign_cores_to_threads'
             // active_sched_threads_ normalization at line 689). Without this

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -149,8 +149,8 @@ void SchedulerContext::complete_slot_task(
 
     if (mixed_complete && !defer_completion_to_consumer) {
 #if PTO2_PROFILING
-        if (is_dump_tensor_enabled()) {
-            dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
+        if (is_dump_args_enabled()) {
+            dump_args_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                 thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
                 [](ActiveMask active_mask, int raw_subtask_id) {
                     return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -203,8 +203,8 @@ int SchedulerContext::prepare_block_for_dispatch(
     int32_t block_idx, PublishHandle *out_handles
 ) {
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
+    if (is_dump_args_enabled()) {
+        dump_args_for_task<PTO2_SUBTASK_SLOT_COUNT>(
             thread_idx, slot_state, TensorDumpStage::BEFORE_DISPATCH,
             [](ActiveMask active_mask, int raw_subtask_id) {
                 return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
@@ -590,8 +590,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
-        if (is_dump_tensor_enabled()) {
-            dump_tensor_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
+        if (is_dump_args_enabled()) {
+            dump_args_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
         }
 #endif
 
@@ -1053,8 +1053,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 #endif
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_flush(thread_idx);
+    if (is_dump_args_enabled()) {
+        dump_args_flush(thread_idx);
     }
 #endif
 #if PTO2_PROFILING

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -105,7 +105,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // Device ordinal for per-device orchestration-SO naming in the executor.
     set_orch_device_id(static_cast<int>(k_args->device_id));
     set_platform_dump_base(k_args->dump_data_base);
-    set_dump_tensor_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
+    set_dump_args_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_swimlane_base(k_args->l2_swimlane_data_base);
     set_l2_swimlane_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_L2_SWIMLANE));
     set_platform_pmu_base(k_args->pmu_data_base);

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -98,7 +98,7 @@ int DeviceRunner::ensure_binaries_loaded() {
         if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_))) return -1;
         if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_))) return -1;
         if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_))) return -1;
-        if (!load_sym("set_dump_tensor_enabled", reinterpret_cast<void **>(&set_dump_tensor_enabled_func_))) return -1;
+        if (!load_sym("set_dump_args_enabled", reinterpret_cast<void **>(&set_dump_args_enabled_func_))) return -1;
         if (!load_sym("set_platform_l2_swimlane_base", reinterpret_cast<void **>(&set_platform_l2_swimlane_base_func_)))
             return -1;
         if (!load_sym("set_l2_swimlane_enabled", reinterpret_cast<void **>(&set_l2_swimlane_enabled_func_))) return -1;
@@ -347,7 +347,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     );
 
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
-        set_platform_dump_base_func_ == nullptr || set_dump_tensor_enabled_func_ == nullptr ||
+        set_platform_dump_base_func_ == nullptr || set_dump_args_enabled_func_ == nullptr ||
         set_platform_pmu_base_func_ == nullptr || set_pmu_enabled_func_ == nullptr ||
         set_platform_dep_gen_base_func_ == nullptr || set_dep_gen_enabled_func_ == nullptr ||
         set_scope_stats_enabled_func_ == nullptr || set_platform_scope_stats_base_func_ == nullptr) {
@@ -357,7 +357,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     set_platform_regs_func_(kernel_args_.regs);
     set_platform_dump_base_func_(kernel_args_.dump_data_base);
-    set_dump_tensor_enabled_func_(enable_dump_tensor_);
+    set_dump_args_enabled_func_(enable_dump_tensor_);
     set_platform_l2_swimlane_base_func_(kernel_args_.l2_swimlane_data_base);
     set_l2_swimlane_enabled_func_(enable_l2_swimlane_);
     set_platform_pmu_base_func_(kernel_args_.pmu_data_base);
@@ -510,7 +510,7 @@ void DeviceRunner::unload_executor_binaries() {
         aicpu_execute_func_ = nullptr;
         set_platform_regs_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;
-        set_dump_tensor_enabled_func_ = nullptr;
+        set_dump_args_enabled_func_ = nullptr;
         set_platform_l2_swimlane_base_func_ = nullptr;
         set_l2_swimlane_enabled_func_ = nullptr;
         set_platform_pmu_base_func_ = nullptr;

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -60,7 +60,7 @@ private:
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_platform_dump_base_func_)(uint64_t){nullptr};
     void (*set_platform_pmu_base_func_)(uint64_t){nullptr};
-    void (*set_dump_tensor_enabled_func_)(bool){nullptr};
+    void (*set_dump_args_enabled_func_)(bool){nullptr};
     void (*set_platform_l2_swimlane_base_func_)(uint64_t){nullptr};
     void (*set_l2_swimlane_enabled_func_)(bool){nullptr};
     void (*set_pmu_enabled_func_)(bool){nullptr};

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -180,7 +180,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
     }
 
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
+    if (is_dump_args_enabled()) {
         uint64_t callable_addr = runtime.get_function_bin_addr(task->func_id);
         if (callable_addr != 0) {
             const CoreCallable *callable = reinterpret_cast<const CoreCallable *>(callable_addr);
@@ -189,7 +189,7 @@ inline void AicpuExecutor::resolve_task_dependencies(
             uint64_t tensor_buffer_addrs[RUNTIME_MAX_ARGS] = {};
             int tensor_buffer_count =
                 collect_task_tensor_buffer_addrs(runtime, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
-            dump_tensors_for_task(
+            dump_args_for_task(
                 thread_idx, static_cast<uint64_t>(task->task_id), task->num_args, *callable, tensor_info,
                 tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::AFTER_COMPLETION
             );
@@ -261,7 +261,7 @@ inline bool AicpuExecutor::try_dispatch_task(
     );
 
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
+    if (is_dump_args_enabled()) {
         Task *task = runtime_->get_task(task_id);
         if (task != nullptr) {
             uint64_t callable_addr = runtime_->get_function_bin_addr(task->func_id);
@@ -272,7 +272,7 @@ inline bool AicpuExecutor::try_dispatch_task(
                 uint64_t tensor_buffer_addrs[RUNTIME_MAX_ARGS] = {};
                 int tensor_buffer_count =
                     collect_task_tensor_buffer_addrs(*runtime_, *task, tensor_buffer_addrs, RUNTIME_MAX_ARGS);
-                dump_tensors_for_task(
+                dump_args_for_task(
                     thread_idx, static_cast<uint64_t>(task_id), task->num_args, *callable, tensor_info,
                     tensor_info_count, tensor_buffer_addrs, tensor_buffer_count, TensorDumpStage::BEFORE_DISPATCH
                 );
@@ -369,8 +369,8 @@ int AicpuExecutor::init(Runtime *runtime) {
         l2_swimlane_aicpu_init(runtime->worker_count);
     }
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_init(aicpu_thread_num_);
+    if (is_dump_args_enabled()) {
+        dump_args_init(aicpu_thread_num_);
     }
     if (is_pmu_enabled()) {
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
@@ -1106,8 +1106,8 @@ int AicpuExecutor::run(Runtime *runtime) {
     if (is_pmu_enabled()) {
         pmu_aicpu_flush_buffers(thread_idx, cur_thread_cores, thread_cores_num_[thread_idx]);
     }
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_flush(thread_idx);
+    if (is_dump_args_enabled()) {
+        dump_args_flush(thread_idx);
     }
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -658,18 +658,18 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
+    if (is_dump_args_enabled()) {
         if (args.scalar_count() > 0) {
-            set_dump_tensor_task_scalar_dtypes(
+            set_dump_args_task_scalar_dtypes(
                 task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
             );
         }
-        // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+        // Selective vs full dump is latched at dump_args_init from DumpDataHeader
         // (host-decided before any dispatch), so it is race-free regardless of
         // submission order. Here we only record each marked task's arg mask, which
         // selective collection consults.
-        if (args.tensor_dump_arg_mask() != 0) {
-            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+        if (args.dump_arg_mask() != 0) {
+            set_dump_args_task_mask(task_id.raw, args.dump_arg_mask());
         }
     }
 #endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -36,7 +36,9 @@
 #include "pto_types.h"
 #include "tensor.h"
 
-extern "C" void set_dump_tensor_task_mask(uint64_t task_id, uint64_t mask);
+#if PTO2_PROFILING
+#include "aicpu/tensor_dump_aicpu.h"
+#endif
 
 // Verify the captured Tensor blob size in DepGenRecord matches the runtime
 // Tensor layout. The platform header defines DEP_GEN_TENSOR_SIZE without
@@ -647,12 +649,19 @@ static TaskOutputTensors submit_task_common(
 
     payload.init(args, result, prepared.alloc_result, layout);
 #if PTO2_PROFILING
-    // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
-    // (host-decided before any dispatch), so it is race-free regardless of
-    // submission order. Here we only record each marked task's arg mask, which
-    // selective collection consults.
-    if (args.tensor_dump_arg_mask() != 0) {
-        set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+    if (is_dump_tensor_enabled()) {
+        if (args.scalar_count() > 0) {
+            set_dump_tensor_task_scalar_dtypes(
+                task_id.raw, static_cast<uint32_t>(args.scalar_count()), args.scalar_dtypes()
+            );
+        }
+        // Selective vs full dump is latched at dump_tensor_init from DumpDataHeader
+        // (host-decided before any dispatch), so it is race-free regardless of
+        // submission order. Here we only record each marked task's arg mask, which
+        // selective collection consults.
+        if (args.tensor_dump_arg_mask() != 0) {
+            set_dump_tensor_task_mask(task_id.raw, args.tensor_dump_arg_mask());
+        }
     }
 #endif
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -28,12 +28,13 @@
 #include <stdint.h>
 #include <string.h>
 
-#include <utility>
-
 #if defined(__aarch64__)
 #include <arm_neon.h>
 #endif
 
+#include <utility>
+
+#include "data_type.h"
 #include "pto_submit_types.h"
 #include "task_args.h"
 #include "tensor.h"
@@ -181,6 +182,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
         tensor_dump_arg_mask_ = 0;
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
+        memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
     }
 
     void reset() {
@@ -316,7 +318,9 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=32)");
             return;
         }
-        ((scalars_[scalar_count_++] = to_u64(args)), ...);
+        ((scalars_[scalar_count_] = to_u64(args),
+          scalar_dtypes_[scalar_count_] = dtype_of<std::remove_cv_t<std::remove_reference_t<Args>>>(), ++scalar_count_),
+         ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
@@ -374,8 +378,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
+        memcpy(&scalar_dtypes_[scalar_count_], &src.scalar_dtypes_[src_offset], count * sizeof(uint8_t));
         scalar_count_ += count;
     }
+
+    const uint8_t *scalar_dtypes() const { return scalar_dtypes_; }
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
@@ -383,6 +390,7 @@ private:
     uint64_t tensor_dump_arg_mask_{0};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
+    uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
     // No-arg dump(): mark every tensor arg already added to this Arg.
     void mark_all_tensor_dump_arg() {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -179,7 +179,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     void clear() {
         TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
-        tensor_dump_arg_mask_ = 0;
+        dump_arg_mask_ = 0;
         explicit_deps_ = nullptr;
         explicit_dep_count_ = 0;
         memset(scalar_dtypes_, 0, sizeof(scalar_dtypes_));
@@ -210,13 +210,13 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             "dump: all arguments must be Tensor or TensorCreateInfo"
         );
         if constexpr (sizeof...(Args) == 0) {
-            mark_all_tensor_dump_arg();
+            mark_all_dump_args();
         } else {
-            (mark_tensor_dump_arg(args), ...);
+            (mark_dump_arg(args), ...);
         }
     }
 
-    uint64_t tensor_dump_arg_mask() const { return tensor_dump_arg_mask_; }
+    uint64_t dump_arg_mask() const { return dump_arg_mask_; }
 
     template <typename... Args>
     void add_input(Args &&...args) {
@@ -386,37 +386,37 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
 private:
     // Caller-owned dependency array; lifetime must extend through submit.
-    static_assert(MAX_TENSOR_ARGS <= 64, "tensor dump arg mask assumes at most 64 tensor arguments");
-    uint64_t tensor_dump_arg_mask_{0};
+    static_assert(MAX_TENSOR_ARGS <= 64, "dump arg mask assumes at most 64 tensor arguments");
+    uint64_t dump_arg_mask_{0};
     const PTO2TaskId *explicit_deps_{nullptr};
     uint32_t explicit_dep_count_{0};
     uint8_t scalar_dtypes_[MAX_SCALAR_ARGS] = {};
 
     // No-arg dump(): mark every tensor arg already added to this Arg.
-    void mark_all_tensor_dump_arg() {
+    void mark_all_dump_args() {
         if (tensor_count_ == 0) {
             set_error("dump: no tensor arguments added to this Arg");
             return;
         }
         for (int32_t i = 0; i < tensor_count_; i++) {
-            tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+            dump_arg_mask_ |= (uint64_t{1} << i);
         }
     }
 
-    void mark_tensor_dump_arg(const Tensor &tensor) {
+    void mark_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].ptr == &tensor) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                dump_arg_mask_ |= (uint64_t{1} << i);
                 return;
             }
         }
         set_error("dump: tensor is not part of this Arg");
     }
 
-    void mark_tensor_dump_arg(const TensorCreateInfo &create_info) {
+    void mark_dump_arg(const TensorCreateInfo &create_info) {
         for (int32_t i = 0; i < tensor_count_; i++) {
             if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].create_info == &create_info) {
-                tensor_dump_arg_mask_ |= (uint64_t{1} << i);
+                dump_arg_mask_ |= (uint64_t{1} << i);
                 return;
             }
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -863,7 +863,7 @@ int32_t SchedulerContext::init(
             // When orchestrator phases merge into scheduler threads
             // (PTO2_ORCH_TO_SCHED=1), phase records flow through
             // aicpu_thread_num_ pools — matches the same branch in
-            // dump_tensor_init (scheduler_dispatch.cpp).
+            // dump_args_init (scheduler_dispatch.cpp).
             // Sched phase pool count = number of scheduler threads.
             // sched_thread_num_ <= 0 is the "use all AICPU threads as
             // scheduler threads" sentinel (see assign_cores_to_threads'

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -137,8 +137,8 @@ void SchedulerContext::complete_slot_task(
 
     if (mixed_complete && !defer_completion_to_consumer) {
 #if PTO2_PROFILING
-        if (is_dump_tensor_enabled()) {
-            dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
+        if (is_dump_args_enabled()) {
+            dump_args_for_task<PTO2_SUBTASK_SLOT_COUNT>(
                 thread_idx, slot_state, TensorDumpStage::AFTER_COMPLETION,
                 [](ActiveMask active_mask, int raw_subtask_id) {
                     return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -235,8 +235,8 @@ void SchedulerContext::dispatch_block(
     bool to_pending, int32_t block_idx
 ) {
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensors_for_task<PTO2_SUBTASK_SLOT_COUNT>(
+    if (is_dump_args_enabled()) {
+        dump_args_for_task<PTO2_SUBTASK_SLOT_COUNT>(
             thread_idx, slot_state, TensorDumpStage::BEFORE_DISPATCH,
             [](ActiveMask active_mask, int raw_subtask_id) {
                 return active_mask.subtask_active(static_cast<PTO2SubtaskSlot>(raw_subtask_id));
@@ -488,8 +488,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING
-        if (is_dump_tensor_enabled()) {
-            dump_tensor_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
+        if (is_dump_args_enabled()) {
+            dump_args_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
         }
         if (is_pmu_enabled()) {
             pmu_aicpu_init(physical_core_ids_, cores_total_num_);
@@ -936,8 +936,8 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     }
 #endif
 #if PTO2_PROFILING
-    if (is_dump_tensor_enabled()) {
-        dump_tensor_flush(thread_idx);
+    if (is_dump_args_enabled()) {
+        dump_args_flush(thread_idx);
     }
 #endif
 #if PTO2_PROFILING

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -76,6 +76,8 @@ void set_dump_tensor_selective_mode(bool enable);
 bool is_dump_tensor_selective_mode();
 void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask);
 TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id);
+void set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes);
+bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes);
 
 #ifdef __cplusplus
 }
@@ -123,8 +125,8 @@ inline void dump_tensors_for_task(
         if (try_log_tensor_dump_layout_mismatch()) {
             LOG_WARN(
                 "Thread %d: tensor dump skipped for task 0x%" PRIx64
-                ": active callable tensor count (%d) does not match payload tensor count (%d). "
-                "Task-level dump assumes payload tensors are concatenated by active subtask order.",
+                ": active callable tensor args (%d) do not match payload tensor args (%d). "
+                "Task-level dump assumes payload tensor args are concatenated by active subtask order.",
                 thread_idx, static_cast<uint64_t>(slot_state.task->task_id.raw), total_tensor_args, pl.tensor_count
             );
         }
@@ -172,19 +174,26 @@ inline void dump_tensors_for_task(
             arg_index++;
             tensor_index++;
         }
-        if (stage == TensorDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
-            for (int32_t i = 0; i < pl.scalar_count; i++) {
-                TensorDumpInfo info = {};
-                info.task_id = slot_state.task->task_id.raw;
-                info.role = TensorDumpRole::INPUT;
-                info.stage = stage;
-                info.dtype = static_cast<uint8_t>(DataType::UINT64);
-                info.ndims = 0;
-                info.arg_index = static_cast<uint32_t>(pl.tensor_count + i);
-                info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
-                info.scalar_value = pl.scalars[i];
-                dump_tensor_record(thread_idx, info);
-            }
+    }
+
+    if (stage == TensorDumpStage::BEFORE_DISPATCH && pl.scalar_count > 0) {
+        uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS] = {};
+        uint32_t dtype_scalar_count = 0;
+        bool has_scalar_dtypes =
+            get_dump_tensor_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
+        for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
+            TensorDumpInfo info = {};
+            info.task_id = slot_state.task->task_id.raw;
+            info.role = TensorDumpRole::INPUT;
+            info.stage = stage;
+            info.dtype = (has_scalar_dtypes && scalar_index < static_cast<int32_t>(dtype_scalar_count)) ?
+                             scalar_dtypes[scalar_index] :
+                             static_cast<uint8_t>(DataType::UINT64);
+            info.ndims = 0;
+            info.arg_index = static_cast<uint32_t>(pl.tensor_count + scalar_index);
+            info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
+            info.scalar_value = pl.scalars[scalar_index];
+            dump_tensor_record(thread_idx, info);
         }
     }
 }

--- a/src/common/platform/include/aicpu/tensor_dump_aicpu.h
+++ b/src/common/platform/include/aicpu/tensor_dump_aicpu.h
@@ -64,42 +64,42 @@ uint64_t get_platform_dump_base();
  *
  * @param enable true to enable tensor dump, false to disable
  */
-void set_dump_tensor_enabled(bool enable);
+void set_dump_args_enabled(bool enable);
 
 /**
  * Get whether tensor dump is enabled for this execution.
  *
  * @return true if tensor dump is enabled
  */
-bool is_dump_tensor_enabled();
-bool is_dump_tensor_selective_mode();
-void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask);
-TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id);
-void set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes);
-bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes);
+bool is_dump_args_enabled();
+bool is_dump_args_selective_mode();
+void set_dump_args_task_mask(uint64_t task_id, TensorDumpArgMask mask);
+TensorDumpArgMask get_dump_args_task_mask(uint64_t task_id);
+void set_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes);
+bool get_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes);
 
 #ifdef __cplusplus
 }
 #endif
 
 #ifdef __cplusplus
-bool get_tensor_dump_role_from_direction(ArgDirection dir, TensorDumpRole *role);
+bool get_dump_arg_role_from_direction(ArgDirection dir, TensorDumpRole *role);
 int32_t count_callable_tensor_args(const CoreCallable &callable);
-bool should_dump_tensor_at_stage(TensorDumpRole role, TensorDumpStage stage);
+bool should_dump_arg_at_stage(TensorDumpRole role, TensorDumpStage stage);
 bool should_dump_task(TensorDumpArgMask arg_mask);
-bool should_dump_tensor_arg(TensorDumpArgMask arg_mask, int32_t arg_index);
-bool try_log_tensor_dump_layout_mismatch();
-int dump_tensor_record(int thread_idx, const TensorDumpInfo &info);
+bool should_dump_arg(TensorDumpArgMask arg_mask, int32_t arg_index);
+bool try_log_dump_args_layout_mismatch();
+int dump_arg_record(int thread_idx, const TensorDumpInfo &info);
 
 template <int MaxSubtaskSlots, typename SlotStateT, typename IsSubtaskActiveFn, typename GetFunctionBinAddrFn>
-inline void dump_tensors_for_task(
+inline void dump_args_for_task(
     int32_t thread_idx, const SlotStateT &slot_state, TensorDumpStage stage, IsSubtaskActiveFn is_subtask_active,
     GetFunctionBinAddrFn get_function_bin_addr
 ) {
     const auto &pl = *slot_state.payload;
     TensorDumpArgMask dump_arg_mask = TENSOR_DUMP_ARG_MASK_NONE;
-    if (is_dump_tensor_selective_mode()) {
-        dump_arg_mask = get_dump_tensor_task_mask(slot_state.task->task_id.raw);
+    if (is_dump_args_selective_mode()) {
+        dump_arg_mask = get_dump_args_task_mask(slot_state.task->task_id.raw);
     }
     if (!should_dump_task(dump_arg_mask)) {
         return;
@@ -121,7 +121,7 @@ inline void dump_tensors_for_task(
     }
 
     if (total_tensor_args != pl.tensor_count) {
-        if (try_log_tensor_dump_layout_mismatch()) {
+        if (try_log_dump_args_layout_mismatch()) {
             LOG_WARN(
                 "Thread %d: tensor dump skipped for task 0x%" PRIx64
                 ": active callable tensor args (%d) do not match payload tensor args (%d). "
@@ -149,9 +149,8 @@ inline void dump_tensors_for_task(
                 continue;
             }
             TensorDumpRole role;
-            bool dump_tensor = get_tensor_dump_role_from_direction(dir, &role) &&
-                               should_dump_tensor_at_stage(role, stage) &&
-                               should_dump_tensor_arg(dump_arg_mask, tensor_index);
+            bool dump_tensor = get_dump_arg_role_from_direction(dir, &role) && should_dump_arg_at_stage(role, stage) &&
+                               should_dump_arg(dump_arg_mask, tensor_index);
             if (dump_tensor) {
                 const auto &t = pl.tensors[tensor_index];
                 TensorDumpInfo info = {};
@@ -168,7 +167,7 @@ inline void dump_tensors_for_task(
                 info.role = role;
                 info.stage = stage;
                 info.kind = static_cast<uint8_t>(TensorDumpKind::TENSOR);
-                dump_tensor_record(thread_idx, info);
+                dump_arg_record(thread_idx, info);
             }
             arg_index++;
             tensor_index++;
@@ -179,7 +178,7 @@ inline void dump_tensors_for_task(
         uint8_t scalar_dtypes[CORE_MAX_SCALAR_ARGS] = {};
         uint32_t dtype_scalar_count = 0;
         bool has_scalar_dtypes =
-            get_dump_tensor_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
+            get_dump_args_task_scalar_dtypes(slot_state.task->task_id.raw, &dtype_scalar_count, scalar_dtypes);
         for (int32_t scalar_index = 0; scalar_index < pl.scalar_count; scalar_index++) {
             TensorDumpInfo info = {};
             info.task_id = slot_state.task->task_id.raw;
@@ -192,13 +191,13 @@ inline void dump_tensors_for_task(
             info.arg_index = static_cast<uint32_t>(pl.tensor_count + scalar_index);
             info.kind = static_cast<uint8_t>(TensorDumpKind::SCALAR);
             info.scalar_value = pl.scalars[scalar_index];
-            dump_tensor_record(thread_idx, info);
+            dump_arg_record(thread_idx, info);
         }
     }
 }
 
 template <typename TensorInfoT>
-inline void dump_tensors_for_task(
+inline void dump_args_for_task(
     int32_t thread_idx, uint64_t task_id, int32_t task_arg_count, const CoreCallable &callable,
     const TensorInfoT *tensor_info, int32_t tensor_info_count, const uint64_t *buffer_addrs, int32_t buffer_count,
     TensorDumpStage stage
@@ -222,7 +221,7 @@ inline void dump_tensors_for_task(
         if (tensor_arg_count == 0) {
             return;
         }
-        if (try_log_tensor_dump_layout_mismatch()) {
+        if (try_log_dump_args_layout_mismatch()) {
             LOG_WARN(
                 "Thread %d: tensor dump skipped for task 0x%" PRIx64
                 ": callable tensor args (%d) do not match registered tensor info (%d)",
@@ -255,7 +254,7 @@ inline void dump_tensors_for_task(
         }
 
         TensorDumpRole role;
-        if (!get_tensor_dump_role_from_direction(dir, &role) || !should_dump_tensor_at_stage(role, stage)) {
+        if (!get_dump_arg_role_from_direction(dir, &role) || !should_dump_arg_at_stage(role, stage)) {
             tensor_arg_index++;
             continue;
         }
@@ -283,23 +282,23 @@ inline void dump_tensors_for_task(
             s *= t.raw_shapes[d];
         }
         info.start_offset = start;
-        dump_tensor_record(thread_idx, info);
+        dump_arg_record(thread_idx, info);
         tensor_arg_index++;
     }
 }
 
 /**
- * Initialize tensor dump.
+ * Initialize args dump.
  *
  * Sets up per-thread DumpBufferState pointers and pops initial
  * metadata buffers from each thread's free_queue.
  *
  * @param num_dump_threads Number of scheduling threads that will dump tensors
  */
-void dump_tensor_init(int num_dump_threads);
+void dump_args_init(int num_dump_threads);
 
 /**
- * Record a single tensor dump.
+ * Record a single dumped arg.
  *
  * Copies tensor data from GM to the thread's arena, appends a
  * TensorDumpRecord to the current metadata buffer. Switches
@@ -312,17 +311,17 @@ void dump_tensor_init(int num_dump_threads);
  * @param info Tensor metadata and identification
  * @return 0 on success or intentional drop, -1 only when dump state is unavailable
  */
-int dump_tensor_record(int thread_idx, const TensorDumpInfo &info);
+int dump_arg_record(int thread_idx, const TensorDumpInfo &info);
 
 /**
- * Flush remaining tensor dump data for a thread.
+ * Flush remaining args dump data for a thread.
  *
  * Marks non-empty metadata buffers as ready and enqueues them
  * for host collection.
  *
  * @param thread_idx Thread index
  */
-void dump_tensor_flush(int thread_idx);
+void dump_args_flush(int thread_idx);
 
 #endif
 

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -143,7 +143,7 @@ using DumpFreeCallback = profiling_common::ProfFreeCallback;
 // =============================================================================
 
 /**
- * Collected tensor metadata + payload bytes
+ * Collected arg metadata + payload bytes
  */
 struct DumpedTensor {
     uint64_t task_id;
@@ -186,7 +186,7 @@ public:
      * buffers are pushed into each thread's free_queue; the rest go into
      * the BufferPoolManager's recycled pool.
      *
-     * `output_prefix` is the per-task directory under which `tensor_dump/`
+     * `output_prefix` is the per-task directory under which `args_dump/`
      * lands. Required (non-empty); CallConfig::validate() enforces this
      * upstream. Stored on the collector so the lazily-started writer thread
      * (kicked off inside on_buffer_collected) can derive its run_dir
@@ -198,7 +198,7 @@ public:
      * @param register_cb       Host-visibility callback (nullptr on a5)
      * @param free_cb           Memory free callback
      * @param user_data         Opaque pointer forwarded to callbacks
-     * @param output_prefix     Per-task directory; tensor_dump/ subdir lands here
+     * @param output_prefix     Per-task directory; args_dump/ subdir lands here
      * @param dump_tensor_level OFF / PARTIAL (only Arg::dump()-marked tasks) /
      *                          FULL / FULL_JSON_ONLY (every task's metadata to
      *                          JSON, no payload or .bin). Written to
@@ -221,8 +221,8 @@ public:
     void on_buffer_collected(const DumpReadyBufferInfo &info);
 
     /**
-     * Write collected dumps to <output_prefix>/tensor_dump/{*.bin, *.json}.
-     * Sorts tensors by (task_id, subtask_id, func_id, stage, arg_index, role).
+     * Write collected dumps to <output_prefix>/args_dump/{*.bin, *.json}.
+     * Sorts args by (task_id, subtask_id, func_id, stage, arg_index, role).
      */
     int export_dump_files();
 
@@ -262,7 +262,7 @@ private:
     int num_dump_threads_{0};
 
     // Per-task output directory captured at initialize() time. The writer
-    // thread builds run_dir_ = output_prefix_ / "tensor_dump" lazily on the
+    // thread builds run_dir_ = output_prefix_ / "args_dump" lazily on the
     // first on_buffer_collected.
     std::string output_prefix_;
 
@@ -275,7 +275,7 @@ private:
     };
     std::vector<ArenaInfo> arenas_;
 
-    // Collected dump tensors (metadata only; payloads live in tensors.bin)
+    // Collected dump args (metadata only; payloads live in args.bin)
     std::vector<DumpedTensor> collected_;
     std::mutex collected_mutex_;
 
@@ -294,7 +294,7 @@ private:
     void process_dump_buffer(const DumpReadyBufferInfo &info);
     void start_writer_thread_once();
 
-    // Writer thread: streams tensor payloads to a single tensors.bin
+    // Writer thread: streams arg payloads to a single args.bin
     std::thread writer_thread_;
     std::mutex write_mutex_;
     std::condition_variable write_cv_;

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -11,7 +11,7 @@
 
 /**
  * @file tensor_dump_aicpu.cpp
- * @brief AICPU tensor dump collection implementation
+ * @brief AICPU args dump collection implementation
  *
  * - Per-thread DumpBufferState with SPSC free queues
  * - Per-thread ready queue for handing off full metadata buffers
@@ -35,7 +35,7 @@ static DumpMetaBuffer *s_current_dump_buf[PLATFORM_MAX_AICPU_THREADS] = {};
 
 static bool s_logged_ready_queue_full[PLATFORM_MAX_AICPU_THREADS] = {};
 static bool s_logged_no_free_meta_buffer[PLATFORM_MAX_AICPU_THREADS] = {};
-static bool s_logged_dump_layout_mismatch = false;
+static bool s_logged_dump_args_layout_mismatch = false;
 static uint32_t s_records_written[PLATFORM_MAX_AICPU_THREADS] = {};
 static uint32_t s_buffers_switched[PLATFORM_MAX_AICPU_THREADS] = {};
 static uint32_t s_buffers_flushed[PLATFORM_MAX_AICPU_THREADS] = {};
@@ -53,11 +53,11 @@ extern "C" void set_platform_dump_base(uint64_t dump_data_base) { g_platform_dum
 
 extern "C" uint64_t get_platform_dump_base() { return g_platform_dump_base; }
 
-static bool g_enable_dump_tensor = false;
-// Dump level latched from the header in dump_tensor_init(). The selective
+static bool g_enable_dump_args = false;
+// Dump level latched from the header in dump_args_init(). The selective
 // (PARTIAL) and json-only (FULL_JSON_ONLY) modes are derived from it rather
 // than tracked as separate flags — mirrors g_l2_swimlane_level.
-static DumpTensorLevel g_dump_tensor_level = DumpTensorLevel::OFF;
+static DumpTensorLevel g_dump_args_level = DumpTensorLevel::OFF;
 struct DumpTaskMaskEntry {
     uint64_t task_id;
     TensorDumpArgMask mask;
@@ -71,14 +71,14 @@ static constexpr uint64_t DUMP_TASK_MASK_EMPTY_TASK_ID = UINT64_MAX;
 static constexpr uint32_t DUMP_TASK_MASK_TABLE_CAPACITY = 32768;
 static DumpTaskMaskEntry *g_dump_mask_table = nullptr;
 static DumpTaskScalarDtypeEntry *g_dump_scalar_dtype_table = nullptr;
-static bool ensure_dump_mask_table() {
+static bool ensure_dump_args_mask_table() {
     if (g_dump_mask_table != nullptr) {
         return true;
     }
     g_dump_mask_table =
         static_cast<DumpTaskMaskEntry *>(malloc(sizeof(DumpTaskMaskEntry) * DUMP_TASK_MASK_TABLE_CAPACITY));
     if (g_dump_mask_table == nullptr) {
-        LOG_ERROR("Failed to allocate tensor dump selective mask table");
+        LOG_ERROR("Failed to allocate args dump selective mask table");
         return false;
     }
     for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
@@ -88,7 +88,7 @@ static bool ensure_dump_mask_table() {
     return true;
 }
 
-static bool ensure_dump_scalar_dtype_table() {
+static bool ensure_dump_args_scalar_dtype_table() {
     if (g_dump_scalar_dtype_table != nullptr) {
         return true;
     }
@@ -96,7 +96,7 @@ static bool ensure_dump_scalar_dtype_table() {
         malloc(sizeof(DumpTaskScalarDtypeEntry) * DUMP_TASK_MASK_TABLE_CAPACITY)
     );
     if (g_dump_scalar_dtype_table == nullptr) {
-        LOG_ERROR("Failed to allocate tensor dump scalar dtype table");
+        LOG_ERROR("Failed to allocate args dump scalar dtype table");
         return false;
     }
     for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
@@ -107,7 +107,7 @@ static bool ensure_dump_scalar_dtype_table() {
     return true;
 }
 
-static void clear_dump_mask_table() {
+static void clear_dump_args_tables() {
     if (g_dump_mask_table != nullptr) {
         for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
             g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
@@ -123,7 +123,7 @@ static void clear_dump_mask_table() {
     }
 }
 
-static bool resolve_dump_task_slot(uint64_t task_id, uint32_t *idx_out) {
+static bool resolve_dump_args_task_slot(uint64_t task_id, uint32_t *idx_out) {
     uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
     if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
         return false;
@@ -134,19 +134,19 @@ static bool resolve_dump_task_slot(uint64_t task_id, uint32_t *idx_out) {
 }
 
 extern "C" void
-set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes) {
+set_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes) {
     if (scalar_count == 0 || scalar_dtypes == nullptr) {
         return;
     }
     if (scalar_count > 32) {
-        LOG_ERROR("tensor dump scalar dtype count exceeds max (%u > 32)", scalar_count);
+        LOG_ERROR("args dump scalar dtype count exceeds max (%u > 32)", scalar_count);
         return;
     }
-    if (!ensure_dump_scalar_dtype_table()) {
+    if (!ensure_dump_args_scalar_dtype_table()) {
         return;
     }
     uint32_t idx = 0;
-    if (!resolve_dump_task_slot(task_id, &idx)) {
+    if (!resolve_dump_args_task_slot(task_id, &idx)) {
         return;
     }
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
@@ -159,15 +159,15 @@ set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, cons
             return;
         }
     }
-    LOG_ERROR("tensor dump scalar dtype table is full");
+    LOG_ERROR("args dump scalar dtype table is full");
 }
 
-extern "C" bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes) {
+extern "C" bool get_dump_args_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes) {
     if (g_dump_scalar_dtype_table == nullptr || scalar_count == nullptr || scalar_dtypes == nullptr) {
         return false;
     }
     uint32_t idx = 0;
-    if (!resolve_dump_task_slot(task_id, &idx)) {
+    if (!resolve_dump_args_task_slot(task_id, &idx)) {
         return false;
     }
     for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
@@ -185,21 +185,21 @@ extern "C" bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *s
     return false;
 }
 
-extern "C" void set_dump_tensor_enabled(bool enable) {
-    g_enable_dump_tensor = enable;
-    g_dump_tensor_level = DumpTensorLevel::OFF;
-    clear_dump_mask_table();
+extern "C" void set_dump_args_enabled(bool enable) {
+    g_enable_dump_args = enable;
+    g_dump_args_level = DumpTensorLevel::OFF;
+    clear_dump_args_tables();
 }
 
-extern "C" bool is_dump_tensor_enabled() { return g_enable_dump_tensor; }
+extern "C" bool is_dump_args_enabled() { return g_enable_dump_args; }
 
-extern "C" bool is_dump_tensor_selective_mode() { return g_dump_tensor_level == DumpTensorLevel::PARTIAL; }
+extern "C" bool is_dump_args_selective_mode() { return g_dump_args_level == DumpTensorLevel::PARTIAL; }
 
-extern "C" void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask mask) {
+extern "C" void set_dump_args_task_mask(uint64_t task_id, TensorDumpArgMask mask) {
     if (mask == TENSOR_DUMP_ARG_MASK_NONE) {
         return;
     }
-    if (!ensure_dump_mask_table()) {
+    if (!ensure_dump_args_mask_table()) {
         return;
     }
     uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
@@ -216,10 +216,10 @@ extern "C" void set_dump_tensor_task_mask(uint64_t task_id, TensorDumpArgMask ma
             return;
         }
     }
-    LOG_ERROR("tensor dump selective mask table is full");
+    LOG_ERROR("args dump selective mask table is full");
 }
 
-extern "C" TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id) {
+extern "C" TensorDumpArgMask get_dump_args_task_mask(uint64_t task_id) {
     if (g_dump_mask_table == nullptr) {
         return TENSOR_DUMP_ARG_MASK_NONE;
     }
@@ -241,7 +241,7 @@ extern "C" TensorDumpArgMask get_dump_tensor_task_mask(uint64_t task_id) {
     return TENSOR_DUMP_ARG_MASK_NONE;
 }
 
-bool get_tensor_dump_role_from_direction(ArgDirection dir, TensorDumpRole *role) {
+bool get_dump_arg_role_from_direction(ArgDirection dir, TensorDumpRole *role) {
     switch (dir) {
     case ArgDirection::IN:
         *role = TensorDumpRole::INPUT;
@@ -268,7 +268,7 @@ int32_t count_callable_tensor_args(const CoreCallable &callable) {
     return tensor_count;
 }
 
-bool should_dump_tensor_at_stage(TensorDumpRole role, TensorDumpStage stage) {
+bool should_dump_arg_at_stage(TensorDumpRole role, TensorDumpStage stage) {
     switch (role) {
     case TensorDumpRole::INPUT:
         return stage == TensorDumpStage::BEFORE_DISPATCH;
@@ -281,25 +281,25 @@ bool should_dump_tensor_at_stage(TensorDumpRole role, TensorDumpStage stage) {
 }
 
 bool should_dump_task(TensorDumpArgMask arg_mask) {
-    if (!is_dump_tensor_selective_mode()) {
+    if (!is_dump_args_selective_mode()) {
         return true;
     }
     return arg_mask != TENSOR_DUMP_ARG_MASK_NONE;
 }
 
-bool should_dump_tensor_arg(TensorDumpArgMask arg_mask, int32_t arg_index) {
-    if (!is_dump_tensor_selective_mode()) {
+bool should_dump_arg(TensorDumpArgMask arg_mask, int32_t arg_index) {
+    if (!is_dump_args_selective_mode()) {
         return true;
     }
     if (arg_index < 0 || arg_index >= static_cast<int32_t>(TENSOR_DUMP_ARG_MASK_BITS)) return false;
     return (arg_mask & (TensorDumpArgMask{1} << arg_index)) != 0;
 }
 
-bool try_log_tensor_dump_layout_mismatch() {
-    if (s_logged_dump_layout_mismatch) {
+bool try_log_dump_args_layout_mismatch() {
+    if (s_logged_dump_args_layout_mismatch) {
         return false;
     }
-    s_logged_dump_layout_mismatch = true;
+    s_logged_dump_args_layout_mismatch = true;
     return true;
 }
 
@@ -368,7 +368,7 @@ static int switch_dump_meta_buffer(int thread_idx) {
         if (!s_logged_no_free_meta_buffer[thread_idx]) {
             s_logged_no_free_meta_buffer[thread_idx] = true;
             LOG_WARN(
-                "Tensor dump ran out of free metadata buffers on thread %d after spin-wait, "
+                "Args dump ran out of free metadata buffers on thread %d after spin-wait, "
                 "overwriting current buffer. Increase PLATFORM_DUMP_BUFFERS_PER_THREAD.",
                 thread_idx
             );
@@ -397,7 +397,7 @@ static int switch_dump_meta_buffer(int thread_idx) {
         if (!s_logged_ready_queue_full[thread_idx]) {
             s_logged_ready_queue_full[thread_idx] = true;
             LOG_WARN(
-                "Tensor dump ready queue full on thread %d after spin-wait, "
+                "Args dump ready queue full on thread %d after spin-wait, "
                 "overwriting current buffer. Increase PLATFORM_DUMP_READYQUEUE_SIZE.",
                 thread_idx
             );
@@ -444,7 +444,7 @@ struct CircularArenaWriter {
     }
 };
 
-static inline uint64_t get_tensor_dump_num_elements(const TensorDumpInfo &info) {
+static inline uint64_t get_dump_arg_num_elements(const TensorDumpInfo &info) {
     uint64_t elements = 1;
     for (uint32_t d = 0; d < info.ndims && d < PLATFORM_DUMP_MAX_DIMS; d++) {
         elements *= info.shapes[d];
@@ -453,7 +453,7 @@ static inline uint64_t get_tensor_dump_num_elements(const TensorDumpInfo &info) 
 }
 
 // PyTorch-style contiguous: strides[d] == prod(shapes[d+1..]) for all d.
-static inline bool tensor_dump_is_contiguous(const TensorDumpInfo &info) {
+static inline bool dump_arg_is_contiguous(const TensorDumpInfo &info) {
     if (info.ndims == 0) return true;
     uint64_t expected = 1;
     for (int32_t d = static_cast<int32_t>(info.ndims) - 1; d >= 0 && d < PLATFORM_DUMP_MAX_DIMS; --d) {
@@ -463,7 +463,7 @@ static inline bool tensor_dump_is_contiguous(const TensorDumpInfo &info) {
     return true;
 }
 
-static inline void write_tensor_dump_contiguous_prefix(
+static inline void write_dump_arg_contiguous_prefix(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint64_t copy_bytes
 ) {
     const char *src = reinterpret_cast<const char *>(info.buffer_addr) + info.start_offset * elem_sz;
@@ -473,7 +473,7 @@ static inline void write_tensor_dump_contiguous_prefix(
 // Recursive per-dim gather: at dim d we step shapes[d] times with element step
 // strides[d]. Inner-most dim writes `shapes[d]` contiguous elements (only valid
 // when strides[innermost] == 1 — non-unit innermost stride degrades to per-element).
-static void gather_tensor_dump_dim(
+static void gather_dump_arg_dim(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint32_t dim,
     uint64_t base_element_index, uint64_t *remaining_bytes
 ) {
@@ -505,29 +505,29 @@ static void gather_tensor_dump_dim(
     const int32_t s = info.strides[dim];
     for (uint32_t i = 0; i < info.shapes[dim] && *remaining_bytes > 0; i++) {
         uint64_t next_base = base_element_index + static_cast<uint64_t>(i) * static_cast<uint64_t>(s);
-        gather_tensor_dump_dim(writer, info, elem_sz, dim + 1, next_base, remaining_bytes);
+        gather_dump_arg_dim(writer, info, elem_sz, dim + 1, next_base, remaining_bytes);
     }
 }
 
-static inline void write_tensor_dump_logical_prefix(
+static inline void write_dump_arg_logical_prefix(
     CircularArenaWriter *writer, const TensorDumpInfo &info, uint64_t elem_sz, uint64_t copy_bytes
 ) {
     if (copy_bytes == 0) {
         return;
     }
-    if (tensor_dump_is_contiguous(info)) {
-        write_tensor_dump_contiguous_prefix(writer, info, elem_sz, copy_bytes);
+    if (dump_arg_is_contiguous(info)) {
+        write_dump_arg_contiguous_prefix(writer, info, elem_sz, copy_bytes);
         return;
     }
     // Walk the view origin first; per-dim recursion adds (i * strides[d]) for each axis.
     uint64_t remaining_bytes = copy_bytes;
-    gather_tensor_dump_dim(writer, info, elem_sz, 0, info.start_offset, &remaining_bytes);
+    gather_dump_arg_dim(writer, info, elem_sz, 0, info.start_offset, &remaining_bytes);
 }
 
-void dump_tensor_init(int num_dump_threads) {
+void dump_args_init(int num_dump_threads) {
     void *dump_base = reinterpret_cast<void *>(get_platform_dump_base());
     if (dump_base == nullptr) {
-        LOG_ERROR("platform dump base is NULL, cannot initialize tensor dump");
+        LOG_ERROR("platform dump base is NULL, cannot initialize args dump");
         return;
     }
 
@@ -536,9 +536,9 @@ void dump_tensor_init(int num_dump_threads) {
     // Latch dump level from the host-written header before any task is dumped.
     // PARTIAL → selective (only Arg::dump()-marked tasks); FULL → every task;
     // FULL_JSON_ONLY → every task, metadata only (no payload copied into arena).
-    g_dump_tensor_level = static_cast<DumpTensorLevel>(s_dump_header->dump_tensor_level);
+    g_dump_args_level = static_cast<DumpTensorLevel>(s_dump_header->dump_tensor_level);
 
-    LOG_INFO_V0("Initializing tensor dump for %d threads", num_dump_threads);
+    LOG_INFO_V0("Initializing args dump for %d threads", num_dump_threads);
 
     // Pop initial metadata buffer from free_queue for each thread
     for (int t = 0; t < num_dump_threads; t++) {
@@ -575,7 +575,7 @@ void dump_tensor_init(int num_dump_threads) {
     memset(s_buffers_flushed, 0, sizeof(s_buffers_flushed));
 }
 
-int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
+int dump_arg_record(int thread_idx, const TensorDumpInfo &info) {
     if (s_dump_header == nullptr) {
         return -1;
     }
@@ -603,15 +603,15 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     // Reserve space in arena
     // Compute actual tensor data size from shape (not buffer.size which may include padding)
     TensorDumpKind kind = static_cast<TensorDumpKind>(info.kind);
-    uint64_t actual_elements = get_tensor_dump_num_elements(info);
+    uint64_t actual_elements = get_dump_arg_num_elements(info);
     uint64_t elem_sz = get_element_size(static_cast<DataType>(info.dtype));
     uint64_t bytes = actual_elements * elem_sz;
     uint64_t copy_bytes = bytes;
     bool truncated = false;
-    bool is_contiguous = tensor_dump_is_contiguous(info);
+    bool is_contiguous = dump_arg_is_contiguous(info);
     bool is_scalar = kind == TensorDumpKind::SCALAR;
 
-    if (is_scalar || g_dump_tensor_level == DumpTensorLevel::FULL_JSON_ONLY) {
+    if (is_scalar || g_dump_args_level == DumpTensorLevel::FULL_JSON_ONLY) {
         // JSON-only level captures full metadata but no payload, so the
         // record carries shape/dtype/strides with payload_size == 0.
         copy_bytes = 0;
@@ -629,7 +629,7 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     uint64_t arena_sz = state->arena_size;
     CircularArenaWriter writer = {arena, arena_sz, offset, 0};
     if (!is_scalar && copy_bytes > 0) {
-        write_tensor_dump_logical_prefix(&writer, info, elem_sz, copy_bytes);
+        write_dump_arg_logical_prefix(&writer, info, elem_sz, copy_bytes);
     }
     wmb();
 
@@ -661,7 +661,7 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
     return 0;
 }
 
-void dump_tensor_flush(int thread_idx) {
+void dump_args_flush(int thread_idx) {
     if (s_dump_header == nullptr) {
         return;
     }
@@ -683,9 +683,9 @@ void dump_tensor_flush(int thread_idx) {
             // buffer so host reconcile sees a clean state (current_buf_ptr=0)
             // and dropped == flush failures rather than silent wip-mismatch.
             // Bounded to one per thread per run (unlike the hot-path
-            // dump_tensor_record site), so no spam guard is needed here.
+            // dump_arg_record site), so no spam guard is needed here.
             LOG_ERROR(
-                "Thread %d: failed to flush tensor-dump buffer (ready_queue full), %u records lost!", thread_idx,
+                "Thread %d: failed to flush args-dump buffer (ready_queue full), %u records lost!", thread_idx,
                 buf->count
             );
             account_dropped_records(state, buf->count);
@@ -699,7 +699,7 @@ void dump_tensor_flush(int thread_idx) {
     s_buffers_flushed[thread_idx]++;
     uint32_t dropped = s_dump_states[thread_idx] ? s_dump_states[thread_idx]->dropped_record_count : 0;
     LOG_INFO_V0(
-        "Thread %d: dump_tensor_flush (records=%u, buf_switches=%u, flushes=%u, dropped=%u)", thread_idx,
+        "Thread %d: dump_args_flush (records=%u, buf_switches=%u, flushes=%u, dropped=%u)", thread_idx,
         s_records_written[thread_idx], s_buffers_switched[thread_idx], s_buffers_flushed[thread_idx], dropped
     );
 }

--- a/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
+++ b/src/common/platform/shared/aicpu/tensor_dump_aicpu.cpp
@@ -59,9 +59,15 @@ struct DumpTaskMaskEntry {
     uint64_t task_id;
     TensorDumpArgMask mask;
 };
+struct DumpTaskScalarDtypeEntry {
+    uint64_t task_id;
+    uint32_t scalar_count;
+    uint8_t scalar_dtypes[32];
+};
 static constexpr uint64_t DUMP_TASK_MASK_EMPTY_TASK_ID = UINT64_MAX;
 static constexpr uint32_t DUMP_TASK_MASK_TABLE_CAPACITY = 32768;
 static DumpTaskMaskEntry *g_dump_mask_table = nullptr;
+static DumpTaskScalarDtypeEntry *g_dump_scalar_dtype_table = nullptr;
 static bool ensure_dump_mask_table() {
     if (g_dump_mask_table != nullptr) {
         return true;
@@ -79,14 +85,101 @@ static bool ensure_dump_mask_table() {
     return true;
 }
 
-static void clear_dump_mask_table() {
-    if (g_dump_mask_table == nullptr) {
-        return;
+static bool ensure_dump_scalar_dtype_table() {
+    if (g_dump_scalar_dtype_table != nullptr) {
+        return true;
+    }
+    g_dump_scalar_dtype_table = static_cast<DumpTaskScalarDtypeEntry *>(
+        malloc(sizeof(DumpTaskScalarDtypeEntry) * DUMP_TASK_MASK_TABLE_CAPACITY)
+    );
+    if (g_dump_scalar_dtype_table == nullptr) {
+        LOG_ERROR("Failed to allocate tensor dump scalar dtype table");
+        return false;
     }
     for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
-        g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
-        g_dump_mask_table[i].mask = TENSOR_DUMP_ARG_MASK_NONE;
+        g_dump_scalar_dtype_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
+        g_dump_scalar_dtype_table[i].scalar_count = 0;
+        memset(g_dump_scalar_dtype_table[i].scalar_dtypes, 0, sizeof(g_dump_scalar_dtype_table[i].scalar_dtypes));
     }
+    return true;
+}
+
+static void clear_dump_mask_table() {
+    if (g_dump_mask_table != nullptr) {
+        for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
+            g_dump_mask_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
+            g_dump_mask_table[i].mask = TENSOR_DUMP_ARG_MASK_NONE;
+        }
+    }
+    if (g_dump_scalar_dtype_table != nullptr) {
+        for (uint32_t i = 0; i < DUMP_TASK_MASK_TABLE_CAPACITY; i++) {
+            g_dump_scalar_dtype_table[i].task_id = DUMP_TASK_MASK_EMPTY_TASK_ID;
+            g_dump_scalar_dtype_table[i].scalar_count = 0;
+            memset(g_dump_scalar_dtype_table[i].scalar_dtypes, 0, sizeof(g_dump_scalar_dtype_table[i].scalar_dtypes));
+        }
+    }
+}
+
+static bool resolve_dump_task_slot(uint64_t task_id, uint32_t *idx_out) {
+    uint32_t ring_id = static_cast<uint32_t>(task_id >> 32);
+    if (ring_id >= TENSOR_DUMP_MASK_POOL_MAX_RINGS) {
+        return false;
+    }
+    uint32_t slot = static_cast<uint32_t>(task_id) & TENSOR_DUMP_MASK_POOL_DEFAULT_SLOT_MASK;
+    *idx_out = (ring_id * TENSOR_DUMP_MASK_POOL_MAX_SLOTS + slot) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1);
+    return true;
+}
+
+extern "C" void
+set_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t scalar_count, const uint8_t *scalar_dtypes) {
+    if (scalar_count == 0 || scalar_dtypes == nullptr) {
+        return;
+    }
+    if (scalar_count > 32) {
+        LOG_ERROR("tensor dump scalar dtype count exceeds max (%u > 32)", scalar_count);
+        return;
+    }
+    if (!ensure_dump_scalar_dtype_table()) {
+        return;
+    }
+    uint32_t idx = 0;
+    if (!resolve_dump_task_slot(task_id, &idx)) {
+        return;
+    }
+    for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
+        DumpTaskScalarDtypeEntry &entry =
+            g_dump_scalar_dtype_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
+        if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID || entry.task_id == task_id) {
+            entry.task_id = task_id;
+            entry.scalar_count = scalar_count;
+            memcpy(entry.scalar_dtypes, scalar_dtypes, scalar_count * sizeof(uint8_t));
+            return;
+        }
+    }
+    LOG_ERROR("tensor dump scalar dtype table is full");
+}
+
+extern "C" bool get_dump_tensor_task_scalar_dtypes(uint64_t task_id, uint32_t *scalar_count, uint8_t *scalar_dtypes) {
+    if (g_dump_scalar_dtype_table == nullptr || scalar_count == nullptr || scalar_dtypes == nullptr) {
+        return false;
+    }
+    uint32_t idx = 0;
+    if (!resolve_dump_task_slot(task_id, &idx)) {
+        return false;
+    }
+    for (uint32_t probe = 0; probe < DUMP_TASK_MASK_TABLE_CAPACITY; probe++) {
+        const DumpTaskScalarDtypeEntry &entry =
+            g_dump_scalar_dtype_table[(idx + probe) & (DUMP_TASK_MASK_TABLE_CAPACITY - 1)];
+        if (entry.task_id == task_id) {
+            *scalar_count = entry.scalar_count;
+            memcpy(scalar_dtypes, entry.scalar_dtypes, entry.scalar_count * sizeof(uint8_t));
+            return true;
+        }
+        if (entry.task_id == DUMP_TASK_MASK_EMPTY_TASK_ID) {
+            return false;
+        }
+    }
+    return false;
 }
 
 extern "C" void set_dump_tensor_enabled(bool enable) {
@@ -509,13 +602,14 @@ int dump_tensor_record(int thread_idx, const TensorDumpInfo &info) {
 
     // Reserve space in arena
     // Compute actual tensor data size from shape (not buffer.size which may include padding)
+    TensorDumpKind kind = static_cast<TensorDumpKind>(info.kind);
     uint64_t actual_elements = get_tensor_dump_num_elements(info);
     uint64_t elem_sz = get_element_size(static_cast<DataType>(info.dtype));
     uint64_t bytes = actual_elements * elem_sz;
     uint64_t copy_bytes = bytes;
     bool truncated = false;
     bool is_contiguous = tensor_dump_is_contiguous(info);
-    bool is_scalar = static_cast<TensorDumpKind>(info.kind) == TensorDumpKind::SCALAR;
+    bool is_scalar = kind == TensorDumpKind::SCALAR;
 
     if (is_scalar) {
         copy_bytes = 0;

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -27,9 +27,11 @@
 
 #include "host/tensor_dump_collector.h"
 
+#include "data_type.h"
+
 #include <algorithm>
 #include <chrono>
-#include <cstdlib>
+#include <cmath>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -226,12 +228,13 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
         dt.is_contiguous = (rec.is_contiguous != 0);
         dt.truncated = (rec.truncated != 0);
         dt.overwritten = false;
-        if (dt.truncated && ++total_truncated_count_ == 1) {
-            LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
-        }
         dt.start_offset = rec.start_offset;
         std::memcpy(dt.shapes, rec.shapes, sizeof(dt.shapes));
         std::memcpy(dt.strides, rec.strides, sizeof(dt.strides));
+
+        if (dt.truncated && ++total_truncated_count_ == 1) {
+            LOG_WARN("Tensor dump truncation detected. Increase PLATFORM_DUMP_AVG_TENSOR_BYTES.");
+        }
 
         if (dt.kind == TensorDumpKind::TENSOR && thread_idx >= 0 && thread_idx < static_cast<int>(arenas_.size())) {
             ArenaInfo &ai = arenas_[thread_idx];
@@ -402,6 +405,43 @@ static const char *tensor_dump_kind_name(TensorDumpKind kind) {
     return "unknown";
 }
 
+static void write_scalar_json_value(std::ofstream &json, const DumpedTensor &dt) {
+    uint64_t raw = dt.scalar_value;
+    if (dt.dtype == static_cast<uint8_t>(DataType::FLOAT32)) {
+        float f;
+        memcpy(&f, &raw, sizeof(float));
+        if (std::isnan(f)) {
+            json << ", \"value\": null";
+        } else if (std::isinf(f)) {
+            json << ", \"value\": " << (f < 0 ? "\"-$Inf\"" : "\"$Inf\"");
+        } else {
+            std::ostringstream val_ss;
+            val_ss << f;
+            std::string val_str = val_ss.str();
+            if (val_str.find('.') == std::string::npos && val_str.find('e') == std::string::npos) {
+                val_str += ".0";
+            }
+            json << ", \"value\": " << val_str;
+        }
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::INT32)) {
+        int32_t val;
+        memcpy(&val, &raw, sizeof(int32_t));
+        json << ", \"value\": " << val;
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::UINT32)) {
+        uint32_t val;
+        memcpy(&val, &raw, sizeof(uint32_t));
+        json << ", \"value\": " << val;
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::BOOL)) {
+        json << ", \"value\": " << (raw != 0 ? "true" : "false");
+    } else if (dt.dtype == static_cast<uint8_t>(DataType::INT64)) {
+        int64_t val;
+        memcpy(&val, &raw, sizeof(int64_t));
+        json << ", \"value\": " << val;
+    } else {
+        json << ", \"value\": " << raw;
+    }
+}
+
 static std::string dims_to_string(const uint32_t dims[], int ndims) {
     std::ostringstream ss;
     ss << "[";
@@ -555,14 +595,15 @@ int TensorDumpCollector::export_dump_files() {
         first_entry = false;
 
         json << "    {\"task_id\": \"0x" << std::hex << std::setfill('0') << std::setw(16) << dt.task_id << std::dec
-             << "\", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
+             << "\"";
+        json << ", \"arg_index\": " << dt.arg_index << ", \"role\": \"" << tensor_dump_role_name(dt.role)
              << "\", \"stage\": \"" << tensor_dump_stage_name(dt.stage) << "\", \"kind\": \""
              << tensor_dump_kind_name(dt.kind) << "\", \"dtype\": \"" << dtype_name
              << "\", \"is_contiguous\": " << (dt.is_contiguous ? "true" : "false") << ", \"shape\": " << shape_str
              << ", \"strides\": " << strides_str << ", \"start_offset\": " << dt.start_offset
              << ", \"numel\": " << numel;
         if (dt.kind == TensorDumpKind::SCALAR) {
-            json << ", \"value\": " << dt.scalar_value;
+            write_scalar_json_value(json, dt);
         }
         json << ", \"bin_offset\": " << dt.bin_offset << ", \"bin_size\": " << dt.payload_size
              << ", \"truncated\": " << (dt.truncated ? "true" : "false")

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -170,15 +170,15 @@ void TensorDumpCollector::start_writer_thread_once() {
     writer_started_ = true;
 
     // `output_prefix_` is captured at initialize() time and is the per-task
-    // uniqueness boundary; the dump dir name is fixed (`<prefix>/tensor_dump`).
-    std::string base_name = "tensor_dump";
-    run_dir_ = std::filesystem::path(output_prefix_) / base_name;
+    // uniqueness boundary; the dump dir name is fixed (`<prefix>/args_dump`).
+    std::string run_dir_name = "args_dump";
+    run_dir_ = std::filesystem::path(output_prefix_) / run_dir_name;
     std::filesystem::create_directories(run_dir_);
     // FULL_JSON_ONLY captures no payload (device sets payload_size == 0), so
     // there is nothing to stream — skip the .bin file rather than leaving a
     // 0-byte artifact next to the manifest.
     if (dump_tensor_level_ != DumpTensorLevel::FULL_JSON_ONLY) {
-        bin_file_.open(run_dir_ / (base_name + ".bin"), std::ios::binary);
+        bin_file_.open(run_dir_ / "args.bin", std::ios::binary);
     }
     next_bin_offset_ = 0;
 
@@ -312,7 +312,7 @@ void TensorDumpCollector::on_buffer_collected(const DumpReadyBufferInfo &info) {
     if (std::chrono::duration_cast<std::chrono::seconds>(now - last_progress_time_).count() >= 5) {
         auto elapsed_s = std::chrono::duration_cast<std::chrono::seconds>(now - run_start_time_).count();
         LOG_INFO_V0(
-            "Collecting: %zu tensors, %.1f GB written (%lds)", collected_.size(), bytes_written_.load() / 1e9, elapsed_s
+            "Collecting: %zu args, %.1f GB written (%lds)", collected_.size(), bytes_written_.load() / 1e9, elapsed_s
         );
         last_progress_time_ = now;
     }
@@ -335,7 +335,7 @@ void TensorDumpCollector::reconcile_counters() {
 
     uint32_t dropped_total = 0;
     int leftover_active = 0;
-    // After stop(), dump_tensor_flush should have either enqueued the
+    // After stop(), dump_args_flush should have either enqueued the
     // active buffer (success → current_buf_ptr=0) or counted it as dropped
     // and cleared it. A non-zero pointer with non-zero count means records
     // AICPU neither delivered nor accounted for — a device-side flush bug.
@@ -510,7 +510,7 @@ int TensorDumpCollector::export_dump_files() {
                 std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - run_start_time_)
                     .count();
             LOG_INFO_V0(
-                "Writing to disk: %.1f GB written, %zu tensors remaining (%lds)", bytes_written_.load() / 1e9,
+                "Writing to disk: %.1f GB written, %zu args remaining (%lds)", bytes_written_.load() / 1e9,
                 write_queue_.size(), elapsed_s
             );
             std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -524,13 +524,13 @@ int TensorDumpCollector::export_dump_files() {
             std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - run_start_time_)
                 .count();
         LOG_INFO_V0(
-            "Collected %zu tensors, wrote %.1f GB to disk (%.1fs)", collected_.size(), bytes_written_.load() / 1e9,
+            "Collected %zu args, wrote %.1f GB to disk (%.1fs)", collected_.size(), bytes_written_.load() / 1e9,
             elapsed_ms / 1000.0
         );
     }
 
     if (collected_.empty()) {
-        LOG_WARN("No tensor dump data to export");
+        LOG_WARN("No args dump data to export");
         writer_started_ = false;
         return 0;
     }
@@ -543,13 +543,13 @@ int TensorDumpCollector::export_dump_files() {
         return static_cast<uint8_t>(a.role) < static_cast<uint8_t>(b.role);
     });
 
-    LOG_INFO_V0("Writing JSON manifest for %zu tensors...", collected_.size());
+    LOG_INFO_V0("Writing JSON manifest for %zu args...", collected_.size());
 
     uint32_t num_before_dispatch = 0;
     uint32_t num_after_completion = 0;
-    uint32_t num_input_tensors = 0;
-    uint32_t num_output_tensors = 0;
-    uint32_t num_inout_tensors = 0;
+    uint32_t num_input_args = 0;
+    uint32_t num_output_args = 0;
+    uint32_t num_inout_args = 0;
     for (const auto &dt : collected_) {
         if (dt.stage == TensorDumpStage::BEFORE_DISPATCH) {
             num_before_dispatch++;
@@ -558,40 +558,40 @@ int TensorDumpCollector::export_dump_files() {
         }
         switch (dt.role) {
         case TensorDumpRole::INPUT:
-            num_input_tensors++;
+            num_input_args++;
             break;
         case TensorDumpRole::OUTPUT:
-            num_output_tensors++;
+            num_output_args++;
             break;
         case TensorDumpRole::INOUT:
-            num_inout_tensors++;
+            num_inout_args++;
             break;
         }
     }
 
-    std::string base_name = run_dir_.filename().string();
-    std::ofstream json(run_dir_ / (base_name + ".json"));
+    std::string run_dir_name = run_dir_.filename().string();
+    std::ofstream json(run_dir_ / "args_dump.json");
     json << "{\n";
-    json << "  \"run_dir\": \"" << base_name << "\",\n";
+    json << "  \"run_dir\": \"" << run_dir_name << "\",\n";
     json << "  \"bin_format\": {\n";
     json << "    \"type\": \"logical_contiguous\",\n";
     json << "    \"byte_order\": \"little_endian\"\n";
     json << "  },\n";
-    json << "  \"total_tensors\": " << collected_.size() << ",\n";
+    json << "  \"total_args\": " << collected_.size() << ",\n";
     json << "  \"before_dispatch\": " << num_before_dispatch << ",\n";
     json << "  \"after_completion\": " << num_after_completion << ",\n";
-    json << "  \"input_tensors\": " << num_input_tensors << ",\n";
-    json << "  \"output_tensors\": " << num_output_tensors << ",\n";
-    json << "  \"inout_tensors\": " << num_inout_tensors << ",\n";
-    json << "  \"truncated_tensors\": " << total_truncated_count_ << ",\n";
+    json << "  \"input_args\": " << num_input_args << ",\n";
+    json << "  \"output_args\": " << num_output_args << ",\n";
+    json << "  \"inout_args\": " << num_inout_args << ",\n";
+    json << "  \"truncated_args\": " << total_truncated_count_ << ",\n";
     json << "  \"dropped_records\": " << total_dropped_record_count_ << ",\n";
     json << "  \"dropped_overwrite\": " << total_overwrite_count_ << ",\n";
     if (dump_tensor_level_ == DumpTensorLevel::FULL_JSON_ONLY) {
         json << "  \"bin_file\": null,\n";
     } else {
-        json << "  \"bin_file\": \"" << base_name << ".bin\",\n";
+        json << "  \"bin_file\": \"args.bin\",\n";
     }
-    json << "  \"tensors\": [\n";
+    json << "  \"args\": [\n";
 
     bool first_entry = true;
 
@@ -627,11 +627,11 @@ int TensorDumpCollector::export_dump_files() {
 
     auto export_end = std::chrono::steady_clock::now();
     auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(export_end - export_start).count();
-    LOG_INFO_V0("Wrote JSON manifest (%zu tensors) to %s (%ldms)", collected_.size(), run_dir_.c_str(), total_ms);
+    LOG_INFO_V0("Wrote JSON manifest (%zu args) to %s (%ldms)", collected_.size(), run_dir_.c_str(), total_ms);
 
     if (total_truncated_count_ > 0 || total_dropped_record_count_ > 0 || total_overwrite_count_ > 0) {
         LOG_WARN(
-            "Tensor dump anomalies: truncated=%u, dropped_records=%u, overwritten=%u", total_truncated_count_,
+            "Args dump anomalies: truncated=%u, dropped_records=%u, overwritten=%u", total_truncated_count_,
             total_dropped_record_count_, total_overwrite_count_
         );
     }

--- a/src/common/task_interface/data_type.h
+++ b/src/common/task_interface/data_type.h
@@ -43,6 +43,7 @@ enum class DataType : uint8_t {
     UINT64,    // 8 bytes
     UINT16,    // 2 bytes
     UINT32,    // 4 bytes
+    BOOL,      // 1 byte (stored as 1/0 in uint64_t slot)
     DATA_TYPE_NUM,
 };
 
@@ -68,6 +69,7 @@ inline uint64_t get_element_size(DataType dtype) {
         8,  // DataType::UINT64
         2,  // DataType::UINT16
         4,  // DataType::UINT32
+        1,  // DataType::BOOL
     };
     return data_type_size[static_cast<int>(dtype)];
 }
@@ -102,6 +104,8 @@ inline const char *get_dtype_name(DataType dtype) {
         return "UINT16";
     case DataType::UINT32:
         return "UINT32";
+    case DataType::BOOL:
+        return "BOOL";
     default:
         return "UNKNOWN";
     }
@@ -136,7 +140,42 @@ inline const char *get_dtype_name(DataType dtype) {
 //
 // Named convenience functions (from_u64_f32 etc.) are removed — use the
 // template form from_u64<T>() / to_u64() directly.
-// -----------------------------------------------------------------------------
+
+/**
+ * Map a C++ type to its DataType enum value.
+ *
+ * Used to preserve original scalar type information through the
+ * Arg -> PTO2TaskPayload -> tensor dump pipeline.
+ */
+template <typename T>
+inline constexpr uint8_t dtype_of() {
+    static_assert(is_supported_scalar_arg_v<T>, "dtype_of: type must be arithmetic or enum");
+    if constexpr (std::is_same_v<T, float>) {
+        return static_cast<uint8_t>(DataType::FLOAT32);
+    } else if constexpr (std::is_same_v<T, double>) {
+        return static_cast<uint8_t>(DataType::FLOAT32);
+    } else if constexpr (std::is_same_v<T, int32_t>) {
+        return static_cast<uint8_t>(DataType::INT32);
+    } else if constexpr (std::is_same_v<T, uint32_t>) {
+        return static_cast<uint8_t>(DataType::UINT32);
+    } else if constexpr (std::is_same_v<T, int64_t>) {
+        return static_cast<uint8_t>(DataType::INT64);
+    } else if constexpr (std::is_same_v<T, uint64_t>) {
+        return static_cast<uint8_t>(DataType::UINT64);
+    } else if constexpr (std::is_same_v<T, int16_t>) {
+        return static_cast<uint8_t>(DataType::INT16);
+    } else if constexpr (std::is_same_v<T, uint16_t>) {
+        return static_cast<uint8_t>(DataType::UINT16);
+    } else if constexpr (std::is_same_v<T, int8_t>) {
+        return static_cast<uint8_t>(DataType::INT8);
+    } else if constexpr (std::is_same_v<T, uint8_t>) {
+        return static_cast<uint8_t>(DataType::UINT8);
+    } else if constexpr (std::is_same_v<T, bool>) {
+        return static_cast<uint8_t>(DataType::BOOL);
+    } else {
+        return static_cast<uint8_t>(DataType::UINT64);
+    }
+}
 
 /**
  * Pack a value into uint64_t storage (zero-extends smaller types).

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py
@@ -7,12 +7,12 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""tensor_dump profiling smoke — capture pipeline produces a usable
-``tensor_dump/`` directory.
+"""args_dump profiling smoke — capture pipeline produces a usable
+``args_dump/`` directory.
 
-Re-uses ``vector_example`` (5 submit_task calls). With ``--dump-tensor`` the
+Re-uses ``vector_example`` (5 submit_task calls). With ``--dump-args`` the
 AICPU writer captures task dump records into a unified manifest + raw-byte
-payload pair under ``<output_prefix>/tensor_dump/``. Smoke asserts:
+payload pair under ``<output_prefix>/args_dump/``. Smoke asserts:
 manifest exists + parses, the ``bin_file`` field it names exists, entries
 use the unified schema, and no legacy args-only manifest is emitted.
 """
@@ -32,19 +32,19 @@ KERNELS_BASE = "../../../../../../examples/a2a3/tensormap_and_ringbuffer/vector_
 
 @scene_test(level=2, runtime="tensormap_and_ringbuffer")
 class TestTensorDump(SceneTestCase):
-    """tensor_dump capture smoke, level-aware on the ``--dump-tensor`` level.
+    """args_dump capture smoke, level-aware on the ``--dump-args`` level.
 
     Uses ``partial_dump_orch`` (5 tasks; two carry ``dump(...)`` markers) so a
     single orchestration exercises both modes:
 
-    - ``--dump-tensor 1`` (partial): only the two marked tasks are captured —
+    - ``--dump-args 1`` (partial): only the two marked tasks are captured —
       task ``0x..02`` via ``dump(d, inter_ci)`` (tensor granularity: args 0+2,
       input ``e`` excluded), task ``0x..03`` via no-arg ``dump()`` (task
       granularity: all three args). Mode is latched host-side before dispatch,
       so it is race-free regardless of submission order.
-    - ``--dump-tensor 2`` (full): markers are ignored, every task is dumped.
+    - ``--dump-args 2`` (full): markers are ignored, every task is dumped.
 
-    The dump level comes straight from the CLI ``--dump-tensor`` value
+    The dump level comes straight from the CLI ``--dump-args`` value
     (no per-case override).
     """
 
@@ -98,35 +98,35 @@ class TestTensorDump(SceneTestCase):
 
     def test_run(self, st_platform, st_worker, request):
         super().test_run(st_platform, st_worker, request)
-        level = int(request.config.getoption("--dump-tensor", default=0))
+        level = int(request.config.getoption("--dump-args", default=0))
         if not level:
             return
         safe_label = _sanitize_for_filename("TestTensorDump_default")
         matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
-        assert matches, "tensor dump output directory missing"
-        dump_dir = matches[-1] / "tensor_dump"
-        assert dump_dir.is_dir(), f"tensor_dump/ missing under {matches[-1]} — dump capture failed?"
-        manifest = dump_dir / "tensor_dump.json"
-        assert manifest.exists(), f"tensor_dump.json missing under {dump_dir} — collector finalize failed?"
+        assert matches, "args dump output directory missing"
+        dump_dir = matches[-1] / "args_dump"
+        assert dump_dir.is_dir(), f"args_dump/ missing under {matches[-1]} — dump capture failed?"
+        manifest = dump_dir / "args_dump.json"
+        assert manifest.exists(), f"args_dump.json missing under {dump_dir} — collector finalize failed?"
         with manifest.open() as f:
             data = json.load(f)
         bin_name = data.get("bin_file")
-        tensors = data.get("tensors", [])
-        assert tensors, f"tensor_dump.json has no entries: {data}"
+        tensors = data.get("args", [])
+        assert tensors, f"args_dump.json has no entries: {data}"
         if level == 3:
             # full_json_only: metadata only, no payload and no .bin file.
             assert bin_name is None, f"level 3 manifest should have bin_file=null: {data}"
-            assert not (dump_dir / "tensor_dump.bin").exists(), "level 3 must not write tensor_dump.bin"
+            assert not (dump_dir / "args.bin").exists(), "level 3 must not write args.bin"
             assert all(t.get("bin_size") == 0 for t in tensors), tensors
         else:
             assert bin_name, f"manifest missing bin_file field: {data}"
             bin_path = dump_dir / bin_name
             assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
-            assert bin_path.stat().st_size > 0, "tensor_dump.bin is empty"
+            assert bin_path.stat().st_size > 0, "args.bin is empty"
 
         # Unified manifest (#792): tensors and scalar args share one
-        # tensor_dump.json keyed by a "kind" field; no separate args files.
-        assert not (dump_dir / "args_dump.json").exists(), "args_dump.json should not be emitted"
+        # args_dump.json keyed by a "kind" field; no separate legacy sidecar files.
+        assert not (dump_dir / "tensor_dump.json").exists(), "tensor_dump.json should not be emitted"
         assert not (dump_dir / "kernel_args_dump.json").exists(), "kernel_args_dump.json should not be emitted"
         assert all("kind" in t for t in tensors), tensors
         scalar_entries = [t for t in tensors if t.get("kind") == "scalar"]
@@ -155,7 +155,7 @@ class TestTensorDump(SceneTestCase):
 
         # ---- Tool smoke: dump_viewer ----
         # Exit-code-only check; the no-filter default lists every captured
-        # tensor without exporting. A schema change that breaks the viewer
+        # arg without exporting. A schema change that breaks the viewer
         # fires here in the same CI step that produced the dump.
         subprocess.run(
             [sys.executable, "-m", "simpler_setup.tools.dump_viewer", str(dump_dir)],


### PR DESCRIPTION
## Summary
- rename the focused PR792/PR966 dump surface from `dump tensor` to `dump args` across the CLI, runtime artifacts, viewer, and manifest schema
- align the runtime helper, host collector, sim `dlsym`, and onboard entrypoints with the new `dump_args` symbol surface while keeping underlying compatibility fields intact
- update the dump smoke test, CI invocations, and user-facing docs/tooling examples to the new `args_dump` contract

## Test plan
- [x] `python -m py_compile conftest.py simpler_setup/scene_test.py simpler_setup/tools/dump_viewer.py tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py`
- [x] `pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 --pto-isa-commit ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8 --dump-args --clone-protocol https`

🤖 Generated with [Claude Code](https://claude.com/claude-code)