### PR TITLE
Fix: classify MIX scheduling by active cores

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -47,10 +47,11 @@ inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all 
 /**
  * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
  *
- * Multi-subtask tasks (2+ active slots) are all scheduled as MIX, which
- * requires a fully-idle cluster (1 AIC + 2 AIV).  The actual cores used
- * are determined at dispatch time by active_mask — unused cores in the
- * cluster remain idle and available for single-core tasks.
+ * Multi-subtask tasks (2+ active slots) are all scheduled as MIX. Dispatch
+ * chooses one cluster, then uses active_mask to decide which cores in that
+ * cluster must be placed together: all used cores idle -> running placement;
+ * all used cores already running with free pending slots -> pending placement;
+ * mixed used-core state is rejected and retried later.
  *
  * DUMMY is a synthetic shape for dep-only tasks (no AICore dispatch). Tasks
  * with an empty core_mask route to a dedicated DUMMY ready queue and are

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -464,10 +464,14 @@ bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t b
 }
 
 // Count total available resources across all scheduler threads for a given shape.
-int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape) {
+int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_t core_mask) {
     int32_t total = 0;
     for (int32_t t = 0; t < active_sched_threads_; t++) {
-        total += core_trackers_[t].get_idle_core_offset_states(shape).count();
+        if (shape == PTO2ResourceShape::MIX) {
+            total += core_trackers_[t].count_mix_running_clusters(core_mask);
+        } else {
+            total += core_trackers_[t].get_idle_core_offset_states(shape).count();
+        }
     }
     return total;
 }
@@ -482,10 +486,13 @@ void SchedulerContext::drain_worker_dispatch(int32_t block_num) {
         return;
     }
     PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+    uint8_t core_mask = slot_state->active_mask.core_mask();
 
     for (int32_t t = 0;
          t < active_sched_threads_ && slot_state->next_block_idx.load(std::memory_order_relaxed) < block_num; t++) {
-        auto valid = core_trackers_[t].get_idle_core_offset_states(shape);
+        auto valid = (shape == PTO2ResourceShape::MIX) ?
+                         core_trackers_[t].get_mix_running_cluster_offset_states(core_mask) :
+                         core_trackers_[t].get_idle_core_offset_states(shape);
         int32_t start = slot_state->next_block_idx.load(std::memory_order_relaxed);
         int32_t remaining = slot_state->logical_block_num - start;
         int32_t claim = std::min(valid.count(), remaining);
@@ -595,7 +602,7 @@ void SchedulerContext::handle_drain_mode(int32_t thread_idx) {
         return;
     }
     PTO2ResourceShape shape = slot_state->active_mask.to_shape();
-    int32_t available = count_global_available(shape);
+    int32_t available = count_global_available(shape, slot_state->active_mask.core_mask());
 
     if (available < block_num) {
         // Insufficient resources -- reset drain fields so threads can resume

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -351,7 +351,7 @@ private:
     );
 
     bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
-    int32_t count_global_available(PTO2ResourceShape shape);
+    int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask);
     void drain_worker_dispatch(int32_t block_num);
     void handle_drain_mode(int32_t thread_idx);
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -231,21 +231,21 @@ int SchedulerContext::prepare_block_for_dispatch(
         uint8_t cmask = slot_state.active_mask.core_mask();
         int n = 0;
         if (cmask & PTO2_SUBTASK_MASK_AIC) {
-            bool p = to_pending && !tracker.is_aic_core_idle(core_offset);
             out_handles[n++] = prepare_subtask_to_core(
-                thread_idx, tracker.get_aic_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIC, p, block_idx
+                thread_idx, tracker.get_aic_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIC, to_pending,
+                block_idx
             );
         }
         if (cmask & PTO2_SUBTASK_MASK_AIV0) {
-            bool p = to_pending && !tracker.is_aiv0_core_idle(core_offset);
             out_handles[n++] = prepare_subtask_to_core(
-                thread_idx, tracker.get_aiv0_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV0, p, block_idx
+                thread_idx, tracker.get_aiv0_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV0, to_pending,
+                block_idx
             );
         }
         if (cmask & PTO2_SUBTASK_MASK_AIV1) {
-            bool p = to_pending && !tracker.is_aiv1_core_idle(core_offset);
             out_handles[n++] = prepare_subtask_to_core(
-                thread_idx, tracker.get_aiv1_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV1, p, block_idx
+                thread_idx, tracker.get_aiv1_core_offset(core_offset), slot_state, PTO2SubtaskSlot::AIV1, to_pending,
+                block_idx
             );
         }
 #if PTO2_PROFILING
@@ -279,7 +279,8 @@ void SchedulerContext::dispatch_shape(
     if (entered_drain) return;
 
     bool is_pending = (phase == CoreTracker::DispatchPhase::PENDING);
-    auto cores = tracker.get_dispatchable_cores(shape, phase);
+    bool is_mix = (shape == PTO2ResourceShape::MIX);
+    auto cores = is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
     if (!cores.has_value()) return;
 
     while (cores.has_value() && !entered_drain) {
@@ -356,6 +357,23 @@ void SchedulerContext::dispatch_shape(
 
         for (int bi = 0; bi < got; bi++) {
             PTO2TaskSlotState *slot_state = batch[bi];
+            CoreTracker::BitStates selected_mix_clusters(0ULL);
+
+            if (is_mix) {
+                auto candidates = cores;
+                uint8_t cmask = slot_state->active_mask.core_mask();
+                auto wanted = is_pending ? CoreTracker::MixPlacement::PENDING : CoreTracker::MixPlacement::RUNNING;
+                while (candidates.has_value()) {
+                    int32_t cluster_offset = candidates.pop_first();
+                    if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
+                        selected_mix_clusters |= CoreTracker::BitStates(1ULL << cluster_offset);
+                    }
+                }
+                if (!selected_mix_clusters.has_value()) {
+                    sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+                    continue;
+                }
+            }
 
             // (Speculative pre-staged tasks never reach this ready-pop: they are
             // released by their doorbell in release_fanin_and_check_ready the
@@ -366,7 +384,7 @@ void SchedulerContext::dispatch_shape(
                     sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
                 }
-                int32_t available = cores.count();
+                int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
                 if (available < slot_state->logical_block_num) {
                     flush_publish();
                     if (!enter_drain_mode(slot_state, slot_state->logical_block_num)) {
@@ -403,7 +421,8 @@ void SchedulerContext::dispatch_shape(
             // by another scheduler that popped the slot.
             int32_t start = slot_state->next_block_idx.load(std::memory_order_relaxed);
             int32_t remaining = slot_state->logical_block_num - start;
-            int32_t claim = std::min(cores.count(), remaining);
+            int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
+            int32_t claim = std::min(available, remaining);
             slot_state->next_block_idx.store(static_cast<int16_t>(start + claim), std::memory_order_relaxed);
 
             if (start + claim < slot_state->logical_block_num) {
@@ -411,7 +430,10 @@ void SchedulerContext::dispatch_shape(
             }
 
             for (int32_t b = 0; b < claim; b++) {
-                auto core_offset = cores.pop_first();
+                auto core_offset = is_mix ? selected_mix_clusters.pop_first() : cores.pop_first();
+                if (is_mix) {
+                    cores.clear_bit(core_offset);
+                }
                 handle_count += prepare_block_for_dispatch(
                     thread_idx, core_offset, *slot_state, shape, is_pending, start + b, &handles[handle_count]
                 );
@@ -440,7 +462,7 @@ void SchedulerContext::dispatch_shape(
         if (!dispatched_any) break;
 
         if (!cores.has_value()) {
-            cores = tracker.get_dispatchable_cores(shape, phase);
+            cores = is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
         }
     }
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -161,6 +161,7 @@ public:
 
         bool has_value() const { return states_ > 0; }
         int32_t count() const { return __builtin_popcountll(states_); }
+        void clear_bit(int32_t offset) { states_ &= ~(1ULL << offset); }
 
         // Extract the lowest set bit from mask, clear it, and return its position.
         // Returns -1 if mask is empty.
@@ -230,6 +231,7 @@ public:
     }
 
     BitStates get_all_running_cores() const { return (~core_states_) & (aic_mask_ | aiv_mask_); }
+    BitStates get_cluster_offset_states() const { return aic_mask_; }
 
     // --- Cluster matching ---
 
@@ -302,19 +304,67 @@ public:
 
     // Pending dispatch: returns bit offsets of cores eligible for pending-slot dispatch.
     // AIC: 1 bit per cluster (aic_mask_ positions). AIV: 1 bit per AIV core (aiv_mask_ positions).
-    // MIX: 1 bit per cluster where ALL 3 cores have free pending slots AND at least one is running.
-    //       Idle cores participate via to_pending=false in the MIX prepare path.
+    // Runtime MIX dispatch uses classify_mix_cluster() so the decision follows the task's active_mask.
+    enum class MixPlacement : uint8_t { RUNNING, PENDING, REJECT };
+
+    // A MIX block must place all cores named by active_mask the same way:
+    // all idle means running placement, all running means pending placement,
+    // and any mixed state is retried later.
+    MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
+        BitStates used(0ULL);
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) {
+            used |= BitStates(1ULL << cluster_offset);
+        }
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
+            used |= BitStates(1ULL << (cluster_offset + 1));
+        }
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
+            used |= BitStates(1ULL << (cluster_offset + 2));
+        }
+        if (!used.has_value() || (pending_occupied_ & used).has_value()) {
+            return MixPlacement::REJECT;
+        }
+
+        BitStates idle = core_states_ & used;
+        if (idle.count() == used.count()) {
+            return MixPlacement::RUNNING;
+        }
+        if (!idle.has_value()) {
+            return MixPlacement::PENDING;
+        }
+        return MixPlacement::REJECT;
+    }
+
+    BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
+        BitStates result(0ULL);
+        BitStates candidates = get_cluster_offset_states();
+        while (candidates.has_value()) {
+            int32_t cluster_offset = candidates.pop_first();
+            if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
+                result |= BitStates(1ULL << cluster_offset);
+            }
+        }
+        return result;
+    }
+
+    int32_t count_mix_running_clusters(uint8_t core_mask) const {
+        return get_mix_running_cluster_offset_states(core_mask).count();
+    }
+
     BitStates get_pending_core_offset_states(PTO2ResourceShape shape) const {
         if (shape == PTO2ResourceShape::MIX) {
+            // Shape-level query kept conservative for legacy callers/tests.
+            // The real MIX dispatch path applies active_mask in classify_mix_cluster().
             // Any core without a pending payload can accept a dispatch (idle or running).
             BitStates available = ~pending_occupied_;
             BitStates mix_available =
                 (available & aic_mask_) & ((available >> 1) & aic_mask_) & ((available >> 2) & aic_mask_);
-            // Exclude fully-idle clusters (handled by IDLE phase) to prevent double-dispatch.
+            // Pending MIX can only reuse a fully-running cluster. Partially-running clusters
+            // could split one MIX block across immediate and pending placement.
             BitStates running = ~core_states_;
-            BitStates cluster_has_running =
-                (running & aic_mask_) | ((running >> 1) & aic_mask_) | ((running >> 2) & aic_mask_);
-            return mix_available & cluster_has_running;
+            BitStates cluster_all_running =
+                (running & aic_mask_) & ((running >> 1) & aic_mask_) & ((running >> 2) & aic_mask_);
+            return mix_available & cluster_all_running;
         }
         if (shape == PTO2ResourceShape::AIC) {
             return (~core_states_) & aic_mask_ & ~(pending_occupied_ & aic_mask_);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_submit_types.h
@@ -47,10 +47,11 @@ inline constexpr uint8_t PTO2_SUBTASK_FLAG_SYNC_START = (1u << 3);  // 0x8: all 
 /**
  * Resource shape — classifies a MixedKernels into one of 3 scheduling buckets.
  *
- * Multi-subtask tasks (2+ active slots) are all scheduled as MIX, which
- * requires a fully-idle cluster (1 AIC + 2 AIV).  The actual cores used
- * are determined at dispatch time by active_mask — unused cores in the
- * cluster remain idle and available for single-core tasks.
+ * Multi-subtask tasks (2+ active slots) are all scheduled as MIX. Dispatch
+ * chooses one cluster, then uses active_mask to decide which cores in that
+ * cluster must be placed together: all used cores idle -> running placement;
+ * all used cores already running with free pending slots -> pending placement;
+ * mixed used-core state is rejected and retried later.
  *
  * DUMMY is a synthetic shape for dep-only tasks (no AICore dispatch). Tasks
  * with an empty core_mask route to a dedicated DUMMY ready queue and are

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -380,10 +380,14 @@ bool SchedulerContext::enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t b
 }
 
 // Count total available resources across all scheduler threads for a given shape.
-int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape) {
+int32_t SchedulerContext::count_global_available(PTO2ResourceShape shape, uint8_t core_mask) {
     int32_t total = 0;
     for (int32_t t = 0; t < active_sched_threads_; t++) {
-        total += core_trackers_[t].get_idle_core_offset_states(shape).count();
+        if (shape == PTO2ResourceShape::MIX) {
+            total += core_trackers_[t].count_mix_running_clusters(core_mask);
+        } else {
+            total += core_trackers_[t].get_idle_core_offset_states(shape).count();
+        }
     }
     return total;
 }
@@ -398,9 +402,12 @@ void SchedulerContext::drain_worker_dispatch(Runtime *runtime, int32_t block_num
         return;
     }
     PTO2ResourceShape shape = slot_state->active_mask.to_shape();
+    uint8_t core_mask = slot_state->active_mask.core_mask();
 
     for (int32_t t = 0; t < active_sched_threads_ && slot_state->next_block_idx < block_num; t++) {
-        auto valid = core_trackers_[t].get_idle_core_offset_states(shape);
+        auto valid = (shape == PTO2ResourceShape::MIX) ?
+                         core_trackers_[t].get_mix_running_cluster_offset_states(core_mask) :
+                         core_trackers_[t].get_idle_core_offset_states(shape);
         while (valid.has_value() && slot_state->next_block_idx < block_num) {
             dispatch_block(runtime, t, valid.pop_first(), *slot_state, shape, false, slot_state->next_block_idx);
             slot_state->next_block_idx++;
@@ -492,7 +499,7 @@ void SchedulerContext::handle_drain_mode(Runtime *runtime, int32_t thread_idx) {
         return;
     }
     PTO2ResourceShape shape = slot_state->active_mask.to_shape();
-    int32_t available = count_global_available(shape);
+    int32_t available = count_global_available(shape, slot_state->active_mask.core_mask());
 
     if (available < block_num) {
         // Insufficient resources -- reset drain fields so threads can resume

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -315,7 +315,7 @@ private:
     );
 
     bool enter_drain_mode(PTO2TaskSlotState *slot_state, int32_t block_num);
-    int32_t count_global_available(PTO2ResourceShape shape);
+    int32_t count_global_available(PTO2ResourceShape shape, uint8_t core_mask);
     void drain_worker_dispatch(Runtime *runtime, int32_t block_num);
     void handle_drain_mode(Runtime *runtime, int32_t thread_idx);
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -208,24 +208,21 @@ void SchedulerContext::dispatch_mix_block_to_cluster(
     CoreTracker &tracker = core_trackers_[thread_idx];
     uint8_t cmask = slot_state.active_mask.core_mask();
     if (cmask & PTO2_SUBTASK_MASK_AIC) {
-        bool aic_to_pending = to_pending && !tracker.is_aic_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aic_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIC,
-            aic_to_pending, block_idx
+            to_pending, block_idx
         );
     }
     if (cmask & PTO2_SUBTASK_MASK_AIV0) {
-        bool aiv0_to_pending = to_pending && !tracker.is_aiv0_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv0_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV0,
-            aiv0_to_pending, block_idx
+            to_pending, block_idx
         );
     }
     if (cmask & PTO2_SUBTASK_MASK_AIV1) {
-        bool aiv1_to_pending = to_pending && !tracker.is_aiv1_core_idle(cluster_offset);
         dispatch_subtask_to_core(
             runtime, thread_idx, tracker.get_aiv1_core_offset(cluster_offset), slot_state, PTO2SubtaskSlot::AIV1,
-            aiv1_to_pending, block_idx
+            to_pending, block_idx
         );
     }
 }
@@ -273,7 +270,8 @@ void SchedulerContext::dispatch_shape(
     if (entered_drain) return;
 
     bool is_pending = (phase == CoreTracker::DispatchPhase::PENDING);
-    auto cores = tracker.get_dispatchable_cores(shape, phase);
+    bool is_mix = (shape == PTO2ResourceShape::MIX);
+    auto cores = is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
     if (!cores.has_value()) return;
 
     while (cores.has_value() && !entered_drain) {
@@ -285,13 +283,30 @@ void SchedulerContext::dispatch_shape(
         bool dispatched_any = false;
         for (int bi = 0; bi < got; bi++) {
             PTO2TaskSlotState *slot_state = batch[bi];
+            CoreTracker::BitStates selected_mix_clusters(0ULL);
+
+            if (is_mix) {
+                auto candidates = cores;
+                uint8_t cmask = slot_state->active_mask.core_mask();
+                auto wanted = is_pending ? CoreTracker::MixPlacement::PENDING : CoreTracker::MixPlacement::RUNNING;
+                while (candidates.has_value()) {
+                    int32_t cluster_offset = candidates.pop_first();
+                    if (tracker.classify_mix_cluster(cluster_offset, cmask) == wanted) {
+                        selected_mix_clusters |= CoreTracker::BitStates(1ULL << cluster_offset);
+                    }
+                }
+                if (!selected_mix_clusters.has_value()) {
+                    sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
+                    continue;
+                }
+            }
 
             if (slot_state->active_mask.requires_sync_start()) {
                 if (is_pending) {
                     sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
                     continue;
                 }
-                int32_t available = cores.count();
+                int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
                 if (available < slot_state->logical_block_num) {
                     if (!enter_drain_mode(slot_state, slot_state->logical_block_num)) {
                         sched_->ready_queues[static_cast<int32_t>(shape)].push(slot_state);
@@ -322,7 +337,8 @@ void SchedulerContext::dispatch_shape(
             // read after the push -- `next_block_idx` may already be advanced
             // by another scheduler that popped the slot.
             int32_t remaining = slot_state->logical_block_num - slot_state->next_block_idx;
-            int32_t claim = std::min(cores.count(), remaining);
+            int32_t available = is_mix ? selected_mix_clusters.count() : cores.count();
+            int32_t claim = std::min(available, remaining);
             int32_t start = slot_state->next_block_idx;
             slot_state->next_block_idx += claim;
 
@@ -331,7 +347,10 @@ void SchedulerContext::dispatch_shape(
             }
 
             for (int32_t b = 0; b < claim; b++) {
-                auto core_offset = cores.pop_first();
+                auto core_offset = is_mix ? selected_mix_clusters.pop_first() : cores.pop_first();
+                if (is_mix) {
+                    cores.clear_bit(core_offset);
+                }
                 dispatch_block(runtime, thread_idx, core_offset, *slot_state, shape, is_pending, start + b);
             }
             made_progress = true;
@@ -343,7 +362,7 @@ void SchedulerContext::dispatch_shape(
         if (!dispatched_any) break;
 
         if (!cores.has_value()) {
-            cores = tracker.get_dispatchable_cores(shape, phase);
+            cores = is_mix ? tracker.get_cluster_offset_states() : tracker.get_dispatchable_cores(shape, phase);
         }
     }
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -162,6 +162,7 @@ public:
 
         bool has_value() const { return states_ > 0; }
         int32_t count() const { return __builtin_popcountll(states_); }
+        void clear_bit(int32_t offset) { states_ &= ~(1ULL << offset); }
 
         // Extract the lowest set bit from mask, clear it, and return its position.
         // Returns -1 if mask is empty.
@@ -231,6 +232,7 @@ public:
     }
 
     BitStates get_all_running_cores() const { return (~core_states_) & (aic_mask_ | aiv_mask_); }
+    BitStates get_cluster_offset_states() const { return aic_mask_; }
 
     // --- Cluster matching ---
 
@@ -303,19 +305,67 @@ public:
 
     // Pending dispatch: returns bit offsets of cores eligible for pending-slot dispatch.
     // AIC: 1 bit per cluster (aic_mask_ positions). AIV: 1 bit per AIV core (aiv_mask_ positions).
-    // MIX: 1 bit per cluster where ALL 3 cores have free pending slots AND at least one is running.
-    //       Idle cores participate via to_pending=false in dispatch_mix_block_to_cluster.
+    // Runtime MIX dispatch uses classify_mix_cluster() so the decision follows the task's active_mask.
+    enum class MixPlacement : uint8_t { RUNNING, PENDING, REJECT };
+
+    // A MIX block must place all cores named by active_mask the same way:
+    // all idle means running placement, all running means pending placement,
+    // and any mixed state is retried later.
+    MixPlacement classify_mix_cluster(int32_t cluster_offset, uint8_t core_mask) const {
+        BitStates used(0ULL);
+        if (core_mask & PTO2_SUBTASK_MASK_AIC) {
+            used |= BitStates(1ULL << cluster_offset);
+        }
+        if (core_mask & PTO2_SUBTASK_MASK_AIV0) {
+            used |= BitStates(1ULL << (cluster_offset + 1));
+        }
+        if (core_mask & PTO2_SUBTASK_MASK_AIV1) {
+            used |= BitStates(1ULL << (cluster_offset + 2));
+        }
+        if (!used.has_value() || (pending_occupied_ & used).has_value()) {
+            return MixPlacement::REJECT;
+        }
+
+        BitStates idle = core_states_ & used;
+        if (idle.count() == used.count()) {
+            return MixPlacement::RUNNING;
+        }
+        if (!idle.has_value()) {
+            return MixPlacement::PENDING;
+        }
+        return MixPlacement::REJECT;
+    }
+
+    BitStates get_mix_running_cluster_offset_states(uint8_t core_mask) const {
+        BitStates result(0ULL);
+        BitStates candidates = get_cluster_offset_states();
+        while (candidates.has_value()) {
+            int32_t cluster_offset = candidates.pop_first();
+            if (classify_mix_cluster(cluster_offset, core_mask) == MixPlacement::RUNNING) {
+                result |= BitStates(1ULL << cluster_offset);
+            }
+        }
+        return result;
+    }
+
+    int32_t count_mix_running_clusters(uint8_t core_mask) const {
+        return get_mix_running_cluster_offset_states(core_mask).count();
+    }
+
     BitStates get_pending_core_offset_states(PTO2ResourceShape shape) const {
         if (shape == PTO2ResourceShape::MIX) {
+            // Shape-level query kept conservative for legacy callers/tests.
+            // The real MIX dispatch path applies active_mask in classify_mix_cluster().
             // Any core without a pending payload can accept a dispatch (idle or running).
             BitStates available = ~pending_occupied_;
             BitStates mix_available =
                 (available & aic_mask_) & ((available >> 1) & aic_mask_) & ((available >> 2) & aic_mask_);
-            // Exclude fully-idle clusters (handled by IDLE phase) to prevent double-dispatch.
+            // Pending MIX can only reuse a fully-running cluster. Partially-running clusters
+            // could split one MIX block across immediate and pending placement.
             BitStates running = ~core_states_;
-            BitStates cluster_has_running =
-                (running & aic_mask_) | ((running >> 1) & aic_mask_) | ((running >> 2) & aic_mask_);
-            return mix_available & cluster_has_running;
+            BitStates cluster_all_running =
+                (running & aic_mask_) & ((running >> 1) & aic_mask_) & ((running >> 2) & aic_mask_);
+            return mix_available & cluster_all_running;
         }
         if (shape == PTO2ResourceShape::AIC) {
             return (~core_states_) & aic_mask_ & ~(pending_occupied_ & aic_mask_);

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -99,6 +99,7 @@ target_include_directories(a2a3_rt_objs PUBLIC
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/common
     ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/aicpu
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
     ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
@@ -241,6 +242,7 @@ target_include_directories(a5_rt_objs PUBLIC
     ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/runtime
     ${CMAKE_SOURCE_DIR}/../../../src/a5/runtime/tensormap_and_ringbuffer/common
     ${CMAKE_SOURCE_DIR}/../../../src/a5/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/sim/aicpu
     ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
     ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
     ${CMAKE_SOURCE_DIR}/../../../src/common/log/include

--- a/tests/ut/cpp/a2a3/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a2a3/test_scheduler_state.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include "utils/device_arena.h"
+#include "scheduler/scheduler_types.h"
 #include "scheduler/pto_scheduler.h"
 
 class SchedulerStateTest : public ::testing::Test {
@@ -208,4 +209,157 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchLocalFirst) {
     // Local buffer drains first (LIFO), so slot_a comes first
     EXPECT_EQ(out[0], &slot_a);
     EXPECT_EQ(out[1], &slot_b);
+}
+
+TEST(CoreTrackerTest, MixPendingRejectsPartiallyRunningCluster) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset + 1);  // AIV0 running, AIC/AIV1 idle
+    tracker.clear_pending_occupied(cluster_offset + 1);
+
+    EXPECT_TRUE(tracker.is_aic_core_idle(cluster_offset));
+    EXPECT_FALSE(tracker.is_aiv0_core_idle(cluster_offset));
+    EXPECT_TRUE(tracker.is_aiv1_core_idle(cluster_offset));
+
+    const bool would_place_aic_pending = !tracker.is_aic_core_idle(cluster_offset);
+    const bool would_place_aiv0_pending = !tracker.is_aiv0_core_idle(cluster_offset);
+    const bool would_place_aiv1_pending = !tracker.is_aiv1_core_idle(cluster_offset);
+    EXPECT_FALSE(would_place_aic_pending);
+    EXPECT_TRUE(would_place_aiv0_pending);
+    EXPECT_FALSE(would_place_aiv1_pending);
+
+    auto idle = tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(idle.has_value());
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(pending.has_value()) << "Pending admission here would split one MIX block across running AIC/AIV1 "
+                                      << "placement and pending AIV0 placement.";
+}
+
+TEST(CoreTrackerTest, MixPendingAcceptsFullyRunningClusterWithFreePendingSlots) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.change_core_state(cluster_offset + 2);
+    tracker.clear_pending_occupied(cluster_offset);
+    tracker.clear_pending_occupied(cluster_offset + 1);
+    tracker.clear_pending_occupied(cluster_offset + 2);
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_TRUE(pending.has_value());
+    EXPECT_EQ(pending.count(), 1);
+}
+
+TEST(CoreTrackerTest, MixPendingRejectsFullyRunningClusterWithOccupiedPendingSlot) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.change_core_state(cluster_offset + 2);
+    tracker.set_pending_occupied(cluster_offset + 1);
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(pending.has_value());
+}
+
+TEST(CoreTrackerTest, MixIdleAndPendingDoNotDoubleAdmitFullyIdleCluster) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    auto idle = tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_TRUE(idle.has_value());
+    EXPECT_EQ(idle.count(), 1);
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(pending.has_value());
+}
+
+TEST(CoreTrackerTest, MixClassifyIgnoresUnusedBusyCoreForRunningPlacement) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset + 2);  // AIV1 running, unused by this 1c1v task
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::RUNNING);
+}
+
+TEST(CoreTrackerTest, MixClassifyAllowsPendingForUsedRunningCoresOnly) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.set_pending_occupied(cluster_offset + 2);  // Unused AIV1 must not block this 1c1v task
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::PENDING);
+}
+
+TEST(CoreTrackerTest, MixClassifyRejectsMixedUsedCores) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset + 1);  // AIV0 running while AIC is idle
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::REJECT);
+}
+
+TEST(CoreTrackerTest, MixClassifyRejectsOccupiedPendingSlotInUsedMask) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.set_pending_occupied(cluster_offset + 1);
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::REJECT);
+}
+
+TEST(CoreTrackerTest, MixRunningClusterHelpersUseActiveMask) {
+    CoreTracker tracker;
+    tracker.init(2);
+    tracker.set_cluster(0, 0, 1, 2);
+    tracker.set_cluster(1, 3, 4, 5);
+
+    tracker.change_core_state(2);
+    tracker.change_core_state(5);
+
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0;
+
+    EXPECT_EQ(tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX).count(), 0);
+    EXPECT_EQ(tracker.count_mix_running_clusters(used_mask), 2);
+    EXPECT_EQ(tracker.get_mix_running_cluster_offset_states(used_mask).count(), 2);
+}
+
+TEST(CoreTrackerTest, MixRunningClusterHelpersRejectOccupiedUsedPendingSlot) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0;
+    tracker.set_pending_occupied(1);
+
+    EXPECT_EQ(tracker.count_mix_running_clusters(used_mask), 0);
 }

--- a/tests/ut/cpp/a5/test_scheduler_state.cpp
+++ b/tests/ut/cpp/a5/test_scheduler_state.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 
 #include "utils/device_arena.h"
+#include "scheduler/scheduler_types.h"
 #include "scheduler/pto_scheduler.h"
 
 class SchedulerStateTest : public ::testing::Test {
@@ -198,4 +199,157 @@ TEST_F(SchedulerStateTest, GetReadyTasksBatchLocalFirst) {
     // Local buffer drains first (LIFO), so slot_a comes first
     EXPECT_EQ(out[0], &slot_a);
     EXPECT_EQ(out[1], &slot_b);
+}
+
+TEST(CoreTrackerTest, MixPendingRejectsPartiallyRunningCluster) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset + 1);  // AIV0 running, AIC/AIV1 idle
+    tracker.clear_pending_occupied(cluster_offset + 1);
+
+    EXPECT_TRUE(tracker.is_aic_core_idle(cluster_offset));
+    EXPECT_FALSE(tracker.is_aiv0_core_idle(cluster_offset));
+    EXPECT_TRUE(tracker.is_aiv1_core_idle(cluster_offset));
+
+    const bool would_place_aic_pending = !tracker.is_aic_core_idle(cluster_offset);
+    const bool would_place_aiv0_pending = !tracker.is_aiv0_core_idle(cluster_offset);
+    const bool would_place_aiv1_pending = !tracker.is_aiv1_core_idle(cluster_offset);
+    EXPECT_FALSE(would_place_aic_pending);
+    EXPECT_TRUE(would_place_aiv0_pending);
+    EXPECT_FALSE(would_place_aiv1_pending);
+
+    auto idle = tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(idle.has_value());
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(pending.has_value()) << "Pending admission here would split one MIX block across running AIC/AIV1 "
+                                      << "placement and pending AIV0 placement.";
+}
+
+TEST(CoreTrackerTest, MixPendingAcceptsFullyRunningClusterWithFreePendingSlots) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.change_core_state(cluster_offset + 2);
+    tracker.clear_pending_occupied(cluster_offset);
+    tracker.clear_pending_occupied(cluster_offset + 1);
+    tracker.clear_pending_occupied(cluster_offset + 2);
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_TRUE(pending.has_value());
+    EXPECT_EQ(pending.count(), 1);
+}
+
+TEST(CoreTrackerTest, MixPendingRejectsFullyRunningClusterWithOccupiedPendingSlot) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.change_core_state(cluster_offset + 2);
+    tracker.set_pending_occupied(cluster_offset + 1);
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(pending.has_value());
+}
+
+TEST(CoreTrackerTest, MixIdleAndPendingDoNotDoubleAdmitFullyIdleCluster) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    auto idle = tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_TRUE(idle.has_value());
+    EXPECT_EQ(idle.count(), 1);
+
+    auto pending = tracker.get_pending_core_offset_states(PTO2ResourceShape::MIX);
+    EXPECT_FALSE(pending.has_value());
+}
+
+TEST(CoreTrackerTest, MixClassifyIgnoresUnusedBusyCoreForRunningPlacement) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset + 2);  // AIV1 running, unused by this 1c1v task
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::RUNNING);
+}
+
+TEST(CoreTrackerTest, MixClassifyAllowsPendingForUsedRunningCoresOnly) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.set_pending_occupied(cluster_offset + 2);  // Unused AIV1 must not block this 1c1v task
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::PENDING);
+}
+
+TEST(CoreTrackerTest, MixClassifyRejectsMixedUsedCores) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset + 1);  // AIV0 running while AIC is idle
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::REJECT);
+}
+
+TEST(CoreTrackerTest, MixClassifyRejectsOccupiedPendingSlotInUsedMask) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr int32_t cluster_offset = 0;
+    tracker.change_core_state(cluster_offset);
+    tracker.change_core_state(cluster_offset + 1);
+    tracker.set_pending_occupied(cluster_offset + 1);
+
+    auto placement = tracker.classify_mix_cluster(cluster_offset, PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0);
+    EXPECT_EQ(placement, CoreTracker::MixPlacement::REJECT);
+}
+
+TEST(CoreTrackerTest, MixRunningClusterHelpersUseActiveMask) {
+    CoreTracker tracker;
+    tracker.init(2);
+    tracker.set_cluster(0, 0, 1, 2);
+    tracker.set_cluster(1, 3, 4, 5);
+
+    tracker.change_core_state(2);
+    tracker.change_core_state(5);
+
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0;
+
+    EXPECT_EQ(tracker.get_idle_core_offset_states(PTO2ResourceShape::MIX).count(), 0);
+    EXPECT_EQ(tracker.count_mix_running_clusters(used_mask), 2);
+    EXPECT_EQ(tracker.get_mix_running_cluster_offset_states(used_mask).count(), 2);
+}
+
+TEST(CoreTrackerTest, MixRunningClusterHelpersRejectOccupiedUsedPendingSlot) {
+    CoreTracker tracker;
+    tracker.init(1);
+    tracker.set_cluster(0, 0, 1, 2);
+
+    constexpr uint8_t used_mask = PTO2_SUBTASK_MASK_AIC | PTO2_SUBTASK_MASK_AIV0;
+    tracker.set_pending_occupied(1);
+
+    EXPECT_EQ(tracker.count_mix_running_clusters(used_mask), 0);
 }


### PR DESCRIPTION
## Summary
- Classify MIX dispatch placement from each task's active_mask.
- Keep used cores together: all idle goes to running placement, all running with free pending slots goes to pending placement, and mixed used-core state is retried later.
- Add a2a3 and a5 C++ unit coverage for idle, pending, partial-running, and occupied pending-slot cases.

## Testing
- git diff --check upstream/main..HEAD
- Attempted: cmake -B tests/ut/cpp/build -S tests/ut/cpp && cmake --build tests/ut/cpp/build (local Windows/MSVC environment cannot build this repo's C++ UTs: missing Unix headers such as sched.h/sys/mman.h/dlfcn.h and GNU builtins such as __builtin_popcount)

Fixes #851