### PR TITLE
Refactor: tensormap L0/L2TaskArgs arg hierarchy + extract paged-attn qtile scope

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -343,7 +343,7 @@ base via `task_id`.
 budget (`PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32` slots → roughly
 `64 + 31 × 582 = 18106` deps max in the best case) is logged via
 `LOG_ERROR` and truncated to the largest dc that fits. Runtime
-correctness is unaffected — `Arg::set_dependencies` keeps the full dep
+correctness is unaffected — `L0TaskArgs::set_dependencies` keeps the full dep
 list; only the dep_gen replay graph loses the tail.
 
 ---

--- a/docs/dfx/tensor-dump.md
+++ b/docs/dfx/tensor-dump.md
@@ -49,7 +49,7 @@ python tests/st/<case>/test_<name>.py -p a5sim --dump-args 2
 | Level | Meaning |
 | ----- | ------- |
 | `0` (or flag absent) | off — zero overhead |
-| `1` (bare `--dump-args`) | **partial** — only args marked with `Arg::dump(...)` (see §3.2) |
+| `1` (bare `--dump-args`) | **partial** — only args marked with `L0TaskArgs::dump(...)` (see §3.2) |
 | `2` (`--dump-args 2`) | **full** — every task's tensor inputs/outputs and scalar args |
 | `3` (`--dump-args 3`) | **full, JSON only** — every task's tensor/scalar metadata (shape, dtype, strides, scalar values) to `args_dump.json`; no payload captured, no `.bin` file |
 
@@ -90,13 +90,13 @@ bit to insert a `pipe_barrier(PIPE_ALL)` before FIN when dump is on, so
 
 ### 3.2 Partial Dump — Select Specific Args
 
-Partial dump (level 1) captures only the tasks whose `Arg` is marked
+Partial dump (level 1) captures only the tasks whose `L0TaskArgs` is marked
 with `dump(...)`; every unmarked task is skipped. Within a marked task,
 only the selected tensor/scalar args are recorded. Mark the arguments on
-the relevant `Arg` before submission:
+the relevant `L0TaskArgs` before submission:
 
 ```cpp
-Arg args;
+L0TaskArgs args;
 args.add_input(x);
 args.add_input(y);
 args.add_output(z);
@@ -106,9 +106,9 @@ args.dump(x, z, scale);
 rt_submit_aiv_task(FUNC_ADD, args);
 ```
 
-`dump(...)` selects arguments from the current `Arg`; it does not execute
+`dump(...)` selects arguments from the current `L0TaskArgs`; it does not execute
 a dump immediately. The selected tensors and scalar lvalues must already
-belong to that `Arg`. Scalar selection is by the lvalue passed to
+belong to that `L0TaskArgs`. Scalar selection is by the lvalue passed to
 `add_scalar(...)`, not by scalar value. Temporaries such as
 `args.dump(1.0f)` are rejected because they do not identify a previously
 added scalar slot. If the same scalar lvalue is added more than once,
@@ -131,16 +131,16 @@ Selective dump comes at two granularities, both expressed with the same
 - **Arg granularity** — `dump(x, z, scale)` selects specific tensor and
   scalar arguments of the task (the example above).
 - **Task granularity** — `dump()` with no arguments selects the whole
-  task (every tensor and scalar argument on the `Arg`), without
+  task (every tensor and scalar argument on the `L0TaskArgs`), without
   enumerating them:
 
   ```cpp
-  Arg args;
+  L0TaskArgs args;
   args.add_input(x);
   args.add_input(y);
   args.add_output(z);
   args.add_scalar(scale);
-  args.dump();        // whole task: every tensor/scalar arg on this Arg
+  args.dump();        // whole task: every tensor/scalar arg on this L0TaskArgs
   rt_submit_aiv_task(FUNC_ADD, args);
   ```
 
@@ -324,9 +324,9 @@ What you can read out of `args_dump.json` + `args.bin`:
 
 ## 5. Design Highlights
 
-`Arg::dump(...)` selection state is compiled only when
+`L0TaskArgs::dump(...)` selection state is compiled only when
 `PTO2_PROFILING=1`. With `PTO2_PROFILING=0`, the public API remains
-available but acts as a no-op: no dump-only `Arg` state is stored and
+available but acts as a no-op: no dump-only `L0TaskArgs` state is stored and
 submit does not propagate dump metadata.
 
 ### 5.1 Common device-side structures
@@ -833,7 +833,7 @@ manifest).
 
 **`args_dump/` exists but the manifest captured nothing.** You are
 most likely at the default partial level (`--dump-args` = level 1)
-with no `Arg::dump(...)` markers in the orchestration, so every task is
+with no `L0TaskArgs::dump(...)` markers in the orchestration, so every task is
 skipped. Add markers (§3.2), or pass `--dump-args 2` for a full dump.
 
 **Manifest has tasks but `tensors[]` is empty.** AICPU received a

--- a/docs/manual-scope.md
+++ b/docs/manual-scope.md
@@ -5,7 +5,7 @@
 Keep manual scope small and explicit:
 
 - same submit API family as AUTO mode
-- explicit task-to-task deps via `Arg.set_dependencies(deps, count)`
+- explicit task-to-task deps via `L0TaskArgs.set_dependencies(deps, count)`
 - publish at submit time, same as AUTO mode
 - support allocation-as-task through `alloc_tensors(...).task_id()`
 
@@ -16,7 +16,7 @@ The v0 design keeps these rules:
 1. `PTO2_SCOPE(PTO2ScopeMode::MANUAL)` opts a scope into manual mode.
 2. `MANUAL` nested inside active `MANUAL` is allowed.
 3. `AUTO` nested inside active `MANUAL` is rejected.
-4. Manual deps are attached before submit through `Arg.set_dependencies(...)`.
+4. Manual deps are attached before submit through `L0TaskArgs.set_dependencies(...)`.
 5. No post-submit `add_dependency(...)` API exists.
 6. `alloc_tensors(...)` remains output-only and returns a task id.
 7. Scope handling stays close to upstream AUTO mode.
@@ -44,7 +44,7 @@ auto out = rt_submit_task(mixed_kernels, args);
 ### Explicit deps
 
 ```cpp
-Arg args;
+L0TaskArgs args;
 args.add_input(tensor);
 PTO2TaskId deps[] = {prev_task_id};
 args.set_dependencies(deps, 1);
@@ -52,7 +52,7 @@ args.set_dependencies(deps, 1);
 
 Rules:
 
-- `set_dependencies(...)` may be called at most once per Arg with `count > 0`;
+- `set_dependencies(...)` may be called at most once per L0TaskArgs with `count > 0`;
   build the full dep set on the caller's stack (or any buffer that outlives the
   submit) and pass `(ptr, count)` in a single call
 - `count == 0` is a valid "set empty" — it clears any previously stored deps,
@@ -85,7 +85,7 @@ the producer that later tasks must explicitly depend on.
 Manual scope v0 is:
 
 - AUTO-style submit and publish
-- plus explicit fanins from `Arg.set_dependencies(...)`
+- plus explicit fanins from `L0TaskArgs.set_dependencies(...)`
 - plus full TensorMap lookup / insert bypass for tasks submitted inside manual
   scope
 
@@ -134,21 +134,21 @@ For a submitted task:
 PTO2_SCOPE(PTO2ScopeMode::MANUAL) {
     auto alloc = alloc_tensors(tmp_ci);
 
-    Arg qk;
+    L0TaskArgs qk;
     qk.add_input(qi, kj);
     qk.add_output(sij_ci);
     PTO2TaskId qk_deps[] = {alloc.task_id()};
     qk.set_dependencies(qk_deps, 1);
     auto qk_out = rt_submit_aic_task(FUNC_QK, qk);
 
-    Arg sf;
+    L0TaskArgs sf;
     sf.add_input(qk_out.get_ref(0));
     sf.add_output(pij_ci, li_ci, mi_ci);
     PTO2TaskId sf_deps[] = {qk_out.task_id()};
     sf.set_dependencies(sf_deps, 1);
     auto sf_out = rt_submit_aiv_task(FUNC_SF, sf);
 
-    Arg up;
+    L0TaskArgs up;
     up.add_input(sf_out.get_ref(1), sf_out.get_ref(2), pv_out.get_ref(0));
     up.add_inout(mi, li, out_view, tmp);
     PTO2TaskId up_deps[] = {sf_out.task_id(), pv_out.task_id()};
@@ -165,7 +165,7 @@ needed on the first iteration:
 ```cpp
 PTO2TaskId prev_update = PTO2TaskId::invalid();
 for (...) {
-    Arg up = ...;
+    L0TaskArgs up = ...;
     PTO2TaskId up_deps[1];
     uint32_t up_dep_count = 0;
     if (prev_update.is_valid()) {
@@ -183,5 +183,5 @@ The a5 port uses the same manual-scope v0 runtime model as a2a3:
 - same `manual_begin_depth` state model
 - same `MANUAL`-inside-`MANUAL` behavior
 - same rejection of `AUTO` inside active `MANUAL`
-- same submit-time explicit dependency model through `Arg.set_dependencies(...)`
+- same submit-time explicit dependency model through `L0TaskArgs.set_dependencies(...)`
 - same submit-time TensorMap bypass for tasks submitted inside manual scope

--- a/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -17,29 +17,28 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-async_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+async_notify_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     return async_notify_orchestration_config(orch_args);
 }
 
-__attribute__((visibility("default"))) void async_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void async_notify_orchestration(const L2TaskArgs &orch_args) {
     if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
         LOG_ERROR("async_notify_demo: expected 5 args");
         return;
     }
 
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor result = from_tensor_arg(orch_args.tensor(2));
-    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &result = orch_args.tensor(2).ref();
+    const Tensor &notify_counter = orch_args.tensor(3).ref();
     auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
 
-    Arg params_producer;
+    L0TaskArgs params_producer;
     params_producer.add_input(input);
     params_producer.add_output(output);
     params_producer.add_scalar(notify_counter.buffer.addr);
@@ -48,14 +47,14 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
-    Arg params_notify;
+    L0TaskArgs params_notify;
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
     TaskOutputTensors notify_outputs = rt_submit_aiv_task(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
-    Arg params_consumer;
+    L0TaskArgs params_consumer;
     params_consumer.add_input(notify_token);
     params_consumer.add_input(output);
     params_consumer.add_output(result);

--- a/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/benchmark_bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -37,23 +37,22 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // Tensor args
-    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_C = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_config = from_tensor_arg(orch_args.tensor(3));
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_C = orch_args.tensor(2).ref();
+    const Tensor &ext_config = orch_args.tensor(3).ref();
 
     // Read config from tensor data: [tile_size, grid_k, num_groups, incore_loop]
-    int64_t *host_config = orch_args.tensor(3).data_as<int64_t>();
+    int64_t *host_config = orch_args.tensor(3).ref().data_as<int64_t>();
     int tile_size = static_cast<int>(host_config[0]);
     int grid_k = static_cast<int>(host_config[1]);
     int num_groups = static_cast<int>(host_config[2]);
@@ -95,7 +94,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             Tensor A_view = ext_A.view(group_shapes, a_view_offsets);
             uint32_t b_view_offsets[1] = {static_cast<uint32_t>(ab_offset)};
             Tensor B_view = ext_B.view(group_shapes, b_view_offsets);
-            Arg params_gemm;
+            L0TaskArgs params_gemm;
             params_gemm.add_input(A_view);
             params_gemm.add_input(B_view);
             params_gemm.add_output(group_ci);
@@ -103,7 +102,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             TaskOutputTensors gemm_outs = rt_submit_aic_task(FUNC_GEMM_TILE, params_gemm);
             total_gemm++;
 
-            Arg params_add;
+            L0TaskArgs params_add;
             params_add.add_inout(C_view);
             params_add.add_input(gemm_outs.get_ref(0));
             params_add.add_input(ext_config);

--- a/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -17,31 +17,30 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-deferred_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+deferred_notify_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     return deferred_notify_orchestration_config(orch_args);
 }
 
-__attribute__((visibility("default"))) void deferred_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void deferred_notify_orchestration(const L2TaskArgs &orch_args) {
     if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
         LOG_ERROR("deferred_notify_demo: expected 5 args");
         return;
     }
 
-    Tensor partial = from_tensor_arg(orch_args.tensor(0));
-    Tensor mailbox = from_tensor_arg(orch_args.tensor(1));
-    Tensor result = from_tensor_arg(orch_args.tensor(2));
-    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    const Tensor &partial = orch_args.tensor(0).ref();
+    const Tensor &mailbox = orch_args.tensor(1).ref();
+    const Tensor &result = orch_args.tensor(2).ref();
+    const Tensor &notify_counter = orch_args.tensor(3).ref();
     auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
 
     uint32_t shapes[1] = {128 * 128};
     TensorCreateInfo producer_output_info(shapes, 1, DataType::FLOAT32);
-    Arg params_producer;
+    L0TaskArgs params_producer;
     params_producer.add_input(partial);
     params_producer.add_inout(mailbox);
     params_producer.add_output(producer_output_info);
@@ -51,14 +50,14 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
-    Arg params_notify;
+    L0TaskArgs params_notify;
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
     TaskOutputTensors notify_outputs = rt_submit_aiv_task(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
-    Arg params_consumer;
+    L0TaskArgs params_consumer;
     params_consumer.add_input(notify_token);
     params_consumer.add_input(mailbox);
     params_consumer.add_output(result);

--- a/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
+++ b/examples/a2a3/tensormap_and_ringbuffer/docs/INCORE_ORCHESTRATION_GUIDE.md
@@ -14,8 +14,8 @@ In tensormap_and_ringbuffer, the orchestration function runs on AICPU and builds
 Your orchestration shared object must export:
 
 ```cpp
-extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args);
-extern "C" void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args);
+extern "C" PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args);
+extern "C" void aicpu_orchestration_entry(const L2TaskArgs &orch_args);
 ```
 
 Both symbols are loaded by AICPU via `dlopen` in `src/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp`.
@@ -35,18 +35,18 @@ Validate `arg_count` in `aicpu_orchestration_config` and interpret pointers as d
 1. Wrap orchestration in scopes with `PTO2_SCOPE()` to control tensor lifetimes.
 2. Use `make_tensor_external` for existing device buffers and `TensorCreateInfo` + `add_output(...)` for runtime-created intermediates.
 3. Use `add_inout(...)` for existing tensors that a kernel writes.
-4. Build `Arg` with `add_input`, `add_output`, `add_inout` for tensors and `add_scalar` for scalars.
+4. Build `L0TaskArgs` with `add_input`, `add_output`, `add_inout` for tensors and `add_scalar` for scalars.
    > **Constraint**: All tensor parameters (`add_input` / `add_output` / `add_inout`) **must** be added before any scalar parameters (`add_scalar` / `add_scalars`). Violating this order will trigger an assertion failure. This is because the runtime dispatches tensor arguments first in kernel args, followed by scalars, and the layout must match.
 
    ```cpp
    // Correct
-   Arg p;
+   L0TaskArgs p;
    p.add_input(a);
    p.add_inout(b);
    p.add_scalar(val);    // scalars after all tensors
 
    // Wrong — triggers assertion
-   Arg p;
+   L0TaskArgs p;
    p.add_scalar(val);    // scalar added too early
    p.add_input(a);       // assertion: "scalar must add after all tensor added"
    ```

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -66,15 +66,14 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
@@ -91,13 +90,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     CYCLE_COUNT_START();
 
     // Read dimensions from tensor metadata
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     uint64_t scale_value = orch_args.scalar(0);
 
@@ -109,12 +108,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     LOG_INFO_V9(">>>>>> batch = %" PRIu64, batch);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -132,10 +131,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -188,7 +187,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     PROF_INC(prof_view_count, 2);
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg params_qk;
+                    L0TaskArgs params_qk;
                     params_qk.add_input(qi);
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
@@ -204,7 +203,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     PROF_INC(prof_view_count, 1);
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg params_sf;
+                    L0TaskArgs params_sf;
                     params_sf.add_input(sij_valid);
                     params_sf.add_output(pij_f16_ci);
                     params_sf.add_output(scalar_ci);
@@ -218,7 +217,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    Arg params_pv;
+                    L0TaskArgs params_pv;
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
@@ -232,7 +231,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    Arg params_up;
+                    L0TaskArgs params_up;
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_tmp);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -62,15 +62,14 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
@@ -87,13 +86,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     CYCLE_COUNT_START();
 
     // Read dimensions from tensor metadata
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     uint64_t scale_value = orch_args.scalar(0);
 
@@ -105,12 +104,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     LOG_INFO_V9(">>>>>> batch = %" PRIu64, batch);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -128,10 +127,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -184,7 +183,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     PROF_INC(prof_view_count, 2);
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg params_qk;
+                    L0TaskArgs params_qk;
                     params_qk.add_input(qi);
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
@@ -203,7 +202,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     // --- Primitive dep API (Arg + set_dependencies) ---
                     // Caller owns the deps buffer; Arg stores (ptr, count).
                     // Suited for codegen and for cases with a fixed dep set.
-                    Arg params_sf;
+                    L0TaskArgs params_sf;
                     params_sf.add_input(sij_valid);
                     params_sf.add_output(pij_f16_ci);
                     params_sf.add_output(scalar_ci);
@@ -219,7 +218,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     PROF_INC(prof_submit_count, 1);
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    Arg params_pv;
+                    L0TaskArgs params_pv;
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
@@ -235,13 +234,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    // --- Convenience dep API (ArgWithDeps + add_dep) ---
+                    // --- Convenience dep API (L0TaskArgsWithDeps + add_dep) ---
                     // Wrapper owns a stack-sized deps buffer and accepts
                     // incremental add_dep() calls; the submit overload binds
                     // them to the underlying Arg via set_dependencies(...).
                     // Suited for hand-written orch where the dep set is
                     // assembled conditionally across branches.
-                    ArgWithDeps<> params_up;
+                    L0TaskArgsWithDeps<> params_up;
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_tmp);

--- a/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -65,15 +65,14 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
@@ -91,16 +90,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
 
     // block_table: shape=[batch, max_num_blocks_per_req]
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
     uint64_t scale_value = orch_args.scalar(0);
@@ -110,12 +109,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     CYCLE_COUNT_LAP(prof_param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -132,10 +131,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
@@ -184,7 +183,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
                 // Reusable Arg objects — reset() before each use avoids
                 // repeated stack-frame construction in the inner loop.
-                Arg params_qk, params_sf, params_pv, params_up;
+                L0TaskArgs params_qk, params_sf, params_pv, params_up;
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
                     uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/qwen3_decode.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/orchestration/qwen3_decode.cpp
@@ -22,36 +22,35 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 20,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // External tensors
-    Tensor ext_hidden_states = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_input_rms_weight = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_wq = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_wk = from_tensor_arg(orch_args.tensor(3));
-    Tensor ext_wv = from_tensor_arg(orch_args.tensor(4));
-    Tensor ext_q_norm_weight = from_tensor_arg(orch_args.tensor(5));
-    Tensor ext_k_norm_weight = from_tensor_arg(orch_args.tensor(6));
-    Tensor ext_seq_lens = from_tensor_arg(orch_args.tensor(7));
-    Tensor ext_block_table = from_tensor_arg(orch_args.tensor(8));
-    Tensor ext_slot_mapping = from_tensor_arg(orch_args.tensor(9));
-    Tensor ext_rope_cos = from_tensor_arg(orch_args.tensor(10));
-    Tensor ext_rope_sin = from_tensor_arg(orch_args.tensor(11));
-    Tensor ext_k_cache = from_tensor_arg(orch_args.tensor(12));
-    Tensor ext_v_cache = from_tensor_arg(orch_args.tensor(13));
-    Tensor ext_wo = from_tensor_arg(orch_args.tensor(14));
-    Tensor ext_post_rms_weight = from_tensor_arg(orch_args.tensor(15));
-    Tensor ext_w_gate = from_tensor_arg(orch_args.tensor(16));
-    Tensor ext_w_up = from_tensor_arg(orch_args.tensor(17));
-    Tensor ext_w_down = from_tensor_arg(orch_args.tensor(18));
-    Tensor ext_out = from_tensor_arg(orch_args.tensor(19));
+    const Tensor &ext_hidden_states = orch_args.tensor(0).ref();
+    const Tensor &ext_input_rms_weight = orch_args.tensor(1).ref();
+    const Tensor &ext_wq = orch_args.tensor(2).ref();
+    const Tensor &ext_wk = orch_args.tensor(3).ref();
+    const Tensor &ext_wv = orch_args.tensor(4).ref();
+    const Tensor &ext_q_norm_weight = orch_args.tensor(5).ref();
+    const Tensor &ext_k_norm_weight = orch_args.tensor(6).ref();
+    const Tensor &ext_seq_lens = orch_args.tensor(7).ref();
+    const Tensor &ext_block_table = orch_args.tensor(8).ref();
+    const Tensor &ext_slot_mapping = orch_args.tensor(9).ref();
+    const Tensor &ext_rope_cos = orch_args.tensor(10).ref();
+    const Tensor &ext_rope_sin = orch_args.tensor(11).ref();
+    const Tensor &ext_k_cache = orch_args.tensor(12).ref();
+    const Tensor &ext_v_cache = orch_args.tensor(13).ref();
+    const Tensor &ext_wo = orch_args.tensor(14).ref();
+    const Tensor &ext_post_rms_weight = orch_args.tensor(15).ref();
+    const Tensor &ext_w_gate = orch_args.tensor(16).ref();
+    const Tensor &ext_w_up = orch_args.tensor(17).ref();
+    const Tensor &ext_w_down = orch_args.tensor(18).ref();
+    const Tensor &ext_out = orch_args.tensor(19).ref();
 
     PTO2_SCOPE() {
         uint32_t current_hidden_ci_shapes[2] = {16, 5120};
@@ -85,14 +84,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &k_proj_norm = alloc_0.get_ref(6);
         const Tensor &attn_out = alloc_0.get_ref(7);
         const Tensor &all_q_padded = alloc_0.get_ref(8);
-        int64_t user_batch = (int64_t)orch_args.tensor(0).shapes[0];
+        int64_t user_batch = (int64_t)orch_args.tensor(0).ref().shapes[0];
         int64_t batch_padded = (((user_batch + 15) / 16) * 16);
         for (int64_t b0 = 0; b0 < batch_padded; b0 += 16) {
             PTO2_SCOPE() {
                 int64_t cur_valid = std::min<int64_t>((user_batch - b0), 16);
 
                 // Task 0: copy_hidden
-                Arg params_t0;
+                L0TaskArgs params_t0;
                 params_t0.add_output(current_hidden);
                 params_t0.add_input(ext_hidden_states);
                 params_t0.add_scalar(b0);
@@ -110,7 +109,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 int64_t cur_valid__ssa_v1 = std::min<int64_t>((user_batch - b0), 16);
 
                 // Task 1: rmsnorm
-                Arg params_t1;
+                L0TaskArgs params_t1;
                 params_t1.add_input(current_hidden);
                 params_t1.add_output(normed_tile);
                 params_t1.add_input(ext_input_rms_weight);
@@ -121,7 +120,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t ob_chunk = 0; ob_chunk < 80; ob_chunk += 4) {
                     PTO2_SCOPE() {
                         // Task 2: q_proj
-                        Arg params_t2;
+                        L0TaskArgs params_t2;
                         params_t2.add_output(q_proj);
                         params_t2.add_input(normed_tile__rv_v2);
                         params_t2.add_input(ext_wq);
@@ -134,7 +133,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t ob_chunk = 0; ob_chunk < 16; ob_chunk += 4) {
                     PTO2_SCOPE() {
                         // Task 3: kv_proj
-                        Arg params_t3;
+                        L0TaskArgs params_t3;
                         params_t3.add_output(k_proj);
                         params_t3.add_output(v_proj);
                         params_t3.add_input(normed_tile__rv_v2);
@@ -152,7 +151,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         for (int64_t b0 = 0; b0 < batch_padded; b0 += 16) {
             PTO2_SCOPE() {
                 // Task 4: qk_norm
-                Arg params_t4;
+                L0TaskArgs params_t4;
                 params_t4.add_output(q_proj_norm);
                 params_t4.add_input(q_proj);
                 params_t4.add_input(ext_q_norm_weight);
@@ -167,7 +166,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         }
 
         // Task 5: q_pad
-        Arg params_t5;
+        L0TaskArgs params_t5;
         params_t5.add_output(all_q_padded);
         rt_submit_aiv_task(5, params_t5);
         const Tensor &all_q_padded__rv_v2 = all_q_padded;
@@ -196,12 +195,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 const Tensor &all_cur_mi = alloc_2.get_ref(4);
                 const Tensor &all_cur_li = alloc_2.get_ref(5);
                 size_t idx_ctx_len = b;
-                int32_t ctx_len = static_cast<int32_t *>(orch_args.tensor(7).data_as<void>())[idx_ctx_len];
+                int32_t ctx_len = static_cast<int32_t *>(orch_args.tensor(7).ref().data_as<void>())[idx_ctx_len];
                 int64_t pos = (static_cast<int64_t>(ctx_len) - 1);
                 int64_t ctx_blocks = ((static_cast<int64_t>(ctx_len) + 255) / 256);
                 int64_t block_table_base = (b * 2);
                 size_t idx_slot = b;
-                int32_t slot = static_cast<int32_t *>(orch_args.tensor(9).data_as<void>())[idx_slot];
+                int32_t slot = static_cast<int32_t *>(orch_args.tensor(9).ref().data_as<void>())[idx_slot];
                 int64_t slot_block = (static_cast<int64_t>(slot) / 256);
                 int64_t slot_offset = (static_cast<int64_t>(slot) - (slot_block * 256));
                 uint32_t cos_row_shapes[2] = {1, 128};
@@ -225,7 +224,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t ki_chunk = 0; ki_chunk < 8; ki_chunk += 8) {
                     PTO2_SCOPE() {
                         // Task 6: rope_kv_cache
-                        Arg params_t6;
+                        L0TaskArgs params_t6;
                         params_t6.add_inout(all_q_padded__rv_v2);
                         params_t6.add_output(ext_k_cache);
                         params_t6.add_output(ext_v_cache);
@@ -252,7 +251,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t sb_chunk = 0; sb_chunk < ctx_blocks; sb_chunk += 64) {
                     PTO2_SCOPE() {
                         // Task 7: qk_matmul
-                        Arg params_t7;
+                        L0TaskArgs params_t7;
                         params_t7.add_output(all_raw_scores);
                         params_t7.add_input(all_q_padded__rv_v2);
                         params_t7.add_input(ext_block_table);
@@ -268,7 +267,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t sb_chunk = 0; sb_chunk < ctx_blocks; sb_chunk += 64) {
                     PTO2_SCOPE() {
                         // Task 8: softmax
-                        Arg params_t8;
+                        L0TaskArgs params_t8;
                         params_t8.add_output(all_cur_li);
                         params_t8.add_output(all_cur_mi);
                         params_t8.add_output(all_exp_padded);
@@ -285,7 +284,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 for (int64_t sb_chunk = 0; sb_chunk < ctx_blocks; sb_chunk += 64) {
                     PTO2_SCOPE() {
                         // Task 9: sv_matmul
-                        Arg params_t9;
+                        L0TaskArgs params_t9;
                         params_t9.add_output(all_oi_tmp);
                         params_t9.add_input(ext_block_table);
                         params_t9.add_input(all_exp_padded);
@@ -299,7 +298,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 }
 
                 // Task 10: online_softmax
-                Arg params_t10;
+                L0TaskArgs params_t10;
                 params_t10.add_output(attn_row_padded);
                 params_t10.add_input(all_oi_tmp);
                 params_t10.add_input(all_cur_mi);
@@ -309,7 +308,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 const Tensor &attn_row_padded__rv_v2 = attn_row_padded;
 
                 // Task 11: attention_writeback
-                Arg params_t11;
+                L0TaskArgs params_t11;
                 params_t11.add_output(attn_row);
                 params_t11.add_input(attn_row_padded__rv_v2);
                 rt_submit_aiv_task(11, params_t11);
@@ -337,7 +336,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         int64_t o0 = (ob * 64);
 
                         // Task 12: out_proj
-                        Arg params_t12;
+                        L0TaskArgs params_t12;
                         params_t12.add_input(attn_out);
                         params_t12.add_input(ext_wo);
                         params_t12.add_inout(ret0__out);
@@ -347,7 +346,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         const Tensor &o_acc = ret0__out;
 
                         // Task 13: out_proj_residual
-                        Arg params_t13;
+                        L0TaskArgs params_t13;
                         params_t13.add_input(current_hidden);
                         params_t13.add_input(o_acc);
                         params_t13.add_inout(resid1_tile);
@@ -360,7 +359,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 }
 
                 // Task 14: post_rmsnorm
-                Arg params_t14;
+                L0TaskArgs params_t14;
                 params_t14.add_input(resid1_tile);
                 params_t14.add_output(post_norm_tile);
                 params_t14.add_input(ext_post_rms_weight);
@@ -378,7 +377,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         int64_t o0__ssa_v1 = (ob * 256);
 
                         // Task 15: gate_proj
-                        Arg params_t15;
+                        L0TaskArgs params_t15;
                         params_t15.add_input(post_norm_tile__rv_v2);
                         params_t15.add_input(ext_w_gate);
                         params_t15.add_inout(ret0__out_1);
@@ -387,7 +386,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         const Tensor &gate_acc = ret0__out_1;
 
                         // Task 16: up_proj
-                        Arg params_t16;
+                        L0TaskArgs params_t16;
                         params_t16.add_input(post_norm_tile__rv_v2);
                         params_t16.add_input(ext_w_up);
                         params_t16.add_inout(ret0__out_2);
@@ -396,7 +395,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         const Tensor &up_acc = ret0__out_2;
 
                         // Task 17: silu
-                        Arg params_t17;
+                        L0TaskArgs params_t17;
                         params_t17.add_input(gate_acc);
                         params_t17.add_input(up_acc);
                         params_t17.add_inout(mlp_tile);
@@ -414,7 +413,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         int64_t d0 = (dob * 128);
 
                         // Task 18: down_proj
-                        Arg params_t18;
+                        L0TaskArgs params_t18;
                         params_t18.add_input(mlp_tile);
                         params_t18.add_input(ext_w_down);
                         params_t18.add_inout(fp32_chunk_gm);
@@ -423,7 +422,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         const Tensor &fp32_chunk_gm__ssa_v1 = fp32_chunk_gm;
 
                         // Task 19: down_proj_residual
-                        Arg params_t19;
+                        L0TaskArgs params_t19;
                         params_t19.add_input(fp32_chunk_gm__ssa_v1);
                         params_t19.add_input(resid1_tile);
                         params_t19.add_inout(next_hidden);
@@ -441,7 +440,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 int64_t cur_valid__ssa_v3 = std::min<int64_t>((user_batch - b0), 16);
 
                 // Task 20: copy_out
-                Arg params_t20;
+                L0TaskArgs params_t20;
                 params_t20.add_output(ext_out);
                 params_t20.add_input(current_hidden__ssa_v8);
                 params_t20.add_scalar(b0);

--- a/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/kernels/orchestration/scalar_data_orch.cpp
@@ -40,23 +40,22 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,  // a, b, result, check
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // External tensors from golden.py
-    Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_result = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_check = from_tensor_arg(orch_args.tensor(3));
+    const Tensor &ext_a = orch_args.tensor(0).ref();
+    const Tensor &ext_b = orch_args.tensor(1).ref();
+    const Tensor &ext_result = orch_args.tensor(2).ref();
+    const Tensor &ext_check = orch_args.tensor(3).ref();
 
-    uint32_t SIZE = orch_args.tensor(0).shapes[0];
-    LOG_INFO_V0("scalar_data_test: SIZE=%u, check_size=%u", SIZE, orch_args.tensor(3).shapes[0]);
+    uint32_t SIZE = orch_args.tensor(0).ref().shapes[0];
+    LOG_INFO_V0("scalar_data_test: SIZE=%u, check_size=%u", SIZE, orch_args.tensor(3).ref().shapes[0]);
 
     uint32_t inter_shapes[1] = {SIZE};
     TensorCreateInfo inter_ci(inter_shapes, 1, DataType::FLOAT32);
@@ -64,7 +63,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // =========================================================
     // Step 1: c = a + b (runtime-created tensor, kernel_add)
     // =========================================================
-    Arg params_c;
+    L0TaskArgs params_c;
     params_c.add_input(ext_a);
     params_c.add_input(ext_b);
     params_c.add_output(inter_ci);
@@ -119,7 +118,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     //   Buffer already exists, so the noop just registers dependency
     // =========================================================
     {
-        Arg args;
+        L0TaskArgs args;
         args.add_inout(scalar_tensor);
         rt_submit_aiv_task(FUNC_NOOP, args);
     }
@@ -170,7 +169,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     idx[0] = 0;
     set_tensor_data(d, 1, idx, 10.0f);
 
-    Arg params_e;
+    L0TaskArgs params_e;
     params_e.add_input(d);
     params_e.add_input(ext_a);
     params_e.add_output(inter_ci);
@@ -199,7 +198,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     //   instead of add_input() so TensorMap tracks the access chain.
     // =========================================================
     {
-        Arg args;
+        L0TaskArgs args;
         args.add_input(c);
         args.add_input(ext_b);
         args.add_output(inter_ci);
@@ -231,7 +230,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     //   set_tensor_data auto-waits for the noop to complete.
     // =========================================================
     {
-        Arg args;
+        L0TaskArgs args;
         args.add_output(ext_b);  // write-only: creates TensorMap entry (not add_input!)
         rt_submit_aiv_task(FUNC_NOOP, args);
     }
@@ -253,7 +252,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // Step 13: result = a + b (external output via add_output, kernel_add)
     // =========================================================
     {
-        Arg args;
+        L0TaskArgs args;
         args.add_input(ext_a);
         args.add_input(ext_b);
         args.add_output(ext_result);

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
@@ -17,34 +17,33 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-sdma_async_completion_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+sdma_async_completion_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 4};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     return sdma_async_completion_orchestration_config(orch_args);
 }
 
-__attribute__((visibility("default"))) void sdma_async_completion_orchestration(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void sdma_async_completion_orchestration(const L2TaskArgs &orch_args) {
     if (orch_args.tensor_count() + orch_args.scalar_count() != 4) {
         LOG_ERROR("sdma_async_completion_demo: expected 4 args");
         return;
     }
 
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor out = from_tensor_arg(orch_args.tensor(1));
-    Tensor result = from_tensor_arg(orch_args.tensor(2));
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &out = orch_args.tensor(1).ref();
+    const Tensor &result = orch_args.tensor(2).ref();
     auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
 
-    Arg producer_args;
+    L0TaskArgs producer_args;
     producer_args.add_input(input);
     producer_args.add_output(out);
     producer_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
     rt_submit_aiv_task(0, producer_args);
 
-    Arg consumer_args;
+    L0TaskArgs consumer_args;
     consumer_args.add_input(out);
     consumer_args.add_output(result);
     rt_submit_aiv_task(1, consumer_args);

--- a/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -39,8 +39,7 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
@@ -52,20 +51,20 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
  * The executor wraps this call in PTO2_SCOPE, so we are already inside
  * the outer scope on entry.
  */
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    // golden shape = kernel shape, use from_tensor_arg() directly
-    Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_f = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    // golden shape = kernel shape, use orch_args.tensor(i).ref() directly
+    const Tensor &ext_a = orch_args.tensor(0).ref();
+    const Tensor &ext_b = orch_args.tensor(1).ref();
+    const Tensor &ext_f = orch_args.tensor(2).ref();
 
-    uint32_t SIZE = orch_args.tensor(0).shapes[0];
+    uint32_t SIZE = orch_args.tensor(0).ref().shapes[0];
     LOG_INFO_V0("===============SIZE=%u", SIZE);
 
     uint32_t inter_shapes[1] = {SIZE};
     TensorCreateInfo inter_ci(inter_shapes, 1, DataType::FLOAT32);
 
     // t0: c = a + b (kernel_id=0, kernel_add) [outer scope]
-    Arg params_t0;
+    L0TaskArgs params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(inter_ci);
@@ -76,7 +75,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
     PTO2_SCOPE() {
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
-        Arg params_t1;
+        L0TaskArgs params_t1;
         params_t1.add_input(c);
         params_t1.add_output(inter_ci);
         params_t1.add_scalar(1.0f);
@@ -85,7 +84,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &d = outs_t1.get_ref(0);
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
-        Arg params_t2;
+        L0TaskArgs params_t2;
         params_t2.add_input(c);
         params_t2.add_output(inter_ci);
         params_t2.add_scalar(2.0f);
@@ -94,7 +93,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &e = outs_t2.get_ref(0);
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
-        Arg params_t3;
+        L0TaskArgs params_t3;
         params_t3.add_input(d);
         params_t3.add_input(e);
         params_t3.add_output(inter_ci);
@@ -103,7 +102,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &g = outs_t3.get_ref(0);
 
         // t4: f = g + c (kernel_id=0, kernel_add)
-        Arg params_t4;
+        L0TaskArgs params_t4;
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);

--- a/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/async_notify_demo/kernels/orchestration/async_notify_orchestration.cpp
@@ -17,29 +17,28 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-async_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+async_notify_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     return async_notify_orchestration_config(orch_args);
 }
 
-__attribute__((visibility("default"))) void async_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void async_notify_orchestration(const L2TaskArgs &orch_args) {
     if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
         LOG_ERROR("async_notify_demo: expected 5 args");
         return;
     }
 
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor result = from_tensor_arg(orch_args.tensor(2));
-    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &result = orch_args.tensor(2).ref();
+    const Tensor &notify_counter = orch_args.tensor(3).ref();
     auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
 
-    Arg params_producer;
+    L0TaskArgs params_producer;
     params_producer.add_input(input);
     params_producer.add_output(output);
     params_producer.add_scalar(notify_counter.buffer.addr);
@@ -48,14 +47,14 @@ __attribute__((visibility("default"))) void async_notify_orchestration(const Chi
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
-    Arg params_notify;
+    L0TaskArgs params_notify;
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
     TaskOutputTensors notify_outputs = rt_submit_aiv_task(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
-    Arg params_consumer;
+    L0TaskArgs params_consumer;
     params_consumer.add_input(notify_token);
     params_consumer.add_input(output);
     params_consumer.add_output(result);

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/orchestration/bgemm_orch.cpp
@@ -53,19 +53,18 @@ static constexpr uint32_t TILE_ELEMS = TILE * TILE;  // 4096 elements
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // 1D external tensors for the full A, B, C arrays
-    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_C = from_tensor_arg(orch_args.tensor(2));
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_C = orch_args.tensor(2).ref();
 
     LOG_INFO_V0("[bgemm_orch] Grid: %dx%dx%d, Batch: %d, Tile: %d", GRID_M, GRID_K, GRID_N, BATCH, TILE);
 
@@ -97,7 +96,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         Tensor B_view = ext_B.view(tile_shapes, b_view_offsets);
 
                         // P = A[m,k] @ B[k,n], then C[m,n] += P
-                        Arg args;
+                        L0TaskArgs args;
                         args.add_input(A_view);
                         args.add_input(B_view);
                         args.add_inout(C_view);

--- a/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/deferred_notify_demo/kernels/orchestration/deferred_notify_orch.cpp
@@ -17,31 +17,30 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-deferred_notify_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+deferred_notify_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     return deferred_notify_orchestration_config(orch_args);
 }
 
-__attribute__((visibility("default"))) void deferred_notify_orchestration(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void deferred_notify_orchestration(const L2TaskArgs &orch_args) {
     if (orch_args.tensor_count() + orch_args.scalar_count() != 5) {
         LOG_ERROR("deferred_notify_demo: expected 5 args");
         return;
     }
 
-    Tensor partial = from_tensor_arg(orch_args.tensor(0));
-    Tensor mailbox = from_tensor_arg(orch_args.tensor(1));
-    Tensor result = from_tensor_arg(orch_args.tensor(2));
-    Tensor notify_counter = from_tensor_arg(orch_args.tensor(3));
+    const Tensor &partial = orch_args.tensor(0).ref();
+    const Tensor &mailbox = orch_args.tensor(1).ref();
+    const Tensor &result = orch_args.tensor(2).ref();
+    const Tensor &notify_counter = orch_args.tensor(3).ref();
     auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
 
     uint32_t shapes[1] = {128 * 128};
     TensorCreateInfo producer_output_info(shapes, 1, DataType::FLOAT32);
-    Arg params_producer;
+    L0TaskArgs params_producer;
     params_producer.add_input(partial);
     params_producer.add_inout(mailbox);
     params_producer.add_output(producer_output_info);
@@ -51,14 +50,14 @@ __attribute__((visibility("default"))) void deferred_notify_orchestration(const 
 
     uint32_t notify_token_shape[1] = {1};
     TensorCreateInfo notify_token_info(notify_token_shape, 1, DataType::INT32);
-    Arg params_notify;
+    L0TaskArgs params_notify;
     params_notify.add_output(notify_token_info);
     params_notify.add_scalar(notify_counter.buffer.addr);
     params_notify.add_scalar(static_cast<uint64_t>(1));
     TaskOutputTensors notify_outputs = rt_submit_aiv_task(2, params_notify);
     Tensor notify_token = notify_outputs.get_ref(0);
 
-    Arg params_consumer;
+    L0TaskArgs params_consumer;
     params_consumer.add_input(notify_token);
     params_consumer.add_input(mailbox);
     params_consumer.add_output(result);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -61,15 +61,14 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void build_paged_attention_graph(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void build_paged_attention_graph(const L2TaskArgs &orch_args) {
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
     uint64_t prof_scope = 0;
@@ -84,13 +83,13 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     CYCLE_COUNT_START();
 
     // Read dimensions from tensor metadata
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     uint64_t scale_value = orch_args.scalar(0);
 
@@ -102,12 +101,12 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     LOG_INFO_V9(">>>>>> batch = %" PRIu64, batch);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -125,10 +124,10 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -183,7 +182,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     prof_view_count += 2;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg params_qk;
+                    L0TaskArgs params_qk;
                     params_qk.add_input(qi);
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
@@ -199,7 +198,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     prof_view_count += 1;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg params_sf;
+                    L0TaskArgs params_sf;
                     params_sf.add_input(sij_valid);
                     params_sf.add_output(pij_f16_ci);
                     params_sf.add_output(scalar_ci);
@@ -213,7 +212,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    Arg params_pv;
+                    L0TaskArgs params_pv;
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
@@ -227,7 +226,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    Arg params_up;
+                    L0TaskArgs params_up;
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_tmp);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -61,15 +61,14 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void build_paged_attention_graph(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void build_paged_attention_graph(const L2TaskArgs &orch_args) {
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
     uint64_t prof_scope = 0;
@@ -84,13 +83,13 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     CYCLE_COUNT_START();
 
     // Read dimensions from tensor metadata
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     uint64_t scale_value = orch_args.scalar(0);
 
@@ -102,12 +101,12 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     LOG_INFO_V9(">>>>>> batch = %" PRIu64, batch);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -125,10 +124,10 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // Create infos are loop-invariant — shapes depend only on q_tile/head_dim/block_size
     uint32_t tile2d_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
@@ -183,7 +182,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     prof_view_count += 2;
                     CYCLE_COUNT_LAP(prof_tensor_view);
 
-                    Arg params_qk;
+                    L0TaskArgs params_qk;
                     params_qk.add_input(qi);
                     params_qk.add_input(kj);
                     params_qk.add_output(sij_ci);
@@ -202,7 +201,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     // --- Primitive dep API (Arg + set_dependencies) ---
                     // Caller owns the deps buffer; Arg stores (ptr, count).
                     // Suited for codegen and for cases with a fixed dep set.
-                    Arg params_sf;
+                    L0TaskArgs params_sf;
                     params_sf.add_input(sij_valid);
                     params_sf.add_output(pij_f16_ci);
                     params_sf.add_output(scalar_ci);
@@ -218,7 +217,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     prof_submit_count++;
                     CYCLE_COUNT_LAP(prof_submit_task);
 
-                    Arg params_pv;
+                    L0TaskArgs params_pv;
                     params_pv.add_input(pij_f16);
                     params_pv.add_input(vj);
                     params_pv.add_output(tile2d_ci);
@@ -234,13 +233,13 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                     uint64_t is_last = (bn == bn_this_batch - 1) ? 1 : 0;
                     CYCLE_COUNT_LAP(prof_param_extract);
 
-                    // --- Convenience dep API (ArgWithDeps + add_dep) ---
+                    // --- Convenience dep API (L0TaskArgsWithDeps + add_dep) ---
                     // Wrapper owns a stack-sized deps buffer and accepts
                     // incremental add_dep() calls; the submit overload binds
                     // them to the underlying Arg via set_dependencies(...).
                     // Suited for hand-written orch where the dep set is
                     // assembled conditionally across branches.
-                    ArgWithDeps<> params_up;
+                    L0TaskArgsWithDeps<> params_up;
                     params_up.add_input(mi);
                     params_up.add_input(li);
                     params_up.add_input(oi_tmp);

--- a/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/paged_attention_unroll_manual_scope/kernels/orchestration/paged_attention_orch.cpp
@@ -70,15 +70,14 @@ inline uint64_t get_sys_cnt_aicpu() {
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void build_paged_attention_graph(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void build_paged_attention_graph(const L2TaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
@@ -94,13 +93,13 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
 
     CYCLE_COUNT_START();
 
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     uint64_t scale_value = orch_args.scalar(0);
     uint64_t q_head_num = num_heads;
@@ -108,12 +107,12 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
     CYCLE_COUNT_LAP(prof_param_extract);
 
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -130,10 +129,10 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
@@ -179,7 +178,7 @@ __attribute__((visibility("default"))) void build_paged_attention_graph(const Ch
                 CYCLE_COUNT_LAP(prof_submit_task);
 #endif
 
-                Arg params_qk, params_sf, params_pv, params_up;
+                L0TaskArgs params_qk, params_sf, params_pv, params_up;
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
                     uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);

--- a/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/vector_example/kernels/orchestration/example_orchestration.cpp
@@ -39,8 +39,7 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
@@ -52,20 +51,20 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
  * The executor wraps this call in PTO2_SCOPE, so we are already inside
  * the outer scope on entry.
  */
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    // golden shape = kernel shape, use from_tensor_arg() directly
-    Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_f = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    // golden shape = kernel shape, use orch_args.tensor(i).ref() directly
+    const Tensor &ext_a = orch_args.tensor(0).ref();
+    const Tensor &ext_b = orch_args.tensor(1).ref();
+    const Tensor &ext_f = orch_args.tensor(2).ref();
 
-    uint32_t SIZE = orch_args.tensor(0).shapes[0];
+    uint32_t SIZE = orch_args.tensor(0).ref().shapes[0];
     LOG_INFO_V0("===============SIZE=%u", SIZE);
 
     uint32_t inter_shapes[1] = {SIZE};
     TensorCreateInfo inter_ci(inter_shapes, 1, DataType::FLOAT32);
 
     // t0: c = a + b (kernel_id=0, kernel_add) [outer scope]
-    Arg params_t0;
+    L0TaskArgs params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(inter_ci);
@@ -76,7 +75,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // c flows in from outer scope (outer-scope tensors are visible to inner scopes).
     PTO2_SCOPE() {
         // t1: d = c + 1 (kernel_id=1, kernel_add_scalar)
-        Arg params_t1;
+        L0TaskArgs params_t1;
         params_t1.add_input(c);
         params_t1.add_output(inter_ci);
         params_t1.add_scalar(1.0f);
@@ -85,7 +84,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &d = outs_t1.get_ref(0);
 
         // t2: e = c + 2 (kernel_id=1, kernel_add_scalar)
-        Arg params_t2;
+        L0TaskArgs params_t2;
         params_t2.add_input(c);
         params_t2.add_output(inter_ci);
         params_t2.add_scalar(2.0f);
@@ -94,7 +93,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &e = outs_t2.get_ref(0);
 
         // t3: g = d * e (kernel_id=2, kernel_mul)
-        Arg params_t3;
+        L0TaskArgs params_t3;
         params_t3.add_input(d);
         params_t3.add_input(e);
         params_t3.add_output(inter_ci);
@@ -103,7 +102,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         const Tensor &g = outs_t3.get_ref(0);
 
         // t4: f = g + c (kernel_id=0, kernel_add)
-        Arg params_t4;
+        L0TaskArgs params_t4;
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);

--- a/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l2/vector_add/kernels/orchestration/vector_add_orch.cpp
@@ -25,19 +25,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-vector_add_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+vector_add_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,  // a, b, out
     };
 }
 
-__attribute__((visibility("default"))) void vector_add_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor a = from_tensor_arg(orch_args.tensor(0));
-    Tensor b = from_tensor_arg(orch_args.tensor(1));
-    Tensor out = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void vector_add_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &a = orch_args.tensor(0).ref();
+    const Tensor &b = orch_args.tensor(1).ref();
+    const Tensor &out = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(a);
     params.add_input(b);
     params.add_output(out);

--- a/examples/workers/l3/all_to_all_distributed/kernels/orchestration/all_to_all_orch.cpp
+++ b/examples/workers/l3/all_to_all_distributed/kernels/orchestration/all_to_all_orch.cpp
@@ -25,19 +25,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-all_to_all_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+all_to_all_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void all_to_all_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void all_to_all_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/allgather_distributed/kernels/orchestration/allgather_orch.cpp
+++ b/examples/workers/l3/allgather_distributed/kernels/orchestration/allgather_orch.cpp
@@ -25,19 +25,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-allgather_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+allgather_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void allgather_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void allgather_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_onephase_orch.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_onephase_orch.cpp
@@ -32,19 +32,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-allreduce_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+allreduce_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void allreduce_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void allreduce_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_ring_orch.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_ring_orch.cpp
@@ -31,19 +31,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-allreduce_ring_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+allreduce_ring_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void allreduce_ring_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void allreduce_ring_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_twophase_orch.cpp
+++ b/examples/workers/l3/allreduce_distributed/kernels/orchestration/allreduce_twophase_orch.cpp
@@ -31,19 +31,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-allreduce_twophase_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+allreduce_twophase_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void allreduce_twophase_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void allreduce_twophase_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/broadcast_distributed/kernels/orchestration/broadcast_orch.cpp
+++ b/examples/workers/l3/broadcast_distributed/kernels/orchestration/broadcast_orch.cpp
@@ -26,19 +26,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-broadcast_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+broadcast_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 6,  // 3 tensors + 3 scalars
     };
 }
 
-__attribute__((visibility("default"))) void broadcast_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void broadcast_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/dual_domain_overlap/kernels/orchestration/affine_orch.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/orchestration/affine_orch.cpp
@@ -16,18 +16,18 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-affine_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+affine_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 4};
 }
 
-__attribute__((visibility("default"))) void affine_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor reduce_out = from_tensor_arg(orch_args.tensor(0));
-    Tensor scale = from_tensor_arg(orch_args.tensor(1));
-    Tensor bias = from_tensor_arg(orch_args.tensor(2));
-    Tensor out = from_tensor_arg(orch_args.tensor(3));
+__attribute__((visibility("default"))) void affine_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &reduce_out = orch_args.tensor(0).ref();
+    const Tensor &scale = orch_args.tensor(1).ref();
+    const Tensor &bias = orch_args.tensor(2).ref();
+    const Tensor &out = orch_args.tensor(3).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(reduce_out);
     params.add_input(scale);
     params.add_input(bias);

--- a/examples/workers/l3/dual_domain_overlap/kernels/orchestration/domain_allreduce_orch.cpp
+++ b/examples/workers/l3/dual_domain_overlap/kernels/orchestration/domain_allreduce_orch.cpp
@@ -16,17 +16,17 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-domain_allreduce_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+domain_allreduce_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 5};
 }
 
-__attribute__((visibility("default"))) void domain_allreduce_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void domain_allreduce_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/examples/workers/l3/ep_dispatch_combine/kernels/orchestration/ep_dispatch_combine_orch.cpp
+++ b/examples/workers/l3/ep_dispatch_combine/kernels/orchestration/ep_dispatch_combine_orch.cpp
@@ -51,29 +51,29 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-ep_dispatch_combine_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+ep_dispatch_combine_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 13,  // 11 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void ep_dispatch_combine_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor indices = from_tensor_arg(orch_args.tensor(0));
-    Tensor x_norm = from_tensor_arg(orch_args.tensor(1));
-    Tensor w_padded = from_tensor_arg(orch_args.tensor(2));
-    Tensor idx_padded = from_tensor_arg(orch_args.tensor(3));
-    Tensor recv_x_out = from_tensor_arg(orch_args.tensor(4));
-    Tensor recv_w_out = from_tensor_arg(orch_args.tensor(5));
-    Tensor recv_idx_out = from_tensor_arg(orch_args.tensor(6));
-    Tensor recv_count_out = from_tensor_arg(orch_args.tensor(7));
-    Tensor recv_y = from_tensor_arg(orch_args.tensor(8));
-    Tensor routed_y = from_tensor_arg(orch_args.tensor(9));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(10));
+__attribute__((visibility("default"))) void ep_dispatch_combine_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &indices = orch_args.tensor(0).ref();
+    const Tensor &x_norm = orch_args.tensor(1).ref();
+    const Tensor &w_padded = orch_args.tensor(2).ref();
+    const Tensor &idx_padded = orch_args.tensor(3).ref();
+    const Tensor &recv_x_out = orch_args.tensor(4).ref();
+    const Tensor &recv_w_out = orch_args.tensor(5).ref();
+    const Tensor &recv_idx_out = orch_args.tensor(6).ref();
+    const Tensor &recv_count_out = orch_args.tensor(7).ref();
+    const Tensor &recv_y = orch_args.tensor(8).ref();
+    const Tensor &routed_y = orch_args.tensor(9).ref();
+    const Tensor &scratch = orch_args.tensor(10).ref();
 
     // child 0: dispatch
     {
-        Arg p;
+        L0TaskArgs p;
         p.add_input(indices);
         p.add_input(x_norm);
         p.add_input(w_padded);
@@ -90,7 +90,7 @@ __attribute__((visibility("default"))) void ep_dispatch_combine_orchestration(co
 
     // child 1: local_expert (pure local, host-backed I/O only — no scratch)
     {
-        Arg p;
+        L0TaskArgs p;
         p.add_input(recv_x_out);
         p.add_input(recv_w_out);
         p.add_input(recv_count_out);
@@ -101,7 +101,7 @@ __attribute__((visibility("default"))) void ep_dispatch_combine_orchestration(co
 
     // child 2: combine (push to routed_y_buf in scratch, barrier, reduce_sum)
     {
-        Arg p;
+        L0TaskArgs p;
         p.add_input(recv_y);
         p.add_input(recv_idx_out);
         p.add_output(routed_y);

--- a/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/allreduce_sum_orch.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/allreduce_sum_orch.cpp
@@ -25,17 +25,17 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-allreduce_sum_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+allreduce_sum_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 5};  // 3 tensors + 2 scalars
 }
 
-__attribute__((visibility("default"))) void allreduce_sum_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor partial_local = from_tensor_arg(orch_args.tensor(0));
-    Tensor y = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void allreduce_sum_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &partial_local = orch_args.tensor(0).ref();
+    const Tensor &y = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(partial_local);
     params.add_output(y);
     params.add_inout(scratch);

--- a/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/ffn_local_orch.cpp
+++ b/examples/workers/l3/ffn_tp_parallel/kernels/orchestration/ffn_local_orch.cpp
@@ -23,17 +23,17 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-ffn_local_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+ffn_local_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 3};
 }
 
-__attribute__((visibility("default"))) void ffn_local_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor x_shard = from_tensor_arg(orch_args.tensor(0));
-    Tensor w_shard = from_tensor_arg(orch_args.tensor(1));
-    Tensor partial_local = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void ffn_local_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &x_shard = orch_args.tensor(0).ref();
+    const Tensor &w_shard = orch_args.tensor(1).ref();
+    const Tensor &partial_local = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(x_shard);
     params.add_input(w_shard);
     params.add_output(partial_local);

--- a/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
+++ b/examples/workers/l3/multi_chip_dispatch/kernels/orchestration/vector_add_orch.cpp
@@ -25,19 +25,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-vector_add_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+vector_add_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,  // a, b, out
     };
 }
 
-__attribute__((visibility("default"))) void vector_add_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor a = from_tensor_arg(orch_args.tensor(0));
-    Tensor b = from_tensor_arg(orch_args.tensor(1));
-    Tensor out = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void vector_add_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &a = orch_args.tensor(0).ref();
+    const Tensor &b = orch_args.tensor(1).ref();
+    const Tensor &out = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(a);
     params.add_input(b);
     params.add_output(out);

--- a/examples/workers/l3/reduce_scatter_distributed/kernels/orchestration/reduce_scatter_orch.cpp
+++ b/examples/workers/l3/reduce_scatter_distributed/kernels/orchestration/reduce_scatter_orch.cpp
@@ -25,19 +25,19 @@
 extern "C" {
 
 __attribute__((visibility("default"))) PTO2OrchestrationConfig
-reduce_scatter_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+reduce_scatter_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,  // 3 tensors + 2 scalars
     };
 }
 
-__attribute__((visibility("default"))) void reduce_scatter_orchestration(const ChipStorageTaskArgs &orch_args) {
-    Tensor input = from_tensor_arg(orch_args.tensor(0));
-    Tensor output = from_tensor_arg(orch_args.tensor(1));
-    Tensor scratch = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void reduce_scatter_orchestration(const L2TaskArgs &orch_args) {
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &output = orch_args.tensor(1).ref();
+    const Tensor &scratch = orch_args.tensor(2).ref();
 
-    Arg params;
+    L0TaskArgs params;
     params.add_input(input);
     params.add_output(output);
     params.add_inout(scratch);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -61,11 +61,11 @@
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
-typedef void (*DeviceOrchestrationFunc)(const ChipStorageTaskArgs &orch_args);
+typedef void (*DeviceOrchestrationFunc)(const L2TaskArgs &orch_args);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
+typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const L2TaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
@@ -132,9 +132,9 @@ struct AicpuExecutor {
     // Default-constructed: libc-backed backend, no ctx.
     DeviceArena runtime_arena_;
 
-    // Cached orch args pointer set by the orchestration thread before scheduler
-    // init; consumed by the (*p_func)(*orch_args_cached_) invocation below.
-    const ChipStorageTaskArgs *orch_args_cached_{nullptr};
+    // Entry-arg L2TaskArgs built (via create_from_chip_args) from get_orch_args()
+    // before scheduler init; consumed by the (*p_func)(orch_args_cached_) below.
+    L2TaskArgs orch_args_cached_;
 
     // Per-callable_id table. Single orch thread today, so first-write/read
     // race is not possible; if multiple orch threads are ever introduced,
@@ -398,9 +398,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 }
             }
 
+            // Build the entry-arg once per run; both the config call below and
+            // the orchestration entry (consumed at orch_args_cached_) use it.
+            orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
+
             // Validate arg count on every run (reload or cache hit).
             if (*p_config_func != nullptr) {
-                PTO2OrchestrationConfig cfg = (*p_config_func)(runtime->get_orch_args());
+                PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                 LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                 if (cfg.expected_arg_count > 0) {
                     const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
@@ -523,8 +527,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // With multi-ring, slot_states are per-ring inside the scheduler.
             runtime->set_slot_states_ptr(nullptr);
 
-            orch_args_cached_ = &args;
-
             // Wire scheduler context to the newly created PTO2Runtime before
             // releasing scheduler threads from runtime_init_ready_.
             sched_ctx_.bind_runtime(rt);
@@ -564,7 +566,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 (*p_bind)(rt);
             }
             rt_scope_begin(rt);
-            (*p_func)(*orch_args_cached_);
+            (*p_func)(orch_args_cached_);
             rt_scope_end(rt);
 
             // Flush the (potentially partially-filled) DepGenBuffer so the host
@@ -758,7 +760,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
 
-    orch_args_cached_ = nullptr;
+    orch_args_cached_.reset();
     // orch_so_table_ entries are intentionally preserved across deinit: the
     // next run reuses cached handles when register_new_callable_id() returns
     // false. The destructor releases them at process teardown.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -60,7 +60,7 @@ args.add_output(ci);
 **Mechanism**:
 
 1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
-2. `add_output(ci)` stores a pointer to `ci` in `Arg` (the original must remain valid until submit)
+2. `add_output(ci)` stores a pointer to `ci` in `L0TaskArgs` (the original must remain valid until submit)
 3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
 4. Fill strategy:
    - Small buffer (< 64 B): element-by-element memcpy directly into dst
@@ -70,7 +70,7 @@ args.add_output(ci);
 
 ## 5. Scalar Dependencies via 1-Element Tensors
 
-Traditional scalars (`Arg::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
+Traditional scalars (`L0TaskArgs::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
 
 ```cpp
 uint32_t shapes[1] = {1};
@@ -78,7 +78,7 @@ TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
 // Submit with initial value and keep the returned tensor
 scalar_ci.set_initial_value(float_to_u64(77.0f));
-Arg args;
+L0TaskArgs args;
 args.add_output(scalar_ci);
 TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
 const Tensor& scalar_tensor = outs.get_ref(0);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -413,7 +413,7 @@ void annot_pass(
         if (ptype == TensorArgType::OUTPUT) {
             continue;
         }
-        const Tensor *tensor = inputs.tensors[i].ptr;
+        const Tensor *tensor = &inputs.tensors[i].ref();
 
         // STEP A: creator retention.
         PTO2TaskId owner = tensor->owner_task_id;
@@ -543,7 +543,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
             tc = CORE_MAX_TENSOR_ARGS;
         }
         for (int32_t i = 0; i < tc; i++) {
-            tref_buf[i].ptr = reinterpret_cast<const Tensor *>(&rec.tensors[i][0]);
+            tref_buf[i] = reinterpret_cast<const Tensor *>(&rec.tensors[i][0]);
             atype_buf[i] = static_cast<TensorArgType>(rec.arg_types[i]);
         }
 
@@ -653,7 +653,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 // a placeholder "alloc" output slot.
                 slot.has_tensor_info = false;
             } else {
-                const Tensor &t = *tref_buf[i].ptr;
+                const Tensor &t = tref_buf[i].ref();
                 register_tensor(tensor_index, tensor_table, t);
                 slot.has_tensor_info = true;
                 slot.tensor_id = make_tensor_id(t.buffer.addr, t.version);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -9,7 +9,6 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 #include "common.h"
-#include "pto_orchestration_api.h"
 
 #ifdef __linux__
 #include <cxxabi.h>
@@ -23,6 +22,14 @@
 #endif
 
 struct PTO2Runtime;
+
+// Unified-log error sink. Forward-declared here rather than pulled via
+// common/unified_log.h: that header lives under common/log/include, which is
+// not on the orchestration .so build's include path. The symbol resolves at
+// link time for the runtime targets, and at dlopen time for the orchestration
+// .so (against the executor's unified_log_device), so onboard diagnostics still
+// reach the CANN device log.
+extern "C" void unified_log_error(const char *func, const char *fmt, ...);
 
 namespace {
 // Plain global (not thread_local) to avoid glibc TLSDESC stale-resolution
@@ -174,11 +181,17 @@ AssertionError::AssertionError(const char *condition, const char *file, int line
     line_(line) {}
 
 [[noreturn]] void assert_impl(const char *condition, const char *file, int line) {
-    LOG_ERROR("\n========================================");
-    LOG_ERROR("Assertion failed: %s", condition);
-    LOG_ERROR("Location: %s:%d", file, line);
-    LOG_ERROR("%s", get_stacktrace(2).c_str());
-    LOG_ERROR("========================================\n");
+    // Use unified_log_error directly rather than the LOG_ERROR macro: that macro
+    // lives in pto_orchestration_api.h and expands to
+    // current_runtime()->ops->log_error, but the ops table's definition pulls in
+    // pto_types.h (Arg → __aicore__-only to_u64), which the AICore build of this
+    // TU cannot compile. unified_log_error reaches the same sink without that
+    // dependency.
+    unified_log_error(__FUNCTION__, "\n========================================");
+    unified_log_error(__FUNCTION__, "Assertion failed: %s", condition);
+    unified_log_error(__FUNCTION__, "Location: %s:%d", file, line);
+    unified_log_error(__FUNCTION__, "%s", get_stacktrace(2).c_str());
+    unified_log_error(__FUNCTION__, "========================================\n");
 
     throw AssertionError(condition, file, line);
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
@@ -11,24 +11,24 @@
 /**
  * Convenience layer over Arg: bundles a fixed-capacity dependency buffer with
  * an Arg and exposes an incremental add_dep(...) API on top of the runtime
- * primitive Arg::set_dependencies(ptr, count).
+ * primitive L0TaskArgs::set_dependencies(ptr, count).
  *
  * Layering:
  *   - Primitive:   Arg + set_dependencies(ptr, count) in pto_types.h.
  *                  No cap, caller owns the deps buffer.
- *   - Convenience: ArgWithDeps<N> in this header. Owns a stack-sized dep
+ *   - Convenience: L0TaskArgsWithDeps<N> in this header. Owns a stack-sized dep
  *                  buffer of capacity N (default 16); provides add_dep().
  *                  Submitted via the rt_submit_*_task overloads below, which
  *                  forward the bundled deps into the underlying Arg.
  *
  * This file is auto-included at the bottom of pto_orchestration_api.h so
- * orchestration sources see ArgWithDeps after a single `#include
+ * orchestration sources see L0TaskArgsWithDeps after a single `#include
  * "pto_orchestration_api.h"`. The split is purely organizational —
  * orchestration code should not include this header directly. Code generated
  * from pypto can ignore the convenience layer entirely and target Arg +
  * set_dependencies(ptr, count) directly.
  *
- * ArgWithDeps uses private inheritance from Arg so that set_dependencies and
+ * L0TaskArgsWithDeps uses private inheritance from Arg so that set_dependencies and
  * the explicit_dep* accessors are NOT reachable on a wrapper instance — users
  * who pick the convenience layer cannot accidentally mix it with the
  * primitive layer's dep API on the same object.
@@ -44,25 +44,25 @@
 #include "pto_orchestration_api.h"  // Arg, MixedKernels, rt_submit_* primitives
 
 template <size_t MAX_DEP_COUNT = 16>
-class ArgWithDeps : private Arg {
+class L0TaskArgsWithDeps : private L0TaskArgs {
 public:
     // Tensor / scalar setters — forward to Arg
-    using Arg::add_inout;
-    using Arg::add_input;
-    using Arg::add_no_dep;
-    using Arg::add_output;
-    using Arg::add_scalar;
-    using Arg::add_scalars;
-    using Arg::add_scalars_i32;
-    using Arg::allow_early_resolve;  // speculative early-dispatch hint (getter)
-    using Arg::copy_scalars_from;
-    using Arg::set_allow_early_resolve;  // speculative early-dispatch hint (setter)
+    using L0TaskArgs::add_inout;
+    using L0TaskArgs::add_input;
+    using L0TaskArgs::add_no_dep;
+    using L0TaskArgs::add_output;
+    using L0TaskArgs::add_scalar;
+    using L0TaskArgs::add_scalars;
+    using L0TaskArgs::add_scalars_i32;
+    using L0TaskArgs::allow_early_resolve;  // speculative early-dispatch hint (getter)
+    using L0TaskArgs::copy_scalars_from;
+    using L0TaskArgs::set_allow_early_resolve;  // speculative early-dispatch hint (setter)
 
     // Error / status — forward to Arg
-    using Arg::error_msg;
-    using Arg::has_error;
-    using Arg::launch_spec;
-    using Arg::set_error;
+    using L0TaskArgs::error_msg;
+    using L0TaskArgs::has_error;
+    using L0TaskArgs::launch_spec;
+    using L0TaskArgs::set_error;
 
     // NOT exposed: set_dependencies, explicit_dep_count, explicit_dep,
     // explicit_deps_data — these are the primitive-layer dep API. Users of
@@ -83,7 +83,9 @@ public:
             (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
         );
         if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
-            Arg::set_error("ArgWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)");
+            L0TaskArgs::set_error(
+                "L0TaskArgsWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)"
+            );
             return;
         }
         ((deps_[count_++] = ids), ...);
@@ -91,10 +93,10 @@ public:
 
     /**
      * Clear the bundled dep buffer and reset the underlying Arg.
-     * Use this to recycle an ArgWithDeps across loop iterations.
+     * Use this to recycle an L0TaskArgsWithDeps across loop iterations.
      */
     void reset() {
-        Arg::reset();
+        L0TaskArgs::reset();
         count_ = 0;
     }
 
@@ -107,9 +109,9 @@ public:
      * so a wrapper can be re-finalized (e.g. resubmitted) without tripping
      * the primitive layer's single-shot check.
      */
-    Arg &finalize_for_submit() {
-        Arg::set_dependencies(nullptr, 0);
-        Arg::set_dependencies(deps_, count_);
+    L0TaskArgs &finalize_for_submit() {
+        L0TaskArgs::set_dependencies(nullptr, 0);
+        L0TaskArgs::set_dependencies(deps_, count_);
         return *this;
     }
 
@@ -119,20 +121,20 @@ private:
 };
 
 // =============================================================================
-// Submit overloads — accept ArgWithDeps<N> transparently
+// Submit overloads — accept L0TaskArgsWithDeps<N> transparently
 // =============================================================================
 
 template <size_t N>
-static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, ArgWithDeps<N> &awd) {
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, L0TaskArgsWithDeps<N> &awd) {
     return rt_submit_task(mixed_kernels, awd.finalize_for_submit());
 }
 
 template <size_t N>
-static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, L0TaskArgsWithDeps<N> &awd) {
     return rt_submit_aic_task(kernel_id, awd.finalize_for_submit());
 }
 
 template <size_t N>
-static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, L0TaskArgsWithDeps<N> &awd) {
     return rt_submit_aiv_task(kernel_id, awd.finalize_for_submit());
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -33,6 +33,7 @@
 #include <type_traits>
 
 // Type headers needed by orchestration
+#include "common.h"              // framework_bind_runtime / framework_current_runtime
 #include "pto_runtime2_types.h"  // PTO2_ERROR_*
 #include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
 #include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType
@@ -47,21 +48,6 @@
 // memory — is defined in the unified tensor.h (common), so host and runtime
 // build Tensors through the same controlled path.
 
-// Adapt an orchestration-arg Tensor into a runtime Tensor, optionally setting
-// creator-only dependency tracking (manual_dep) and an initial version. Since
-// TaskArgs now carries Tensor directly, this is a copy with those two fields
-// applied; buffer / shapes / strides / start_offset / child_memory are kept.
-// Precondition: `t` is an external, submit-time tensor (owner_task_id invalid,
-// start_offset 0, contiguous) — the construction path enforces this. The copy
-// therefore preserves owner_task_id, which is equivalent to the former
-// make_tensor_external rebuild (it forced owner invalid) for every caller.
-inline Tensor from_tensor_arg(const Tensor &t, bool manual_dep = false, int32_t version = 0) {
-    Tensor result = t;
-    result.manual_dep = manual_dep;
-    result.version = version;
-    return result;
-}
-
 // =============================================================================
 // Ops Table and Opaque Runtime
 // =============================================================================
@@ -73,30 +59,12 @@ inline Tensor from_tensor_arg(const Tensor &t, bool manual_dep = false, int32_t 
  */
 typedef struct PTO2Runtime PTO2Runtime;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * Framework-internal TLS bridge.
- *
- * The executor binds the current thread's runtime before invoking
- * aicpu_orchestration_entry(), so orchestration helpers can fetch the
- * current PTO2Runtime without explicit parameter threading.
- */
-PTO2Runtime *framework_current_runtime(void);
-void framework_bind_runtime(PTO2Runtime *rt);
-
-#ifdef __cplusplus
-}
-#endif
-
 /**
  * Function-pointer table for runtime operations.
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const L0TaskArgs &args);
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
@@ -116,8 +84,8 @@ typedef struct PTO2RuntimeOps {
     void (*set_tensor_data)(
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -144,7 +112,7 @@ struct PTO2Runtime {
 
 static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
 
-static inline TaskOutputTensors alloc_tensors(const Arg &args) {
+static inline TaskOutputTensors alloc_tensors(const L0TaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -157,7 +125,7 @@ static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_info
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
-    Arg args;
+    L0TaskArgs args;
     for (uint32_t i = 0; i < count; i++) {
         args.add_output(create_infos[i]);
     }
@@ -182,7 +150,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
-    Arg args;
+    L0TaskArgs args;
     (args.add_output(cis), ...);
     if (args.has_error) {
         rt->ops->report_fatal(
@@ -194,7 +162,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
     return alloc_tensors(args);
 }
 
-static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const L0TaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -205,7 +173,7 @@ static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const L0TaskArgs &args) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt_submit_task(mk, args);
@@ -214,7 +182,7 @@ static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const Arg 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const L0TaskArgs &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt_submit_task(mk, args);
@@ -227,7 +195,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg 
  * waits on its fanin and notifies its fanout. Useful as a synchronization
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
-static inline TaskOutputTensors rt_submit_dummy_task(const Arg &args) {
+static inline TaskOutputTensors rt_submit_dummy_task(const L0TaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -410,8 +378,8 @@ struct PTO2OrchestrationConfig {
 };
 #endif
 
-// Convenience layer (ArgWithDeps<N> + matching rt_submit_*_task overloads).
-// Pulled in at the bottom so the wrapper sees Arg, MixedKernels, and the
+// Convenience layer (L0TaskArgsWithDeps<N> + matching rt_submit_*_task overloads).
+// Pulled in at the bottom so the wrapper sees L0TaskArgs, MixedKernels, and the
 // rt_submit_*_task primitives defined above. Orchestration sources include
 // only this single header to access both the primitive and convenience APIs.
 #include "pto_arg_with_deps.h"  // NOLINT(build/include_subdir)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -20,3 +20,20 @@
 // on this runtime-specific header. assert_impl / get_stacktrace are defined in
 // orchestration/common.cpp for runtime targets.
 #include "assert_compat.h"
+
+// Framework-internal TLS bridge. The executor binds the current thread's
+// runtime before invoking the orchestration entry, so orchestration helpers can
+// fetch the current PTO2Runtime without explicit parameter threading. Declared
+// here (rather than in pto_orchestration_api.h) so framework TUs the AICore
+// build also compiles — notably orchestration/common.cpp — see these symbols
+// without pulling in pto_types.h, whose Arg::add_scalar → to_u64 path is
+// __aicore__-only and would break the ccec build.
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct PTO2Runtime;
+PTO2Runtime *framework_current_runtime(void);
+void framework_bind_runtime(PTO2Runtime *rt);
+#ifdef __cplusplus
+}
+#endif

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -36,8 +36,8 @@
 
 #include <stdint.h>
 
+#include "arg_direction.h"
 #include "intrinsic.h"
-#include "pto_types.h"
 
 /** Max dispatch arguments: 16 scalars + up to 32 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
@@ -92,7 +92,7 @@ compute_task_fanin(const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_m
             continue;
         }
 
-        const Tensor *tensor = inputs.tensors[i].ptr;
+        const Tensor *tensor = &inputs.tensors[i].ref();
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
         PTO2TaskId owner = tensor->owner_task_id;
@@ -144,7 +144,7 @@ register_task_outputs(const DepInputs &inputs, PTO2TaskId task_id, PTO2TensorMap
     for (int32_t i = 0; i < inputs.tensor_count; i++) {
         TensorArgType ptype = inputs.arg_types[i];
         if (ptype == TensorArgType::INOUT || ptype == TensorArgType::OUTPUT_EXISTING) {
-            const Tensor *tensor = inputs.tensors[i].ptr;
+            const Tensor *tensor = &inputs.tensors[i].ref();
             if (!tensor->manual_dep) {
                 tensor_map.insert(*tensor, task_id);
             }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -307,7 +307,7 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
-static PTO2OutputLayout calculate_output_layout(const Arg &args) {
+static PTO2OutputLayout calculate_output_layout(const L0TaskArgs &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) != TensorArgType::OUTPUT) {
@@ -315,7 +315,7 @@ static PTO2OutputLayout calculate_output_layout(const Arg &args) {
         }
         layout.offsets[i] = layout.total_output_size;
         layout.buffer_sizes[i] =
-            PTO2_ALIGN_UP(args.tensor(i).create_info->buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
+            PTO2_ALIGN_UP(args.tensor(i).create_info().buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
         layout.total_output_size += layout.buffer_sizes[i];
     }
     return layout;
@@ -355,7 +355,7 @@ static bool check_scope_can_accept_task(PTO2OrchestratorState *orch, PTO2TaskAll
 }
 
 static bool prepare_task(
-    PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, ActiveMask active_mask,
+    PTO2OrchestratorState *orch, const L0TaskArgs &args, int32_t total_output_size, ActiveMask active_mask,
     PTO2PreparedTask *out
 ) {
     uint8_t ring_id = orch->current_ring_id();
@@ -530,8 +530,8 @@ void PTO2OrchestratorState::end_scope() {
 // computation (explicit_deps + auto), output registration, slot init, and pushes
 // to the scheduler wiring queue.
 static TaskOutputTensors submit_task_common(
-    PTO2OrchestratorState *orch, const Arg &args, ActiveMask active_mask, int32_t aic_kernel_id, int32_t aiv0_kernel_id,
-    int32_t aiv1_kernel_id
+    PTO2OrchestratorState *orch, const L0TaskArgs &args, ActiveMask active_mask, int32_t aic_kernel_id,
+    int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
     CYCLE_COUNT_START();
     TaskOutputTensors result;
@@ -572,7 +572,7 @@ static TaskOutputTensors submit_task_common(
             // OUTPUT slots carry create_info (not yet a Tensor); skip them —
             // they have no producer to look up and replay's per-tensor loop
             // also skips OUTPUT.
-            tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : args.tensor(i).ptr;
+            tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : &args.tensor(i).ref();
             arg_types_u8[i] = static_cast<uint8_t>(args.tag(i));
         }
         const int32_t kernel_ids_capture[3] = {aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id};
@@ -723,7 +723,7 @@ static TaskOutputTensors submit_task_common(
     return result;
 }
 
-TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const L0TaskArgs &args) {
     auto *orch = this;
 
     // Orchestration API should short-circuit after fatal, but keep this entry
@@ -794,7 +794,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
 // AICore dispatch. Empty active_mask routes the slot to the DUMMY ready
 // bucket; dispatch loop short-circuits to completion. Accepts the same Arg
 // shape as submit_task; scalars are permitted but never consumed.
-TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const L0TaskArgs &args) {
     auto *orch = this;
 
     if (orch->fatal) {
@@ -816,7 +816,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const Arg &args) {
     return submit_task_common(orch, args, ActiveMask{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID);
 }
 
-TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const L0TaskArgs &args) {
     auto *orch = this;
     // Orchestration API should short-circuit after fatal, but keep this entry
     // robust as a no-op in case a caller reaches it directly.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -174,9 +174,9 @@ struct PTO2OrchestratorState {
     void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
     void end_scope();
-    TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const Arg &args);
-    TaskOutputTensors submit_dummy_task(const Arg &args);
-    TaskOutputTensors alloc_tensors(const Arg &args);
+    TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const L0TaskArgs &args);
+    TaskOutputTensors submit_dummy_task(const L0TaskArgs &args);
+    TaskOutputTensors alloc_tensors(const L0TaskArgs &args);
     void mark_done();
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -41,15 +41,15 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
+static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const L0TaskArgs &args) {
     return rt->orchestrator.submit_task(mixed_kernels, args);
 }
 
-static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
+static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const L0TaskArgs &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
-static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const Arg &args) {
+static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const L0TaskArgs &args) {
     return rt->orchestrator.submit_dummy_task(args);
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -67,7 +67,7 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const L0TaskArgs &args);
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
@@ -87,8 +87,8 @@ struct PTO2RuntimeOps {
     void (*set_tensor_data)(
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present in the struct to keep ops-table layout stable
     // across PTO2_PROFILING settings; set to nullptr at PTO2_PROFILING=0.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -304,17 +304,19 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param result  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout) {
+    void init(
+        const L0TaskArgs &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout
+    ) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
         // int32_t out_idx = 0;
         for (int32_t i = 0; i < args.tensor_count(); i++) {
             if (args.tag(i) != TensorArgType::OUTPUT) {
-                tensors[i].copy(*args.tensor(i).ptr);
+                tensors[i].copy(args.tensor(i).ref());
             } else {
                 init_tensor_from_create_info(
-                    tensors[i], *args.tensor(i).create_info,
+                    tensors[i], args.tensor(i).create_info(),
                     reinterpret_cast<void *>(reinterpret_cast<char *>(alloc_result.packed_base) + layout.offsets[i]),
                     layout.buffer_sizes[i]
                 );

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -42,14 +43,6 @@
 #include "task_args.h"
 #include "tensor.h"
 #include "tensor_create_info.h"  // runtime-only TensorCreateInfo + materialization helpers
-
-// Task arguments — alias the common CORE_MAX_* constants (single source of
-// truth in src/common/task_interface/arg_direction.h, transitively included
-// via task_args.h above). Keeping the MAX_TENSOR_ARGS / MAX_SCALAR_ARGS names
-// because they are referenced widely in this runtime (pto_runtime2_types.h,
-// pto2_dispatch_payload.h, intrinsic.h comments).
-#define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
-#define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 
 typedef enum {
     ASYNC_ENGINE_SDMA = 0,
@@ -144,14 +137,42 @@ using TaskSubmitResult = TaskOutputTensors;
 // TensorArgType is defined in tensor.h (included via task_args.h above)
 
 /**
- * Tagged union for a single Arg slot — either a Tensor* or a TensorCreateInfo value.
- * The active member is determined by TensorArgType (OUTPUT → create_info, else → ptr).
+ * Tagged reference to a single Arg slot — either a Tensor* or a
+ * TensorCreateInfo*. The active member is determined by the slot's
+ * TensorArgType tag (OUTPUT → create_info, else → tensor pointer).
+ *
+ * Minimal-permission: the union members are private; content is set only via
+ * operator=(ptr) and read via ref()/create_info(). Copy/move are deleted — a
+ * TensorRef is written in place inside an Arg's slot array, never passed by
+ * value.
  */
-union TensorRef {
-    const Tensor *ptr;
-    const TensorCreateInfo *create_info;
+class TensorRef {
+    union {
+        const Tensor *ptr_;
+        const TensorCreateInfo *create_info_;
+    };
+
+public:
     TensorRef() :
-        ptr(nullptr) {}
+        ptr_(nullptr) {}
+    TensorRef(const TensorRef &) = delete;
+    TensorRef(TensorRef &&) = delete;
+    TensorRef &operator=(const TensorRef &) = delete;
+    TensorRef &operator=(TensorRef &&) = delete;
+
+    TensorRef &operator=(const Tensor *p) {
+        ptr_ = p;
+        return *this;
+    }
+    TensorRef &operator=(const TensorCreateInfo *ci) {
+        create_info_ = ci;
+        return *this;
+    }
+
+    const Tensor &ref() const { return *ptr_; }
+    const TensorCreateInfo &create_info() const { return *create_info_; }
+    bool refers_to(const Tensor *t) const { return ptr_ == t; }
+    bool refers_to(const TensorCreateInfo *ci) const { return create_info_ == ci; }
 };
 
 /**
@@ -177,7 +198,26 @@ union TensorRef {
  *   TaskOutputTensors outs = rt_submit_aic_task(kernel_id, args);
  *   const Tensor& y = outs.get_ref(0);
  */
-struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
+template <size_t MaxT, size_t MaxS>
+struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
+    using Base = TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType>;
+    // Make dependent-base members visible for unqualified use (two-phase lookup
+    // does not search a dependent base in a class template).
+    using Base::scalar_count_;
+    using Base::scalars_;
+    using Base::tags_;
+    using Base::tensor_count_;
+    using Base::tensors_;
+
+    // Minimal-permission: an Arg is built in place and consumed by reference;
+    // it is never copied/moved (it is a large object, and its TensorRef slots
+    // are non-copyable by design).
+    Arg() = default;
+    Arg(const Arg &) = delete;
+    Arg(Arg &&) = delete;
+    Arg &operator=(const Arg &) = delete;
+    Arg &operator=(Arg &&) = delete;
+
     bool has_error{false};
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
@@ -192,7 +232,7 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     bool allow_early_resolve() const { return allow_early_resolve_; }
 
     void clear() {
-        TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
+        Base::clear();
 #if PTO2_PROFILING
         dump_arg_selection_.clear();
 #endif
@@ -245,10 +285,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     template <typename... Args>
     void add_input(Args &&...args) {
-        if (!check_add_tensor_valid<false>(args...)) {
+        assert_add_tensor_args<false, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) {
             return;
         }
-        ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::INPUT, tensor_count_++), ...);
+        ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::INPUT, tensor_count_++), ...);
     }
 
     /// Batch add outputs — all Tensor or all TensorCreateInfo:
@@ -256,31 +297,31 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     ///   add_output(t1, t2)           — write-only existing tensors (OUTPUT_EXISTING)
     template <typename... Args>
     void add_output(Args &&...args) {
-        if (!check_add_tensor_valid<true>(args...)) return;
+        assert_add_tensor_args<true, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) return;
         if constexpr ((std::is_same_v<std::decay_t<Args>, TensorCreateInfo> && ...)) {
-            ((tensors_[tensor_count_].create_info = &args, tags_[tensor_count_] = TensorArgType::OUTPUT,
-              tensor_count_++),
-             ...);
+            ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::OUTPUT, tensor_count_++), ...);
         } else {
-            ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::OUTPUT_EXISTING,
-              tensor_count_++),
+            ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::OUTPUT_EXISTING, tensor_count_++),
              ...);
         }
     }
 
     template <typename... Args>
     void add_inout(Args &&...args) {
-        if (!check_add_tensor_valid<false>(args...)) {
+        assert_add_tensor_args<false, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) {
             return;
         }
-        ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::INOUT, tensor_count_++), ...);
+        ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::INOUT, tensor_count_++), ...);
     }
 
     /// No-dependency existing tensor: skips OverlapMap lookup, depends on creator only.
     template <typename... Args>
     void add_no_dep(Args &&...args) {
-        if (!check_add_tensor_valid<false>(args...)) return;
-        ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::NO_DEP, tensor_count_++), ...);
+        assert_add_tensor_args<false, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) return;
+        ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::NO_DEP, tensor_count_++), ...);
     }
 
     /**
@@ -339,16 +380,16 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     void add_scalar(Args &&...args) {
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
-        if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (scalar_count_ + sizeof...(Args) > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         (add_scalar_one(std::forward<Args>(args)), ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
-        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (count < 0 || scalar_count_ + count > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -365,8 +406,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
     void add_scalars_i32(const int32_t *values, int count) {
-        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (count < 0 || scalar_count_ + count > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -402,8 +443,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;
         }
-        if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (scalar_count_ + count > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
@@ -433,6 +474,18 @@ private:
         is_supported_scalar_arg_v<T>;
 #endif
 
+    // Capacity-overflow messages — spell the actual limit (MaxS/MaxT, whatever
+    // the instantiation is) into the text via std::to_string. Built once into a
+    // function-local static so set_error() can hold the const char* safely.
+    static const char *scalar_cap_msg() {
+        static const std::string msg = "Too many scalar args (max " + std::to_string(MaxS) + ")";
+        return msg.c_str();
+    }
+    static const char *tensor_cap_msg() {
+        static const std::string msg = "Too many tensor args (max " + std::to_string(MaxT) + ")";
+        return msg.c_str();
+    }
+
     template <typename T>
     void add_scalar_one(T &&value) {
         scalars_[scalar_count_] = to_u64(value);
@@ -460,7 +513,7 @@ private:
 
     void mark_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {
-            if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].ptr == &tensor) {
+            if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].refers_to(&tensor)) {
                 dump_arg_selection_.mark_index(i);
                 return;
             }
@@ -470,7 +523,7 @@ private:
 
     void mark_dump_arg(const TensorCreateInfo &create_info) {
         for (int32_t i = 0; i < tensor_count_; i++) {
-            if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].create_info == &create_info) {
+            if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].refers_to(&create_info)) {
                 dump_arg_selection_.mark_index(i);
                 return;
             }
@@ -488,8 +541,11 @@ private:
     }
 #endif
 
+    // Compile-time validation: arg count, value category (reject temporaries —
+    // a stored &arg would dangle after the call), and element type. Driven
+    // purely by Args, with no runtime state.
     template <bool is_output, typename... Args>
-    bool check_add_tensor_valid(Args &&...) {
+    static void assert_add_tensor_args() {
         static_assert(sizeof...(Args) >= 1, "at least one argument required");
         static_assert(
             (std::is_lvalue_reference_v<Args> && ...),
@@ -504,6 +560,11 @@ private:
         } else {
             static_assert((std::is_same_v<std::decay_t<Args>, Tensor> && ...), "all arguments must be Tensor");
         }
+    }
+
+    // Runtime validation: tensor-before-scalar ordering + slot capacity. Records
+    // an error and returns false on violation.
+    bool check_add_tensor_capacity(int32_t count) {
         if (scalar_count_ != 0) {
             set_error(
                 "add_input/add_output/add_inout called after add_scalar: "
@@ -511,11 +572,42 @@ private:
             );
             return false;
         }
-        if (tensor_count_ + sizeof...(Args) > MAX_TENSOR_ARGS) {
-            set_error("Too many tensor args (exceeds MAX_TENSOR_ARGS=32)");
+        if (tensor_count_ + count > static_cast<int32_t>(MaxT)) {
+            set_error(tensor_cap_msg());
             return false;
         }
         return true;
+    }
+};
+
+// =============================================================================
+// Task-args layer aliases
+// =============================================================================
+//
+// L0TaskArgs — core-level container used to build and submit tasks inside
+//   orchestration (small, stack-friendly).
+using L0TaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
+
+// L2TaskArgs — chip-level entry-arg holding the orchestration entry's
+// already-allocated inputs (capacity matches ChipStorageTaskArgs).
+// aicpu_orchestration_entry/config receive a const L2TaskArgs&.
+struct L2TaskArgs : Arg<CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS> {
+    // Build from the executor's ChipStorageTaskArgs: each input becomes a
+    // TensorRef pointing at src's Tensor, so `src` must outlive this (on the
+    // executor path src is runtime->orch_args_storage_, alive for the whole run).
+    void create_from_chip_args(const ChipStorageTaskArgs &src) {
+        reset();
+        for (int32_t i = 0; i < src.tensor_count(); ++i) {
+            // Entry inputs are external submit-time tensors; the entry binds them
+            // by const Tensor& (replacing from_tensor_arg's old version/manual_dep
+            // reset), so this invariant is what keeps that binding behavior-preserving.
+            const Tensor &t = src.tensor(i);
+            debug_assert(!t.manual_dep && t.version == 0);
+            add_input(t);
+        }
+        for (int32_t i = 0; i < src.scalar_count(); ++i) {
+            add_scalar(src.scalar(i));
+        }
     }
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
@@ -89,8 +89,6 @@ public:
     uint32_t shapes[MAX_TENSOR_DIMS];  // → Tensor::shapes
 
     TensorCreateInfo() = default;
-
-    friend struct Arg;
 };
 
 // TensorCreateInfo layout must match Tensor cacheline 1 for memcpy optimization

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -62,11 +62,11 @@
 // Device orchestration function signature (loaded via dlopen).
 // The executor binds the current thread's PTO2Runtime into orchestration TLS
 // before calling the user entry.
-typedef void (*DeviceOrchestrationFunc)(const ChipStorageTaskArgs &orch_args);
+typedef void (*DeviceOrchestrationFunc)(const L2TaskArgs &orch_args);
 typedef void (*DeviceOrchestrationBindRuntimeFunc)(PTO2Runtime *rt);
 
 // Config function exported by orchestration .so
-typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const ChipStorageTaskArgs &orch_args);
+typedef PTO2OrchestrationConfig (*DeviceOrchestrationConfigFunc)(const L2TaskArgs &orch_args);
 
 // From orchestration/common.cpp linked into this DSO — updates g_current_runtime here (distinct from
 // framework_bind_runtime in the dlopen'd libdevice_orch_*.so).
@@ -135,9 +135,9 @@ struct AicpuExecutor {
     // Default-constructed: libc-backed backend, no ctx.
     DeviceArena runtime_arena_;
 
-    // Cached orch args pointer set by the orchestration thread before scheduler
-    // init; consumed by the (*p_func)(*orch_args_cached_) invocation below.
-    const ChipStorageTaskArgs *orch_args_cached_{nullptr};
+    // Entry-arg L2TaskArgs built (via create_from_chip_args) from get_orch_args()
+    // before scheduler init; consumed by the (*p_func)(orch_args_cached_) below.
+    L2TaskArgs orch_args_cached_;
 
     // Per-callable_id table. Single orch thread today, so first-write/read
     // race is not possible; if multiple orch threads are ever introduced,
@@ -407,9 +407,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 }
             }
 
+            // Build the entry-arg once per run; both the config call below and
+            // the orchestration entry (consumed at orch_args_cached_) use it.
+            orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
+
             // Validate arg count on every run (reload or cache hit).
             if (*p_config_func != nullptr) {
-                PTO2OrchestrationConfig cfg = (*p_config_func)(runtime->get_orch_args());
+                PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                 LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
                 if (cfg.expected_arg_count > 0) {
                     const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
@@ -533,8 +537,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // With multi-ring, slot_states are per-ring inside the scheduler.
             runtime->set_slot_states_ptr(nullptr);
 
-            orch_args_cached_ = &args;
-
             // Wire scheduler context to the newly created PTO2Runtime before
             // releasing scheduler threads from runtime_init_ready_.
             sched_ctx_.bind_runtime(rt);
@@ -571,7 +573,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 (*p_bind)(rt);
             }
             rt_scope_begin(rt);
-            (*p_func)(*orch_args_cached_);
+            (*p_func)(orch_args_cached_);
             rt_scope_end(rt);
 
             // Flush the (potentially partially-filled) DepGenBuffer so the host
@@ -765,7 +767,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
 
-    orch_args_cached_ = nullptr;
+    orch_args_cached_.reset();
     // orch_so_table_ entries are intentionally preserved across deinit: the
     // next run reuses cached handles when register_new_callable_id() returns
     // false. The destructor releases them at process teardown.

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/SCALAR_DATA_ACCESS.md
@@ -60,7 +60,7 @@ args.add_output(ci);
 **Mechanism**:
 
 1. `ci.set_initial_value(value)` marks the create-info with an initial value before submission
-2. `add_output(ci)` stores a pointer to `ci` in `Arg` (the original must remain valid until submit)
+2. `add_output(ci)` stores a pointer to `ci` in `L0TaskArgs` (the original must remain valid until submit)
 3. During payload init, the output tensor is materialized via `init_from_create_info()` which triggers the fill
 4. Fill strategy:
    - Small buffer (< 64 B): element-by-element memcpy directly into dst
@@ -70,7 +70,7 @@ args.add_output(ci);
 
 ## 5. Scalar Dependencies via 1-Element Tensors
 
-Traditional scalars (`Arg::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
+Traditional scalars (`L0TaskArgs::add_scalar`) are one-way inputs with no TensorMap tracking. For cross-task scalar values, use a 1-element tensor as the carrier:
 
 ```cpp
 uint32_t shapes[1] = {1};
@@ -78,7 +78,7 @@ TensorCreateInfo scalar_ci(shapes, 1, DataType::FLOAT32);
 
 // Submit with initial value and keep the returned tensor
 scalar_ci.set_initial_value(float_to_u64(77.0f));
-Arg args;
+L0TaskArgs args;
 args.add_output(scalar_ci);
 TaskOutputTensors outs = rt_submit_aiv_task(FUNC_NOOP, args);
 const Tensor& scalar_tensor = outs.get_ref(0);

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -413,7 +413,7 @@ void annot_pass(
         if (ptype == TensorArgType::OUTPUT) {
             continue;
         }
-        const Tensor *tensor = inputs.tensors[i].ptr;
+        const Tensor *tensor = &inputs.tensors[i].ref();
 
         // STEP A: creator retention.
         PTO2TaskId owner = tensor->owner_task_id;
@@ -543,7 +543,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
             tc = CORE_MAX_TENSOR_ARGS;
         }
         for (int32_t i = 0; i < tc; i++) {
-            tref_buf[i].ptr = reinterpret_cast<const Tensor *>(&rec.tensors[i][0]);
+            tref_buf[i] = reinterpret_cast<const Tensor *>(&rec.tensors[i][0]);
             atype_buf[i] = static_cast<TensorArgType>(rec.arg_types[i]);
         }
 
@@ -653,7 +653,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
                 // a placeholder "alloc" output slot.
                 slot.has_tensor_info = false;
             } else {
-                const Tensor &t = *tref_buf[i].ptr;
+                const Tensor &t = tref_buf[i].ref();
                 register_tensor(tensor_index, tensor_table, t);
                 slot.has_tensor_info = true;
                 slot.tensor_id = make_tensor_id(t.buffer.addr, t.version);

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/common.cpp
@@ -9,7 +9,6 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 #include "common.h"
-#include "pto_orchestration_api.h"
 
 #ifdef __linux__
 #include <cxxabi.h>
@@ -23,6 +22,14 @@
 #endif
 
 struct PTO2Runtime;
+
+// Unified-log error sink. Forward-declared here rather than pulled via
+// common/unified_log.h: that header lives under common/log/include, which is
+// not on the orchestration .so build's include path. The symbol resolves at
+// link time for the runtime targets, and at dlopen time for the orchestration
+// .so (against the executor's unified_log_device), so onboard diagnostics still
+// reach the CANN device log.
+extern "C" void unified_log_error(const char *func, const char *fmt, ...);
 
 namespace {
 // Plain global (not thread_local) to avoid glibc TLSDESC stale-resolution
@@ -174,11 +181,17 @@ AssertionError::AssertionError(const char *condition, const char *file, int line
     line_(line) {}
 
 [[noreturn]] void assert_impl(const char *condition, const char *file, int line) {
-    LOG_ERROR("\n========================================");
-    LOG_ERROR("Assertion failed: %s", condition);
-    LOG_ERROR("Location: %s:%d", file, line);
-    LOG_ERROR("%s", get_stacktrace(2).c_str());
-    LOG_ERROR("========================================\n");
+    // Use unified_log_error directly rather than the LOG_ERROR macro: that macro
+    // lives in pto_orchestration_api.h and expands to
+    // current_runtime()->ops->log_error, but the ops table's definition pulls in
+    // pto_types.h (Arg → __aicore__-only to_u64), which the AICore build of this
+    // TU cannot compile. unified_log_error reaches the same sink without that
+    // dependency.
+    unified_log_error(__FUNCTION__, "\n========================================");
+    unified_log_error(__FUNCTION__, "Assertion failed: %s", condition);
+    unified_log_error(__FUNCTION__, "Location: %s:%d", file, line);
+    unified_log_error(__FUNCTION__, "%s", get_stacktrace(2).c_str());
+    unified_log_error(__FUNCTION__, "========================================\n");
 
     throw AssertionError(condition, file, line);
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_arg_with_deps.h
@@ -11,24 +11,24 @@
 /**
  * Convenience layer over Arg: bundles a fixed-capacity dependency buffer with
  * an Arg and exposes an incremental add_dep(...) API on top of the runtime
- * primitive Arg::set_dependencies(ptr, count).
+ * primitive L0TaskArgs::set_dependencies(ptr, count).
  *
  * Layering:
  *   - Primitive:   Arg + set_dependencies(ptr, count) in pto_types.h.
  *                  No cap, caller owns the deps buffer.
- *   - Convenience: ArgWithDeps<N> in this header. Owns a stack-sized dep
+ *   - Convenience: L0TaskArgsWithDeps<N> in this header. Owns a stack-sized dep
  *                  buffer of capacity N (default 16); provides add_dep().
  *                  Submitted via the rt_submit_*_task overloads below, which
  *                  forward the bundled deps into the underlying Arg.
  *
  * This file is auto-included at the bottom of pto_orchestration_api.h so
- * orchestration sources see ArgWithDeps after a single `#include
+ * orchestration sources see L0TaskArgsWithDeps after a single `#include
  * "pto_orchestration_api.h"`. The split is purely organizational —
  * orchestration code should not include this header directly. Code generated
  * from pypto can ignore the convenience layer entirely and target Arg +
  * set_dependencies(ptr, count) directly.
  *
- * ArgWithDeps uses private inheritance from Arg so that set_dependencies and
+ * L0TaskArgsWithDeps uses private inheritance from Arg so that set_dependencies and
  * the explicit_dep* accessors are NOT reachable on a wrapper instance — users
  * who pick the convenience layer cannot accidentally mix it with the
  * primitive layer's dep API on the same object.
@@ -44,23 +44,23 @@
 #include "pto_orchestration_api.h"  // Arg, MixedKernels, rt_submit_* primitives
 
 template <size_t MAX_DEP_COUNT = 16>
-class ArgWithDeps : private Arg {
+class L0TaskArgsWithDeps : private L0TaskArgs {
 public:
     // Tensor / scalar setters — forward to Arg
-    using Arg::add_inout;
-    using Arg::add_input;
-    using Arg::add_no_dep;
-    using Arg::add_output;
-    using Arg::add_scalar;
-    using Arg::add_scalars;
-    using Arg::add_scalars_i32;
-    using Arg::copy_scalars_from;
+    using L0TaskArgs::add_inout;
+    using L0TaskArgs::add_input;
+    using L0TaskArgs::add_no_dep;
+    using L0TaskArgs::add_output;
+    using L0TaskArgs::add_scalar;
+    using L0TaskArgs::add_scalars;
+    using L0TaskArgs::add_scalars_i32;
+    using L0TaskArgs::copy_scalars_from;
 
     // Error / status — forward to Arg
-    using Arg::error_msg;
-    using Arg::has_error;
-    using Arg::launch_spec;
-    using Arg::set_error;
+    using L0TaskArgs::error_msg;
+    using L0TaskArgs::has_error;
+    using L0TaskArgs::launch_spec;
+    using L0TaskArgs::set_error;
 
     // NOT exposed: set_dependencies, explicit_dep_count, explicit_dep,
     // explicit_deps_data — these are the primitive-layer dep API. Users of
@@ -81,7 +81,9 @@ public:
             (std::is_same_v<std::decay_t<Ids>, PTO2TaskId> && ...), "add_dep: all arguments must be PTO2TaskId"
         );
         if (count_ + sizeof...(Ids) > MAX_DEP_COUNT) {
-            Arg::set_error("ArgWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)");
+            L0TaskArgs::set_error(
+                "L0TaskArgsWithDeps::add_dep: dep count exceeds MAX_DEP_COUNT (bump the template arg)"
+            );
             return;
         }
         ((deps_[count_++] = ids), ...);
@@ -89,10 +91,10 @@ public:
 
     /**
      * Clear the bundled dep buffer and reset the underlying Arg.
-     * Use this to recycle an ArgWithDeps across loop iterations.
+     * Use this to recycle an L0TaskArgsWithDeps across loop iterations.
      */
     void reset() {
-        Arg::reset();
+        L0TaskArgs::reset();
         count_ = 0;
     }
 
@@ -105,9 +107,9 @@ public:
      * so a wrapper can be re-finalized (e.g. resubmitted) without tripping
      * the primitive layer's single-shot check.
      */
-    Arg &finalize_for_submit() {
-        Arg::set_dependencies(nullptr, 0);
-        Arg::set_dependencies(deps_, count_);
+    L0TaskArgs &finalize_for_submit() {
+        L0TaskArgs::set_dependencies(nullptr, 0);
+        L0TaskArgs::set_dependencies(deps_, count_);
         return *this;
     }
 
@@ -117,20 +119,20 @@ private:
 };
 
 // =============================================================================
-// Submit overloads — accept ArgWithDeps<N> transparently
+// Submit overloads — accept L0TaskArgsWithDeps<N> transparently
 // =============================================================================
 
 template <size_t N>
-static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, ArgWithDeps<N> &awd) {
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, L0TaskArgsWithDeps<N> &awd) {
     return rt_submit_task(mixed_kernels, awd.finalize_for_submit());
 }
 
 template <size_t N>
-static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, L0TaskArgsWithDeps<N> &awd) {
     return rt_submit_aic_task(kernel_id, awd.finalize_for_submit());
 }
 
 template <size_t N>
-static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, ArgWithDeps<N> &awd) {
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, L0TaskArgsWithDeps<N> &awd) {
     return rt_submit_aiv_task(kernel_id, awd.finalize_for_submit());
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/orchestration/pto_orchestration_api.h
@@ -33,6 +33,7 @@
 #include <type_traits>
 
 // Type headers needed by orchestration
+#include "common.h"              // framework_bind_runtime / framework_current_runtime
 #include "pto_runtime2_types.h"  // PTO2_ERROR_*
 #include "pto_submit_types.h"    // MixedKernels, INVALID_KERNEL_ID, subtask slots
 #include "pto_types.h"           // Arg, TaskOutputTensors, TensorArgType
@@ -47,21 +48,6 @@
 // memory — is defined in the unified tensor.h (common), so host and runtime
 // build Tensors through the same controlled path.
 
-// Adapt an orchestration-arg Tensor into a runtime Tensor, optionally setting
-// creator-only dependency tracking (manual_dep) and an initial version. Since
-// TaskArgs now carries Tensor directly, this is a copy with those two fields
-// applied; buffer / shapes / strides / start_offset / child_memory are kept.
-// Precondition: `t` is an external, submit-time tensor (owner_task_id invalid,
-// start_offset 0, contiguous) — the construction path enforces this. The copy
-// therefore preserves owner_task_id, which is equivalent to the former
-// make_tensor_external rebuild (it forced owner invalid) for every caller.
-inline Tensor from_tensor_arg(const Tensor &t, bool manual_dep = false, int32_t version = 0) {
-    Tensor result = t;
-    result.manual_dep = manual_dep;
-    result.version = version;
-    return result;
-}
-
 // =============================================================================
 // Ops Table and Opaque Runtime
 // =============================================================================
@@ -73,30 +59,12 @@ inline Tensor from_tensor_arg(const Tensor &t, bool manual_dep = false, int32_t 
  */
 typedef struct PTO2Runtime PTO2Runtime;
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-/**
- * Framework-internal TLS bridge.
- *
- * The executor binds the current thread's runtime before invoking
- * aicpu_orchestration_entry(), so orchestration helpers can fetch the
- * current PTO2Runtime without explicit parameter threading.
- */
-PTO2Runtime *framework_current_runtime(void);
-void framework_bind_runtime(PTO2Runtime *rt);
-
-#ifdef __cplusplus
-}
-#endif
-
 /**
  * Function-pointer table for runtime operations.
  * Populated by the runtime; called by orchestration through inline wrappers.
  */
 typedef struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const L0TaskArgs &args);
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
@@ -116,8 +84,8 @@ typedef struct PTO2RuntimeOps {
     void (*set_tensor_data)(
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
     // Stash the call-site of the next PTO2ScopeGuard so the [ScopeStats]
     // collector can log it. Always present to keep ops-table layout stable
@@ -144,7 +112,7 @@ struct PTO2Runtime {
 
 static inline PTO2Runtime *current_runtime() { return framework_current_runtime(); }
 
-static inline TaskOutputTensors alloc_tensors(const Arg &args) {
+static inline TaskOutputTensors alloc_tensors(const L0TaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -157,7 +125,7 @@ static inline TaskOutputTensors alloc_tensors(const TensorCreateInfo create_info
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
-    Arg args;
+    L0TaskArgs args;
     for (uint32_t i = 0; i < count; i++) {
         args.add_output(create_infos[i]);
     }
@@ -182,7 +150,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
     }
-    Arg args;
+    L0TaskArgs args;
     (args.add_output(cis), ...);
     if (args.has_error) {
         rt->ops->report_fatal(
@@ -194,7 +162,7 @@ static inline TaskOutputTensors alloc_tensors(const CIs &...cis) {
     return alloc_tensors(args);
 }
 
-static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels, const L0TaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -205,7 +173,7 @@ static inline TaskOutputTensors rt_submit_task(const MixedKernels &mixed_kernels
 /**
  * Convenience wrapper: submit an AIC-only task.
  */
-static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const L0TaskArgs &args) {
     MixedKernels mk;
     mk.aic_kernel_id = kernel_id;
     return rt_submit_task(mk, args);
@@ -214,7 +182,7 @@ static inline TaskOutputTensors rt_submit_aic_task(int32_t kernel_id, const Arg 
 /**
  * Convenience wrapper: submit an AIV-only task (uses AIV0 slot).
  */
-static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg &args) {
+static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const L0TaskArgs &args) {
     MixedKernels mk;
     mk.aiv0_kernel_id = kernel_id;
     return rt_submit_task(mk, args);
@@ -227,7 +195,7 @@ static inline TaskOutputTensors rt_submit_aiv_task(int32_t kernel_id, const Arg 
  * waits on its fanin and notifies its fanout. Useful as a synchronization
  * barrier or as a placeholder producer for tests / dep-graph wiring.
  */
-static inline TaskOutputTensors rt_submit_dummy_task(const Arg &args) {
+static inline TaskOutputTensors rt_submit_dummy_task(const L0TaskArgs &args) {
     PTO2Runtime *rt = current_runtime();
     if (rt->ops->is_fatal(rt)) {
         return TaskOutputTensors{};
@@ -411,8 +379,8 @@ struct PTO2OrchestrationConfig {
 };
 #endif
 
-// Convenience layer (ArgWithDeps<N> + matching rt_submit_*_task overloads).
-// Pulled in at the bottom so the wrapper sees Arg, MixedKernels, and the
+// Convenience layer (L0TaskArgsWithDeps<N> + matching rt_submit_*_task overloads).
+// Pulled in at the bottom so the wrapper sees L0TaskArgs, MixedKernels, and the
 // rt_submit_*_task primitives defined above. Orchestration sources include
 // only this single header to access both the primitive and convenience APIs.
 #include "pto_arg_with_deps.h"  // NOLINT(build/include_subdir)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/common.h
@@ -20,3 +20,20 @@
 // on this runtime-specific header. assert_impl / get_stacktrace are defined in
 // orchestration/common.cpp for runtime targets.
 #include "assert_compat.h"
+
+// Framework-internal TLS bridge. The executor binds the current thread's
+// runtime before invoking the orchestration entry, so orchestration helpers can
+// fetch the current PTO2Runtime without explicit parameter threading. Declared
+// here (rather than in pto_orchestration_api.h) so framework TUs the AICore
+// build also compiles — notably orchestration/common.cpp — see these symbols
+// without pulling in pto_types.h, whose Arg::add_scalar → to_u64 path is
+// __aicore__-only and would break the ccec build.
+#ifdef __cplusplus
+extern "C" {
+#endif
+struct PTO2Runtime;
+PTO2Runtime *framework_current_runtime(void);
+void framework_bind_runtime(PTO2Runtime *rt);
+#ifdef __cplusplus
+}
+#endif

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto2_dispatch_payload.h
@@ -36,8 +36,8 @@
 
 #include <stdint.h>
 
+#include "arg_direction.h"
 #include "intrinsic.h"
-#include "pto_types.h"
 
 /** Max dispatch arguments: 16 scalars + up to 32 tensor pointers + ext params */
 #ifndef PTO2_DISPATCH_MAX_ARGS

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_dep_compute.h
@@ -92,7 +92,7 @@ compute_task_fanin(const DepInputs &inputs, PTO2TensorMap &tensor_map, bool in_m
             continue;
         }
 
-        const Tensor *tensor = inputs.tensors[i].ptr;
+        const Tensor *tensor = &inputs.tensors[i].ref();
 
         // Step A: creator retention — all existing tensors extend their creator lifetime.
         PTO2TaskId owner = tensor->owner_task_id;
@@ -144,7 +144,7 @@ register_task_outputs(const DepInputs &inputs, PTO2TaskId task_id, PTO2TensorMap
     for (int32_t i = 0; i < inputs.tensor_count; i++) {
         TensorArgType ptype = inputs.arg_types[i];
         if (ptype == TensorArgType::INOUT || ptype == TensorArgType::OUTPUT_EXISTING) {
-            const Tensor *tensor = inputs.tensors[i].ptr;
+            const Tensor *tensor = &inputs.tensors[i].ref();
             if (!tensor->manual_dep) {
                 tensor_map.insert(*tensor, task_id);
             }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -302,7 +302,7 @@ struct PTO2PreparedTask {
     PTO2TaskSlotState *slot_state = nullptr;
 };
 
-static PTO2OutputLayout calculate_output_layout(const Arg &args) {
+static PTO2OutputLayout calculate_output_layout(const L0TaskArgs &args) {
     PTO2OutputLayout layout;
     for (int32_t i = 0; i < args.tensor_count(); i++) {
         if (args.tag(i) != TensorArgType::OUTPUT) {
@@ -310,7 +310,7 @@ static PTO2OutputLayout calculate_output_layout(const Arg &args) {
         }
         layout.offsets[i] = layout.total_output_size;
         layout.buffer_sizes[i] =
-            PTO2_ALIGN_UP(args.tensor(i).create_info->buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
+            PTO2_ALIGN_UP(args.tensor(i).create_info().buffer_size_bytes(), PTO2_PACKED_OUTPUT_ALIGN);
         layout.total_output_size += layout.buffer_sizes[i];
     }
     return layout;
@@ -363,7 +363,7 @@ static void prefetch_payload(PTO2TaskPayload *payload, int32_t tensor_count, int
 }
 
 static bool prepare_task(
-    PTO2OrchestratorState *orch, const Arg &args, int32_t total_output_size, ActiveMask active_mask,
+    PTO2OrchestratorState *orch, const L0TaskArgs &args, int32_t total_output_size, ActiveMask active_mask,
     PTO2PreparedTask *out
 ) {
     uint8_t ring_id = orch->current_ring_id();
@@ -535,8 +535,8 @@ void PTO2OrchestratorState::end_scope() {
 // computation (explicit_deps + auto), output registration, slot init, and pushes
 // to the scheduler wiring queue.
 static TaskOutputTensors submit_task_common(
-    PTO2OrchestratorState *orch, const Arg &args, ActiveMask active_mask, int32_t aic_kernel_id, int32_t aiv0_kernel_id,
-    int32_t aiv1_kernel_id
+    PTO2OrchestratorState *orch, const L0TaskArgs &args, ActiveMask active_mask, int32_t aic_kernel_id,
+    int32_t aiv0_kernel_id, int32_t aiv1_kernel_id
 ) {
     CYCLE_COUNT_START();
     TaskOutputTensors result;
@@ -577,7 +577,7 @@ static TaskOutputTensors submit_task_common(
             // OUTPUT slots carry create_info (not yet a Tensor); skip them —
             // they have no producer to look up and replay's per-tensor loop
             // also skips OUTPUT.
-            tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : args.tensor(i).ptr;
+            tensor_ptrs[i] = (args.tag(i) == TensorArgType::OUTPUT) ? nullptr : &args.tensor(i).ref();
             arg_types_u8[i] = static_cast<uint8_t>(args.tag(i));
         }
         const int32_t kernel_ids_capture[3] = {aic_kernel_id, aiv0_kernel_id, aiv1_kernel_id};
@@ -728,7 +728,7 @@ static TaskOutputTensors submit_task_common(
     return result;
 }
 
-TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_kernels, const L0TaskArgs &args) {
     auto *orch = this;
 
     // Orchestration API should short-circuit after fatal, but keep this entry
@@ -799,7 +799,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_task(const MixedKernels &mixed_k
 // AICore dispatch. Empty active_mask routes the slot to the DUMMY ready
 // bucket; dispatch loop short-circuits to completion. Accepts the same Arg
 // shape as submit_task; scalars are permitted but never consumed.
-TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const L0TaskArgs &args) {
     auto *orch = this;
 
     if (orch->fatal) {
@@ -821,7 +821,7 @@ TaskOutputTensors PTO2OrchestratorState::submit_dummy_task(const Arg &args) {
     return submit_task_common(orch, args, ActiveMask{}, INVALID_KERNEL_ID, INVALID_KERNEL_ID, INVALID_KERNEL_ID);
 }
 
-TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const Arg &args) {
+TaskOutputTensors PTO2OrchestratorState::alloc_tensors(const L0TaskArgs &args) {
     auto *orch = this;
     // Orchestration API should short-circuit after fatal, but keep this entry
     // robust as a no-op in case a caller reaches it directly.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.h
@@ -173,9 +173,9 @@ struct PTO2OrchestratorState {
     void report_fatal(int32_t error_code, const char *func, const char *fmt, ...);
     void begin_scope(PTO2ScopeMode mode = PTO2ScopeMode::AUTO);
     void end_scope();
-    TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const Arg &args);
-    TaskOutputTensors submit_dummy_task(const Arg &args);
-    TaskOutputTensors alloc_tensors(const Arg &args);
+    TaskOutputTensors submit_task(const MixedKernels &mixed_kernels, const L0TaskArgs &args);
+    TaskOutputTensors submit_dummy_task(const L0TaskArgs &args);
+    TaskOutputTensors alloc_tensors(const L0TaskArgs &args);
     void mark_done();
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.cpp
@@ -41,15 +41,15 @@ __attribute__((weak, visibility("hidden"))) uint64_t get_sys_cnt_aicpu() { retur
 // Orchestration Ops Table (function-pointer dispatch for orchestration .so)
 // =============================================================================
 
-static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args) {
+static TaskOutputTensors submit_task_impl(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const L0TaskArgs &args) {
     return rt->orchestrator.submit_task(mixed_kernels, args);
 }
 
-static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const Arg &args) {
+static TaskOutputTensors alloc_tensors_impl(PTO2Runtime *rt, const L0TaskArgs &args) {
     return rt->orchestrator.alloc_tensors(args);
 }
 
-static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const Arg &args) {
+static TaskOutputTensors submit_dummy_task_impl(PTO2Runtime *rt, const L0TaskArgs &args) {
     return rt->orchestrator.submit_dummy_task(args);
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2.h
@@ -67,7 +67,7 @@ enum PTO2RuntimeMode {
 typedef struct PTO2Runtime PTO2Runtime;  // forward declare for ops signatures
 
 struct PTO2RuntimeOps {
-    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const Arg &args);
+    TaskOutputTensors (*submit_task)(PTO2Runtime *rt, const MixedKernels &mixed_kernels, const L0TaskArgs &args);
     void (*scope_begin)(PTO2Runtime *rt);
     void (*scope_end)(PTO2Runtime *rt);
     void (*orchestration_done)(PTO2Runtime *rt);
@@ -87,8 +87,8 @@ struct PTO2RuntimeOps {
     void (*set_tensor_data)(
         PTO2Runtime *rt, const Tensor &tensor, uint32_t ndims, const uint32_t indices[], uint64_t value
     );
-    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const Arg &args);
-    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const Arg &args);
+    TaskOutputTensors (*alloc_tensors)(PTO2Runtime *rt, const L0TaskArgs &args);
+    TaskOutputTensors (*submit_dummy_task)(PTO2Runtime *rt, const L0TaskArgs &args);
 
     // Stash the call-site captured by PTO2ScopeGuard into the [ScopeStats]
     // collector. Always present to keep ops-table layout stable across

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_runtime2_types.h
@@ -231,17 +231,19 @@ struct PTO2TaskPayload {
      * @param args                Task arguments (tensors + scalars)
      * @param result  Materialized output tensors (from TensorCreateInfo path)
      */
-    void init(const Arg &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout) {
+    void init(
+        const L0TaskArgs &args, TaskOutputTensors &result, PTO2TaskAllocResult &alloc_result, PTO2OutputLayout &layout
+    ) {
         tensor_count = args.tensor_count();
         scalar_count = args.scalar_count();
 
         // int32_t out_idx = 0;
         for (int32_t i = 0; i < args.tensor_count(); i++) {
             if (args.tag(i) != TensorArgType::OUTPUT) {
-                tensors[i].copy(*args.tensor(i).ptr);
+                tensors[i].copy(args.tensor(i).ref());
             } else {
                 init_tensor_from_create_info(
-                    tensors[i], *args.tensor(i).create_info,
+                    tensors[i], args.tensor(i).create_info(),
                     reinterpret_cast<void *>(reinterpret_cast<char *>(alloc_result.packed_base) + layout.offsets[i]),
                     layout.buffer_sizes[i]
                 );

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <string>
 #include <type_traits>
 #include <utility>
 
@@ -42,14 +43,6 @@
 #include "task_args.h"
 #include "tensor.h"
 #include "tensor_create_info.h"  // runtime-only TensorCreateInfo + materialization helpers
-
-// Task arguments — alias the common CORE_MAX_* constants (single source of
-// truth in src/common/task_interface/arg_direction.h, transitively included
-// via task_args.h above). Keeping the MAX_TENSOR_ARGS / MAX_SCALAR_ARGS names
-// because they are referenced widely in this runtime (pto_runtime2_types.h,
-// pto2_dispatch_payload.h, intrinsic.h comments).
-#define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
-#define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
 
 typedef enum {
     ASYNC_ENGINE_SDMA = 0,
@@ -142,14 +135,42 @@ private:
 // TensorArgType is defined in tensor.h (included via task_args.h above)
 
 /**
- * Tagged union for a single Arg slot — either a Tensor* or a TensorCreateInfo value.
- * The active member is determined by TensorArgType (OUTPUT → create_info, else → ptr).
+ * Tagged reference to a single Arg slot — either a Tensor* or a
+ * TensorCreateInfo*. The active member is determined by the slot's
+ * TensorArgType tag (OUTPUT → create_info, else → tensor pointer).
+ *
+ * Minimal-permission: the union members are private; content is set only via
+ * operator=(ptr) and read via ref()/create_info(). Copy/move are deleted — a
+ * TensorRef is written in place inside an Arg's slot array, never passed by
+ * value.
  */
-union TensorRef {
-    const Tensor *ptr;
-    const TensorCreateInfo *create_info;
+class TensorRef {
+    union {
+        const Tensor *ptr_;
+        const TensorCreateInfo *create_info_;
+    };
+
+public:
     TensorRef() :
-        ptr(nullptr) {}
+        ptr_(nullptr) {}
+    TensorRef(const TensorRef &) = delete;
+    TensorRef(TensorRef &&) = delete;
+    TensorRef &operator=(const TensorRef &) = delete;
+    TensorRef &operator=(TensorRef &&) = delete;
+
+    TensorRef &operator=(const Tensor *p) {
+        ptr_ = p;
+        return *this;
+    }
+    TensorRef &operator=(const TensorCreateInfo *ci) {
+        create_info_ = ci;
+        return *this;
+    }
+
+    const Tensor &ref() const { return *ptr_; }
+    const TensorCreateInfo &create_info() const { return *create_info_; }
+    bool refers_to(const Tensor *t) const { return ptr_ == t; }
+    bool refers_to(const TensorCreateInfo *ci) const { return create_info_ == ci; }
 };
 
 /**
@@ -175,13 +196,32 @@ union TensorRef {
  *   TaskOutputTensors outs = rt_submit_aic_task(kernel_id, args);
  *   const Tensor& y = outs.get_ref(0);
  */
-struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType> {
+template <size_t MaxT, size_t MaxS>
+struct Arg : TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType> {
+    using Base = TaskArgsTpl<TensorRef, uint64_t, MaxT, MaxS, TensorArgType>;
+    // Make dependent-base members visible for unqualified use (two-phase lookup
+    // does not search a dependent base in a class template).
+    using Base::scalar_count_;
+    using Base::scalars_;
+    using Base::tags_;
+    using Base::tensor_count_;
+    using Base::tensors_;
+
+    // Minimal-permission: an Arg is built in place and consumed by reference;
+    // it is never copied/moved (it is a large object, and its TensorRef slots
+    // are non-copyable by design).
+    Arg() = default;
+    Arg(const Arg &) = delete;
+    Arg(Arg &&) = delete;
+    Arg &operator=(const Arg &) = delete;
+    Arg &operator=(Arg &&) = delete;
+
     bool has_error{false};
     const char *error_msg{nullptr};
     PTO2LaunchSpec launch_spec;  // SPMD launch parameters (block_num, etc.)
 
     void clear() {
-        TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, TensorArgType>::clear();
+        Base::clear();
 #if PTO2_PROFILING
         dump_arg_selection_.clear();
 #endif
@@ -233,10 +273,11 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
 
     template <typename... Args>
     void add_input(Args &&...args) {
-        if (!check_add_tensor_valid<false>(std::forward<Args>(args)...)) {
+        assert_add_tensor_args<false, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) {
             return;
         }
-        ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::INPUT, tensor_count_++), ...);
+        ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::INPUT, tensor_count_++), ...);
     }
 
     /// Batch add outputs — all Tensor or all TensorCreateInfo:
@@ -244,31 +285,31 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     ///   add_output(t1, t2)           — write-only existing tensors (OUTPUT_EXISTING)
     template <typename... Args>
     void add_output(Args &&...args) {
-        if (!check_add_tensor_valid<true>(std::forward<Args>(args)...)) return;
+        assert_add_tensor_args<true, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) return;
         if constexpr ((std::is_same_v<std::decay_t<Args>, TensorCreateInfo> && ...)) {
-            ((tensors_[tensor_count_].create_info = &args, tags_[tensor_count_] = TensorArgType::OUTPUT,
-              tensor_count_++),
-             ...);
+            ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::OUTPUT, tensor_count_++), ...);
         } else {
-            ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::OUTPUT_EXISTING,
-              tensor_count_++),
+            ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::OUTPUT_EXISTING, tensor_count_++),
              ...);
         }
     }
 
     template <typename... Args>
     void add_inout(Args &&...args) {
-        if (!check_add_tensor_valid<false>(std::forward<Args>(args)...)) {
+        assert_add_tensor_args<false, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) {
             return;
         }
-        ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::INOUT, tensor_count_++), ...);
+        ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::INOUT, tensor_count_++), ...);
     }
 
     /// No-dependency existing tensor: skips OverlapMap lookup, depends on creator only.
     template <typename... Args>
     void add_no_dep(Args &&...args) {
-        if (!check_add_tensor_valid<false>(std::forward<Args>(args)...)) return;
-        ((tensors_[tensor_count_].ptr = &args, tags_[tensor_count_] = TensorArgType::NO_DEP, tensor_count_++), ...);
+        assert_add_tensor_args<false, Args...>();
+        if (!check_add_tensor_capacity(static_cast<int32_t>(sizeof...(Args)))) return;
+        ((tensors_[tensor_count_] = &args, tags_[tensor_count_] = TensorArgType::NO_DEP, tensor_count_++), ...);
     }
 
     /**
@@ -327,16 +368,16 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
     void add_scalar(Args &&...args) {
         static_assert(sizeof...(Args) >= 1, "add_scalar: at least one argument required");
         static_assert((is_supported_scalar_arg_v<Args> && ...), "add_scalar: all types must be arithmetic or enum");
-        if (scalar_count_ + sizeof...(Args) > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (scalar_count_ + sizeof...(Args) > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         (add_scalar_one(std::forward<Args>(args)), ...);
     }
 
     void add_scalars(const uint64_t *values, int count) {
-        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (count < 0 || scalar_count_ + count > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         memcpy(&scalars_[scalar_count_], values, count * sizeof(uint64_t));
@@ -353,8 +394,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
      * Uses NEON to process 4 elements per iteration on aarch64.
      */
     void add_scalars_i32(const int32_t *values, int count) {
-        if (count < 0 || scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (count < 0 || scalar_count_ + count > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         uint64_t *dst = &scalars_[scalar_count_];
@@ -390,8 +431,8 @@ struct Arg : TaskArgsTpl<TensorRef, uint64_t, MAX_TENSOR_ARGS, MAX_SCALAR_ARGS, 
             set_error("Source scalar range out of bounds in copy_scalars_from");
             return;
         }
-        if (scalar_count_ + count > MAX_SCALAR_ARGS) {
-            set_error("Too many scalar args (exceeds MAX_SCALAR_ARGS=16)");
+        if (scalar_count_ + count > MaxS) {
+            set_error(scalar_cap_msg());
             return;
         }
         memcpy(&scalars_[scalar_count_], &src.scalars_[src_offset], count * sizeof(uint64_t));
@@ -421,6 +462,18 @@ private:
         is_supported_scalar_arg_v<T>;
 #endif
 
+    // Capacity-overflow messages — spell the actual limit (MaxS/MaxT, whatever
+    // the instantiation is) into the text via std::to_string. Built once into a
+    // function-local static so set_error() can hold the const char* safely.
+    static const char *scalar_cap_msg() {
+        static const std::string msg = "Too many scalar args (max " + std::to_string(MaxS) + ")";
+        return msg.c_str();
+    }
+    static const char *tensor_cap_msg() {
+        static const std::string msg = "Too many tensor args (max " + std::to_string(MaxT) + ")";
+        return msg.c_str();
+    }
+
     template <typename T>
     void add_scalar_one(T &&value) {
         scalars_[scalar_count_] = to_u64(value);
@@ -448,7 +501,7 @@ private:
 
     void mark_dump_arg(const Tensor &tensor) {
         for (int32_t i = 0; i < tensor_count_; i++) {
-            if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].ptr == &tensor) {
+            if (tags_[i] != TensorArgType::OUTPUT && tensors_[i].refers_to(&tensor)) {
                 dump_arg_selection_.mark_index(i);
                 return;
             }
@@ -458,7 +511,7 @@ private:
 
     void mark_dump_arg(const TensorCreateInfo &create_info) {
         for (int32_t i = 0; i < tensor_count_; i++) {
-            if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].create_info == &create_info) {
+            if (tags_[i] == TensorArgType::OUTPUT && tensors_[i].refers_to(&create_info)) {
                 dump_arg_selection_.mark_index(i);
                 return;
             }
@@ -476,8 +529,11 @@ private:
     }
 #endif
 
+    // Compile-time validation: arg count, value category (reject temporaries —
+    // a stored &arg would dangle after the call), and element type. Driven
+    // purely by Args, with no runtime state.
     template <bool is_output, typename... Args>
-    bool check_add_tensor_valid(Args &&...) {
+    static void assert_add_tensor_args() {
         static_assert(sizeof...(Args) >= 1, "at least one argument required");
         static_assert(
             (std::is_lvalue_reference_v<Args> && ...),
@@ -492,6 +548,11 @@ private:
         } else {
             static_assert((std::is_same_v<std::decay_t<Args>, Tensor> && ...), "all arguments must be Tensor");
         }
+    }
+
+    // Runtime validation: tensor-before-scalar ordering + slot capacity. Records
+    // an error and returns false on violation.
+    bool check_add_tensor_capacity(int32_t count) {
         if (scalar_count_ != 0) {
             set_error(
                 "add_input/add_output/add_inout called after add_scalar: "
@@ -499,11 +560,42 @@ private:
             );
             return false;
         }
-        if (tensor_count_ + sizeof...(Args) > MAX_TENSOR_ARGS) {
-            set_error("Too many tensor args (exceeds MAX_TENSOR_ARGS=32)");
+        if (tensor_count_ + count > static_cast<int32_t>(MaxT)) {
+            set_error(tensor_cap_msg());
             return false;
         }
         return true;
+    }
+};
+
+// =============================================================================
+// Task-args layer aliases
+// =============================================================================
+//
+// L0TaskArgs — core-level container used to build and submit tasks inside
+//   orchestration (small, stack-friendly).
+using L0TaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
+
+// L2TaskArgs — chip-level entry-arg holding the orchestration entry's
+// already-allocated inputs (capacity matches ChipStorageTaskArgs).
+// aicpu_orchestration_entry/config receive a const L2TaskArgs&.
+struct L2TaskArgs : Arg<CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS> {
+    // Build from the executor's ChipStorageTaskArgs: each input becomes a
+    // TensorRef pointing at src's Tensor, so `src` must outlive this (on the
+    // executor path src is runtime->orch_args_storage_, alive for the whole run).
+    void create_from_chip_args(const ChipStorageTaskArgs &src) {
+        reset();
+        for (int32_t i = 0; i < src.tensor_count(); ++i) {
+            // Entry inputs are external submit-time tensors; the entry binds them
+            // by const Tensor& (replacing from_tensor_arg's old version/manual_dep
+            // reset), so this invariant is what keeps that binding behavior-preserving.
+            const Tensor &t = src.tensor(i);
+            debug_assert(!t.manual_dep && t.version == 0);
+            add_input(t);
+        }
+        for (int32_t i = 0; i < src.scalar_count(); ++i) {
+            add_scalar(src.scalar(i));
+        }
     }
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/tensor_create_info.h
@@ -89,8 +89,6 @@ public:
     uint32_t shapes[MAX_TENSOR_DIMS];  // → Tensor::shapes
 
     TensorCreateInfo() = default;
-
-    friend struct Arg;
 };
 
 // TensorCreateInfo layout must match Tensor cacheline 1 for memcpy optimization

--- a/src/common/task_interface/arg_direction.h
+++ b/src/common/task_interface/arg_direction.h
@@ -36,6 +36,11 @@ inline constexpr int CORE_MAX_SCALAR_ARGS = 16;
 inline constexpr int CHIP_MAX_SCALAR_ARGS = 128;
 inline constexpr uint32_t CALLABLE_ALIGN = 64;
 
+// L0 (Arg<>) capacity aliases. Kept next to the CORE_MAX_* source so size-only
+// consumers (e.g. pto2_dispatch_payload.h) need not include pto_types.h.
+#define MAX_TENSOR_ARGS CORE_MAX_TENSOR_ARGS
+#define MAX_SCALAR_ARGS CORE_MAX_SCALAR_ARGS
+
 // Minimum alignment of a child kernel binary's device address within a
 // ChipCallable. The device address is
 //   chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)

--- a/src/common/task_interface/tensor.h
+++ b/src/common/task_interface/tensor.h
@@ -91,7 +91,6 @@ enum class TensorArgType : int32_t {
  * constructor is private, so a *valid* Tensor (real buffer, row-major strides)
  * is obtained only through controlled entry points:
  *   - make_tensor_external(...)
- *   - from_tensor_arg(...)
  *   - TaskOutputTensors returned by submit(...)
  *   - Tensor::view() / reshape() / transpose() / permute() / slice() on an existing valid Tensor
  */

--- a/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/alternating_matmul_add/kernels/orchestration/alternating_orch.cpp
@@ -39,22 +39,21 @@ static constexpr uint64_t ADD_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 11,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // Tensor args
-    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_C = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_X = from_tensor_arg(orch_args.tensor(3));
-    Tensor ext_Y = from_tensor_arg(orch_args.tensor(4));
-    Tensor ext_Z = from_tensor_arg(orch_args.tensor(5));
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_C = orch_args.tensor(2).ref();
+    const Tensor &ext_X = orch_args.tensor(3).ref();
+    const Tensor &ext_Y = orch_args.tensor(4).ref();
+    const Tensor &ext_Z = orch_args.tensor(5).ref();
 
     // Scalar config args
     int batch = static_cast<int>(orch_args.scalar(0));
@@ -92,7 +91,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             Tensor B_view = ext_B.view(matmul_group_shapes, view_offsets);
             Tensor C_view = ext_C.view(matmul_group_shapes, view_offsets);
 
-            Arg params_matmul;
+            L0TaskArgs params_matmul;
             params_matmul.add_input(A_view);
             params_matmul.add_input(B_view);
             params_matmul.add_output(C_view);
@@ -112,7 +111,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
             Tensor Y_view = ext_Y.view(add_group_shapes, view_offsets);
             Tensor Z_view = ext_Z.view(add_group_shapes, view_offsets);
 
-            Arg params_add;
+            L0TaskArgs params_add;
             params_add.add_input(X_view);
             params_add.add_input(Y_view);
             params_add.add_output(Z_view);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/batch_paged_attention/kernels/orchestration/paged_attention_orch.cpp
@@ -51,23 +51,22 @@
 #define FUNC_ONLINE_UPDATE 3
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // Read dimensions from tensor metadata
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     uint64_t scale_value = orch_args.scalar(0);
 
@@ -77,18 +76,18 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     LOG_INFO_V0("batch_paged_attention: batch=%" PRIu64 ", num_heads=%" PRIu64, batch, num_heads);
 
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
 
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     uint64_t max_bn = 0;
     for (uint64_t b = 0; b < batch; b++) {
@@ -99,7 +98,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     }
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
     uint64_t kv_total_rows = total_blocks_count * block_size;
     uint32_t key_cache_shapes[2] = {static_cast<uint32_t>(kv_total_rows), static_cast<uint32_t>(head_dim)};
     uint32_t value_cache_shapes[2] = {static_cast<uint32_t>(kv_total_rows), static_cast<uint32_t>(head_dim)};
@@ -142,7 +141,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
                 for (uint64_t bn = 0; bn < max_bn; bn++) {
                     PTO2_SCOPE() {
-                        Arg params_qk;
+                        L0TaskArgs params_qk;
                         params_qk.add_input(query);
                         params_qk.add_input(key_cache);
                         params_qk.add_input(block_table);
@@ -156,7 +155,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
                         const Tensor &sij_b = qk_outs.get_ref(0);
 
-                        Arg params_sf;
+                        L0TaskArgs params_sf;
                         params_sf.add_input(sij_b);
                         params_sf.add_input(context_lens);
                         params_sf.add_output(pij_ci);
@@ -171,7 +170,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                         const Tensor &mij_b = sf_outs.get_ref(1);
                         const Tensor &lij_b = sf_outs.get_ref(2);
 
-                        Arg params_pv;
+                        L0TaskArgs params_pv;
                         params_pv.add_input(pij_b);
                         params_pv.add_input(value_cache);
                         params_pv.add_input(block_table);
@@ -185,7 +184,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
                         uint64_t is_first = (bn == 0) ? 1 : 0;
                         uint64_t is_last = (bn == max_bn - 1) ? 1 : 0;
-                        Arg params_up;
+                        L0TaskArgs params_up;
                         params_up.add_input(mij_b);
                         params_up.add_input(lij_b);
                         params_up.add_input(oi_new_b);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -42,17 +42,16 @@ static constexpr int32_t MAX_PRODUCERS = 500;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,  // X, Y, scalar(N)
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_X = orch_args.tensor(0).ref();
+    const Tensor &ext_Y = orch_args.tensor(1).ref();
 
     uint64_t n_raw = orch_args.scalar(0);
     int32_t n = static_cast<int32_t>(n_raw);
@@ -67,7 +66,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // stays at SENTINEL through all of them — the host only checks the final
     // value, which proves the barrier waited for every producer to finish.
     for (int32_t i = 0; i < n; i++) {
-        Arg args;
+        L0TaskArgs args;
         args.add_inout(ext_X);
         producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
     }
@@ -76,14 +75,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // the dep_gen writer to emit base + overflow chain.
     PTO2TaskId barrier_id;
     {
-        Arg args;
+        L0TaskArgs args;
         args.set_dependencies(producer_ids, n);
         barrier_id = rt_submit_dummy_task(args).task_id();
     }
 
     // Consumer: explicit dep on barrier only, reads X, writes Y.
     {
-        Arg args;
+        L0TaskArgs args;
         PTO2TaskId consumer_deps[] = {barrier_id};
         args.set_dependencies(consumer_deps, 1);
         args.add_input(ext_X);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/kernels/orchestration/chained_mix_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/kernels/orchestration/chained_mix_orch.cpp
@@ -47,23 +47,22 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 8,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_D = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_E = from_tensor_arg(orch_args.tensor(3));
-    Tensor ext_ws_aic = from_tensor_arg(orch_args.tensor(4));
-    Tensor ext_ws_aiv = from_tensor_arg(orch_args.tensor(5));
-    Tensor ext_aic_out = from_tensor_arg(orch_args.tensor(6));
-    Tensor ext_aiv_out = from_tensor_arg(orch_args.tensor(7));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_D = orch_args.tensor(2).ref();
+    const Tensor &ext_E = orch_args.tensor(3).ref();
+    const Tensor &ext_ws_aic = orch_args.tensor(4).ref();
+    const Tensor &ext_ws_aiv = orch_args.tensor(5).ref();
+    const Tensor &ext_aic_out = orch_args.tensor(6).ref();
+    const Tensor &ext_aiv_out = orch_args.tensor(7).ref();
 
     uint32_t slot_shape[1] = {TILE_ELEMS};
     uint32_t off_slot0[1] = {0};
@@ -81,7 +80,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         MixedKernels mk;
         mk.aic_kernel_id = FUNC_MATMUL;
         mk.aiv0_kernel_id = FUNC_ADD;
-        Arg args;
+        L0TaskArgs args;
         args.add_input(ext_A);
         args.add_input(ext_B);
         args.add_output(ws_aic_slot0);
@@ -98,7 +97,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         MixedKernels mk;
         mk.aic_kernel_id = FUNC_MATMUL;
         mk.aiv0_kernel_id = FUNC_ADD;
-        Arg args;
+        L0TaskArgs args;
         args.add_input(ws_aic_slot0);
         args.add_input(ext_B);
         args.add_output(ws_aic_slot1);
@@ -113,7 +112,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         MixedKernels mk;
         mk.aic_kernel_id = FUNC_MATMUL;
         mk.aiv0_kernel_id = FUNC_ADD;
-        Arg args;
+        L0TaskArgs args;
         args.add_input(ws_aic_slot1);
         args.add_input(ext_B);
         args.add_output(ext_aic_out);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -15,24 +15,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_a = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_b = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_f = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_a = orch_args.tensor(0).ref();
+    const Tensor &ext_b = orch_args.tensor(1).ref();
+    const Tensor &ext_f = orch_args.tensor(2).ref();
 
-    uint32_t size = orch_args.tensor(0).shapes[0];
+    uint32_t size = orch_args.tensor(0).ref().shapes[0];
     uint32_t inter_shapes[1] = {size};
     TensorCreateInfo inter_ci(inter_shapes, 1, DataType::FLOAT32);
 
-    Arg params_t0;
+    L0TaskArgs params_t0;
     params_t0.add_input(ext_a);
     params_t0.add_input(ext_b);
     params_t0.add_output(inter_ci);
@@ -40,7 +39,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     const Tensor &c = outs_t0.get_ref(0);
 
     PTO2_SCOPE() {
-        Arg params_t1;
+        L0TaskArgs params_t1;
         params_t1.add_input(c);
         params_t1.add_output(inter_ci);
         float t1_addend = 1.0f;
@@ -52,7 +51,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskOutputTensors outs_t1 = rt_submit_aiv_task(1, params_t1);
         const Tensor &d = outs_t1.get_ref(0);
 
-        Arg params_t2;
+        L0TaskArgs params_t2;
         params_t2.add_input(c);
         params_t2.add_output(inter_ci);
         float t2_addend = 2.0f;
@@ -64,7 +63,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskOutputTensors outs_t2 = rt_submit_aiv_task(1, params_t2);
         const Tensor &e = outs_t2.get_ref(0);
 
-        Arg params_t3;
+        L0TaskArgs params_t3;
         params_t3.add_input(d);
         params_t3.add_input(e);
         params_t3.add_output(inter_ci);
@@ -78,7 +77,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         TaskOutputTensors outs_t3 = rt_submit_aiv_task(2, params_t3);
         const Tensor &g = outs_t3.get_ref(0);
 
-        Arg params_t4;
+        L0TaskArgs params_t4;
         params_t4.add_input(g);
         params_t4.add_input(c);
         params_t4.add_output(ext_f);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -52,18 +52,17 @@ static constexpr int32_t LONG_CHAIN_DUMMIES = 4;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_W = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_X = orch_args.tensor(0).ref();
+    const Tensor &ext_Y = orch_args.tensor(1).ref();
+    const Tensor &ext_W = orch_args.tensor(2).ref();
 
     uint64_t case_id = orch_args.scalar(0);
     LOG_INFO_V0("[dummy_task_orch] case_id=%llu", static_cast<unsigned long long>(case_id));
@@ -71,19 +70,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     if (case_id == 1) {
         // producer writes X
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_aic_task(FUNC_WRITE_CONST, args);
         }
         // dummy_T INOUTs X (becomes new producer)
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_dummy_task(args);
         }
         // consumer reads X -> writes Y
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_input(ext_X);
             args.add_inout(ext_Y);
             rt_submit_aic_task(FUNC_COPY_FIRST, args);
@@ -91,19 +90,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     } else if (case_id == 2) {
         // producer writes X
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_aic_task(FUNC_WRITE_CONST, args);
         }
         // long dummy chain
         for (int32_t i = 0; i < LONG_CHAIN_DUMMIES; i++) {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_dummy_task(args);
         }
         // consumer
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_input(ext_X);
             args.add_inout(ext_Y);
             rt_submit_aic_task(FUNC_COPY_FIRST, args);
@@ -113,26 +112,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         PTO2TaskId a_id;
         PTO2TaskId b_id;
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             a_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_W);
             b_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
         // dummy barrier on A + B (no tensor args, only explicit deps)
         PTO2TaskId dummy_id;
         {
-            Arg args;
+            L0TaskArgs args;
             PTO2TaskId barrier_deps[] = {a_id, b_id};
             args.set_dependencies(barrier_deps, 2);
             dummy_id = rt_submit_dummy_task(args).task_id();
         }
         // consumer: explicit dep on dummy, reads X
         {
-            Arg args;
+            L0TaskArgs args;
             PTO2TaskId consumer_deps[] = {dummy_id};
             args.set_dependencies(consumer_deps, 1);
             args.add_input(ext_X);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/fanin_lookup_perf/kernels/orchestration/fanin_lookup_perf_orch.cpp
@@ -40,17 +40,16 @@ static constexpr uint32_t SLOT_ELEMS = 16;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 5,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor producer_outputs = from_tensor_arg(orch_args.tensor(0));
-    Tensor consumer_outputs = from_tensor_arg(orch_args.tensor(1));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &producer_outputs = orch_args.tensor(0).ref();
+    const Tensor &consumer_outputs = orch_args.tensor(1).ref();
     int32_t producer_count = static_cast<int32_t>(orch_args.scalar(0));
     int32_t consumer_count = static_cast<int32_t>(orch_args.scalar(1));
     bool use_real_kernels = orch_args.scalar(2) != 0;
@@ -66,7 +65,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     PTO2TaskId producer_ids[MAX_PRODUCERS];
     uint32_t slot_shape[1] = {SLOT_ELEMS};
     for (int32_t i = 0; i < producer_count; i++) {
-        Arg args;
+        L0TaskArgs args;
         if (use_real_kernels) {
             uint32_t offset[1] = {static_cast<uint32_t>(i) * SLOT_ELEMS};
             Tensor producer_out = producer_outputs.view(slot_shape, offset);
@@ -78,7 +77,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     }
 
     for (int32_t c = 0; c < consumer_count; c++) {
-        Arg args;
+        L0TaskArgs args;
         args.set_dependencies(producer_ids, static_cast<uint32_t>(producer_count));
         if (use_real_kernels) {
             uint32_t offset[1] = {static_cast<uint32_t>(c) * SLOT_ELEMS};

--- a/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -40,36 +40,35 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 15,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    // Input tensors use from_tensor_arg() — golden shape = kernel shape
-    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_D = from_tensor_arg(orch_args.tensor(3));
-    Tensor ext_E = from_tensor_arg(orch_args.tensor(4));
-    Tensor ext_G = from_tensor_arg(orch_args.tensor(6));
-    Tensor ext_H = from_tensor_arg(orch_args.tensor(7));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    // Input tensors use orch_args.tensor(i).ref() — golden shape = kernel shape
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_D = orch_args.tensor(3).ref();
+    const Tensor &ext_E = orch_args.tensor(4).ref();
+    const Tensor &ext_G = orch_args.tensor(6).ref();
+    const Tensor &ext_H = orch_args.tensor(7).ref();
 
     // Output tensors — full buffers
-    Tensor ext_C = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_F = from_tensor_arg(orch_args.tensor(5));
-    Tensor ext_I = from_tensor_arg(orch_args.tensor(8));
-    Tensor ext_J = from_tensor_arg(orch_args.tensor(9));
-    Tensor ext_K = from_tensor_arg(orch_args.tensor(10));
-    Tensor ext_L = from_tensor_arg(orch_args.tensor(11));
-    Tensor ext_M = from_tensor_arg(orch_args.tensor(12));
-    Tensor ext_N = from_tensor_arg(orch_args.tensor(13));
-    Tensor ext_O = from_tensor_arg(orch_args.tensor(14));
+    const Tensor &ext_C = orch_args.tensor(2).ref();
+    const Tensor &ext_F = orch_args.tensor(5).ref();
+    const Tensor &ext_I = orch_args.tensor(8).ref();
+    const Tensor &ext_J = orch_args.tensor(9).ref();
+    const Tensor &ext_K = orch_args.tensor(10).ref();
+    const Tensor &ext_L = orch_args.tensor(11).ref();
+    const Tensor &ext_M = orch_args.tensor(12).ref();
+    const Tensor &ext_N = orch_args.tensor(13).ref();
+    const Tensor &ext_O = orch_args.tensor(14).ref();
 
     // Derive num_iters from output tensor size
-    uint32_t total_elems = orch_args.tensor(2).shapes[0];
+    uint32_t total_elems = orch_args.tensor(2).ref().shapes[0];
     int num_iters = static_cast<int>(total_elems / TILE_ELEMS);
 
     LOG_INFO_V0("[mixed_orch] num_iters=%d", num_iters);
@@ -95,7 +94,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 mk.aic_kernel_id = FUNC_MATMUL;
                 mk.aiv0_kernel_id = FUNC_ADD;
                 mk.aiv1_kernel_id = FUNC_MUL;
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(C_view);
@@ -110,7 +109,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
             // 2. AIC_ONLY: standalone matmul
             {
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(J_view);
@@ -119,7 +118,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
             // 3. AIV_X1: standalone add
             {
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(K_view);
@@ -131,7 +130,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 MixedKernels mk;
                 mk.aiv0_kernel_id = FUNC_ADD_STANDALONE;
                 mk.aiv1_kernel_id = FUNC_MUL_STANDALONE;
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(L_view);
@@ -146,7 +145,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 MixedKernels mk;
                 mk.aic_kernel_id = FUNC_MATMUL;
                 mk.aiv0_kernel_id = FUNC_ADD;
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(N_view);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -48,17 +48,190 @@ inline uint64_t get_sys_cnt_aicpu() {
 }
 
 #ifdef ENABLE_PROFILING
-#define CYCLE_COUNT_START() uint64_t _t0 = get_sys_cnt_aicpu(), _t1
-#define CYCLE_COUNT_LAP(acc)       \
-    do {                           \
-        _t1 = get_sys_cnt_aicpu(); \
-        acc += (_t1 - _t0);        \
-        _t0 = _t1;                 \
+struct ProfCounters {
+    uint64_t param_extract = 0;
+    uint64_t ext_tensor = 0;
+    uint64_t make_tensor = 0;
+    uint64_t tensor_view = 0;
+    uint64_t param_setup = 0;
+    uint64_t submit_task = 0;
+    uint64_t scope_and_loop = 0;
+    int submit_count = 0;
+    int make_count = 0;
+    int view_count = 0;
+    // Running lap timestamps. File-global so the lap timeline stays continuous
+    // across the entry/process_qtile_scope() boundary — orchestration runs on a
+    // single thread, so a shared counter needs no synchronization.
+    uint64_t t0 = 0;
+    uint64_t t1 = 0;
+};
+static ProfCounters g_prof;
+#define CYCLE_COUNT_START() (g_prof.t0 = get_sys_cnt_aicpu())
+#define CYCLE_COUNT_LAP(acc)              \
+    do {                                  \
+        g_prof.t1 = get_sys_cnt_aicpu();  \
+        (acc) += (g_prof.t1 - g_prof.t0); \
+        g_prof.t0 = g_prof.t1;            \
     } while (0)
 #else
 #define CYCLE_COUNT_START() (void)0
 #define CYCLE_COUNT_LAP(acc) (void)0
 #endif
+
+/**
+ * Submit the QK -> softmax -> PV -> update task chain for one (batch, q-tile) unit.
+ *
+ * All context is passed positionally through a transport `Arg` (built by the
+ * caller, never submitted — only its slots are read back here). Every tensor
+ * slot is a materialized Tensor; the Arg carries no TensorCreateInfo (the
+ * scope's create-infos are rebuilt locally from the q_tile/head_dim scalars):
+ *   tensors: 0 query, 1 key_cache, 2 value_cache, 3 block_table (inputs),
+ *            4 out (output buffer the update task writes — add_output(Tensor))
+ *   scalars: 0 b_idx, 1 q_idx, 2 q_head_num, 3 q_tile, 4 head_dim,
+ *            5 block_size, 6 block_num, 7 scale_value, 8 bn_this_batch,
+ *            9 cur_seq, 10 data_type
+ * Adding/removing a slot here must be mirrored at the caller's build site.
+ *
+ * Must run inside a PTO2_SCOPE: the alloc'd / submitted tensors it references
+ * do not outlive that scope.
+ */
+static void process_qtile_scope(const Arg &ctx) {
+    const Tensor &query = *ctx.tensor(0).ptr;
+    const Tensor &key_cache = *ctx.tensor(1).ptr;
+    const Tensor &value_cache = *ctx.tensor(2).ptr;
+    const Tensor &block_table = *ctx.tensor(3).ptr;
+    const Tensor &out = *ctx.tensor(4).ptr;
+    uint64_t b_idx = ctx.scalar(0);
+    uint64_t q_idx = ctx.scalar(1);
+    uint64_t q_head_num = ctx.scalar(2);
+    uint64_t q_tile = ctx.scalar(3);
+    uint64_t head_dim = ctx.scalar(4);
+    uint64_t block_size = ctx.scalar(5);
+    uint64_t block_num = ctx.scalar(6);
+    uint64_t scale_value = ctx.scalar(7);
+    uint64_t bn_this_batch = ctx.scalar(8);
+    uint64_t cur_seq = ctx.scalar(9);
+    DataType data_type = static_cast<DataType>(ctx.scalar(10));
+
+    CYCLE_COUNT_START();
+
+    // Create infos for the per-scope accumulators — shapes depend only on
+    // q_tile/head_dim, so build once before the block loop. Kept out of the
+    // transport Arg, which carries only materialized Tensors.
+    uint32_t oi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
+    uint32_t li_shapes[1] = {static_cast<uint32_t>(q_tile)};
+    TensorCreateInfo tile2d_ci(oi_shapes, 2, DataType::FLOAT32);
+    TensorCreateInfo scalar_ci(li_shapes, 1, DataType::FLOAT32);
+#ifdef ENABLE_PROFILING
+    g_prof.make_count += 2;
+    CYCLE_COUNT_LAP(g_prof.make_tensor);
+#endif
+
+    uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
+
+    uint32_t qi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
+    uint32_t qi_offsets[2] = {static_cast<uint32_t>(cur_offset), 0};
+    Tensor qi = query.view(qi_shapes, qi_offsets);
+    uint32_t out_view_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
+    uint32_t out_view_offsets[2] = {static_cast<uint32_t>(cur_offset), 0};
+    Tensor out_view = out.view(out_view_shapes, out_view_offsets, true);
+#ifdef ENABLE_PROFILING
+    g_prof.view_count += 2;
+    CYCLE_COUNT_LAP(g_prof.tensor_view);
+#endif
+    CYCLE_COUNT_LAP(g_prof.param_setup);
+    TaskOutputTensors alloc_outs = alloc_tensors(tile2d_ci, scalar_ci, scalar_ci);
+    const Tensor &oi = alloc_outs.get_ref(0);
+    const Tensor &li_update = alloc_outs.get_ref(1);
+    const Tensor &mi_update = alloc_outs.get_ref(2);
+#ifdef ENABLE_PROFILING
+    g_prof.submit_count++;
+    CYCLE_COUNT_LAP(g_prof.submit_task);
+#endif
+
+    // Reusable Arg objects — reset() before each use avoids
+    // repeated stack-frame construction in the inner loop.
+    Arg params_qk, params_sf, params_pv, params_up;
+
+    for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
+        uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);
+
+        // Valid length for last block in this group
+        uint64_t last_block_seq_start = (bn + n_blocks - 1) * block_size;
+        uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
+        CYCLE_COUNT_LAP(g_prof.param_extract);
+
+        // === Task 1: Batched QK matmul ===
+        uint32_t sij_buf_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+        TensorCreateInfo sij_buf_ci(sij_buf_shapes, 2, DataType::FLOAT32);
+#ifdef ENABLE_PROFILING
+        g_prof.make_count += 1;
+        CYCLE_COUNT_LAP(g_prof.make_tensor);
+#endif
+
+        params_qk.reset();
+        params_qk.add_input(qi, key_cache, block_table);
+        params_qk.add_output(sij_buf_ci);
+        params_qk.add_scalar(n_blocks, b_idx * block_num + bn);
+        CYCLE_COUNT_LAP(g_prof.param_setup);
+        TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
+        const Tensor &sij_buf = qk_outs.get_ref(0);
+#ifdef ENABLE_PROFILING
+        g_prof.submit_count++;
+        CYCLE_COUNT_LAP(g_prof.submit_task);
+#endif
+
+        // === Task 2: Two-pass softmax over all blocks in group ===
+        uint32_t pij_buf_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)};
+        TensorCreateInfo pij_buf_ci(pij_buf_shapes, 2, data_type);
+#ifdef ENABLE_PROFILING
+        g_prof.make_count += 1;
+        CYCLE_COUNT_LAP(g_prof.make_tensor);
+#endif
+
+        params_sf.reset();
+        params_sf.add_input(sij_buf);
+        params_sf.add_output(pij_buf_ci, scalar_ci, scalar_ci);
+        params_sf.add_scalar(scale_value, n_blocks, valid_len_last);
+        CYCLE_COUNT_LAP(g_prof.param_setup);
+        TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
+        const Tensor &pij_buf = sf_outs.get_ref(0);
+        const Tensor &mi = sf_outs.get_ref(1);
+        const Tensor &li = sf_outs.get_ref(2);
+#ifdef ENABLE_PROFILING
+        g_prof.submit_count++;
+        CYCLE_COUNT_LAP(g_prof.submit_task);
+#endif
+
+        // === Task 3: SplitK PV matmul (accumulated P @ V) ===
+        params_pv.reset();
+        params_pv.add_input(pij_buf, value_cache, block_table);
+        params_pv.add_output(tile2d_ci);
+        params_pv.add_scalar(n_blocks, b_idx * block_num + bn);
+        CYCLE_COUNT_LAP(g_prof.param_setup);
+        TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
+        const Tensor &oi_new = pv_outs.get_ref(0);
+#ifdef ENABLE_PROFILING
+        g_prof.submit_count++;
+        CYCLE_COUNT_LAP(g_prof.submit_task);
+#endif
+
+        // === Task 4: Online update (per-group) ===
+        uint64_t is_first = (bn == 0) ? 1 : 0;
+        uint64_t is_last = (bn + n_blocks >= bn_this_batch) ? 1 : 0;
+
+        params_up.reset();
+        params_up.add_input(mi, li, oi_new);
+        params_up.add_inout(mi_update, li_update, oi, out_view);
+        params_up.add_scalar(is_first, is_last);
+        CYCLE_COUNT_LAP(g_prof.param_setup);
+        rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
+#ifdef ENABLE_PROFILING
+        g_prof.submit_count++;
+        CYCLE_COUNT_LAP(g_prof.submit_task);
+#endif
+    }
+}
 
 extern "C" {
 /**
@@ -75,16 +248,7 @@ aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
 
 __attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
-    uint64_t prof_param_extract = 0;
-    uint64_t prof_ext_tensor = 0;
-    uint64_t prof_make_tensor = 0;
-    uint64_t prof_tensor_view = 0;
-    uint64_t prof_param_setup = 0;
-    uint64_t prof_submit_task = 0;
-    uint64_t prof_scope_and_loop = 0;
-    int prof_submit_count = 0;
-    int prof_make_count = 0;
-    int prof_view_count = 0;
+    g_prof = ProfCounters{};  // reset per entry — single-threaded orchestration
 #endif
 
     CYCLE_COUNT_START();
@@ -107,7 +271,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t q_head_num = num_heads;
     uint64_t q_tile = std::min(num_heads, static_cast<uint64_t>(128));
     uint64_t q_loop = (q_head_num + q_tile - 1) / q_tile;
-    CYCLE_COUNT_LAP(prof_param_extract);
+    CYCLE_COUNT_LAP(g_prof.param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
     void *query_ptr = orch_args.tensor(0).data_as<void>();
@@ -138,18 +302,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
-    CYCLE_COUNT_LAP(prof_ext_tensor);
+    CYCLE_COUNT_LAP(g_prof.ext_tensor);
 #endif
 
-    // Create infos are loop-invariant — shapes depend only on q_tile/head_dim
-    uint32_t oi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
-    uint32_t li_shapes[1] = {static_cast<uint32_t>(q_tile)};
-    TensorCreateInfo tile2d_ci(oi_shapes, 2, DataType::FLOAT32);
-    TensorCreateInfo scalar_ci(li_shapes, 1, DataType::FLOAT32);
-#ifdef ENABLE_PROFILING
-    prof_make_count += 2;
-    CYCLE_COUNT_LAP(prof_make_tensor);
-#endif
+    // Transport Arg reused across iterations — packs the scope's context for
+    // process_qtile_scope(); see that function for the positional slot layout.
+    // It carries only materialized Tensors (no TensorCreateInfo); the scope's
+    // create-infos are rebuilt inside the helper from the q_tile/head_dim scalars.
+    Arg ctx;
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};
@@ -157,158 +317,58 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         uint64_t bn_this_batch = (cur_seq + block_size - 1) / block_size;
 
         for (uint64_t q_idx = 0; q_idx < q_loop; q_idx++) {
-            CYCLE_COUNT_LAP(prof_scope_and_loop);
-            PTO2_SCOPE() {
-                uint64_t cur_offset = b_idx * q_head_num + q_idx * q_tile;
+            CYCLE_COUNT_LAP(g_prof.scope_and_loop);
 
-                uint32_t qi_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
-                uint32_t qi_offsets[2] = {static_cast<uint32_t>(cur_offset), 0};
-                Tensor qi = query.view(qi_shapes, qi_offsets);
-                uint32_t out_view_shapes[2] = {static_cast<uint32_t>(q_tile), static_cast<uint32_t>(head_dim)};
-                uint32_t out_view_offsets[2] = {static_cast<uint32_t>(cur_offset), 0};
-                Tensor out_view = out.view(out_view_shapes, out_view_offsets, true);
-#ifdef ENABLE_PROFILING
-                prof_view_count += 2;
-                CYCLE_COUNT_LAP(prof_tensor_view);
-#endif
-                CYCLE_COUNT_LAP(prof_param_setup);
-                TaskOutputTensors alloc_outs = alloc_tensors(tile2d_ci, scalar_ci, scalar_ci);
-                const Tensor &oi = alloc_outs.get_ref(0);
-                const Tensor &li_update = alloc_outs.get_ref(1);
-                const Tensor &mi_update = alloc_outs.get_ref(2);
-#ifdef ENABLE_PROFILING
-                prof_submit_count++;
-                CYCLE_COUNT_LAP(prof_submit_task);
-#endif
+            ctx.reset();
+            ctx.add_input(query, key_cache, value_cache, block_table);
+            ctx.add_output(out);
+            ctx.add_scalar(
+                b_idx, q_idx, q_head_num, q_tile, head_dim, block_size, block_num, scale_value, bn_this_batch, cur_seq,
+                static_cast<uint64_t>(data_type)
+            );
 
-                // Reusable Arg objects — reset() before each use avoids
-                // repeated stack-frame construction in the inner loop.
-                Arg params_qk, params_sf, params_pv, params_up;
-
-                for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
-                    uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);
-
-                    // Valid length for last block in this group
-                    uint64_t last_block_seq_start = (bn + n_blocks - 1) * block_size;
-                    uint64_t valid_len_last = std::min(block_size, cur_seq - last_block_seq_start);
-                    CYCLE_COUNT_LAP(prof_param_extract);
-
-                    // === Task 1: Batched QK matmul ===
-                    uint32_t sij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
-                    };
-                    TensorCreateInfo sij_buf_ci(sij_buf_shapes, 2, DataType::FLOAT32);
-#ifdef ENABLE_PROFILING
-                    prof_make_count += 1;
-                    CYCLE_COUNT_LAP(prof_make_tensor);
-#endif
-
-                    params_qk.reset();
-                    params_qk.add_input(qi, key_cache, block_table);
-                    params_qk.add_output(sij_buf_ci);
-                    params_qk.add_scalar(n_blocks, b_idx * block_num + bn);
-                    CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors qk_outs = rt_submit_aic_task(FUNC_QK_MATMUL, params_qk);
-                    const Tensor &sij_buf = qk_outs.get_ref(0);
-#ifdef ENABLE_PROFILING
-                    prof_submit_count++;
-                    CYCLE_COUNT_LAP(prof_submit_task);
-#endif
-
-                    // === Task 2: Two-pass softmax over all blocks in group ===
-                    uint32_t pij_buf_shapes[2] = {
-                        static_cast<uint32_t>(q_tile), static_cast<uint32_t>(n_blocks * block_size)
-                    };
-                    TensorCreateInfo pij_buf_ci(pij_buf_shapes, 2, data_type);
-#ifdef ENABLE_PROFILING
-                    prof_make_count += 1;
-                    CYCLE_COUNT_LAP(prof_make_tensor);
-#endif
-
-                    params_sf.reset();
-                    params_sf.add_input(sij_buf);
-                    params_sf.add_output(pij_buf_ci, scalar_ci, scalar_ci);
-                    params_sf.add_scalar(scale_value, n_blocks, valid_len_last);
-                    CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors sf_outs = rt_submit_aiv_task(FUNC_SOFTMAX_PREPARE, params_sf);
-                    const Tensor &pij_buf = sf_outs.get_ref(0);
-                    const Tensor &mi = sf_outs.get_ref(1);
-                    const Tensor &li = sf_outs.get_ref(2);
-#ifdef ENABLE_PROFILING
-                    prof_submit_count++;
-                    CYCLE_COUNT_LAP(prof_submit_task);
-#endif
-
-                    // === Task 3: SplitK PV matmul (accumulated P @ V) ===
-                    params_pv.reset();
-                    params_pv.add_input(pij_buf, value_cache, block_table);
-                    params_pv.add_output(tile2d_ci);
-                    params_pv.add_scalar(n_blocks, b_idx * block_num + bn);
-                    CYCLE_COUNT_LAP(prof_param_setup);
-                    TaskOutputTensors pv_outs = rt_submit_aic_task(FUNC_PV_MATMUL, params_pv);
-                    const Tensor &oi_new = pv_outs.get_ref(0);
-#ifdef ENABLE_PROFILING
-                    prof_submit_count++;
-                    CYCLE_COUNT_LAP(prof_submit_task);
-#endif
-
-                    // === Task 4: Online update (per-group) ===
-                    uint64_t is_first = (bn == 0) ? 1 : 0;
-                    uint64_t is_last = (bn + n_blocks >= bn_this_batch) ? 1 : 0;
-
-                    params_up.reset();
-                    params_up.add_input(mi, li, oi_new);
-                    params_up.add_inout(mi_update, li_update, oi, out_view);
-                    params_up.add_scalar(is_first, is_last);
-                    CYCLE_COUNT_LAP(prof_param_setup);
-                    rt_submit_aiv_task(FUNC_ONLINE_UPDATE, params_up);
-#ifdef ENABLE_PROFILING
-                    prof_submit_count++;
-                    CYCLE_COUNT_LAP(prof_submit_task);
-#endif
-                }
-            }
-            CYCLE_COUNT_LAP(prof_scope_and_loop);
+            PTO2_SCOPE() { process_qtile_scope(ctx); }
         }
     }
-    CYCLE_COUNT_LAP(prof_scope_and_loop);
+    CYCLE_COUNT_LAP(g_prof.scope_and_loop);
 
 #ifdef ENABLE_PROFILING
-    uint64_t total = prof_param_extract + prof_ext_tensor + prof_make_tensor + prof_tensor_view + prof_param_setup +
-                     prof_submit_task + prof_scope_and_loop;
+    uint64_t total = g_prof.param_extract + g_prof.ext_tensor + g_prof.make_tensor + g_prof.tensor_view +
+                     g_prof.param_setup + g_prof.submit_task + g_prof.scope_and_loop;
     LOG_INFO_V9(
-        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", prof_submit_count,
-        prof_make_count, prof_view_count, cycles_to_us(total)
+        "=== PagedAttn Orch Profiling: %d submits, %d makes, %d views, total=%.3fus ===", g_prof.submit_count,
+        g_prof.make_count, g_prof.view_count, cycles_to_us(total)
     );
     if (total > 0) {
         LOG_INFO_V9(
-            "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_extract),
-            prof_param_extract * 100.0 / total
+            "  param_extract    : %7.3fus (%5.1f%%)", cycles_to_us(g_prof.param_extract),
+            g_prof.param_extract * 100.0 / total
         );
         LOG_INFO_V9(
-            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(prof_ext_tensor), prof_ext_tensor * 100.0 / total
+            "  ext_tensor(x4)   : %7.3fus (%5.1f%%)", cycles_to_us(g_prof.ext_tensor), g_prof.ext_tensor * 100.0 / total
         );
         LOG_INFO_V9(
-            "  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_make_count, cycles_to_us(prof_make_tensor),
-            prof_make_tensor * 100.0 / total,
-            prof_make_count > 0 ? cycles_to_us(prof_make_tensor) / prof_make_count : 0.0
+            "  create_info(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", g_prof.make_count, cycles_to_us(g_prof.make_tensor),
+            g_prof.make_tensor * 100.0 / total,
+            g_prof.make_count > 0 ? cycles_to_us(g_prof.make_tensor) / g_prof.make_count : 0.0
         );
         LOG_INFO_V9(
-            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_view_count, cycles_to_us(prof_tensor_view),
-            prof_tensor_view * 100.0 / total,
-            prof_view_count > 0 ? cycles_to_us(prof_tensor_view) / prof_view_count : 0.0
+            "  tensor_view(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", g_prof.view_count, cycles_to_us(g_prof.tensor_view),
+            g_prof.tensor_view * 100.0 / total,
+            g_prof.view_count > 0 ? cycles_to_us(g_prof.tensor_view) / g_prof.view_count : 0.0
         );
         LOG_INFO_V9(
-            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(prof_param_setup), prof_param_setup * 100.0 / total
+            "  param_setup      : %7.3fus (%5.1f%%)", cycles_to_us(g_prof.param_setup),
+            g_prof.param_setup * 100.0 / total
         );
         LOG_INFO_V9(
-            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", prof_submit_count, cycles_to_us(prof_submit_task),
-            prof_submit_task * 100.0 / total,
-            prof_submit_count > 0 ? cycles_to_us(prof_submit_task) / prof_submit_count : 0.0
+            "  submit_task(x%d) : %7.3fus (%5.1f%%)  avg=%.3fus", g_prof.submit_count, cycles_to_us(g_prof.submit_task),
+            g_prof.submit_task * 100.0 / total,
+            g_prof.submit_count > 0 ? cycles_to_us(g_prof.submit_task) / g_prof.submit_count : 0.0
         );
         LOG_INFO_V9(
-            "  scope_and_loop   : %7.3fus (%5.1f%%)", cycles_to_us(prof_scope_and_loop),
-            prof_scope_and_loop * 100.0 / total
+            "  scope_and_loop   : %7.3fus (%5.1f%%)", cycles_to_us(g_prof.scope_and_loop),
+            g_prof.scope_and_loop * 100.0 / total
         );
     }
 #endif

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -95,12 +95,12 @@ static ProfCounters g_prof;
  * Must run inside a PTO2_SCOPE: the alloc'd / submitted tensors it references
  * do not outlive that scope.
  */
-static void process_qtile_scope(const Arg &ctx) {
-    const Tensor &query = *ctx.tensor(0).ptr;
-    const Tensor &key_cache = *ctx.tensor(1).ptr;
-    const Tensor &value_cache = *ctx.tensor(2).ptr;
-    const Tensor &block_table = *ctx.tensor(3).ptr;
-    const Tensor &out = *ctx.tensor(4).ptr;
+static void process_qtile_scope(const L0TaskArgs &ctx) {
+    const Tensor &query = ctx.tensor(0).ref();
+    const Tensor &key_cache = ctx.tensor(1).ref();
+    const Tensor &value_cache = ctx.tensor(2).ref();
+    const Tensor &block_table = ctx.tensor(3).ref();
+    const Tensor &out = ctx.tensor(4).ref();
     uint64_t b_idx = ctx.scalar(0);
     uint64_t q_idx = ctx.scalar(1);
     uint64_t q_head_num = ctx.scalar(2);
@@ -151,7 +151,7 @@ static void process_qtile_scope(const Arg &ctx) {
 
     // Reusable Arg objects — reset() before each use avoids
     // repeated stack-frame construction in the inner loop.
-    Arg params_qk, params_sf, params_pv, params_up;
+    L0TaskArgs params_qk, params_sf, params_pv, params_up;
 
     for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
         uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);
@@ -238,15 +238,14 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     g_prof = ProfCounters{};  // reset per entry — single-threaded orchestration
 #endif
@@ -255,16 +254,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
 
     // block_table: shape=[batch, max_num_blocks_per_req]
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
     uint64_t scale_value = orch_args.scalar(0);
@@ -274,12 +273,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     CYCLE_COUNT_LAP(g_prof.param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -296,10 +295,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(g_prof.ext_tensor);
@@ -309,7 +308,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // process_qtile_scope(); see that function for the positional slot layout.
     // It carries only materialized Tensors (no TensorCreateInfo); the scope's
     // create-infos are rebuilt inside the helper from the q_tile/head_dim scalars.
-    Arg ctx;
+    L0TaskArgs ctx;
 
     for (uint64_t b_idx = 0; b_idx < batch; b_idx++) {
         uint32_t cl_idx[1] = {static_cast<uint32_t>(b_idx)};

--- a/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/paged_attention_unroll_4dims/kernels/orchestration/paged_attention_orch.cpp
@@ -42,27 +42,26 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     // Read dimensions from tensor metadata
     // query: shape=[batch, seq_len, num_heads, head_dim]
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[2];
-    uint64_t head_dim = orch_args.tensor(0).shapes[3];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[2];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[3];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
 
     // block_table: shape=[batch, max_num_blocks_per_req]
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
     uint64_t scale_value = orch_args.scalar(0);
@@ -70,13 +69,13 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     uint64_t q_loop = (num_heads + q_tile - 1) / q_tile;
 
     // External 4D tensors inherit shape/dtype from TaskArg (golden provides 4D).
-    Tensor query = from_tensor_arg(orch_args.tensor(0));
-    Tensor key_cache = from_tensor_arg(orch_args.tensor(1));
-    Tensor value_cache = from_tensor_arg(orch_args.tensor(2));
-    Tensor block_table = from_tensor_arg(orch_args.tensor(3));
-    Tensor out = from_tensor_arg(orch_args.tensor(5));
+    const Tensor &query = orch_args.tensor(0).ref();
+    const Tensor &key_cache = orch_args.tensor(1).ref();
+    const Tensor &value_cache = orch_args.tensor(2).ref();
+    const Tensor &block_table = orch_args.tensor(3).ref();
+    const Tensor &out = orch_args.tensor(5).ref();
 
-    int *host_context_lens = orch_args.tensor(4).data_as<int>();
+    int *host_context_lens = orch_args.tensor(4).ref().data_as<int>();
 
     // Loop-invariant shape descriptors: 4D data tiles (1, 1, q_tile, head_dim),
     // 3D scalar vectors (1, 1, q_tile).
@@ -112,7 +111,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
                 // Reusable Arg objects — reset() before each use avoids
                 // repeated stack-frame construction in the inner loop.
-                Arg params_qk, params_sf, params_pv, params_up;
+                L0TaskArgs params_qk, params_sf, params_pv, params_up;
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
                     uint64_t n_blocks = std::min((uint64_t)N_UNROLL, bn_this_batch - bn);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -30,23 +30,22 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_READ_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_READ_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_READ_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(ext_output);
 
     rt_submit_task(mk, args);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_batch_dispatch_oob/kernels/orchestration/spmd_batch_dispatch_oob_orch.cpp
@@ -29,29 +29,28 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_spmd_mix(Tensor &out, int16_t block_num, int64_t base_cl) {
+static void submit_spmd_mix(const Tensor &out, int16_t block_num, int64_t base_cl) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_AIC;
     mk.aiv0_kernel_id = FUNC_AIV0;
     mk.aiv1_kernel_id = FUNC_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // Two back-to-back tasks with block_num=48 (2x cluster count).
     // Both land in the ready queue simultaneously, triggering got=2 in

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -32,24 +32,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, int64_t base_cl) {
-    Arg args;
+static void submit_spmd_aiv(int32_t kernel_id, const Tensor &out, int16_t block_num, int64_t base_cl) {
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     rt_submit_aiv_task(kernel_id, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 4 blocks — basic multi-block
     submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 4, 0);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -34,30 +34,30 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void
-submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, int16_t block_num, int64_t base_cl) {
+static void submit_spmd_mix(
+    int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, const Tensor &out, int16_t block_num, int64_t base_cl
+) {
     MixedKernels mk;
     mk.aic_kernel_id = aic_id;
     mk.aiv0_kernel_id = aiv0_id;
     mk.aiv1_kernel_id = aiv1_id;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 2 blocks (6 CL) — basic multi-block MIX
     submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 2, 0);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/orchestration/spmd_paged_attention_orch.cpp
@@ -54,22 +54,21 @@ static constexpr uint32_t FIFO_DEPTH = 2;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
-    uint64_t max_num_blocks_per_req = orch_args.tensor(3).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
+    uint64_t max_num_blocks_per_req = orch_args.tensor(3).ref().shapes[1];
     uint64_t scale_value = orch_args.scalar(0);
 
     // q_tile adapts to num_heads: use 64 when num_heads >= 64, else 16.
@@ -85,12 +84,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     );
 
     // Wrap host tensors
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_kv_blocks = orch_args.tensor(1).shapes[0];
+    uint64_t total_kv_blocks = orch_args.tensor(1).ref().shapes[0];
     uint64_t kv_total_rows = total_kv_blocks * block_size;
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
@@ -104,10 +103,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(max_num_blocks_per_req)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
     // GM FIFO buffers for TPUSH/TPOP (one set of slots per hardware block)
     uint32_t sij_fifo_total = static_cast<uint32_t>(SPMD_BLOCK_NUM) * SIJ_SLOT_SIZE * FIFO_DEPTH;
@@ -124,7 +123,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     TensorCreateInfo oi_fifo_ci(oi_fifo_shapes, 1, DataType::INT32);
 
     PTO2_SCOPE() {
-        Arg args;
+        L0TaskArgs args;
         args.add_input(query);
         args.add_input(key_cache);
         args.add_input(value_cache);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/kernels/orchestration/paged_attention_highperf_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention_highperf/kernels/orchestration/paged_attention_highperf_orch.cpp
@@ -18,36 +18,35 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 16,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     int64_t block_dim = static_cast<int64_t>(orch_args.scalar(0));
 
     LOG_INFO_V1("SPMD PA highperf: block_dim=%" PRId64, block_dim);
 
-    Tensor query = from_tensor_arg(orch_args.tensor(0));
-    Tensor key_cache = from_tensor_arg(orch_args.tensor(1));
-    Tensor value_cache = from_tensor_arg(orch_args.tensor(2));
-    Tensor block_table = from_tensor_arg(orch_args.tensor(3));
-    Tensor out = from_tensor_arg(orch_args.tensor(4));
-    Tensor s_gm = from_tensor_arg(orch_args.tensor(5));
-    Tensor p_gm = from_tensor_arg(orch_args.tensor(6));
-    Tensor o_tmp_gm = from_tensor_arg(orch_args.tensor(7));
-    Tensor go_gm = from_tensor_arg(orch_args.tensor(8));
-    Tensor o_core_tmp_gm = from_tensor_arg(orch_args.tensor(9));
-    Tensor l_gm = from_tensor_arg(orch_args.tensor(10));
-    Tensor gm_k16 = from_tensor_arg(orch_args.tensor(11));
-    Tensor gm_v16 = from_tensor_arg(orch_args.tensor(12));
-    Tensor tiling = from_tensor_arg(orch_args.tensor(13));
-    Tensor null_tensor = from_tensor_arg(orch_args.tensor(14));
+    const Tensor &query = orch_args.tensor(0).ref();
+    const Tensor &key_cache = orch_args.tensor(1).ref();
+    const Tensor &value_cache = orch_args.tensor(2).ref();
+    const Tensor &block_table = orch_args.tensor(3).ref();
+    const Tensor &out = orch_args.tensor(4).ref();
+    const Tensor &s_gm = orch_args.tensor(5).ref();
+    const Tensor &p_gm = orch_args.tensor(6).ref();
+    const Tensor &o_tmp_gm = orch_args.tensor(7).ref();
+    const Tensor &go_gm = orch_args.tensor(8).ref();
+    const Tensor &o_core_tmp_gm = orch_args.tensor(9).ref();
+    const Tensor &l_gm = orch_args.tensor(10).ref();
+    const Tensor &gm_k16 = orch_args.tensor(11).ref();
+    const Tensor &gm_v16 = orch_args.tensor(12).ref();
+    const Tensor &tiling = orch_args.tensor(13).ref();
+    const Tensor &null_tensor = orch_args.tensor(14).ref();
 
-    Arg args;
+    L0TaskArgs args;
     args.add_input(query);
     args.add_input(key_cache);
     args.add_input(value_cache);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -43,21 +43,20 @@ static constexpr int32_t SYNC_CL = SYNC_BLOCK_NUM * SLOTS_PER_BLOCK;      // 18
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
@@ -65,8 +64,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     int64_t cl = 0;
 

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -38,21 +38,20 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
@@ -60,8 +59,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 2 blocks, sync_start=true  (6 CL)
     submit_mix(ext_output, 2, 0, true);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -37,16 +37,15 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
-    Arg args;
+static void submit_aiv(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
@@ -54,8 +53,8 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 4 blocks, sync_start=true (fast path: 4 <= idle AIV cores on one thread)
     submit_aiv(ext_output, 4, 0, true);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -36,21 +36,20 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
@@ -58,8 +57,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: block_num=1, sync_start=true (degenerate: always fast path, 3 CL)
     submit_mix(ext_output, 1, 0, true);

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -48,18 +48,17 @@ static constexpr int32_t ROUNDS = 6;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 1};
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
@@ -67,8 +66,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
-    Arg args;
+static void submit_aiv(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_block_num(block_num);
@@ -76,8 +75,8 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     int64_t cl = 0;
 

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/dep_gen/kernels/orchestration/chain_barrier_orch.cpp
@@ -42,17 +42,16 @@ static constexpr int32_t MAX_PRODUCERS = 500;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,  // X, Y, scalar(N)
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_X = orch_args.tensor(0).ref();
+    const Tensor &ext_Y = orch_args.tensor(1).ref();
 
     uint64_t n_raw = orch_args.scalar(0);
     int32_t n = static_cast<int32_t>(n_raw);
@@ -67,7 +66,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // stays at SENTINEL through all of them — the host only checks the final
     // value, which proves the barrier waited for every producer to finish.
     for (int32_t i = 0; i < n; i++) {
-        Arg args;
+        L0TaskArgs args;
         args.add_inout(ext_X);
         producer_ids[i] = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
     }
@@ -76,14 +75,14 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     // the dep_gen writer to emit base + overflow chain.
     PTO2TaskId barrier_id;
     {
-        Arg args;
+        L0TaskArgs args;
         args.set_dependencies(producer_ids, n);
         barrier_id = rt_submit_dummy_task(args).task_id();
     }
 
     // Consumer: explicit dep on barrier only, reads X, writes Y.
     {
-        Arg args;
+        L0TaskArgs args;
         PTO2TaskId consumer_deps[] = {barrier_id};
         args.set_dependencies(consumer_deps, 1);
         args.add_input(ext_X);

--- a/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dummy_task/kernels/orchestration/dummy_task_orch.cpp
@@ -52,18 +52,17 @@ static constexpr int32_t LONG_CHAIN_DUMMIES = 4;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 4,  // 3 tensors + 1 case scalar
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_X = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_Y = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_W = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_X = orch_args.tensor(0).ref();
+    const Tensor &ext_Y = orch_args.tensor(1).ref();
+    const Tensor &ext_W = orch_args.tensor(2).ref();
 
     uint64_t case_id = orch_args.scalar(0);
     LOG_INFO_V0("[dummy_task_orch] case_id=%llu", static_cast<unsigned long long>(case_id));
@@ -71,19 +70,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     if (case_id == 1) {
         // producer writes X
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_aic_task(FUNC_WRITE_CONST, args);
         }
         // dummy_T INOUTs X (becomes new producer)
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_dummy_task(args);
         }
         // consumer reads X -> writes Y
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_input(ext_X);
             args.add_inout(ext_Y);
             rt_submit_aic_task(FUNC_COPY_FIRST, args);
@@ -91,19 +90,19 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     } else if (case_id == 2) {
         // producer writes X
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_aic_task(FUNC_WRITE_CONST, args);
         }
         // long dummy chain
         for (int32_t i = 0; i < LONG_CHAIN_DUMMIES; i++) {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             rt_submit_dummy_task(args);
         }
         // consumer
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_input(ext_X);
             args.add_inout(ext_Y);
             rt_submit_aic_task(FUNC_COPY_FIRST, args);
@@ -113,26 +112,26 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
         PTO2TaskId a_id;
         PTO2TaskId b_id;
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_X);
             a_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
         {
-            Arg args;
+            L0TaskArgs args;
             args.add_inout(ext_W);
             b_id = rt_submit_aic_task(FUNC_WRITE_CONST, args).task_id();
         }
         // dummy barrier on A + B (no tensor args, only explicit deps)
         PTO2TaskId dummy_id;
         {
-            Arg args;
+            L0TaskArgs args;
             PTO2TaskId barrier_deps[] = {a_id, b_id};
             args.set_dependencies(barrier_deps, 2);
             dummy_id = rt_submit_dummy_task(args).task_id();
         }
         // consumer: explicit dep on dummy, reads X
         {
-            Arg args;
+            L0TaskArgs args;
             PTO2TaskId consumer_deps[] = {dummy_id};
             args.set_dependencies(consumer_deps, 1);
             args.add_input(ext_X);

--- a/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/mixed_example/kernels/orchestration/mixed_orch.cpp
@@ -40,36 +40,35 @@ static constexpr uint32_t TILE_ELEMS = 128 * 128;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 15,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    // Input tensors use from_tensor_arg() — golden shape = kernel shape
-    Tensor ext_A = from_tensor_arg(orch_args.tensor(0));
-    Tensor ext_B = from_tensor_arg(orch_args.tensor(1));
-    Tensor ext_D = from_tensor_arg(orch_args.tensor(3));
-    Tensor ext_E = from_tensor_arg(orch_args.tensor(4));
-    Tensor ext_G = from_tensor_arg(orch_args.tensor(6));
-    Tensor ext_H = from_tensor_arg(orch_args.tensor(7));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    // Input tensors use orch_args.tensor(i).ref() — golden shape = kernel shape
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_D = orch_args.tensor(3).ref();
+    const Tensor &ext_E = orch_args.tensor(4).ref();
+    const Tensor &ext_G = orch_args.tensor(6).ref();
+    const Tensor &ext_H = orch_args.tensor(7).ref();
 
     // Output tensors — full buffers
-    Tensor ext_C = from_tensor_arg(orch_args.tensor(2));
-    Tensor ext_F = from_tensor_arg(orch_args.tensor(5));
-    Tensor ext_I = from_tensor_arg(orch_args.tensor(8));
-    Tensor ext_J = from_tensor_arg(orch_args.tensor(9));
-    Tensor ext_K = from_tensor_arg(orch_args.tensor(10));
-    Tensor ext_L = from_tensor_arg(orch_args.tensor(11));
-    Tensor ext_M = from_tensor_arg(orch_args.tensor(12));
-    Tensor ext_N = from_tensor_arg(orch_args.tensor(13));
-    Tensor ext_O = from_tensor_arg(orch_args.tensor(14));
+    const Tensor &ext_C = orch_args.tensor(2).ref();
+    const Tensor &ext_F = orch_args.tensor(5).ref();
+    const Tensor &ext_I = orch_args.tensor(8).ref();
+    const Tensor &ext_J = orch_args.tensor(9).ref();
+    const Tensor &ext_K = orch_args.tensor(10).ref();
+    const Tensor &ext_L = orch_args.tensor(11).ref();
+    const Tensor &ext_M = orch_args.tensor(12).ref();
+    const Tensor &ext_N = orch_args.tensor(13).ref();
+    const Tensor &ext_O = orch_args.tensor(14).ref();
 
     // Derive num_iters from output tensor size
-    uint32_t total_elems = orch_args.tensor(2).shapes[0];
+    uint32_t total_elems = orch_args.tensor(2).ref().shapes[0];
     int num_iters = static_cast<int>(total_elems / TILE_ELEMS);
 
     LOG_INFO_V0("[mixed_orch] num_iters=%d", num_iters);
@@ -95,7 +94,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 mk.aic_kernel_id = FUNC_MATMUL;
                 mk.aiv0_kernel_id = FUNC_ADD;
                 mk.aiv1_kernel_id = FUNC_MUL;
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(C_view);
@@ -110,7 +109,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
             // 2. AIC_ONLY: standalone matmul
             {
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(J_view);
@@ -119,7 +118,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
             // 3. AIV_X1: standalone add
             {
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(K_view);
@@ -131,7 +130,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 MixedKernels mk;
                 mk.aiv0_kernel_id = FUNC_ADD_STANDALONE;
                 mk.aiv1_kernel_id = FUNC_MUL_STANDALONE;
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_D);
                 args.add_input(ext_E);
                 args.add_output(L_view);
@@ -146,7 +145,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
                 MixedKernels mk;
                 mk.aic_kernel_id = FUNC_MATMUL;
                 mk.aiv0_kernel_id = FUNC_ADD;
-                Arg args;
+                L0TaskArgs args;
                 args.add_input(ext_A);
                 args.add_input(ext_B);
                 args.add_output(N_view);

--- a/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/paged_attention_unroll/kernels/orchestration/paged_attention_orch.cpp
@@ -65,15 +65,14 @@ extern "C" {
  * Orchestration config — the executor reads these values to set up
  * shared memory and runtime before calling aicpu_orchestration_entry.
  */
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 7,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
 #ifdef ENABLE_PROFILING
     uint64_t prof_param_extract = 0;
     uint64_t prof_ext_tensor = 0;
@@ -91,16 +90,16 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Read dimensions from tensor metadata
     // query: shape=[batch, num_heads, head_dim]
-    uint64_t batch = orch_args.tensor(0).shapes[0];
-    uint64_t num_heads = orch_args.tensor(0).shapes[1];
-    uint64_t head_dim = orch_args.tensor(0).shapes[2];
-    DataType data_type = orch_args.tensor(0).dtype;
+    uint64_t batch = orch_args.tensor(0).ref().shapes[0];
+    uint64_t num_heads = orch_args.tensor(0).ref().shapes[1];
+    uint64_t head_dim = orch_args.tensor(0).ref().shapes[2];
+    DataType data_type = orch_args.tensor(0).ref().dtype;
 
     // key_cache: shape=[total_blocks, block_size, kv_head_num, head_dim]
-    uint64_t block_size = orch_args.tensor(1).shapes[1];
+    uint64_t block_size = orch_args.tensor(1).ref().shapes[1];
 
     // block_table: shape=[batch, max_num_blocks_per_req]
-    uint64_t block_num = orch_args.tensor(3).shapes[1];
+    uint64_t block_num = orch_args.tensor(3).ref().shapes[1];
 
     // scale from scalar arg
     uint64_t scale_value = orch_args.scalar(0);
@@ -110,12 +109,12 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
     CYCLE_COUNT_LAP(prof_param_extract);
 
     // Reshape tensors for kernel consumption (2D flattened)
-    void *query_ptr = orch_args.tensor(0).data_as<void>();
-    void *kc_ptr = orch_args.tensor(1).data_as<void>();
-    void *vc_ptr = orch_args.tensor(2).data_as<void>();
-    void *out_ptr = orch_args.tensor(5).data_as<void>();
+    void *query_ptr = orch_args.tensor(0).ref().data_as<void>();
+    void *kc_ptr = orch_args.tensor(1).ref().data_as<void>();
+    void *vc_ptr = orch_args.tensor(2).ref().data_as<void>();
+    void *out_ptr = orch_args.tensor(5).ref().data_as<void>();
 
-    uint64_t total_blocks_count = orch_args.tensor(1).shapes[0];
+    uint64_t total_blocks_count = orch_args.tensor(1).ref().shapes[0];
 
     uint32_t query_shapes[2] = {static_cast<uint32_t>(batch * num_heads), static_cast<uint32_t>(head_dim)};
     uint32_t key_cache_shapes[2] = {
@@ -132,10 +131,10 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     uint32_t bt_shapes[2] = {static_cast<uint32_t>(batch), static_cast<uint32_t>(block_num)};
     Tensor block_table =
-        make_tensor_external(orch_args.tensor(3).data_as<void>(), bt_shapes, 2, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(3).ref().data_as<void>(), bt_shapes, 2, DataType::INT32, false);
     uint32_t cl_shapes[1] = {static_cast<uint32_t>(batch)};
     Tensor context_lens =
-        make_tensor_external(orch_args.tensor(4).data_as<void>(), cl_shapes, 1, DataType::INT32, false);
+        make_tensor_external(orch_args.tensor(4).ref().data_as<void>(), cl_shapes, 1, DataType::INT32, false);
 
 #ifdef ENABLE_PROFILING
     CYCLE_COUNT_LAP(prof_ext_tensor);
@@ -182,7 +181,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
                 // Reusable Arg objects — reset() before each use avoids
                 // repeated stack-frame construction in the inner loop.
-                Arg params_qk, params_sf, params_pv, params_up;
+                L0TaskArgs params_qk, params_sf, params_pv, params_up;
 
                 for (uint64_t bn = 0; bn < bn_this_batch; bn += N_UNROLL) {
                     uint64_t n_blocks = std::min(static_cast<uint64_t>(N_UNROLL), bn_this_batch - bn);

--- a/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/simt_basic/kernels/orchestration/simt_basic_orch.cpp
@@ -24,24 +24,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 3,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor src = from_tensor_arg(orch_args.tensor(0));
-    Tensor indices = from_tensor_arg(orch_args.tensor(1));
-    Tensor out = from_tensor_arg(orch_args.tensor(2));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &src = orch_args.tensor(0).ref();
+    const Tensor &indices = orch_args.tensor(1).ref();
+    const Tensor &out = orch_args.tensor(2).ref();
 
     // PTO2_SCOPE ensures rt_submit_aiv_task flushes through the task
     // ringbuffer before the entry returns. No set_core_num — let the
     // runtime use the config's block_dim.
     PTO2_SCOPE() {
-        Arg args;
+        L0TaskArgs args;
         args.add_input(src);
         args.add_input(indices);
         args.add_output(out);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_basic/kernels/orchestration/spmd_basic_orch.cpp
@@ -30,23 +30,22 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_READ_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_READ_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_READ_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(ext_output);
 
     rt_submit_task(mk, args);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_aiv/kernels/orchestration/spmd_multiblock_aiv_orch.cpp
@@ -32,24 +32,23 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_spmd_aiv(int32_t kernel_id, Tensor &out, int16_t block_num, int64_t base_cl) {
-    Arg args;
+static void submit_spmd_aiv(int32_t kernel_id, const Tensor &out, int16_t block_num, int64_t base_cl) {
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     rt_submit_aiv_task(kernel_id, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 4 blocks — basic multi-block
     submit_spmd_aiv(FUNC_SPMD_WRITE_AIV, ext_output, 4, 0);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_multiblock_mix/kernels/orchestration/spmd_multiblock_mix_orch.cpp
@@ -34,30 +34,30 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void
-submit_spmd_mix(int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, Tensor &out, int16_t block_num, int64_t base_cl) {
+static void submit_spmd_mix(
+    int32_t aic_id, int32_t aiv0_id, int32_t aiv1_id, const Tensor &out, int16_t block_num, int64_t base_cl
+) {
     MixedKernels mk;
     mk.aic_kernel_id = aic_id;
     mk.aiv0_kernel_id = aiv0_id;
     mk.aiv1_kernel_id = aiv1_id;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 2 blocks (6 CL) — basic multi-block MIX
     submit_spmd_mix(FUNC_SPMD_MIX_AIC, FUNC_SPMD_MIX_AIV0, FUNC_SPMD_MIX_AIV1, ext_output, 2, 0);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_starvation/kernels/orchestration/spmd_starvation_orch.cpp
@@ -43,21 +43,20 @@ static constexpr int32_t SYNC_CL = SYNC_BLOCK_NUM * SLOTS_PER_BLOCK;      // 18
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
@@ -65,8 +64,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     int64_t cl = 0;
 

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start/kernels/orchestration/spmd_sync_start_orch.cpp
@@ -38,21 +38,20 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
@@ -60,8 +59,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 2 blocks, sync_start=true  (6 CL)
     submit_mix(ext_output, 2, 0, true);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_aiv/kernels/orchestration/spmd_sync_start_aiv_orch.cpp
@@ -37,16 +37,15 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
-    Arg args;
+static void submit_aiv(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
@@ -54,8 +53,8 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: 4 blocks, sync_start=true (fast path: 4 <= idle AIV cores on one thread)
     submit_aiv(ext_output, 4, 0, true);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_edge/kernels/orchestration/spmd_sync_start_edge_orch.cpp
@@ -36,21 +36,20 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;  // NOLINT(readability/casting)
     return PTO2OrchestrationConfig{
         .expected_arg_count = 1,
     };
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
 
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
@@ -58,8 +57,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     // T0: block_num=1, sync_start=true (degenerate: always fast path, 3 CL)
     submit_mix(ext_output, 1, 0, true);

--- a/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/spmd_sync_start_stress/kernels/orchestration/spmd_sync_start_stress_orch.cpp
@@ -48,18 +48,17 @@ static constexpr int32_t ROUNDS = 6;
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{.expected_arg_count = 1};
 }
 
-static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+static void submit_mix(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
     MixedKernels mk;
     mk.aic_kernel_id = FUNC_SPMD_MIX_AIC;
     mk.aiv0_kernel_id = FUNC_SPMD_MIX_AIV0;
     mk.aiv1_kernel_id = FUNC_SPMD_MIX_AIV1;
-    Arg args;
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
@@ -67,8 +66,8 @@ static void submit_mix(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_task(mk, args);
 }
 
-static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
-    Arg args;
+static void submit_aiv(const Tensor &out, int16_t block_num, int64_t base_cl, bool sync_start) {
+    L0TaskArgs args;
     args.add_inout(out);
     args.add_scalar(base_cl);
     args.launch_spec.set_core_num(block_num);
@@ -76,8 +75,8 @@ static void submit_aiv(Tensor &out, int16_t block_num, int64_t base_cl, bool syn
     rt_submit_aiv_task(FUNC_SPMD_WRITE_AIV, args);
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
-    Tensor ext_output = from_tensor_arg(orch_args.tensor(0));
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_output = orch_args.tensor(0).ref();
 
     int64_t cl = 0;
 

--- a/tests/st/aicore_op_timeout/kernels/orchestration/aicore_op_timeout_orch.cpp
+++ b/tests/st/aicore_op_timeout/kernels/orchestration/aicore_op_timeout_orch.cpp
@@ -27,21 +27,20 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     (void)orch_args;
 
     uint32_t shape[1] = {1};
     TensorCreateInfo ci(shape, 1, DataType::INT32);
 
-    Arg args;
+    L0TaskArgs args;
     args.add_output(ci);
     rt_submit_aic_task(FUNC_AIC_HANG, args);
 

--- a/tests/st/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
+++ b/tests/st/explicit_fatal/kernels/orchestration/explicit_fatal_orch.cpp
@@ -15,15 +15,14 @@
 
 extern "C" {
 
-__attribute__((visibility("default"))) PTO2OrchestrationConfig
-aicpu_orchestration_config(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
     (void)orch_args;
     return PTO2OrchestrationConfig{
         .expected_arg_count = 0,
     };
 }
 
-__attribute__((visibility("default"))) void aicpu_orchestration_entry(const ChipStorageTaskArgs &orch_args) {
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
     (void)orch_args;
 
     uint32_t shape[1] = {1};
@@ -34,7 +33,7 @@ __attribute__((visibility("default"))) void aicpu_orchestration_entry(const Chip
 
     // Exercise API short-circuit after fatal. These calls must become no-ops
     // instead of falling through into runtime-side asserts or extra reporting.
-    Arg alloc_args;
+    L0TaskArgs alloc_args;
     (void)alloc_tensors(alloc_args);
 
     Tensor dummy = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);

--- a/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
+++ b/tests/ut/cpp/a2a3/test_a2a3_fatal.cpp
@@ -51,7 +51,7 @@ static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast belo
 
 FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &) {
+TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const L0TaskArgs &) {
     as_fake(rt)->submit_calls++;
     return TaskOutputTensors{};
 }
@@ -90,12 +90,12 @@ void fake_set_tensor_data(PTO2Runtime *rt, const Tensor &, uint32_t, const uint3
     as_fake(rt)->set_calls++;
 }
 
-TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const Arg &) {
+TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const L0TaskArgs &) {
     as_fake(rt)->alloc_calls++;
     return TaskOutputTensors{};
 }
 
-TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const Arg &) { return TaskOutputTensors{}; }
+TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const L0TaskArgs &) { return TaskOutputTensors{}; }
 
 const PTO2RuntimeOps kFakeOps = {
     .submit_task = fake_submit,
@@ -135,7 +135,7 @@ TEST(A2A3Fatal, ApiShortCircuitsAfterFatal) {
     RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
 
     MixedKernels mixed{};
-    Arg args;
+    L0TaskArgs args;
     uint32_t indices[1] = {0};
     uint32_t shape[1] = {1};
     Tensor tensor = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
@@ -174,7 +174,7 @@ TEST(A2A3Fatal, ExplicitFatalRoutesThroughOps) {
     EXPECT_FALSE(runtime.last_fatal_func.empty());
 
     MixedKernels mixed{};
-    Arg args;
+    L0TaskArgs args;
     EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_EQ(runtime.submit_calls, 0);
 }

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -62,12 +62,12 @@ protected:
 TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     orch.begin_scope();
 
-    Arg producer_args;
+    L0TaskArgs producer_args;
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
     PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
-    Arg consumer_args;
+    L0TaskArgs consumer_args;
     consumer_args.set_dependencies(deps, 2);
     TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
     ASSERT_TRUE(consumer.task_id().is_valid());

--- a/tests/ut/cpp/a5/test_a5_fatal.cpp
+++ b/tests/ut/cpp/a5/test_a5_fatal.cpp
@@ -45,7 +45,7 @@ static_assert(offsetof(FakeRuntime, ops) == 0);  // Guard: reinterpret_cast belo
 
 FakeRuntime *as_fake(PTO2Runtime *rt) { return reinterpret_cast<FakeRuntime *>(rt); }
 
-TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const Arg &) {
+TaskOutputTensors fake_submit(PTO2Runtime *rt, const MixedKernels &, const L0TaskArgs &) {
     as_fake(rt)->submit_calls++;
     return TaskOutputTensors{};
 }
@@ -84,12 +84,12 @@ void fake_set_tensor_data(PTO2Runtime *rt, const Tensor &, uint32_t, const uint3
     as_fake(rt)->set_calls++;
 }
 
-TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const Arg &) {
+TaskOutputTensors fake_alloc_tensors(PTO2Runtime *rt, const L0TaskArgs &) {
     as_fake(rt)->alloc_calls++;
     return TaskOutputTensors{};
 }
 
-TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const Arg &) { return TaskOutputTensors{}; }
+TaskOutputTensors fake_submit_dummy(PTO2Runtime *, const L0TaskArgs &) { return TaskOutputTensors{}; }
 
 const PTO2RuntimeOps kFakeOps = {
     .submit_task = fake_submit,
@@ -129,7 +129,7 @@ TEST(A5Fatal, ApiShortCircuitsAfterFatal) {
     RuntimeBindingGuard bind(reinterpret_cast<PTO2Runtime *>(&runtime));
 
     MixedKernels mixed{};
-    Arg args;
+    L0TaskArgs args;
     uint32_t indices[1] = {0};
     uint32_t shape[1] = {1};
     Tensor tensor = make_tensor_external(reinterpret_cast<void *>(0x1), shape, 1);
@@ -168,7 +168,7 @@ TEST(A5Fatal, ExplicitFatalRoutesThroughOps) {
     EXPECT_FALSE(runtime.last_fatal_func.empty());
 
     MixedKernels mixed{};
-    Arg args;
+    L0TaskArgs args;
     EXPECT_TRUE(rt_submit_task(mixed, args).empty());
     EXPECT_EQ(runtime.submit_calls, 0);
 }

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -62,12 +62,12 @@ protected:
 TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     orch.begin_scope();
 
-    Arg producer_args;
+    L0TaskArgs producer_args;
     TaskOutputTensors producer = orch.submit_dummy_task(producer_args);
     ASSERT_TRUE(producer.task_id().is_valid());
 
     PTO2TaskId deps[] = {producer.task_id(), producer.task_id()};
-    Arg consumer_args;
+    L0TaskArgs consumer_args;
     consumer_args.set_dependencies(deps, 2);
     TaskOutputTensors consumer = orch.submit_dummy_task(consumer_args);
     ASSERT_TRUE(consumer.task_id().is_valid());


### PR DESCRIPTION
## Summary

Two independent, behavior-preserving refactors of the
`tensormap_and_ringbuffer` orchestration layer. They are unrelated in scope;
the arg-hierarchy change (1) is the bulk of the diff, the scope extraction (2)
is a single-file cleanup.

### 1. Layer the tensormap `Arg` into an `L0TaskArgs` / `L2TaskArgs` hierarchy

Split the orchestration arg types into a capacity-parameterized hierarchy so
the chip-level entry input and the core-level submit container are distinct
types, and decouple AICore from the orchestration header. Touches every
orchestration entry across a2a3 and a5.

- **`TensorRef`**: bare `union` → `class` (`operator=(ptr)` writers,
  `ref()` / `create_info()` / `refers_to()` readers; copy/move deleted so slots
  are written in place, never passed by value).
- **`Arg` is now `template<size_t MaxT, size_t MaxS>`**: `L0TaskArgs=Arg<32,16>`
  for core submit; `L2TaskArgs:Arg<128,128>` with `create_from_chip_args()` for
  the entry input; `L0TaskArgsWithDeps` (was `ArgWithDeps`).
- `aicpu_orchestration_entry` / `config` now take `const L2TaskArgs&`; the
  executor builds `orch_args_cached_` once per run via `create_from_chip_args`.
- Move `MAX_TENSOR_ARGS` / `MAX_SCALAR_ARGS` to common `arg_direction.h` so
  `pto2_dispatch_payload.h` (and thus AICore) no longer pulls in `pto_types.h`,
  fixing ccec instantiating the `__aicore__` device fn `to_u64` in a host
  context.
- Drop `from_tensor_arg()`; entry tensor reads unify on `tensor(i).ref()` bound
  by `const Tensor&` to avoid 128B copies. **Precondition** (carried over from
  the old helper): entry-input tensors are external, submit-time tensors with
  `version == 0` / `manual_dep == false` — binding `.ref()` preserves those
  fields, matching the reset `from_tensor_arg` used to apply.
- Tensor-arg validation split into compile-time
  `assert_add_tensor_args<is_output, Args...>()` (type-only; rejects temporaries
  without a use-after-move false positive) and runtime
  `check_add_tensor_capacity()`; `set_error` spells the actual `MaxS` / `MaxT`
  limit.
- Mirrored to a5 (a5sim + a5 onboard build clean).

### 2. Extract the paged-attn unroll scope into `process_qtile_scope`

Extract the per-`(batch, q-tile)` `PTO2_SCOPE` body of the
`paged_attention_unroll` orchestration entry into a file-local helper,
`process_qtile_scope(const Arg &ctx)`. The entry is now a thin skeleton (dim
extraction → tensor construction → double loop → scope), and the
task-submission logic lives in one focused function.

- **Transport `Arg`**: all scope context is passed through a single `Arg` (built
  by the caller, never submitted; slots read back positionally). It carries only
  materialized Tensors — 4 inputs via `add_input` (query / key_cache /
  value_cache / block_table) and `out` via `add_output(Tensor)` — plus 11
  scalars. No `TensorCreateInfo` is placed in the Arg; the scope's create-infos
  are rebuilt locally in the helper from the `q_tile` / `head_dim` scalars.
- **Profiling**: `ProfCounters` (and the lap timestamps) are hoisted to a
  file-global `g_prof`, so the `ENABLE_PROFILING` lap timeline stays continuous
  across the entry/helper boundary. Reset once per entry; single orchestration
  thread, so the file-global is safe.

No behavior change — both commits are pure code reorganization.

## Testing

- [x] Hardware: `pytest tests/st/.../paged_attention_unroll --platform a2a3 --device 9` → `1 passed`
- [x] a2a3 builds onboard + sim; `paged_attention_unroll`, 9 spmd variants,
      highperf, demo, workers, platform-agnostic all pass / compile
- [x] a5sim + a5 onboard build clean
- [x] clang-format / cpplint / check-headers pre-commit hooks pass
