### PR TITLE
feat(runtime): unify runtime_env ring sizing into one int-or-list field

### DIFF
--- a/examples/workers/l2/per_task_runtime_env/README.md
+++ b/examples/workers/l2/per_task_runtime_env/README.md
@@ -9,21 +9,22 @@ carried on `CallConfig` — not a process-wide env export.
 ## What it shows
 
 `CallConfig.runtime_env` groups the ring overrides as a distinct config tier,
-separate from the top-level execution knobs (`block_dim`, …). Each resource
-comes in a scalar field and a 4-entry per-ring array:
+separate from the top-level execution knobs (`block_dim`, …). Each resource is a
+single field that accepts **either** a scalar (broadcast to every ring) **or** a
+4-entry list (one value per scope-depth ring):
 
-| scalar field | per-ring array | unit | constraint (per value) |
-| ------------ | -------------- | ---- | ---------------------- |
-| `ring_task_window` | `ring_task_windows` | tasks | power of 2 in [4, INT32_MAX] |
-| `ring_heap` | `ring_heaps` | bytes / ring | >= 1024 |
-| `ring_dep_pool` | `ring_dep_pools` | entries | 4 .. INT32_MAX |
+| field | unit | constraint (per value) |
+| ----- | ---- | ---------------------- |
+| `ring_task_window` | tasks | power of 2 in [4, INT32_MAX] |
+| `ring_heap` | bytes / ring | >= 1024 |
+| `ring_dep_pool` | entries | 4 .. INT32_MAX |
 
-The array fields must contain exactly **4 entries**, indexed by scope-depth
-ring `0..3` (depth `>=3` maps to ring 3). A `0` entry — or a field left unset —
-falls through to the next precedence tier:
+A list must contain exactly **4 entries**, indexed by scope-depth ring `0..3`
+(depth `>=3` maps to ring 3). A `0` entry — or a field left unset — falls
+through to the next precedence tier:
 
 ```text
-per-ring field > scalar field > per-ring env > scalar env > compile-time default
+per-ring CallConfig entry > per-ring env > scalar env > compile-time default
 ```
 
 ```python
@@ -33,10 +34,10 @@ cfg.runtime_env.ring_task_window = 128
 cfg.runtime_env.ring_heap = 8 * 1024 * 1024   # bytes per ring
 cfg.runtime_env.ring_dep_pool = 256
 
-# Per-ring: size rings 0..3 independently (overrides the scalar tier per ring).
-cfg.runtime_env.ring_task_windows = [128, 64, 32, 16]
-cfg.runtime_env.ring_heaps = [8 * 1024 * 1024, 4 * 1024 * 1024, 2 * 1024 * 1024, 1 * 1024 * 1024]
-cfg.runtime_env.ring_dep_pools = [256, 128, 64, 64]
+# ...or a 4-entry list: size rings 0..3 independently.
+cfg.runtime_env.ring_task_window = [128, 64, 32, 16]
+cfg.runtime_env.ring_heap = [8 * 1024 * 1024, 4 * 1024 * 1024, 2 * 1024 * 1024, 1 * 1024 * 1024]
+cfg.runtime_env.ring_dep_pool = [256, 128, 64, 64]
 worker.run(chip_handle, args, cfg)
 ```
 

--- a/examples/workers/l2/per_task_runtime_env/main.py
+++ b/examples/workers/l2/per_task_runtime_env/main.py
@@ -16,18 +16,14 @@ scope-depth ring sized independently). Ring sizing is a per-run knob carried on
 ``CallConfig`` — no process-wide ``PTO2_RING_*`` env export needed, and each
 ``worker.run`` binds its ring buffers from the config it was handed.
 
-    runtime_env fields (0 / unset => fall back to env var / compile default):
-      scalar (broadcast to every ring):
+    Each runtime_env field takes EITHER a scalar (broadcast to every ring) OR a
+    4-entry list (one per scope-depth ring 0..3; a 0 entry falls through). Unset
+    (0) falls back to the env var / compile default.
         ring_task_window    power of 2 in [4, INT32_MAX]
         ring_heap           bytes per ring, >= 1024
         ring_dep_pool       4 .. INT32_MAX
-      per-ring arrays (exactly 4 entries, indexed by scope-depth ring 0..3;
-      a 0 entry falls through to the scalar / env / default tier):
-        ring_task_windows   [w0, w1, w2, w3]
-        ring_heaps          [h0, h1, h2, h3]   bytes per ring
-        ring_dep_pools      [d0, d1, d2, d3]
     Precedence per resource and ring:
-      per-ring field > scalar field > per-ring env > scalar env > default.
+      per-ring CallConfig entry > per-ring env > scalar env > default.
 
 See ../vector_add/main.py for the full L2 lifecycle walk-through; this example
 reuses that kernel verbatim and only varies the per-run ring configuration.
@@ -67,22 +63,15 @@ N_COLS = 128
 N_ELEMS = N_ROWS * N_COLS
 NBYTES = N_ELEMS * 4  # float32
 
-# RuntimeEnv keys a config dict may carry. Scalar keys broadcast one value to
-# every ring; the array keys size the four scope-depth rings independently.
-RING_FIELDS = (
-    "ring_task_window",
-    "ring_heap",
-    "ring_dep_pool",
-    "ring_task_windows",
-    "ring_heaps",
-    "ring_dep_pools",
-)
+# RuntimeEnv keys a config dict may carry. Each takes a scalar (broadcast to
+# every ring) or a 4-entry list (one value per scope-depth ring).
+RING_FIELDS = ("ring_task_window", "ring_heap", "ring_dep_pool")
 
 # (label, runtime_env dict or None). None => no override; falls back to the
 # PTO2_RING_* env var / compile-time default. Same kernel + same inputs run
 # under every sizing, so all of them produce identical (correct) output.
 RING_CONFIGS = [
-    # Scalar form: one value broadcast to every ring (the #1042 behavior).
+    # Scalar form: one value broadcast to every ring.
     ("scalar_small", {"ring_task_window": 16, "ring_heap": 1 * 1024 * 1024, "ring_dep_pool": 64}),
     ("scalar_large", {"ring_task_window": 128, "ring_heap": 8 * 1024 * 1024, "ring_dep_pool": 256}),
     # Per-ring form: each scope-depth ring (0..3) sized independently. Ring 0 is
@@ -92,9 +81,9 @@ RING_CONFIGS = [
     (
         "per_ring",
         {
-            "ring_task_windows": [128, 64, 32, 16],
-            "ring_heaps": [8 * 1024 * 1024, 4 * 1024 * 1024, 2 * 1024 * 1024, 1 * 1024 * 1024],
-            "ring_dep_pools": [256, 128, 64, 64],
+            "ring_task_window": [128, 64, 32, 16],
+            "ring_heap": [8 * 1024 * 1024, 4 * 1024 * 1024, 2 * 1024 * 1024, 1 * 1024 * 1024],
+            "ring_dep_pool": [256, 128, 64, 64],
         },
     ),
     ("env_or_default", None),

--- a/examples/workers/l3/per_task_runtime_env/README.md
+++ b/examples/workers/l3/per_task_runtime_env/README.md
@@ -11,16 +11,16 @@ Before this knob, every L2 dispatched from one L3 shared the process-wide
 `PTO2_RING_*` env and could not be sized independently. Now each
 `submit_next_level` gets its own `CallConfig`:
 
-Each spec carries one form — scalar keys (`ring_task_window`, …) *or* the
-per-ring arrays (`ring_task_windows`, …) — so the loop sets whichever keys the
-spec contains:
+Each spec sets `ring_task_window` / `ring_heap` / `ring_dep_pool` to a scalar
+(broadcast to every ring) or a 4-entry list (per-ring), so the loop just sets
+whichever keys the spec contains:
 
 ```python
 def orch_fn(orch, _args, _cfg):
     for spec in L2_TASKS:                      # one entry per L2 task
         cfg = CallConfig()
-        for key in RING_FIELDS:                # scalar OR per-ring keys
-            if key in spec:                    # a spec carries just one form
+        for key in RING_FIELDS:                # ring_task_window / ring_heap / ring_dep_pool
+            if key in spec:                    # value is a scalar or a 4-entry list
                 setattr(cfg.runtime_env, key, spec[key])
         orch.submit_next_level(chip_handle, chip_args, cfg)  # per-task config
 ```
@@ -29,10 +29,9 @@ The per-task config travels through the mailbox to the chip child, so each L2
 binds its rings from its own values. The demo dispatches three L2 tasks:
 `l2_scalar_small` (16 / 1 MiB / 64) and `l2_scalar_large` (128 / 8 MiB / 256)
 use the scalar form, and `l2_per_ring` sizes the four scope-depth rings
-independently (`ring_task_windows=[128, 64, 32, 16]`, etc.). All run the same
-vector_add and pass golden. The array fields take exactly four entries (one per
-scope-depth ring `0..3`); a `0` entry falls through to the scalar / env /
-default tier.
+independently (`ring_task_window=[128, 64, 32, 16]`, etc.). All run the same
+vector_add and pass golden. A list takes exactly four entries (one per
+scope-depth ring `0..3`); a `0` entry falls through to the env / default tier.
 
 ### Derive per-task config from the base, don't rebuild it
 

--- a/examples/workers/l3/per_task_runtime_env/main.py
+++ b/examples/workers/l3/per_task_runtime_env/main.py
@@ -17,9 +17,9 @@ fine with the default). Before this knob, all L2 tasks in one L3 launch shared
 the process-wide ``PTO2_RING_*`` env and could not be sized independently.
 
 The demo dispatches three L2 tasks: two use the scalar form (one ring value
-broadcast to every ring), and a third uses the per-ring arrays
-(``ring_task_windows`` / ``ring_heaps`` / ``ring_dep_pools``) to size each of
-the four scope-depth rings independently.
+broadcast to every ring), and a third passes 4-entry lists for
+``ring_task_window`` / ``ring_heap`` / ``ring_dep_pool`` to size each of the four
+scope-depth rings independently.
 
 The key line is inside ``orch_fn``: each ``submit_next_level`` gets its OWN
 ``CallConfig`` whose ``runtime_env`` is set per task. That per-task config
@@ -61,21 +61,14 @@ VECTOR_ADD_KERNELS = os.path.join(HERE, "..", "..", "l2", "vector_add", "kernels
 N_ROWS = 128
 N_COLS = 128
 
-# RuntimeEnv keys an L2 spec may carry. Scalar keys broadcast one value to every
-# ring; the array keys size the four scope-depth rings (0..3) independently.
-RING_FIELDS = (
-    "ring_task_window",
-    "ring_heap",
-    "ring_dep_pool",
-    "ring_task_windows",
-    "ring_heaps",
-    "ring_dep_pools",
-)
+# RuntimeEnv keys an L2 spec may carry. Each takes a scalar (broadcast to every
+# ring) or a 4-entry list (one value per scope-depth ring 0..3).
+RING_FIELDS = ("ring_task_window", "ring_heap", "ring_dep_pool")
 
 # One entry per L2 task dispatched by the orchestration. Each carries its own
 # ring sizing; the inputs differ so the golden checks are independent. The first
-# two tasks use the scalar form (one value per ring); the third uses the
-# per-ring arrays to size each scope-depth ring independently.
+# two tasks use the scalar form (one value broadcast to every ring); the third
+# passes 4-entry lists to size each scope-depth ring independently.
 L2_TASKS = [
     {
         "label": "l2_scalar_small",
@@ -97,9 +90,9 @@ L2_TASKS = [
         "label": "l2_per_ring",
         "a": 1.0,
         "b": 4.0,
-        "ring_task_windows": [128, 64, 32, 16],
-        "ring_heaps": [8 * 1024 * 1024, 4 * 1024 * 1024, 2 * 1024 * 1024, 1 * 1024 * 1024],
-        "ring_dep_pools": [256, 128, 64, 64],
+        "ring_task_window": [128, 64, 32, 16],
+        "ring_heap": [8 * 1024 * 1024, 4 * 1024 * 1024, 2 * 1024 * 1024, 1 * 1024 * 1024],
+        "ring_dep_pool": [256, 128, 64, 64],
     },
 ]
 

--- a/python/bindings/task_interface.cpp
+++ b/python/bindings/task_interface.cpp
@@ -614,6 +614,10 @@ NB_MODULE(_task_interface, m) {
         });
 
     // --- RuntimeEnv (per-task PTO2_RING_* overrides; nested under CallConfig.runtime_env) ---
+    // Each ring resource is exposed as ONE property that accepts either an int
+    // (broadcast to every ring) or a list of RUNTIME_ENV_RING_COUNT ints
+    // (per-ring). The value always reads back as a list — the wire layout is the
+    // four-entry array, so a broadcast scalar is stored as [v, v, v, v].
     auto get_ring_values = [](const uint64_t values[RUNTIME_ENV_RING_COUNT]) -> std::vector<uint64_t> {
         std::vector<uint64_t> out;
         out.reserve(RUNTIME_ENV_RING_COUNT);
@@ -622,21 +626,38 @@ NB_MODULE(_task_interface, m) {
         }
         return out;
     };
-    auto set_ring_values = [](uint64_t values[RUNTIME_ENV_RING_COUNT], const std::vector<uint64_t> &input,
-                              const char *name) {
-        if (input.size() != RUNTIME_ENV_RING_COUNT) {
-            throw std::invalid_argument(
-                std::string("RuntimeEnv.") + name + " must contain exactly " + std::to_string(RUNTIME_ENV_RING_COUNT) +
-                " entries"
-            );
+    auto set_ring_values = [](uint64_t values[RUNTIME_ENV_RING_COUNT], nb::handle obj, const char *name) {
+        uint64_t scalar = 0;
+        if (nb::try_cast<uint64_t>(obj, scalar)) {  // int -> broadcast to every ring
+            for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+                values[i] = scalar;
+            }
+            return;
         }
-        for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
-            values[i] = input[static_cast<size_t>(i)];
+        std::vector<uint64_t> input;
+        if (nb::try_cast<std::vector<uint64_t>>(obj, input)) {  // list -> per-ring
+            if (input.size() != RUNTIME_ENV_RING_COUNT) {
+                throw std::invalid_argument(
+                    std::string("RuntimeEnv.") + name + " list must contain exactly " +
+                    std::to_string(RUNTIME_ENV_RING_COUNT) + " entries"
+                );
+            }
+            for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
+                values[i] = input[static_cast<size_t>(i)];
+            }
+            return;
         }
+        throw std::invalid_argument(
+            std::string("RuntimeEnv.") + name + " must be an int (broadcast) or a list of " +
+            std::to_string(RUNTIME_ENV_RING_COUNT) + " ints"
+        );
     };
-    auto append_ring_values = [](std::ostringstream &os, const char *name,
+    auto append_ring_values = [](std::ostringstream &os, const char *name, bool leading_comma,
                                  const uint64_t values[RUNTIME_ENV_RING_COUNT]) {
-        os << ", " << name << "=[";
+        if (leading_comma) {
+            os << ", ";
+        }
+        os << name << "=[";
         for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
             if (i != 0) {
                 os << ", ";
@@ -648,45 +669,39 @@ NB_MODULE(_task_interface, m) {
 
     nb::class_<RuntimeEnv>(m, "RuntimeEnv")
         .def(nb::init<>())
-        .def_rw("ring_task_window", &RuntimeEnv::ring_task_window)
-        .def_rw("ring_heap", &RuntimeEnv::ring_heap)
-        .def_rw("ring_dep_pool", &RuntimeEnv::ring_dep_pool)
         .def_prop_rw(
-            "ring_task_windows",
+            "ring_task_window",
             [get_ring_values](const RuntimeEnv &self) {
-                return get_ring_values(self.ring_task_windows);
+                return get_ring_values(self.ring_task_window);
             },
-            [set_ring_values](RuntimeEnv &self, const std::vector<uint64_t> &values) {
-                set_ring_values(self.ring_task_windows, values, "ring_task_windows");
+            [set_ring_values](RuntimeEnv &self, nb::handle value) {
+                set_ring_values(self.ring_task_window, value, "ring_task_window");
             }
         )
         .def_prop_rw(
-            "ring_heaps",
+            "ring_heap",
             [get_ring_values](const RuntimeEnv &self) {
-                return get_ring_values(self.ring_heaps);
+                return get_ring_values(self.ring_heap);
             },
-            [set_ring_values](RuntimeEnv &self, const std::vector<uint64_t> &values) {
-                set_ring_values(self.ring_heaps, values, "ring_heaps");
+            [set_ring_values](RuntimeEnv &self, nb::handle value) {
+                set_ring_values(self.ring_heap, value, "ring_heap");
             }
         )
         .def_prop_rw(
-            "ring_dep_pools",
+            "ring_dep_pool",
             [get_ring_values](const RuntimeEnv &self) {
-                return get_ring_values(self.ring_dep_pools);
+                return get_ring_values(self.ring_dep_pool);
             },
-            [set_ring_values](RuntimeEnv &self, const std::vector<uint64_t> &values) {
-                set_ring_values(self.ring_dep_pools, values, "ring_dep_pools");
+            [set_ring_values](RuntimeEnv &self, nb::handle value) {
+                set_ring_values(self.ring_dep_pool, value, "ring_dep_pool");
             }
         )
         .def("__repr__", [append_ring_values](const RuntimeEnv &self) -> std::string {
             std::ostringstream os;
-            os << "RuntimeEnv(ring_task_window=" << self.ring_task_window << ", ring_heap=" << self.ring_heap
-               << ", ring_dep_pool=" << self.ring_dep_pool;
-            if (self.per_ring_any()) {
-                append_ring_values(os, "ring_task_windows", self.ring_task_windows);
-                append_ring_values(os, "ring_heaps", self.ring_heaps);
-                append_ring_values(os, "ring_dep_pools", self.ring_dep_pools);
-            }
+            os << "RuntimeEnv(";
+            append_ring_values(os, "ring_task_window", false, self.ring_task_window);
+            append_ring_values(os, "ring_heap", true, self.ring_heap);
+            append_ring_values(os, "ring_dep_pool", true, self.ring_dep_pool);
             os << ")";
             return os.str();
         });
@@ -787,14 +802,9 @@ NB_MODULE(_task_interface, m) {
                << ", enable_dep_gen=" << (self.enable_dep_gen ? "True" : "False")
                << ", enable_scope_stats=" << (self.enable_scope_stats ? "True" : "False");
             if (self.runtime_env.any()) {
-                os << ", runtime_env.ring_task_window=" << self.runtime_env.ring_task_window
-                   << ", runtime_env.ring_heap=" << self.runtime_env.ring_heap
-                   << ", runtime_env.ring_dep_pool=" << self.runtime_env.ring_dep_pool;
-                if (self.runtime_env.per_ring_any()) {
-                    append_ring_values(os, "runtime_env.ring_task_windows", self.runtime_env.ring_task_windows);
-                    append_ring_values(os, "runtime_env.ring_heaps", self.runtime_env.ring_heaps);
-                    append_ring_values(os, "runtime_env.ring_dep_pools", self.runtime_env.ring_dep_pools);
-                }
+                append_ring_values(os, "runtime_env.ring_task_window", true, self.runtime_env.ring_task_window);
+                append_ring_values(os, "runtime_env.ring_heap", true, self.runtime_env.ring_heap);
+                append_ring_values(os, "runtime_env.ring_dep_pool", true, self.runtime_env.ring_dep_pool);
             }
             if (self.output_prefix_set()) {
                 os << ", output_prefix='" << self.output_prefix << "'";

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -129,10 +129,10 @@ _OFF_CONFIG = 16
 # Packed CallConfig wire layout — must match call_config.h byte for byte:
 # 7 int32 (block_dim, aicpu_thread_num, enable_l2_swimlane, enable_dump_tensor,
 # enable_pmu, enable_dep_gen, enable_scope_stats) + uint64 ring sizing
-# overrides (3 scalar fields + 3 x RUNTIME_ENV_RING_COUNT per-ring arrays) + 1024-byte
-# NUL-terminated output_prefix. Log config travels separately via
-# ChipWorker.init(log_level, log_info_v) — not on per-task wire.
-_RUNTIME_ENV_UINT64_FIELD_COUNT = 3 + 3 * RUNTIME_ENV_RING_COUNT
+# overrides (3 per-ring arrays of RUNTIME_ENV_RING_COUNT: ring_task_window,
+# ring_heap, ring_dep_pool) + 1024-byte NUL-terminated output_prefix. Log config
+# travels separately via ChipWorker.init(log_level, log_info_v) — not on per-task wire.
+_RUNTIME_ENV_UINT64_FIELD_COUNT = 3 * RUNTIME_ENV_RING_COUNT
 _CFG_FMT = struct.Struct("=iiiiiii" + ("Q" * _RUNTIME_ENV_UINT64_FIELD_COUNT) + "1024s")
 # Args region starts after CONFIG, rounded up to 8 bytes so the first
 # Tensor.data (uint64_t at OFF_ARGS+8) is 8-byte aligned, avoiding
@@ -1025,15 +1025,12 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
         pmu,
         dep_gen,
         scope_stats,
-        ring_task_window,
-        ring_heap,
-        ring_dep_pool,
         *ring_values,
         prefix_bytes,
     ) = _CFG_FMT.unpack_from(buf, _OFF_CONFIG)
-    ring_task_windows = list(ring_values[:RUNTIME_ENV_RING_COUNT])
-    ring_heaps = list(ring_values[RUNTIME_ENV_RING_COUNT : 2 * RUNTIME_ENV_RING_COUNT])
-    ring_dep_pools = list(ring_values[2 * RUNTIME_ENV_RING_COUNT : 3 * RUNTIME_ENV_RING_COUNT])
+    ring_task_window = list(ring_values[:RUNTIME_ENV_RING_COUNT])
+    ring_heap = list(ring_values[RUNTIME_ENV_RING_COUNT : 2 * RUNTIME_ENV_RING_COUNT])
+    ring_dep_pool = list(ring_values[2 * RUNTIME_ENV_RING_COUNT : 3 * RUNTIME_ENV_RING_COUNT])
     cfg = CallConfig()
     cfg.block_dim = block_dim
     cfg.aicpu_thread_num = aicpu_tn
@@ -1045,9 +1042,6 @@ def _read_config_from_mailbox(buf: memoryview) -> "CallConfig":
     cfg.runtime_env.ring_task_window = ring_task_window
     cfg.runtime_env.ring_heap = ring_heap
     cfg.runtime_env.ring_dep_pool = ring_dep_pool
-    cfg.runtime_env.ring_task_windows = ring_task_windows
-    cfg.runtime_env.ring_heaps = ring_heaps
-    cfg.runtime_env.ring_dep_pools = ring_dep_pools
     # NUL-terminated C string in a 1024-byte field.
     cfg.output_prefix = prefix_bytes.split(b"\x00", 1)[0].decode("utf-8")
     return cfg

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1091,17 +1091,13 @@ class SceneTestCase:
         config.aicpu_thread_num = config_dict.get("aicpu_thread_num", 3)
         # Per-task ring sizing (tensormap_and_ringbuffer only; 0 = unset),
         # nested under the "runtime_env" key. Takes precedence over the
-        # PTO2_RING_* env vars / RUNTIME_ENV.
+        # PTO2_RING_* env vars / RUNTIME_ENV. Each value is either a scalar
+        # (broadcast to every ring) or a list of RUNTIME_ENV_RING_COUNT ints
+        # (per-ring); the binding accepts both forms.
         runtime_env = config_dict.get("runtime_env", {})
         config.runtime_env.ring_task_window = runtime_env.get("ring_task_window", 0)
         config.runtime_env.ring_heap = runtime_env.get("ring_heap", 0)
         config.runtime_env.ring_dep_pool = runtime_env.get("ring_dep_pool", 0)
-        if "ring_task_windows" in runtime_env:
-            config.runtime_env.ring_task_windows = runtime_env["ring_task_windows"]
-        if "ring_heaps" in runtime_env:
-            config.runtime_env.ring_heaps = runtime_env["ring_heaps"]
-        if "ring_dep_pools" in runtime_env:
-            config.runtime_env.ring_dep_pools = runtime_env["ring_dep_pools"]
         config.enable_l2_swimlane = enable_l2_swimlane
         config.enable_dump_tensor = enable_dump_args
         config.enable_pmu = enable_pmu  # 0=disabled, >0=enabled with event type

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -359,8 +359,8 @@ int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(co
  */
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t /*ring_task_window*/, uint64_t /*ring_heap*/, uint64_t /*ring_dep_pool*/,
-    const uint64_t * /*ring_task_windows*/, const uint64_t * /*ring_heaps*/, const uint64_t * /*ring_dep_pools*/
+    int sig_count, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    const uint64_t * /*ring_dep_pool*/
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -237,12 +237,13 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 
 ### 7.2 Runtime Overrides
 
-Ring sizing can be configured either uniformly for every ring or independently
-per ring. Precedence is resolved independently for each resource and ring:
+Each ring resource (`ring_task_window` / `ring_heap` / `ring_dep_pool`) is a
+single `CallConfig.runtime_env` field that accepts **either** a scalar (broadcast
+to every ring) **or** a list of four per-ring values. Precedence is resolved
+independently for each resource and ring:
 
 ```text
-per-ring CallConfig value
-  > scalar CallConfig value
+per-ring CallConfig entry (a scalar is broadcast to every entry)
   > per-ring PTO2_RING_* env value
   > scalar PTO2_RING_* env value
   > compile-time default
@@ -259,8 +260,7 @@ scope depth >=3 -> ring 3
 
 Per-task via `CallConfig.runtime_env` — different L2 tasks in one launch can
 each carry their own sizes. Invalid values raise at submit time (`validate()`).
-The scalar fields preserve the old behavior and broadcast one value to all
-rings:
+Assign a scalar to size every ring the same:
 
 ```python
 cfg = CallConfig()
@@ -270,33 +270,33 @@ cfg.runtime_env.ring_dep_pool = 256      # 4 .. INT32_MAX
 orchestrator.submit_next_level(handle, args, cfg)
 ```
 
-Set the array fields to tune the four scope-depth rings independently. Each
-array must contain exactly four entries; use `0` for an entry that should fall
-through to the next precedence tier. All `CallConfig` values are integer
-byte/count values.
+Assign a four-entry list to tune the scope-depth rings independently. The list
+must contain exactly four entries; use `0` for an entry that should fall through
+to the next precedence tier. All `CallConfig` values are integer byte/count
+values, and each field always reads back as a four-entry list.
 
 ```python
 cfg = CallConfig()
-cfg.runtime_env.ring_task_windows = [8192, 16384, 131072, 524288]
-cfg.runtime_env.ring_heaps = [
+cfg.runtime_env.ring_task_window = [8192, 16384, 131072, 524288]
+cfg.runtime_env.ring_heap = [
     128 * 1024 * 1024,
     256 * 1024 * 1024,
     384 * 1024 * 1024,
     512 * 1024 * 1024,
 ]
-cfg.runtime_env.ring_dep_pools = [4096, 8192, 16384, 32768]
+cfg.runtime_env.ring_dep_pool = [4096, 8192, 16384, 32768]
 orchestrator.submit_next_level(handle, args, cfg)
 ```
 
 Scene tests set the same keys under a nested `runtime_env` block in the
-per-case `config` dict:
+per-case `config` dict — each value is a scalar or a four-entry list:
 
 ```python
 "config": {
     "runtime_env": {
-        "ring_task_windows": [8192, 16384, 131072, 524288],
-        "ring_heaps": [134217728, 268435456, 402653184, 536870912],
-        "ring_dep_pools": [4096, 8192, 16384, 32768],
+        "ring_task_window": [8192, 16384, 131072, 524288],
+        "ring_heap": [134217728, 268435456, 402653184, 536870912],
+        "ring_dep_pool": 256,  # scalar broadcasts to every ring
     }
 }
 ```

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -173,10 +173,14 @@ static void apply_env_ring_values(
     }
 }
 
+// Each of ring_task_window / ring_heap / ring_dep_pool is a per-ring array of
+// PTO2_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
+// PTO2_RING_* env value > compile-time default. A "size all rings the same"
+// request arrives already broadcast to every entry by the caller.
 static bool resolve_ring_config(
-    uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool, const uint64_t *ring_task_windows,
-    const uint64_t *ring_heaps, const uint64_t *ring_dep_pools, uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
-    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
+    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH],
+    int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
     uint64_t dep_pool_values[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -189,61 +193,30 @@ static bool resolve_ring_config(
     apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
     apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
 
-    if (ring_task_window != 0) {
-        if (ring_task_window < 4 || ring_task_window > static_cast<uint64_t>(INT32_MAX) ||
-            !is_power_of_2_u64(ring_task_window)) {
-            LOG_ERROR(
-                "runtime_env.ring_task_window=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", ring_task_window
-            );
-            return false;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            eff_task_window_sizes[r] = ring_task_window;
-        }
-    }
-    if (ring_heap != 0) {
-        if (ring_heap < 1024) {
-            LOG_ERROR("runtime_env.ring_heap=%" PRIu64 " must be >= 1024", ring_heap);
-            return false;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            eff_heap_sizes[r] = ring_heap;
-        }
-    }
-    if (ring_dep_pool != 0) {
-        if (ring_dep_pool < 4 || ring_dep_pool > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR("runtime_env.ring_dep_pool=%" PRIu64 " must be in [4, INT32_MAX]", ring_dep_pool);
-            return false;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            dep_pool_values[r] = ring_dep_pool;
-        }
-    }
-
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (ring_task_windows != nullptr && ring_task_windows[r] != 0) {
-            eff_task_window_sizes[r] = ring_task_windows[r];
+        if (ring_task_window != nullptr && ring_task_window[r] != 0) {
+            eff_task_window_sizes[r] = ring_task_window[r];
         }
-        if (ring_heaps != nullptr && ring_heaps[r] != 0) {
-            eff_heap_sizes[r] = ring_heaps[r];
+        if (ring_heap != nullptr && ring_heap[r] != 0) {
+            eff_heap_sizes[r] = ring_heap[r];
         }
-        if (ring_dep_pools != nullptr && ring_dep_pools[r] != 0) {
-            dep_pool_values[r] = ring_dep_pools[r];
+        if (ring_dep_pool != nullptr && ring_dep_pool[r] != 0) {
+            dep_pool_values[r] = ring_dep_pool[r];
         }
 
         if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||
             !is_power_of_2_u64(eff_task_window_sizes[r])) {
             LOG_ERROR(
-                "ring_task_windows[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
+                "ring_task_window[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
             );
             return false;
         }
         if (eff_heap_sizes[r] < 1024) {
-            LOG_ERROR("ring_heaps[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
+            LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
             return false;
         }
         if (dep_pool_values[r] < 4 || dep_pool_values[r] > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR("ring_dep_pools[%d]=%" PRIu64 " must be in [4, INT32_MAX]", r, dep_pool_values[r]);
+            LOG_ERROR("ring_dep_pool[%d]=%" PRIu64 " must be in [4, INT32_MAX]", r, dep_pool_values[r]);
             return false;
         }
         eff_dep_pool_capacities[r] = static_cast<int32_t>(dep_pool_values[r]);
@@ -341,8 +314,7 @@ prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const 
  */
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
+    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -370,8 +342,7 @@ extern "C" int bind_callable_to_runtime_impl(
     uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
     int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH];
     if (!resolve_ring_config(
-            ring_task_window, ring_heap, ring_dep_pool, ring_task_windows, ring_heaps, ring_dep_pools,
-            eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities
+            ring_task_window, ring_heap, ring_dep_pool, eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities
         )) {
         return -1;
     }

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -359,8 +359,8 @@ int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(co
  */
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t /*ring_task_window*/, uint64_t /*ring_heap*/, uint64_t /*ring_dep_pool*/,
-    const uint64_t * /*ring_task_windows*/, const uint64_t * /*ring_heaps*/, const uint64_t * /*ring_dep_pools*/
+    int sig_count, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    const uint64_t * /*ring_dep_pool*/
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md
@@ -237,12 +237,13 @@ AICore uses `last_reg_val` to detect new dispatches — identical values cause s
 
 ### 7.2 Runtime Overrides
 
-Ring sizing can be configured either uniformly for every ring or independently
-per ring. Precedence is resolved independently for each resource and ring:
+Each ring resource (`ring_task_window` / `ring_heap` / `ring_dep_pool`) is a
+single `CallConfig.runtime_env` field that accepts **either** a scalar (broadcast
+to every ring) **or** a list of four per-ring values. Precedence is resolved
+independently for each resource and ring:
 
 ```text
-per-ring CallConfig value
-  > scalar CallConfig value
+per-ring CallConfig entry (a scalar is broadcast to every entry)
   > per-ring PTO2_RING_* env value
   > scalar PTO2_RING_* env value
   > compile-time default
@@ -259,8 +260,7 @@ scope depth >=3 -> ring 3
 
 Per-task via `CallConfig.runtime_env` — different L2 tasks in one launch can
 each carry their own sizes. Invalid values raise at submit time (`validate()`).
-The scalar fields preserve the old behavior and broadcast one value to all
-rings:
+Assign a scalar to size every ring the same:
 
 ```python
 cfg = CallConfig()
@@ -270,33 +270,33 @@ cfg.runtime_env.ring_dep_pool = 256      # 4 .. INT32_MAX
 orchestrator.submit_next_level(handle, args, cfg)
 ```
 
-Set the array fields to tune the four scope-depth rings independently. Each
-array must contain exactly four entries; use `0` for an entry that should fall
-through to the next precedence tier. All `CallConfig` values are integer
-byte/count values.
+Assign a four-entry list to tune the scope-depth rings independently. The list
+must contain exactly four entries; use `0` for an entry that should fall through
+to the next precedence tier. All `CallConfig` values are integer byte/count
+values, and each field always reads back as a four-entry list.
 
 ```python
 cfg = CallConfig()
-cfg.runtime_env.ring_task_windows = [8192, 16384, 131072, 524288]
-cfg.runtime_env.ring_heaps = [
+cfg.runtime_env.ring_task_window = [8192, 16384, 131072, 524288]
+cfg.runtime_env.ring_heap = [
     128 * 1024 * 1024,
     256 * 1024 * 1024,
     384 * 1024 * 1024,
     512 * 1024 * 1024,
 ]
-cfg.runtime_env.ring_dep_pools = [4096, 8192, 16384, 32768]
+cfg.runtime_env.ring_dep_pool = [4096, 8192, 16384, 32768]
 orchestrator.submit_next_level(handle, args, cfg)
 ```
 
 Scene tests set the same keys under a nested `runtime_env` block in the
-per-case `config` dict:
+per-case `config` dict — each value is a scalar or a four-entry list:
 
 ```python
 "config": {
     "runtime_env": {
-        "ring_task_windows": [8192, 16384, 131072, 524288],
-        "ring_heaps": [134217728, 268435456, 402653184, 536870912],
-        "ring_dep_pools": [4096, 8192, 16384, 32768],
+        "ring_task_window": [8192, 16384, 131072, 524288],
+        "ring_heap": [134217728, 268435456, 402653184, 536870912],
+        "ring_dep_pool": 256,  # scalar broadcasts to every ring
     }
 }
 ```

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -173,10 +173,14 @@ static void apply_env_ring_values(
     }
 }
 
+// Each of ring_task_window / ring_heap / ring_dep_pool is a per-ring array of
+// PTO2_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
+// PTO2_RING_* env value > compile-time default. A "size all rings the same"
+// request arrives already broadcast to every entry by the caller.
 static bool resolve_ring_config(
-    uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool, const uint64_t *ring_task_windows,
-    const uint64_t *ring_heaps, const uint64_t *ring_dep_pools, uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH],
-    uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH], int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
+    const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
+    uint64_t eff_task_window_sizes[PTO2_MAX_RING_DEPTH], uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH],
+    int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
     uint64_t dep_pool_values[PTO2_MAX_RING_DEPTH];
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
@@ -189,61 +193,30 @@ static bool resolve_ring_config(
     apply_env_ring_values("PTO2_RING_HEAP", 1024, std::numeric_limits<uint64_t>::max(), false, eff_heap_sizes);
     apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
 
-    if (ring_task_window != 0) {
-        if (ring_task_window < 4 || ring_task_window > static_cast<uint64_t>(INT32_MAX) ||
-            !is_power_of_2_u64(ring_task_window)) {
-            LOG_ERROR(
-                "runtime_env.ring_task_window=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", ring_task_window
-            );
-            return false;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            eff_task_window_sizes[r] = ring_task_window;
-        }
-    }
-    if (ring_heap != 0) {
-        if (ring_heap < 1024) {
-            LOG_ERROR("runtime_env.ring_heap=%" PRIu64 " must be >= 1024", ring_heap);
-            return false;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            eff_heap_sizes[r] = ring_heap;
-        }
-    }
-    if (ring_dep_pool != 0) {
-        if (ring_dep_pool < 4 || ring_dep_pool > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR("runtime_env.ring_dep_pool=%" PRIu64 " must be in [4, INT32_MAX]", ring_dep_pool);
-            return false;
-        }
-        for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-            dep_pool_values[r] = ring_dep_pool;
-        }
-    }
-
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (ring_task_windows != nullptr && ring_task_windows[r] != 0) {
-            eff_task_window_sizes[r] = ring_task_windows[r];
+        if (ring_task_window != nullptr && ring_task_window[r] != 0) {
+            eff_task_window_sizes[r] = ring_task_window[r];
         }
-        if (ring_heaps != nullptr && ring_heaps[r] != 0) {
-            eff_heap_sizes[r] = ring_heaps[r];
+        if (ring_heap != nullptr && ring_heap[r] != 0) {
+            eff_heap_sizes[r] = ring_heap[r];
         }
-        if (ring_dep_pools != nullptr && ring_dep_pools[r] != 0) {
-            dep_pool_values[r] = ring_dep_pools[r];
+        if (ring_dep_pool != nullptr && ring_dep_pool[r] != 0) {
+            dep_pool_values[r] = ring_dep_pool[r];
         }
 
         if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||
             !is_power_of_2_u64(eff_task_window_sizes[r])) {
             LOG_ERROR(
-                "ring_task_windows[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
+                "ring_task_window[%d]=%" PRIu64 " must be a power of 2 in [4, INT32_MAX]", r, eff_task_window_sizes[r]
             );
             return false;
         }
         if (eff_heap_sizes[r] < 1024) {
-            LOG_ERROR("ring_heaps[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
+            LOG_ERROR("ring_heap[%d]=%" PRIu64 " must be >= 1024", r, eff_heap_sizes[r]);
             return false;
         }
         if (dep_pool_values[r] < 4 || dep_pool_values[r] > static_cast<uint64_t>(INT32_MAX)) {
-            LOG_ERROR("ring_dep_pools[%d]=%" PRIu64 " must be in [4, INT32_MAX]", r, dep_pool_values[r]);
+            LOG_ERROR("ring_dep_pool[%d]=%" PRIu64 " must be in [4, INT32_MAX]", r, dep_pool_values[r]);
             return false;
         }
         eff_dep_pool_capacities[r] = static_cast<int32_t>(dep_pool_values[r]);
@@ -341,8 +314,7 @@ prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const 
  */
 extern "C" int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
+    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
@@ -370,8 +342,7 @@ extern "C" int bind_callable_to_runtime_impl(
     uint64_t eff_heap_sizes[PTO2_MAX_RING_DEPTH];
     int32_t eff_dep_pool_capacities[PTO2_MAX_RING_DEPTH];
     if (!resolve_ring_config(
-            ring_task_window, ring_heap, ring_dep_pool, ring_task_windows, ring_heaps, ring_dep_pools,
-            eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities
+            ring_task_window, ring_heap, ring_dep_pool, eff_task_window_sizes, eff_heap_sizes, eff_dep_pool_capacities
         )) {
         return -1;
     }

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -56,8 +56,7 @@ extern "C" {
 int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
+    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 );
 int validate_runtime_impl(Runtime *runtime);
 
@@ -340,8 +339,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools,
+    int enable_scope_stats, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
     const char *output_prefix, PtoRunTiming *out_timing
 ) {
     if (out_timing != NULL) {
@@ -402,8 +400,7 @@ int run_prepared(
         // Per-run binding (tensor args, GM heap, SM alloc)
         rc = bind_callable_to_runtime_impl(
             r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
-            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool, ring_task_windows,
-            ring_heaps, ring_dep_pools
+            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
         );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -49,8 +49,7 @@ extern "C" {
 int prepare_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools
+    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
 );
 int validate_runtime_impl(Runtime *runtime);
 
@@ -304,8 +303,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools,
+    int enable_scope_stats, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
     const char *output_prefix, PtoRunTiming *out_timing
 ) {
     if (out_timing != NULL) {
@@ -354,8 +352,7 @@ int run_prepared(
 
         rc = bind_callable_to_runtime_impl(
             r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
-            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool, ring_task_windows,
-            ring_heaps, ring_dep_pools
+            bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
         );
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);

--- a/src/common/task_interface/call_config.h
+++ b/src/common/task_interface/call_config.h
@@ -12,7 +12,7 @@
 /**
  * CallConfig — per-NEXT_LEVEL-task config. Carries execution knobs
  * (block_dim, aicpu_thread_num), per-task runtime-environment overrides
- * (`runtime_env.ring_task_window` / `.ring_heap` / `.ring_dep_pool`, plus per-ring variants) plus the five parallel
+ * (`runtime_env.ring_task_window` / `.ring_heap` / `.ring_dep_pool`, each a per-ring array) plus the five parallel
  * diagnostics sub-features under the profiling umbrella: `enable_l2_swimlane` (swimlane), `enable_dump_tensor`,
  * `enable_pmu`, `enable_dep_gen`, and `enable_scope_stats`. All five require `output_prefix` because they each write
  * sibling artifacts into that directory
@@ -47,42 +47,36 @@
 #include <cstdint>
 #include <cstring>
 #include <stdexcept>
-#include <string>
 
 inline constexpr int RUNTIME_ENV_RING_COUNT = 4;
-inline constexpr int RUNTIME_ENV_SCALAR_FIELD_COUNT = 3;
-inline constexpr int RUNTIME_ENV_PER_RING_FIELD_GROUPS = 3;
-inline constexpr int RUNTIME_ENV_UINT64_FIELD_COUNT =
-    RUNTIME_ENV_SCALAR_FIELD_COUNT + RUNTIME_ENV_PER_RING_FIELD_GROUPS * RUNTIME_ENV_RING_COUNT;
+inline constexpr int RUNTIME_ENV_FIELD_GROUPS = 3;  // ring_task_window, ring_heap, ring_dep_pool
+inline constexpr int RUNTIME_ENV_UINT64_FIELD_COUNT = RUNTIME_ENV_FIELD_GROUPS * RUNTIME_ENV_RING_COUNT;
 
 #pragma pack(push, 1)
 // Per-task runtime-environment overrides — the programmatic equivalent of the
 // `PTO2_RING_*` env vars, grouped under their own sub-struct so they read as a
 // distinct configuration tier from the top-level execution knobs (block_dim,
 // aicpu_thread_num). Consumed by tensormap_and_ringbuffer only; other runtimes
-// ignore them. 0 = unset; precedence: field > PTO2_RING_* env var >
-// compile-time default. ring_heap is bytes per ring. The scalar fields retain
-// #1042 behavior (broadcast to every ring); the array fields selectively
-// override individual scope-depth rings for #1029.
+// ignore them.
+//
+// Each resource is a per-scope-depth-ring array (index 0..3). A 0 entry is
+// unset and falls through to the next precedence tier: per-ring entry >
+// PTO2_RING_* env var > compile-time default. ring_heap is bytes per ring.
+// The Python/scene-test layer accepts a scalar and broadcasts it to every ring
+// before populating these arrays, so a one-value "size all rings the same"
+// request arrives here as [v, v, v, v].
 struct RuntimeEnv {
-    uint64_t ring_task_window = 0;
-    uint64_t ring_heap = 0;
-    uint64_t ring_dep_pool = 0;
-    uint64_t ring_task_windows[RUNTIME_ENV_RING_COUNT] = {};
-    uint64_t ring_heaps[RUNTIME_ENV_RING_COUNT] = {};
-    uint64_t ring_dep_pools[RUNTIME_ENV_RING_COUNT] = {};
+    uint64_t ring_task_window[RUNTIME_ENV_RING_COUNT] = {};
+    uint64_t ring_heap[RUNTIME_ENV_RING_COUNT] = {};
+    uint64_t ring_dep_pool[RUNTIME_ENV_RING_COUNT] = {};
 
-    bool per_ring_any() const noexcept {
+    bool any() const noexcept {
         for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
-            if (ring_task_windows[i] != 0 || ring_heaps[i] != 0 || ring_dep_pools[i] != 0) {
+            if (ring_task_window[i] != 0 || ring_heap[i] != 0 || ring_dep_pool[i] != 0) {
                 return true;
             }
         }
         return false;
-    }
-
-    bool any() const noexcept {
-        return ring_task_window != 0 || ring_heap != 0 || ring_dep_pool != 0 || per_ring_any();
     }
 
     // Throws if a ring sizing override violates the ring buffer's constraints.
@@ -90,30 +84,25 @@ struct RuntimeEnv {
         auto pow2 = [](uint64_t v) {
             return (v & (v - 1)) == 0;
         };
-        auto validate_task_window = [&](uint64_t value, const char *name) {
+        auto validate_task_window = [&](uint64_t value) {
             if (value != 0 && (value < 4 || value > INT32_MAX || !pow2(value))) {
-                throw std::invalid_argument(
-                    std::string("RuntimeEnv: ") + name + " must be a power of 2 in [4, INT32_MAX]"
-                );
+                throw std::invalid_argument("RuntimeEnv: ring_task_window must be a power of 2 in [4, INT32_MAX]");
             }
         };
-        auto validate_heap = [&](uint64_t value, const char *name) {
+        auto validate_heap = [&](uint64_t value) {
             if (value != 0 && value < 1024) {
-                throw std::invalid_argument(std::string("RuntimeEnv: ") + name + " must be >= 1024 (bytes per ring)");
+                throw std::invalid_argument("RuntimeEnv: ring_heap must be >= 1024 (bytes per ring)");
             }
         };
-        auto validate_dep_pool = [&](uint64_t value, const char *name) {
+        auto validate_dep_pool = [&](uint64_t value) {
             if (value != 0 && (value < 4 || value > INT32_MAX)) {
-                throw std::invalid_argument(std::string("RuntimeEnv: ") + name + " must be in [4, INT32_MAX]");
+                throw std::invalid_argument("RuntimeEnv: ring_dep_pool must be in [4, INT32_MAX]");
             }
         };
-        validate_task_window(ring_task_window, "ring_task_window");
-        validate_heap(ring_heap, "ring_heap");
-        validate_dep_pool(ring_dep_pool, "ring_dep_pool");
         for (int i = 0; i < RUNTIME_ENV_RING_COUNT; ++i) {
-            validate_task_window(ring_task_windows[i], "ring_task_windows");
-            validate_heap(ring_heaps[i], "ring_heaps");
-            validate_dep_pool(ring_dep_pools[i], "ring_dep_pools");
+            validate_task_window(ring_task_window[i]);
+            validate_heap(ring_heap[i]);
+            validate_dep_pool(ring_dep_pool[i]);
         }
     }
 };

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -320,19 +320,12 @@ RunTiming ChipWorker::run(int32_t callable_id, const ChipStorageTaskArgs *args, 
     }
 
     void *rt = runtime_buf_.data();
-    uint64_t ring_task_windows[RUNTIME_ENV_RING_COUNT];
-    uint64_t ring_heaps[RUNTIME_ENV_RING_COUNT];
-    uint64_t ring_dep_pools[RUNTIME_ENV_RING_COUNT];
-    std::memcpy(ring_task_windows, config.runtime_env.ring_task_windows, sizeof(ring_task_windows));
-    std::memcpy(ring_heaps, config.runtime_env.ring_heaps, sizeof(ring_heaps));
-    std::memcpy(ring_dep_pools, config.runtime_env.ring_dep_pools, sizeof(ring_dep_pools));
-
     PtoRunTiming timing{0, 0};
     int rc = run_prepared_fn_(
         device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, config.enable_l2_swimlane,
         config.enable_dump_tensor, config.enable_pmu, config.enable_dep_gen, config.enable_scope_stats,
         config.runtime_env.ring_task_window, config.runtime_env.ring_heap, config.runtime_env.ring_dep_pool,
-        ring_task_windows, ring_heaps, ring_dep_pools, config.output_prefix, &timing
+        config.output_prefix, &timing
     );
     if (rc != 0) {
         throw std::runtime_error("run_prepared failed with code " + std::to_string(rc));

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -143,8 +143,8 @@ private:
         int (*)(void *, int, const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *, size_t);
     using PrepareCallableFn = int (*)(void *, int32_t, const void *);
     using RunPreparedFn = int (*)(
-        void *, void *, int32_t, const void *, int, int, int, int, int, int, int, uint64_t, uint64_t, uint64_t,
-        const uint64_t *, const uint64_t *, const uint64_t *, const char *, PtoRunTiming *
+        void *, void *, int32_t, const void *, int, int, int, int, int, int, int, const uint64_t *, const uint64_t *,
+        const uint64_t *, const char *, PtoRunTiming *
     );
     using UnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -190,20 +190,19 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
  * entry and partially populated on early-error returns.
  *
  * `ring_task_window` / `ring_heap` / `ring_dep_pool` are per-task ring sizing
- * overrides (0 = unset, scalar value broadcasts to every ring). The three
- * per-ring arrays have four entries each and selectively override individual
- * ring depths when an entry is nonzero. Precedence per ring: per-ring entry >
- * scalar per-task value > PTO2_RING_* env var > compile-time default.
- * Consumed by tensormap_and_ringbuffer only; other runtime variants accept
- * and ignore them.
+ * overrides, each a per-scope-depth-ring array of RUNTIME_ENV_RING_COUNT
+ * entries (0 = unset). A nonzero entry overrides that ring; a 0 entry falls
+ * through. Precedence per ring: per-ring entry > PTO2_RING_* env var >
+ * compile-time default. A "size every ring the same" request is broadcast to
+ * all entries by the caller. Consumed by tensormap_and_ringbuffer only; other
+ * runtime variants accept and ignore them.
  *
  * @return 0 on success, negative on error (no prep state, NULL ctx, etc.).
  */
 int run_prepared(
     DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
     int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, uint64_t ring_task_window, uint64_t ring_heap, uint64_t ring_dep_pool,
-    const uint64_t *ring_task_windows, const uint64_t *ring_heaps, const uint64_t *ring_dep_pools,
+    int enable_scope_stats, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
     const char *output_prefix, PtoRunTiming *out_timing
 );
 

--- a/tests/ut/cpp/types/test_call_config.cpp
+++ b/tests/ut/cpp/types/test_call_config.cpp
@@ -17,73 +17,73 @@
 #include "call_config.h"
 
 // Wire contract: parent and forked child move CallConfig with one memcpy.
-TEST(CallConfig, WireLayoutUnchanged) {
+TEST(CallConfig, WireLayoutMatchesConstant) {
     EXPECT_EQ(sizeof(RuntimeEnv), RUNTIME_ENV_UINT64_FIELD_COUNT * sizeof(uint64_t));
     EXPECT_EQ(sizeof(CallConfig), 7 * sizeof(int32_t) + RUNTIME_ENV_UINT64_FIELD_COUNT * sizeof(uint64_t) + 1024);
 }
 
 TEST(CallConfig, RuntimeEnvDefaultsAreUnset) {
     CallConfig cfg;
-    EXPECT_EQ(cfg.runtime_env.ring_task_window, 0u);
-    EXPECT_EQ(cfg.runtime_env.ring_heap, 0u);
-    EXPECT_EQ(cfg.runtime_env.ring_dep_pool, 0u);
     for (int r = 0; r < RUNTIME_ENV_RING_COUNT; ++r) {
-        EXPECT_EQ(cfg.runtime_env.ring_task_windows[r], 0u);
-        EXPECT_EQ(cfg.runtime_env.ring_heaps[r], 0u);
-        EXPECT_EQ(cfg.runtime_env.ring_dep_pools[r], 0u);
+        EXPECT_EQ(cfg.runtime_env.ring_task_window[r], 0u);
+        EXPECT_EQ(cfg.runtime_env.ring_heap[r], 0u);
+        EXPECT_EQ(cfg.runtime_env.ring_dep_pool[r], 0u);
     }
-    EXPECT_FALSE(cfg.runtime_env.per_ring_any());
     EXPECT_FALSE(cfg.runtime_env.any());
     EXPECT_NO_THROW(cfg.validate());
 }
 
 TEST(CallConfig, ValidRuntimeEnvPasses) {
     CallConfig cfg;
-    cfg.runtime_env.ring_task_window = 64;
-    cfg.runtime_env.ring_heap = 2621440;
-    cfg.runtime_env.ring_dep_pool = 256;
-    cfg.runtime_env.ring_task_windows[2] = 1024;
-    cfg.runtime_env.ring_heaps[2] = 1536 * 1024 * 1024ull;
-    cfg.runtime_env.ring_dep_pools[2] = 1024;
+    // A broadcast scalar arrives here as every entry set to the same value...
+    for (int r = 0; r < RUNTIME_ENV_RING_COUNT; ++r) {
+        cfg.runtime_env.ring_task_window[r] = 64;
+        cfg.runtime_env.ring_heap[r] = 2621440;
+        cfg.runtime_env.ring_dep_pool[r] = 256;
+    }
+    // ...and a per-ring override sets a single ring independently.
+    cfg.runtime_env.ring_task_window[2] = 1024;
+    cfg.runtime_env.ring_heap[2] = 1536 * 1024 * 1024ull;
+    cfg.runtime_env.ring_dep_pool[2] = 1024;
     EXPECT_TRUE(cfg.runtime_env.any());
-    EXPECT_TRUE(cfg.runtime_env.per_ring_any());
     EXPECT_NO_THROW(cfg.validate());
 }
 
 TEST(CallConfig, RejectsRingTaskWindowBelowMinOrNonPow2) {
     CallConfig cfg;
-    cfg.runtime_env.ring_task_window = 3;
+    cfg.runtime_env.ring_task_window[0] = 3;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
-    cfg.runtime_env.ring_task_window = 48;
+    cfg.runtime_env.ring_task_window[0] = 48;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
-    cfg.runtime_env.ring_task_window = static_cast<uint64_t>(INT32_MAX) + 1;
+    cfg.runtime_env.ring_task_window[0] = static_cast<uint64_t>(INT32_MAX) + 1;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }
 
 TEST(CallConfig, RejectsRingHeapBelowMin) {
     CallConfig cfg;
-    cfg.runtime_env.ring_heap = 512;
+    cfg.runtime_env.ring_heap[0] = 512;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }
 
 TEST(CallConfig, RejectsRingDepPoolOutOfRange) {
     CallConfig cfg;
-    cfg.runtime_env.ring_dep_pool = 3;
+    cfg.runtime_env.ring_dep_pool[0] = 3;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
-    cfg.runtime_env.ring_dep_pool = static_cast<uint64_t>(INT32_MAX) + 1;
+    cfg.runtime_env.ring_dep_pool[0] = static_cast<uint64_t>(INT32_MAX) + 1;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }
 
-TEST(CallConfig, RejectsPerRingRuntimeEnvValues) {
+// Constraints are enforced on every ring index, not just ring 0.
+TEST(CallConfig, RejectsInvalidValuesAtNonZeroRing) {
     CallConfig cfg;
-    cfg.runtime_env.ring_task_windows[1] = 48;
+    cfg.runtime_env.ring_task_window[1] = 48;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 
     cfg = CallConfig{};
-    cfg.runtime_env.ring_heaps[1] = 512;
+    cfg.runtime_env.ring_heap[1] = 512;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 
     cfg = CallConfig{};
-    cfg.runtime_env.ring_dep_pools[1] = static_cast<uint64_t>(INT32_MAX) + 1;
+    cfg.runtime_env.ring_dep_pool[1] = static_cast<uint64_t>(INT32_MAX) + 1;
     EXPECT_THROW(cfg.validate(), std::invalid_argument);
 }

--- a/tests/ut/py/test_chip_worker.py
+++ b/tests/ut/py/test_chip_worker.py
@@ -83,55 +83,51 @@ class TestCallConfig:
 
     def test_runtime_env_defaults_and_roundtrip(self):
         config = CallConfig()
-        # Nested runtime_env tier — writes through the internal reference.
-        assert config.runtime_env.ring_task_window == 0
-        assert config.runtime_env.ring_heap == 0
-        assert config.runtime_env.ring_dep_pool == 0
-        assert config.runtime_env.ring_task_windows == [0, 0, 0, 0]
-        assert config.runtime_env.ring_heaps == [0, 0, 0, 0]
-        assert config.runtime_env.ring_dep_pools == [0, 0, 0, 0]
+        # Each resource reads back as a 4-entry list; unset = all zeros.
+        assert config.runtime_env.ring_task_window == [0, 0, 0, 0]
+        assert config.runtime_env.ring_heap == [0, 0, 0, 0]
+        assert config.runtime_env.ring_dep_pool == [0, 0, 0, 0]
+        # A scalar broadcasts to every ring...
         config.runtime_env.ring_task_window = 64
-        config.runtime_env.ring_heap = 2621440
-        config.runtime_env.ring_dep_pool = 256
-        config.runtime_env.ring_task_windows = [16, 32, 128, 256]
-        config.runtime_env.ring_heaps = [
+        assert config.runtime_env.ring_task_window == [64, 64, 64, 64]
+        # ...a list sizes each scope-depth ring independently.
+        config.runtime_env.ring_task_window = [16, 32, 128, 256]
+        config.runtime_env.ring_heap = [
             10 * 1024 * 1024,
             64 * 1024 * 1024,
             1536 * 1024 * 1024,
             4 * 1024 * 1024 * 1024,
         ]
-        config.runtime_env.ring_dep_pools = [64, 128, 256, 512]
-        assert config.runtime_env.ring_task_window == 64
-        assert config.runtime_env.ring_heap == 2621440
-        assert config.runtime_env.ring_dep_pool == 256
-        assert config.runtime_env.ring_task_windows == [16, 32, 128, 256]
-        assert config.runtime_env.ring_heaps == [
+        config.runtime_env.ring_dep_pool = [64, 128, 256, 512]
+        assert config.runtime_env.ring_task_window == [16, 32, 128, 256]
+        assert config.runtime_env.ring_heap == [
             10 * 1024 * 1024,
             64 * 1024 * 1024,
             1536 * 1024 * 1024,
             4 * 1024 * 1024 * 1024,
         ]
-        assert config.runtime_env.ring_dep_pools == [64, 128, 256, 512]
+        assert config.runtime_env.ring_dep_pool == [64, 128, 256, 512]
         config.validate()
         r = repr(config)
-        assert "runtime_env.ring_task_window=64" in r
-        assert "runtime_env.ring_heap=2621440" in r
-        assert "runtime_env.ring_dep_pool=256" in r
-        assert "runtime_env.ring_task_windows=[16, 32, 128, 256]" in r
+        assert "runtime_env.ring_task_window=[16, 32, 128, 256]" in r
+        assert "runtime_env.ring_dep_pool=[64, 128, 256, 512]" in r
 
     def test_runtime_env_whole_object_assignment(self):
         re = RuntimeEnv()
-        re.ring_heap = 1024
-        re.ring_heaps = [1024, 2048, 3072, 4096]
+        re.ring_heap = 1024  # scalar broadcasts to every ring
         config = CallConfig()
         config.runtime_env = re
-        assert config.runtime_env.ring_heap == 1024
-        assert config.runtime_env.ring_heaps == [1024, 2048, 3072, 4096]
+        assert config.runtime_env.ring_heap == [1024, 1024, 1024, 1024]
+
+        re2 = RuntimeEnv()
+        re2.ring_heap = [1024, 2048, 3072, 4096]  # per-ring list
+        config.runtime_env = re2
+        assert config.runtime_env.ring_heap == [1024, 2048, 3072, 4096]
 
     def test_runtime_env_per_ring_length_validation(self):
         config = CallConfig()
         with pytest.raises(ValueError):
-            config.runtime_env.ring_task_windows = [16, 32, 64]
+            config.runtime_env.ring_task_window = [16, 32, 64]  # must be exactly 4 entries
 
     @pytest.mark.parametrize(
         ("field", "value"),
@@ -151,17 +147,17 @@ class TestCallConfig:
 
     def test_runtime_env_per_ring_validate_rejects(self):
         config = CallConfig()
-        config.runtime_env.ring_task_windows = [16, 32, 48, 64]
+        config.runtime_env.ring_task_window = [16, 32, 48, 64]  # 48 not a power of 2
         with pytest.raises(ValueError):
             config.validate()
 
         config = CallConfig()
-        config.runtime_env.ring_heaps = [1024, 512, 2048, 4096]
+        config.runtime_env.ring_heap = [1024, 512, 2048, 4096]  # 512 below min 1024
         with pytest.raises(ValueError):
             config.validate()
 
         config = CallConfig()
-        config.runtime_env.ring_dep_pools = [4, 8, 2**31, 16]
+        config.runtime_env.ring_dep_pool = [4, 8, 2**31, 16]  # 2**31 above INT32_MAX
         with pytest.raises(ValueError):
             config.validate()
 
@@ -332,12 +328,9 @@ class TestMailboxConfigRoundtrip:
         cfg.enable_pmu = 5
         cfg.enable_dep_gen = True
         cfg.enable_scope_stats = True
-        cfg.runtime_env.ring_task_window = 64
-        cfg.runtime_env.ring_heap = 4 * 1024 * 1024
-        cfg.runtime_env.ring_dep_pool = 256
-        cfg.runtime_env.ring_task_windows = [16, 32, 128, 256]
-        cfg.runtime_env.ring_heaps = [1024, 2048, 4096, 8192]
-        cfg.runtime_env.ring_dep_pools = [64, 128, 256, 512]
+        cfg.runtime_env.ring_task_window = [16, 32, 128, 256]
+        cfg.runtime_env.ring_heap = [1024, 2048, 4096, 8192]
+        cfg.runtime_env.ring_dep_pool = [64, 128, 256, 512]
         cfg.output_prefix = "/tmp/out"
 
         buf = bytearray(_OFF_CONFIG + _CFG_FMT.size)
@@ -351,12 +344,9 @@ class TestMailboxConfigRoundtrip:
             cfg.enable_pmu,
             int(cfg.enable_dep_gen),
             int(cfg.enable_scope_stats),
-            cfg.runtime_env.ring_task_window,
-            cfg.runtime_env.ring_heap,
-            cfg.runtime_env.ring_dep_pool,
-            *cfg.runtime_env.ring_task_windows,
-            *cfg.runtime_env.ring_heaps,
-            *cfg.runtime_env.ring_dep_pools,
+            *cfg.runtime_env.ring_task_window,
+            *cfg.runtime_env.ring_heap,
+            *cfg.runtime_env.ring_dep_pool,
             cfg.output_prefix.encode(),
         )
 
@@ -368,10 +358,7 @@ class TestMailboxConfigRoundtrip:
         assert decoded.enable_pmu == 5
         assert decoded.enable_dep_gen is True
         assert decoded.enable_scope_stats is True
-        assert decoded.runtime_env.ring_task_window == 64
-        assert decoded.runtime_env.ring_heap == 4 * 1024 * 1024
-        assert decoded.runtime_env.ring_dep_pool == 256
-        assert decoded.runtime_env.ring_task_windows == [16, 32, 128, 256]
-        assert decoded.runtime_env.ring_heaps == [1024, 2048, 4096, 8192]
-        assert decoded.runtime_env.ring_dep_pools == [64, 128, 256, 512]
+        assert decoded.runtime_env.ring_task_window == [16, 32, 128, 256]
+        assert decoded.runtime_env.ring_heap == [1024, 2048, 4096, 8192]
+        assert decoded.runtime_env.ring_dep_pool == [64, 128, 256, 512]
         assert decoded.output_prefix == "/tmp/out"


### PR DESCRIPTION
Closes #1126.

## Problem

#1099 exposed ring sizing through **two near-identical** `CallConfig.runtime_env` names per resource that differ only by a trailing `s`:

| scalar (broadcast) | per-ring array |
| --- | --- |
| `ring_task_window` | `ring_task_windows` |
| `ring_heap` | `ring_heaps` |
| `ring_dep_pool` | `ring_dep_pools` |

The one-letter difference is an ergonomics footgun (easy to mistype, silently accepted), and the layered "scalar baseline + per-ring override" semantics it bought are not worth the confusing twin names for this project's usage.

## Change

Collapse each pair into a **single field that accepts either an `int` (broadcast) or a 4-entry list (per-ring)**:

```python
cfg.runtime_env.ring_task_window = 128             # broadcast to every ring
cfg.runtime_env.ring_task_window = [128, 0, 0, 0]  # per-ring; 0 falls through
```

- Broadcast happens in the Python binding (`int` → `[v, v, v, v]`); the wire format now carries only the three 4-element arrays (**12 × uint64, down from 15**) and the getter always returns a 4-list.
- A `0` entry falls through to `PTO2_RING_*` env → compile-time default. The separate scalar-CallConfig precedence tier is intentionally dropped (accepted trade-off): a `0` in a list can no longer fall back to a sibling scalar, only to env/default.
- The internal C-API (`run_prepared`) and wire layout are internal-only (no external consumers; everything rebuilds together via `pip install`), so this is a clean break with no back-compat shim.

## Surface (mirrored a2a3 ⇄ a5)

Core struct + validate + wire asserts (`call_config.h`); Python binding int|list property + repr (`task_interface.cpp`); wire pack/unpack (`worker.py`); scene-test parse (`scene_test.py`); internal C-API (`pto_runtime_c_api.h`, `chip_worker.{h,cpp}`, onboard+sim `c_api_shared.cpp`, both `host_build_graph/runtime_maker.cpp`); resolution (both `tensormap_and_ringbuffer/host/runtime_maker.cpp`); docs (both `MULTI_RING.md`); tests (`test_call_config.cpp`, `test_chip_worker.py`); and the l2/l3 `per_task_runtime_env` examples.

## Test

- `tests/ut/py/test_chip_worker.py` — 26 passed (defaults/roundtrip, validate rejects, mailbox wire roundtrip, length validation), updated to the unified API.
- `tests/ut/cpp/types/test_call_config.cpp` — updated to the array struct (compiles clean; the local cpput run hits a pre-existing, change-unrelated gtest `EqFailure` link error that also fails on untouched targets like `test_child_memory`).
- l2 + l3 `per_task_runtime_env` examples and the `paged_attention*` scene tests pass under `a2a3sim`, exercising the full path: binding → wire → C-API → `resolve_ring_config` → runtime → device sim. Scalar inputs correctly arrive as `[v, v, v, v]`; lists pass through; repr shows lists.

```bash
python examples/workers/l2/per_task_runtime_env/main.py -p a2a3sim -d 0
python examples/workers/l3/per_task_runtime_env/main.py -p a2a3sim -d 0
```