### PR TITLE
Refactor: rename init-claim flag to init_claimed_ in trb scheduler

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -640,13 +640,13 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 | Flag | Set by | Waited by | Purpose |
 | ---- | ------ | --------- | ------- |
 | `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
-| `pto2_init_done_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
+| `pto2_init_claimed_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
 | `pto2_init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
 
 Startup sequence:
 
 1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
-2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_done_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
+2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_claimed_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
 3. Thread 3: wait for `pto2_init_complete_` → configure orchestrator-scheduler pointers
 4. Scheduler threads: enter main loop
 5. Thread 3: call orchestration function → set `orchestrator_done_`

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -972,7 +972,7 @@ void SchedulerContext::deinit() {
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
     orchestrator_done_ = false;
-    pto2_init_done_.store(false, std::memory_order_release);
+    pto2_init_claimed_.store(false, std::memory_order_release);
     pto2_init_complete_.store(false, std::memory_order_release);
 
     // Reset core transition state

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -180,7 +180,7 @@ private:
 #endif
 
     // --- One-time init coordination ---
-    std::atomic<bool> pto2_init_done_{false};
+    std::atomic<bool> pto2_init_claimed_{false};
     std::atomic<bool> pto2_init_complete_{false};
 
     // =========================================================================

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -781,7 +781,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     );
 
     // One-time init: assign perf buffers (one thread does it; others wait)
-    if (!pto2_init_done_.exchange(true, std::memory_order_acq_rel)) {
+    if (!pto2_init_claimed_.exchange(true, std::memory_order_acq_rel)) {
         LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -640,14 +640,14 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 | Flag | Set by | Waited by | Purpose |
 | ---- | ------ | --------- | ------- |
 | `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
-| `pto2_init_done_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
-| `pto2_init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
+| `init_claimed_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
+| `init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
 
 Startup sequence:
 
 1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
-2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_done_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
-3. Thread 3: wait for `pto2_init_complete_` → configure orchestrator-scheduler pointers
+2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `init_claimed_` exchange → memset per-task arrays → set `init_complete_`; other threads wait for `init_complete_`
+3. Thread 3: wait for `init_complete_` → configure orchestrator-scheduler pointers
 4. Scheduler threads: enter main loop
 5. Thread 3: call orchestration function → set `orchestrator_done_`
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -982,7 +982,7 @@ void SchedulerContext::deinit() {
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
     orchestrator_done_ = false;
-    init_done_.store(false, std::memory_order_release);
+    init_claimed_.store(false, std::memory_order_release);
     init_complete_.store(false, std::memory_order_release);
 
     // Reset core transition state

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -180,7 +180,7 @@ private:
     uint64_t regs_{0};
 
     // --- One-time init coordination ---
-    std::atomic<bool> init_done_{false};
+    std::atomic<bool> init_claimed_{false};
     std::atomic<bool> init_complete_{false};
 
     // =========================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -503,7 +503,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     // promoted g_l2_swimlane_level before caching it on rt->orchestrator. Only
     // dump_tensor / pmu init remain dispatch-time because they depend on
     // handshake-derived core IDs / counts.
-    if (!init_done_.exchange(true, std::memory_order_acq_rel)) {
+    if (!init_claimed_.exchange(true, std::memory_order_acq_rel)) {
         LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
 
 #if PTO2_PROFILING


### PR DESCRIPTION
## Summary
Rename the misleadingly-named init-claim flag in the `tensormap_and_ringbuffer` scheduler. Its real meaning is "init has been **claimed/started**" (set by the winner of `exchange(true)`), not "init is done" — and `done`/`complete` are near-synonyms denoting opposite phases here, which trips up readers. The new name pairs cleanly with the complete flag (claimed → complete).

Applied to both arches' trb scheduler:
- **a2a3**: `pto2_init_done_` → `pto2_init_claimed_`
- **a5**: `init_done_` → `init_claimed_` (scheduler context only)

The separate `aicpu_executor` `init_done_` flag genuinely means "done" (`store(true)` when finished, others `wait` on it) and is intentionally left untouched.

Naming only — behavior is unchanged. Also updates the a2a3 and a5 `RUNTIME_LOGIC.md` init-coordination flag references to match the code.

## Review notes
- **Declined: relax the claim `exchange` to `memory_order_relaxed`.** Correct in theory (the complete flag's release/acquire carries all init-data ordering), but kept `acq_rel`: it's a one-time cold path (no measurable benefit), `acq_rel` keeps correctness self-evident, and a memory-order change is out of scope for a naming-only PR. If pursued, it should be a dedicated change covering both arches. See thread for full rationale.

## Note (out of scope)
The a5 `RUNTIME_LOGIC.md` §10.3 carries other a2a3 symbol names copied verbatim that don't exist in a5 code (`wait_pto2_init_complete()` → a5's `wait_init_complete()`; `runtime_init_ready_` has no a5 counterpart). That is pre-existing doc drift, left for a separate cleanup.

## Testing
- [x] `pip install --no-build-isolation -e .` incremental rebuild succeeds (both arches)
- [x] `pytest tests/st/a2a3/tensormap_and_ringbuffer/{dummy_task,spmd_basic} --platform a2a3sim` → 2 passed
- [x] `pytest tests/st/a5/tensormap_and_ringbuffer/{dummy_task,spmd_basic} --platform a5sim` → 2 passed

Resolves #1116