### PR TITLE
Fix: unify build/run pto-isa version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # Single source of truth for the pinned pto-isa revision. Drives BOTH the
+  # build (`pip install` threads it into build_runtimes.py via
+  # SIMPLER_PTO_ISA_COMMIT, so host_runtime.so embeds these pto-isa headers)
+  # and the run (scene tests check it out via `--pto-isa-commit`). Bump here to
+  # update both at once — never pin one without the other (issue #1067).
   PTO_ISA_COMMIT: ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8
 
 jobs:
@@ -223,25 +228,25 @@ jobs:
         run: |
           pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --enable-dep-gen --clone-protocol https
+            --enable-dep-gen --clone-protocol https --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: l2_swimlane smoke
         run: |
           pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/ \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --enable-l2-swimlane --enable-dep-gen --clone-protocol https
+            --enable-l2-swimlane --enable-dep-gen --clone-protocol https --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: PMU smoke
         run: |
           pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --enable-pmu 2 --clone-protocol https
+            --enable-pmu 2 --clone-protocol https --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: tensor_dump smoke
         run: |
           pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py \
             --platform a2a3sim --device 0-15 -p no:xdist --pto-session-timeout 600 \
-            --dump-tensor --clone-protocol https
+            --dump-tensor --clone-protocol https --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
   st-sim-a5:
     needs: detect-changes
@@ -445,19 +450,26 @@ jobs:
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install '.[test]'
+          # Pin the onboard a2a3 host_runtime build to the same pto-isa commit
+          # the scene tests check out (PTO_ISA_COMMIT), so host_runtime.so and
+          # the test-time kernels share one pto-isa revision (see issue #1067).
+          pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT="${PTO_ISA_COMMIT}" '.[test]'
 
       - name: Run Python hardware unit tests
         run: |
           source .venv/bin/activate
-          python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v
+          # Pin to the same commit pip install built host_runtime against, so
+          # conftest does not reset build/pto-isa to HEAD (which would diverge
+          # from the pre-built host_runtime and break the C++ UT rebuild below).
+          python -m pytest tests -m requires_hardware --platform a2a3 --device ${DEVICE_RANGE} -v \
+            --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: Build and run C++ hardware unit tests
         run: |
           source .venv/bin/activate
           # pip install's build_runtimes.py already cloned pto-isa into
-          # build/pto-isa; point this step's RuntimeBuilder at it so
-          # _init_a2a3's PTO_ISA_ROOT check passes without re-cloning.
+          # build/pto-isa at PTO_ISA_COMMIT; point this step's RuntimeBuilder at
+          # it so _init_a2a3's PTO_ISA_ROOT check passes without re-cloning.
           export PTO_ISA_ROOT="$(pwd)/build/pto-isa"
           python -c "from simpler_setup.runtime_builder import RuntimeBuilder; RuntimeBuilder('a2a3').get_binaries('tensormap_and_ringbuffer', build=True)"
           cmake -B tests/ut/cpp/build -S tests/ut/cpp -DSIMPLER_ENABLE_HARDWARE_TESTS=ON
@@ -517,7 +529,10 @@ jobs:
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install '.[test]'
+          # Pin the onboard a2a3 host_runtime build to the same pto-isa commit
+          # the scene tests check out (PTO_ISA_COMMIT), so host_runtime.so and
+          # the test-time kernels share one pto-isa revision (see issue #1067).
+          pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT="${PTO_ISA_COMMIT}" '.[test]'
           # Warn if graphviz isn't installed on the runner — the dep_gen
           # smoke step needs `dot` to render deps_viewer. The Python
           # has_binary("dot") guard in the test will skip cleanly without
@@ -541,28 +556,28 @@ jobs:
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --enable-dep-gen --clone-protocol ssh
+            --enable-dep-gen --clone-protocol ssh --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: l2_swimlane smoke
         run: |
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/ \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --enable-l2-swimlane --enable-dep-gen --clone-protocol ssh
+            --enable-l2-swimlane --enable-dep-gen --clone-protocol ssh --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: PMU smoke
         run: |
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --enable-pmu 2 --clone-protocol ssh
+            --enable-pmu 2 --clone-protocol ssh --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
       - name: tensor_dump smoke
         run: |
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
-            --dump-tensor --clone-protocol ssh
+            --dump-tensor --clone-protocol ssh --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}
 
 
   # ---------- Detect platform-specific changes (runs on GitHub server) ----------
@@ -623,13 +638,16 @@ jobs:
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install '.[test]'
+          # Pin the onboard a2a3 host_runtime build to the same pto-isa commit
+          # the scene tests check out (PTO_ISA_COMMIT), so host_runtime.so and
+          # the test-time kernels share one pto-isa revision (see issue #1067).
+          pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT="${PTO_ISA_COMMIT}" '.[test]'
 
       - name: Run Python hardware unit tests (a5)
         run: |
           source .venv/bin/activate
           DEVICE_LIST=$(python -c "p='${DEVICE_RANGE}'.split('-'); s,e=p[0],p[-1]; print(','.join(str(i) for i in range(int(s),int(e)+1)))")
-          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v"
+          task-submit --timeout 1800 --max-time 1800 --device "$DEVICE_LIST" --run "python -m pytest tests -m requires_hardware --platform a5 --device ${DEVICE_RANGE} -v --pto-isa-commit ${{ env.PTO_ISA_COMMIT }}"
 
       - name: Build and run C++ hardware unit tests (a5)
         run: |
@@ -688,7 +706,10 @@ jobs:
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
-          pip install '.[test]'
+          # Pin the onboard a2a3 host_runtime build to the same pto-isa commit
+          # the scene tests check out (PTO_ISA_COMMIT), so host_runtime.so and
+          # the test-time kernels share one pto-isa revision (see issue #1067).
+          pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT="${PTO_ISA_COMMIT}" '.[test]'
 
       - name: Run pytest scene tests (a5)
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,12 +36,28 @@ add_subdirectory(python/bindings)
 set(SIMPLER_PTO_CLONE_PROTOCOL "ssh" CACHE STRING
     "Protocol for cloning pto-isa during install (ssh or https)")
 
+# Pin pto-isa to a specific commit when `build_runtimes.py` builds the onboard
+# a2a3 host runtime (which compiles the pto-isa SDMA headers into
+# host_runtime.so). Must match the `--pto-isa-commit` the scene tests pin at
+# run time, otherwise host_runtime.so and the test-time kernels are built
+# against different pto-isa revisions. Empty (default) clones/uses HEAD. Set at
+# `pip install` time via
+#   pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT=<sha> .
+set(SIMPLER_PTO_ISA_COMMIT "" CACHE STRING
+    "pto-isa commit to pin the onboard a2a3 host build to (empty = HEAD)")
+
 # Compiler sanitizer for host-compiled targets (sim runtime/kernels and the
 # onboard host runtime). Default `none`. Preset (asan/ubsan/tsan) or a raw
 # -fsanitize token list. Enable at `pip install` time via
 #   pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZER=asan .
 set(SIMPLER_SANITIZER "none" CACHE STRING
     "Sanitizer for host targets during install (none/asan/ubsan/tsan)")
+
+# Pass --pto-isa-commit only when pinned; an empty cache var leaves the flag
+# off (build_runtimes then clones/uses HEAD).
+if(NOT SIMPLER_PTO_ISA_COMMIT STREQUAL "")
+    set(_pto_isa_commit_arg --pto-isa-commit "${SIMPLER_PTO_ISA_COMMIT}")
+endif()
 
 # Pre-build runtime binaries (persistent build dirs for incremental compilation)
 add_custom_target(build_runtimes ALL
@@ -51,6 +67,7 @@ add_custom_target(build_runtimes ALL
         --cache-dir ${CMAKE_SOURCE_DIR}/build/cache
         --clone-protocol ${SIMPLER_PTO_CLONE_PROTOCOL}
         --sanitizer ${SIMPLER_SANITIZER}
+        ${_pto_isa_commit_arg}
     COMMENT "Building runtime binaries (incremental)..."
 )
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -185,6 +185,7 @@ This builds the nanobind `_task_interface` extension **and** pre-builds all runt
 | Nanobind bindings (`python/bindings/`) | Re-run `pip install --no-build-isolation -e .` (no rebuild-on-import; `editable.rebuild = false`) |
 | Python-only code (`python/*.py`, `simpler_setup/*.py`) | No rebuild needed (editable install) |
 | Examples / kernels (`examples/{arch}/`, `tests/st/`) | No rebuild needed, just re-run |
+| Pinned pto-isa commit (CI `PTO_ISA_COMMIT`) | Re-run `pip install` — onboard a2a3 `host_runtime.so` embeds pto-isa SDMA headers, so a commit bump must rebuild it. Pin the build to the same commit the tests use via `--config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT=<sha>` (issue #1067). |
 
 ### Runtime binary lookup
 

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -77,6 +77,7 @@ def build_all(
     platforms: Optional[list] = None,
     clone_protocol: str = "ssh",
     sanitizer: str = "none",
+    pto_isa_commit: Optional[str] = None,
 ) -> None:
     """Build all runtime variants for the given platforms.
 
@@ -90,6 +91,10 @@ def build_all(
         sanitizer: Sanitizer preset (asan/ubsan/tsan/none) or raw `-fsanitize`
             token list. Only host-compiled targets honor it; see
             BuildTarget.gen_cmake_args.
+        pto_isa_commit: pto-isa commit to pin the onboard a2a3 host build to.
+            None = clone/use HEAD. Must match the `--pto-isa-commit` the scene
+            tests pin at run time so host_runtime.so (which compiles the pto-isa
+            SDMA headers) and the test-time kernels share one pto-isa revision.
     """
     # Override default paths to respect CLI args
     RuntimeBuilder._LIB_DIR = lib_dir
@@ -121,10 +126,17 @@ def build_all(
     # CMakeLists invocation) is the one actually used, instead of relying on
     # the fallback in RuntimeCompiler._init_a2a3. No-ops when PTO_ISA_ROOT
     # is already set. Skipped when only sim platforms are being built.
+    #
+    # pto_isa_commit pins the clone to the same revision the scene tests later
+    # check out via `--pto-isa-commit`. Without it, host_runtime.so would be
+    # built against whatever pto-isa HEAD (or a stale clone) happened to be at
+    # install time, diverging from the test-time kernels — see issue #1067.
     if "a2a3" in platforms:
         from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
-        os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(clone_protocol=clone_protocol, verbose=True)
+        os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(
+            commit=pto_isa_commit, clone_protocol=clone_protocol, verbose=True
+        )
 
     # libsimpler_log.so and libcpu_sim_context.so are process-global (one per
     # host toolchain, not per arch/variant) — build them once before iterating
@@ -229,6 +241,16 @@ def main():
             "Default: none. asan/tsan are mutually exclusive (separate builds)."
         ),
     )
+    parser.add_argument(
+        "--pto-isa-commit",
+        default=None,
+        help=(
+            "Pin the onboard a2a3 pto-isa clone to this commit before building "
+            "host_runtime. Must match the scene tests' --pto-isa-commit so the "
+            "host runtime and test-time kernels share one pto-isa revision "
+            "(default: clone/use HEAD)."
+        ),
+    )
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -254,6 +276,7 @@ def main():
         platforms=args.platforms,
         clone_protocol=args.clone_protocol,
         sanitizer=args.sanitizer,
+        pto_isa_commit=args.pto_isa_commit,
     )
 
 


### PR DESCRIPTION
## Summary

Onboard a2a3 `host_runtime.so` embeds the pto-isa SDMA headers
(`comm_hccl.cpp`'s `#include "pto/npu/comm/.../sdma_workspace_manager.hpp"`),
but it was built during `pip install` against an **unpinned** pto-isa (HEAD,
or a stale clone left on the self-hosted runner), while scene tests pin
pto-isa via `--pto-isa-commit`. So in one CI run `host_runtime.so` and the
test-time kernels could be built against **two different pto-isa revisions**.
Because pto-isa HEAD has since moved `sdma_workspace_manager.hpp` out of the
`pto/npu/comm/...` path, an unpinned fresh clone would now also fail to
compile the a2a3 host outright.

This makes both ends use the **single** `ci.yml` `env.PTO_ISA_COMMIT` — bump
that one line and build + run update together.

- **`build_runtimes.py`**: add `--pto-isa-commit`, pass it to
  `ensure_pto_isa_root(commit=...)` for the a2a3 host build.
- **`CMakeLists.txt`**: add `SIMPLER_PTO_ISA_COMMIT` cache var (mirrors
  `SIMPLER_PTO_CLONE_PROTOCOL`), threaded into the `build_runtimes` target
  only when set.
- **`.github/workflows/ci.yml`**: onboard `pip install` passes the commit via
  `--config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT="${PTO_ISA_COMMIT}"`;
  the `requires_hardware` pytest steps also pin `--pto-isa-commit` so
  `conftest` doesn't reset `build/pto-isa` back to HEAD before the a2a3 C++ UT
  host rebuild.
- **`docs/developer-guide.md`**: document the pto-isa-commit rebuild trigger.

Note: the pinned commit value is **unchanged** (`ddafa8da…`); this only makes
the build honor the same value the tests already use.

## Scope / non-goals

This is the build-hygiene problem found while investigating #1067 — it is
**not** that issue's root cause (which is a device-side CANN op runtime
failure of `aclnnShmemSdmaStarsQueryGetWorkspaceSize`, independent of the
pto-isa header revision). The `@pytest.mark.skip` on
`test_sdma_async_completion_demo` therefore stays in place.

## Testing

- [x] `pre-commit` hooks pass (markdownlint, ruff, pyright, yaml, headers)
- [x] CMake conditional-arg expansion verified (empty cache var → flag
      omitted, 0 stray args; set → `--pto-isa-commit <sha>`)
- [x] `python -m py_compile build_runtimes.py`, YAML parse
- [ ] Full effect is only observable on the self-hosted onboard runners
      (a2a3 / a5) — verify the onboard CI jobs build host_runtime against the
      pinned commit.

Fixes #1077
Related: #1067