### PR TITLE
test: enable spmd_paged_attention_highperf s8192 case in CI

### DIFF
--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/test_spmd_paged_attention_highperf.py
@@ -251,7 +251,6 @@ class TestSpmdPagedAttentionHighPerf(SceneTestCase):
         },
         {
             "name": "b1_h32_kv8_s8192_bs128_fp16",
-            "manual": True,
             "platforms": ["a2a3"],
             "config": {"aicpu_thread_num": 4, "block_dim": 24},
             "params": {


### PR DESCRIPTION
## Why

Issue #1022 (SPMD paged attention highperf fails for >= 8192 sequences) was
closed by PR #1091. However, #1091 added the new long-sequence cases
(s4096 / s6144 / s8192 / s16384 / b2 variants) with `manual: True`, so CI
never actually exercised the `s8192` case that the bug report targeted — the
fix went in unverified by the pipeline.

## What

Drop `manual: True` on `b1_h32_kv8_s8192_bs128_fp16` so the case that
reproduced #1022 now runs in the a2a3 onboard CI and guards against
regression. The other newly-added long-sequence cases remain `manual` to keep
CI runtime bounded.

## Test

CI (a2a3 onboard) will run the s8192 highperf paged-attention case.