### PR TITLE
Add SPMD block markers to dep viewer

### DIFF
--- a/docs/dfx/dep_gen.md
+++ b/docs/dfx/dep_gen.md
@@ -35,8 +35,8 @@ race — which is why deps.json now fully replaces the removed `fanout[]`.
 
 - **Capture point.** `pto_orchestrator::submit_task` writes a
   `DepGenRecord` (task_id, scope flag, tensor blobs, arg types,
-  explicit deps) into a per-thread shared-memory ring buffer for every
-  call when `enable_dep_gen` is on.
+  explicit deps, kernel ids, and SPMD block num) into a per-thread
+  shared-memory ring buffer for every call when `enable_dep_gen` is on.
 - **In-memory drain.** The host `DepGenCollector` (background mgmt
   thread, ProfilerBase machinery shared with PMU / L2 Perf / Tensor
   Dump) drains the ring into a `std::vector<DepGenRecord>` resident on
@@ -109,8 +109,8 @@ The standard SceneTest path
 ```json
 {
   "tasks": [
-    {"task_id": "0",          "scope": "auto", "args": []},
-    {"task_id": "4294967296", "scope": "auto", "args": [
+    {"task_id": "0",          "scope": "auto", "kernel_ids": [-1,-1,-1], "block_num": 1, "args": []},
+    {"task_id": "4294967296", "scope": "auto", "kernel_ids": [7,-1,-1], "block_num": 4, "args": [
       {"idx": 0, "type": "INPUT", "tensor_id": "13451765318376212391",
        "dtype": "FLOAT32", "shape": [16384],
        "start_offset": "0", "strides": [1]}
@@ -158,8 +158,11 @@ local = raw & 0xFFFFFFFF
 
 One entry per task observed in the trace. `scope` is `"manual"` when the
 submit happened inside a manual scope (no automatic dependency wiring)
-and `"auto"` otherwise. Tools that only need task-pair edges can ignore
-this block.
+and `"auto"` otherwise. `kernel_ids` is the per-subslot
+`[aic,aiv0,aiv1]` kernel id triple, with inactive subslots encoded as
+`-1`. `block_num` is the SPMD logical block num for the submit; `1`
+means a normal single-block task and values greater than `1` identify
+SPMD tasks. Tools that only need task-pair edges can ignore this block.
 
 ### `tensors[]`
 
@@ -241,8 +244,9 @@ The default text output contains:
     `name_map_*.json`. When the `kernel_ids` fallback is used, `func_id=` shows an
     aligned 3-slot integer array in `[aic,aiv0,aiv1]` order; inactive slots remain
     `-1`. `func_name_map` stays `no` unless a real human-readable name was resolved.
-- `TASK INDEX` — one line per task with `kind=` + `func_id=` and unique `fanin=` /
-  `fanout=` counts for quick grep.
+- `TASK INDEX` — one line per task with `kind=` + `func_id=` and unique
+  `fanin=` / `fanout=` counts for quick grep. SPMD tasks additionally carry
+  `SPMD block num = N`, where `N` is the captured logical block num.
 - `TASK DETAILS` — one block per task with `FANIN` / `FANOUT` peer task references
   (task-adjacency-only, no tensor detail).
 
@@ -257,13 +261,14 @@ Node visual encoding (legend top-right of the rendered HTML):
 | Orange ellipse | AIV (vector) — kernel ran on the vector unit |
 | Green diamond | mix — single `submit_task` with `MixedKernels` spanning both core types |
 | Gray dashed note | alloc — task from `alloc_tensors` (got a task_id, references downstream via `owner_task_id`, but never dispatched a kernel so has no perf record) |
+| Red border + right-side `xN` label | SPMD task with `block_num=N` |
 
-Node labels read as `(ring, local)` only — no func_name or func_id is
-shown in the HTML view. The text output (`deps_viewer.txt`) carries the
-`kind=` + `func_id=` labels; the HTML view focuses on structural layout and stays
-agnostic to function naming. When you need per-task tensor rows (storage / shape /
-strides / start_offset) and arg-port edge routing, rerun the HTML export with
-`--show-tensor-info`.
+Node labels read as `(ring, local)` with a red border and right-side `xN` block num label for SPMD
+tasks. The text output (`deps_viewer.txt`) carries the full `kind=` +
+`func_id=` labels and adds `SPMD block num = N` only for SPMD tasks; the HTML
+view keeps the graph focused on structure and the SPMD marker.
+When you need per-task tensor rows (storage / shape / strides / start_offset)
+and arg-port edge routing, rerun the HTML export with `--show-tensor-info`.
 
 Browser controls in the HTML viewer:
 
@@ -352,10 +357,10 @@ list; only the dep_gen replay graph loses the tail.
 
 | Layer | File | Role |
 | ----- | ---- | ---- |
-| Shared-mem layout | `src/{a2a3,a5}/platform/include/common/dep_gen.h` | `DepGenRecord` (4672 B base, cache-line aligned, ≤64 inline explicit_deps) + `DepGenOverflowRecord` chain view (≤582 deps per slot) + SPSC ring + per-thread ready queue. Byte-identical layout across platforms. |
+| Shared-mem layout | `src/{a2a3,a5}/platform/include/common/dep_gen.h` | `DepGenRecord` (4672 B base, cache-line aligned, ≤64 inline explicit_deps, per-task `block_num`) + `DepGenOverflowRecord` chain view (≤582 deps per slot) + SPSC ring + per-thread ready queue. Byte-identical layout across platforms. |
 | AICPU writer | `src/{a2a3,a5}/platform/{include,shared}/aicpu/dep_gen_collector_aicpu.{h,cpp}` | Single-instance write path; weak-fallback exported to host build. a5 reuses the a2a3 source verbatim — the writer accesses its own device-side view of shared memory, independent of how host↔device transport is implemented. |
 | Host collector | `src/{a2a3,a5}/platform/{include/host,shared/host}/dep_gen_collector.{h,cpp}` | `ProfilerBase<DepGenCollector, DepGenModule>` — drains ring → `records_` vector. On a5 (no SVM) it uses the base `alloc_paired_buffer`, which malloc's a host shadow + `copy_to_device`'s it and registers it via `add_malloc_shadow` so teardown can free it; `reconcile_counters` explicitly `copy_from_device`'s the BufferState before reading, and `finalize` lets `BufferPoolManager::clear_mappings()` release all shadows as the single source of truth. |
-| Capture call site | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. **a2a3 only:** the schema additionally carries `kernel_id[3] = {aic, aiv0, aiv1}` so the swimlane post-processor can resolve `task_id → kernel` from `deps.json` at level=1 where the AICore record is the sole device-side identity source. Inactive subslots stay at `INVALID_KERNEL_ID = -1`. |
+| Capture call site | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp` `submit_task_common` | One conditional block that snapshots inputs into the ring when `is_dep_gen_enabled()`; fires for both `submit_task` and `submit_dummy_task`. The schema carries `kernel_ids[3] = {aic, aiv0, aiv1}` so the swimlane post-processor can resolve `task_id → kernel` from `deps.json` at level=1 where the AICore record is the sole device-side identity source. Inactive subslots stay at `INVALID_KERNEL_ID = -1`. It also carries the SPMD logical block num (`block_num` on a2a3, `core_num` on a5's launch spec) as `tasks[].block_num`. |
 | Replay | `src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.{h,cpp}` | Pure CPU; runs dual-pass differential replay — `compute_task_fanin` (oracle) + inlined STEP A/B mirror (annotated) against two `PTO2TensorMap` instances. Emits `deps.json` when both passes agree per record. Platform-agnostic — a5 reuses the a2a3 source verbatim. |
 | Device-runner hookup | `src/{a2a3,a5}/platform/{onboard,sim}/host/device_runner.cpp` | post-`reconcile_counters` calls `dep_gen_replay_emit_deps_json(records.data(), records.size(), deps_path)` |
 | Viewer | `simpler_setup/tools/deps_viewer.py` | `deps.json` → text (default) or pan/zoom HTML |

--- a/simpler_setup/tools/deps_viewer.py
+++ b/simpler_setup/tools/deps_viewer.py
@@ -19,12 +19,13 @@ tool supports two output formats:
 - html: Graphviz SVG wrapped in a self-contained pan/zoom HTML page
 
 In text mode the default view shows task identity ``(ring, local)`` together
-with ``kind=`` and ``func_id=``. Text-mode ``func_id=`` comes only from the
-three-slot ``kernel_ids`` layout and preserves ``[aic,aiv0,aiv1]`` with
-inactive slots kept as ``-1``; ``alloc`` / ``dummy`` tasks render as
-``func_id=none``. In HTML mode nodes are labeled ``(ring, local)`` only; they
-are colored by ``core_type`` when a perf sidecar is colocated (AIC blue, AIV
-orange).
+with ``kind=``, ``func_id=``, and SPMD block num when applicable. Text-mode
+``func_id=`` comes only from the three-slot ``kernel_ids`` layout and preserves
+``[aic,aiv0,aiv1]`` with inactive slots kept as ``-1``; ``alloc`` / ``dummy``
+tasks render as ``func_id=none``. ``SPMD block num = N`` is the logical block
+num captured from ``block_num``. In HTML mode SPMD nodes use a red border plus a
+transparent right-side ``xN`` block num label; nodes are colored by
+``core_type`` when a perf sidecar is colocated (AIC blue, AIV orange).
 
 Usage:
     python -m simpler_setup.tools.deps_viewer DEPS_JSON
@@ -277,6 +278,15 @@ def _merge_task_meta_with_kernel_ids(meta, task_table, func_names=None):
                 entry["func_name"] = entry["func_labels"][0]
         elif any(s >= 0 for s in slots):
             entry["func_labels"] = [f"f{slot}" if slot >= 0 else "-1" for slot in slots]
+        if not entry.get("core_type"):
+            has_aic = slots[0] >= 0
+            has_aiv = slots[1] >= 0 or slots[2] >= 0
+            if has_aic and has_aiv:
+                entry["core_type"] = "mix"
+            elif has_aic:
+                entry["core_type"] = "aic"
+            elif has_aiv:
+                entry["core_type"] = "aiv"
     return merged
 
 
@@ -342,7 +352,8 @@ def _load_task_meta(deps_path, func_names=None):
 
 def _label(task_id, meta, task_table, fmt_task):
     base = fmt_task(task_id)
-    kind = _task_kind(_normalize_task_id(task_id), meta, task_table)
+    normalized_task_id = _normalize_task_id(task_id)
+    kind = _task_kind(normalized_task_id, meta, task_table)
     if kind == "alloc":
         return f"{base} · alloc"
     if kind == "dummy":
@@ -379,10 +390,15 @@ _CORE_HEADER_COLOR = {
 _INPUT_BG = "#EAF2FF"
 _OUTPUT_BG = "#FFF2E5"
 _HEADER_FALLBACK = "#D8D8D8"
+_SPMD_COLOR = "#C62828"
 
 
 def _html_escape(text):
     return str(text).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+
+
+def _dot_escape_label(text):
+    return str(text).replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
 
 def _short_tensor_label(tid, tensor_table):
@@ -465,17 +481,16 @@ def _task_node_html(task_id, task_entry, meta_entry, tensor_table, fmt_task):
     outputs = [a for a in args if a.get("type") in ("INOUT", "OUTPUT", "OUTPUT_EXISTING")]
     core_type = meta_entry.get("core_type") if meta_entry else None
     header_bg = _CORE_HEADER_COLOR.get(core_type if isinstance(core_type, str) else "", _HEADER_FALLBACK)
-
-    header_label = fmt_task(task_id)
+    border_attrs = f'BORDER="1" COLOR="{_SPMD_COLOR}"' if _task_block_num(task_entry) > 1 else 'BORDER="0"'
 
     rows = []
     for a in inputs:
         rows.append(_arg_row_html(a, tensor_table, "in"))
-    rows.append(f'<TR><TD ALIGN="CENTER" BGCOLOR="{header_bg}"><B>{_html_escape(header_label)}</B></TD></TR>')
+    rows.append(f'<TR><TD ALIGN="CENTER" BGCOLOR="{header_bg}"><B>{_html_escape(fmt_task(task_id))}</B></TD></TR>')
     for a in outputs:
         rows.append(_arg_row_html(a, tensor_table, "out"))
 
-    table = '<TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0" CELLPADDING="3">' + "".join(rows) + "</TABLE>"
+    table = f'<TABLE {border_attrs} CELLBORDER="1" CELLSPACING="0" CELLPADDING="3">' + "".join(rows) + "</TABLE>"
     return table
 
 
@@ -521,6 +536,43 @@ def _task_func_id_label(task_id, meta, task_table):
     return "func_id=unknown"
 
 
+def _task_block_num(task_entry):
+    if not isinstance(task_entry, dict):
+        return 1
+    block_num = _normalize_small_int(task_entry.get("block_num"))
+    if block_num is None or block_num < 1:
+        return 1
+    return block_num
+
+
+def _task_blocks_text(task_entry):
+    block_num = _task_block_num(task_entry)
+    if block_num <= 1:
+        return ""
+    return f"SPMD block num = {block_num}"
+
+
+def _plain_node_attrs(task_id, meta, task_table, fmt_task):
+    meta_entry = meta.get(task_id)
+    kind = _task_kind(task_id, meta, task_table)
+    if kind == "submit" and meta_entry:
+        style = _node_style(meta_entry.get("core_type"))
+    elif kind == "alloc":
+        style = _CORE_STYLE["alloc"]
+    else:
+        style = _DEFAULT_STYLE
+
+    task_entry = task_table.get(task_id)
+    label = _dot_escape_label(_label(task_id, meta, task_table, fmt_task))
+    label_attr = f'label="{label}"'
+    style_attr = style["style"]
+    if _task_block_num(task_entry) > 1:
+        extra = f', color="{_SPMD_COLOR}", penwidth=1.5'
+    else:
+        extra = ""
+    return f'{label_attr}, shape={style["shape"]}, style="{style_attr}", fillcolor="{style["fillcolor"]}"{extra}'
+
+
 def emit_text(edges, nodes, meta, deps_path, annotations=None, tensor_table=None, task_table=None):
     """Render deps.json as grep-friendly plain text.
 
@@ -559,16 +611,20 @@ def emit_text(edges, nodes, meta, deps_path, annotations=None, tensor_table=None
     for task_id in sorted_nodes:
         kind = _task_kind(task_id, meta, task_table)
         func_label = _task_func_id_label(task_id, meta, task_table)
+        block_label = _task_blocks_text(task_table.get(task_id))
+        task_labels = " ".join(label for label in (func_label, block_label) if label)
         lines.append(
-            f"TASK {fmt_task(task_id)} kind={kind} {func_label} "
+            f"TASK {fmt_task(task_id)} kind={kind} {task_labels} "
             f"fanin={len(pred_map.get(task_id, set()))} fanout={len(succ_map.get(task_id, set()))}"
         )
 
     for task_id in sorted_nodes:
         kind = _task_kind(task_id, meta, task_table)
         func_label = _task_func_id_label(task_id, meta, task_table)
+        block_label = _task_blocks_text(task_table.get(task_id))
+        task_labels = " ".join(label for label in (func_label, block_label) if label)
         lines.append("")
-        lines.append(f"=== TASK {fmt_task(task_id)} kind={kind} {func_label} ===")
+        lines.append(f"=== TASK {fmt_task(task_id)} kind={kind} {task_labels} ===")
 
         pred_peers = sorted(pred_map.get(task_id, set()), key=_sort_task_id_key)
         lines.append(f"FANIN {len(pred_peers)}")
@@ -583,11 +639,20 @@ def emit_text(edges, nodes, meta, deps_path, annotations=None, tensor_table=None
     return "\n".join(lines) + "\n"
 
 
-def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=None, task_table=None):
+def emit_dot(
+    edges,
+    nodes,
+    meta,
+    direction="LR",
+    annotations=None,
+    tensor_table=None,
+    task_table=None,
+    show_tensor_info=None,
+):
     """Graphviz DOT source. Used internally to feed the layout engine before
     wrapping the SVG in HTML.
 
-    Two rendering modes selected by whether ``task_table`` is non-empty:
+    Two rendering modes selected by ``show_tensor_info``:
 
     1. Plain mode (``task_table`` is None or empty) — bare shape/color nodes,
        bare arrows. Used when only task-level structure is available.
@@ -599,10 +664,10 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
        tensor_id matches the edge's tensor_id.
     """
     fmt_task = _make_task_formatter(nodes)
-    show_tensor = bool(task_table)
     annotations = annotations or {}
     tensor_table = tensor_table or {}
     task_table = task_table or {}
+    show_tensor = bool(task_table) if show_tensor_info is None else bool(show_tensor_info and task_table)
     lines = [
         "digraph deps {",
         f"  rankdir={direction};",
@@ -616,16 +681,7 @@ def emit_dot(edges, nodes, meta, direction="LR", annotations=None, tensor_table=
             html = _task_node_html(n, task_table.get(n), m, tensor_table, fmt_task)
             lines.append(f"  {_node_id(n)} [shape=none, margin=0, label=<{html}>];")
             continue
-        kind = _task_kind(n, meta, task_table)
-        if kind == "submit" and m:
-            style = _node_style(m.get("core_type"))
-        elif kind == "alloc":
-            style = _CORE_STYLE["alloc"]
-        else:
-            style = _DEFAULT_STYLE
-        label = _label(n, meta, task_table, fmt_task).replace("\\", "\\\\").replace('"', '\\"')
-        attrs = f'label="{label}", shape={style["shape"]}, style="{style["style"]}", fillcolor="{style["fillcolor"]}"'
-        lines.append(f"  {_node_id(n)} [{attrs}];")
+        lines.append(f"  {_node_id(n)} [{_plain_node_attrs(n, meta, task_table, fmt_task)}];")
     for pred, succ in edges:
         if not show_tensor:
             lines.append(f"  {_node_id(pred)} -> {_node_id(succ)};")
@@ -677,32 +733,73 @@ def render_svg(dot_text, engine="dot"):
     return proc.stdout
 
 
+def _spmd_badges_json(nodes, task_table):
+    task_table = task_table or {}
+    badges = {}
+    for task_id in nodes:
+        block_num = _task_block_num(task_table.get(task_id))
+        if block_num > 1:
+            badges[_node_id(task_id)] = block_num
+    return json.dumps(badges, sort_keys=True, separators=(",", ":"))
+
+
 _HTML_TEMPLATE = """<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
 <title>deps.json — {n_nodes} nodes, {n_edges} edges</title>
 <style>
-  html, body {{ margin: 0; height: 100%; background: #fafafa; font-family: -apple-system, sans-serif; }}
-  #hud {{ position: fixed; top: 8px; left: 8px; background: #fff; padding: 6px 10px;
-         border: 1px solid #ddd; border-radius: 4px; font-size: 12px; z-index: 10;
-         box-shadow: 0 1px 3px rgba(0,0,0,0.08); }}
-  #hud kbd {{ font-family: ui-monospace, monospace; background: #f0f0f0;
-              padding: 1px 4px; border-radius: 2px; }}
-  #legend {{ position: fixed; top: 8px; right: 8px; background: #fff; padding: 6px 10px;
-             border: 1px solid #ddd; border-radius: 4px; font-size: 12px; z-index: 10;
-             box-shadow: 0 1px 3px rgba(0,0,0,0.08); display: flex; gap: 12px; align-items: center; }}
-  #legend .swatch {{ display: inline-flex; align-items: center; gap: 4px; }}
+  html, body {{
+    margin: 0; height: 100%; background: #f8fafc;
+    font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
+    color: #0f172a; overflow: hidden; -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }}
+  #hud, #legend {{
+    position: fixed; z-index: 10; display: flex; align-items: center;
+    background: rgba(255,255,255,0.94); border: 1px solid rgba(203,213,225,0.9);
+    border-radius: 10px; color: #0f172a; font-size: 12px;
+    box-shadow: 0 10px 26px rgba(15,23,42,0.10); backdrop-filter: blur(10px);
+  }}
+  #hud {{ top: 12px; left: 12px; gap: 8px; padding: 8px 12px; }}
+  #hud .stat {{ font-weight: 600; color: #020617; }}
+  #hud .muted {{ color: #cbd5e1; }}
+  #hud .divider {{ width: 1px; height: 16px; margin: 0 4px; background: #e2e8f0; }}
+  #hud kbd {{
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; background: #f1f5f9;
+    border: 1px solid #cbd5e1; color: #334155; padding: 1px 5px; border-radius: 5px;
+  }}
+  #legend {{
+    top: 12px; right: 12px; gap: 12px; padding: 8px 12px;
+    flex-wrap: wrap; max-width: min(760px, calc(100vw - 24px));
+  }}
+  #legend .swatch {{ display: inline-flex; align-items: center; gap: 6px; color: #334155; white-space: nowrap; }}
   #legend svg {{ display: block; }}
-  #stage {{ width: 100vw; height: 100vh; overflow: hidden; cursor: grab; }}
+  #stage {{ width: 100vw; height: 100vh; overflow: hidden; cursor: grab; background:
+    radial-gradient(circle at 20px 20px, rgba(100,116,139,0.18) 1px, transparent 1px), #eef2f7;
+    background-size: 24px 24px; }}
   #stage.panning {{ cursor: grabbing; }}
-  #stage > svg {{ transform-origin: 0 0; transition: none; max-width: none; }}
+  #stage > svg {{
+    transform-origin: 0 0; transition: none; max-width: none; overflow: visible;
+    filter: drop-shadow(0 16px 28px rgba(15,23,42,0.10));
+  }}
+  #stage .node path, #stage .node ellipse, #stage .node polygon {{
+    filter: drop-shadow(0 3px 4px rgba(15,23,42,0.18));
+  }}
+  #stage .edge path, #stage .edge polygon {{ opacity: 0.78; }}
 </style>
 </head>
 <body>
 <div id="hud">
-  {n_nodes} nodes · {n_edges} edges &nbsp;|&nbsp;
-  <kbd>drag</kbd> pan &nbsp; <kbd>wheel</kbd> zoom &nbsp; <kbd>f</kbd> fit &nbsp; <kbd>r</kbd> reset
+  <span class="stat">{n_nodes} nodes</span>
+  <span class="muted">·</span>
+  <span class="stat">{n_edges} edges</span>
+  <span class="divider"></span>
+  <kbd>drag</kbd><span>pan</span>
+  <kbd>wheel</kbd><span>zoom</span>
+  <kbd>f</kbd><span>fit</span>
+  <kbd>r</kbd><span>reset</span>
 </div>
 <div id="legend">
   <span class="swatch">
@@ -729,6 +826,15 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
     </svg>
     alloc
   </span>
+  <span class="swatch">
+    <svg width="34" height="14" viewBox="0 0 34 14">
+      <rect x="1" y="2" width="18" height="10" rx="3" ry="3" fill="none"
+            stroke="#C62828" stroke-width="1"/>
+      <text x="20" y="8" fill="#C62828"
+            font-family="Helvetica, sans-serif" font-size="7" font-weight="700">xN</text>
+    </svg>
+    SPMD block num
+  </span>
 </div>
 <div id="stage">
 {svg_body}
@@ -740,6 +846,42 @@ _HTML_TEMPLATE = """<!DOCTYPE html>
   if (!svg) return;
   svg.removeAttribute('width');
   svg.removeAttribute('height');
+  const spmdBlocks = {spmd_badges_json};
+  const svgNS = 'http://www.w3.org/2000/svg';
+
+  function svgEl(name, attrs) {{
+    const el = document.createElementNS(svgNS, name);
+    for (const [key, value] of Object.entries(attrs)) {{
+      el.setAttribute(key, value);
+    }}
+    return el;
+  }}
+
+  function addSpmdBadges() {{
+    for (const [nodeId, blocks] of Object.entries(spmdBlocks)) {{
+      const title = Array.from(svg.querySelectorAll('g.node > title')).find((item) => item.textContent === nodeId);
+      if (!title) continue;
+      const group = title.parentElement;
+      const graph = group ? group.parentElement : null;
+      if (!group || !graph || graph.querySelector(`.spmd-badge[data-node-id="${{nodeId}}"]`)) continue;
+
+      const box = group.getBBox();
+      const text = `x${{blocks}}`;
+      const x = box.x + box.width + 1;
+      const y = box.y + box.height / 2 - 3;
+      const badge = svgEl('g', {{ class: 'spmd-badge', 'data-node-id': nodeId }});
+      badge.appendChild(svgEl('title', {{}}));
+      badge.lastChild.textContent = `SPMD block num: ${{blocks}}`;
+
+      badge.appendChild(svgEl('text', {{
+        x, y, fill: '#C62828', 'font-family': 'Helvetica, sans-serif',
+        'font-size': 8, 'font-weight': 700,
+      }}));
+      badge.lastChild.textContent = text;
+      graph.appendChild(badge);
+    }}
+  }}
+  addSpmdBadges();
 
   let scale = 1, tx = 0, ty = 0;
   const apply = () => {{ svg.style.transform = `translate(${{tx}}px, ${{ty}}px) scale(${{scale}})`; }};
@@ -799,6 +941,7 @@ def emit_html(
     annotations=None,
     tensor_table=None,
     task_table=None,
+    show_tensor_info=None,
 ):
     """Build the pan/zoom HTML page: DOT → Graphviz SVG → inline into template."""
     dot = emit_dot(
@@ -809,6 +952,7 @@ def emit_html(
         annotations=annotations,
         tensor_table=tensor_table,
         task_table=task_table,
+        show_tensor_info=show_tensor_info,
     )
     svg_bytes = render_svg(dot, engine=engine)
     svg_text = svg_bytes.decode("utf-8", errors="replace")
@@ -818,6 +962,7 @@ def emit_html(
         n_nodes=len(nodes),
         n_edges=len(edges),
         svg_body=svg_text,
+        spmd_badges_json=_spmd_badges_json(nodes, task_table),
     )
 
 
@@ -972,7 +1117,8 @@ def main(argv=None):
         engine=args.engine,
         annotations=annotations,
         tensor_table=tensor_table,
-        task_table=task_table if args.show_tensor_info else None,
+        task_table=task_table,
+        show_tensor_info=args.show_tensor_info,
     )
     out.write_text(html)
     print(f"Wrote {out} ({len(nodes)} nodes, {len(edges)} edges, engine={args.engine}, format=html)")

--- a/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -97,6 +97,7 @@ void dep_gen_aicpu_init();
  * @param explicit_dep_count  Number of explicit_deps — no static cap; truncated only when the
  *                            chain would not fit in a single DepGenBuffer
  * @param explicit_deps_raw   Per-dep PTO2TaskId::raw (length = explicit_dep_count)
+ * @param block_num           SPMD logical block count; 1 means non-SPMD
  * @param kernel_ids          Per-subslot kernel id triple {AIC, AIV0, AIV1};
  *                            inactive subslots use INVALID_KERNEL_ID (-1).
  *                            Captured here so the host swimlane post-processor
@@ -105,7 +106,8 @@ void dep_gen_aicpu_init();
  */
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
-    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, const int32_t kernel_ids[3]
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
+    const int32_t kernel_ids[3]
 );
 
 /**

--- a/src/a2a3/platform/include/common/dep_gen.h
+++ b/src/a2a3/platform/include/common/dep_gen.h
@@ -95,9 +95,9 @@ enum DepGenRecordFlags : uint32_t {
  *     cache lines
  *   - tensors[] (32 × 128 B opaque blobs) at the tail; covers ~88% of the entry
  *
- * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (pad) + 32*128
+ * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (block_num) + 32*128
  *           = 4672 bytes.
- * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + _pad0
+ * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + block_num
  * together pad tensors[] up to offset 576 = 9 * 64 so each 128-byte tensor
  * blob covers exactly two cache lines instead of straddling three.
  */
@@ -109,7 +109,7 @@ struct DepGenRecord {
     uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // PTO2TaskId::raw, length = explicit_dep_count
     uint8_t arg_types[CORE_MAX_TENSOR_ARGS];            // TensorArgType, length = tensor_count
     int32_t kernel_id[3];  // per-subslot kernel id (AIC, AIV0, AIV1); INVALID_KERNEL_ID = -1
-    uint8_t _pad0[4];      // align tensors[] to 64 B (offset 576)
+    uint32_t block_num;    // SPMD logical block count; 1 means non-SPMD
     uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
 } __attribute__((aligned(64)));
 

--- a/src/a2a3/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/a2a3/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -162,7 +162,8 @@ void dep_gen_aicpu_init() {
 
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
-    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, const int32_t kernel_ids[3]
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
+    const int32_t kernel_ids[3]
 ) {
     if (!g_enable_dep_gen || s_dep_gen_state == nullptr) {
         return;
@@ -257,6 +258,7 @@ void dep_gen_aicpu_record_submit(
     }
     rec->flags = base_flags;
     rec->tensor_count = static_cast<uint16_t>(tc);
+    rec->block_num = block_num > 0 ? static_cast<uint32_t>(block_num) : 1u;
 
     int base_dc = (dc < DEP_GEN_MAX_EXPLICIT_DEPS) ? dc : DEP_GEN_MAX_EXPLICIT_DEPS;
     rec->explicit_dep_count = static_cast<uint16_t>(base_dc);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -202,6 +202,7 @@ struct TaskTableEntry {
     uint64_t task_id;
     bool in_manual_scope;
     int32_t kernel_id[3];  // per-subslot {AIC, AIV0, AIV1}, -1 = inactive
+    uint32_t block_num;
     std::vector<TaskArgEntry> args;
 };
 
@@ -328,6 +329,7 @@ bool write_deps_json(
         // (and the swimlane host post-processor) use it to resolve task_id →
         // kernel without the AICore record carrying the field itself.
         out << ",\"kernel_ids\":[" << t.kernel_id[0] << ',' << t.kernel_id[1] << ',' << t.kernel_id[2] << ']';
+        out << ",\"block_num\":" << t.block_num;
         out << ",\"args\":[";
         for (size_t a = 0; a < t.args.size(); a++) {
             if (a > 0) out << ',';
@@ -642,6 +644,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         task_entry.kernel_id[0] = rec.kernel_id[0];
         task_entry.kernel_id[1] = rec.kernel_id[1];
         task_entry.kernel_id[2] = rec.kernel_id[2];
+        task_entry.block_num = rec.block_num > 0 ? rec.block_num : 1u;
         task_entry.args.reserve(tc);
         for (int32_t i = 0; i < tc; i++) {
             TaskArgEntry slot{};

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -58,7 +58,7 @@ static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot
 // (same pattern as get_sys_cnt_aicpu / l2_swimlane_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, const int32_t[3]
+    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
 ) {}
 
 // Scope_stats enable gate, queried via the same predicate idiom as
@@ -579,7 +579,7 @@ static TaskOutputTensors submit_task_common(
         dep_gen_aicpu_record_submit(
             task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
-            kernel_ids_capture
+            args.launch_spec.block_num(), kernel_ids_capture
         );
     }
 

--- a/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -97,6 +97,7 @@ void dep_gen_aicpu_init();
  * @param explicit_dep_count  Number of explicit_deps — no static cap; truncated only when the
  *                            chain would not fit in a single DepGenBuffer
  * @param explicit_deps_raw   Per-dep PTO2TaskId::raw (length = explicit_dep_count)
+ * @param block_num           SPMD logical block count; 1 means non-SPMD
  * @param kernel_ids          Per-subslot kernel id triple {AIC, AIV0, AIV1};
  *                            inactive subslots use INVALID_KERNEL_ID (-1).
  *                            Captured here so the host swimlane post-processor
@@ -105,7 +106,8 @@ void dep_gen_aicpu_init();
  */
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
-    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, const int32_t kernel_ids[3]
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
+    const int32_t kernel_ids[3]
 );
 
 /**

--- a/src/a5/platform/include/common/dep_gen.h
+++ b/src/a5/platform/include/common/dep_gen.h
@@ -95,9 +95,9 @@ enum DepGenRecordFlags : uint32_t {
  *     cache lines
  *   - tensors[] (32 × 128 B opaque blobs) at the tail; covers ~88% of the entry
  *
- * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (pad) + 32*128
+ * Total size: 8 + 4 + 4 + 64*8 + 32 + 12 (kernel_id) + 4 (block_num) + 32*128
  *           = 4672 bytes.
- * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + _pad0
+ * Aligned to 64 B → 4672 B (already a multiple of 64). kernel_id + block_num
  * together pad tensors[] up to offset 576 = 9 * 64 so each 128-byte tensor
  * blob covers exactly two cache lines instead of straddling three.
  */
@@ -109,7 +109,7 @@ struct DepGenRecord {
     uint64_t explicit_deps[DEP_GEN_MAX_EXPLICIT_DEPS];  // PTO2TaskId::raw, length = explicit_dep_count
     uint8_t arg_types[CORE_MAX_TENSOR_ARGS];            // TensorArgType, length = tensor_count
     int32_t kernel_id[3];  // per-subslot kernel id (AIC, AIV0, AIV1); INVALID_KERNEL_ID = -1
-    uint8_t _pad0[4];      // align tensors[] to 64 B (offset 576)
+    uint32_t block_num;    // SPMD logical block count; 1 means non-SPMD
     uint8_t tensors[CORE_MAX_TENSOR_ARGS][DEP_GEN_TENSOR_SIZE];  // opaque Tensor blobs
 } __attribute__((aligned(64)));
 

--- a/src/a5/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
+++ b/src/a5/platform/shared/aicpu/dep_gen_collector_aicpu.cpp
@@ -162,7 +162,8 @@ void dep_gen_aicpu_init() {
 
 void dep_gen_aicpu_record_submit(
     uint64_t task_id_raw, bool in_manual_scope, int tensor_count, const void *const *tensor_ptrs,
-    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, const int32_t kernel_ids[3]
+    const uint8_t *arg_types, int explicit_dep_count, const uint64_t *explicit_deps_raw, int block_num,
+    const int32_t kernel_ids[3]
 ) {
     if (!g_enable_dep_gen || s_dep_gen_state == nullptr) {
         return;
@@ -257,6 +258,7 @@ void dep_gen_aicpu_record_submit(
     }
     rec->flags = base_flags;
     rec->tensor_count = static_cast<uint16_t>(tc);
+    rec->block_num = block_num > 0 ? static_cast<uint32_t>(block_num) : 1u;
 
     int base_dc = (dc < DEP_GEN_MAX_EXPLICIT_DEPS) ? dc : DEP_GEN_MAX_EXPLICIT_DEPS;
     rec->explicit_dep_count = static_cast<uint16_t>(base_dc);

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/dep_gen_replay.cpp
@@ -202,6 +202,7 @@ struct TaskTableEntry {
     uint64_t task_id;
     bool in_manual_scope;
     int32_t kernel_id[3];  // per-subslot {AIC, AIV0, AIV1}, -1 = inactive
+    uint32_t block_num;
     std::vector<TaskArgEntry> args;
 };
 
@@ -328,6 +329,7 @@ bool write_deps_json(
         // (and the swimlane host post-processor) use it to resolve task_id →
         // kernel without the AICore record carrying the field itself.
         out << ",\"kernel_ids\":[" << t.kernel_id[0] << ',' << t.kernel_id[1] << ',' << t.kernel_id[2] << ']';
+        out << ",\"block_num\":" << t.block_num;
         out << ",\"args\":[";
         for (size_t a = 0; a < t.args.size(); a++) {
             if (a > 0) out << ',';
@@ -642,6 +644,7 @@ dep_gen_replay_emit_deps_json(const DepGenRecord *records, size_t num_records, c
         task_entry.kernel_id[0] = rec.kernel_id[0];
         task_entry.kernel_id[1] = rec.kernel_id[1];
         task_entry.kernel_id[2] = rec.kernel_id[2];
+        task_entry.block_num = rec.block_num > 0 ? rec.block_num : 1u;
         task_entry.args.reserve(tc);
         for (int32_t i = 0; i < tc; i++) {
             TaskArgEntry slot{};

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -57,7 +57,7 @@ static_assert(sizeof(Tensor) == DEP_GEN_TENSOR_SIZE, "DepGenRecord::tensors slot
 // (same pattern as get_sys_cnt_aicpu / l2_perf_aicpu_record_orch_phase below).
 extern "C" __attribute__((weak, visibility("hidden"))) bool is_dep_gen_enabled() { return false; }
 __attribute__((weak, visibility("hidden"))) void dep_gen_aicpu_record_submit(
-    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, const int32_t[3]
+    uint64_t, bool, int, const void *const *, const uint8_t *, int, const uint64_t *, int, const int32_t[3]
 ) {}
 
 #if PTO2_PROFILING
@@ -584,7 +584,7 @@ static TaskOutputTensors submit_task_common(
         dep_gen_aicpu_record_submit(
             task_id.raw, orch->in_manual_scope(), tc, tensor_ptrs, arg_types_u8,
             static_cast<int>(args.explicit_dep_count()), reinterpret_cast<const uint64_t *>(args.explicit_deps_data()),
-            kernel_ids_capture
+            args.launch_spec.core_num(), kernel_ids_capture
         );
     }
 

--- a/tests/ut/py/test_deps_viewer.py
+++ b/tests/ut/py/test_deps_viewer.py
@@ -85,6 +85,26 @@ def test_kernel_ids_fill_func_id_when_perf_sidecar_is_absent():
     assert "func_name_map: no" in text
 
 
+def test_emit_text_marks_spmd_block_count():
+    meta = _merge_task_meta_with_kernel_ids(
+        {},
+        {1: {"task_id": 1, "kernel_ids": [-1, 2, -1], "block_num": 4}},
+    )
+
+    text = emit_text(
+        edges=[],
+        nodes=[1],
+        meta=meta,
+        deps_path="deps.json",
+        annotations={},
+        tensor_table={},
+        task_table={1: {"task_id": 1, "kernel_ids": [-1, 2, -1], "block_num": 4}},
+    )
+
+    assert "TASK 1 kind=submit func_id=[-1,2,-1] SPMD block num = 4 fanin=0 fanout=0" in text
+    assert "=== TASK 1 kind=submit func_id=[-1,2,-1] SPMD block num = 4 ===" in text
+
+
 def test_kernel_ids_render_all_active_funcs_for_mixed_task():
     meta = _merge_task_meta_with_kernel_ids(
         {},
@@ -113,6 +133,21 @@ def test_kernel_ids_render_all_active_funcs_for_mixed_task():
     assert "TASK 2 kind=submit func_id=[0,1,-1] fanin=0 fanout=0" in text
     assert "TASK 3 kind=submit func_id=[-1,3,4] fanin=0 fanout=0" in text
     assert "func_name_map: no" in text
+
+
+def test_kernel_ids_infer_core_type_when_perf_sidecar_is_absent():
+    meta = _merge_task_meta_with_kernel_ids(
+        {},
+        {
+            1: {"task_id": 1, "kernel_ids": [0, -1, -1]},
+            2: {"task_id": 2, "kernel_ids": [-1, 1, -1]},
+            3: {"task_id": 3, "kernel_ids": [0, 1, 2]},
+        },
+    )
+
+    assert meta[1]["core_type"] == "aic"
+    assert meta[2]["core_type"] == "aiv"
+    assert meta[3]["core_type"] == "mix"
 
 
 def test_kernel_ids_use_func_name_map_when_available():
@@ -157,6 +192,70 @@ def test_kernel_ids_use_all_named_funcs_when_available():
     assert "func_name_map: yes" in text
 
 
+def test_emit_dot_marks_spmd_nodes_without_expanding_labels():
+    task_table = {1: {"task_id": 1, "kernel_ids": [-1, 2, -1], "block_num": 4, "args": []}}
+    meta = _merge_task_meta_with_kernel_ids({}, task_table)
+
+    plain = deps_viewer.emit_dot(
+        edges=[],
+        nodes=[1],
+        meta=meta,
+        task_table=task_table,
+        show_tensor_info=False,
+    )
+
+    assert 'label="1"' in plain
+    assert 'color="#C62828"' in plain
+    assert "penwidth=1.5" in plain
+    assert 'style="filled"' in plain
+    assert "SPMD" not in plain
+    assert "4 blocks" not in plain
+
+    rich = deps_viewer.emit_dot(
+        edges=[],
+        nodes=[1],
+        meta=meta,
+        task_table=task_table,
+        tensor_table={},
+    )
+
+    assert '<TABLE BORDER="1" COLOR="#C62828"' in rich
+    assert "SPMD" not in rich
+    assert "4 blocks" not in rich
+
+
+def test_spmd_badges_json_includes_only_multiblock_tasks():
+    task_table = {
+        1: {"task_id": 1, "block_num": 1},
+        2: {"task_id": 2, "block_num": 8},
+    }
+
+    badges = deps_viewer._spmd_badges_json([1, 2], task_table)
+
+    assert badges == '{"T0_2":8}'
+
+
+def test_emit_dot_handles_missing_task_table():
+    dot = deps_viewer.emit_dot(edges=[], nodes=[1], meta={}, task_table=None)
+
+    assert 'label="1 · alloc"' in dot
+
+
+def test_emit_html_default_preserves_task_table_rendering(monkeypatch):
+    captured = {}
+
+    def fake_emit_dot(*args, **kwargs):
+        captured["show_tensor_info"] = kwargs["show_tensor_info"]
+        return "digraph deps { T0_1 [label=<1>]; }"
+
+    monkeypatch.setattr(deps_viewer, "emit_dot", fake_emit_dot)
+    monkeypatch.setattr(deps_viewer, "render_svg", lambda dot, engine="dot": b"<svg></svg>")
+
+    deps_viewer.emit_html(edges=[], nodes=[1], meta={}, task_table={1: {"task_id": 1, "args": []}})
+
+    assert captured["show_tensor_info"] is None
+
+
 def test_validate_args_rejects_show_tensor_info_in_text_mode(capsys):
     rc = deps_viewer.main(["deps.json", "--show-tensor-info"])
 
@@ -185,9 +284,18 @@ def test_main_passes_task_table_when_show_tensor_info_enabled(tmp_path, monkeypa
     captured = {}
 
     def fake_emit_html(
-        edges, nodes, meta, direction="LR", engine="dot", annotations=None, tensor_table=None, task_table=None
+        edges,
+        nodes,
+        meta,
+        direction="LR",
+        engine="dot",
+        annotations=None,
+        tensor_table=None,
+        task_table=None,
+        show_tensor_info=False,
     ):
         captured["task_table"] = task_table
+        captured["show_tensor_info"] = show_tensor_info
         return "<html></html>"
 
     monkeypatch.setattr(deps_viewer, "emit_html", fake_emit_html)
@@ -196,9 +304,10 @@ def test_main_passes_task_table_when_show_tensor_info_enabled(tmp_path, monkeypa
 
     assert rc == 0
     assert captured["task_table"] == {1: {"task_id": 1, "args": []}}
+    assert captured["show_tensor_info"] is True
 
 
-def test_main_keeps_plain_html_when_show_tensor_info_disabled(tmp_path, monkeypatch):
+def test_main_keeps_task_metadata_when_show_tensor_info_disabled(tmp_path, monkeypatch):
     deps_json = tmp_path / "deps.json"
     deps_json.write_text("{}")
 
@@ -219,9 +328,18 @@ def test_main_keeps_plain_html_when_show_tensor_info_disabled(tmp_path, monkeypa
     captured = {}
 
     def fake_emit_html(
-        edges, nodes, meta, direction="LR", engine="dot", annotations=None, tensor_table=None, task_table=None
+        edges,
+        nodes,
+        meta,
+        direction="LR",
+        engine="dot",
+        annotations=None,
+        tensor_table=None,
+        task_table=None,
+        show_tensor_info=False,
     ):
         captured["task_table"] = task_table
+        captured["show_tensor_info"] = show_tensor_info
         return "<html></html>"
 
     monkeypatch.setattr(deps_viewer, "emit_html", fake_emit_html)
@@ -229,4 +347,5 @@ def test_main_keeps_plain_html_when_show_tensor_info_disabled(tmp_path, monkeypa
     rc = deps_viewer.main([str(deps_json), "--format", "html"])
 
     assert rc == 0
-    assert captured["task_table"] is None
+    assert captured["task_table"] == {1: {"task_id": 1, "args": []}}
+    assert captured["show_tensor_info"] is False


### PR DESCRIPTION
## Summary

Fixes #1084.

This PR makes SPMD task information visible in `deps_viewer` output by carrying the logical block count through dep_gen and rendering it in both text and HTML views.

## Changes

- Add `block_num` to `DepGenRecord` using the existing 4-byte padding, so the record size/layout stays stable.
- Thread SPMD block count through the dep_gen capture path for a2a3 and a5.
- Emit `tasks[].block_num` in generated `deps.json`.
- Show `spmd=no` / `spmd=N` in text output.
- Show a red `xN` suffix on SPMD nodes in HTML and add a matching legend entry.
- Keep HTML focused on task structure and SPMD markers; `func_id` remains in text output only.
- Update docs and unit tests for the new behavior.

## Validation

- `python -m pytest tests/ut/py/test_deps_viewer.py -q`
- `.venv/bin/python -m ruff check simpler_setup/tools/deps_viewer.py tests/ut/py/test_deps_viewer.py`
- `.venv/bin/python -m ruff format --check simpler_setup/tools/deps_viewer.py tests/ut/py/test_deps_viewer.py`
- `git diff --check`

Also manually generated dep viewer HTML/text outputs from SPMD examples, including multiblock and paged-attention style cases, to verify the red `xN` marker appears for `block_num > 1`.