### PR TITLE
test(#1070): enable highperf s128 + s8192 onboard a2a3 in CI

### DIFF
--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
@@ -170,9 +170,10 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
     CASES = [
         {
             "name": "b1_h32_kv8_s128_bs128_fp16",
-            # onboard a2a3 stays out pending the
-            # separate 'out' golden mismatch (hw-native-sys/simpler#1070).
-            "platforms": ["a2a3sim"],
+            # onboard a2a3 enabled: the 'out' golden mismatch is closed by the
+            # producer-side DdrBarrierBeforeFfts cross-core DDR fence, validated
+            # over 19 st-onboard-a2a3 rounds.
+            "platforms": ["a2a3sim", "a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {
                 "batch": 1,
@@ -251,7 +252,7 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
         },
         {
             "name": "b1_h32_kv8_s8192_bs128_fp16",
-            "manual": True,
+            # enabled in CI to guard the long-sequence fix onboard.
             "platforms": ["a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {


### PR DESCRIPTION
Closes #1070. Supersedes #1094 (folds its s8192 enable in here).

## Background

#1091 (merged) fixed the #1070 onboard `out` golden mismatch with a
**producer-side** cross-core DDR fence (`DdrBarrierBeforeFfts`) before each
decode FFTS signal — but it left `b1_h32_kv8_s128` **a2a3sim-only**, so CI never
guarded the regression onboard, and its long-sequence cases were all
`manual:True` (CI-excluded).

## A/B validation

I ran a controlled onboard experiment on the #1070 `s128` case:

| arm | kernel | st-onboard-a2a3 |
|-----|--------|-----------------|
| producer-side only (#1091 as merged) | `DdrBarrierBeforeFfts` | **10/10 green** |
| producer + consumer-side invalidate | + `dcci` invalidate after each `wait_flag_dev` | 9/9 green (+1 infra flake) |

→ **The producer-side fence alone closes the race** (19/19 onboard rounds clean
total); the consumer-side invalidate added no measurable benefit, so it is **not
included**.

## Change (test-only, no kernel change)

- Re-enable `b1_h32_kv8_s128` on **a2a3** (was a2a3sim-only) so CI guards the
  #1070 regression onboard.
- Drop `manual:True` from `b1_h32_kv8_s8192` so CI also guards the long-sequence
  fix onboard (was PR #1094).