### PR TITLE
Fix: honor completed_ in sync_start drain spins (a2a3 + a5)

### DIFF
--- a/docs/investigations/2026-06-cross-task-batched-publish.md
+++ b/docs/investigations/2026-06-cross-task-batched-publish.md
@@ -123,6 +123,42 @@ The qwen3 metrics validate the workload class the doc's original
 (50 single-AIC `out_proj` tasks ready together) and kernel duration
 short enough (~22 µs each) that the per-task wmb cost matters.
 
+## Root cause found (2026-06-16) — drain ack-barrier had no `completed_` escape
+
+The "exact race window was not pinpointed" note above is now resolved. The
+507018 was **not** fundamentally about batched-publish timing — that change
+only widened an existing window. The real defect is a liveness bug in the
+sync_start drain protocol (`SchedulerContext::handle_drain_mode`):
+
+the three drain spin-waits (sentinel wait, **ack barrier**, non-elected wait)
+require all `active_sched_threads_` to keep participating, but a scheduler
+thread leaves the dispatch loop (`SchedulerContext::resolve_and_dispatch`) the
+instant `completed_` latches — at the loop-top check or via
+`SchedulerContext::handle_orchestrator_exit`. A thread that
+enters the ack barrier in the window where its peers are exiting on
+`completed_` waits forever for acks that can never arrive. The in-runtime 2 s
+watchdog can't catch it (it lives in the dispatch loop's idle path, not inside
+the barrier spin), so the hang escalates to the 3 s STARS op-exec timeout →
+507018 → device poison → force-reset.
+
+`spmd_sync_start_stress` is the only test that hits it because it is the sole
+case that maximizes all four required factors simultaneously: many drain
+cycles (24 sync tasks), concurrent normal tasks occupying cores (forces the
+drain *retry* state to linger), cross-shape MIX+AIV contention on the single
+drain slot, and a long multi-round tail that produces thread skew. `--rounds N`
+multiplies the per-run hit probability. Pure sync_start tests dispatch their
+drains instantly (resources always available) so the barrier is a sub-µs
+transient; siblings with contention (`spmd_starvation`) have too few drain
+cycles.
+
+**Fix**: every drain spin now honors `is_completed()` and returns when the run
+has latched `completed_`, mirroring the existing escape in
+`SchedulerContext::handle_core_transition`. Abandoning a drain under
+`completed_` is safe — any
+pending sync_start task is either already dispatched (a stale re-popped slot)
+or moot under teardown, and `deinit()` resets `drain_state_` before the next
+run. Applied to both a2a3 and a5.
+
 ## References
 
 - PR #989 (this PR): where per-task batched publish + the sync_start-

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -84,7 +84,7 @@ that ...".
 
 Newest first.
 
-- [2026-06 — Cross-task batched publish: hoist wmb across distinct tasks in one pop](2026-06-cross-task-batched-publish.md)
+- [2026-06 — Cross-task batched publish: hoist wmb across distinct tasks in one pop](2026-06-cross-task-batched-publish.md) — also carries the root cause + fix for the `spmd_sync_start_stress` 507018 drain-barrier hang
 - [2026-06 — AICore first-task cold-start: pre-warm dispatch path](2026-06-aicore-cold-start-warmup.md)
 - [2026-06 — a5 AICore op-timeout poisons the shared L2 worker (cascade)](2026-06-a5-aicore-op-timeout-cascade.md)
 - [2026-06 — a5 AICPU filter gate: Scenario B fail-fast guard not added](2026-06-a5-aicpu-filter-gate-scenario-b-validation.md)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -457,9 +457,20 @@ void SchedulerContext::drain_worker_dispatch(int32_t block_num) {
 //      Non-elected threads spin-wait until sync_start_pending == 0.
 //      During dispatch the elected thread has exclusive tracker access.
 void SchedulerContext::handle_drain_mode(int32_t thread_idx) {
+    // Every spin in this function honors is_completed(): once the run latches
+    // completed_ (all tasks done, or a fatal error raised elsewhere), peers leave
+    // the dispatch loop and stop participating in the drain. A thread parked in a
+    // drain spin would then wait forever for acks / a gate-open that can no longer
+    // arrive -- the AICPU watchdog never fires here because these spins live
+    // outside the dispatch loop's wall-clock budget, so the hang escalates straight
+    // to the 3 s STARS op-exec timeout (507018) and poisons the device. Bailing on
+    // completed_ is always safe: any pending sync_start task is either already
+    // dispatched (a stale re-popped slot) or moot under teardown, and deinit()
+    // resets drain_state_ before the next run, so leaving it dirty is harmless.
     // Spin until drain is fully initialized (sentinel -1 -> block_num > 0).
     int32_t block_num;
     do {
+        if (is_completed()) return;
         block_num = drain_state_.sync_start_pending.load(std::memory_order_acquire);
     } while (block_num < 0);
     if (block_num == 0) return;
@@ -472,6 +483,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx) {
     // Spin until all threads have acked.
     // If our bit is cleared while waiting, elected reset due to insufficient resources.
     while (true) {
+        if (is_completed()) return;
         uint32_t ack = drain_state_.drain_ack_mask.load(std::memory_order_acquire);
         if ((ack & all_acked) == all_acked) break;
         if ((ack & (1u << thread_idx)) == 0) return;
@@ -487,6 +499,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx) {
     if (drain_state_.drain_worker_elected.load(std::memory_order_relaxed) != thread_idx + 1) {
         // Non-elected: spin-wait for drain completion or resource-insufficient reset.
         while (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
+            if (is_completed()) return;
             if (drain_state_.drain_worker_elected.load(std::memory_order_acquire) == 0) return;
             SPIN_WAIT_HINT();
         }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -430,9 +430,20 @@ void SchedulerContext::drain_worker_dispatch(Runtime *runtime, int32_t block_num
 //      Non-elected threads spin-wait until sync_start_pending == 0.
 //      During dispatch the elected thread has exclusive tracker access.
 void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
+    // Every spin in this function honors is_completed(): once the run latches
+    // completed_ (all tasks done, or a fatal error raised elsewhere), peers leave
+    // the dispatch loop and stop participating in the drain. A thread parked in a
+    // drain spin would then wait forever for acks / a gate-open that can no longer
+    // arrive -- the AICPU watchdog never fires here because these spins live
+    // outside the dispatch loop's wall-clock budget, so the hang escalates straight
+    // to the 3 s STARS op-exec timeout (507018) and poisons the device. Bailing on
+    // completed_ is always safe: any pending sync_start task is either already
+    // dispatched (a stale re-popped slot) or moot under teardown, and deinit()
+    // resets drain_state_ before the next run, so leaving it dirty is harmless.
     // Spin until drain is fully initialized (sentinel -1 -> block_num > 0).
     int32_t block_num;
     do {
+        if (is_completed()) return;
         block_num = drain_state_.sync_start_pending.load(std::memory_order_acquire);
     } while (block_num < 0);
     if (block_num == 0) return;
@@ -445,6 +456,7 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
     // Spin until all threads have acked.
     // If our bit is cleared while waiting, elected reset due to insufficient resources.
     while (true) {
+        if (is_completed()) return;
         uint32_t ack = drain_state_.drain_ack_mask.load(std::memory_order_acquire);
         if ((ack & all_acked) == all_acked) break;
         if ((ack & (1u << thread_idx)) == 0) return;
@@ -460,6 +472,7 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
     if (drain_state_.drain_worker_elected.load(std::memory_order_relaxed) != thread_idx + 1) {
         // Non-elected: spin-wait for drain completion or resource-insufficient reset.
         while (drain_state_.sync_start_pending.load(std::memory_order_acquire) != 0) {
+            if (is_completed()) return;
             if (drain_state_.drain_worker_elected.load(std::memory_order_acquire) == 0) return;
             SPIN_WAIT_HINT();
         }


### PR DESCRIPTION
## Summary

Fixes a liveness bug in the `tensormap_and_ringbuffer` sync_start **drain protocol** (`SchedulerContext::handle_drain_mode`) that hangs the AICPU and surfaces as **507018 / 507014 + forced card reset**.

- The three drain spin-waits (sentinel wait, **ack barrier**, non-elected wait) required all `active_sched_threads_` to keep participating, but none checked `completed_`.
- A scheduler thread leaves the dispatch loop the instant `completed_` latches. A late-joining thread that entered the ack barrier in the window where its peers were exiting on `completed_` waited forever for acks that can never arrive.
- The in-runtime 2 s watchdog can't catch it (it lives in the dispatch loop's idle path, not the barrier spin), so the hang escalates to the 3 s STARS op-exec timeout → 507018 → device unrecoverable 507014 → card reset.
- **Fix**: add an `is_completed()` escape to all three drain spins, mirroring the existing guard in `handle_core_transition`. Applied to both **a2a3** and **a5** (identical code apart from the `Runtime*` param).
- Bailing under `completed_` is safe: any pending sync_start task is already dispatched (stale re-popped slot) or moot under teardown, and `deinit()` resets `drain_state_` before the next run.
- Docs: root-caused the 507018 that PR #989 left as *"exact race window not pinpointed"* in `docs/investigations/2026-06-cross-task-batched-publish.md` (+ index hook).

## Why only `spmd_sync_start_stress` hits it

It is the sole test that simultaneously maximizes all four required factors: many drain cycles (24 sync tasks), normal tasks occupying cores (forces the drain *retry* state to linger), cross-shape MIX+AIV contention on the single drain slot, and a long multi-round tail producing scheduler-thread skew. `--rounds N` multiplies the per-run hit probability; each round is independent, the failure is a probabilistic timing race.

## Testing

- [x] Hardware (a2a3 onboard, dedicated `task-submit` lock): `spmd_sync_start_stress` **15 × `--rounds 20` = 300 rounds, 0 failures** (pre-fix: a single `--rounds 10` reproduces 507018).
- [ ] Full sim / hardware CI via pipeline.

Fixes #1073.