### PR TITLE
Fix: complete incore tensor signatures in tensormap_and_ringbuffer ST

### DIFF
--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen_chain.py
@@ -64,12 +64,17 @@ class TestDepGenChain(SceneTestCase):
                 "name": "WRITE_CONST",
                 "source": f"{DUMMY_KERNELS}/aic/kernel_write_const.cpp",
                 "core_type": "aic",
+                # Single-AIC task with one INOUT tensor (args[0]). Declared so
+                # the tensor dump's per-subtask sum matches the payload.
+                "signature": [D.INOUT],
             },
             {
                 "func_id": 1,
                 "name": "COPY_FIRST",
                 "source": f"{DUMMY_KERNELS}/aic/kernel_copy_first.cpp",
                 "core_type": "aic",
+                # Single-AIC task: copies args[0] -> args[1] (IN, INOUT).
+                "signature": [D.IN, D.INOUT],
             },
         ],
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/test_dummy_task.py
@@ -57,12 +57,17 @@ class TestDummyTask(SceneTestCase):
                 "name": "WRITE_CONST",
                 "source": "kernels/aic/kernel_write_const.cpp",
                 "core_type": "aic",
+                # Single-AIC task with one INOUT tensor (args[0]). Declared so
+                # the tensor dump's per-subtask sum matches the payload.
+                "signature": [D.INOUT],
             },
             {
                 "func_id": 1,
                 "name": "COPY_FIRST",
                 "source": "kernels/aic/kernel_copy_first.cpp",
                 "core_type": "aic",
+                # Single-AIC task: copies args[0] -> args[1] (IN, INOUT).
+                "signature": [D.IN, D.INOUT],
             },
         ],
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/test_fanin_lookup_perf.py
@@ -39,6 +39,9 @@ class TestFaninLookupPerf(SceneTestCase):
                 "name": "WRITE_CONST",
                 "source": "kernels/aic/kernel_write_const_visible.cpp",
                 "core_type": "aic",
+                # Single-AIC task with one INOUT tensor (args[0]). Declared so
+                # the tensor dump's per-subtask sum matches the payload.
+                "signature": [D.INOUT],
             },
         ],
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -34,7 +34,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "QK",
                 "source": "kernels/aic/aic_qk_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 1,
@@ -48,7 +48,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 3,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/test_spmd_basic.py
@@ -40,7 +40,17 @@ class TestSpmdBasic(SceneTestCase):
             "signature": [D.INOUT],
         },
         "incores": [
-            {"func_id": 0, "name": "SPMD_READ_AIC", "source": "kernels/aic/kernel_spmd_read.cpp", "core_type": "aic"},
+            {
+                "func_id": 0,
+                "name": "SPMD_READ_AIC",
+                "source": "kernels/aic/kernel_spmd_read.cpp",
+                "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
+            },
             {"func_id": 1, "name": "SPMD_READ_AIV0", "source": "kernels/aiv/kernel_spmd_read.cpp", "core_type": "aiv"},
             {"func_id": 2, "name": "SPMD_READ_AIV1", "source": "kernels/aiv/kernel_spmd_read.cpp", "core_type": "aiv"},
         ],

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/test_spmd_batch_dispatch_oob.py
@@ -42,7 +42,16 @@ class TestSpmdBatchDispatchOob(SceneTestCase):
             "signature": [D.INOUT],
         },
         "incores": [
-            {"func_id": 0, "source": "kernels/aic/kernel_write.cpp", "core_type": "aic"},
+            {
+                "func_id": 0,
+                "source": "kernels/aic/kernel_write.cpp",
+                "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
+            },
             {"func_id": 1, "source": "kernels/aiv/kernel_write.cpp", "core_type": "aiv"},
             {"func_id": 2, "source": "kernels/aiv/kernel_write.cpp", "core_type": "aiv"},
         ],

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/test_spmd_multiblock_aiv.py
@@ -35,7 +35,17 @@ class TestSpmdMultiblockAiv(SceneTestCase):
             "signature": [D.INOUT],
         },
         "incores": [
-            {"func_id": 0, "name": "SPMD_WRITE_AIV", "source": "kernels/aiv/kernel_spmd_write.cpp", "core_type": "aiv"},
+            {
+                "func_id": 0,
+                "name": "SPMD_WRITE_AIV",
+                "source": "kernels/aiv/kernel_spmd_write.cpp",
+                "core_type": "aiv",
+                # Declare the single output tensor so the tensor dump (which
+                # sums per-subtask signature tensors and matches them to the
+                # payload) captures it under func_id 0 — without it the count is
+                # 0 != payload 1 and the dump is skipped.
+                "signature": [D.INOUT],
+            },
         ],
     }
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/test_spmd_multiblock_mix.py
@@ -36,7 +36,17 @@ class TestSpmdMultiblockMix(SceneTestCase):
             "signature": [D.INOUT],
         },
         "incores": [
-            {"func_id": 0, "name": "SPMD_MIX_AIC", "source": "kernels/aic/kernel_spmd_mix.cpp", "core_type": "aic"},
+            {
+                "func_id": 0,
+                "name": "SPMD_MIX_AIC",
+                "source": "kernels/aic/kernel_spmd_mix.cpp",
+                "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
+            },
             {"func_id": 1, "name": "SPMD_MIX_AIV0", "source": "kernels/aiv/kernel_spmd_mix.cpp", "core_type": "aiv"},
             {"func_id": 2, "name": "SPMD_MIX_AIV1", "source": "kernels/aiv/kernel_spmd_mix.cpp", "core_type": "aiv"},
         ],

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/test_spmd_paged_attention.py
@@ -37,6 +37,11 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
                 "name": "PA_AIC",
                 "source": "kernels/mix/paged_attention_parallel.cpp",
                 "core_type": "aic",
+                # Declare the full 9-tensor layout here (AIV entry left empty)
+                # so the tensor dump — which sums per-subtask signature tensors
+                # and matches them to the payload — captures all args under
+                # func_id 0. Consumed only by the dump; dispatch ignores it.
+                "signature": [D.IN, D.IN, D.IN, D.IN, D.IN, D.INOUT, D.OUT, D.OUT, D.OUT],
             },
             {
                 "func_id": 1,
@@ -74,6 +79,27 @@ class TestPagedAttentionUnrollTpushPop(SceneTestCase):
                 "kv_head_num": 1,
                 "head_dim": 128,
                 "block_size": 64,
+                "context_len": 8192,
+                "max_model_len": 32768,
+                "dtype": "bfloat16",
+            },
+        },
+        {
+            # Intra-core trace target only (--case SmallCase1; manual -> not in
+            # the default onboard CI sweep). batch=24 == the orchestration's
+            # hardcoded SPMD_BLOCK_NUM, so every hw block gets one logical block
+            # (fewer stalls in the AIC<->AIV handshake). Same q_tile=16 path as
+            # Case1; passes golden at context_len=8192.
+            "name": "SmallCase1",
+            "platforms": ["a2a3"],
+            "manual": True,
+            "config": {"aicpu_thread_num": 4, "block_dim": 24},
+            "params": {
+                "batch": 24,
+                "num_heads": 16,
+                "kv_head_num": 1,
+                "head_dim": 128,
+                "block_size": 128,
                 "context_len": 8192,
                 "max_model_len": 32768,
                 "dtype": "bfloat16",

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/test_spmd_starvation.py
@@ -62,6 +62,11 @@ class TestSpmdStarvation(SceneTestCase):
                 "name": "SPMD_MIX_AIC",
                 "source": "../spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
                 "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
             },
             {
                 "func_id": 1,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/test_spmd_sync_start.py
@@ -37,6 +37,11 @@ class TestSpmdSyncStart(SceneTestCase):
                 "name": "SPMD_MIX_AIC",
                 "source": "../spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
                 "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
             },
             {
                 "func_id": 1,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/test_spmd_sync_start_aiv.py
@@ -36,6 +36,9 @@ class TestSpmdSyncStartAiv(SceneTestCase):
                 "name": "SPMD_WRITE_AIV",
                 "source": "../spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp",
                 "core_type": "aiv",
+                # Single-AIV task: one INOUT tensor in args[]. Declare it so the
+                # tensor dump's per-subtask sum matches the payload (1).
+                "signature": [D.INOUT],
             },
         ],
     }

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/test_spmd_sync_start_edge.py
@@ -37,6 +37,11 @@ class TestSpmdSyncStartEdge(SceneTestCase):
                 "name": "SPMD_MIX_AIC",
                 "source": "../spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
                 "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
             },
             {
                 "func_id": 1,

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/test_spmd_sync_start_stress.py
@@ -62,6 +62,11 @@ class TestSpmdSyncStartStress(SceneTestCase):
                 "name": "SPMD_MIX_AIC",
                 "source": "../spmd_multiblock_mix/kernels/aic/kernel_spmd_mix.cpp",
                 "core_type": "aic",
+                # Cooperative MIX (AIC+AIV0+AIV1 share one args[]). Declare the
+                # payload signature on exactly ONE subtask so the tensor dump's
+                # per-subtask sum equals the payload (1 INOUT tensor); the AIVs
+                # stay empty or the sum would triple and the dump is skipped.
+                "signature": [D.INOUT],
             },
             {
                 "func_id": 1,
@@ -80,6 +85,9 @@ class TestSpmdSyncStartStress(SceneTestCase):
                 "name": "SPMD_WRITE_AIV",
                 "source": "../spmd_multiblock_aiv/kernels/aiv/kernel_spmd_write.cpp",
                 "core_type": "aiv",
+                # Separate single-AIV task (not part of the MIX above): its own
+                # args[] has one INOUT tensor, so declare it here.
+                "signature": [D.INOUT],
             },
         ],
     }

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/test_paged_attention_unroll.py
@@ -34,7 +34,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "QK",
                 "source": "kernels/aic/aic_qk_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 1,
@@ -48,7 +48,7 @@ class TestPagedAttentionUnroll(SceneTestCase):
                 "name": "PV",
                 "source": "kernels/aic/aic_pv_matmul.cpp",
                 "core_type": "aic",
-                "signature": [D.IN, D.IN, D.OUT],
+                "signature": [D.IN, D.IN, D.IN, D.OUT],
             },
             {
                 "func_id": 3,


### PR DESCRIPTION
The incore 'signature' is consumed only by the tensor dump (dispatch ignores it). Many incores declared it incompletely or not at all, so the dump's per-subtask signature tensor-count sum did not equal the payload tensor count and the dump was silently skipped.

Complete/correct the signatures so each kernel's args are captured:

- Single-task kernels: signature tensor count == payload tensor count (paged_attention_unroll QK/PV [IN,IN,OUT] -> [IN,IN,IN,OUT]; dummy_task / dep_gen_chain WRITE_CONST [INOUT], COPY_FIRST [IN,INOUT]; fanin_lookup_perf, spmd_sync_start_aiv, spmd_multiblock_aiv).
- Cooperative MIX (same source as AIC+AIV subtasks sharing one args[]): declare the full signature on exactly one subtask, leave the others empty, so the per-subtask sum matches the single-tensor payload (spmd_basic, spmd_multiblock_mix, spmd_batch_dispatch_oob, spmd_sync_start, spmd_sync_start_edge, spmd_starvation, spmd_sync_start_stress; spmd_paged_attention PA_AIC full 9-tensor layout, AIV left empty).
- spmd_paged_attention: add manual SmallCase1 (batch == SPMD_BLOCK_NUM) as an intra-core trace target.
- Mirror the QK/PV fix in the a5 paged_attention_unroll test.

Verified per kernel via --dump-args 3 on a2a3 (correct arg_index / shape / role captured, no dump-skip) and golden PASS on all cases. Dispatch is unaffected, so existing behavior is unchanged.