### PR TITLE
Fix: restore SDMA async completion demo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,7 @@ jobs:
 
       - name: Set up environment
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
@@ -461,6 +462,7 @@ jobs:
 
       - name: Run Python hardware unit tests
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           # Pin to the same commit pip install built host_runtime against, so
           # conftest does not reset build/pto-isa to HEAD (which would diverge
@@ -470,6 +472,7 @@ jobs:
 
       - name: Build and run C++ hardware unit tests
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           # pip install's build_runtimes.py already cloned pto-isa into
           # build/pto-isa at PTO_ISA_COMMIT; point this step's RuntimeBuilder at
@@ -492,6 +495,7 @@ jobs:
 
       - name: Build cann-examples/query (CANN host-API smoke)
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           cd tools/cann-examples/query
           cmake -B build .
           cmake --build build
@@ -499,6 +503,7 @@ jobs:
 
       - name: Build cann-examples/aicpu-device-query (device-side HAL probe smoke)
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           export CROSS=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu
           cd tools/cann-examples/aicpu-device-query/device
           cmake -B build . -DCMAKE_C_COMPILER=${CROSS}-gcc -DCMAKE_CXX_COMPILER=${CROSS}-g++
@@ -509,6 +514,7 @@ jobs:
 
       - name: Build cann-examples/aicpu-kernel-launch (dispatcher bootstrap smoke)
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           export CROSS=${ASCEND_HOME_PATH}/tools/hcc/bin/aarch64-target-linux-gnu
           cd tools/cann-examples/aicpu-kernel-launch/device
           cmake -B build . -DCMAKE_C_COMPILER=${CROSS}-gcc -DCMAKE_CXX_COMPILER=${CROSS}-g++
@@ -530,6 +536,7 @@ jobs:
 
       - name: Set up environment
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           python3 -m venv --system-site-packages .venv
           source .venv/bin/activate
           pip install --upgrade pip
@@ -547,6 +554,7 @@ jobs:
 
       - name: Run pytest scene tests (a2a3)
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           python -m pytest examples tests/st --platform a2a3 --device ${DEVICE_RANGE} -v \
             --pto-session-timeout 600 --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol ssh --require-pto-isa
@@ -557,6 +565,7 @@ jobs:
       # propagation #742 fixed.
       - name: dep_gen smoke
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/dep_gen/test_dep_gen.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
@@ -564,6 +573,7 @@ jobs:
 
       - name: l2_swimlane smoke
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/l2_swimlane/ \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
@@ -571,6 +581,7 @@ jobs:
 
       - name: PMU smoke
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \
@@ -578,6 +589,7 @@ jobs:
 
       - name: tensor_dump smoke
         run: |
+          source /usr/local/Ascend/cann/set_env.sh
           source .venv/bin/activate
           python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/dfx/tensor_dump/test_tensor_dump.py \
             --platform a2a3 --device ${DEVICE_RANGE} -p no:xdist --pto-session-timeout 600 \

--- a/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -189,11 +189,6 @@ def run(
         worker.close()
 
 
-@pytest.mark.skip(
-    reason="onboard a2a3 SDMA STARS completion path broken "
-    "(aclnnShmemSdmaStarsQueryGetWorkspaceSize failed); disabled from CI "
-    "pending fix, see hw-native-sys/simpler#1067"
-)
 @pytest.mark.platforms(["a2a3"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)


### PR DESCRIPTION
## Summary
- Remove the temporary `@pytest.mark.skip` from `sdma_async_completion_demo`.
- Re-enable the onboard a2a3 SDMA async completion coverage that was disabled by #1068.

## Testing
- Pre-commit hooks: passed during commit (`check-headers`, `check-english-only`, `ruff`, `pyright`, etc.).
- Onboard a2a3 2-card standalone demo on myserver: passed.
  - Worktree: `/data/sunkaixuan/all_simplers/pr-1109-rebased-c1a39ce4`
  - Code: `53d33b606df21a717d7ce21fd4c2dca88d9ac63a`
  - PTO-ISA: `ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8`
  - Devices: `2,7`
  - Task: `task_20260623_114350_372863523991` (`exit=0`)
  - Key log lines:
    - `[SDMA] Created 48 STARS streams OK`
    - `[SDMA] STARS query AICPU kernel completed OK`
    - `[sdma_async_completion_demo] rank 0: max_out=0.000e+00 max_result=0.000e+00`
    - `[sdma_async_completion_demo] rank 1: max_out=0.000e+00 max_result=0.000e+00`
- Note: when running from a non-login ssh environment, I had to source `/usr/local/Ascend/cann-9.0.0/set_env.sh` before the standalone command so CANN runtime libraries are visible. Without that, the run can fail before the SDMA result check due to missing or incomplete CANN dynamic library setup.

Fixes #1067