### PR TITLE
Byte-address TaskArgsView to remove under-aligned Tensor* (#1098)

### DIFF
--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -943,7 +943,7 @@ NB_MODULE(_task_interface, m) {
             TaskArgsView view = read_blob(reinterpret_cast<const uint8_t *>(blob_ptr), MAILBOX_ARGS_CAPACITY);
             TaskArgs args;
             for (int32_t i = 0; i < view.tensor_count; i++) {
-                args.add_tensor(view.tensors[i]);
+                args.add_tensor(view.tensors(i));
             }
             for (int32_t i = 0; i < view.scalar_count; i++) {
                 args.add_scalar(view.scalars[i]);

--- a/src/common/hierarchical/remote_endpoint.cpp
+++ b/src/common/hierarchical/remote_endpoint.cpp
@@ -622,7 +622,7 @@ remote_l3::TaskPayloadWire RemoteL3Endpoint::build_task_payload(const TaskSlotSt
     payload.args.remote_desc.reserve(static_cast<size_t>(view.tensor_count));
 
     for (int32_t i = 0; i < view.tensor_count; ++i) {
-        Tensor tensor = view.tensors[i];
+        Tensor tensor = view.tensors(i);
         RemoteTensorSidecar tensor_sidecar{};
         if (!sidecar.tensors.empty()) tensor_sidecar = sidecar.tensors[static_cast<size_t>(i)];
         if (tensor.buffer.addr != 0 && !tensor_sidecar.present) {

--- a/src/common/hierarchical/worker_manager.cpp
+++ b/src/common/hierarchical/worker_manager.cpp
@@ -305,7 +305,7 @@ WorkerCompletion LocalMailboxEndpoint::run(Ring *ring, const WorkerDispatch &dis
     std::memcpy(d + 4, &view.scalar_count, sizeof(int32_t));
     if (view.tensor_count > 0) {
         std::memcpy(
-            d + TASK_ARGS_BLOB_HEADER_SIZE, view.tensors, static_cast<size_t>(view.tensor_count) * sizeof(Tensor)
+            d + TASK_ARGS_BLOB_HEADER_SIZE, view.tensor_bytes, static_cast<size_t>(view.tensor_count) * sizeof(Tensor)
         );
     }
     if (view.scalar_count > 0) {

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -190,13 +190,29 @@ using ChipStorageTaskArgs = TaskArgsTpl<Tensor, uint64_t, CHIP_MAX_TENSOR_ARGS, 
 struct TaskArgsView {
     int32_t tensor_count;
     int32_t scalar_count;
-    const Tensor *tensors;
-    const uint64_t *scalars;
+    // Raw bytes of the tensor array, NOT a `const Tensor*`. When this view is
+    // over a mailbox blob the tensor region starts at an 8-byte boundary, but
+    // `Tensor` is `alignas(64)` — forming a `Tensor*`/`Tensor&` to it would be
+    // undefined behavior. Copy a tensor out with tensors(i); bulk movers
+    // memcpy straight from these bytes. (For the make_view path the bytes are
+    // a 64-aligned vector, but the accessor keeps a single uniform contract.)
+    const uint8_t *tensor_bytes;
+    const uint64_t *scalars;  // 8-byte aligned by blob construction; safe to address as uint64_t*
+
+    // Copy the i-th tensor into a properly-aligned local. Never forms a pointer
+    // into the (possibly under-aligned) tensor_bytes region.
+    Tensor tensors(int32_t i) const {
+        Tensor t;
+        std::memcpy(&t, tensor_bytes + static_cast<size_t>(i) * sizeof(Tensor), sizeof(Tensor));
+        return t;
+    }
 };
 
 // Build a view directly over a TaskArgs's vectors (THREAD-mode dispatch).
 inline TaskArgsView make_view(const TaskArgs &a) {
-    return TaskArgsView{a.tensor_count(), a.scalar_count(), a.tensor_data(), a.scalar_data()};
+    return TaskArgsView{
+        a.tensor_count(), a.scalar_count(), reinterpret_cast<const uint8_t *>(a.tensor_data()), a.scalar_data()
+    };
 }
 
 // ============================================================================
@@ -276,7 +292,7 @@ inline TaskArgsView read_blob(const uint8_t *src, size_t capacity) {
     return TaskArgsView{
         T,
         S,
-        reinterpret_cast<const Tensor *>(src + TASK_ARGS_BLOB_HEADER_SIZE),
+        src + TASK_ARGS_BLOB_HEADER_SIZE,
         reinterpret_cast<const uint64_t *>(src + TASK_ARGS_BLOB_HEADER_SIZE + static_cast<size_t>(T) * sizeof(Tensor)),
     };
 }
@@ -297,7 +313,7 @@ inline ChipStorageTaskArgs view_to_chip_storage(TaskArgsView view) {
     out.tensor_count_ = view.tensor_count;
     out.scalar_count_ = view.scalar_count;
     if (view.tensor_count > 0) {
-        std::memcpy(out.tensors_, view.tensors, static_cast<size_t>(view.tensor_count) * sizeof(Tensor));
+        std::memcpy(out.tensors_, view.tensor_bytes, static_cast<size_t>(view.tensor_count) * sizeof(Tensor));
     }
     if (view.scalar_count > 0) {
         std::memcpy(out.scalars_, view.scalars, static_cast<size_t>(view.scalar_count) * sizeof(uint64_t));

--- a/src/common/task_interface/task_args.h
+++ b/src/common/task_interface/task_args.h
@@ -200,8 +200,12 @@ struct TaskArgsView {
     const uint64_t *scalars;  // 8-byte aligned by blob construction; safe to address as uint64_t*
 
     // Copy the i-th tensor into a properly-aligned local. Never forms a pointer
-    // into the (possibly under-aligned) tensor_bytes region.
+    // into the (possibly under-aligned) tensor_bytes region. Bounds-checked: a
+    // negative index would otherwise wrap to a huge offset once cast to size_t.
     Tensor tensors(int32_t i) const {
+        if (i < 0 || i >= tensor_count) {
+            throw std::out_of_range("TaskArgsView::tensors: index out of range");
+        }
         Tensor t;
         std::memcpy(&t, tensor_bytes + static_cast<size_t>(i) * sizeof(Tensor), sizeof(Tensor));
         return t;

--- a/tests/ut/cpp/hierarchical/test_orchestrator.cpp
+++ b/tests/ut/cpp/hierarchical/test_orchestrator.cpp
@@ -223,8 +223,8 @@ TEST_F(OrchestratorFixture, GroupTaskStoresArgsListPerMember) {
     EXPECT_EQ(S(res.task_slot).task_args_list.size(), 2u);
 
     // args_view(i) yields each member's distinct tensor list.
-    EXPECT_EQ(S(res.task_slot).args_view(0).tensors[0].buffer.addr, 0xA0u);
-    EXPECT_EQ(S(res.task_slot).args_view(1).tensors[0].buffer.addr, 0xA1u);
+    EXPECT_EQ(S(res.task_slot).args_view(0).tensors(0).buffer.addr, 0xA0u);
+    EXPECT_EQ(S(res.task_slot).args_view(1).tensors(0).buffer.addr, 0xA1u);
 
     // Both keys registered as producers for the group slot.
     EXPECT_EQ(tm.lookup(TensorKey{0xA0, -1}), res.task_slot);
@@ -238,7 +238,7 @@ TEST_F(OrchestratorFixture, SingleTaskStoresTaskArgsDirectly) {
     EXPECT_FALSE(S(res.task_slot).is_group());
     EXPECT_EQ(S(res.task_slot).group_size(), 1);
     EXPECT_EQ(S(res.task_slot).task_args.tensor_count(), 1);
-    EXPECT_EQ(S(res.task_slot).args_view(0).tensors[0].buffer.addr, 0xC0u);
+    EXPECT_EQ(S(res.task_slot).args_view(0).tensors(0).buffer.addr, 0xC0u);
 }
 
 TEST_F(OrchestratorFixture, OutputAutoAllocsFromHeapRing) {

--- a/tests/ut/cpp/types/test_child_memory.cpp
+++ b/tests/ut/cpp/types/test_child_memory.cpp
@@ -77,12 +77,12 @@ TEST(ChildMemory, BlobRoundtripPreservesChildMemory) {
     ASSERT_EQ(view.tensor_count, 2);
     ASSERT_EQ(view.scalar_count, 1);
 
-    EXPECT_EQ(view.tensors[0].child_memory, 0);
-    EXPECT_FALSE(view.tensors[0].is_child_memory());
+    EXPECT_EQ(view.tensors(0).child_memory, 0);
+    EXPECT_FALSE(view.tensors(0).is_child_memory());
 
-    EXPECT_EQ(view.tensors[1].child_memory, 1);
-    EXPECT_TRUE(view.tensors[1].is_child_memory());
-    EXPECT_EQ(view.tensors[1].buffer.addr, 0x2000u);
+    EXPECT_EQ(view.tensors(1).child_memory, 1);
+    EXPECT_TRUE(view.tensors(1).is_child_memory());
+    EXPECT_EQ(view.tensors(1).buffer.addr, 0x2000u);
 }
 
 // ---------------------------------------------------------------------------
@@ -104,7 +104,7 @@ TEST(ChildMemory, ViewToChipStoragePreservesChildMemory) {
     tensors[1].child_memory = 1;
 
     uint64_t scalars[] = {99};
-    TaskArgsView view{2, 1, tensors, scalars};
+    TaskArgsView view{2, 1, reinterpret_cast<const uint8_t *>(tensors), scalars};
 
     ChipStorageTaskArgs chip = view_to_chip_storage(view);
 

--- a/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
+++ b/tests/ut/cpp/types/test_chip_max_tensor_args.cpp
@@ -65,7 +65,7 @@ TEST(ChipMaxTensorArgs, ViewToChipStorageAcceptsCap) {
     for (int i = 0; i < CHIP_MAX_TENSOR_ARGS; ++i) {
         tensors.push_back(make_tensor(static_cast<uint64_t>(0x2000 + i)));
     }
-    TaskArgsView view{CHIP_MAX_TENSOR_ARGS, 0, tensors.data(), nullptr};
+    TaskArgsView view{CHIP_MAX_TENSOR_ARGS, 0, reinterpret_cast<const uint8_t *>(tensors.data()), nullptr};
 
     ChipStorageTaskArgs chip;
     ASSERT_NO_THROW(chip = view_to_chip_storage(view));
@@ -75,6 +75,6 @@ TEST(ChipMaxTensorArgs, ViewToChipStorageAcceptsCap) {
 
 TEST(ChipMaxTensorArgs, ViewToChipStorageRejectsOverflow) {
     std::vector<Tensor> tensors(CHIP_MAX_TENSOR_ARGS + 1, make_tensor(0));
-    TaskArgsView view{CHIP_MAX_TENSOR_ARGS + 1, 0, tensors.data(), nullptr};
+    TaskArgsView view{CHIP_MAX_TENSOR_ARGS + 1, 0, reinterpret_cast<const uint8_t *>(tensors.data()), nullptr};
     EXPECT_THROW(view_to_chip_storage(view), std::out_of_range);
 }


### PR DESCRIPTION
## Summary

Fixes #1098 — a standards-level alignment UB introduced by #1093.

`read_blob` returned a `TaskArgsView` whose `tensors` was a `const Tensor*`
formed by `reinterpret_cast` over the **8-byte-aligned** mailbox blob, while
`Tensor` is `alignas(64)`. Forming a pointer/reference to an under-aligned
over-aligned object is UB even when no access faults. Before #1093 the blob
element was the 40 B / align-8 `ContinuousTensor`, so `src + 8` was naturally
aligned; the over-aligned `Tensor` made it UB.

Safe in practice on aarch64 (every `Tensor` field is ≤8-byte aligned, the blob
is 8-aligned, and consumers copy via trivially-copyable copy / `memcpy`), but
this removes the UB at the root.

## Change

`TaskArgsView` no longer exposes a `const Tensor*`:

- `const Tensor *tensors` → `const uint8_t *tensor_bytes` + a
  `Tensor tensors(int i)` accessor that `memcpy`s into an aligned local.
- Producers (`make_view`, `read_blob`, the two cpp UTs that build views) set the
  byte pointer.
- Bulk movers (`view_to_chip_storage`, `LocalMailboxEndpoint::run`) `memcpy`
  straight from `tensor_bytes`.
- Element consumers (`remote_endpoint`, the binding's `read_args_from_blob`, the
  UTs) read via `view.tensors(i)` (was `view.tensors[i]`).

No mailbox / wire layout change. The sharpest UB site was the binding's
`read_args_from_blob`, which bound `view.tensors[i]` directly to a
`const Tensor&`.

## Verification

- ut-cpp: 44/44 (no-hardware).
- ut-py: `test_task_interface` + `test_remote_l3_protocol` + `test_worker` —
  220 passed, 2 skipped.

Rebased onto current `main` (post-#1093 merge).