### PR TITLE
Fix: close unpublished host orchestration handles

### DIFF
--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -30,6 +30,7 @@
 #include "pto_runtime_c_api.h"
 #include "task_args.h"
 
+#include <dlfcn.h>
 #include <pthread.h>
 
 #include <chrono>
@@ -298,6 +299,11 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         if (rc != 0) {
             return rc;
         }
+        auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
+            if (artifacts.host_dlopen_handle != nullptr) {
+                dlclose(artifacts.host_dlopen_handle);
+            }
+        });
 
         // Re-pack ChildKernelAddr -> std::pair to match the existing
         // register_callable* signature. The named struct only crosses
@@ -312,10 +318,14 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
         // hbg's prepare_callable_impl populates host_dlopen_handle; trb's
         // leaves it null and fills orch_so_data + func_name/config_name.
         if (artifacts.host_dlopen_handle != nullptr) {
-            return runner->register_callable_host_orch(
+            rc = runner->register_callable_host_orch(
                 callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
                 std::move(artifacts.signature)
             );
+            if (rc == 0) {
+                host_dlopen_guard.dismiss();
+            }
+            return rc;
         }
         return runner->register_callable(
             callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),


### PR DESCRIPTION
## Summary

  - Add a local RAII guard for host-build-graph orchestration `dlopen` handles
    returned by `prepare_callable_impl()`.
  - Dismiss the guard only after `register_callable_host_orch()` successfully
    publishes the callable state.
  - This prevents leaked host orchestration SO handles when publish/register
    fails before `DeviceRunnerBase` takes ownership.

  ## Testing

  - `.venv/bin/python -m pip install --no-build-isolation --config-
  settings=cmake.define.SIMPLER_PTO_ISA_COMMIT=ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8 -e '.
  [test]'`
  - `CCACHE_DIR=/tmp/simpler-hbg-dlopen-leak-pr-ccache cmake -B tests/ut/cpp/build-gtest-
  fetch -S tests/ut/cpp -DGTEST_LIB=GTEST_LIB-NOTFOUND -DGTEST_MAIN_LIB=GTEST_MAIN_LIB-
  NOTFOUND`
  - `CCACHE_DIR=/tmp/simpler-hbg-dlopen-leak-pr-ccache cmake --build tests/ut/cpp/build-
  gtest-fetch`
  - `CCACHE_DIR=/tmp/simpler-hbg-dlopen-leak-pr-ccache ctest --test-dir tests/ut/cpp/build-
  gtest-fetch -LE requires_hardware --output-on-failure`

  Notes:

  - The first C++ UT attempt used the system GoogleTest and hit the documented
    old-ABI `EqFailure` link failure, so the passing run used the documented
    FetchContent override.
  - The first `ctest` run inside the sandbox failed only on a socket permission
    error in `test_remote_endpoint`; the same `ctest` command passed outside the
    sandbox.
  - Hardware tests were not run locally because `npu-smi info` failed with
    `dcmi module initialize failed. ret is -8005`.
  - `pre-commit` was not run per maintainer guidance for this environment.