### PR TITLE
feat(a2a3): compute onboard AICPU affinity on host

### DIFF
--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -92,9 +92,21 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     set_scope_stats_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_SCOPE_STATS));
     set_platform_scope_stats_base(k_args->scope_stats_data_base);
 
-    // Affinity gate: drop excess threads before entering runtime
-    if (!platform_aicpu_affinity_gate(runtime->aicpu_thread_num, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)) {
-        LOG_INFO_V0("Thread dropped by cluster affinity");
+    // Filter-style affinity gate. Host computed ALLOWED_CPUS from AICPU
+    // OCCUPY and wrote it into Runtime; the device side only matches
+    // sched_getcpu() against that table and exposes the table position as
+    // exec_idx.
+    if (runtime->aicpu_allowed_cpu_count <= 0 || runtime->aicpu_launch_count <= 0) {
+        LOG_ERROR(
+            "AICPU affinity inputs missing: allowed_cpu_count=%d launch_count=%d (host probe must run before exec)",
+            runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+        );
+        return -1;
+    }
+    if (!platform_aicpu_affinity_gate_filter(
+            runtime->aicpu_allowed_cpus, runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+        )) {
+        LOG_INFO_V0("Thread dropped by filter affinity gate");
         return 0;
     }
 

--- a/src/a2a3/platform/onboard/host/CMakeLists.txt
+++ b/src/a2a3/platform/onboard/host/CMakeLists.txt
@@ -50,6 +50,7 @@ list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS
 set(HOST_RUNTIME_SOURCES "")
 list(APPEND HOST_RUNTIME_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/aicpu_topology_probe.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/device_runner.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/memory_allocator.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/profiling_copy.cpp"

--- a/src/a2a3/platform/onboard/host/aicpu_topology_probe.cpp
+++ b/src/a2a3/platform/onboard/host/aicpu_topology_probe.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include "aicpu_topology_probe.h"
+
+#include <dlfcn.h>
+
+#include <algorithm>
+#include <mutex>
+#include <unordered_map>
+
+#include "common/unified_log.h"
+
+namespace pto::a2a3 {
+
+namespace {
+
+// halGetDeviceInfo module/info selectors (CANN driver ABI). Provenance:
+// driver/ascend_hal.h — replicated here to keep the runtime .so free of a
+// CANN header dependency (see tools/cann-examples/query for the reference use).
+constexpr int32_t kModuleAicpu = 1;
+constexpr int32_t kInfoOccupy = 8;
+// a2a3 AICPU has NO SMT: each logical cpu_id maps 1:1 to a physical core, so
+// the cluster can be derived arithmetically from cpu_id alone (no DSMI CPU_TOPO
+// probe is needed, unlike a5). 8 cores/die, 4 cores/cluster ⇒ 2 clusters/die.
+constexpr int32_t kAicpuCoresPerDie = 8;
+constexpr int32_t kCpusPerCluster = 4;
+
+using HalGetDeviceInfoFn = int (*)(uint64_t deviceId, int32_t moduleType, int32_t infoType, int64_t *value);
+
+HalGetDeviceInfoFn load_hal_get_device_info() {
+    static HalGetDeviceInfoFn cached_fn = []() -> HalGetDeviceInfoFn {
+        auto fn = reinterpret_cast<HalGetDeviceInfoFn>(dlsym(nullptr, "halGetDeviceInfo"));
+        if (fn != nullptr) return fn;
+        static const char *const kHalLibs[] = {
+            "libascend_hal.so",
+            "/usr/local/Ascend/driver/lib64/driver/libascend_hal.so",
+        };
+        for (const char *path : kHalLibs) {
+            if (dlopen(path, RTLD_LAZY | RTLD_GLOBAL) == nullptr) continue;
+            fn = reinterpret_cast<HalGetDeviceInfoFn>(dlsym(nullptr, "halGetDeviceInfo"));
+            if (fn != nullptr) return fn;
+        }
+        LOG_WARN("a2a3_aicpu_topology_probe: halGetDeviceInfo not found after dlopen fallback");
+        return nullptr;
+    }();
+    return cached_fn;
+}
+
+bool query_occupy(uint32_t device_id, uint64_t &out_mask) {
+    auto fn = load_hal_get_device_info();
+    if (fn == nullptr) return false;
+
+    int64_t v = 0;
+    int rc = fn(static_cast<uint64_t>(device_id), kModuleAicpu, kInfoOccupy, &v);
+    if (rc != 0) {
+        LOG_WARN("a2a3_aicpu_topology_probe: halGetDeviceInfo(AICPU,OCCUPY) rc=%d", rc);
+        return false;
+    }
+
+    out_mask = static_cast<uint64_t>(v);
+    return true;
+}
+
+std::mutex s_topo_cache_mu;
+std::unordered_map<uint32_t, std::vector<AicpuLogicalCpu>> s_topo_cache;
+
+bool probe_aicpu_topology_uncached(uint32_t device_id, std::vector<AicpuLogicalCpu> &out_user_cpus) {
+    out_user_cpus.clear();
+
+    uint64_t occupy = 0;
+    if (!query_occupy(device_id, occupy)) return false;
+
+    for (int32_t cpu_id = 0; cpu_id < 64; ++cpu_id) {
+        if (((occupy >> cpu_id) & 1ULL) == 0) continue;
+        AicpuLogicalCpu e{};
+        e.cpu_id = cpu_id;
+        e.cluster_id = (cpu_id % kAicpuCoresPerDie) / kCpusPerCluster;
+        out_user_cpus.push_back(e);
+    }
+
+    std::sort(out_user_cpus.begin(), out_user_cpus.end(), [](const AicpuLogicalCpu &a, const AicpuLogicalCpu &b) {
+        return a.cpu_id < b.cpu_id;
+    });
+    return !out_user_cpus.empty();
+}
+
+}  // namespace
+
+bool probe_aicpu_topology(uint32_t device_id, std::vector<AicpuLogicalCpu> &out_user_cpus) {
+    {
+        std::lock_guard<std::mutex> lk(s_topo_cache_mu);
+        auto it = s_topo_cache.find(device_id);
+        if (it != s_topo_cache.end()) {
+            out_user_cpus = it->second;
+            return !out_user_cpus.empty();
+        }
+    }
+
+    std::vector<AicpuLogicalCpu> probed;
+    bool ok = probe_aicpu_topology_uncached(device_id, probed);
+    if (!ok) {
+        out_user_cpus.clear();
+        return false;
+    }
+
+    LOG_INFO_V0("A2A3 AICPU topology probed for device %u: %zu user-schedulable cpu_ids", device_id, probed.size());
+
+    {
+        std::lock_guard<std::mutex> lk(s_topo_cache_mu);
+        s_topo_cache[device_id] = probed;
+    }
+    out_user_cpus = std::move(probed);
+    return true;
+}
+
+bool compute_allowed_cpus(
+    const std::vector<AicpuLogicalCpu> &user_cpus, int32_t active_count, std::vector<int32_t> &out_allowed_cpus
+) {
+    out_allowed_cpus.clear();
+    if (active_count <= 0 || static_cast<int32_t>(user_cpus.size()) < active_count) return false;
+
+    int32_t max_cluster = -1;
+    for (const auto &c : user_cpus)
+        max_cluster = std::max(max_cluster, c.cluster_id);
+    if (max_cluster < 0) return false;
+
+    std::vector<std::vector<int32_t>> buckets(max_cluster + 1);
+    for (int32_t i = 0; i < static_cast<int32_t>(user_cpus.size()); ++i) {
+        if (user_cpus[i].cluster_id >= 0 && user_cpus[i].cluster_id <= max_cluster) {
+            buckets[user_cpus[i].cluster_id].push_back(i);
+        }
+    }
+
+    // Prefer one cluster that can hold all active AICPU threads. On the
+    // observed 0xfc pool this selects cpu_id 4..7 for active_count=4.
+    int32_t chosen_cluster = -1;
+    for (int32_t cluster = max_cluster; cluster >= 0; --cluster) {
+        if (static_cast<int32_t>(buckets[cluster].size()) >= active_count) {
+            chosen_cluster = cluster;
+            break;
+        }
+    }
+
+    if (chosen_cluster >= 0) {
+        auto ordered = buckets[chosen_cluster];
+        std::sort(ordered.begin(), ordered.end(), [&](int32_t a, int32_t b) {
+            return user_cpus[a].cpu_id < user_cpus[b].cpu_id;
+        });
+        for (int32_t i = 0; i < active_count; ++i) {
+            out_allowed_cpus.push_back(user_cpus[ordered[i]].cpu_id);
+        }
+        return true;
+    }
+
+    // No single cluster fits the request (for example a pathological 3+3 pool
+    // with active_count=4). Keep deterministic behavior rather than doing
+    // device-side majority classification again. This crosses a NUMA boundary
+    // and reintroduces the cross-cluster penalty issue #1045 is about, so warn
+    // loudly — the only reason to be here is active_count exceeding a single
+    // cluster, which is outside the supported topology.
+    LOG_WARN(
+        "A2A3 AICPU: no single cluster holds %d active threads (user_cpus=%zu); "
+        "falling back to cross-cluster selection — expect NUMA-crossing slowdown",
+        active_count, user_cpus.size()
+    );
+    std::vector<AicpuLogicalCpu> ordered = user_cpus;
+    std::sort(ordered.begin(), ordered.end(), [](const AicpuLogicalCpu &a, const AicpuLogicalCpu &b) {
+        return a.cpu_id < b.cpu_id;
+    });
+    for (int32_t i = 0; i < active_count; ++i) {
+        out_allowed_cpus.push_back(ordered[i].cpu_id);
+    }
+    return true;
+}
+
+}  // namespace pto::a2a3

--- a/src/a2a3/platform/onboard/host/aicpu_topology_probe.h
+++ b/src/a2a3/platform/onboard/host/aicpu_topology_probe.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_A2A3_PLATFORM_ONBOARD_HOST_AICPU_TOPOLOGY_PROBE_H_
+#define SRC_A2A3_PLATFORM_ONBOARD_HOST_AICPU_TOPOLOGY_PROBE_H_
+
+#include <cstdint>
+#include <vector>
+
+namespace pto::a2a3 {
+
+struct AicpuLogicalCpu {
+    int32_t cpu_id;
+    int32_t cluster_id;
+};
+
+// Probe host-side AICPU OCCUPY and return the user-schedulable cpu_id pool.
+// a2a3 exposes two AICPU clusters per die, four logical cpu_ids per cluster;
+// cluster_id is derived as (cpu_id % 8) / 4 to mirror the historical device
+// affinity gate's cluster classification.
+bool probe_aicpu_topology(uint32_t device_id, std::vector<AicpuLogicalCpu> &out_user_cpus);
+
+// Pick the active cpu_ids that should survive the on-device filter gate.
+// The result order is the deterministic exec_idx order consumed by the runtime:
+// for tensormap_and_ringbuffer, the highest index is the orchestrator slot.
+bool compute_allowed_cpus(
+    const std::vector<AicpuLogicalCpu> &user_cpus, int32_t active_count, std::vector<int32_t> &out_allowed_cpus
+);
+
+}  // namespace pto::a2a3
+
+#endif  // SRC_A2A3_PLATFORM_ONBOARD_HOST_AICPU_TOPOLOGY_PROBE_H_

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -32,6 +32,7 @@
 
 // Include HAL constants from CANN (header only, library loaded dynamically)
 #include "ascend_hal.h"
+#include "aicpu_topology_probe.h"
 #include "callable.h"
 #include "callable_protocol.h"
 #include "chip_callable_layout.h"
@@ -263,6 +264,52 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     if (prepare_runtime_for_launch(runtime, block_dim, launch_aicpu_num) != 0) return -1;
 
+    // a2a3 onboard now uses the same host-computed, device-filtered affinity
+    // shape as a5. Host probes the AICPU user pool once, chooses the active
+    // cpu_ids deterministically, writes them into Runtime, and the AICPU-side
+    // gate only matches sched_getcpu() against this table.
+    {
+        std::vector<pto::a2a3::AicpuLogicalCpu> user_cpus;
+        std::vector<int32_t> allowed;
+        runtime.aicpu_allowed_cpu_count = 0;
+        runtime.aicpu_launch_count = 0;
+        if (!pto::a2a3::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
+            LOG_ERROR("A2A3 AICPU topology probe failed; cannot configure affinity gate");
+            return -1;
+        }
+        if (!pto::a2a3::compute_allowed_cpus(user_cpus, runtime.aicpu_thread_num, allowed)) {
+            LOG_ERROR(
+                "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(),
+                runtime.aicpu_thread_num
+            );
+            return -1;
+        }
+        const size_t cap = sizeof(runtime.aicpu_allowed_cpus) / sizeof(runtime.aicpu_allowed_cpus[0]);
+        if (allowed.size() > cap) {
+            LOG_ERROR("A2A3 compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
+            return -1;
+        }
+        for (size_t i = 0; i < allowed.size(); ++i)
+            runtime.aicpu_allowed_cpus[i] = allowed[i];
+        runtime.aicpu_allowed_cpu_count = static_cast<int32_t>(allowed.size());
+        int32_t launch_n = static_cast<int32_t>(user_cpus.size());
+        if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
+            launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
+        }
+        runtime.aicpu_launch_count = launch_n;
+
+        std::string dump;
+        for (size_t i = 0; i < allowed.size(); ++i) {
+            if (i) dump += ", ";
+            dump += std::to_string(allowed[i]);
+            if (i + 1 == allowed.size()) dump += "(last)";
+        }
+        LOG_INFO_V0(
+            "A2A3 AICPU ALLOWED_CPUS = [%s] (active=%d, launch=%d, user_cpus=%zu)", dump.c_str(),
+            runtime.aicpu_thread_num, runtime.aicpu_launch_count, user_cpus.size()
+        );
+    }
+
     auto runtime_args_cleanup = RAIIScopeGuard([this]() {
         kernel_args_.finalize_device_kernel_args();
         kernel_args_.finalize_runtime_args();
@@ -388,9 +435,8 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
-    rc = launch_aicpu_kernel(
-        stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH
-    );
+    int aicpu_launch_n = (runtime.aicpu_launch_count > 0) ? runtime.aicpu_launch_count : launch_aicpu_num;
+    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
         // The AICore worker was already launched above and is now spinning in

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -17,6 +17,7 @@
 #include "aicpu/device_log.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
+#include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
 #include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
@@ -1084,9 +1085,17 @@ int AicpuExecutor::resolve_and_dispatch(Runtime &runtime, int thread_idx, const 
 }
 
 int AicpuExecutor::run(Runtime *runtime) {
-    int thread_idx = thread_idx_++;
+    int affinity_exec_idx = platform_aicpu_affinity_thread_idx();
+    int thread_idx = (affinity_exec_idx >= 0) ? affinity_exec_idx : (thread_idx_++);
+    if (thread_idx < 0 || thread_idx >= aicpu_thread_num_ || thread_idx >= MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "Thread index %d out of bounds (active=%d max=%d exec_idx=%d)", thread_idx, aicpu_thread_num_,
+            MAX_AICPU_THREADS, affinity_exec_idx
+        );
+        return -1;
+    }
 
-    LOG_INFO_V0("Thread %d: Start", thread_idx);
+    LOG_INFO_V0("Thread %d: Start (exec_idx=%d)", thread_idx, affinity_exec_idx);
 
     const int *cur_thread_cores = core_assignments_[thread_idx];
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -45,6 +45,9 @@ Runtime::Runtime() {
     initial_ready_count = 0;
     worker_count = 0;
     aicpu_thread_num = 1;
+    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
+    aicpu_allowed_cpu_count = 0;
+    aicpu_launch_count = 0;
     tensor_info_storage_ = nullptr;
     tensor_info_storage_bytes_ = 0;
     tensor_allocation_storage_ = nullptr;

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -222,6 +222,15 @@ public:
     // Task storage
     Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
 
+    // Filter-style affinity gate input (a2a3 onboard). Placed AFTER `tasks`
+    // because AICore reads runtime->tasks[] by offset. Host fills these before
+    // launch from AICPU OCCUPY; the device gate keeps threads whose
+    // sched_getcpu() lands on one of the cpu_ids. The array position is the
+    // deterministic exec_idx used by AicpuExecutor for stable core assignment.
+    int32_t aicpu_allowed_cpus[16];
+    int32_t aicpu_allowed_cpu_count;
+    int32_t aicpu_launch_count;
+
 private:
     int next_task_id;  // Next available task ID
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -43,6 +43,7 @@
 #include "common/unified_log.h"
 
 // Register-based communication
+#include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
 
@@ -353,9 +354,17 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
  * Shutdown AICore - Send exit signal via registers to all AICore kernels
  */
 int32_t AicpuExecutor::run(Runtime *runtime) {
-    int32_t thread_idx = thread_idx_++;
+    int32_t affinity_exec_idx = platform_aicpu_affinity_thread_idx();
+    int32_t thread_idx = (affinity_exec_idx >= 0) ? affinity_exec_idx : (thread_idx_++);
+    if (thread_idx < 0 || thread_idx >= aicpu_thread_num_ || thread_idx >= MAX_AICPU_THREADS) {
+        LOG_ERROR(
+            "Thread index %d out of bounds (active=%d max=%d exec_idx=%d)", thread_idx, aicpu_thread_num_,
+            MAX_AICPU_THREADS, affinity_exec_idx
+        );
+        return -1;
+    }
     int32_t run_rc = 0;
-    LOG_INFO_V0("Thread %d: Start", thread_idx);
+    LOG_INFO_V0("Thread %d: Start (exec_idx=%d)", thread_idx, affinity_exec_idx);
 
     // Orchestrator check
     if (thread_idx >= sched_thread_num_) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -201,6 +201,15 @@ public:
     int aicpu_thread_num;
     int ready_queue_shards;  // Number of ready queue shards (1..MAX_AICPU_THREADS, default MAX-1)
 
+    // Filter-style affinity gate input (a2a3 onboard). Host fills these
+    // before launch from AICPU OCCUPY, and the device gate keeps threads whose
+    // sched_getcpu() lands on one of the cpu_ids. The array position is the
+    // deterministic exec_idx used by AicpuExecutor for sched/orch role
+    // assignment; the highest active index is the orchestrator slot.
+    int32_t aicpu_allowed_cpus[16];
+    int32_t aicpu_allowed_cpu_count;
+    int32_t aicpu_launch_count;
+
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
     // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -34,6 +34,9 @@ Runtime::Runtime() {
     worker_count = 0;
     aicpu_thread_num = 1;
     ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
+    aicpu_allowed_cpu_count = 0;
+    aicpu_launch_count = 0;
     orch_to_sched = false;
 
     // Initialize device orchestration state

--- a/src/common/platform/include/aicpu/platform_aicpu_affinity.h
+++ b/src/common/platform/include/aicpu/platform_aicpu_affinity.h
@@ -17,8 +17,8 @@
 // logical_count: desired active threads (from runtime.aicpu_thread_num)
 // total_launched: actual threads launched (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH)
 //
-// Used by a2a3 (cluster-majority heuristic) and a5 sim. a5 onboard uses the
-// _filter variant below instead.
+// Used by sim platforms. a2a3/a5 onboard use the _filter variant below
+// instead.
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched);
 
 // Filter-style affinity gate. Every launched thread reads sched_getcpu(),
@@ -28,11 +28,9 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 // platform_aicpu_affinity_thread_idx() and drives role assignment
 // downstream (sched / orch).
 //
-// Convention used by a5: indices 0..allowed_count-2 are scheduler slots,
-// index allowed_count-1 is the orchestrator slot. The host builds
-// `allowed_cpus` from device-side OCCUPY + DSMI CPU_TOPO via
-// `pto::a5::compute_allowed_cpus` (see
-// src/a5/platform/onboard/host/aicpu_topology_probe.h) and passes the
+// Convention used by tensormap_and_ringbuffer: indices 0..allowed_count-2
+// are scheduler slots, index allowed_count-1 is the orchestrator slot. The
+// host builds `allowed_cpus` from platform topology/OCCUPY and passes the
 // array down through the Runtime struct.
 //
 // total_launched is the number of AICPU threads CANN actually launched

--- a/src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -18,177 +18,27 @@
 
 #include "common/unified_log.h"
 
-static constexpr int32_t AICPU_CORES_PER_CHIP = 8;
-static constexpr int32_t MAX_CLUSTERS = 2;
-static constexpr int32_t CPUS_PER_CLUSTER = 4;
 // 16 = headroom for a5's launch budget (14 logical user cpus on the
 // 0x7ffe SKU) + a small over-launch margin. a2a3 only ever launches 6
 // threads and never approaches this bound.
 static constexpr int32_t MAX_GATE_THREADS = 16;
 
-// Bit i is set once thread-slot i has written its s_thread_cpu[] report. Keyed
-// on the reporting slot (not the cpu) so the barrier still reaches
-// total_launched when two unpinned threads share a cpu (sim).
-static std::atomic<uint64_t> s_done_mask{0};
-static std::atomic<int32_t> s_reported{0};
-static std::atomic<int32_t> s_gate_init{0};
-static std::atomic<int32_t> s_gate_ready{0};
-
-static int32_t s_thread_cpu[MAX_GATE_THREADS];
-static bool s_thread_survive[MAX_GATE_THREADS];
-
-// Per-thread exec/slot index set by BOTH gates (legacy a2a3 + filter a5):
-// -1 = dropped, otherwise this thread's index among the launched threads.
+// Per-thread exec/slot index set by the filter gate:
+// -1 = dropped, otherwise this thread's index in allowed_cpus[].
 // Read via platform_aicpu_affinity_thread_idx(); used as the run-wall buffer
-// slot and (filter gate) the sched/orch role id.
+// slot and the sched/orch role id.
 static thread_local int32_t tl_exec_idx = -1;
 
-static inline int32_t popcount64(uint64_t v) { return __builtin_popcountll(static_cast<unsigned long long>(v)); }
-
-bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
-    tl_exec_idx = -1;
-
-    // Bound-check both inputs against the static slot buffers (s_thread_cpu[],
-    // s_thread_survive[], both MAX_GATE_THREADS) before any indexing. Without
-    // this, total_launched > MAX_GATE_THREADS makes the classifier loop read
-    // s_thread_cpu[tid] and write s_thread_survive[tid] out of bounds; a
-    // negative count would bypass the bounds checks entirely. Mirrors the
-    // validation in platform_aicpu_affinity_gate_filter().
-    if (total_launched <= 0 || total_launched > MAX_GATE_THREADS || logical_count < 0) {
-        LOG_ERROR(
-            "AICPU affinity gate: invalid config logical_count=%d total_launched=%d (max=%d) — dropping all threads",
-            logical_count, total_launched, MAX_GATE_THREADS
-        );
-        return false;
-    }
-    if (logical_count >= total_launched) {
-        // No over-launch (unreachable for a2a3, where logical < total always):
-        // every thread survives. Leave tl_exec_idx = -1 so no run-wall slot is
-        // claimed on this degenerate path.
-        return true;
-    }
-
-    // Assign this thread a reporting slot.
-    int32_t idx = s_reported.fetch_add(1, std::memory_order_acq_rel);
-
-    // Report CPU
-#if defined(__aarch64__)
-    int32_t cpu = sched_getcpu();
-#elif defined(__x86_64__)
-    int32_t cpu = sched_getcpu();
-#else
-    int32_t cpu = -1;
-#endif
-    int32_t normalized_cpu = (cpu >= 0) ? cpu % AICPU_CORES_PER_CHIP : -1;
-    if (idx < MAX_GATE_THREADS) {
-        s_thread_cpu[idx] = normalized_cpu;
-    }
-
-    // Barrier: publish this slot (the release pairs with the acquire load below
-    // so the s_thread_cpu[] write above is visible), then wait until every slot
-    // has reported. The old barrier released on s_reported, which is bumped
-    // *before* the write, so the classifier below could run on half-written or
-    // stale slots and non-deterministically keep cluster #0.
-    if (idx < 64) {
-        s_done_mask.fetch_or(1ULL << idx, std::memory_order_release);
-    }
-    while (popcount64(s_done_mask.load(std::memory_order_acquire)) < total_launched) {}
-
-    // CAS winner does cluster classification
-    int32_t expected = 0;
-    if (s_gate_init.compare_exchange_strong(expected, 1, std::memory_order_acq_rel, std::memory_order_acquire)) {
-        // Initialize survive flags
-        for (int32_t i = 0; i < total_launched; ++i) {
-            s_thread_survive[i] = false;
-        }
-
-        struct ClusterInfo {
-            int32_t count{0};
-            int32_t tids[MAX_GATE_THREADS];
-        };
-        ClusterInfo clusters[MAX_CLUSTERS];
-
-        for (int32_t tid = 0; tid < total_launched; ++tid) {
-            int32_t c = s_thread_cpu[tid];
-            if (c < 0) continue;
-            int32_t cluster_id = c / CPUS_PER_CLUSTER;
-            if (cluster_id < 0 || cluster_id >= MAX_CLUSTERS) continue;
-            ClusterInfo &info = clusters[cluster_id];
-            if (info.count < MAX_GATE_THREADS) info.tids[info.count++] = tid;
-        }
-
-        int32_t major_id = (clusters[0].count >= clusters[1].count) ? 0 : 1;
-        int32_t minor_id = 1 - major_id;
-        int32_t major_cnt = clusters[major_id].count;
-        int32_t minor_cnt = clusters[minor_id].count;
-
-        LOG_INFO_V0(
-            "AICPU affinity gate: major=%d(cnt=%d) minor=%d(cnt=%d) logical=%d", major_id, major_cnt, minor_id,
-            minor_cnt, logical_count
-        );
-
-        if (major_cnt == logical_count && minor_cnt == (total_launched - logical_count)) {
-            // Expected topology: major cluster threads survive
-            for (int32_t i = 0; i < clusters[major_id].count; ++i) {
-                s_thread_survive[clusters[major_id].tids[i]] = true;
-            }
-        } else {
-            // Unexpected topology: fall back to first logical_count threads
-            LOG_WARN(
-                "AICPU affinity gate: unexpected topology (major=%d minor=%d), "
-                "falling back to index-based cutoff",
-                major_cnt, minor_cnt
-            );
-            for (int32_t i = 0; i < logical_count && i < total_launched; ++i) {
-                s_thread_survive[i] = true;
-            }
-        }
-
-        s_gate_ready.store(1, std::memory_order_release);
-    }
-
-    // Wait for classification to complete
-    while (s_gate_ready.load(std::memory_order_acquire) == 0) {}
-
-    bool survive = (idx < total_launched) ? s_thread_survive[idx] : false;
-
-    // Last thread resets state for next invocation
-    static std::atomic<int32_t> s_cleanup{0};
-    int32_t cleanup_idx = s_cleanup.fetch_add(1, std::memory_order_acq_rel);
-    if (cleanup_idx + 1 == total_launched) {
-        s_done_mask.store(0, std::memory_order_release);
-        s_reported.store(0, std::memory_order_release);
-        s_gate_init.store(0, std::memory_order_release);
-        s_gate_ready.store(0, std::memory_order_release);
-        s_cleanup.store(0, std::memory_order_release);
-    }
-
-    if (!survive) {
-        LOG_INFO_V0("AICPU affinity gate: thread idx=%d cpu=%d DROPPED", idx, normalized_cpu);
-    } else {
-        LOG_INFO_V0("AICPU affinity gate: thread idx=%d cpu=%d ACTIVE", idx, normalized_cpu);
-    }
-
-    // Publish this thread's slot index (survivors only) for the run-wall
-    // buffer; dropped threads report -1 so they never claim a slot.
-    tl_exec_idx = survive ? idx : -1;
-    return survive;
-}
-
 // =============================================================================
-// Filter-style gate (a5 onboard).
+// Filter-style gate (onboard).
 // =============================================================================
 //
 // All `total_launched` threads enter, each reads sched_getcpu() and reports
 // to s_filter_thread_cpu[]. After the barrier, the CAS-winner classifies:
 // for each report, look up cpu_id in `allowed_cpus[]`; if found, the thread
 // survives and gets exec_idx = index in allowed_cpus[]. Misses are dropped.
-//
-// State is shared with the legacy gate where harmless (s_reported,
-// s_gate_init, s_gate_ready, s_cleanup) — only one variant runs in any
-// given build (a2a3 uses the legacy gate; a5 onboard uses this one).
 
-// Per-launch barrier + classification state, parallel to the legacy gate.
+// Per-launch barrier + classification state.
 // Two counters: s_filter_claim hands out a unique slot via fetch_add so each
 // thread writes to a distinct s_filter_thread_cpu[idx]. s_filter_published
 // is bumped (release) AFTER the cpu write — the classification barrier
@@ -251,6 +101,7 @@ bool platform_aicpu_affinity_gate_filter(const int32_t *allowed_cpus, int32_t al
         // sink cpu when launch_count >= popcount(OCCUPY)). The first thread
         // that lands on each allowed cpu wins; later duplicates are dropped.
         bool slot_filled[MAX_GATE_THREADS] = {false};
+        int32_t filled_count = 0;
         for (int32_t tid = 0; tid < total_launched && tid < MAX_GATE_THREADS; ++tid) {
             int32_t my_cpu = s_filter_thread_cpu[tid];
             if (my_cpu < 0) continue;
@@ -258,8 +109,33 @@ bool platform_aicpu_affinity_gate_filter(const int32_t *allowed_cpus, int32_t al
                 if (allowed_cpus[a] == my_cpu && !slot_filled[a]) {
                     s_filter_thread_exec_idx[tid] = a;
                     slot_filled[a] = true;
+                    ++filled_count;
                     break;
                 }
+            }
+        }
+
+        // Forward-progress guard: launch_count=popcount(OCCUPY) is expected
+        // to give one representative for each host-selected cpu_id, but some
+        // runtime dispatch patterns can duplicate a cpu and miss another one.
+        // If that happens, keep the exact-match assignments and fill the
+        // missing exec slots by reported thread order so sched/orch roles are
+        // still all present instead of timing out the AICore side.
+        if (filled_count < allowed_count) {
+            LOG_WARN(
+                "AICPU filter gate: only matched %d/%d allowed cpus; filling missing exec slots by report order",
+                filled_count, allowed_count
+            );
+            int32_t next_slot = 0;
+            for (int32_t tid = 0; tid < total_launched && tid < MAX_GATE_THREADS && filled_count < allowed_count;
+                 ++tid) {
+                if (s_filter_thread_exec_idx[tid] >= 0) continue;
+                while (next_slot < allowed_count && slot_filled[next_slot])
+                    ++next_slot;
+                if (next_slot >= allowed_count) break;
+                s_filter_thread_exec_idx[tid] = next_slot;
+                slot_filled[next_slot] = true;
+                ++filled_count;
             }
         }
 

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -470,6 +470,31 @@ target_link_libraries(test_host_log_off PRIVATE
 )
 add_test(NAME test_host_log_off COMMAND test_host_log_off)
 
+# a2a3 host-side AICPU affinity selection (compute_allowed_cpus). Pure logic —
+# no CANN headers, no hardware: compile the probe .cpp alongside the test. The
+# test provides its own no-op logger stubs, so no logger sources are linked.
+# The dlopen/dlsym HAL path is never exercised by these tests (only
+# compute_allowed_cpus is), but the .cpp references libdl symbols, so link it.
+# Regression barrier for issue #1045 (all survivors in one cluster).
+set(A2A3_ONBOARD_HOST_DIR ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/onboard/host)
+add_executable(test_a2a3_aicpu_affinity_select
+    a2a3/test_aicpu_affinity_select.cpp
+    ${A2A3_ONBOARD_HOST_DIR}/aicpu_topology_probe.cpp
+)
+target_include_directories(test_a2a3_aicpu_affinity_select PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${A2A3_ONBOARD_HOST_DIR}
+    ${SIMPLER_LOG_DIR}/include
+)
+target_link_libraries(test_a2a3_aicpu_affinity_select PRIVATE
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    ${CMAKE_DL_LIBS}
+    pthread
+)
+add_test(NAME test_a2a3_aicpu_affinity_select COMMAND test_a2a3_aicpu_affinity_select)
+set_tests_properties(test_a2a3_aicpu_affinity_select PROPERTIES LABELS "no_hardware")
+
 # Hardware-gated tests.  Block is only entered when the project is configured
 # with -DSIMPLER_ENABLE_HARDWARE_TESTS=ON.  CI's no-hw `ut` job does not pass
 # this flag, so nothing here is compiled there — this is the structural

--- a/tests/ut/cpp/a2a3/test_aicpu_affinity_select.cpp
+++ b/tests/ut/cpp/a2a3/test_aicpu_affinity_select.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Unit tests for a2a3 host-side AICPU affinity selection
+ * (compute_allowed_cpus from src/a2a3/platform/onboard/host/aicpu_topology_probe).
+ *
+ * This is the regression barrier for issue #1045: AICPU survivors must all
+ * land in one NUMA cluster. Moving selection host-side (PR #1119) made it a
+ * pure, deterministic function, so the property is testable without hardware.
+ *
+ * Covered:
+ * - the standard 0xfc pool (cpu_id 2..7): active=4 (tensormap) and active=3
+ *   (host_build_graph) both land entirely in the high cluster (cpu 4..7);
+ * - determinism (same input → same output);
+ * - the cross-cluster fallback when no single cluster fits;
+ * - invalid-input rejection.
+ */
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+#include "aicpu_topology_probe.h"
+
+// Minimal logger stubs so aicpu_topology_probe.cpp links without pulling in
+// HostLogger. compute_allowed_cpus only emits LOG_WARN; the probe path (not
+// exercised here) also uses LOG_INFO_V0. The unified_log symbols have C
+// linkage (see common/unified_log.h), so match it. No-ops — these tests
+// assert on return values, not log text.
+extern "C" {
+void unified_log_error(const char *, const char *, ...) {}
+void unified_log_warn(const char *, const char *, ...) {}
+void unified_log_info_v(const char *, int, const char *, ...) {}
+}
+
+using pto::a2a3::AicpuLogicalCpu;
+using pto::a2a3::compute_allowed_cpus;
+
+namespace {
+
+// a2a3: cluster_id = (cpu_id % 8) / 4 — no SMT, cpu_id == physical core.
+AicpuLogicalCpu cpu(int32_t cpu_id) { return AicpuLogicalCpu{cpu_id, (cpu_id % 8) / 4}; }
+
+// The OCCUPY pool observed on a2a3 silicon: 0xfc ⇒ cpu_id 2,3,4,5,6,7
+// (0 and 1 reserved for the OS). Cluster 0 = {2,3}, cluster 1 = {4,5,6,7}.
+std::vector<AicpuLogicalCpu> standard_pool() { return {cpu(2), cpu(3), cpu(4), cpu(5), cpu(6), cpu(7)}; }
+
+int32_t cluster_of(int32_t cpu_id) { return (cpu_id % 8) / 4; }
+
+}  // namespace
+
+// tensormap_and_ringbuffer needs 4 active threads (3 sched + 1 orch); all four
+// must come from the single cluster that can hold them — cpu_id 4..7.
+TEST(A2a3AffinitySelect, TensormapFourThreadsLandInHighCluster) {
+    std::vector<int32_t> allowed;
+    ASSERT_TRUE(compute_allowed_cpus(standard_pool(), /*active_count=*/4, allowed));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{4, 5, 6, 7}));
+    for (int32_t id : allowed)
+        EXPECT_EQ(cluster_of(id), 1) << "cpu " << id << " crossed a cluster";
+}
+
+// host_build_graph needs only 3 active threads (2 sched + 1 orch). They must
+// still all share one cluster — the high cluster, picked deterministically.
+TEST(A2a3AffinitySelect, HbgThreeThreadsLandInOneCluster) {
+    std::vector<int32_t> allowed;
+    ASSERT_TRUE(compute_allowed_cpus(standard_pool(), /*active_count=*/3, allowed));
+    ASSERT_EQ(allowed.size(), 3u);
+    EXPECT_EQ(allowed, (std::vector<int32_t>{4, 5, 6}));
+    const int32_t c = cluster_of(allowed[0]);
+    for (int32_t id : allowed)
+        EXPECT_EQ(cluster_of(id), c) << "cpu " << id << " crossed a cluster";
+}
+
+// Selection is a pure function of its input — repeated calls are identical.
+TEST(A2a3AffinitySelect, Deterministic) {
+    std::vector<int32_t> a, b;
+    ASSERT_TRUE(compute_allowed_cpus(standard_pool(), 4, a));
+    ASSERT_TRUE(compute_allowed_cpus(standard_pool(), 4, b));
+    EXPECT_EQ(a, b);
+}
+
+// When the request fits inside a cluster smaller than the largest, the chosen
+// cluster is the highest-id one that can hold it.
+TEST(A2a3AffinitySelect, PrefersHighestClusterThatFits) {
+    // Both clusters full (2,3 | 4,5,6,7). active=2 fits in either; pick high.
+    std::vector<int32_t> allowed;
+    ASSERT_TRUE(compute_allowed_cpus(standard_pool(), /*active_count=*/2, allowed));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{4, 5}));
+}
+
+// No single cluster can hold the request (3 + 3 split, active=4): the function
+// keeps deterministic behavior and falls back to a cross-cluster selection by
+// ascending cpu_id rather than failing.
+TEST(A2a3AffinitySelect, CrossClusterFallbackWhenNoClusterFits) {
+    // cluster 0 = {1,2,3}, cluster 1 = {4,5,6} — neither holds 4.
+    std::vector<AicpuLogicalCpu> pool = {cpu(1), cpu(2), cpu(3), cpu(4), cpu(5), cpu(6)};
+    std::vector<int32_t> allowed;
+    ASSERT_TRUE(compute_allowed_cpus(pool, /*active_count=*/4, allowed));
+    EXPECT_EQ(allowed, (std::vector<int32_t>{1, 2, 3, 4}));  // first 4 by cpu_id
+}
+
+// Requesting more threads than the pool has must fail (not truncate).
+TEST(A2a3AffinitySelect, RejectsRequestLargerThanPool) {
+    std::vector<int32_t> allowed;
+    EXPECT_FALSE(compute_allowed_cpus(standard_pool(), /*active_count=*/7, allowed));
+    EXPECT_TRUE(allowed.empty());
+}
+
+// Non-positive active_count is rejected.
+TEST(A2a3AffinitySelect, RejectsNonPositiveCount) {
+    std::vector<int32_t> allowed;
+    EXPECT_FALSE(compute_allowed_cpus(standard_pool(), 0, allowed));
+    EXPECT_FALSE(compute_allowed_cpus(standard_pool(), -1, allowed));
+}


### PR DESCRIPTION
## Summary

Move a2a3 onboard AICPU affinity selection from device-side cluster-majority classification to host-side computation.

The host now probes the AICPU user pool, computes `allowed_cpus`, stores it in `Runtime`, and the AICPU entry filters launched threads against that table.

## Changes

- Add a2a3 host-side AICPU topology probe based on `halGetDeviceInfo(AICPU, OCCUPY)`.
- Add Runtime affinity fields for both `tensormap_and_ringbuffer` and `host_build_graph`.
- Switch a2a3 onboard AICPU entry to `platform_aicpu_affinity_gate_filter`.
- Use filter-gate `exec_idx` for deterministic scheduler/orchestrator slot assignment.
- Remove the old onboard cluster-majority gate implementation.
- Keep sim-side gate unchanged because sim does not use real CANN AICPU/OCCUPY probing.

## Validation

- `pre-commit run --files ...`
- `python simpler_setup/build_runtimes.py --platforms a2a3 ...`
- `examples/a2a3/tensormap_and_ringbuffer/scalar_data_test/test_scalar_data.py`
- `tests/st/a2a3/host_build_graph/vector_example/test_vector_example.py`

Observed log:

```text
A2A3 AICPU ALLOWED_CPUS = [4, 5, 6, 7(last)] (active=4, launch=6, user_cpus=6)