### PR TITLE
Fix: close unpublished sim host orchestration handles

### DIFF
--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -28,6 +28,7 @@
 #include "prepare_callable_common.h"
 #include "task_args.h"
 
+#include <dlfcn.h>
 #include <pthread.h>
 
 #include <chrono>
@@ -266,6 +267,11 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
+        auto host_dlopen_guard = RAIIScopeGuard([&artifacts]() {
+            if (artifacts.host_dlopen_handle != nullptr) {
+                dlclose(artifacts.host_dlopen_handle);
+            }
+        });
 
         std::vector<std::pair<int, uint64_t>> kernel_addrs;
         kernel_addrs.reserve(artifacts.kernel_addrs.size());
@@ -278,6 +284,9 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
                 callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
                 std::move(artifacts.signature)
             );
+            if (rc == 0) {
+                host_dlopen_guard.dismiss();
+            }
         } else {
             rc = runner->register_callable(
                 callable_id, artifacts.orch_so_data, artifacts.orch_so_size, artifacts.func_name.c_str(),

--- a/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a2a3/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -16,6 +16,8 @@ on every run. The dlopen counter to assert is `host_dlopen_count`,
 not `aicpu_dlopen_count` (which stays 0 — AICPU never sees the orch SO).
 """
 
+from pathlib import Path
+
 import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
@@ -26,6 +28,23 @@ from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 _VECTOR_KERNELS = "../vector_example/kernels"
 _SLOT_PRIMARY = 0
 _SLOT_SECONDARY = 1
+_ORCH_SO_MAP_TOKEN = "/tmp/orch_so_"
+
+
+def _count_live_orch_so_mappings():
+    try:
+        lines = Path("/proc/self/maps").read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        pytest.skip(f"/proc/self/maps unavailable: {exc}")
+
+    paths = set()
+    for line in lines:
+        if _ORCH_SO_MAP_TOKEN not in line:
+            continue
+        parts = line.split(None, 5)
+        if len(parts) == 6:
+            paths.add(parts[5])
+    return len(paths)
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -226,6 +245,33 @@ class TestPreparedCallableHbg(SceneTestCase):
         finally:
             if prepared:
                 chip_worker._unregister_slot(_SLOT_PRIMARY)
+
+    def test_failed_double_prepare_closes_unpublished_host_handle(self, st_platform, st_worker):
+        if not st_platform.endswith("sim"):
+            pytest.skip("unpublished host dlopen guard is validated on sim")
+
+        callable_obj, _config, _case = self._setup_dlopen_count_test(st_worker, st_platform)
+        baseline_count = st_worker.host_dlopen_count
+        baseline_maps = _count_live_orch_so_mappings()
+        prepared = False
+        chip_worker = self._chip_worker(st_worker)
+        try:
+            chip_worker._prepare_callable_at_slot(_SLOT_PRIMARY, callable_obj)
+            prepared = True
+            after_first_maps = _count_live_orch_so_mappings()
+            assert st_worker.host_dlopen_count - baseline_count == 1
+            assert after_first_maps == baseline_maps + 1
+
+            with pytest.raises(RuntimeError):
+                chip_worker._prepare_callable_at_slot(_SLOT_PRIMARY, callable_obj)
+
+            assert st_worker.host_dlopen_count - baseline_count == 1
+            assert _count_live_orch_so_mappings() == after_first_maps
+        finally:
+            if prepared:
+                chip_worker._unregister_slot(_SLOT_PRIMARY)
+
+        assert _count_live_orch_so_mappings() == baseline_maps
 
     def test_dlopen_count_unregister_re_prepare(self, st_platform, st_worker):
         """prepare+run+unregister+prepare+run -> host_dlopen delta == 2.

--- a/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
+++ b/tests/st/a5/host_build_graph/prepared_callable/test_prepared_callable.py
@@ -14,6 +14,8 @@ Reuses the dump_tensor example kernels (a + b + 1) since a5/hbg has no
 vector_example today and dump_tensor already runs cleanly on a5sim.
 """
 
+from pathlib import Path
+
 import pytest
 import torch
 from simpler.task_interface import ArgDirection as D
@@ -23,6 +25,23 @@ from simpler_setup.scene_test import _build_chip_task_args, _compare_outputs
 
 _SLOT_PRIMARY = 0
 _SLOT_SECONDARY = 1
+_ORCH_SO_MAP_TOKEN = "/tmp/orch_so_"
+
+
+def _count_live_orch_so_mappings():
+    try:
+        lines = Path("/proc/self/maps").read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        pytest.skip(f"/proc/self/maps unavailable: {exc}")
+
+    paths = set()
+    for line in lines:
+        if _ORCH_SO_MAP_TOKEN not in line:
+            continue
+        parts = line.split(None, 5)
+        if len(parts) == 6:
+            paths.add(parts[5])
+    return len(paths)
 
 
 @scene_test(level=2, runtime="host_build_graph")
@@ -198,6 +217,33 @@ class TestPreparedCallableHbgA5(SceneTestCase):
         finally:
             if prepared:
                 chip_worker._unregister_slot(_SLOT_PRIMARY)
+
+    def test_failed_double_prepare_closes_unpublished_host_handle(self, st_platform, st_worker):
+        if not st_platform.endswith("sim"):
+            pytest.skip("unpublished host dlopen guard is validated on sim")
+
+        callable_obj, _config, _case = self._setup_dlopen_count_test(st_worker, st_platform)
+        baseline_count = st_worker.host_dlopen_count
+        baseline_maps = _count_live_orch_so_mappings()
+        prepared = False
+        chip_worker = self._chip_worker(st_worker)
+        try:
+            chip_worker._prepare_callable_at_slot(_SLOT_PRIMARY, callable_obj)
+            prepared = True
+            after_first_maps = _count_live_orch_so_mappings()
+            assert st_worker.host_dlopen_count - baseline_count == 1
+            assert after_first_maps == baseline_maps + 1
+
+            with pytest.raises(RuntimeError):
+                chip_worker._prepare_callable_at_slot(_SLOT_PRIMARY, callable_obj)
+
+            assert st_worker.host_dlopen_count - baseline_count == 1
+            assert _count_live_orch_so_mappings() == after_first_maps
+        finally:
+            if prepared:
+                chip_worker._unregister_slot(_SLOT_PRIMARY)
+
+        assert _count_live_orch_so_mappings() == baseline_maps
 
     def test_dlopen_count_unregister_re_prepare(self, st_platform, st_worker):
         callable_obj, config, case = self._setup_dlopen_count_test(st_worker, st_platform)


### PR DESCRIPTION
## Summary

Close unpublished host orchestration `dlopen` handles on the simulator
`host_build_graph` prepare path.

`host_build_graph::prepare_callable_impl()` opens the orchestration SO on the
host and returns the handle in `CallableArtifacts`. Ownership should transfer
to `SimDeviceRunnerBase` only after `register_callable_host_orch()` succeeds.
If registration fails, for example duplicate prepared-callable slot
registration, the handle was not owned by the runner and was leaked.

This PR adds an RAII guard in `src/common/platform/sim/host/c_api_shared.cpp`
so failed registration closes the unpublished handle, and dismisses the guard
only after successful registration.

## Relation to PR #1095

PR #1095 fixed the same ownership hole for the onboard platform path in
`src/common/platform/onboard/host/c_api_shared.cpp`.

This PR is the simulator-side counterpart:

- PR #1095: onboard `host_build_graph` prepare failure closes unpublished host
  orchestration handles.
- This PR: sim `host_build_graph` prepare failure closes unpublished host
  orchestration handles.

The two fixes are independent and touch different platform glue files. This is
not part of PR #1089; PR #1089 is the AICPU callable prewarm change, while this
PR is a host-side resource ownership cleanup for `host_build_graph` failure
paths.

## Validation

- `git diff --check`
- `a2a3sim` host_build_graph prepared callable tests: 6 passed
- `a5sim` host_build_graph prepared callable tests: 6 passed

Test command note: this dev environment's conda `libstdc++.so.6` lacks
`GLIBCXX_3.4.32`, so the sim tests were run with
`LD_PRELOAD=/data/software/gcc-15/lib64/libstdc++.so.6` to use the GCC 15
runtime required by the compiled sim child kernels.
