### PR TITLE
Update: right-size DFX buffers per cross-subsystem capacity audit

### DIFF
--- a/src/a2a3/platform/include/common/platform_config.h
+++ b/src/a2a3/platform/include/common/platform_config.h
@@ -240,8 +240,13 @@ constexpr int PLATFORM_PMU_SLOT_COUNT = 4;
 
 /**
  * Pre-allocated PmuBuffer count per AICore.
+ * In-flight buffers needed (Little's Law L = produce-rate × recycle-latency) is
+ * ~1: PMU records are produced at the slow fixed sampling rate (decoupled from
+ * submit) and the 64 B record drains instantly, so the host never lets more
+ * than 1 buffer be borrowed. 2 keeps a 2× margin; was 4 (a 4× over-provision).
+ * Validated zero-drop onboard a2a3 under a 65536-submit flood.
  */
-constexpr int PLATFORM_PMU_BUFFERS_PER_CORE = 4;
+constexpr int PLATFORM_PMU_BUFFERS_PER_CORE = 2;
 
 /**
  * Ready queue capacity for PMU data collection.
@@ -260,19 +265,41 @@ constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
 
 /**
  * Number of DepGenRecord entries per DepGenBuffer.
- * Each DepGenRecord is ~2.3 KB (16 Tensor blobs + small header), so a buffer
- * of 32 records is ~74 KB — sized to fit a typical example's submit count
- * (~100-200) in a few buffers.
+ * Each DepGenRecord is 4672 B (16 Tensor blobs + small header). 4 buffers ×
+ * 1024 records = 4096 in-flight records (~19 MB), which aligns dep_gen's
+ * in-flight count with the scope_stats / l2 AicoreTask pools (also 4096) per
+ * the issue #977 cross-subsystem review. 1024 is #977 Primary's proposal; the
+ * original 32 dropped 50% of records on paged_attention_unroll Case1.
+ * Drops depend on submit ARRIVAL RATE, not total count: records are produced at
+ * submit_task time on the AICPU, so a dependency-paced workload (real decoder,
+ * submits gated by compute) drains faster than it fills and never drops, while
+ * an independent-submit flood (paged_attention Case1, 65536 back-to-back
+ * submits) outruns host drain and drops ~24576/65536. That drop is rate-bound,
+ * not capacity-bound — onboard a2a3, doubling RECORDS / BUFFERS / SLOT_COUNT
+ * each left it unchanged — so buffer sizing is not the lever for floods; 4096
+ * in-flight covers the largest realistic single-scope decoder burst.
+ * dep_gen is opt-in (--enable-dep-gen).
  */
-constexpr int PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32;
+constexpr int PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 1024;
 
 /**
  * SPSC free_queue slot count for dep_gen buffers (Host→Device hand-off depth).
+ * Caps how many empty buffers the device can pre-borrow before it starves;
+ * top_up_free_queue refills the ring only up to SLOT_COUNT. Tunable up to 15
+ * within the fixed 128 B DepGenFreeQueue layout (see dep_gen.h), but onboard
+ * tests showed raising it does not reduce flood drops (the drop is rate-bound,
+ * not capacity-bound — see RECORDS_PER_BUFFER above), so it stays at the
+ * default 4.
  */
 constexpr int PLATFORM_DEP_GEN_SLOT_COUNT = 4;
 
 /**
  * Pre-allocated DepGenBuffer count per orchestrator instance.
+ * 4 buffers × 1024 records = 4096 in-flight records (~19 MB per instance).
+ * Must be ≥ SLOT_COUNT to fill the free_queue ring; any beyond SLOT_COUNT seed
+ * the host recycled pool. Raising it does not cut flood drops on its own (the
+ * device is bounded by SLOT_COUNT, and the drop is rate-bound anyway) — see the
+ * RECORDS_PER_BUFFER comment. dep_gen is opt-in (--enable-dep-gen).
  */
 constexpr int PLATFORM_DEP_GEN_BUFFERS_PER_INSTANCE = 4;
 
@@ -306,8 +333,13 @@ constexpr int PLATFORM_SCOPE_STATS_SLOT_COUNT = 8;
 
 /**
  * Pre-allocated ScopeStatsBuffer count per orchestrator instance.
+ * In-flight buffers needed (Little's Law L = produce-rate × recycle-latency) is
+ * ~1: scope_stats records are produced per scope enter/exit (decoupled from
+ * submit volume) and the 52 B record drains instantly, so the host never lets
+ * more than 1 buffer be borrowed. 4 keeps margin; was 8 (an 8× over-provision).
+ * Validated zero-drop onboard a2a3 under a 65536-submit flood.
  */
-constexpr int PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE = 8;
+constexpr int PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE = 4;
 
 /**
  * Ready queue capacity for scope_stats (per AICPU thread). scope_stats is

--- a/src/a5/platform/include/common/platform_config.h
+++ b/src/a5/platform/include/common/platform_config.h
@@ -281,8 +281,14 @@ constexpr int PLATFORM_PMU_SLOT_COUNT = 4;
 
 /**
  * Number of PmuBuffers pre-allocated per core (initial pool size).
+ * In-flight buffers needed (Little's Law L = produce-rate × recycle-latency) is
+ * ~1: PMU records are produced at the slow fixed sampling rate (decoupled from
+ * submit) and the 64 B record drains instantly, so peak in-flight is 1. 2 keeps
+ * a 2× margin; was 4 (a 4× over-provision). Mirrors the a2a3 change (validated
+ * zero-drop on a2a3); the argument is arch-independent, but a5-silicon onboard
+ * validation is still pending.
  */
-constexpr int PLATFORM_PMU_BUFFERS_PER_CORE = 4;
+constexpr int PLATFORM_PMU_BUFFERS_PER_CORE = 2;
 
 /**
  * Ready queue capacity for PMU data per AICPU thread.
@@ -300,10 +306,17 @@ constexpr int PLATFORM_PMU_TIMEOUT_SECONDS = 30;
 
 /**
  * Number of DepGenRecord entries per DepGenBuffer.
- * Each DepGenRecord is ~2.3 KB (16 Tensor blobs + small header), so a buffer
- * is ~74 KB. Mirrors a2a3 sizing — same orchestrator submit cadence.
+ * Each DepGenRecord is 4672 B (16 Tensor blobs + small header). 4 buffers ×
+ * 1024 records = 4096 in-flight records (~19 MB), aligning dep_gen's in-flight
+ * count with the scope_stats / l2 AicoreTask pools (also 4096) per the issue
+ * #977 cross-subsystem review. 1024 is #977 Primary's proposal; the original 32
+ * dropped 50% of records on paged_attention_unroll Case1. Flood drops are
+ * rate-bound, not capacity-bound — buffer sizing cannot fix them; real
+ * dependency-paced workloads never drop. dep_gen is opt-in (--enable-dep-gen).
+ * a5 record size (4672 B) and cohort (4096) are identical to a2a3, so the same
+ * 1024 applies; a5-silicon validation still pending.
  */
-constexpr int PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 32;
+constexpr int PLATFORM_DEP_GEN_RECORDS_PER_BUFFER = 1024;
 
 /**
  * SPSC free_queue slot count for dep_gen buffers (Host→Device hand-off depth).
@@ -346,8 +359,14 @@ constexpr int PLATFORM_SCOPE_STATS_SLOT_COUNT = 8;
 
 /**
  * Pre-allocated ScopeStatsBuffer count per orchestrator instance.
+ * In-flight buffers needed (Little's Law L = produce-rate × recycle-latency) is
+ * ~1: scope_stats records are produced per scope enter/exit (decoupled from
+ * submit volume) and the 52 B record drains instantly, so peak in-flight is 1.
+ * 4 keeps margin; was 8 (an 8× over-provision). Mirrors the a2a3 change
+ * (validated zero-drop on a2a3); the argument is arch-independent, but
+ * a5-silicon validation still pending.
  */
-constexpr int PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE = 8;
+constexpr int PLATFORM_SCOPE_STATS_BUFFERS_PER_INSTANCE = 4;
 
 /**
  * Ready queue capacity for scope_stats (per AICPU thread). scope_stats is


### PR DESCRIPTION
## Summary

Right-sizes three DFX profiling buffer constants on both **a2a3** and **a5**, from a cross-subsystem capacity audit (issue #977 Secondary). Config-only.

| constant | before | after | why |
|---|---|---|---|
| `DEP_GEN_RECORDS_PER_BUFFER` | 32 | **1024** | 4×1024 = 4096 in-flight aligns dep_gen with the scope_stats / l2 AicoreTask cohort (also 4096). 1024 is #977 Primary's proposal; the original 32 dropped 50% of records on `paged_attention_unroll` Case1. |
| `PMU_BUFFERS_PER_CORE` | 4 | **2** | In-flight need (Little's Law `L = produce-rate × recycle-latency`) is ~1 — PMU records are produced at the slow fixed sampling rate (decoupled from submit) and the 64 B record drains instantly. 4 was a 4× over-provision. |
| `SCOPE_STATS_BUFFERS_PER_INSTANCE` | 8 | **4** | Same — produced per scope enter/exit, 52 B record, instant drain. 8 was an 8× over-provision. |

## Validation (a2a3 silicon)

- **pmu / scope**: onboard-validated **zero-drop** under the worst-case 65536-submit flood (`paged_attention` Case1) at the reduced sizes.
- **dep_gen**: measured across 6 `tensormap_and_ringbuffer` examples. Only the bare un-scoped flood drops, and that drop is **rate-bound, not capacity-bound** — doubling `RECORDS` / `BUFFERS` / `SLOT_COUNT` each left the drop count unchanged. Real dependency-paced workloads (`manual_scope`, decoder, GEMM) never drop.

## a5

Mirrors a2a3 (identical 4672 B record size and 4096 cohort). a5 follows by the same arch-independent reasoning; **a5-silicon onboard validation is still pending**.

All three paths are opt-in DFX (`--enable-dep-gen` / `--enable-pmu` / `--enable-scope-stats`); no behavior change beyond buffer sizing.