### PR TITLE
Fix: rename a2a3 scope_stats_collector test target to avoid name clash

### DIFF
--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -374,7 +374,7 @@ add_a2a3_runtime_test(test_fanin_pool       a2a3/test_fanin_pool.cpp)
 add_a2a3_runtime_test(test_spsc_queue       a2a3/test_spsc_queue.cpp)
 add_a2a3_runtime_test(test_wiring           a2a3/test_wiring.cpp)
 add_a2a3_runtime_test(test_aicore_completion_mailbox a2a3/test_aicore_completion_mailbox.cpp)
-add_a2a3_runtime_test(test_scope_stats_collector a2a3/test_scope_stats_collector.cpp)
+add_a2a3_runtime_test(test_a2a3_scope_stats_collector a2a3/test_scope_stats_collector.cpp)
 
 # ---------------------------------------------------------------------------
 # A5 tests (src/a5/runtime/tensormap_and_ringbuffer/)


### PR DESCRIPTION
## Summary
- `tests/ut/cpp/CMakeLists.txt` defined the logical target name
  `test_scope_stats_collector` twice: once via `add_executable` for the
  host-side test (`common/test_scope_stats_collector.cpp`, line 319) and
  once via `add_a2a3_runtime_test` for the a2a3 runtime variant
  (`a2a3/test_scope_stats_collector.cpp`, line 377). The macro internally
  calls `add_executable(${name} ...)`, so the duplicate logical target
  violated CMake CMP0002 and failed **configure** with exit 1 (no build /
  device involvement).
- Prefix the a2a3 variant as `test_a2a3_scope_stats_collector`, following
  the existing convention in this file (`test_a2a3_tensormap`, and the
  `a5_` prefix note on the A5 block) so both tests coexist as distinct
  targets.

## Testing
- [x] `cmake` configure now succeeds (CMP0002 clash resolved)
- [x] Both tests register distinctly: `test_scope_stats_collector` (host)
  and `test_a2a3_scope_stats_collector` (a2a3 runtime)