### PR TITLE
Fix: bump paged_attention_manual_scope Case1 task-ring window to 32768

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/test_paged_attention.py
@@ -64,7 +64,11 @@ class TestPagedAttentionManualScope(SceneTestCase):
         {
             "name": "Case1",
             "platforms": ["a2a3"],
-            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            # Long-context cases submit >16384 in-flight tasks into a single
+            # MANUAL scope; the default per-ring task window (16384) can fill
+            # before the oldest task retires and wedge the orchestrator
+            # (FLOW_CONTROL_DEADLOCK / code 3). Double the window for headroom.
+            "config": {"aicpu_thread_num": 4, "block_dim": 24, "runtime_env": {"ring_task_window": 32768}},
             "params": {
                 "batch": 256,
                 "num_heads": 16,


### PR DESCRIPTION
## Problem

`paged_attention_manual_scope` Case1 (batch=256, context_len=8192) intermittently fails on `st-onboard-a2a3` with `run_prepared failed with code 507018` / `orch_error_code=3` (FLOW_CONTROL_DEADLOCK).

## Root cause (from the failing CI device log)

Case1 streams ~65k tasks through a **single** `PTO2_SCOPE(MANUAL)` per (batch, q) pair. The device log at the failure shows the **task ring** (not heap, not dep_pool) saturated:

```
[TaskAllocator] BLOCKED: tasks=16383/16384, heap=...37%, on=task, spins=100000
report_deadlock: FATAL: Task Allocator Deadlock - Task Ring Full!
  Task ring: current=17740, last_alive=1357, active=16383/16384 (100.0%)
```

The orchestrator ran ~16383 tasks ahead of the oldest un-retired task (1357) and filled the default 16384-slot ring → `code 3` → surfaced on host as 507018.

## Fix

Set `ring_task_window=32768` (2x) for Case1 via per-case `config.runtime_env`, giving headroom so the ring does not fill before retirement catches up. Mitigation scoped to the one case CI runs.

## Validation

Re-running st-onboard-a2a3 multiple times to confirm the intermittent failure no longer reproduces.