### PR TITLE
Add: dispatcher fresh-process retry for L2 poison-skips (#1110)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -17,12 +17,14 @@ subprocess per runtime so each gets a clean CANN context. See docs/testing.md.
 from __future__ import annotations
 
 import faulthandler
+import json
 import logging
 import os
 import re
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 import typing
 
@@ -899,6 +901,15 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
         cmd = base_args + ["--runtime", rt, "--level", "2"]
         if xdist_available:
             cmd += ["-n", str(max_parallel), "--dist", "loadfile"]
+        # Per-runtime sink for the in-process poison guards (issue #1110). Each
+        # xdist worker appends the classes it poison-skips; we re-run them in a
+        # fresh subprocess after this one exits so they don't silently lose
+        # coverage. mkstemp gives an unpredictable, exclusively-created path
+        # (this dev box is shared — a predictable /tmp name is exposed to symlink
+        # / TOCTOU attacks and pid-recycle collisions); the children just append.
+        sink_fd, sink_path = tempfile.mkstemp(prefix="simpler_l2_poison_", suffix=f"_{rt}.jsonl")
+        os.close(sink_fd)
+        run_env = {**os.environ, _L2_POISON_SINK_ENV: sink_path}
         # L2 subprocesses run serially (one runtime at a time) so we don't
         # need to buffer their stdout — we can stream it directly through
         # the group markers. ``::group::`` on its own line before the run
@@ -906,7 +917,7 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
         label = f"L2 {rt}" + (f" [-n {max_parallel}]" if xdist_available else "")
         start = time.monotonic()
         print(f"::group::{label}", flush=True)
-        result = subprocess.run(cmd, check=False, cwd=cwd)
+        result = subprocess.run(cmd, check=False, cwd=cwd, env=run_env)
         duration = time.monotonic() - start
         tag = "PASS" if result.returncode == 0 else f"FAIL rc={result.returncode}"
         print(f"--- L2 {rt}: {tag} {duration:.1f}s ---", flush=True)
@@ -915,6 +926,22 @@ def _dispatch_test_phases(session, resource_specs):  # noqa: PLR0912
         if result.returncode == TIMEOUT_EXIT_CODE:
             print(f"*** L2 {rt}: TIMED OUT ***", flush=True)
             os._exit(TIMEOUT_EXIT_CODE)
+
+        # Restore coverage for classes the in-process poison guard skipped: a
+        # fresh subprocess gets a clean card. Collect strictly from the sink the
+        # guards registered, never from "outcome == skipped", so legitimate
+        # skips are untouched.
+        deferred = _read_l2_poison_sink(sink_path)
+        try:
+            os.unlink(sink_path)
+        except FileNotFoundError:
+            pass
+        if deferred and _l2_poison_retry(base_args, rt, deferred, cwd) != 0:
+            l2_failed = True
+            print(f"*** FAIL: L2 {rt} poison-retry — expand group above ***", flush=True)
+            if fail_fast:
+                break
+
         if result.returncode != 0:
             l2_failed = True
             print(f"*** FAIL: L2 {rt} — expand group above ***", flush=True)
@@ -1058,14 +1085,18 @@ def _register_l2_pool_heal(request, pool, key):
     fresh Worker / ACL context instead of inheriting a poisoned one. No-op on
     pass or on a non-device failure (golden mismatch, assertion).
 
-    NOTE: on a5, an AICore op-timeout poisons the device context for the life of
-    the *process*: an in-process rebuild's Worker.init fails (rtStreamCreate
-    507899), and aclrtResetDeviceForce is unsafe on this shared box (it resets
-    the physical device for other users). So this heal can only *recover* on
-    arches where in-process re-init works; where it cannot, the st_worker L2
-    branch falls back to skipping the remaining tests for that runtime (see
-    _l2_poisoned). Either way one device error stops cascading into a worker-wide
-    storm of confusing 507899 failures."""
+    NOTE: an AICore op-timeout poisons the device context. `DeviceRunner::
+    finalize()` force-resets the card (`aclrtResetDeviceForce`, per-card safe
+    under the exclusive task-submit lock), so the rebuilt Worker.init normally
+    lands on a clean card and the next test runs. But force-reset only fires
+    when `device_unusable_` was set, and that flag is gated on the bounded drain
+    failing — a "drain succeeded but card still poisoned" false-negative skips
+    force-reset, the rebuild's Worker.init then fails (rtStreamCreate 507899),
+    and the st_worker L2 branch falls back to skipping the rest of the runtime
+    (see _l2_poisoned). The dispatcher re-runs those poison-skipped classes in a
+    fresh subprocess (= clean card) so they keep coverage — see
+    _register_l2_poison_skip / issue #1110. Either way one device error stops
+    cascading into a worker-wide storm of confusing 507899 failures."""
 
     def _heal():
         if not _is_device_runtime_error(getattr(request.node, _ST_CALL_EXCINFO, None)):
@@ -1126,6 +1157,95 @@ def _l2_worker_pool(request, st_platform):
     pool.clear()
 
 
+_L2_POISON_SINK_ENV = "SIMPLER_L2_POISON_SINK"
+
+
+def _register_l2_poison_skip(node):
+    """Record a poison-skipped L2 class so the dispatcher can re-run it in a
+    fresh subprocess (= clean card), restoring coverage the in-process skip
+    would otherwise drop (issue #1110).
+
+    Called from the *two* ``st_worker`` poison guards only — legitimate skips
+    (``@pytest.mark.skip``, platform-required, ``requires SceneTestCase``,
+    ``No cases matched``) never reach this sink and so are never retried. The
+    record is a class selector (``ClassName::``) because one ``test_run`` node
+    runs every case of its class; ``--case ClassName::`` reselects them all.
+
+    The sink is a per-runtime JSONL file shared across the xdist-worker → L2
+    subprocess → dispatcher process boundaries; ``O_APPEND`` makes concurrent
+    worker writes atomic. No-op when the env var is unset (a direct ``pytest``
+    run not under the dispatcher) — registration is then simply skipped.
+
+    Best-effort: this runs immediately before an intended ``pytest.skip`` in the
+    poison guards, so an I/O failure here must not raise — that would convert
+    the skip into a setup ERROR. A failed write only costs the coverage retry
+    (the class is not re-run in a fresh process), which is no worse than the
+    pre-#1110 behavior; we warn so the dropped retry is diagnosable."""
+    sink = os.environ.get(_L2_POISON_SINK_ENV)
+    if not sink:
+        return
+    cls = getattr(node, "cls", None)
+    if cls is None:
+        return
+    record = json.dumps({"selector": f"{cls.__name__}::", "nodeid": node.nodeid})
+    try:
+        fd = os.open(sink, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+        try:
+            os.write(fd, (record + "\n").encode())
+        finally:
+            os.close(fd)
+    except OSError as e:
+        print(
+            f"*** WARN: could not register L2 poison-skip for {cls.__name__} "
+            f"(sink write failed: {e}); class will not be retried ***",
+            flush=True,
+        )
+
+
+def _read_l2_poison_sink(path):
+    """Read poison-skipped class selectors from the sink, deduped and
+    order-preserved (both poison guards may register the same class)."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            lines = fh.readlines()
+    except FileNotFoundError:
+        return []
+    selectors = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            sel = json.loads(line).get("selector")
+        except json.JSONDecodeError:
+            continue
+        if sel:
+            selectors.append(sel)
+    return list(dict.fromkeys(selectors))
+
+
+def _l2_poison_retry(base_args, rt, selectors, cwd):
+    """Re-run poison-skipped L2 classes for ``rt`` in a fresh subprocess.
+
+    A new process gets a clean card — the op-timeout poison does not survive a
+    process exit — so classes the in-process skip dropped get real coverage
+    (issue #1110), independent of whether the in-place force-reset recovery
+    worked. Runs *without* the sink env so a retried class that itself
+    re-poisons is not collected again: this is a single bounded pass, not a
+    recursive loop. Returns the subprocess return code."""
+    cmd = base_args + ["--runtime", rt, "--level", "2"]
+    for sel in selectors:
+        cmd += ["--case", sel]
+    env = {k: v for k, v in os.environ.items() if k != _L2_POISON_SINK_ENV}
+    label = f"L2 {rt} poison-retry ({len(selectors)} class(es), fresh process)"
+    print(f"::group::{label}", flush=True)
+    result = subprocess.run(cmd, check=False, cwd=cwd, env=env)
+    tag = "PASS" if result.returncode == 0 else f"FAIL rc={result.returncode}"
+    print(f"--- {label}: {tag} ---", flush=True)
+    print("::endgroup::", flush=True)
+    return result.returncode
+
+
 @pytest.fixture(scope="session")
 def _l2_poisoned():
     """Runtimes whose L2 device context was poisoned by a device-runtime error
@@ -1158,6 +1278,7 @@ def st_worker(request, st_platform, device_pool, _l2_worker_pool, _l2_poisoned):
         # the triggering failure is already reported; a fresh worker process is
         # the only real recovery.
         if runtime in _l2_poisoned:
+            _register_l2_poison_skip(request.node)
             pytest.skip(
                 f"L2 device context for runtime '{runtime}' was poisoned by an earlier device-runtime error on "
                 f"this worker process and cannot be re-initialized in-process; skipping to avoid a misleading "
@@ -1198,6 +1319,7 @@ def st_worker(request, st_platform, device_pool, _l2_worker_pool, _l2_poisoned):
         except RuntimeError as e:
             if _is_device_runtime_error_msg(str(e)):
                 _l2_poisoned.add(runtime)
+                _register_l2_poison_skip(request.node)
                 try:
                     w.close()
                 except Exception:  # noqa: BLE001

--- a/docs/investigations/2026-06-a5-aicore-op-timeout-cascade.md
+++ b/docs/investigations/2026-06-a5-aicore-op-timeout-cascade.md
@@ -173,10 +173,55 @@ recovery is possible after all:
 Verified on a5: a pooled `hang → noop` pair, hang FAILED (trigger, not retried),
 noop **PASSED** 3/3 (force-reset recovered the card and the victim ran). The
 `fixture rebuild-then-skip` path remains as the fallback when a force reset ever
-fails (and on a2a3, which has no force-reset).
+fails or is never triggered (the a2a3 mirror has the same
+`force_reset_device` — see "a2a3 hardware verification" below).
 
 This is the recovery layer; the triggering test itself is still red (retrying it
 on a fresh card is a separate, later step).
+
+## a2a3 hardware verification + option B (2026-06-23)
+
+The "no a2a3 silicon on this box" caveat is environment-specific to the original
+a5 dev box. On an **a2a3** box (Ascend910 / NPU 9392, exclusive `task-submit`
+lock) the chain was measured directly with the `tests/st/aicore_op_timeout`
+hang kernel:
+
+| Measurement (10×, a2a3) | Result |
+| ----------------------- | ------ |
+| op-timeout poison triggered | 10/10, reaped in ~3.9 s (507018) |
+| in-process rebuild after force-reset (`INPROCESS_REINIT_OK`) | 10/10 |
+| fresh-process recovery (`FRESH_INIT_OK`) | 10/10 |
+
+So `aclrtResetDeviceForce` **does** clear the poison on a2a3 — when it runs.
+
+**The gap is the trigger, not the reset.** `force_reset_device()` only fires
+when `device_unusable_` is set, which `recover_device_or_mark_unusable()` sets
+**only if the bounded `aclrtSynchronizeDeviceWithTimeout` drain itself errors**.
+When that drain *returns success on a still-poisoned card* (a false-negative —
+timing/workload dependent), the flag stays clear, force-reset is skipped, the
+rebuild's `Worker.init()` fails 507899, and the runtime poison-skips. Real CI
+evidence: run **27742754024** job `st-onboard-a2a3`, worker gw3 —
+`TestPagedAttentionManualScope` FAILED (507018, drain reported *success*), then
+**16** tensormap_and_ringbuffer L2 classes SKIPPED, losing coverage. The local
+probe instead hit the drain-*fails* branch (507015 → force-reset → recovered),
+which is why a standalone probe and CI can disagree on the same arch.
+
+**Option B (issue #1110): dispatcher fresh-process retry.** Independent of
+whether force-reset was triggered, the dispatcher re-runs the poison-skipped
+classes in a fresh subprocess (= clean card, which the 10/10 above confirms
+recovers) so they keep coverage. The two `st_worker` poison guards register
+`(selector, nodeid)` into a per-runtime JSONL sink (`O_APPEND`, survives the
+xdist-worker → L2-subprocess → dispatcher boundaries); the dispatcher reads
+exactly that sink after the L2 subprocess exits and re-runs only those classes
+via `--case ClassName::` with the sink env stripped (single bounded pass).
+Collection is strictly sink-based, never `outcome == "skipped"`, so legitimate
+skips (`@pytest.mark.skip`, platform-required, `No cases matched`) are never
+retried. Implemented in `conftest.py` (`_register_l2_poison_skip`,
+`_read_l2_poison_sink`, `_l2_poison_retry`, the L2 dispatch loop).
+
+Fixing the trigger gate itself (make the recovery decision observable /
+self-checked rather than trusting the drain rc) is the complementary
+issue **#1111**; B is the hardware-independent coverage floor underneath it.
 
 ## Why this shape
 
@@ -191,35 +236,41 @@ The same three guards are mirrored into `src/a2a3/` (the a2a3 device_runner
 had none of them; #1005 was a5-only). a2a3 has the identical
 `device_unusable_` / `recover_device_or_mark_unusable` / `force_reset_device`
 chain wired into its `run()` / `finalize()`. The mechanism is CANN-level
-(`aclrtResetDeviceForce`), so it is expected to behave as on a5, but a2a3
-**was not hardware-verified locally** — this dev box is Ascend950PR (a5) only;
-the `st-onboard-a2a3` CI job is the a2a3 verification channel.
+(`aclrtResetDeviceForce`); it was originally CI-verified only (the first dev box
+was Ascend950PR / a5), and is now also hardware-verified on an a2a3 box —
+force-reset recovers 10/10 when triggered, but the drain-success false-negative
+means it is not always triggered (see "a2a3 hardware verification + option B").
 
 ## When to reconsider
 
 - The triggering test is still reported failed (its `207001` is likely
   transient). Adding a bounded retry (≤3 attempts) of just that test on a
   freshly-reset card would turn the last red into green — a follow-up step.
-- a2a3 now carries the mirrored guards (see "Why this shape") but they are
-  CI-verified only — no a2a3 silicon on this box. If the `st-onboard-a2a3`
-  job ever shows the force reset failing or not recovering on real a2a3
-  hardware, revisit `force_reset_device()` there (the CANN force-reset
-  semantics may differ from a5).
+- a2a3 force-reset is now hardware-verified (recovers 10/10 when triggered),
+  but `recover_device_or_mark_unusable()` gates it on the bounded drain's rc, so
+  a drain-success false-negative skips it and the runtime poison-skips. Making
+  that recovery decision observable / self-checked (return the reset rc,
+  conditionally clear `device_unusable_`, probe the card post-reset) is issue
+  **#1111**; option B (#1110) is the coverage backstop until that lands.
 
 ## References
 
 - CI run 27090242388, job `st-onboard-a5` (`gh run view --job 79952403308`) —
   original 8-failure cascade. CI run 27182822054 — post-#1005 contained run
-  (`1 failed, 13 skipped`).
+  (`1 failed, 13 skipped`). CI run 27742754024, job `st-onboard-a2a3` (gw3) —
+  a2a3 cascade: 1 FAILED + 16 SKIPPED after a drain-success false-negative.
 - Containment (#1005): `src/a5/platform/onboard/host/device_runner.{h,cpp}`
   (`device_unusable_`, `recover_device_or_mark_unusable`), `conftest.py`
   (`pytest_runtest_makereport`, `_register_l2_pool_heal`).
 - Force-reset recovery: `src/a5/platform/onboard/host/device_runner.{h,cpp}`
   (`force_reset_device`, called from `finalize()` on the `device_unusable_`
   path).
-- a2a3 mirror (CI-verified only): `src/a2a3/platform/onboard/host/`
-  `device_runner.{h,cpp}` — identical `device_unusable_` /
+- a2a3 mirror (now hardware-verified, 2026-06-23): `src/a2a3/platform/onboard/`
+  `host/device_runner.{h,cpp}` — identical `device_unusable_` /
   `recover_device_or_mark_unusable` / `force_reset_device` chain.
+- Option B dispatcher retry (#1110): `conftest.py` (`_register_l2_poison_skip`,
+  `_read_l2_poison_sink`, `_l2_poison_retry`, the L2 dispatch loop). Related:
+  #1111 (make the in-place recovery decision observable / self-checked).
 - `DeviceRunnerBase::finalize_common` — prior note on why finalize skips a
   pre-destroy stream sync on the error-state stream.
 - `.claude/rules/running-onboard.md` — `task-submit` device isolation.


### PR DESCRIPTION
## What

Option B for #1110: restore coverage for L2 classes that get
`pytest.skip`ped after an AICore op-timeout poisons a gw xdist worker's
device context. The dispatcher re-runs exactly those classes in a fresh
subprocess (= clean card) so they aren't silently dropped.

Real CI evidence of the gap: run 27742754024 `st-onboard-a2a3` gw3 —
`TestPagedAttentionManualScope` FAILED (507018) then **16** tensormap L2
classes SKIPPED, all losing coverage.

## How

- Each of the two `st_worker` poison guards registers the skipped class
  `(selector, nodeid)` into a per-runtime JSONL sink (`O_APPEND`, crosses
  the xdist-worker → L2-subprocess → dispatcher boundaries).
- The dispatcher reads exactly that sink after the L2 subprocess exits and
  re-runs only those classes via `--case ClassName::` in a fresh subprocess
  with the sink env stripped (single bounded pass).
- Collection is strictly sink-based, never `outcome == "skipped"`, so
  legitimate skips (`@pytest.mark.skip`, platform-required, `No cases
  matched`) are never retried.
- Independent of whether the in-place force-reset recovery fired — this is
  the hardware-independent coverage floor. Complementary to #1111 (make the
  in-place recovery decision observable / self-checked).

## Verification

- Unit + end-to-end tests drive the real `_dispatch_test_phases` loop with a
  stateful fake subprocess that reproduces the cascade → fresh-process
  retry; a mutation check confirms the e2e test fails if the retry is removed.
  (Tests kept local for now, not in this PR.)
- a2a3 hardware (Ascend910, exclusive task-submit lock): a fresh process
  recovers a poisoned card 10/10; force-reset itself recovers 10/10 when
  triggered. Investigation doc updated with these measurements and the
  drain-success false-negative that explains why the cascade still happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)