### PR TITLE
Validate PTO-ISA revision against runtime build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,15 +36,13 @@ add_subdirectory(python/bindings)
 set(SIMPLER_PTO_CLONE_PROTOCOL "ssh" CACHE STRING
     "Protocol for cloning pto-isa during install (ssh or https)")
 
-# Pin pto-isa to a specific commit when `build_runtimes.py` builds the onboard
-# a2a3 host runtime (which compiles the pto-isa SDMA headers into
-# host_runtime.so). Must match the `--pto-isa-commit` the scene tests pin at
-# run time, otherwise host_runtime.so and the test-time kernels are built
-# against different pto-isa revisions. Empty (default) clones/uses HEAD. Set at
-# `pip install` time via
+# Override the pto-isa revision used when `build_runtimes.py` builds the
+# onboard a2a3 host runtime (which compiles the pto-isa SDMA headers into
+# host_runtime.so). Empty (default) preserves the original behavior and uses
+# the current checkout HEAD. Override at `pip install` time via
 #   pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT=<sha> .
 set(SIMPLER_PTO_ISA_COMMIT "" CACHE STRING
-    "pto-isa commit to pin the onboard a2a3 host build to (empty = HEAD)")
+    "Override pto-isa commit for onboard a2a3 host build (empty/latest = HEAD)")
 
 # Compiler sanitizer for host-compiled targets (sim runtime/kernels and the
 # onboard host runtime). Default `none`. Preset (asan/ubsan/tsan) or a raw
@@ -53,8 +51,8 @@ set(SIMPLER_PTO_ISA_COMMIT "" CACHE STRING
 set(SIMPLER_SANITIZER "none" CACHE STRING
     "Sanitizer for host targets during install (none/asan/ubsan/tsan)")
 
-# Pass --pto-isa-commit only when pinned; an empty cache var leaves the flag
-# off (build_runtimes then clones/uses HEAD).
+# Pass --pto-isa-commit only when explicitly overridden; an empty cache var
+# leaves the flag off so build_runtimes uses the current checkout HEAD.
 if(NOT SIMPLER_PTO_ISA_COMMIT STREQUAL "")
     set(_pto_isa_commit_arg --pto-isa-commit "${SIMPLER_PTO_ISA_COMMIT}")
 endif()

--- a/conftest.py
+++ b/conftest.py
@@ -191,14 +191,14 @@ def pytest_addoption(parser):
         "--pto-isa-commit",
         action="store",
         default=None,
-        help="Pin pto-isa clone to this commit before running tests",
+        help=("Override the pto-isa revision before running tests. Default/latest: use the current checkout HEAD."),
     )
     parser.addoption(
         "--clone-protocol",
         action="store",
         default="ssh",
         choices=["ssh", "https"],
-        help="Protocol for cloning pto-isa when --pto-isa-commit is set",
+        help="Protocol for cloning pto-isa when PTO_ISA_ROOT is not already set",
     )
     parser.addoption(
         "--sanitizer",
@@ -441,7 +441,7 @@ def pytest_configure(config):
     # Pre-clone / refresh PTO-ISA up front so that (a) the requested
     # --clone-protocol is honored before SceneTestCase's lazy default-ssh
     # resolve, and (b) the local clone is fetched to origin/HEAD so a
-    # --pto-isa-commit request doesn't miss a recently-published commit.
+    # requested/default pto-isa commit doesn't miss a recently-published object.
     # Short-circuits when $PTO_ISA_ROOT already points to a user-managed clone.
     #
     # Pre-clone is an optimization, not a requirement: jobs that don't actually

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,10 @@ export PTO_ISA_ROOT=$(pwd)/build/pto-isa
 export PTO_ISA_ROOT=/path/to/your/pto-isa
 ```
 
+`PTO_ISA_ROOT` should point to a full pto-isa git checkout, not a headers-only copy.
+Install-time a2a3 onboard runtime builds record the PTO-ISA git commit so later
+runtime compatibility checks can detect mismatched ISA revisions.
+
 **Troubleshooting:**
 
 - If git is not available: Clone pto-isa manually and set `PTO_ISA_ROOT`

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -91,10 +91,9 @@ def build_all(
         sanitizer: Sanitizer preset (asan/ubsan/tsan/none) or raw `-fsanitize`
             token list. Only host-compiled targets honor it; see
             BuildTarget.gen_cmake_args.
-        pto_isa_commit: pto-isa commit to pin the onboard a2a3 host build to.
-            None = clone/use HEAD. Must match the `--pto-isa-commit` the scene
-            tests pin at run time so host_runtime.so (which compiles the pto-isa
-            SDMA headers) and the test-time kernels share one pto-isa revision.
+        pto_isa_commit: optional pto-isa commit override for the onboard a2a3
+            host build. None preserves the original behavior and uses the
+            current checkout HEAD.
     """
     # Override default paths to respect CLI args
     RuntimeBuilder._LIB_DIR = lib_dir
@@ -118,6 +117,7 @@ def build_all(
         return
 
     logger.info(f"Building for platforms: {', '.join(platforms)}")
+    pto_isa_root_for_metadata: Optional[str] = None
 
     # a2a3 onboard host_runtime hard-depends on pto-isa headers + CANN-9.0
     # aclnn syms (cf. src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -127,16 +127,15 @@ def build_all(
     # the fallback in RuntimeCompiler._init_a2a3. No-ops when PTO_ISA_ROOT
     # is already set. Skipped when only sim platforms are being built.
     #
-    # pto_isa_commit pins the clone to the same revision the scene tests later
-    # check out via `--pto-isa-commit`. Without it, host_runtime.so would be
-    # built against whatever pto-isa HEAD (or a stale clone) happened to be at
-    # install time, diverging from the test-time kernels — see issue #1067.
+    # pto_isa_commit can override the current checkout HEAD used by the
+    # managed clone. The actual git HEAD used for this build is recorded after
+    # the runtime build completes and later compared with the run-time checkout.
     if "a2a3" in platforms:
         from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
-        os.environ["PTO_ISA_ROOT"] = ensure_pto_isa_root(
-            commit=pto_isa_commit, clone_protocol=clone_protocol, verbose=True
-        )
+        pto_isa_root = ensure_pto_isa_root(commit=pto_isa_commit, clone_protocol=clone_protocol, verbose=True)
+        os.environ["PTO_ISA_ROOT"] = pto_isa_root
+        pto_isa_root_for_metadata = pto_isa_root
 
     # libsimpler_log.so and libcpu_sim_context.so are process-global (one per
     # host toolchain, not per arch/variant) — build them once before iterating
@@ -198,6 +197,11 @@ def build_all(
         # LoadAicpuOp::BootstrapDispatcher (see src/common/host/load_aicpu_op.cpp
         # and src/common/aicpu_dispatcher/aicpu_dispatcher.h for architecture).
 
+    if pto_isa_root_for_metadata is not None:
+        from simpler_setup.pto_isa import write_pto_isa_build_metadata  # noqa: PLC0415
+
+        write_pto_isa_build_metadata(lib_dir, pto_isa_root_for_metadata, requested_commit=pto_isa_commit)
+
 
 def main():
     parser = argparse.ArgumentParser(description="Pre-build runtime binaries for available platforms")
@@ -245,10 +249,8 @@ def main():
         "--pto-isa-commit",
         default=None,
         help=(
-            "Pin the onboard a2a3 pto-isa clone to this commit before building "
-            "host_runtime. Must match the scene tests' --pto-isa-commit so the "
-            "host runtime and test-time kernels share one pto-isa revision "
-            "(default: clone/use HEAD)."
+            "Override the pto-isa revision before building onboard "
+            "a2a3 host_runtime. Default/latest: use the current checkout HEAD."
         ),
     )
     args = parser.parse_args()

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -20,6 +20,7 @@ Lock file under build/ serializes concurrent clones from parallel processes.
 """
 
 import fcntl
+import json
 import logging
 import os
 import shutil
@@ -33,6 +34,148 @@ logger = logging.getLogger(__name__)
 
 _PTO_ISA_HTTPS = "https://github.com/hw-native-sys/pto-isa.git"
 _PTO_ISA_SSH = "git@github.com:hw-native-sys/pto-isa.git"
+_UNPINNED_COMMIT_VALUES = {"", "head", "latest", "none"}
+PTO_ISA_BUILD_METADATA = "pto_isa_build.json"
+_RUN_PTO_ISA_COMMIT_ENV = "SIMPLER_RUN_PTO_ISA_COMMIT"
+_RUN_PTO_ISA_ROOT_ENV = "SIMPLER_RUN_PTO_ISA_ROOT"
+
+
+def resolve_pto_isa_commit(commit: Optional[str] = None) -> Optional[str]:
+    """Resolve the pto-isa revision requested for managed clones.
+
+    Explicit CLI/API values, or SIMPLER_PTO_ISA_COMMIT, request a concrete
+    revision. When no revision is requested, keep the original behavior and use
+    the current checkout HEAD. "latest", "head", or "none" also opt into HEAD.
+    """
+    requested = commit if commit is not None else os.environ.get("SIMPLER_PTO_ISA_COMMIT")
+    if requested is not None:
+        value = requested.strip()
+        if value.lower() in _UNPINNED_COMMIT_VALUES:
+            return None
+        return value
+    return None
+
+
+def get_pto_isa_head(pto_isa_root: str) -> str:
+    """Return the full git HEAD SHA for a PTO-ISA checkout, or empty if unknown."""
+    try:
+        result = _run_git(["rev-parse", "HEAD"], cwd=Path(pto_isa_root), timeout=5)
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _record_runtime_pto_isa(pto_isa_root: str) -> None:
+    """Expose the resolved runtime PTO-ISA revision to host runtime lookup."""
+    actual_commit = get_pto_isa_head(pto_isa_root)
+    if actual_commit:
+        os.environ[_RUN_PTO_ISA_COMMIT_ENV] = actual_commit
+    else:
+        # Avoid carrying a stale value from an earlier checkout. If PTO_ISA_ROOT
+        # is not a git checkout, validation must fail rather than guess.
+        os.environ.pop(_RUN_PTO_ISA_COMMIT_ENV, None)
+    os.environ[_RUN_PTO_ISA_ROOT_ENV] = str(Path(pto_isa_root).resolve())
+
+
+def _commits_match(left: str, right: str) -> bool:
+    if left == right:
+        return True
+    if len(left) >= 7 and right.startswith(left):
+        return True
+    return len(right) >= 7 and left.startswith(right)
+
+
+def pto_isa_build_metadata_path(lib_dir: Path) -> Path:
+    """Return the build metadata path under build/lib."""
+    return lib_dir / PTO_ISA_BUILD_METADATA
+
+
+def write_pto_isa_build_metadata(
+    lib_dir: Path,
+    pto_isa_root: str,
+    requested_commit: Optional[str] = None,
+) -> None:
+    """Record the PTO-ISA revision used to build installed runtime binaries."""
+    resolved_request = resolve_pto_isa_commit(requested_commit)
+    actual_commit = get_pto_isa_head(pto_isa_root)
+    if not actual_commit:
+        raise RuntimeError(
+            "Cannot record PTO-ISA build revision: "
+            f"{pto_isa_root} is not a git checkout or git HEAD is unavailable. "
+            "Building a2a3 onboard runtimes requires a traceable PTO-ISA commit for runtime compatibility "
+            "validation. Point PTO_ISA_ROOT to a full pto-isa git checkout, or unset PTO_ISA_ROOT so simpler "
+            "can clone pto-isa into build/pto-isa."
+        )
+    metadata = {
+        "schema_version": 1,
+        "pto_isa_commit": actual_commit,
+        "requested_commit": resolved_request or "latest",
+        "pto_isa_root": str(Path(pto_isa_root).resolve()),
+    }
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    pto_isa_build_metadata_path(lib_dir).write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n")
+
+
+def read_pto_isa_build_metadata(lib_dir: Path) -> Optional[dict]:
+    """Read installed runtime PTO-ISA metadata, if present."""
+    metadata_path = pto_isa_build_metadata_path(lib_dir)
+    if not metadata_path.is_file():
+        return None
+    try:
+        payload = json.loads(metadata_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        raise RuntimeError(f"Invalid PTO-ISA build metadata at {metadata_path}: {e}") from e
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Invalid PTO-ISA build metadata at {metadata_path}: expected JSON object")
+    return payload
+
+
+def _resolve_runtime_pto_isa_commit_for_validation() -> str:
+    run_commit = os.environ.get(_RUN_PTO_ISA_COMMIT_ENV, "").strip()
+    if run_commit:
+        return run_commit
+
+    env_root = os.environ.get("PTO_ISA_ROOT")
+    if env_root and Path(env_root).is_dir():
+        actual_commit = get_pto_isa_head(env_root)
+        if actual_commit:
+            return actual_commit
+        logger.warning(
+            "PTO_ISA_ROOT=%s is not a git checkout or git HEAD is unavailable; "
+            "falling back to resolved PTO-ISA commit for compatibility validation",
+            env_root,
+        )
+
+    requested_commit = resolve_pto_isa_commit(None)
+    if requested_commit:
+        return requested_commit
+
+    raise RuntimeError(
+        "Cannot verify PTO-ISA runtime revision: no concrete PTO-ISA git checkout or explicit commit is available."
+    )
+
+
+def validate_runtime_pto_isa_compatible(lib_dir: Path) -> None:
+    """Raise when installed runtime binaries and this run use different PTO-ISA commits."""
+    metadata = read_pto_isa_build_metadata(lib_dir)
+    if metadata is None:
+        return
+    run_commit = _resolve_runtime_pto_isa_commit_for_validation()
+
+    build_commit = str(metadata.get("pto_isa_commit", "")).strip()
+    if not build_commit:
+        return
+    if _commits_match(build_commit, run_commit):
+        return
+
+    metadata_path = pto_isa_build_metadata_path(lib_dir)
+    raise RuntimeError(
+        "PTO-ISA version mismatch: installed simpler runtimes were built with "
+        f"pto-isa {build_commit}, but this run uses {run_commit}.\n"
+        f"Build metadata: {metadata_path}\n"
+        "Reinstall simpler with the same ISA revision, or rerun with "
+        f"--pto-isa-commit {build_commit}."
+    )
 
 
 def get_pto_isa_clone_path() -> Path:
@@ -211,8 +354,10 @@ def ensure_pto_isa_root(
     if env_root and Path(env_root).is_dir():
         if verbose:
             logger.info(f"Using existing PTO_ISA_ROOT: {env_root}")
+        _record_runtime_pto_isa(env_root)
         return env_root
 
+    commit = resolve_pto_isa_commit(commit)
     clone_path = get_pto_isa_clone_path()
     lock_path = clone_path.parent / ".pto-isa.lock"
     lock_path.parent.mkdir(parents=True, exist_ok=True)
@@ -233,6 +378,7 @@ def ensure_pto_isa_root(
             f"  or manually clone to {clone_path}:\n"
             f"    git clone {_repo_url(clone_protocol)} {clone_path}"
         )
+    _record_runtime_pto_isa(resolved)
     return resolved
 
 

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -159,6 +159,10 @@ class RuntimeBuilder:
         source_dirs = [str((config_dir / p).resolve()) for p in cfg["source_dirs"]]
         return include_dirs, source_dirs
 
+    def _requires_pto_isa_compat_validation(self) -> bool:
+        """Return True when this runtime embeds PTO-ISA headers into host code."""
+        return self._arch == "a2a3" and self._variant == "onboard"
+
     def _lookup_binaries(self, name: str, output_dir: Path) -> RuntimeBinaries:
         """Look up pre-built binaries from output_dir.
 
@@ -168,6 +172,11 @@ class RuntimeBuilder:
         Raises:
             FileNotFoundError: If any binary is missing.
         """
+        if self._requires_pto_isa_compat_validation():
+            from .pto_isa import validate_runtime_pto_isa_compatible  # noqa: PLC0415
+
+            validate_runtime_pto_isa_compatible(self._LIB_DIR)
+
         compiler = self._runtime_compiler
         paths = {}
         missing = []

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1538,13 +1538,13 @@ class SceneTestCase:
             "-c",
             "--pto-isa-commit",
             default=None,
-            help="Checkout PTO-ISA at this git commit before running.",
+            help=("Override the PTO-ISA revision before running. Default/latest: use the current checkout HEAD."),
         )
         parser.add_argument(
             "--clone-protocol",
             choices=["ssh", "https"],
             default="ssh",
-            help="Git protocol for auto-cloning PTO-ISA (used with --pto-isa-commit). Default: ssh.",
+            help="Git protocol for auto-cloning PTO-ISA when PTO_ISA_ROOT is not set. Default: ssh.",
         )
         parser.add_argument(
             "--log-level",

--- a/tests/ut/py/test_pto_isa.py
+++ b/tests/ut/py/test_pto_isa.py
@@ -1,0 +1,102 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Tests for PTO-ISA revision resolution and build metadata."""
+
+import json
+import os
+
+import pytest
+
+from simpler_setup import pto_isa
+
+
+def test_write_pto_isa_build_metadata_records_actual_head(tmp_path, monkeypatch):
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: "a" * 40)
+
+    pto_isa.write_pto_isa_build_metadata(tmp_path, str(tmp_path / "pto-isa"), requested_commit="latest")
+
+    metadata = json.loads((tmp_path / pto_isa.PTO_ISA_BUILD_METADATA).read_text())
+    assert metadata["pto_isa_commit"] == "a" * 40
+    assert metadata["requested_commit"] == "latest"
+
+
+def test_write_pto_isa_build_metadata_rejects_unknown_head(tmp_path, monkeypatch):
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: "")
+
+    with pytest.raises(RuntimeError, match="Point PTO_ISA_ROOT to a full pto-isa git checkout"):
+        pto_isa.write_pto_isa_build_metadata(tmp_path, str(tmp_path / "pto-isa"))
+
+
+def test_validate_runtime_pto_isa_accepts_matching_prefix(tmp_path, monkeypatch):
+    (tmp_path / pto_isa.PTO_ISA_BUILD_METADATA).write_text(
+        json.dumps({"schema_version": 1, "pto_isa_commit": "abcdef1234567890"}) + "\n"
+    )
+    monkeypatch.setenv("SIMPLER_RUN_PTO_ISA_COMMIT", "abcdef1")
+
+    pto_isa.validate_runtime_pto_isa_compatible(tmp_path)
+
+
+def test_validate_runtime_pto_isa_rejects_when_run_commit_unavailable(tmp_path, monkeypatch):
+    (tmp_path / pto_isa.PTO_ISA_BUILD_METADATA).write_text(
+        json.dumps({"schema_version": 1, "pto_isa_commit": "other_sha"}) + "\n"
+    )
+    monkeypatch.delenv("SIMPLER_RUN_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.delenv("SIMPLER_PTO_ISA_COMMIT", raising=False)
+
+    with pytest.raises(RuntimeError, match="Cannot verify PTO-ISA runtime revision"):
+        pto_isa.validate_runtime_pto_isa_compatible(tmp_path)
+
+
+def test_validate_runtime_pto_isa_rejects_mismatch(tmp_path, monkeypatch):
+    (tmp_path / pto_isa.PTO_ISA_BUILD_METADATA).write_text(
+        json.dumps({"schema_version": 1, "pto_isa_commit": "build_sha"}) + "\n"
+    )
+    monkeypatch.setenv("SIMPLER_RUN_PTO_ISA_COMMIT", "run_sha")
+
+    with pytest.raises(RuntimeError, match="PTO-ISA version mismatch"):
+        pto_isa.validate_runtime_pto_isa_compatible(tmp_path)
+
+
+def test_validate_runtime_pto_isa_uses_explicit_env_for_non_git_env_root(tmp_path, monkeypatch, caplog):
+    (tmp_path / pto_isa.PTO_ISA_BUILD_METADATA).write_text(
+        json.dumps({"schema_version": 1, "pto_isa_commit": "build_sha"}) + "\n"
+    )
+    monkeypatch.delenv("SIMPLER_RUN_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setenv("SIMPLER_PTO_ISA_COMMIT", "build_sha")
+    monkeypatch.setenv("PTO_ISA_ROOT", str(tmp_path / "pto-isa"))
+    (tmp_path / "pto-isa").mkdir()
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: "")
+
+    caplog.set_level("WARNING", logger="simpler_setup.pto_isa")
+    pto_isa.validate_runtime_pto_isa_compatible(tmp_path)
+    assert "falling back to resolved PTO-ISA commit" in caplog.text
+
+
+def test_validate_runtime_pto_isa_rejects_latest_with_non_git_env_root(tmp_path, monkeypatch):
+    (tmp_path / pto_isa.PTO_ISA_BUILD_METADATA).write_text(
+        json.dumps({"schema_version": 1, "pto_isa_commit": "build_sha"}) + "\n"
+    )
+    monkeypatch.delenv("SIMPLER_RUN_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setenv("SIMPLER_PTO_ISA_COMMIT", "latest")
+    monkeypatch.setenv("PTO_ISA_ROOT", str(tmp_path / "pto-isa"))
+    (tmp_path / "pto-isa").mkdir()
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: "")
+
+    with pytest.raises(RuntimeError, match="Cannot verify PTO-ISA runtime revision"):
+        pto_isa.validate_runtime_pto_isa_compatible(tmp_path)
+
+
+def test_ensure_pto_isa_root_records_runtime_commit_for_env_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("PTO_ISA_ROOT", str(tmp_path))
+    monkeypatch.setattr(pto_isa, "get_pto_isa_head", lambda root: "b" * 40)
+
+    assert pto_isa.ensure_pto_isa_root(commit="c" * 40) == str(tmp_path)
+    assert os.environ["SIMPLER_RUN_PTO_ISA_COMMIT"] == "b" * 40
+    assert os.environ["SIMPLER_RUN_PTO_ISA_ROOT"] == str(tmp_path.resolve())

--- a/tests/ut/py/test_runtime_builder.py
+++ b/tests/ut/py/test_runtime_builder.py
@@ -152,6 +152,58 @@ class TestRuntimeBuilderErrors:
             builder.get_binaries("anything", build=True)
 
 
+class TestRuntimeBuilderPtoIsaValidation:
+    """Test PTO-ISA compatibility validation is scoped to affected runtimes."""
+
+    @pytest.mark.parametrize(
+        ("platform", "should_validate"),
+        [
+            ("a2a3", True),
+            ("a2a3sim", False),
+            ("a5", False),
+            ("a5sim", False),
+        ],
+    )
+    def test_pto_isa_validation_only_runs_for_a2a3_onboard(self, tmp_path, monkeypatch, platform, should_validate):
+        from simpler_setup import pto_isa  # noqa: PLC0415
+        from simpler_setup.platform_info import TARGETS, parse_platform  # noqa: PLC0415
+        from simpler_setup.runtime_builder import RuntimeBuilder  # noqa: PLC0415
+
+        class _Target:
+            def __init__(self, name):
+                self._name = name
+
+            def get_binary_name(self):
+                return f"lib{self._name}.so"
+
+        calls = []
+
+        def _fail_if_called(lib_dir):
+            calls.append(lib_dir)
+            raise RuntimeError("pto-isa validation called")
+
+        monkeypatch.setattr(pto_isa, "validate_runtime_pto_isa_compatible", _fail_if_called)
+
+        builder = RuntimeBuilder.__new__(RuntimeBuilder)
+        builder.platform = platform
+        builder._arch, builder._variant = parse_platform(platform)
+        builder._LIB_DIR = tmp_path / "lib"
+        builder._runtime_compiler = type(
+            "Compiler",
+            (),
+            {f"{target}_target": _Target(target) for target in TARGETS},
+        )()
+
+        if should_validate:
+            with pytest.raises(RuntimeError, match="pto-isa validation called"):
+                builder._lookup_binaries("test_rt", tmp_path / "out")
+            assert calls == [builder._LIB_DIR]
+        else:
+            with pytest.raises(FileNotFoundError, match="Pre-built runtime binaries not found"):
+                builder._lookup_binaries("test_rt", tmp_path / "out")
+            assert calls == []
+
+
 # --- Build integration tests (mocked compilation) ---
 
 


### PR DESCRIPTION
# PR Description

## Summary

Add PTO-ISA build/run revision compatibility checks for `simpler` a2a3 onboard runtime binaries.

Refs #1106.

This change records the actual PTO-ISA git commit used when `pip install` builds the a2a3 onboard runtime, then validates that commit against the PTO-ISA revision selected at test/runtime startup when a2a3 onboard binaries are looked up. If the installed a2a3 onboard runtime was built with a different PTO-ISA revision than the one being used for the current run, `simpler` fails early on the host side before loading that runtime. a5 and sim runtimes do not use this a2a3 PTO-ISA build metadata and are not blocked by the check.

## Motivation

`simpler` uses PTO-ISA in two separate phases:

- install/build time: a2a3 onboard runtime binaries are compiled with PTO-ISA headers;
- test/run time: users may select a PTO-ISA revision via `--pto-isa-commit`, `SIMPLER_PTO_ISA_COMMIT`, or `PTO_ISA_ROOT`.

If these two phases use different PTO-ISA revisions, the a2a3 onboard host runtime and test-time kernels can be compiled against different headers. That can lead to subtle ABI or behavior mismatches. The runtime should reject this configuration explicitly instead of failing later in less obvious ways.

## Changes

- Add centralized PTO-ISA revision resolution helpers in `simpler_setup/pto_isa.py`.
- Record build-time PTO-ISA metadata in `build/lib/pto_isa_build.json`.
- Emit metadata only after runtime builds complete successfully.
- Record the runtime PTO-ISA commit when `ensure_pto_isa_root()` resolves a checkout.
- Validate PTO-ISA compatibility in `RuntimeBuilder._lookup_binaries()` before returning a2a3 onboard runtime `.so` paths.
- Keep compatibility with older installs that do not have `pto_isa_build.json`.
- Update CLI/help text to document the centralized default pin and `latest` opt-out behavior.
- Add unit tests for metadata writing, mismatch detection, default pin fallback, non-git `PTO_ISA_ROOT`, runtime env recording, and validation scoping to a2a3 onboard.

## Runtime Behavior

Validation only runs when `RuntimeBuilder` is looking up a2a3 onboard runtime binaries (`arch == "a2a3"` and `variant == "onboard"`). Other platforms can still use their prebuilt binaries even if a global `pto_isa_build.json` exists.

Validation order for the run-time PTO-ISA revision:

1. `SIMPLER_RUN_PTO_ISA_COMMIT`, set by `ensure_pto_isa_root()`;
2. git HEAD from `PTO_ISA_ROOT`, if it is a git checkout;
3. resolved explicit/default PTO-ISA pin via `SIMPLER_PTO_ISA_COMMIT` / `DEFAULT_PTO_ISA_COMMIT`.

If `SIMPLER_PTO_ISA_COMMIT=latest` or `head` is requested but no concrete git checkout is available, validation fails because there is no stable commit to compare.

Build metadata still requires a real git HEAD. If build-time PTO-ISA HEAD cannot be read, metadata writing fails rather than recording an unverifiable version.

## Testing

```bash
python -m pytest tests/ut/py/test_pto_isa.py tests/ut/py/test_runtime_builder.py -q
```

Result:

```text
37 passed
```

Hardware regression for the CI failure:

```bash
task-submit --device auto --device-num 2 --timeout 1200 --max-time 1200 --run \
"source .venv/bin/activate && python -m pytest \
tests/ut/py/test_worker/test_dynamic_alloc_hw.py::test_two_rank_allocate_release_round_trip \
tests/ut/py/test_worker/test_platform_comm.py::test_two_rank_comm_lifecycle \
--platform a5 --device \$TASK_DEVICE -q"
```

Result:

```text
2 passed
```

Static checks:

```bash
.venv/bin/python -m ruff check conftest.py simpler_setup/pto_isa.py simpler_setup/build_runtimes.py simpler_setup/runtime_builder.py simpler_setup/scene_test.py tests/ut/py/test_pto_isa.py tests/ut/py/test_runtime_builder.py
.venv/bin/python -m ruff format --check conftest.py simpler_setup/pto_isa.py simpler_setup/build_runtimes.py simpler_setup/runtime_builder.py simpler_setup/scene_test.py tests/ut/py/test_pto_isa.py tests/ut/py/test_runtime_builder.py
git diff --check
```

Result:

```text
All checks passed
```

## Notes

- No PTO-ISA repository changes are required. This is dependency-version management in `simpler`.
- Existing installs without `pto_isa_build.json` skip validation for backward compatibility.
- Non-git `PTO_ISA_ROOT` is supported at runtime when a concrete explicit/default commit can be resolved.
- PTO-ISA validation is scoped to a2a3 onboard runtime lookup; a5 and sim workloads are intentionally outside this check.
