### PR TITLE
Fix: atomic acquire/release for sim register handshake gate (a2a3 + a5)

### DIFF
--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -84,6 +84,20 @@ uint64_t get_platform_pmu_reg_addrs();
 volatile uint32_t *get_reg_ptr(uint64_t reg_base_addr, RegId reg);
 
 /**
+ * Register-cell synchronizing accessors for the AICPU<->AICore handshake gate
+ * (COND / DATA_MAIN_BASE). Implemented per-variant:
+ *   sim/aicpu/inner_platform_regs.cpp     -- atomic acquire/release. The
+ *       simulated registers are plain host memory shared across host threads,
+ *       so the access itself must carry inter-thread happens-before (and be
+ *       visible to ThreadSanitizer) against the AICore side.
+ *   onboard/aicpu/inner_platform_regs.cpp -- plain Device-nGnRnE MMIO load/store
+ *       (atomics are not valid on Device memory); ordering is the caller's
+ *       explicit rmb()/wmb(), so the hardware path is the legacy behavior.
+ */
+uint32_t reg_load_acquire(const volatile uint32_t *p);
+void reg_store_release(volatile uint32_t *p, uint32_t v);
+
+/**
  * Read a register value from an AICore's register block
  *
  * No memory barrier is emitted. Callers that read a hand-off bit
@@ -109,7 +123,9 @@ uint64_t read_reg(uint64_t reg_base_addr, RegId reg);
  * @param value          Value to write (truncated to register width)
  */
 inline void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
-    *reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg)) = static_cast<uint32_t>(value);
+    reg_store_release(
+        reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg)), static_cast<uint32_t>(value)
+    );
 }
 
 /**

--- a/src/a2a3/platform/onboard/aicpu/inner_platform_regs.cpp
+++ b/src/a2a3/platform/onboard/aicpu/inner_platform_regs.cpp
@@ -13,15 +13,22 @@
  * @brief Variant-specific platform_regs hooks for real hardware (a2a3)
  *
  * a2a3 sim and onboard share the same register layout, so read_reg /
- * write_reg live in the shared src/aicpu/platform_regs.cpp. This file
- * exists only for the deinit-timeout split where onboard keeps the
- * legacy 1 s budget while sim widens it — see platform_regs.h for the
- * rationale.
+ * write_reg live in the shared src/aicpu/platform_regs.cpp. This file holds
+ * the variant-specific hooks: the reg_load_acquire / reg_store_release
+ * handshake-gate accessors (plain MMIO here) and the deinit-timeout budget —
+ * see platform_regs.h for the rationale of each.
  */
 
 #include <cstdint>
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
+
+// Plain Device-nGnRnE MMIO load/store (atomics are not valid on Device
+// memory); cross Device<->Normal ordering is the caller's rmb()/wmb(). See
+// platform_regs.h.
+uint32_t reg_load_acquire(const volatile uint32_t *p) { return *p; }
+
+void reg_store_release(volatile uint32_t *p, uint32_t v) { *p = v; }
 
 /**
  * @brief Deinit ACK-wait budget on real hardware: 1 s.

--- a/src/a2a3/platform/shared/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/shared/aicpu/platform_regs.cpp
@@ -50,7 +50,9 @@ volatile uint32_t *get_reg_ptr(uint64_t reg_base_addr, RegId reg) {
     return reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg));
 }
 
-uint64_t read_reg(uint64_t reg_base_addr, RegId reg) { return static_cast<uint64_t>(*get_reg_ptr(reg_base_addr, reg)); }
+uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
+    return static_cast<uint64_t>(reg_load_acquire(get_reg_ptr(reg_base_addr, reg)));
+}
 
 void platform_init_aicore_regs(uint64_t reg_addr) {
     // Both a2a3 and a2a3sim require fast path control to be enabled before use

--- a/src/a2a3/platform/sim/aicore/inner_kernel.h
+++ b/src/a2a3/platform/sim/aicore/inner_kernel.h
@@ -157,9 +157,14 @@ uint32_t sim_get_physical_core_id();
  */
 inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
-    uint64_t val = static_cast<uint64_t>(*reinterpret_cast<volatile uint32_t *>(sim_get_reg_base() + offset));
-    OUT_OF_ORDER_LOAD_BARRIER();
-    return val;
+    // The register cell is the AICPU<->AICore handshake gate (dispatch / COND).
+    // In sim it is plain host memory shared across the AICore and AICPU host
+    // threads, so the load itself must be an atomic acquire for happens-before
+    // to hold against the writer's release (and for TSAN to see it). A bare
+    // fence beside a non-atomic load does neither, so __atomic_load_n subsumes
+    // the old OUT_OF_ORDER_LOAD_BARRIER().
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sim_get_reg_base() + offset);
+    return static_cast<uint64_t>(__atomic_load_n(ptr, __ATOMIC_ACQUIRE));
 }
 
 /**
@@ -181,8 +186,11 @@ inline uint32_t read_dmb_high32() {
  */
 inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
-    *reinterpret_cast<volatile uint32_t *>(sim_get_reg_base() + offset) = static_cast<uint32_t>(value);
-    OUT_OF_ORDER_STORE_BARRIER();
+    // Atomic release store: publishes any prior stores (e.g. kernel outputs,
+    // the COND task_id payload) before the gate becomes visible to the AICPU's
+    // acquire load. Subsumes the old OUT_OF_ORDER_STORE_BARRIER().
+    volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sim_get_reg_base() + offset);
+    __atomic_store_n(ptr, static_cast<uint32_t>(value), __ATOMIC_RELEASE);
 }
 
 /**

--- a/src/a2a3/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a2a3/platform/sim/aicpu/inner_platform_regs.cpp
@@ -13,14 +13,22 @@
  * @brief Variant-specific platform_regs hooks for simulation (a2a3sim)
  *
  * a2a3 sim and onboard share the same register layout, so read_reg /
- * write_reg live in the shared src/aicpu/platform_regs.cpp. This file
- * exists only for the deinit-timeout split where sim wants a much wider
- * budget than onboard — see platform_regs.h for the rationale.
+ * write_reg live in the shared src/aicpu/platform_regs.cpp. This file holds
+ * the variant-specific hooks: the reg_load_acquire / reg_store_release
+ * handshake-gate accessors (atomic here) and the deinit-timeout budget — see
+ * platform_regs.h for the rationale of each.
  */
 
 #include <cstdint>
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
+
+// Atomic acquire/release: simulated registers are plain host memory shared
+// across the AICPU and AICore host threads, so the access itself must carry
+// happens-before (and be visible to TSAN). See platform_regs.h.
+uint32_t reg_load_acquire(const volatile uint32_t *p) { return __atomic_load_n(p, __ATOMIC_ACQUIRE); }
+
+void reg_store_release(volatile uint32_t *p, uint32_t v) { __atomic_store_n(p, v, __ATOMIC_RELEASE); }
 
 /**
  * @brief Deinit ACK-wait budget on sim: 10 s.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -328,7 +328,11 @@ void SchedulerContext::check_running_cores_for_completion(
         // --- Judgment phase: read register, derive transition ---
         // Use the precomputed cond_ptr (resolved once in handshake) to skip
         // the reg_offset switch and reg_addr addition on every poll.
-        uint64_t reg_val = static_cast<uint64_t>(*core.cond_ptr);
+        // reg_load_acquire makes this an atomic acquire under __CPU_SIM so it
+        // pairs with the AICore's release store of the FIN (without it the sim
+        // poll races the FIN publish and can miss it); on hardware it is the
+        // same plain volatile load the bare deref used to be.
+        uint64_t reg_val = static_cast<uint64_t>(reg_load_acquire(core.cond_ptr));
         // ARM64 allows Device-nGnRnE -> Normal-cacheable load reorder; the
         // rmb() pins any AICore-published cacheable reads downstream of the
         // FIN observation. Replaces the post-`__sync_synchronize` that the

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -76,6 +76,20 @@ uint64_t get_platform_regs();
 volatile uint32_t *get_reg_ptr(uint64_t reg_base_addr, RegId reg);
 
 /**
+ * Register-cell synchronizing accessors for the AICPU<->AICore handshake gate
+ * (COND / DATA_MAIN_BASE). Implemented per-variant:
+ *   sim/aicpu/inner_platform_regs.cpp     -- atomic acquire/release. The
+ *       simulated registers are plain host memory shared across host threads,
+ *       so the access itself must carry inter-thread happens-before (and be
+ *       visible to ThreadSanitizer) against the AICore side.
+ *   onboard/aicpu/inner_platform_regs.cpp -- plain Device-nGnRnE MMIO load/store
+ *       (atomics are not valid on Device memory); ordering is the caller's
+ *       explicit rmb()/wmb(), so the hardware path is the legacy behavior.
+ */
+uint32_t reg_load_acquire(const volatile uint32_t *p);
+void reg_store_release(volatile uint32_t *p, uint32_t v);
+
+/**
  * Read a register value from an AICore's register block
  *
  * No memory barrier is emitted. Callers that read a hand-off bit

--- a/src/a5/platform/onboard/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/onboard/aicpu/inner_platform_regs.cpp
@@ -31,6 +31,13 @@ volatile uint32_t *get_reg_ptr(uint64_t reg_base_addr, RegId reg) {
     return reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg));
 }
 
+// Plain Device-nGnRnE MMIO load/store (atomics are not valid on Device
+// memory); cross Device<->Normal ordering is the caller's rmb()/wmb(). See
+// platform_regs.h.
+uint32_t reg_load_acquire(const volatile uint32_t *p) { return *p; }
+
+void reg_store_release(volatile uint32_t *p, uint32_t v) { *p = v; }
+
 uint64_t read_reg(uint64_t reg_base_addr, RegId reg) { return static_cast<uint64_t>(*get_reg_ptr(reg_base_addr, reg)); }
 
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {

--- a/src/a5/platform/sim/aicore/inner_kernel.h
+++ b/src/a5/platform/sim/aicore/inner_kernel.h
@@ -179,9 +179,13 @@ inline uint64_t read_reg(RegId reg) {
     uint32_t offset = reg_offset(reg);
     volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(sim_get_reg_base(), offset));
 
-    uint64_t val = static_cast<uint64_t>(*ptr);
-    OUT_OF_ORDER_LOAD_BARRIER();
-    return val;
+    // The register cell is the AICPU<->AICore handshake gate (dispatch / COND).
+    // In sim it is plain host memory shared across the AICore and AICPU host
+    // threads, so the load itself must be an atomic acquire for happens-before
+    // to hold against the writer's release (and for TSAN to see it). A bare
+    // fence beside a non-atomic load does neither, so __atomic_load_n subsumes
+    // the old OUT_OF_ORDER_LOAD_BARRIER().
+    return static_cast<uint64_t>(__atomic_load_n(ptr, __ATOMIC_ACQUIRE));
 }
 
 /**
@@ -196,8 +200,10 @@ inline void write_reg(RegId reg, uint64_t value) {
     uint32_t offset = reg_offset(reg);
     volatile uint32_t *ptr = reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(sim_get_reg_base(), offset));
 
-    *ptr = static_cast<uint32_t>(value);
-    OUT_OF_ORDER_STORE_BARRIER();
+    // Atomic release store: publishes any prior stores (e.g. kernel outputs,
+    // the COND task_id payload) before the gate becomes visible to the AICPU's
+    // acquire load. Subsumes the old OUT_OF_ORDER_STORE_BARRIER().
+    __atomic_store_n(ptr, static_cast<uint32_t>(value), __ATOMIC_RELEASE);
 }
 
 /**

--- a/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
+++ b/src/a5/platform/sim/aicpu/inner_platform_regs.cpp
@@ -28,10 +28,19 @@ volatile uint32_t *get_reg_ptr(uint64_t reg_base_addr, RegId reg) {
     return reinterpret_cast<volatile uint32_t *>(sparse_reg_ptr(reg_base, reg_offset(reg)));
 }
 
-uint64_t read_reg(uint64_t reg_base_addr, RegId reg) { return static_cast<uint64_t>(*get_reg_ptr(reg_base_addr, reg)); }
+// Atomic acquire/release: simulated registers are plain host memory shared
+// across the AICPU and AICore host threads, so the access itself must carry
+// happens-before (and be visible to TSAN). See platform_regs.h.
+uint32_t reg_load_acquire(const volatile uint32_t *p) { return __atomic_load_n(p, __ATOMIC_ACQUIRE); }
+
+void reg_store_release(volatile uint32_t *p, uint32_t v) { __atomic_store_n(p, v, __ATOMIC_RELEASE); }
+
+uint64_t read_reg(uint64_t reg_base_addr, RegId reg) {
+    return static_cast<uint64_t>(reg_load_acquire(get_reg_ptr(reg_base_addr, reg)));
+}
 
 void write_reg(uint64_t reg_base_addr, RegId reg, uint64_t value) {
-    *get_reg_ptr(reg_base_addr, reg) = static_cast<uint32_t>(value);
+    reg_store_release(get_reg_ptr(reg_base_addr, reg), static_cast<uint32_t>(value));
 }
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -253,7 +253,11 @@ void SchedulerContext::check_running_cores_for_completion(
         // --- Judgment phase: read register, derive transition ---
         // Use the precomputed cond_ptr (resolved once in handshake) to skip
         // the reg_offset switch and reg_addr addition on every poll.
-        uint64_t reg_val = static_cast<uint64_t>(*core.cond_ptr);
+        // reg_load_acquire makes this an atomic acquire under __CPU_SIM so it
+        // pairs with the AICore's release store of the FIN (without it the sim
+        // poll races the FIN publish and can miss it); on hardware it is the
+        // same plain volatile load the bare deref used to be.
+        uint64_t reg_val = static_cast<uint64_t>(reg_load_acquire(core.cond_ptr));
         // ARM64 allows Device-nGnRnE -> Normal-cacheable load reorder; the
         // rmb() pins any AICore-published cacheable reads downstream of the
         // FIN observation. Replaces the post-`__sync_synchronize` that the


### PR DESCRIPTION
## Problem

The nightly **tsan / a2a3sim** sanitizer job intermittently fails on
`test_dedup_shared_so_independent_unregister` with a scheduler stall:

```
[STALL thread=N] TIMEOUT_EXIT after_idle_iterations=...
PTO2 runtime failed: orch_error_code=0 sched_error_code=100 runtime_status=-100
RuntimeError: run_prepared failed with code -100
```

Root cause is **not** a too-small timeout and is unrelated to the
sync_start drain fix (#1074). The AICPU<->AICore handshake registers
(`COND`, `DATA_MAIN_BASE`) are accessed in the **sim** platform as plain
`volatile` loads/stores ordered only by standalone fences
(`OUT_OF_ORDER_*_BARRIER` / `rmb` / `wmb`). In sim those "registers" are
plain host memory shared across the AICore and AICPU host threads, so a
bare fence beside a non-atomic access establishes no inter-thread
happens-before in the C++ memory model — ThreadSanitizer correctly flags
every COND/dispatch access as a data race, and the unsynchronized COND
poll can miss the AICore's FIN publish, leaving a task stuck `RUNNING`
(`cond_reg_state=ack`) until the idle watchdog fires.

## Fix

Make the register cell itself the synchronizing object on the sim path:

- **AICore sim** `read_reg`/`write_reg` → `__atomic_load_n(ACQUIRE)` /
  `__atomic_store_n(RELEASE)` (sim-only `inner_kernel.h`).
- **AICPU** side: add `reg_load_acquire` / `reg_store_release` in
  `platform_regs.h`, gated on `__CPU_SIM` (now defined on the sim aicpu
  target). `write_reg`, the shared `read_reg` (a2a3) /
  `inner_platform_regs.cpp` (a5), and the hot-path `*core.cond_ptr`
  completion poll route through them.

**Onboard is unchanged**: `__CPU_SIM` is undefined there, so the
accessors stay plain Device-MMIO `volatile` + the existing explicit
`rmb()`/`wmb()` (atomics on Device-nGnRnE memory are not valid). The
atomic release/acquire subsumes the now-removed per-access fences on the
sim path only.

## Validation

Built with `SIMPLER_SANITIZER=tsan` and ran the previously-failing test
**40x on a2a3sim under TSAN**:

- 40/40 pass, **0 stalls**, **0 ThreadSanitizer data races**
  (previously dozens at these exact lines: `aicore_executor.cpp`,
  `handshake_all_cores`, `check_running_cores_for_completion`,
  `platform_regs`).
- The built `libaicpu_kernel.so` now contains `__tsan_atomic_*` calls,
  confirming the accesses became instrumented atomics.

## Notes

- Independent of #1074; touches only `src/{a2a3,a5}/platform/sim` +
  the sim register-cell accessor and one completion-poll line.
- Startup/teardown races on `bind_runtime` / `on_orchestration_done`
  seen in the original failing log are a separate pre-existing issue
  (scheduler init/teardown, not the register handshake) and are not
  addressed here.