### PR TITLE
chore(runtime): remove dead PTO2_READY_QUEUE_SHARDS env gate

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -246,25 +246,6 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     int64_t t_args_end = _now_ms();
 
-    // Read ready queue shard count from environment for AICPU scheduler
-    {
-        const char *env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
-        if (env_shards) {
-            char *endptr;
-            int64_t val = strtol(env_shards, &endptr, 10);
-            if (endptr != env_shards && *endptr == '\0' && val >= 1 && val <= PLATFORM_MAX_AICPU_THREADS) {
-                runtime->ready_queue_shards = static_cast<int>(val);
-            } else {
-                LOG_WARN(
-                    "PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d", env_shards,
-                    PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS
-                );
-                runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-            }
-        }
-        LOG_INFO_V0("Ready queue shards: %d", runtime->ready_queue_shards);
-    }
-
     // Read orchestrator-to-scheduler transition flag from environment
     {
         const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -246,25 +246,6 @@ extern "C" int bind_callable_to_runtime_impl(
     }
     int64_t t_args_end = _now_ms();
 
-    // Read ready queue shard count from environment for AICPU scheduler
-    {
-        const char *env_shards = std::getenv("PTO2_READY_QUEUE_SHARDS");
-        if (env_shards) {
-            char *endptr;
-            int64_t val = strtol(env_shards, &endptr, 10);
-            if (endptr != env_shards && *endptr == '\0' && val >= 1 && val <= PLATFORM_MAX_AICPU_THREADS) {
-                runtime->ready_queue_shards = static_cast<int>(val);
-            } else {
-                LOG_WARN(
-                    "PTO2_READY_QUEUE_SHARDS=%s is invalid or out of range [1,%d], using default %d", env_shards,
-                    PLATFORM_MAX_AICPU_THREADS, RUNTIME_DEFAULT_READY_QUEUE_SHARDS
-                );
-                runtime->ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-            }
-        }
-        LOG_INFO_V0("Ready queue shards: %d", runtime->ready_queue_shards);
-    }
-
     // Read orchestrator-to-scheduler transition flag from environment
     {
         const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");


### PR DESCRIPTION
## What

Removes `PTO2_READY_QUEUE_SHARDS`, a raw `std::getenv` read in
`runtime_maker.cpp`. Its target field `runtime->ready_queue_shards` is
**never read** by any scheduler/dispatch code — pure dead config surface.
Per the repo's env-macro-gating rule, the gate is deleted.

The field keeps its constructor default
(`RUNTIME_DEFAULT_READY_QUEUE_SHARDS`), so behavior is unchanged.

## Changes (a2a3 + a5)

- Drop the `PTO2_READY_QUEUE_SHARDS` `getenv` block in
  `host/runtime_maker.cpp` (both arches).

## Why not also remove PTO2_ORCH_TO_SCHED?

#834 named two knobs. `PTO2_ORCH_TO_SCHED` is **intentionally left in
place** here: unlike `ready_queue_shards`, its field is actively read
([aicpu_executor.cpp](../blob/main/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp))
and gates **live** core-reassignment logic in the scheduler
(`handle_core_transition`, `reassign_cores_for_all_threads`, and the
`transition_requested_`/`wait_reassign_`/`reassigned_` handshake).
Removing its env entry would strand that whole subsystem as unreachable
dead code, so it is deferred to a dedicated follow-up rather than bundled
here.

Refs #834 (partial — `READY_QUEUE_SHARDS` only).