### PR TITLE
Feat/per ring runtime env #1029

### DIFF
--- a/docs/dfx/scope-stats.md
+++ b/docs/dfx/scope-stats.md
@@ -24,7 +24,9 @@ resulting `scope_stats/scope_stats.jsonl` into an HTML report.
 Pass the flag to any T&R example or scene test:
 
 ```bash
-python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-scope-stats
+CASE=...
+NAME=...
+python "tests/st/${CASE}/test_${NAME}.py" -p a2a3 -d 0 --enable-scope-stats
 ```
 
 The flag is bit 4 of `enable_profiling_flag`; on a T&R run it turns on
@@ -37,6 +39,35 @@ The run writes `scope_stats/scope_stats.jsonl` under the per-task
 output prefix. It is NDJSON: line 1 is run metadata, every subsequent
 line is one scope sample. See [§3](#3-output-scope_statsjsonl) for the
 schema.
+
+The metadata line is also the quickest way to verify per-ring runtime sizing.
+For example, after running with:
+
+```bash
+CASE=...
+NAME=...
+PTO2_RING_TASK_WINDOW=8192,16384,131072,524288 \
+PTO2_RING_HEAP=134217728,268435456,402653184,536870912 \
+PTO2_RING_DEP_POOL=4096,8192,16384,32768 \
+python "tests/st/${CASE}/test_${NAME}.py" -p a2a3 -d 0 --enable-scope-stats
+```
+
+inspect the first line:
+
+```bash
+python - <<'PY' path/to/output_prefix/scope_stats/scope_stats.jsonl
+import json, sys
+with open(sys.argv[1]) as f:
+    meta = json.loads(f.readline())
+print("task_window_max =", meta["task_window_max"])
+print("heap_max        =", meta["heap_max"])
+print("dep_pool_max    =", meta["dep_pool_max"])
+PY
+```
+
+The three arrays are indexed by `ring` (`0..3`) and should match the effective
+runtime configuration. Per-sample `ring` values show which scope-depth rings
+were actually touched by the run; they are scope records, not task counts.
 
 ### Step 3 — Visualize with `scope_stats_plot.py`
 

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_ringbuffer/test_paged_attention_ringbuffer.py
@@ -69,10 +69,8 @@ class TestPagedAttentionRingbuffer(SceneTestCase):
         {
             "name": "ringbuffer_stress",
             "platforms": ["a2a3"],
-            # ring_heap must be a power of 2; the historical RUNTIME_ENV value
-            # 2621440 (2.5 MiB) was silently rejected by the env parser, so the
-            # case actually ran with the 256 MiB default. 4 MiB keeps the
-            # small-ring stress intent with a valid size.
+            # ring_heap is bytes per ring. Non power-of-2 sizes are accepted,
+            # but 4 MiB keeps the small-ring stress intent compact.
             "config": {
                 "aicpu_thread_num": 4,
                 "block_dim": 24,

--- a/examples/workers/l2/per_task_runtime_env/README.md
+++ b/examples/workers/l2/per_task_runtime_env/README.md
@@ -12,7 +12,7 @@ tier, separate from the top-level execution knobs (`block_dim`, …):
 | field | unit | constraint |
 | ----- | ---- | ---------- |
 | `ring_task_window` | tasks | power of 2, >= 4 |
-| `ring_heap` | bytes / ring | power of 2, >= 1024 |
+| `ring_heap` | bytes / ring | >= 1024 |
 | `ring_dep_pool` | entries | 4 .. INT32_MAX |
 
 Precedence per value: **`runtime_env` field > `PTO2_RING_*` env var >

--- a/examples/workers/l2/per_task_runtime_env/main.py
+++ b/examples/workers/l2/per_task_runtime_env/main.py
@@ -17,7 +17,7 @@ it was handed.
 
     runtime_env fields (0 / unset => fall back to env var / compile default):
       ring_task_window   power of 2, >= 4
-      ring_heap          bytes per ring, power of 2, >= 1024
+      ring_heap          bytes per ring, >= 1024
       ring_dep_pool      4 .. INT32_MAX
     Precedence: runtime_env field > PTO2_RING_* env var > compile-time default.
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -78,6 +78,7 @@ NB_MODULE(_task_interface, m) {
     // --- Constants ---
     m.attr("MAX_TENSOR_DIMS") = MAX_TENSOR_DIMS;
     m.attr("MAX_REGISTERED_CALLABLE_IDS") = MAX_REGISTERED_CALLABLE_IDS;
+    m.attr("RUNTIME_ENV_RING_COUNT") = RUNTIME_ENV_RING_COUNT;
 
     // --- Tensor ---
     // The unified strided tensor descriptor. Constructed contiguous via make()
@@ -613,15 +614,80 @@ NB_MODULE(_task_interface, m) {
         });
 
     // --- RuntimeEnv (per-task PTO2_RING_* overrides; nested under CallConfig.runtime_env) ---
+    auto get_ring_values = [](const uint64_t values[RUNTIME_ENV_RING_COUNT]) -> std::vector<uint64_t> {
+        std::vector<uint64_t> out;
+        out.reserve(RUNTIME_ENV_RING_COUNT);
+        for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+            out.push_back(values[i]);
+        }
+        return out;
+    };
+    auto set_ring_values = [](uint64_t values[RUNTIME_ENV_RING_COUNT], const std::vector<uint64_t> &input,
+                              const char *name) {
+        if (input.size() != RUNTIME_ENV_RING_COUNT) {
+            throw std::invalid_argument(
+                std::string("RuntimeEnv.") + name + " must contain exactly " + std::to_string(RUNTIME_ENV_RING_COUNT) +
+                " entries"
+            );
+        }
+        for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+            values[i] = input[static_cast<size_t>(i)];
+        }
+    };
+    auto append_ring_values = [](std::ostringstream &os, const char *name,
+                                 const uint64_t values[RUNTIME_ENV_RING_COUNT]) {
+        os << ", " << name << "=[";
+        for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+            if (i != 0) {
+                os << ", ";
+            }
+            os << values[i];
+        }
+        os << "]";
+    };
+
     nb::class_<RuntimeEnv>(m, "RuntimeEnv")
         .def(nb::init<>())
         .def_rw("ring_task_window", &RuntimeEnv::ring_task_window)
         .def_rw("ring_heap", &RuntimeEnv::ring_heap)
         .def_rw("ring_dep_pool", &RuntimeEnv::ring_dep_pool)
-        .def("__repr__", [](const RuntimeEnv &self) -> std::string {
+        .def_prop_rw(
+            "ring_task_windows",
+            [get_ring_values](const RuntimeEnv &self) {
+                return get_ring_values(self.ring_task_windows);
+            },
+            [set_ring_values](RuntimeEnv &self, const std::vector<uint64_t> &values) {
+                set_ring_values(self.ring_task_windows, values, "ring_task_windows");
+            }
+        )
+        .def_prop_rw(
+            "ring_heaps",
+            [get_ring_values](const RuntimeEnv &self) {
+                return get_ring_values(self.ring_heaps);
+            },
+            [set_ring_values](RuntimeEnv &self, const std::vector<uint64_t> &values) {
+                set_ring_values(self.ring_heaps, values, "ring_heaps");
+            }
+        )
+        .def_prop_rw(
+            "ring_dep_pools",
+            [get_ring_values](const RuntimeEnv &self) {
+                return get_ring_values(self.ring_dep_pools);
+            },
+            [set_ring_values](RuntimeEnv &self, const std::vector<uint64_t> &values) {
+                set_ring_values(self.ring_dep_pools, values, "ring_dep_pools");
+            }
+        )
+        .def("__repr__", [append_ring_values](const RuntimeEnv &self) -> std::string {
             std::ostringstream os;
             os << "RuntimeEnv(ring_task_window=" << self.ring_task_window << ", ring_heap=" << self.ring_heap
-               << ", ring_dep_pool=" << self.ring_dep_pool << ")";
+               << ", ring_dep_pool=" << self.ring_dep_pool;
+            if (self.per_ring_any()) {
+                append_ring_values(os, "ring_task_windows", self.ring_task_windows);
+                append_ring_values(os, "ring_heaps", self.ring_heaps);
+                append_ring_values(os, "ring_dep_pools", self.ring_dep_pools);
+            }
+            os << ")";
             return os.str();
         });
 
@@ -713,7 +779,7 @@ NB_MODULE(_task_interface, m) {
                 std::memcpy(c.output_prefix, s.data(), s.size());
             }
         )
-        .def("__repr__", [](const CallConfig &self) -> std::string {
+        .def("__repr__", [append_ring_values](const CallConfig &self) -> std::string {
             std::ostringstream os;
             os << "CallConfig(block_dim=" << self.block_dim << ", aicpu_thread_num=" << self.aicpu_thread_num
                << ", enable_l2_swimlane=" << self.enable_l2_swimlane
@@ -724,6 +790,11 @@ NB_MODULE(_task_interface, m) {
                 os << ", runtime_env.ring_task_window=" << self.runtime_env.ring_task_window
                    << ", runtime_env.ring_heap=" << self.runtime_env.ring_heap
                    << ", runtime_env.ring_dep_pool=" << self.runtime_env.ring_dep_pool;
+                if (self.runtime_env.per_ring_any()) {
+                    append_ring_values(os, "runtime_env.ring_task_windows", self.runtime_env.ring_task_windows);
+                    append_ring_values(os, "runtime_env.ring_heaps", self.runtime_env.ring_heaps);
+                    append_ring_values(os, "runtime_env.ring_dep_pools", self.runtime_env.ring_dep_pools);
+                }
             }
             if (self.output_prefix_set()) {
                 os << ", output_prefix='" << self.output_prefix << "'";

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -72,6 +72,7 @@ from typing import Any, Optional
 import cloudpickle
 from _task_interface import (  # pyright: ignore[reportMissingImports]
     MAX_REGISTERED_CALLABLE_IDS,
+    RUNTIME_ENV_RING_COUNT,
     RunTiming,
     WorkerType,
     _mailbox_load_i32,
@@ -127,11 +128,12 @@ _OFF_CALLABLE = 8
 _OFF_CONFIG = 16
 # Packed CallConfig wire layout — must match call_config.h byte for byte:
 # 7 int32 (block_dim, aicpu_thread_num, enable_l2_swimlane, enable_dump_tensor,
-# enable_pmu, enable_dep_gen, enable_scope_stats) + 3 uint64 ring sizing
-# overrides (ring_task_window, ring_heap, ring_dep_pool) + 1024-byte
+# enable_pmu, enable_dep_gen, enable_scope_stats) + uint64 ring sizing
+# overrides (3 scalar fields + 3 x RUNTIME_ENV_RING_COUNT per-ring arrays) + 1024-byte
 # NUL-terminated output_prefix. Log config travels separately via
 # ChipWorker.init(log_level, log_info_v) — not on per-task wire.
-_CFG_FMT = struct.Struct("=iiiiiiiQQQ1024s")
+_RUNTIME_ENV_UINT64_FIELD_COUNT = 3 + 3 * RUNTIME_ENV_RING_COUNT
+_CFG_FMT = struct.Struct("=iiiiiii" + ("Q" * _RUNTIME_ENV_UINT64_FIELD_COUNT) + "1024s")
 # Args region starts after CONFIG, rounded up to 8 bytes so the first
 # Tensor.data (uint64_t at OFF_ARGS+8) is 8-byte aligned, avoiding
 # SIGBUS on strict-alignment platforms (aarch64 atomics, some ARM cores).
@@ -1026,8 +1028,12 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
         ring_task_window,
         ring_heap,
         ring_dep_pool,
+        *ring_values,
         prefix_bytes,
     ) = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
+    ring_task_windows = list(ring_values[:RUNTIME_ENV_RING_COUNT])
+    ring_heaps = list(ring_values[RUNTIME_ENV_RING_COUNT : 2 * RUNTIME_ENV_RING_COUNT])
+    ring_dep_pools = list(ring_values[2 * RUNTIME_ENV_RING_COUNT : 3 * RUNTIME_ENV_RING_COUNT])
     cfg = CallConfig()
     cfg.block_dim = block_dim
     cfg.aicpu_thread_num = aicpu_tn
@@ -1039,6 +1045,9 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     cfg.runtime_env.ring_task_window = ring_task_window
     cfg.runtime_env.ring_heap = ring_heap
     cfg.runtime_env.ring_dep_pool = ring_dep_pool
+    cfg.runtime_env.ring_task_windows = ring_task_windows
+    cfg.runtime_env.ring_heaps = ring_heaps
+    cfg.runtime_env.ring_dep_pools = ring_dep_pools
     # NUL-terminated C string in a 1024-byte field.
     cfg.output_prefix = prefix_bytes.split(b"\x00", 1)[0].decode("utf-8")
     return cfg

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1081,6 +1081,12 @@ class SceneTestCase:
         config.runtime_env.ring_task_window = runtime_env.get("ring_task_window", 0)
         config.runtime_env.ring_heap = runtime_env.get("ring_heap", 0)
         config.runtime_env.ring_dep_pool = runtime_env.get("ring_dep_pool", 0)
+        if "ring_task_windows" in runtime_env:
+            config.runtime_env.ring_task_windows = runtime_env["ring_task_windows"]
+        if "ring_heaps" in runtime_env:
+            config.runtime_env.ring_heaps = runtime_env["ring_heaps"]
+        if "ring_dep_pools" in runtime_env:
+            config.runtime_env.ring_dep_pools = runtime_env["ring_dep_pools"]
         config.enable_l2_swimlane = enable_l2_swimlane
         config.enable_dump_tensor = enable_dump_args
         config.enable_pmu = enable_pmu  # 0=disabled, >0=enabled with event type

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -359,7 +359,8 @@ int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(co
  */
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t /*ring_task_window*/, uint64_t /*ring_heap*/, uint64_t /*ring_dep_pool*/
+    int sig_count, uint64_t /*ring_task_window*/, uint64_t /*ring_heap*/, uint64_t /*ring_dep_pool*/,
+    const uint64_t * /*ring_task_windows*/, const uint64_t * /*ring_heaps*/, const uint64_t * /*ring_dep_pools*/
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -452,32 +452,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 );
             }
 
-            uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
-            uint64_t heap_size = PTO2_HEAP_SIZE;
-
-            if (runtime->task_window_size > 0) {
-                task_window_size = runtime->task_window_size;
-            }
-            if (runtime->heap_size > 0) {
-                heap_size = runtime->heap_size;
-            }
-            int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-            if (runtime->dep_pool_size > 0) {
-                dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
-            }
-            LOG_INFO_V0(
-                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
-                static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
-            );
-
-            // gm_heap pointer / dep_pool_capacity are encoded into the prebuilt
-            // runtime arena image at host build time, so we no longer fetch
-            // them here. They remain on the host Runtime instance and on the
-            // PTO2Runtime header for diagnostic purposes only.
-            (void)dep_pool_capacity;
-
             void *sm_ptr = runtime->get_gm_sm_ptr();
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(task_window_size);
 
             // Prebuilt-arena fast path. Host has pre-populated the entire
             // runtime arena (PTO2Runtime + orchestrator/scheduler/tensor_map
@@ -499,6 +474,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Wire every arena-internal pointer field (host wrote host-mirror
             // addresses; we overwrite them with device addresses).
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
+            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+                LOG_INFO_V0(
+                    "Thread %d: Ring %d sizes: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%d", thread_idx, r,
+                    rt->prebuilt_layout.task_window_sizes[r], rt->prebuilt_layout.heap_sizes[r],
+                    rt->prebuilt_layout.dep_pool_capacities[r]
+                );
+            }
 
             // Reset SM state. setup_pointers + init_header_per_ring restore
             // ring flow-control counters, layout metadata, error flags, and
@@ -506,8 +489,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // fanin_count/active_mask zero — previously done inside
             // RingSchedState::init).
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->init(sm_ptr, sm_size, task_window_size, heap_size)) {
-                LOG_ERROR("Thread %d: sm_handle->init failed", thread_idx);
+            if (!rt->sm_handle->init_per_ring(
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, rt->prebuilt_layout.heap_sizes
+                )) {
+                LOG_ERROR("Thread %d: sm_handle->init_per_ring failed", thread_idx);
+                rt = nullptr;
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
             }
@@ -527,7 +513,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                     auto &alloc = orch.rings[r].task_allocator;
                     scope_stats_set_ring_capacity(
-                        r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacity
+                        r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacities[r]
                     );
                 }
                 scope_stats_set_tensormap_capacity(orch.tensor_map.pool_capacity());

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -237,17 +237,54 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 
 ### 7.2 Runtime Overrides
 
-Precedence per value: **per-task `CallConfig` field > `PTO2_RING_*` env var
-> compile-time default**. Uniform across all rings of that task's runtime.
+Ring sizing can be configured either uniformly for every ring or independently
+per ring. Precedence is resolved independently for each resource and ring:
+
+```text
+per-ring CallConfig value
+  > scalar CallConfig value
+  > per-ring PTO2_RING_* env value
+  > scalar PTO2_RING_* env value
+  > compile-time default
+```
+
+`ring_id` is the scope-depth ring selected by the runtime:
+
+```text
+scope depth 0 -> ring 0
+scope depth 1 -> ring 1
+scope depth 2 -> ring 2
+scope depth >=3 -> ring 3
+```
 
 Per-task via `CallConfig.runtime_env` — different L2 tasks in one launch can
-each carry their own sizes. Invalid values raise at submit time (`validate()`):
+each carry their own sizes. Invalid values raise at submit time (`validate()`).
+The scalar fields preserve the old behavior and broadcast one value to all
+rings:
 
 ```python
 cfg = CallConfig()
 cfg.runtime_env.ring_task_window = 128   # power of 2, >= 4
-cfg.runtime_env.ring_heap = 262144       # bytes/ring, power of 2, >= 1024
+cfg.runtime_env.ring_heap = 262144       # bytes/ring, >= 1024
 cfg.runtime_env.ring_dep_pool = 256      # 4 .. INT32_MAX
+orchestrator.submit_next_level(handle, args, cfg)
+```
+
+Set the array fields to tune the four scope-depth rings independently. Each
+array must contain exactly four entries; use `0` for an entry that should fall
+through to the next precedence tier. All `CallConfig` values are integer
+byte/count values.
+
+```python
+cfg = CallConfig()
+cfg.runtime_env.ring_task_windows = [8192, 16384, 131072, 524288]
+cfg.runtime_env.ring_heaps = [
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    384 * 1024 * 1024,
+    512 * 1024 * 1024,
+]
+cfg.runtime_env.ring_dep_pools = [4096, 8192, 16384, 32768]
 orchestrator.submit_next_level(handle, args, cfg)
 ```
 
@@ -255,16 +292,34 @@ Scene tests set the same keys under a nested `runtime_env` block in the
 per-case `config` dict:
 
 ```python
-"config": {"runtime_env": {"ring_task_window": 128, "ring_heap": 262144, "ring_dep_pool": 256}}
+"config": {
+    "runtime_env": {
+        "ring_task_windows": [8192, 16384, 131072, 524288],
+        "ring_heaps": [134217728, 268435456, 402653184, 536870912],
+        "ring_dep_pools": [4096, 8192, 16384, 32768],
+    }
+}
 ```
 
-Process-wide env fallback (invalid values are silently ignored):
+Process-wide env fallback accepts either one scalar value or exactly four
+comma-separated per-ring values. Invalid env values are logged and ignored, then
+fall through to defaults. `PTO2_RING_HEAP` values are integer bytes:
 
 ```bash
+# Uniform, old behavior:
 PTO2_RING_TASK_WINDOW=1024
 PTO2_RING_HEAP=1048576
 PTO2_RING_DEP_POOL=1024
+
+# Per-ring, indexed by ring_id 0..3:
+PTO2_RING_TASK_WINDOW=8192,16384,131072,524288
+PTO2_RING_HEAP=134217728,268435456,402653184,536870912
+PTO2_RING_DEP_POOL=4096,8192,16384,32768
 ```
+
+Use `--enable-scope-stats` to confirm the effective values for a real run. The
+first line of `scope_stats/scope_stats.jsonl` includes `task_window_max`,
+`heap_max`, and `dep_pool_max`, indexed by `ring`.
 
 ### 7.3 Sizing Guidelines
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -34,18 +34,26 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <string>
 
 #include "../common/pto_runtime_status.h"
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/runtime.h"
+#include "../../../../common/task_interface/call_config.h"
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
+
+static_assert(
+    RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match PTO2 runtime ring depth"
+);
 
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
@@ -54,25 +62,194 @@ static int64_t _now_ms() {
     return static_cast<int64_t>(tv.tv_sec) * 1000 + tv.tv_usec / 1000;
 }
 
-/**
- * Parse an environment variable as uint64_t with optional power-of-2 constraint.
- * Returns the parsed value on success, or 0 if unset or validation fails.
- */
-static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool require_power_of_2) {
-    const char *env = std::getenv(name);
-    if (!env) return 0;
-    char *endptr;
+static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+
+template <typename T>
+static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
+    std::string out = "[";
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+        if (r != 0) {
+            out += ", ";
+        }
+        out += std::to_string(values[r]);
+    }
+    out += "]";
+    return out;
+}
+
+static std::string trim_copy(const std::string &input) {
+    size_t begin = 0;
+    while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
+        ++begin;
+    }
+    size_t end = input.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(input[end - 1]))) {
+        --end;
+    }
+    return input.substr(begin, end - begin);
+}
+
+static bool parse_uint_token(
+    const char *name, const std::string &raw, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t *out
+) {
+    std::string token = trim_copy(raw);
+    if (token.empty()) {
+        LOG_WARN("%s has an empty value in '%s', ignored", name, raw.c_str());
+        return false;
+    }
+
+    if (token[0] == '-') {
+        LOG_WARN("%s=%s invalid (must be a non-negative integer), ignored", name, token.c_str());
+        return false;
+    }
+    char *endptr = nullptr;
     errno = 0;
-    uint64_t val = strtoull(env, &endptr, 10);
-    if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
-        LOG_WARN("%s=%s invalid (must be a valid integer >= %" PRIu64 "), ignored", name, env, min_val);
-        return 0;
+    unsigned long long parsed = std::strtoull(token.c_str(), &endptr, 10);
+    if (errno == ERANGE || endptr == token.c_str() || *endptr != '\0') {
+        LOG_WARN("%s=%s invalid (must be a non-negative integer), ignored", name, token.c_str());
+        return false;
     }
-    if (require_power_of_2 && (val & (val - 1)) != 0) {
-        LOG_WARN("%s=%s invalid (must be a power of 2, >= %" PRIu64 "), ignored", name, env, min_val);
-        return 0;
+    uint64_t val = static_cast<uint64_t>(parsed);
+
+    if (val < min_val || val > max_val) {
+        LOG_WARN(
+            "%s=%s invalid (must be in [%" PRIu64 ", %" PRIu64 "]), ignored", name, token.c_str(), min_val, max_val
+        );
+        return false;
     }
-    return static_cast<uint64_t>(val);
+    if (require_power_of_2 && !is_power_of_2_u64(val)) {
+        LOG_WARN("%s=%s invalid (must be a power of 2), ignored", name, token.c_str());
+        return false;
+    }
+    *out = val;
+    return true;
+}
+
+static void apply_env_ring_values(
+    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[PTO2_MAX_RING_DEPTH]
+) {
+    const char *env = std::getenv(name);
+    if (!env) return;
+
+    std::string text(env);
+    if (text.find(',') == std::string::npos) {
+        uint64_t value = 0;
+        if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
+            return;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            out[r] = value;
+        }
+        return;
+    }
+
+    uint64_t parsed[PTO2_MAX_RING_DEPTH]{};
+    size_t pos = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        size_t comma = text.find(',', pos);
+        std::string token = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
+        if (!parse_uint_token(name, token, min_val, max_val, require_power_of_2, &parsed[r])) {
+            return;
+        }
+        if (comma == std::string::npos) {
+            if (r != PTO2_MAX_RING_DEPTH - 1) {
+                LOG_WARN(
+                    "%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env,
+                    PTO2_MAX_RING_DEPTH
+                );
+                return;
+            }
+            pos = text.size();
+        } else {
+            pos = comma + 1;
+        }
+    }
+    if (pos < text.size() || (!text.empty() && text.back() == ',')) {
+        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, PTO2_MAX_RING_DEPTH);
+        return;
+    }
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        out[r] = parsed[r];
+    }
+}
+
+static bool resolve_ring_config(
+    uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool, const uint64_t *ring_task_windows,
+    const uint64_t *ring_heaps, const uint64_t *ring_dep_pools, uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
+    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+) {
+    uint64_t dep_pool_values[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        eff_task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
+        eff_heap_sizes[r] = PTO2_HEAP_SIZE;
+        dep_pool_values[r] = PTO2_DEP_LIST_POOL_SIZE;
+    }
+
+    apply_env_ring_values("PTO2_RING_TASK_WINDOW", 4, static_cast<uint64_t>(INT32_MAX), true, eff_task_window_sizes);
+    apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
+    apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
+
+    if (ring_task_window != 0) {
+        if (ring_task_window < 4 || ring_task_window > static_cast<uint64_t>(INT32_MAX) ||
+            !is_power_of_2_u64(ring_task_window)) {
+            LOG_ERROR(
+                "runtime_env.ring_task_window=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", ring_task_window
+            );
+            return false;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            eff_task_window_sizes[r] = ring_task_window;
+        }
+    }
+    if (ring_heap != 0) {
+        if (ring_heap < 1024) {
+            LOG_ERROR("runtime_env.ring_heap=%" PRIu64 " must be >= 1024", ring_heap);
+            return false;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            eff_heap_sizes[r] = ring_heap;
+        }
+    }
+    if (ring_dep_pool != 0) {
+        if (ring_dep_pool < 4 || ring_dep_pool > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR("runtime_env.ring_dep_pool=%" PRIu64 " must be in [4, INT32_MAX]", ring_dep_pool);
+            return false;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            dep_pool_values[r] = ring_dep_pool;
+        }
+    }
+
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (ring_task_windows != nullptr && ring_task_windows[r] != 0) {
+            eff_task_window_sizes[r] = ring_task_windows[r];
+        }
+        if (ring_heaps != nullptr && ring_heaps[r] != 0) {
+            eff_heap_sizes[r] = ring_heaps[r];
+        }
+        if (ring_dep_pools != nullptr && ring_dep_pools[r] != 0) {
+            dep_pool_values[r] = ring_dep_pools[r];
+        }
+
+        if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||
+            !is_power_of_2_u64(eff_task_window_sizes[r])) {
+            LOG_ERROR(
+                "ring_task_windows[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
+            );
+            return false;
+        }
+        if (eff_heap_sizes[r] < 1024) {
+            LOG_ERROR("ring_heaps[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
+            return false;
+        }
+        if (dep_pool_values[r] < 4 || dep_pool_values[r] > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR("ring_dep_pools[%d]=%" PRIu64 " must be in [4, INT32_MAX]", r, dep_pool_values[r]);
+            return false;
+        }
+        eff_dep_pool_capacities[r] = static_cast<int32_t>(dep_pool_values[r]);
+    }
+
+    return true;
 }
 
 static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
@@ -164,7 +341,8 @@ prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const 
  */
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool
+    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -187,6 +365,23 @@ extern "C" int bind_callable_to_runtime_impl(
     LOG_INFO_V0("RT2 bind: %d tensors + %d scalars, device orchestration mode", tensor_count, scalar_count);
 
     int64_t t_total_start = _now_ms();
+
+    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
+    int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    if (!resolve_ring_config(
+            ring_task_window, ring_heap, ring_dep_pool, ring_task_windows, ring_heaps, ring_dep_pools,
+            eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities
+        )) {
+        return -1;
+    }
+    const std::string task_window_log = format_ring_array(eff_task_window_sizes);
+    const std::string heap_log = format_ring_array(eff_heap_sizes);
+    const std::string dep_pool_log = format_ring_array(eff_dep_pool_capacities);
+    LOG_INFO_V0(
+        "Ring buffer sizes: task_window=%s heap=%s dep_pool=%s", task_window_log.c_str(), heap_log.c_str(),
+        dep_pool_log.c_str()
+    );
 
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
@@ -255,49 +450,26 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
     }
 
-    // Ring buffer size overrides: per-task CallConfig value wins over the
-    // env var; both fall back to the compile-time default when zero.
-    {
-        runtime->task_window_size =
-            ring_task_window ? ring_task_window : parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->heap_size = ring_heap ? ring_heap : parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->dep_pool_size = ring_dep_pool ? ring_dep_pool : parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
-        if (runtime->task_window_size || runtime->heap_size || runtime->dep_pool_size) {
-            LOG_INFO_V0(
-                "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
-                (uint64_t)(runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE),
-                (uint64_t)(runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE),
-                (uint64_t)(runtime->dep_pool_size ? runtime->dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
-            );
-        }
-    }
-
-    // Resolve effective sizes (env override or compile-time default)
-    uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
-
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena all live in a single backing allocation;
     // setup_static_arena reserves the three regions and commits in one shot.
     // Owned by DeviceRunner across runs — do NOT record in tensor_pairs_; the
     // free is deferred to DeviceRunner::finalize(). The runtime-arena size is
     // determined by replaying the reserve sequence on a host-side arena.
-    uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
-    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
-    // dep_pool_size comes from a uint64 env var; reject values that don't fit
-    // the int32_t layout-sizing path rather than silently truncating.
-    int32_t eff_dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-    if (runtime->dep_pool_size != 0) {
-        if (runtime->dep_pool_size > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR("PTO2_RING_DEP_POOL=%" PRIu64 " exceeds INT32_MAX", runtime->dep_pool_size);
+    uint64_t total_heap_size = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (eff_heap_sizes[r] > std::numeric_limits<uint64_t>::max() - total_heap_size) {
+            LOG_ERROR("Total ring heap size overflows uint64_t");
             return -1;
         }
-        eff_dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
+        total_heap_size += eff_heap_sizes[r];
     }
+    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(eff_task_window_sizes);
 
     int64_t t_prebuilt_start = _now_ms();
     DeviceArena host_arena;  // libc malloc backend by default
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_dep_pool_capacity);
+    PTO2RuntimeArenaLayout layout =
+        runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return -1;
@@ -348,7 +520,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
     PTO2Runtime *rt =
-        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_size);
+        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
         return -1;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -49,7 +49,7 @@ struct PTO2OrchestratorLayout {
     size_t off_scope_tasks;
     size_t off_scope_begins;
     PTO2TensorMapLayout tensor_map;
-    int32_t dep_pool_capacity;
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
     int32_t scope_tasks_cap;
     uint64_t scope_stack_capacity;
 };
@@ -144,6 +144,10 @@ struct PTO2OrchestratorState {
         DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
     );
+    static PTO2OrchestratorLayout reserve_layout(
+        DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+        const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // sm_dev_base is the SM device address (only stored, never dereferenced);
@@ -152,6 +156,10 @@ struct PTO2OrchestratorState {
     bool init_data_from_layout(
         const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
         uint64_t task_window_size
+    );
+    bool init_data_from_layout(
+        const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
+        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
     );
 
     // Phase 3b: write the arena-internal pointer fields (scope_tasks,

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -383,7 +383,7 @@ private:
                 "  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")", heap_size_, heap_size_ * 2
             );
             LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
         } else {
             LOG_ERROR("  Increase task window size (current: %d, recommended: %d)", window_size_, active_tasks * 2);
             LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -110,9 +110,9 @@ struct PTO2RuntimeArenaLayout {
     size_t off_mailbox{0};
 
     // Cached parameters (re-used by init_data + wire stages).
-    uint64_t task_window_size{0};
-    uint64_t heap_size{0};
-    int32_t dep_pool_capacity{0};
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]{};
 
     // Total arena byte size post-commit. Used by host to size the prebuilt
     // image buffer and as the rtMemcpy length.
@@ -172,6 +172,10 @@ struct PTO2Runtime {
 PTO2RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
+PTO2RuntimeArenaLayout runtime_reserve_layout(
+    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+);
 
 /**
  * Phase 2 — write the data half of the runtime arena: standalone fields,
@@ -191,6 +195,10 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
+);
+PTO2Runtime *runtime_init_data_from_layout(
+    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 );
 
 /**

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -160,7 +160,7 @@ struct PTO2FaninPool;      // Forward declaration
 struct PTO2FaninSpillEntry {
     PTO2TaskSlotState *slot_state;
 };
-static_assert(sizeof(PTO2FaninSpillEntry) == sizeof(PTO2TaskSlotState *));
+static_assert(sizeof(PTO2FaninSpillEntry) == sizeof(uintptr_t));
 
 /**
  * Dependency list entry (singly-linked list node)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -187,6 +187,10 @@ struct PTO2SharedMemoryHandle {
     // init_header. Returns false when `sm_size` is too small for the requested
     // `task_window_size`.
     bool init(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
+    bool init_per_ring(
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    );
 
     void destroy();
     void print_layout();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -201,11 +201,6 @@ public:
     int aicpu_thread_num;
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
-    // Ring buffer size overrides (0 = use compile-time defaults)
-    uint64_t task_window_size;
-    uint64_t heap_size;
-    uint64_t dep_pool_size;
-
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -457,7 +457,7 @@ struct alignas(64) PTO2SpscQueue {
     // orchestrator (push) and scheduler thread 0 (pop_batch), so its base
     // must not false-share with neighboring regions.
     static size_t reserve_layout(DeviceArena &arena, uint64_t capacity) {
-        return arena.reserve(capacity * sizeof(PTO2TaskSlotState *), PTO2_ALIGN_SIZE);
+        return arena.reserve(capacity * sizeof(uintptr_t), PTO2_ALIGN_SIZE);
     }
 
     // Writes everything except the arena-internal `buffer_` pointer field
@@ -559,7 +559,7 @@ struct PTO2SchedulerLayout {
     size_t off_wiring_spsc_buffer;
     uint64_t ready_queue_capacity;
     uint64_t spsc_capacity;
-    int32_t dep_pool_capacity;
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
 };
 
 /**
@@ -1286,6 +1286,8 @@ struct PTO2SchedulerState {
     // Capacities are baked into the returned layout; init_data_from_layout uses
     // the same values.
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    static PTO2SchedulerLayout
+    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -22,12 +22,27 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <limits>
+
 #include "pto_orchestrator.h"
 #include "pto_runtime2.h"
 #include "pto_ring_buffer.h"
 #include "pto_shared_memory.h"
 #include "pto_tensormap.h"
 #include "scheduler/pto_scheduler.h"
+
+static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], uint64_t *total) {
+    uint64_t sum = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (heap_sizes[r] > std::numeric_limits<uint64_t>::max() - sum) {
+            LOG_ERROR("Total ring heap size overflows uint64_t");
+            return false;
+        }
+        sum += heap_sizes[r];
+    }
+    *total = sum;
+    return true;
+}
 
 // =============================================================================
 // Ready queue
@@ -92,10 +107,21 @@ bool PTO2SchedulerState::RingSchedState::init_data_from_layout(void *sm_dev_base
 void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
 
 PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity) {
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        dep_pool_capacities[r] = dep_pool_capacity;
+    }
+    return reserve_layout(arena, dep_pool_capacities);
+}
+
+PTO2SchedulerLayout
+PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]) {
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
     layout.spsc_capacity = PTO2_WRIRING_QUEUE_SIZE;
-    layout.dep_pool_capacity = dep_pool_capacity;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        layout.dep_pool_capacities[r] = dep_pool_capacities[r];
+    }
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         layout.off_ready_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
@@ -107,7 +133,7 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32
         // writer of this ring's dep_pool) do not invalidate adjacent
         // multi-threaded regions like ready_queue.slots.
         layout.off_dep_pool_entries[r] =
-            arena.reserve(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2DepListEntry), PTO2_ALIGN_SIZE);
+            arena.reserve(static_cast<size_t>(dep_pool_capacities[r]) * sizeof(PTO2DepListEntry), PTO2_ALIGN_SIZE);
     }
     layout.off_wiring_spsc_buffer = PTO2SpscQueue::reserve_layout(arena, PTO2_WRIRING_QUEUE_SIZE);
     return layout;
@@ -150,8 +176,8 @@ bool PTO2SchedulerState::init_data_from_layout(
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         auto *dep_entries = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
-        memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacity) * sizeof(PTO2DepListEntry));
-        sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacity, orch_err);
+        memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2DepListEntry));
+        sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacities[r], orch_err);
     }
 
     if (!sched->wiring.queue.init_data_from_layout(arena, layout.off_wiring_spsc_buffer, layout.spsc_capacity)) {
@@ -199,14 +225,27 @@ void PTO2SchedulerState::destroy() {
 PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
     DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH], int32_t dep_pool_capacity
 ) {
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        dep_pool_capacities[r] = dep_pool_capacity;
+    }
+    return reserve_layout(arena, task_window_sizes, dep_pool_capacities);
+}
+
+PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
+    DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+) {
     PTO2OrchestratorLayout layout{};
-    layout.dep_pool_capacity = dep_pool_capacity;
     layout.scope_tasks_cap = PTO2_SCOPE_TASKS_CAP;
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        layout.dep_pool_capacities[r] = dep_pool_capacities[r];
+    }
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         const size_t fanin_pool_bytes =
-            PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
+            PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacities[r]) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         layout.off_fanin_pool[r] = arena.reserve(fanin_pool_bytes, PTO2_ALIGN_SIZE);
 
         always_assert(task_window_sizes[r] > 0 && (task_window_sizes[r] & (task_window_sizes[r] - 1)) == 0);
@@ -214,9 +253,8 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
             PTO2_ALIGN_UP(static_cast<size_t>(task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
         layout.off_fanin_seen_epoch[r] = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
     }
-    layout.off_scope_tasks = arena.reserve(
-        static_cast<size_t>(layout.scope_tasks_cap) * sizeof(PTO2TaskSlotState *), alignof(PTO2TaskSlotState *)
-    );
+    layout.off_scope_tasks =
+        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(PTO2TaskSlotState *));
     layout.off_scope_begins =
         arena.reserve(static_cast<size_t>(layout.scope_stack_capacity) * sizeof(int32_t), alignof(int32_t));
     layout.tensor_map = PTO2TensorMap::reserve_layout_default(arena, task_window_sizes);
@@ -227,37 +265,51 @@ bool PTO2OrchestratorState::init_data_from_layout(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
     uint64_t task_window_size
 ) {
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        heap_sizes[r] = heap_size;
+        task_window_sizes[r] = task_window_size;
+    }
+    return init_data_from_layout(layout, arena, sm_dev_base, gm_heap, heap_sizes, task_window_sizes);
+}
+
+bool PTO2OrchestratorState::init_data_from_layout(
+    const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+) {
     auto *orch = this;
     *orch = PTO2OrchestratorState{};
 
     orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
     orch->gm_heap_base = gm_heap;
-    orch->gm_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
+    uint64_t total_heap_size = 0;
+    if (!sum_ring_heap_sizes(heap_sizes, &total_heap_size)) {
+        return false;
+    }
+    orch->gm_heap_size = total_heap_size;
     orch->fatal = false;
 
-    // Mirror the SM API's per-ring window-size shape so a future per-ring
-    // SM layout cannot silently disagree with the addresses we compute here.
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
-        task_window_sizes[r] = task_window_size;
-
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
+    uint64_t heap_offset = 0;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + r * heap_size;
+        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + heap_offset;
         auto *task_descs_dev = pto2_sm_layout::ring_task_descriptors_addr(sm_dev_base, task_window_sizes, r);
         auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_dev_base, r);
         auto *last_alive_dev = pto2_sm_layout::ring_last_task_alive_addr(sm_dev_base, r);
 
         orch->rings[r].task_allocator.init(
-            task_descs_dev, static_cast<int32_t>(task_window_size), cur_idx_dev, last_alive_dev, ring_heap_base,
-            heap_size, orch_err
+            task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
+            heap_sizes[r], orch_err
         );
+        heap_offset += heap_sizes[r];
 
-        const size_t fanin_pool_bytes =
-            PTO2_ALIGN_UP(static_cast<size_t>(layout.dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
+        const size_t fanin_pool_bytes = PTO2_ALIGN_UP(
+            static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE
+        );
         auto *fanin_entries = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
         memset(fanin_entries, 0, fanin_pool_bytes);
-        orch->rings[r].fanin_pool.init(fanin_entries, layout.dep_pool_capacity, orch_err);
+        orch->rings[r].fanin_pool.init(fanin_entries, layout.dep_pool_capacities[r], orch_err);
 
         const size_t seen_epoch_bytes = PTO2_ALIGN_UP(
             static_cast<size_t>(layout.tensor_map.task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE
@@ -313,18 +365,36 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 
 PTO2RuntimeArenaLayout
 runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
-    PTO2RuntimeArenaLayout layout{};
-    layout.task_window_size = task_window_size;
-    layout.dep_pool_capacity = dep_pool_capacity;
-
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = static_cast<int32_t>(task_window_size);
+        task_window_sizes[r] = task_window_size;
+        heap_sizes[r] = 0;
+        dep_pool_capacities[r] = dep_pool_capacity;
+    }
+    return runtime_reserve_layout(arena, task_window_sizes, heap_sizes, dep_pool_capacities);
+}
+
+PTO2RuntimeArenaLayout runtime_reserve_layout(
+    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+) {
+    PTO2RuntimeArenaLayout layout{};
+
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        layout.task_window_sizes[r] = task_window_sizes[r];
+        layout.heap_sizes[r] = heap_sizes[r];
+        layout.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes, dep_pool_capacity);
-    layout.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacity);
+    int32_t task_window_sizes_i32[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        task_window_sizes_i32[r] = static_cast<int32_t>(task_window_sizes[r]);
+    }
+    layout.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
+    layout.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacities);
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
 
@@ -336,6 +406,17 @@ PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
     uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
 ) {
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        heap_sizes[r] = heap_size;
+    }
+    return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
+}
+
+PTO2Runtime *runtime_init_data_from_layout(
+    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
+    uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
@@ -345,12 +426,16 @@ PTO2Runtime *runtime_init_data_from_layout(
     // rt->ops is filled by the AICPU at boot.
     rt->mode = mode;
     rt->gm_heap = gm_heap_dev_base;
-    rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
+    uint64_t total_heap_size = 0;
+    if (!sum_ring_heap_sizes(heap_sizes, &total_heap_size)) {
+        return nullptr;
+    }
+    rt->gm_heap_size = total_heap_size;
     rt->gm_heap_owned = false;
     rt->total_cycles = 0;
 
     if (!rt->orchestrator.init_data_from_layout(
-            layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_size, layout.task_window_size
+            layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_sizes, layout.task_window_sizes
         )) {
         return nullptr;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -87,14 +87,27 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        task_window_sizes[r] = task_window_size;
+        heap_sizes[r] = heap_size;
+    }
+    return init_per_ring(sm_base_arg, sm_size_arg, task_window_sizes, heap_sizes);
+}
+
+bool PTO2SharedMemoryHandle::init_per_ring(
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size(task_window_size)) return false;
+    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers(task_window_size);
-    init_header(task_window_size, heap_size);
+    setup_pointers_per_ring(task_window_sizes);
+    init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -34,9 +34,6 @@ Runtime::Runtime() {
     worker_count = 0;
     aicpu_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    task_window_size = 0;
-    heap_size = 0;
-    dep_pool_size = 0;
     orch_to_sched = false;
 
     // Initialize device orchestration state

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -359,7 +359,8 @@ int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(co
  */
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t /*ring_task_window*/, uint64_t /*ring_heap*/, uint64_t /*ring_dep_pool*/
+    int sig_count, uint64_t /*ring_task_window*/, uint64_t /*ring_heap*/, uint64_t /*ring_dep_pool*/,
+    const uint64_t * /*ring_task_windows*/, const uint64_t * /*ring_heaps*/, const uint64_t * /*ring_dep_pools*/
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -461,32 +461,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 );
             }
 
-            uint64_t task_window_size = PTO2_TASK_WINDOW_SIZE;
-            uint64_t heap_size = PTO2_HEAP_SIZE;
-
-            if (runtime->task_window_size > 0) {
-                task_window_size = runtime->task_window_size;
-            }
-            if (runtime->heap_size > 0) {
-                heap_size = runtime->heap_size;
-            }
-            int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-            if (runtime->dep_pool_size > 0) {
-                dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
-            }
-            LOG_INFO_V0(
-                "Thread %d: Ring sizes: task_window=%lu, heap=%lu, dep_pool=%d", thread_idx,
-                static_cast<uint64_t>(task_window_size), static_cast<uint64_t>(heap_size), dep_pool_capacity
-            );
-
-            // gm_heap pointer / dep_pool_capacity are encoded into the prebuilt
-            // runtime arena image at host build time, so we no longer fetch
-            // them here. They remain on the host Runtime instance and on the
-            // PTO2Runtime header for diagnostic purposes only.
-            (void)dep_pool_capacity;
-
             void *sm_ptr = runtime->get_gm_sm_ptr();
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(task_window_size);
 
             // Prebuilt-arena fast path. Host has pre-populated the entire
             // runtime arena (PTO2Runtime + orchestrator/scheduler/tensor_map
@@ -508,6 +483,14 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // Wire every arena-internal pointer field (host wrote host-mirror
             // addresses; we overwrite them with device addresses).
             runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
+            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+            for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+                LOG_INFO_V0(
+                    "Thread %d: Ring %d sizes: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%d", thread_idx, r,
+                    rt->prebuilt_layout.task_window_sizes[r], rt->prebuilt_layout.heap_sizes[r],
+                    rt->prebuilt_layout.dep_pool_capacities[r]
+                );
+            }
 
             // Reset SM state. setup_pointers + init_header_per_ring restore
             // ring flow-control counters, layout metadata, error flags, and
@@ -515,8 +498,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // fanin_count/active_mask zero — previously done inside
             // RingSchedState::init).
             memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->init(sm_ptr, sm_size, task_window_size, heap_size)) {
-                LOG_ERROR("Thread %d: sm_handle->init failed", thread_idx);
+            if (!rt->sm_handle->init_per_ring(
+                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, rt->prebuilt_layout.heap_sizes
+                )) {
+                LOG_ERROR("Thread %d: sm_handle->init_per_ring failed", thread_idx);
+                rt = nullptr;
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
             }
@@ -537,7 +523,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
                     auto &alloc = orch.rings[r].task_allocator;
                     scope_stats_set_ring_capacity(
-                        r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacity
+                        r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacities[r]
                     );
                 }
                 scope_stats_set_tensormap_capacity(orch.tensor_map.pool_capacity());

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -237,17 +237,54 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 
 ### 7.2 Runtime Overrides
 
-Precedence per value: **per-task `CallConfig` field > `PTO2_RING_*` env var
-> compile-time default**. Uniform across all rings of that task's runtime.
+Ring sizing can be configured either uniformly for every ring or independently
+per ring. Precedence is resolved independently for each resource and ring:
+
+```text
+per-ring CallConfig value
+  > scalar CallConfig value
+  > per-ring PTO2_RING_* env value
+  > scalar PTO2_RING_* env value
+  > compile-time default
+```
+
+`ring_id` is the scope-depth ring selected by the runtime:
+
+```text
+scope depth 0 -> ring 0
+scope depth 1 -> ring 1
+scope depth 2 -> ring 2
+scope depth >=3 -> ring 3
+```
 
 Per-task via `CallConfig.runtime_env` — different L2 tasks in one launch can
-each carry their own sizes. Invalid values raise at submit time (`validate()`):
+each carry their own sizes. Invalid values raise at submit time (`validate()`).
+The scalar fields preserve the old behavior and broadcast one value to all
+rings:
 
 ```python
 cfg = CallConfig()
 cfg.runtime_env.ring_task_window = 128   # power of 2, >= 4
-cfg.runtime_env.ring_heap = 262144       # bytes/ring, power of 2, >= 1024
+cfg.runtime_env.ring_heap = 262144       # bytes/ring, >= 1024
 cfg.runtime_env.ring_dep_pool = 256      # 4 .. INT32_MAX
+orchestrator.submit_next_level(handle, args, cfg)
+```
+
+Set the array fields to tune the four scope-depth rings independently. Each
+array must contain exactly four entries; use `0` for an entry that should fall
+through to the next precedence tier. All `CallConfig` values are integer
+byte/count values.
+
+```python
+cfg = CallConfig()
+cfg.runtime_env.ring_task_windows = [8192, 16384, 131072, 524288]
+cfg.runtime_env.ring_heaps = [
+    128 * 1024 * 1024,
+    256 * 1024 * 1024,
+    384 * 1024 * 1024,
+    512 * 1024 * 1024,
+]
+cfg.runtime_env.ring_dep_pools = [4096, 8192, 16384, 32768]
 orchestrator.submit_next_level(handle, args, cfg)
 ```
 
@@ -255,16 +292,34 @@ Scene tests set the same keys under a nested `runtime_env` block in the
 per-case `config` dict:
 
 ```python
-"config": {"runtime_env": {"ring_task_window": 128, "ring_heap": 262144, "ring_dep_pool": 256}}
+"config": {
+    "runtime_env": {
+        "ring_task_windows": [8192, 16384, 131072, 524288],
+        "ring_heaps": [134217728, 268435456, 402653184, 536870912],
+        "ring_dep_pools": [4096, 8192, 16384, 32768],
+    }
+}
 ```
 
-Process-wide env fallback (invalid values are silently ignored):
+Process-wide env fallback accepts either one scalar value or exactly four
+comma-separated per-ring values. Invalid env values are logged and ignored, then
+fall through to defaults. `PTO2_RING_HEAP` values are integer bytes:
 
 ```bash
+# Uniform, old behavior:
 PTO2_RING_TASK_WINDOW=1024
 PTO2_RING_HEAP=1048576
 PTO2_RING_DEP_POOL=1024
+
+# Per-ring, indexed by ring_id 0..3:
+PTO2_RING_TASK_WINDOW=8192,16384,131072,524288
+PTO2_RING_HEAP=134217728,268435456,402653184,536870912
+PTO2_RING_DEP_POOL=4096,8192,16384,32768
 ```
+
+Use `--enable-scope-stats` to confirm the effective values for a real run. The
+first line of `scope_stats/scope_stats.jsonl` includes `task_window_max`,
+`heap_max`, and `dep_pool_max`, indexed by `ring`.
 
 ### 7.3 Sizing Guidelines
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -34,18 +34,26 @@
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
+#include <cctype>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
+#include <string>
 
 #include "../common/pto_runtime_status.h"
 #include "../runtime/pto_runtime2.h"
 #include "../runtime/pto_shared_memory.h"
 #include "../runtime/runtime.h"
+#include "../../../../common/task_interface/call_config.h"
 #include "utils/device_arena.h"
 #include "callable.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "prepare_callable_common.h"
+
+static_assert(
+    RUNTIME_ENV_RING_COUNT == PTO2_MAX_RING_DEPTH, "RuntimeEnv ring count must match PTO2 runtime ring depth"
+);
 
 // Helper: return current time in milliseconds
 static int64_t _now_ms() {
@@ -54,25 +62,194 @@ static int64_t _now_ms() {
     return static_cast<int64_t>(tv.tv_sec) * 1000 + tv.tv_usec / 1000;
 }
 
-/**
- * Parse an environment variable as uint64_t with optional power-of-2 constraint.
- * Returns the parsed value on success, or 0 if unset or validation fails.
- */
-static uint64_t parse_env_uint64(const char *name, uint64_t min_val, bool require_power_of_2) {
-    const char *env = std::getenv(name);
-    if (!env) return 0;
-    char *endptr;
+static bool is_power_of_2_u64(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+
+template <typename T>
+static std::string format_ring_array(const T (&values)[PTO2_MAX_RING_DEPTH]) {
+    std::string out = "[";
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+        if (r != 0) {
+            out += ", ";
+        }
+        out += std::to_string(values[r]);
+    }
+    out += "]";
+    return out;
+}
+
+static std::string trim_copy(const std::string &input) {
+    size_t begin = 0;
+    while (begin < input.size() && std::isspace(static_cast<unsigned char>(input[begin]))) {
+        ++begin;
+    }
+    size_t end = input.size();
+    while (end > begin && std::isspace(static_cast<unsigned char>(input[end - 1]))) {
+        --end;
+    }
+    return input.substr(begin, end - begin);
+}
+
+static bool parse_uint_token(
+    const char *name, const std::string &raw, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t *out
+) {
+    std::string token = trim_copy(raw);
+    if (token.empty()) {
+        LOG_WARN("%s has an empty value in '%s', ignored", name, raw.c_str());
+        return false;
+    }
+
+    if (token[0] == '-') {
+        LOG_WARN("%s=%s invalid (must be a non-negative integer), ignored", name, token.c_str());
+        return false;
+    }
+    char *endptr = nullptr;
     errno = 0;
-    uint64_t val = strtoull(env, &endptr, 10);
-    if (errno == ERANGE || endptr == env || *endptr != '\0' || val < min_val) {
-        LOG_WARN("%s=%s invalid (must be a valid integer >= %" PRIu64 "), ignored", name, env, min_val);
-        return 0;
+    unsigned long long parsed = std::strtoull(token.c_str(), &endptr, 10);
+    if (errno == ERANGE || endptr == token.c_str() || *endptr != '\0') {
+        LOG_WARN("%s=%s invalid (must be a non-negative integer), ignored", name, token.c_str());
+        return false;
     }
-    if (require_power_of_2 && (val & (val - 1)) != 0) {
-        LOG_WARN("%s=%s invalid (must be a power of 2, >= %" PRIu64 "), ignored", name, env, min_val);
-        return 0;
+    uint64_t val = static_cast<uint64_t>(parsed);
+
+    if (val < min_val || val > max_val) {
+        LOG_WARN(
+            "%s=%s invalid (must be in [%" PRIu64 ", %" PRIu64 "]), ignored", name, token.c_str(), min_val, max_val
+        );
+        return false;
     }
-    return static_cast<uint64_t>(val);
+    if (require_power_of_2 && !is_power_of_2_u64(val)) {
+        LOG_WARN("%s=%s invalid (must be a power of 2), ignored", name, token.c_str());
+        return false;
+    }
+    *out = val;
+    return true;
+}
+
+static void apply_env_ring_values(
+    const char *name, uint64_t min_val, uint64_t max_val, bool require_power_of_2, uint64_t out[PTO2_MAX_RING_DEPTH]
+) {
+    const char *env = std::getenv(name);
+    if (!env) return;
+
+    std::string text(env);
+    if (text.find(',') == std::string::npos) {
+        uint64_t value = 0;
+        if (!parse_uint_token(name, text, min_val, max_val, require_power_of_2, &value)) {
+            return;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            out[r] = value;
+        }
+        return;
+    }
+
+    uint64_t parsed[PTO2_MAX_RING_DEPTH]{};
+    size_t pos = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        size_t comma = text.find(',', pos);
+        std::string token = text.substr(pos, comma == std::string::npos ? std::string::npos : comma - pos);
+        if (!parse_uint_token(name, token, min_val, max_val, require_power_of_2, &parsed[r])) {
+            return;
+        }
+        if (comma == std::string::npos) {
+            if (r != PTO2_MAX_RING_DEPTH - 1) {
+                LOG_WARN(
+                    "%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env,
+                    PTO2_MAX_RING_DEPTH
+                );
+                return;
+            }
+            pos = text.size();
+        } else {
+            pos = comma + 1;
+        }
+    }
+    if (pos < text.size() || (!text.empty() && text.back() == ',')) {
+        LOG_WARN("%s=%s invalid (expected exactly %d comma-separated values), ignored", name, env, PTO2_MAX_RING_DEPTH);
+        return;
+    }
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        out[r] = parsed[r];
+    }
+}
+
+static bool resolve_ring_config(
+    uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool, const uint64_t *ring_task_windows,
+    const uint64_t *ring_heaps, const uint64_t *ring_dep_pools, uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
+    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+) {
+    uint64_t dep_pool_values[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        eff_task_window_sizes[r] = PTO2_TASK_WINDOW_SIZE;
+        eff_heap_sizes[r] = PTO2_HEAP_SIZE;
+        dep_pool_values[r] = PTO2_DEP_LIST_POOL_SIZE;
+    }
+
+    apply_env_ring_values("PTO2_RING_TASK_WINDOW", 4, static_cast<uint64_t>(INT32_MAX), true, eff_task_window_sizes);
+    apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
+    apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
+
+    if (ring_task_window != 0) {
+        if (ring_task_window < 4 || ring_task_window > static_cast<uint64_t>(INT32_MAX) ||
+            !is_power_of_2_u64(ring_task_window)) {
+            LOG_ERROR(
+                "runtime_env.ring_task_window=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", ring_task_window
+            );
+            return false;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            eff_task_window_sizes[r] = ring_task_window;
+        }
+    }
+    if (ring_heap != 0) {
+        if (ring_heap < 1024) {
+            LOG_ERROR("runtime_env.ring_heap=%" PRIu64 " must be >= 1024", ring_heap);
+            return false;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            eff_heap_sizes[r] = ring_heap;
+        }
+    }
+    if (ring_dep_pool != 0) {
+        if (ring_dep_pool < 4 || ring_dep_pool > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR("runtime_env.ring_dep_pool=%" PRIu64 " must be in [4, INT32_MAX]", ring_dep_pool);
+            return false;
+        }
+        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+            dep_pool_values[r] = ring_dep_pool;
+        }
+    }
+
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (ring_task_windows != nullptr && ring_task_windows[r] != 0) {
+            eff_task_window_sizes[r] = ring_task_windows[r];
+        }
+        if (ring_heaps != nullptr && ring_heaps[r] != 0) {
+            eff_heap_sizes[r] = ring_heaps[r];
+        }
+        if (ring_dep_pools != nullptr && ring_dep_pools[r] != 0) {
+            dep_pool_values[r] = ring_dep_pools[r];
+        }
+
+        if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||
+            !is_power_of_2_u64(eff_task_window_sizes[r])) {
+            LOG_ERROR(
+                "ring_task_windows[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
+            );
+            return false;
+        }
+        if (eff_heap_sizes[r] < 1024) {
+            LOG_ERROR("ring_heaps[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
+            return false;
+        }
+        if (dep_pool_values[r] < 4 || dep_pool_values[r] > static_cast<uint64_t>(INT32_MAX)) {
+            LOG_ERROR("ring_dep_pools[%d]=%" PRIu64 " must be in [4, INT32_MAX]", r, dep_pool_values[r]);
+            return false;
+        }
+        eff_dep_pool_capacities[r] = static_cast<int32_t>(dep_pool_values[r]);
+    }
+
+    return true;
 }
 
 static int32_t read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
@@ -164,7 +341,8 @@ prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const 
  */
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool
+    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -187,6 +365,23 @@ extern "C" int bind_callable_to_runtime_impl(
     LOG_INFO_V0("RT2 bind: %d tensors + %d scalars, device orchestration mode", tensor_count, scalar_count);
 
     int64_t t_total_start = _now_ms();
+
+    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
+    int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    if (!resolve_ring_config(
+            ring_task_window, ring_heap, ring_dep_pool, ring_task_windows, ring_heaps, ring_dep_pools,
+            eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities
+        )) {
+        return -1;
+    }
+    const std::string task_window_log = format_ring_array(eff_task_window_sizes);
+    const std::string heap_log = format_ring_array(eff_heap_sizes);
+    const std::string dep_pool_log = format_ring_array(eff_dep_pool_capacities);
+    LOG_INFO_V0(
+        "Ring buffer sizes: task_window=%s heap=%s dep_pool=%s", task_window_log.c_str(), heap_log.c_str(),
+        dep_pool_log.c_str()
+    );
 
     // Build device args: copy from input, replace host tensor pointers with device pointers
     ChipStorageTaskArgs device_args;
@@ -255,49 +450,26 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
     }
 
-    // Ring buffer size overrides: per-task CallConfig value wins over the
-    // env var; both fall back to the compile-time default when zero.
-    {
-        runtime->task_window_size =
-            ring_task_window ? ring_task_window : parse_env_uint64("PTO2_RING_TASK_WINDOW", 4, true);
-        runtime->heap_size = ring_heap ? ring_heap : parse_env_uint64("PTO2_RING_HEAP", 1024, true);
-        runtime->dep_pool_size = ring_dep_pool ? ring_dep_pool : parse_env_uint64("PTO2_RING_DEP_POOL", 4, false);
-        if (runtime->task_window_size || runtime->heap_size || runtime->dep_pool_size) {
-            LOG_INFO_V0(
-                "Ring buffer overrides: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%" PRIu64,
-                (uint64_t)(runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE),
-                (uint64_t)(runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE),
-                (uint64_t)(runtime->dep_pool_size ? runtime->dep_pool_size : PTO2_DEP_LIST_POOL_SIZE)
-            );
-        }
-    }
-
-    // Resolve effective sizes (env override or compile-time default)
-    uint64_t eff_heap_size = runtime->heap_size ? runtime->heap_size : PTO2_HEAP_SIZE;
-    uint64_t eff_task_window_size = runtime->task_window_size ? runtime->task_window_size : PTO2_TASK_WINDOW_SIZE;
-
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena all live in a single backing allocation;
     // setup_static_arena reserves the three regions and commits in one shot.
     // Owned by DeviceRunner across runs — do NOT record in tensor_pairs_; the
     // free is deferred to DeviceRunner::finalize(). The runtime-arena size is
     // determined by replaying the reserve sequence on a host-side arena.
-    uint64_t total_heap_size = eff_heap_size * PTO2_MAX_RING_DEPTH;
-    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size(eff_task_window_size);
-    // dep_pool_size comes from a uint64 env var; reject values that don't fit
-    // the int32_t layout-sizing path rather than silently truncating.
-    int32_t eff_dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE;
-    if (runtime->dep_pool_size != 0) {
-        if (runtime->dep_pool_size > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR("PTO2_RING_DEP_POOL=%" PRIu64 " exceeds INT32_MAX", runtime->dep_pool_size);
+    uint64_t total_heap_size = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (eff_heap_sizes[r] > std::numeric_limits<uint64_t>::max() - total_heap_size) {
+            LOG_ERROR("Total ring heap size overflows uint64_t");
             return -1;
         }
-        eff_dep_pool_capacity = static_cast<int32_t>(runtime->dep_pool_size);
+        total_heap_size += eff_heap_sizes[r];
     }
+    uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(eff_task_window_sizes);
 
     int64_t t_prebuilt_start = _now_ms();
     DeviceArena host_arena;  // libc malloc backend by default
-    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(host_arena, eff_task_window_size, eff_dep_pool_capacity);
+    PTO2RuntimeArenaLayout layout =
+        runtime_reserve_layout(host_arena, eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities);
     if (host_arena.commit(DeviceArena::kDefaultBaseAlign) == nullptr) {
         LOG_ERROR("Failed to commit host arena for prebuilt runtime image");
         return -1;
@@ -348,7 +520,7 @@ extern "C" int bind_callable_to_runtime_impl(
     // reset) + a handful of device-only field fixups.
     // -------------------------------------------------------------------------
     PTO2Runtime *rt =
-        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_size);
+        runtime_init_data_from_layout(host_arena, layout, PTO2_MODE_EXECUTE, sm_ptr, sm_size, gm_heap, eff_heap_sizes);
     if (rt == nullptr) {
         LOG_ERROR("runtime_init_data_from_layout failed");
         return -1;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -48,7 +48,7 @@ struct PTO2OrchestratorLayout {
     size_t off_scope_tasks;
     size_t off_scope_begins;
     PTO2TensorMapLayout tensor_map;
-    int32_t dep_pool_capacity;
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
     int32_t scope_tasks_cap;
     uint64_t scope_stack_capacity;
 };
@@ -143,6 +143,10 @@ struct PTO2OrchestratorState {
         DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
         int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
     );
+    static PTO2OrchestratorLayout reserve_layout(
+        DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+        const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    );
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // sm_dev_base is the SM device address (only stored, never dereferenced);
@@ -151,6 +155,10 @@ struct PTO2OrchestratorState {
     bool init_data_from_layout(
         const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
         uint64_t task_window_size
+    );
+    bool init_data_from_layout(
+        const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
+        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
     );
 
     // Phase 3b: write the arena-internal pointer fields (scope_tasks,

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -384,7 +384,7 @@ private:
                 "  Increase heap size (current: %" PRIu64 ", recommended: %" PRIu64 ")", heap_size_, heap_size_ * 2
             );
             LOG_ERROR("  Compile-time: PTO2_HEAP_SIZE in pto_runtime2_types.h");
-            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<power-of-2 bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
+            LOG_ERROR("  Runtime env:  PTO2_RING_HEAP=<bytes> (e.g. %" PRIu64 ")", heap_size_ * 2);
         } else {
             LOG_ERROR("  Increase task window size (current: %d, recommended: %d)", window_size_, active_tasks * 2);
             LOG_ERROR("  Compile-time: PTO2_TASK_WINDOW_SIZE in pto_runtime2_types.h");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -111,9 +111,9 @@ struct PTO2RuntimeArenaLayout {
     size_t off_mailbox{0};
 
     // Cached parameters (re-used by init_data + wire stages).
-    uint64_t task_window_size{0};
-    uint64_t heap_size{0};
-    int32_t dep_pool_capacity{0};
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]{};
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]{};
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]{};
 
     // Total arena byte size post-commit. Used by host to size the prebuilt
     // image buffer and as the rtMemcpy length.
@@ -173,6 +173,10 @@ struct PTO2Runtime {
 PTO2RuntimeArenaLayout runtime_reserve_layout(
     DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE
 );
+PTO2RuntimeArenaLayout runtime_reserve_layout(
+    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+);
 
 /**
  * Phase 2 — write the data half of the runtime arena: standalone fields,
@@ -192,6 +196,10 @@ PTO2RuntimeArenaLayout runtime_reserve_layout(
 PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
     void *gm_heap_dev_base, uint64_t heap_size
+);
+PTO2Runtime *runtime_init_data_from_layout(
+    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base, uint64_t sm_size,
+    void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
 );
 
 /**

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -157,7 +157,7 @@ struct PTO2FaninPool;      // Forward declaration
 struct PTO2FaninSpillEntry {
     PTO2TaskSlotState *slot_state;
 };
-static_assert(sizeof(PTO2FaninSpillEntry) == sizeof(PTO2TaskSlotState *));
+static_assert(sizeof(PTO2FaninSpillEntry) == sizeof(uintptr_t));
 
 /**
  * Dependency list entry (singly-linked list node)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_shared_memory.h
@@ -187,6 +187,10 @@ struct PTO2SharedMemoryHandle {
     // init_header. Returns false when `sm_size` is too small for the requested
     // `task_window_size`.
     bool init(void *sm_base, uint64_t sm_size, uint64_t task_window_size, uint64_t heap_size);
+    bool init_per_ring(
+        void *sm_base, uint64_t sm_size, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+        const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+    );
 
     void destroy();
     void print_layout();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -224,11 +224,6 @@ public:
     // src/a5/runtime/host_build_graph/runtime/runtime.h for rationale.
     int32_t aicpu_launch_count;
 
-    // Ring buffer size overrides (0 = use compile-time defaults)
-    uint64_t task_window_size;
-    uint64_t heap_size;
-    uint64_t dep_pool_size;
-
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -456,7 +456,7 @@ struct alignas(64) PTO2SpscQueue {
     // orchestrator (push) and scheduler thread 0 (pop_batch), so its base
     // must not false-share with neighboring regions.
     static size_t reserve_layout(DeviceArena &arena, uint64_t capacity) {
-        return arena.reserve(capacity * sizeof(PTO2TaskSlotState *), PTO2_ALIGN_SIZE);
+        return arena.reserve(capacity * sizeof(uintptr_t), PTO2_ALIGN_SIZE);
     }
 
     // Writes everything except the arena-internal `buffer_` pointer field
@@ -557,7 +557,7 @@ struct PTO2SchedulerLayout {
     size_t off_wiring_spsc_buffer;
     uint64_t ready_queue_capacity;
     uint64_t spsc_capacity;
-    int32_t dep_pool_capacity;
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
 };
 
 /**
@@ -1095,6 +1095,8 @@ struct PTO2SchedulerState {
     // Capacities are baked into the returned layout; init_data_from_layout uses
     // the same values.
     static PTO2SchedulerLayout reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity = PTO2_DEP_LIST_POOL_SIZE);
+    static PTO2SchedulerLayout
+    reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]);
 
     // Phase 3a: write everything *except* arena-internal pointer fields.
     // `sm_dev_base` is the device address of the SM (only stored, never

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -22,12 +22,27 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <limits>
+
 #include "pto_orchestrator.h"
 #include "pto_runtime2.h"
 #include "pto_ring_buffer.h"
 #include "pto_shared_memory.h"
 #include "pto_tensormap.h"
 #include "scheduler/pto_scheduler.h"
+
+static bool sum_ring_heap_sizes(const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], uint64_t *total) {
+    uint64_t sum = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        if (heap_sizes[r] > std::numeric_limits<uint64_t>::max() - sum) {
+            LOG_ERROR("Total ring heap size overflows uint64_t");
+            return false;
+        }
+        sum += heap_sizes[r];
+    }
+    *total = sum;
+    return true;
+}
 
 // =============================================================================
 // Ready queue
@@ -92,10 +107,21 @@ bool PTO2SchedulerState::RingSchedState::init_data_from_layout(void *sm_dev_base
 void PTO2SchedulerState::RingSchedState::destroy() { ring = nullptr; }
 
 PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32_t dep_pool_capacity) {
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        dep_pool_capacities[r] = dep_pool_capacity;
+    }
+    return reserve_layout(arena, dep_pool_capacities);
+}
+
+PTO2SchedulerLayout
+PTO2SchedulerState::reserve_layout(DeviceArena &arena, const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]) {
     PTO2SchedulerLayout layout{};
     layout.ready_queue_capacity = PTO2_READY_QUEUE_SIZE;
     layout.spsc_capacity = PTO2_WRIRING_QUEUE_SIZE;
-    layout.dep_pool_capacity = dep_pool_capacity;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        layout.dep_pool_capacities[r] = dep_pool_capacities[r];
+    }
 
     for (int i = 0; i < PTO2_NUM_RESOURCE_SHAPES; i++) {
         layout.off_ready_queue_slots[i] = ready_queue_reserve_layout(arena, PTO2_READY_QUEUE_SIZE);
@@ -106,7 +132,7 @@ PTO2SchedulerLayout PTO2SchedulerState::reserve_layout(DeviceArena &arena, int32
         // writer of this ring's dep_pool) do not invalidate adjacent
         // multi-threaded regions like ready_queue.slots.
         layout.off_dep_pool_entries[r] =
-            arena.reserve(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2DepListEntry), PTO2_ALIGN_SIZE);
+            arena.reserve(static_cast<size_t>(dep_pool_capacities[r]) * sizeof(PTO2DepListEntry), PTO2_ALIGN_SIZE);
     }
     layout.off_wiring_spsc_buffer = PTO2SpscQueue::reserve_layout(arena, PTO2_WRIRING_QUEUE_SIZE);
     return layout;
@@ -144,8 +170,8 @@ bool PTO2SchedulerState::init_data_from_layout(
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         auto *dep_entries = static_cast<PTO2DepListEntry *>(arena.region_ptr(layout.off_dep_pool_entries[r]));
-        memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacity) * sizeof(PTO2DepListEntry));
-        sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacity, orch_err);
+        memset(dep_entries, 0, static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2DepListEntry));
+        sched->ring_sched_states[r].dep_pool.init(dep_entries, layout.dep_pool_capacities[r], orch_err);
     }
 
     if (!sched->wiring.queue.init_data_from_layout(arena, layout.off_wiring_spsc_buffer, layout.spsc_capacity)) {
@@ -191,14 +217,27 @@ void PTO2SchedulerState::destroy() {
 PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
     DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH], int32_t dep_pool_capacity
 ) {
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        dep_pool_capacities[r] = dep_pool_capacity;
+    }
+    return reserve_layout(arena, task_window_sizes, dep_pool_capacities);
+}
+
+PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
+    DeviceArena &arena, const int32_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+) {
     PTO2OrchestratorLayout layout{};
-    layout.dep_pool_capacity = dep_pool_capacity;
     layout.scope_tasks_cap = PTO2_SCOPE_TASKS_CAP;
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        layout.dep_pool_capacities[r] = dep_pool_capacities[r];
+    }
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         const size_t fanin_pool_bytes =
-            PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
+            PTO2_ALIGN_UP(static_cast<size_t>(dep_pool_capacities[r]) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
         layout.off_fanin_pool[r] = arena.reserve(fanin_pool_bytes, PTO2_ALIGN_SIZE);
 
         always_assert(task_window_sizes[r] > 0 && (task_window_sizes[r] & (task_window_sizes[r] - 1)) == 0);
@@ -206,9 +245,8 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
             PTO2_ALIGN_UP(static_cast<size_t>(task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE);
         layout.off_fanin_seen_epoch[r] = arena.reserve(seen_epoch_bytes, PTO2_ALIGN_SIZE);
     }
-    layout.off_scope_tasks = arena.reserve(
-        static_cast<size_t>(layout.scope_tasks_cap) * sizeof(PTO2TaskSlotState *), alignof(PTO2TaskSlotState *)
-    );
+    layout.off_scope_tasks =
+        arena.reserve(static_cast<size_t>(layout.scope_tasks_cap) * sizeof(uintptr_t), alignof(PTO2TaskSlotState *));
     layout.off_scope_begins =
         arena.reserve(static_cast<size_t>(layout.scope_stack_capacity) * sizeof(int32_t), alignof(int32_t));
     layout.tensor_map = PTO2TensorMap::reserve_layout_default(arena, task_window_sizes);
@@ -219,37 +257,51 @@ bool PTO2OrchestratorState::init_data_from_layout(
     const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap, uint64_t heap_size,
     uint64_t task_window_size
 ) {
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        heap_sizes[r] = heap_size;
+        task_window_sizes[r] = task_window_size;
+    }
+    return init_data_from_layout(layout, arena, sm_dev_base, gm_heap, heap_sizes, task_window_sizes);
+}
+
+bool PTO2OrchestratorState::init_data_from_layout(
+    const PTO2OrchestratorLayout &layout, DeviceArena &arena, void *sm_dev_base, void *gm_heap,
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH]
+) {
     auto *orch = this;
     *orch = PTO2OrchestratorState{};
 
     orch->sm_header = reinterpret_cast<PTO2SharedMemoryHeader *>(sm_dev_base);
     orch->gm_heap_base = gm_heap;
-    orch->gm_heap_size = heap_size * PTO2_MAX_RING_DEPTH;
+    uint64_t total_heap_size = 0;
+    if (!sum_ring_heap_sizes(heap_sizes, &total_heap_size)) {
+        return false;
+    }
+    orch->gm_heap_size = total_heap_size;
     orch->fatal = false;
 
-    // Mirror the SM API's per-ring window-size shape so a future per-ring
-    // SM layout cannot silently disagree with the addresses we compute here.
-    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
-        task_window_sizes[r] = task_window_size;
-
     auto *orch_err = pto2_sm_layout::orch_error_code_addr(sm_dev_base);
+    uint64_t heap_offset = 0;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + r * heap_size;
+        void *ring_heap_base = reinterpret_cast<char *>(gm_heap) + heap_offset;
         auto *task_descs_dev = pto2_sm_layout::ring_task_descriptors_addr(sm_dev_base, task_window_sizes, r);
         auto *cur_idx_dev = pto2_sm_layout::ring_current_task_index_addr(sm_dev_base, r);
         auto *last_alive_dev = pto2_sm_layout::ring_last_task_alive_addr(sm_dev_base, r);
 
         orch->rings[r].task_allocator.init(
-            task_descs_dev, static_cast<int32_t>(task_window_size), cur_idx_dev, last_alive_dev, ring_heap_base,
-            heap_size, orch_err
+            task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
+            heap_sizes[r], orch_err
         );
+        heap_offset += heap_sizes[r];
 
-        const size_t fanin_pool_bytes =
-            PTO2_ALIGN_UP(static_cast<size_t>(layout.dep_pool_capacity) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE);
+        const size_t fanin_pool_bytes = PTO2_ALIGN_UP(
+            static_cast<size_t>(layout.dep_pool_capacities[r]) * sizeof(PTO2FaninSpillEntry), PTO2_ALIGN_SIZE
+        );
         auto *fanin_entries = static_cast<PTO2FaninSpillEntry *>(arena.region_ptr(layout.off_fanin_pool[r]));
         memset(fanin_entries, 0, fanin_pool_bytes);
-        orch->rings[r].fanin_pool.init(fanin_entries, layout.dep_pool_capacity, orch_err);
+        orch->rings[r].fanin_pool.init(fanin_entries, layout.dep_pool_capacities[r], orch_err);
 
         const size_t seen_epoch_bytes = PTO2_ALIGN_UP(
             static_cast<size_t>(layout.tensor_map.task_window_sizes[r]) * sizeof(uint32_t), PTO2_ALIGN_SIZE
@@ -305,18 +357,35 @@ void PTO2OrchestratorState::set_scheduler(PTO2SchedulerState *scheduler) { this-
 
 PTO2RuntimeArenaLayout
 runtime_reserve_layout(DeviceArena &arena, uint64_t task_window_size, int32_t dep_pool_capacity) {
-    PTO2RuntimeArenaLayout layout{};
-    layout.task_window_size = task_window_size;
-    layout.dep_pool_capacity = dep_pool_capacity;
-
-    int32_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        task_window_sizes[r] = static_cast<int32_t>(task_window_size);
+        task_window_sizes[r] = task_window_size;
+        heap_sizes[r] = 0;
+        dep_pool_capacities[r] = dep_pool_capacity;
+    }
+    return runtime_reserve_layout(arena, task_window_sizes, heap_sizes, dep_pool_capacities);
+}
+
+PTO2RuntimeArenaLayout runtime_reserve_layout(
+    DeviceArena &arena, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH], const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+) {
+    PTO2RuntimeArenaLayout layout{};
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        layout.task_window_sizes[r] = task_window_sizes[r];
+        layout.heap_sizes[r] = heap_sizes[r];
+        layout.dep_pool_capacities[r] = dep_pool_capacities[r];
     }
 
     layout.off_sm_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
-    layout.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes, dep_pool_capacity);
-    layout.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacity);
+    int32_t task_window_sizes_i32[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        task_window_sizes_i32[r] = static_cast<int32_t>(task_window_sizes[r]);
+    }
+    layout.orch = PTO2OrchestratorState::reserve_layout(arena, task_window_sizes_i32, dep_pool_capacities);
+    layout.sched = PTO2SchedulerState::reserve_layout(arena, dep_pool_capacities);
     layout.off_runtime = arena.reserve(sizeof(PTO2Runtime), PTO2_ALIGN_SIZE);
     layout.off_mailbox = arena.reserve(sizeof(AICoreCompletionMailbox), alignof(AICoreCompletionMailbox));
 
@@ -328,6 +397,17 @@ PTO2Runtime *runtime_init_data_from_layout(
     DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
     uint64_t /*sm_size*/, void *gm_heap_dev_base, uint64_t heap_size
 ) {
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        heap_sizes[r] = heap_size;
+    }
+    return runtime_init_data_from_layout(arena, layout, mode, sm_dev_base, 0, gm_heap_dev_base, heap_sizes);
+}
+
+PTO2Runtime *runtime_init_data_from_layout(
+    DeviceArena &arena, const PTO2RuntimeArenaLayout &layout, PTO2RuntimeMode mode, void *sm_dev_base,
+    uint64_t /*sm_size*/, void *gm_heap_dev_base, const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
     PTO2Runtime *rt = static_cast<PTO2Runtime *>(arena.region_ptr(layout.off_runtime));
     memset(rt, 0, sizeof(*rt));
 
@@ -337,12 +417,16 @@ PTO2Runtime *runtime_init_data_from_layout(
     // rt->ops is filled by the AICPU at boot.
     rt->mode = mode;
     rt->gm_heap = gm_heap_dev_base;
-    rt->gm_heap_size = heap_size > 0 ? heap_size * PTO2_MAX_RING_DEPTH : 0;
+    uint64_t total_heap_size = 0;
+    if (!sum_ring_heap_sizes(heap_sizes, &total_heap_size)) {
+        return nullptr;
+    }
+    rt->gm_heap_size = total_heap_size;
     rt->gm_heap_owned = false;
     rt->total_cycles = 0;
 
     if (!rt->orchestrator.init_data_from_layout(
-            layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_size, layout.task_window_size
+            layout.orch, arena, sm_dev_base, gm_heap_dev_base, heap_sizes, layout.task_window_sizes
         )) {
         return nullptr;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -87,14 +87,27 @@ void PTO2SharedMemoryHandle::setup_pointers(uint64_t task_window_size) {
 bool PTO2SharedMemoryHandle::init(
     void *sm_base_arg, uint64_t sm_size_arg, uint64_t task_window_size, uint64_t heap_size
 ) {
+    uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH];
+    uint64_t heap_sizes[PTO2_MAX_RING_DEPTH];
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        task_window_sizes[r] = task_window_size;
+        heap_sizes[r] = heap_size;
+    }
+    return init_per_ring(sm_base_arg, sm_size_arg, task_window_sizes, heap_sizes);
+}
+
+bool PTO2SharedMemoryHandle::init_per_ring(
+    void *sm_base_arg, uint64_t sm_size_arg, const uint64_t task_window_sizes[PTO2_MAX_RING_DEPTH],
+    const uint64_t heap_sizes[PTO2_MAX_RING_DEPTH]
+) {
     if (!sm_base_arg || sm_size_arg == 0) return false;
-    if (sm_size_arg < calculate_size(task_window_size)) return false;
+    if (sm_size_arg < calculate_size_per_ring(task_window_sizes)) return false;
 
     sm_base = sm_base_arg;
     sm_size = sm_size_arg;
     is_owner = false;
-    setup_pointers(task_window_size);
-    init_header(task_window_size, heap_size);
+    setup_pointers_per_ring(task_window_sizes);
+    init_header_per_ring(task_window_sizes, heap_sizes);
     return true;
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -37,9 +37,6 @@ Runtime::Runtime() {
     memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
-    task_window_size = 0;
-    heap_size = 0;
-    dep_pool_size = 0;
     orch_to_sched = false;
 
     // Initialize profiling state

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -56,7 +56,8 @@ extern "C" {
 int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool
+    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
 );
 int validate_runtime_impl(Runtime *runtime);
 
@@ -340,6 +341,7 @@ int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
     int enable_scope_stats, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools,
     const char *output_prefix, PtoRunTiming *out_timing
 ) {
     if (out_timing != NULL) {
@@ -400,7 +402,8 @@ int run_prepared(
         // Per-run binding (tensor args, GM heap, SM alloc)
         rc = bind_callable_to_runtime_impl(
             r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
-            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
+            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool, ring_task_windows,
+            ring_heaps, ring_dep_pools
         );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -48,7 +48,8 @@ extern "C" {
 int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool
+    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
 );
 int validate_runtime_impl(Runtime *runtime);
 
@@ -295,6 +296,7 @@ int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
     int enable_scope_stats, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools,
     const char *output_prefix, PtoRunTiming *out_timing
 ) {
     if (out_timing != NULL) {
@@ -343,7 +345,8 @@ int run_prepared(
 
         rc = bind_callable_to_runtime_impl(
             r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
-            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
+            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool, ring_task_windows,
+            ring_heaps, ring_dep_pools
         );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -12,11 +12,10 @@
 /**
  * CallConfig — per-NEXT_LEVEL-task config. Carries execution knobs
  * (block_dim, aicpu_thread_num), per-task runtime-environment overrides
- * (`runtime_env.ring_task_window` / `.ring_heap` / `.ring_dep_pool`) plus the five parallel diagnostics
- * sub-features under the profiling umbrella: `enable_l2_swimlane` (swimlane),
- * `enable_dump_tensor`, `enable_pmu`, `enable_dep_gen`, and
- * `enable_scope_stats`. All five require `output_prefix` because they each
- * write sibling artifacts into that directory
+ * (`runtime_env.ring_task_window` / `.ring_heap` / `.ring_dep_pool`, plus per-ring variants) plus the five parallel
+ * diagnostics sub-features under the profiling umbrella: `enable_l2_swimlane` (swimlane), `enable_dump_tensor`,
+ * `enable_pmu`, `enable_dep_gen`, and `enable_scope_stats`. All five require `output_prefix` because they each write
+ * sibling artifacts into that directory
  * (`l2_swimlane_records.json` / `tensor_dump/` / `pmu.csv` / `deps.json` /
  * `scope_stats/scope_stats.jsonl`).
  *
@@ -48,6 +47,13 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
+#include <string>
+
+inline constexpr int RUNTIME_ENV_RING_COUNT = 4;
+inline constexpr int RUNTIME_ENV_SCALAR_FIELD_COUNT = 3;
+inline constexpr int RUNTIME_ENV_PER_RING_FIELD_GROUPS = 3;
+inline constexpr int RUNTIME_ENV_UINT64_FIELD_COUNT =
+    RUNTIME_ENV_SCALAR_FIELD_COUNT + RUNTIME_ENV_PER_RING_FIELD_GROUPS * RUNTIME_ENV_RING_COUNT;
 
 #pragma pack(push, 1)
 // Per-task runtime-environment overrides — the programmatic equivalent of the
@@ -55,27 +61,59 @@
 // distinct configuration tier from the top-level execution knobs (block_dim,
 // aicpu_thread_num). Consumed by tensormap_and_ringbuffer only; other runtimes
 // ignore them. 0 = unset; precedence: field > PTO2_RING_* env var >
-// compile-time default. ring_heap is bytes per ring.
+// compile-time default. ring_heap is bytes per ring. The scalar fields retain
+// #1042 behavior (broadcast to every ring); the array fields selectively
+// override individual scope-depth rings for #1029.
 struct RuntimeEnv {
     uint64_t ring_task_window = 0;
     uint64_t ring_heap = 0;
     uint64_t ring_dep_pool = 0;
+    uint64_t ring_task_windows[RUNTIME_ENV_RING_COUNT] = {};
+    uint64_t ring_heaps[RUNTIME_ENV_RING_COUNT] = {};
+    uint64_t ring_dep_pools[RUNTIME_ENV_RING_COUNT] = {};
 
-    bool any() const noexcept { return ring_task_window != 0 || ring_heap != 0 || ring_dep_pool != 0; }
+    bool per_ring_any() const noexcept {
+        for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+            if (ring_task_windows[i] != 0 || ring_heaps[i] != 0 || ring_dep_pools[i] != 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool any() const noexcept {
+        return ring_task_window != 0 || ring_heap != 0 || ring_dep_pool != 0 || per_ring_any();
+    }
 
     // Throws if a ring sizing override violates the ring buffer's constraints.
     void validate() const {
         auto pow2 = [](uint64_t v) {
             return (v & (v - 1)) == 0;
         };
-        if (ring_task_window != 0 && (ring_task_window < 4 || !pow2(ring_task_window))) {
-            throw std::invalid_argument("RuntimeEnv: ring_task_window must be a power of 2 >= 4");
-        }
-        if (ring_heap != 0 && (ring_heap < 1024 || !pow2(ring_heap))) {
-            throw std::invalid_argument("RuntimeEnv: ring_heap must be a power of 2 >= 1024 (bytes per ring)");
-        }
-        if (ring_dep_pool != 0 && (ring_dep_pool < 4 || ring_dep_pool > INT32_MAX)) {
-            throw std::invalid_argument("RuntimeEnv: ring_dep_pool must be in [4, INT32_MAX]");
+        auto validate_task_window = [&](uint64_t value, const char *name) {
+            if (value != 0 && (value < 4 || value > INT32_MAX || !pow2(value))) {
+                throw std::invalid_argument(
+                    std::string("RuntimeEnv: ") + name + " must be a power of 2 in [4, INT32_MAX]"
+                );
+            }
+        };
+        auto validate_heap = [&](uint64_t value, const char *name) {
+            if (value != 0 && value < 1024) {
+                throw std::invalid_argument(std::string("RuntimeEnv: ") + name + " must be >= 1024 (bytes per ring)");
+            }
+        };
+        auto validate_dep_pool = [&](uint64_t value, const char *name) {
+            if (value != 0 && (value < 4 || value > INT32_MAX)) {
+                throw std::invalid_argument(std::string("RuntimeEnv: ") + name + " must be in [4, INT32_MAX]");
+            }
+        };
+        validate_task_window(ring_task_window, "ring_task_window");
+        validate_heap(ring_heap, "ring_heap");
+        validate_dep_pool(ring_dep_pool, "ring_dep_pool");
+        for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+            validate_task_window(ring_task_windows[i], "ring_task_windows");
+            validate_heap(ring_heaps[i], "ring_heaps");
+            validate_dep_pool(ring_dep_pools[i], "ring_dep_pools");
         }
     }
 };
@@ -114,5 +152,8 @@ struct CallConfig {
     }
 };
 #pragma pack(pop)
-static_assert(sizeof(RuntimeEnv) == 3 * sizeof(uint64_t), "RuntimeEnv wire layout drift");
-static_assert(sizeof(CallConfig) == 7 * sizeof(int32_t) + 3 * sizeof(uint64_t) + 1024, "CallConfig wire layout drift");
+static_assert(sizeof(RuntimeEnv) == RUNTIME_ENV_UINT64_FIELD_COUNT * sizeof(uint64_t), "RuntimeEnv wire layout drift");
+static_assert(
+    sizeof(CallConfig) == 7 * sizeof(int32_t) + RUNTIME_ENV_UINT64_FIELD_COUNT * sizeof(uint64_t) + 1024,
+    "CallConfig wire layout drift"
+);

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -13,6 +13,7 @@
 
 #include <dlfcn.h>
 
+#include <cstring>
 #include <fstream>
 #include <stdexcept>
 #include <string>
@@ -319,13 +320,19 @@ RunTiming ChipWorker::run(int32_t callable_id, const ChipStorageTaskArgs *args, 
     }
 
     void *rt = runtime_buf_.data();
+    uint64_t ring_task_windows[RUNTIME_ENV_RING_COUNT];
+    uint64_t ring_heaps[RUNTIME_ENV_RING_COUNT];
+    uint64_t ring_dep_pools[RUNTIME_ENV_RING_COUNT];
+    std::memcpy(ring_task_windows, config.runtime_env.ring_task_windows, sizeof(ring_task_windows));
+    std::memcpy(ring_heaps, config.runtime_env.ring_heaps, sizeof(ring_heaps));
+    std::memcpy(ring_dep_pools, config.runtime_env.ring_dep_pools, sizeof(ring_dep_pools));
 
     PtoRunTiming timing{0, 0};
     int rc = run_prepared_fn_(
         device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, config.enable_l2_swimlane,
         config.enable_dump_tensor, config.enable_pmu, config.enable_dep_gen, config.enable_scope_stats,
         config.runtime_env.ring_task_window, config.runtime_env.ring_heap, config.runtime_env.ring_dep_pool,
-        config.output_prefix, &timing
+        ring_task_windows, ring_heaps, ring_dep_pools, config.output_prefix, &timing
     );
     if (rc != 0) {
         throw std::runtime_error("run_prepared failed with code " + std::to_string(rc));

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -144,7 +144,7 @@ private:
     using PrepareCallableFn = int (*)(void *, int32_t, const void *);
     using RunPreparedFn = int (*)(
         void *, void *, int32_t, const void *, int, int, int, int, int, int, int, uint64_t, uint64_t, uint64_t,
-        const char *, PtoRunTiming *
+        const uint64_t *, const uint64_t *, const uint64_t *, const char *, PtoRunTiming *
     );
     using UnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -190,9 +190,12 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
  * entry and partially populated on early-error returns.
  *
  * `ring_task_window` / `ring_heap` / `ring_dep_pool` are per-task ring sizing
- * overrides (0 = unset). Precedence: per-task value > PTO2_RING_* env var >
- * compile-time default. Consumed by tensormap_and_ringbuffer only; other
- * runtime variants accept and ignore them.
+ * overrides (0 = unset, scalar value broadcasts to every ring). The three
+ * per-ring arrays have four entries each and selectively override individual
+ * ring depths when an entry is nonzero. Precedence per ring: per-ring entry >
+ * scalar per-task value > PTO2_RING_* env var > compile-time default.
+ * Consumed by tensormap_and_ringbuffer only; other runtime variants accept
+ * and ignore them.
  *
  * @return 0 on success, negative on error (no prep state, NULL ctx, etc.).
  */
@@ -200,6 +203,7 @@ int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
     int enable_scope_stats, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
+    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools,
     const char *output_prefix, PtoRunTiming *out_timing
 );
 

--- a/tests/ut/cpp/a2a3/test_shared_memory.cpp
+++ b/tests/ut/cpp/a2a3/test_shared_memory.cpp
@@ -19,6 +19,9 @@
 
 #include <gtest/gtest.h>
 #include <cstring>
+#include <limits>
+#include <vector>
+#include "pto_runtime2.h"
 #include "pto_shared_memory.h"
 
 namespace {
@@ -158,6 +161,84 @@ TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
 
     uint64_t uniform_size = PTO2SharedMemoryHandle::calculate_size(128);
     EXPECT_GT(size, uniform_size);
+}
+
+TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
+
+    DeviceArena arena;
+    const size_t off_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    const size_t off_buffer = arena.reserve(static_cast<size_t>(sm_size), PTO2_ALIGN_SIZE);
+    ASSERT_NE(arena.commit(), nullptr);
+
+    auto *handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(off_handle));
+    std::memset(handle, 0, sizeof(*handle));
+    void *buffer = arena.region_ptr(off_buffer);
+    std::memset(buffer, 0, static_cast<size_t>(sm_size));
+    ASSERT_TRUE(handle->init_per_ring(buffer, sm_size, ws, heaps));
+
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        EXPECT_EQ(handle->header->rings[r].task_window_size, ws[r]);
+        EXPECT_EQ(handle->header->rings[r].heap_size, heaps[r]);
+        EXPECT_EQ(handle->header->rings[r].task_window_mask, static_cast<int32_t>(ws[r] - 1));
+    }
+}
+
+TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
+    uint64_t total_heap = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        total_heap += heaps[r];
+    }
+
+    DeviceArena runtime_arena;
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
+
+    DeviceArena sm_arena;
+    const size_t sm_off = sm_arena.reserve(static_cast<size_t>(sm_size), PTO2_ALIGN_SIZE);
+    ASSERT_NE(sm_arena.commit(), nullptr);
+    void *sm = sm_arena.region_ptr(sm_off);
+    std::memset(sm, 0, static_cast<size_t>(sm_size));
+
+    std::vector<char> gm(static_cast<size_t>(total_heap));
+    PTO2Runtime *rt =
+        runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, sm, sm_size, gm.data(), heaps);
+    ASSERT_NE(rt, nullptr);
+    runtime_wire_arena_pointers(runtime_arena, layout, rt);
+
+    EXPECT_EQ(rt->gm_heap_size, total_heap);
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        EXPECT_EQ(layout.task_window_sizes[r], ws[r]);
+        EXPECT_EQ(layout.heap_sizes[r], heaps[r]);
+        EXPECT_EQ(layout.dep_pool_capacities[r], dep_caps[r]);
+        EXPECT_EQ(rt->orchestrator.rings[r].task_allocator.window_size(), static_cast<int32_t>(ws[r]));
+        EXPECT_EQ(rt->orchestrator.rings[r].task_allocator.heap_capacity(), heaps[r]);
+        EXPECT_EQ(rt->orchestrator.rings[r].fanin_pool.capacity, dep_caps[r]);
+        EXPECT_EQ(rt->scheduler.ring_sched_states[r].dep_pool.capacity, dep_caps[r]);
+    }
+}
+
+TEST(RuntimeArenaLayout, RejectsOverflowingPerRingHeapSum) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {std::numeric_limits<uint64_t>::max(), 1, 0, 0};
+    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+
+    DeviceArena runtime_arena;
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
+
+    char sm = 0;
+    char gm = 0;
+    EXPECT_EQ(runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, &sm, 0, &gm, heaps), nullptr);
+
+    PTO2OrchestratorState orch{};
+    EXPECT_FALSE(orch.init_data_from_layout(layout.orch, runtime_arena, &sm, &gm, heaps, ws));
 }
 
 // =============================================================================

--- a/tests/ut/cpp/a5/test_shared_memory.cpp
+++ b/tests/ut/cpp/a5/test_shared_memory.cpp
@@ -19,6 +19,9 @@
 
 #include <gtest/gtest.h>
 #include <cstring>
+#include <limits>
+#include <vector>
+#include "pto_runtime2.h"
 #include "pto_shared_memory.h"
 
 namespace {
@@ -158,6 +161,84 @@ TEST(SharedMemoryCalcSize, PerRingDifferentSizes) {
 
     uint64_t uniform_size = PTO2SharedMemoryHandle::calculate_size(128);
     EXPECT_GT(size, uniform_size);
+}
+
+TEST(SharedMemoryLayout, InitPerRingWritesHeaderValues) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
+
+    DeviceArena arena;
+    const size_t off_handle = arena.reserve(sizeof(PTO2SharedMemoryHandle), alignof(PTO2SharedMemoryHandle));
+    const size_t off_buffer = arena.reserve(static_cast<size_t>(sm_size), PTO2_ALIGN_SIZE);
+    ASSERT_NE(arena.commit(), nullptr);
+
+    auto *handle = static_cast<PTO2SharedMemoryHandle *>(arena.region_ptr(off_handle));
+    std::memset(handle, 0, sizeof(*handle));
+    void *buffer = arena.region_ptr(off_buffer);
+    std::memset(buffer, 0, static_cast<size_t>(sm_size));
+    ASSERT_TRUE(handle->init_per_ring(buffer, sm_size, ws, heaps));
+
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        EXPECT_EQ(handle->header->rings[r].task_window_size, ws[r]);
+        EXPECT_EQ(handle->header->rings[r].heap_size, heaps[r]);
+        EXPECT_EQ(handle->header->rings[r].task_window_mask, static_cast<int32_t>(ws[r] - 1));
+    }
+}
+
+TEST(RuntimeArenaLayout, PerRingConfigInitializesRuntimeComponents) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {10 * 1024, 20 * 1024, 30 * 1024, 40 * 1024};
+    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+    const uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(ws);
+    uint64_t total_heap = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        total_heap += heaps[r];
+    }
+
+    DeviceArena runtime_arena;
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
+
+    DeviceArena sm_arena;
+    const size_t sm_off = sm_arena.reserve(static_cast<size_t>(sm_size), PTO2_ALIGN_SIZE);
+    ASSERT_NE(sm_arena.commit(), nullptr);
+    void *sm = sm_arena.region_ptr(sm_off);
+    std::memset(sm, 0, static_cast<size_t>(sm_size));
+
+    std::vector<char> gm(static_cast<size_t>(total_heap));
+    PTO2Runtime *rt =
+        runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, sm, sm_size, gm.data(), heaps);
+    ASSERT_NE(rt, nullptr);
+    runtime_wire_arena_pointers(runtime_arena, layout, rt);
+
+    EXPECT_EQ(rt->gm_heap_size, total_heap);
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        EXPECT_EQ(layout.task_window_sizes[r], ws[r]);
+        EXPECT_EQ(layout.heap_sizes[r], heaps[r]);
+        EXPECT_EQ(layout.dep_pool_capacities[r], dep_caps[r]);
+        EXPECT_EQ(rt->orchestrator.rings[r].task_allocator.window_size(), static_cast<int32_t>(ws[r]));
+        EXPECT_EQ(rt->orchestrator.rings[r].task_allocator.heap_capacity(), heaps[r]);
+        EXPECT_EQ(rt->orchestrator.rings[r].fanin_pool.capacity, dep_caps[r]);
+        EXPECT_EQ(rt->scheduler.ring_sched_states[r].dep_pool.capacity, dep_caps[r]);
+    }
+}
+
+TEST(RuntimeArenaLayout, RejectsOverflowingPerRingHeapSum) {
+    uint64_t ws[PTO2_MAX_RING_DEPTH] = {16, 32, 64, 128};
+    uint64_t heaps[PTO2_MAX_RING_DEPTH] = {std::numeric_limits<uint64_t>::max(), 1, 0, 0};
+    int32_t dep_caps[PTO2_MAX_RING_DEPTH] = {4, 8, 16, 32};
+
+    DeviceArena runtime_arena;
+    PTO2RuntimeArenaLayout layout = runtime_reserve_layout(runtime_arena, ws, heaps, dep_caps);
+    ASSERT_NE(runtime_arena.commit(DeviceArena::kDefaultBaseAlign), nullptr);
+
+    char sm = 0;
+    char gm = 0;
+    EXPECT_EQ(runtime_init_data_from_layout(runtime_arena, layout, PTO2_MODE_EXECUTE, &sm, 0, &gm, heaps), nullptr);
+
+    PTO2OrchestratorState orch{};
+    EXPECT_FALSE(orch.init_data_from_layout(layout.orch, runtime_arena, &sm, &gm, heaps, ws));
 }
 
 // =============================================================================

--- a/tests/ut/cpp/types/test_call_config.cpp
+++ b/tests/ut/cpp/types/test_call_config.cpp
@@ -18,8 +18,8 @@
 
 // Wire contract: parent and forked child move CallConfig with one memcpy.
 TEST(CallConfig, WireLayoutUnchanged) {
-    EXPECT_EQ(sizeof(RuntimeEnv), 3 * sizeof(uint64_t));
-    EXPECT_EQ(sizeof(CallConfig), 7 * sizeof(int32_t) + 3 * sizeof(uint64_t) + 1024);
+    EXPECT_EQ(sizeof(RuntimeEnv), RUNTIME_ENV_UINT64_FIELD_COUNT * sizeof(uint64_t));
+    EXPECT_EQ(sizeof(CallConfig), 7 * sizeof(int32_t) + RUNTIME_ENV_UINT64_FIELD_COUNT * sizeof(uint64_t) + 1024);
 }
 
 TEST(CallConfig, RuntimeEnvDefaultsAreUnset) {
@@ -27,6 +27,12 @@ TEST(CallConfig, RuntimeEnvDefaultsAreUnset) {
     EXPECT_EQ(cfg.runtime_env.ring_task_window, 0u);
     EXPECT_EQ(cfg.runtime_env.ring_heap, 0u);
     EXPECT_EQ(cfg.runtime_env.ring_dep_pool, 0u);
+    for (int r = 0; r < RUNTIME_ENV_RING_COUNT; ++r) {
+        EXPECT_EQ(cfg.runtime_env.ring_task_windows[r], 0u);
+        EXPECT_EQ(cfg.runtime_env.ring_heaps[r], 0u);
+        EXPECT_EQ(cfg.runtime_env.ring_dep_pools[r], 0u);
+    }
+    EXPECT_FALSE(cfg.runtime_env.per_ring_any());
     EXPECT_FALSE(cfg.runtime_env.any());
     EXPECT_NO_THROW(cfg.validate());
 }
@@ -34,9 +40,13 @@ TEST(CallConfig, RuntimeEnvDefaultsAreUnset) {
 TEST(CallConfig, ValidRuntimeEnvPasses) {
     CallConfig cfg;
     cfg.runtime_env.ring_task_window = 64;
-    cfg.runtime_env.ring_heap = 4 * 1024 * 1024;
+    cfg.runtime_env.ring_heap = 2621440;
     cfg.runtime_env.ring_dep_pool = 256;
+    cfg.runtime_env.ring_task_windows[2] = 1024;
+    cfg.runtime_env.ring_heaps[2] = 1536 * 1024 * 1024ull;
+    cfg.runtime_env.ring_dep_pools[2] = 1024;
     EXPECT_TRUE(cfg.runtime_env.any());
+    EXPECT_TRUE(cfg.runtime_env.per_ring_any());
     EXPECT_NO_THROW(cfg.validate());
 }
 
@@ -46,13 +56,13 @@ TEST(CallConfig, RejectsRingTaskWindowBelowMinOrNonPow2) {
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
     cfg.runtime_env.ring_task_window = 48;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
+    cfg.runtime_env.ring_task_window = static_cast<uint64_t>(INT32_MAX) + 1;
+    EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }
 
-TEST(CallConfig, RejectsRingHeapBelowMinOrNonPow2) {
+TEST(CallConfig, RejectsRingHeapBelowMin) {
     CallConfig cfg;
     cfg.runtime_env.ring_heap = 512;
-    EXPECT_THROW(cfg.validate(), std::invalid_argument);
-    cfg.runtime_env.ring_heap = 2621440;  // 2.5 MiB — the historical RUNTIME_ENV value the env parser silently dropped
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }
 
@@ -61,5 +71,19 @@ TEST(CallConfig, RejectsRingDepPoolOutOfRange) {
     cfg.runtime_env.ring_dep_pool = 3;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
     cfg.runtime_env.ring_dep_pool = static_cast<uint64_t>(INT32_MAX) + 1;
+    EXPECT_THROW(cfg.validate(), std::invalid_argument);
+}
+
+TEST(CallConfig, RejectsPerRingRuntimeEnvValues) {
+    CallConfig cfg;
+    cfg.runtime_env.ring_task_windows[1] = 48;
+    EXPECT_THROW(cfg.validate(), std::invalid_argument);
+
+    cfg = CallConfig{};
+    cfg.runtime_env.ring_heaps[1] = 512;
+    EXPECT_THROW(cfg.validate(), std::invalid_argument);
+
+    cfg = CallConfig{};
+    cfg.runtime_env.ring_dep_pools[1] = static_cast<uint64_t>(INT32_MAX) + 1;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -87,24 +87,51 @@ class TestCallConfig:
         assert config.runtime_env.ring_task_window == 0
         assert config.runtime_env.ring_heap == 0
         assert config.runtime_env.ring_dep_pool == 0
+        assert config.runtime_env.ring_task_windows == [0, 0, 0, 0]
+        assert config.runtime_env.ring_heaps == [0, 0, 0, 0]
+        assert config.runtime_env.ring_dep_pools == [0, 0, 0, 0]
         config.runtime_env.ring_task_window = 64
-        config.runtime_env.ring_heap = 4 * 1024 * 1024
+        config.runtime_env.ring_heap = 2621440
         config.runtime_env.ring_dep_pool = 256
+        config.runtime_env.ring_task_windows = [16, 32, 128, 256]
+        config.runtime_env.ring_heaps = [
+            10 * 1024 * 1024,
+            64 * 1024 * 1024,
+            1536 * 1024 * 1024,
+            4 * 1024 * 1024 * 1024,
+        ]
+        config.runtime_env.ring_dep_pools = [64, 128, 256, 512]
         assert config.runtime_env.ring_task_window == 64
-        assert config.runtime_env.ring_heap == 4 * 1024 * 1024
+        assert config.runtime_env.ring_heap == 2621440
         assert config.runtime_env.ring_dep_pool == 256
+        assert config.runtime_env.ring_task_windows == [16, 32, 128, 256]
+        assert config.runtime_env.ring_heaps == [
+            10 * 1024 * 1024,
+            64 * 1024 * 1024,
+            1536 * 1024 * 1024,
+            4 * 1024 * 1024 * 1024,
+        ]
+        assert config.runtime_env.ring_dep_pools == [64, 128, 256, 512]
         config.validate()
         r = repr(config)
         assert "runtime_env.ring_task_window=64" in r
-        assert "runtime_env.ring_heap=4194304" in r
+        assert "runtime_env.ring_heap=2621440" in r
         assert "runtime_env.ring_dep_pool=256" in r
+        assert "runtime_env.ring_task_windows=[16, 32, 128, 256]" in r
 
     def test_runtime_env_whole_object_assignment(self):
         re = RuntimeEnv()
         re.ring_heap = 1024
+        re.ring_heaps = [1024, 2048, 3072, 4096]
         config = CallConfig()
         config.runtime_env = re
         assert config.runtime_env.ring_heap == 1024
+        assert config.runtime_env.ring_heaps == [1024, 2048, 3072, 4096]
+
+    def test_runtime_env_per_ring_length_validation(self):
+        config = CallConfig()
+        with pytest.raises(ValueError):
+            config.runtime_env.ring_task_windows = [16, 32, 64]
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -112,7 +139,6 @@ class TestCallConfig:
             ("ring_task_window", 3),  # below min 4
             ("ring_task_window", 48),  # not a power of 2
             ("ring_heap", 512),  # below min 1024
-            ("ring_heap", 2621440),  # not a power of 2
             ("ring_dep_pool", 3),  # below min 4
             ("ring_dep_pool", 2**31),  # above INT32_MAX
         ],
@@ -120,6 +146,22 @@ class TestCallConfig:
     def test_runtime_env_validate_rejects(self, field, value):
         config = CallConfig()
         setattr(config.runtime_env, field, value)
+        with pytest.raises(ValueError):
+            config.validate()
+
+    def test_runtime_env_per_ring_validate_rejects(self):
+        config = CallConfig()
+        config.runtime_env.ring_task_windows = [16, 32, 48, 64]
+        with pytest.raises(ValueError):
+            config.validate()
+
+        config = CallConfig()
+        config.runtime_env.ring_heaps = [1024, 512, 2048, 4096]
+        with pytest.raises(ValueError):
+            config.validate()
+
+        config = CallConfig()
+        config.runtime_env.ring_dep_pools = [4, 8, 2**31, 16]
         with pytest.raises(ValueError):
             config.validate()
 
@@ -293,6 +335,9 @@ class TestMailboxConfigRoundtrip:
         cfg.runtime_env.ring_task_window = 64
         cfg.runtime_env.ring_heap = 4 * 1024 * 1024
         cfg.runtime_env.ring_dep_pool = 256
+        cfg.runtime_env.ring_task_windows = [16, 32, 128, 256]
+        cfg.runtime_env.ring_heaps = [1024, 2048, 4096, 8192]
+        cfg.runtime_env.ring_dep_pools = [64, 128, 256, 512]
         cfg.output_prefix = "/tmp/out"
 
         buf = bytearray(_OFF_CONFIG + _CFG_FMT.size)
@@ -309,6 +354,9 @@ class TestMailboxConfigRoundtrip:
             cfg.runtime_env.ring_task_window,
             cfg.runtime_env.ring_heap,
             cfg.runtime_env.ring_dep_pool,
+            *cfg.runtime_env.ring_task_windows,
+            *cfg.runtime_env.ring_heaps,
+            *cfg.runtime_env.ring_dep_pools,
             cfg.output_prefix.encode(),
         )
 
@@ -323,4 +371,7 @@ class TestMailboxConfigRoundtrip:
         assert decoded.runtime_env.ring_task_window == 64
         assert decoded.runtime_env.ring_heap == 4 * 1024 * 1024
         assert decoded.runtime_env.ring_dep_pool == 256
+        assert decoded.runtime_env.ring_task_windows == [16, 32, 128, 256]
+        assert decoded.runtime_env.ring_heaps == [1024, 2048, 4096, 8192]
+        assert decoded.runtime_env.ring_dep_pools == [64, 128, 256, 512]
         assert decoded.output_prefix == "/tmp/out"


### PR DESCRIPTION
## Summary

Add per-ring runtime sizing for the `tensormap_and_ringbuffer` runtime.

This keeps the scalar `runtime_env` fields introduced by #1042 and adds per-ring array fields so a single task can size `ring0..ring3` independently:

- `ring_task_windows[4]`
- `ring_heaps[4]`
- `ring_dep_pools[4]`

This addresses #1029, where deep kernels have very different resource pressure across scope-depth rings. A single scalar value can either be too small for deeper rings or too large for shallow rings, causing unnecessary shared-memory growth.

## Behavior

Effective sizing is resolved per resource and per ring:

```text
per-ring CallConfig value
  > scalar CallConfig value
  > per-ring PTO2_RING_* env value
  > scalar PTO2_RING_* env value
  > compile-time default
```

Environment variables now support either scalar values or four comma-separated per-ring values:

```bash
PTO2_RING_TASK_WINDOW=8192,16384,131072,524288
PTO2_RING_HEAP=134217728,268435456,402653184,536870912
PTO2_RING_DEP_POOL=4096,8192,16384,32768
```

`PTO2_RING_HEAP` values are integer byte counts; size suffixes such as `K/M/G/T` are not supported.

## Usage

Users can configure per-ring sizing through environment variables or through `CallConfig.runtime_env`.

### Environment variables

Scalar values are still supported and are broadcast to all rings:

```bash
PTO2_RING_TASK_WINDOW=131072
PTO2_RING_HEAP=4294967296
PTO2_RING_DEP_POOL=262144
```

Per-ring values use exactly four comma-separated entries, indexed by `ring0..ring3`:

```bash
PTO2_RING_TASK_WINDOW=8192,16384,131072,524288
PTO2_RING_HEAP=134217728,268435456,402653184,536870912
PTO2_RING_DEP_POOL=4096,8192,16384,32768
```

### CallConfig

```python
cfg.runtime_env.ring_task_windows = [8192, 16384, 131072, 524288]
cfg.runtime_env.ring_heaps = [
    128 * 1024 * 1024,
    256 * 1024 * 1024,
    384 * 1024 * 1024,
    512 * 1024 * 1024,
]
cfg.runtime_env.ring_dep_pools = [4096, 8192, 16384, 32768]
```

Ring entries map to scope depth as follows:

```text
ring0 -> scope depth 0
ring1 -> scope depth 1
ring2 -> scope depth 2
ring3 -> scope depth >= 3
```

## Verification

Run a T&R scene test with `--enable-scope-stats`:

```bash
PTO2_RING_TASK_WINDOW=8192,16384,131072,524288 \
PTO2_RING_HEAP=134217728,268435456,402653184,536870912 \
PTO2_RING_DEP_POOL=4096,8192,16384,32768 \
python tests/st/<case>/test_<name>.py -p a2a3 -d 0 --enable-scope-stats
```

Then inspect the first line of `scope_stats.jsonl`. The metadata contains the effective capacities:

```text
task_window_max = [...]
heap_max        = [...]
dep_pool_max    = [...]
```

These arrays are indexed by `ring`, so they can confirm the per-ring configuration took effect.

Validated with `qwen3_14b_decode` and `--enable-scope-stats`:

```text
task_window_max = [8192, 16384, 131072, 524288]
heap_max        = [134217728, 268435456, 402653184, 536870912]
dep_pool_max    = [4096, 8192, 16384, 32768]
fatal           = false
dropped         = 0
```

## Documentation

The new usage is documented in:

- `src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md`
- `src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md`
- `docs/dfx/scope-stats.md`