### PR TITLE
Refactor: consolidate profiling init into SchedulerContext::init()

### DIFF
--- a/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a2a3/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -13,12 +13,15 @@
  * @file dep_gen_collector_aicpu.h
  * @brief AICPU-side dep_gen (SubmitTrace) capture interface
  *
- * Lifecycle (called from aicpu_executor.cpp + pto_orchestrator.cpp):
+ * Lifecycle (called from scheduler cold path + aicpu_executor.cpp):
+ *   dep_gen_aicpu_init()                — pop the initial DepGenBuffer from
+ *                                         the (single) instance's free_queue.
+ *                                         Runs in SchedulerContext::init() on
+ *                                         the single-threaded cold path.
  *   dep_gen_aicpu_set_orch_thread_idx() — record which AICPU thread runs the
  *                                         orchestrator (used to select the
  *                                         per-thread ready_queue on flush).
- *   dep_gen_aicpu_init()                — pop the initial DepGenBuffer from
- *                                         the (single) instance's free_queue.
+ *                                         Runs later on the orchestrator thread.
  *   [submit_task loop]
  *     dep_gen_aicpu_record_submit()     — append one DepGenRecord; rotate
  *                                         buffer when full.
@@ -64,7 +67,11 @@ void dep_gen_aicpu_set_orch_thread_idx(int thread_idx);
  * Pre-conditions:
  *   - Host has set the data base via set_platform_dep_gen_base()
  *   - dep_gen is enabled via set_dep_gen_enabled(true)
- *   - dep_gen_aicpu_set_orch_thread_idx() has been called
+ *
+ * The initial pop only touches instance 0's free_queue, so it does not depend
+ * on the orchestrator thread index; dep_gen_aicpu_set_orch_thread_idx() may run
+ * after this (and does — on the orchestrator thread), as long as it precedes
+ * the first record_submit.
  *
  * If the free_queue is empty at init (host bug), the function leaves the
  * current buffer as null and subsequent record_submit calls will bump

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -533,9 +533,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             runtime_init_ready_.store(true, std::memory_order_release);
 
-            // Wait for scheduler's one-time init to complete
-            sched_ctx_.wait_pto2_init_complete();
-
 #if PTO2_PROFILING
             if (get_l2_swimlane_level() >= L2SwimlaneLevel::ORCH_PHASES) {
                 l2_swimlane_aicpu_set_orch_thread_idx(thread_idx);
@@ -543,11 +540,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
-            // set the per-thread queue index and pop the initial buffer before any
-            // submit_task can fire inside orch_func_.
+            // record the per-thread ready_queue index before any submit_task fires
+            // inside orch_func_.
             if (is_dep_gen_enabled()) {
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
-                dep_gen_aicpu_init();
             }
 
 #if PTO2_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -550,7 +550,7 @@ Public surface (called from `AicpuExecutor::init/run/deinit`):
 | `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores; PMU finalize when enabled |
 | `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | orchestrator thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_`, drive orch→sched core transition (or `emergency_shutdown` on fatal) |
 | `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
-| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` / `wait_pto2_init_complete()` |
+| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` |
 
 Private internals are split across three .cpp files by responsibility:
 
@@ -640,16 +640,17 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 | Flag | Set by | Waited by | Purpose |
 | ---- | ------ | --------- | ------- |
 | `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
-| `pto2_init_claimed_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
-| `pto2_init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
+
+Profiling-subsystem init (`dump_args` / `pmu` / `dep_gen` / `l2_swimlane`) runs
+once in `SchedulerContext::init()` on the single-threaded cold path, before any
+scheduler/orchestrator thread starts — so it needs no cross-thread init
+handshake.
 
 Startup sequence:
 
 1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
-2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `pto2_init_claimed_` exchange → memset per-task arrays → set `pto2_init_complete_`; other threads wait for `pto2_init_complete_`
-3. Thread 3: wait for `pto2_init_complete_` → configure orchestrator-scheduler pointers
-4. Scheduler threads: enter main loop
-5. Thread 3: call orchestration function → set `orchestrator_done_`
+2. Scheduler threads: wait for `runtime_init_ready_` → enter main loop
+3. Thread 3: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
 
 ---
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 
 #include "common/unified_log.h"
+#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
@@ -873,12 +874,13 @@ int32_t SchedulerContext::init(
         l2_swimlane_aicpu_init(runtime->worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
-            // Sched-phase pool count: matches the dump_args_init branch in
-            // scheduler_dispatch.cpp. sched_thread_num_ <= 0 means "use all
-            // AICPU threads as scheduler threads" (see assign_cores_to_threads'
-            // active_sched_threads_ normalization at line 689). Without this
-            // normalization here, init_phase would prime zero sched pools and
-            // all sched_phase emits would silently drop.
+            // Sched-phase pool count must match the dump_args_init thread count
+            // below. This block runs before assign_cores_to_threads, so the
+            // active_sched_threads_ member isn't set yet — recompute the same
+            // normalization locally: sched_thread_num_ <= 0 means "use all AICPU
+            // threads as scheduler threads" (see assign_cores_to_threads'
+            // active_sched_threads_). Without it, init_phase would prime zero
+            // sched pools and all sched_phase emits would silently drop.
             const int active_sched = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
             const int sched_phase_threads = orch_to_sched_ ? aicpu_thread_num_ : active_sched;
             // Orchestration is always single-threaded, so orch-phase is one pool
@@ -899,6 +901,29 @@ int32_t SchedulerContext::init(
     }
     if (!assign_cores_to_threads()) {
         return -1;
+    }
+
+    // Profiling-subsystem buffer/state init: single-threaded cold path, so the
+    // "do it once" guarantee is structural (no CAS needed). Runs after
+    // handshake_all_cores / assign_cores_to_threads because pmu_aicpu_init needs
+    // physical_core_ids_ / cores_total_num_. Mirrors the l2_swimlane_aicpu_init
+    // convention above; the per-thread *_set_orch_thread_idx setters stay on the
+    // orchestrator thread (see aicpu_executor.cpp).
+#if PTO2_PROFILING
+    if (is_dump_args_enabled()) {
+        dump_args_init(orch_to_sched_ ? aicpu_thread_num_ : active_sched_threads_);
+    }
+    if (is_pmu_enabled()) {
+        pmu_aicpu_init(physical_core_ids_, cores_total_num_);
+        LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
+    }
+#endif
+    // dep_gen is host-driven (SubmitTrace) and gated independently of
+    // PTO2_PROFILING. init() only pops the initial buffer from instance 0's
+    // free_queue; the orchestrator thread still records its idx via
+    // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
+    if (is_dep_gen_enabled()) {
+        dep_gen_aicpu_init();
     }
 
     // Initialize task counters. Task count comes from PTO2 shared memory.
@@ -972,8 +997,6 @@ void SchedulerContext::deinit() {
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
     orchestrator_done_ = false;
-    pto2_init_claimed_.store(false, std::memory_order_release);
-    pto2_init_complete_.store(false, std::memory_order_release);
 
     // Reset core transition state
     transition_requested_.store(false, std::memory_order_release);
@@ -997,12 +1020,6 @@ void SchedulerContext::deinit() {
     sched_ = nullptr;
     rt_ = nullptr;
     func_id_to_addr_ = nullptr;
-}
-
-void SchedulerContext::wait_pto2_init_complete() const {
-    while (!pto2_init_complete_.load(std::memory_order_acquire)) {
-        SPIN_WAIT_HINT();
-    }
 }
 
 void SchedulerContext::bind_runtime(PTO2Runtime *rt) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -103,10 +103,6 @@ public:
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
 
-    // Block until the first scheduler thread has finished one-time PTO2 init.
-    // Called by the orchestrator thread in device-orch mode.
-    void wait_pto2_init_complete() const;
-
 private:
     // =========================================================================
     // State
@@ -178,10 +174,6 @@ private:
     // physical_core_id when PTO2_PROFILING=1.
     uint32_t physical_core_ids_[RUNTIME_MAX_WORKER]{};
 #endif
-
-    // --- One-time init coordination ---
-    std::atomic<bool> pto2_init_claimed_{false};
-    std::atomic<bool> pto2_init_complete_{false};
 
     // =========================================================================
     // Core management (scheduler_cold_path.cpp)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -780,32 +780,6 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
-    // One-time init: assign perf buffers (one thread does it; others wait)
-    if (!pto2_init_claimed_.exchange(true, std::memory_order_acq_rel)) {
-        LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
-
-#if PTO2_PROFILING
-        if (is_dump_args_enabled()) {
-            dump_args_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
-        }
-#endif
-
-#if PTO2_PROFILING
-        // Initialize PMU: program events, start counters, and pop initial buffers
-        if (is_pmu_enabled()) {
-            pmu_aicpu_init(physical_core_ids_, cores_total_num_);
-            LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
-        }
-#endif
-
-        LOG_INFO_V0("Thread %d: one-time init done", thread_idx);
-        pto2_init_complete_.store(true, std::memory_order_release);
-    } else {
-        while (!pto2_init_complete_.load(std::memory_order_acquire)) {
-            SPIN_WAIT_HINT();
-        }
-    }
-
     LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, core_trackers_[thread_idx].core_num());
     int32_t cur_thread_completed = 0;
     // Non-zero once a scheduler-hang timeout latches; returned in place of the

--- a/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
+++ b/src/a5/platform/include/aicpu/dep_gen_collector_aicpu.h
@@ -13,12 +13,15 @@
  * @file dep_gen_collector_aicpu.h
  * @brief AICPU-side dep_gen (SubmitTrace) capture interface
  *
- * Lifecycle (called from aicpu_executor.cpp + pto_orchestrator.cpp):
+ * Lifecycle (called from scheduler cold path + aicpu_executor.cpp):
+ *   dep_gen_aicpu_init()                — pop the initial DepGenBuffer from
+ *                                         the (single) instance's free_queue.
+ *                                         Runs in SchedulerContext::init() on
+ *                                         the single-threaded cold path.
  *   dep_gen_aicpu_set_orch_thread_idx() — record which AICPU thread runs the
  *                                         orchestrator (used to select the
  *                                         per-thread ready_queue on flush).
- *   dep_gen_aicpu_init()                — pop the initial DepGenBuffer from
- *                                         the (single) instance's free_queue.
+ *                                         Runs later on the orchestrator thread.
  *   [submit_task loop]
  *     dep_gen_aicpu_record_submit()     — append one DepGenRecord; rotate
  *                                         buffer when full.
@@ -64,7 +67,11 @@ void dep_gen_aicpu_set_orch_thread_idx(int thread_idx);
  * Pre-conditions:
  *   - Host has set the data base via set_platform_dep_gen_base()
  *   - dep_gen is enabled via set_dep_gen_enabled(true)
- *   - dep_gen_aicpu_set_orch_thread_idx() has been called
+ *
+ * The initial pop only touches instance 0's free_queue, so it does not depend
+ * on the orchestrator thread index; dep_gen_aicpu_set_orch_thread_idx() may run
+ * after this (and does — on the orchestrator thread), as long as it precedes
+ * the first record_submit.
  *
  * If the free_queue is empty at init (host bug), the function leaves the
  * current buffer as null and subsequent record_submit calls will bump

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -543,9 +543,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 
             runtime_init_ready_.store(true, std::memory_order_release);
 
-            // Wait for scheduler's one-time init to complete
-            sched_ctx_.wait_init_complete();
-
 #if PTO2_PROFILING
             if (get_l2_swimlane_level() >= L2SwimlaneLevel::ORCH_PHASES) {
                 l2_swimlane_aicpu_set_orch_thread_idx(thread_idx);
@@ -558,11 +555,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 #endif
 
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
-            // set the per-thread queue index and pop the initial buffer before any
-            // submit_task can fire inside orch_func_.
+            // record the per-thread ready_queue index before any submit_task fires
+            // inside orch_func_.
             if (is_dep_gen_enabled()) {
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
-                dep_gen_aicpu_init();
             }
 
 #if PTO2_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -550,7 +550,7 @@ Public surface (called from `AicpuExecutor::init/run/deinit`):
 | `shutdown(thread_idx)` | per thread on exit | `platform_deinit_aicore_regs` for this thread's cores |
 | `on_orchestration_done(runtime, rt, thread_idx, total_tasks)` | orchestrator thread | Publish core assignments, latch task count, fold inline-completed tasks, flip `orchestrator_done_`, drive orch→sched core transition (or `emergency_shutdown` on fatal) |
 | `deinit()` | once per run | Reset every scheduler-owned field to its post-construction default |
-| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` / `wait_pto2_init_complete()` |
+| Read-only accessors | various | `aic_count()` / `aiv_count()` / `is_completed()` / `completed_tasks_count()` |
 
 Private internals are split across three .cpp files by responsibility:
 
@@ -640,16 +640,17 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 | Flag | Set by | Waited by | Purpose |
 | ---- | ------ | --------- | ------- |
 | `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
-| `init_claimed_` | First init thread | Others | One-time memset of arrays started (exchange guard) |
-| `init_complete_` | Init thread | Thread 3 + others | One-time init of per-task arrays done |
+
+Profiling-subsystem init (`dump_args` / `pmu` / `dep_gen` / `l2_swimlane`) runs
+once in `SchedulerContext::init()` on the single-threaded cold path, before any
+scheduler/orchestrator thread starts — so it needs no cross-thread init
+handshake.
 
 Startup sequence:
 
 1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
-2. Scheduler threads: wait for `runtime_init_ready_` → one thread wins `init_claimed_` exchange → memset per-task arrays → set `init_complete_`; other threads wait for `init_complete_`
-3. Thread 3: wait for `init_complete_` → configure orchestrator-scheduler pointers
-4. Scheduler threads: enter main loop
-5. Thread 3: call orchestration function → set `orchestrator_done_`
+2. Scheduler threads: wait for `runtime_init_ready_` → enter main loop
+3. Thread 3: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -14,6 +14,7 @@
 #include <cstdio>
 
 #include "common/unified_log.h"
+#include "aicpu/dep_gen_collector_aicpu.h"
 #include "aicpu/device_time.h"
 #include "aicpu/l2_swimlane_collector_aicpu.h"
 #include "aicpu/platform_regs.h"
@@ -881,12 +882,14 @@ int32_t SchedulerContext::init(
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
             // When orchestrator phases merge into scheduler threads
             // (PTO2_ORCH_TO_SCHED=1), phase records flow through
-            // aicpu_thread_num_ pools — matches the same branch in
-            // dump_args_init (scheduler_dispatch.cpp).
+            // aicpu_thread_num_ pools — matches the same branch in the
+            // dump_args_init call below.
             // Sched phase pool count = number of scheduler threads.
-            // sched_thread_num_ <= 0 is the "use all AICPU threads as
-            // scheduler threads" sentinel (see assign_cores_to_threads'
-            // active_sched_threads_ normalization). Without this
+            // This block runs before assign_cores_to_threads, so the
+            // active_sched_threads_ member isn't set yet — recompute the same
+            // normalization locally: sched_thread_num_ <= 0 is the "use all
+            // AICPU threads as scheduler threads" sentinel (see
+            // assign_cores_to_threads' active_sched_threads_). Without this
             // normalization here, init_phase would prime zero sched pools
             // and all sched_phase emits would silently drop.
             const int active_sched = (sched_thread_num_ > 0) ? sched_thread_num_ : aicpu_thread_num_;
@@ -909,6 +912,29 @@ int32_t SchedulerContext::init(
     }
     if (!assign_cores_to_threads()) {
         return -1;
+    }
+
+    // Profiling-subsystem buffer/state init: single-threaded cold path, so the
+    // "do it once" guarantee is structural (no CAS needed). Runs after
+    // handshake_all_cores / assign_cores_to_threads because pmu_aicpu_init needs
+    // physical_core_ids_ / cores_total_num_. Mirrors the l2_swimlane_aicpu_init
+    // convention above; the per-thread *_set_orch_thread_idx setters stay on the
+    // orchestrator thread (see aicpu_executor.cpp).
+#if PTO2_PROFILING
+    if (is_dump_args_enabled()) {
+        dump_args_init(orch_to_sched_ ? aicpu_thread_num_ : active_sched_threads_);
+    }
+    if (is_pmu_enabled()) {
+        pmu_aicpu_init(physical_core_ids_, cores_total_num_);
+        LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
+    }
+#endif
+    // dep_gen is host-driven (SubmitTrace) and gated independently of
+    // PTO2_PROFILING. init() only pops the initial buffer from instance 0's
+    // free_queue; the orchestrator thread still records its idx via
+    // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
+    if (is_dep_gen_enabled()) {
+        dep_gen_aicpu_init();
     }
 
     // Initialize task counters. Task count comes from PTO2 shared memory.
@@ -982,8 +1008,6 @@ void SchedulerContext::deinit() {
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
     orchestrator_done_ = false;
-    init_claimed_.store(false, std::memory_order_release);
-    init_complete_.store(false, std::memory_order_release);
 
     // Reset core transition state
     transition_requested_.store(false, std::memory_order_release);
@@ -1007,12 +1031,6 @@ void SchedulerContext::deinit() {
     sched_ = nullptr;
     rt_ = nullptr;
     func_id_to_addr_ = nullptr;
-}
-
-void SchedulerContext::wait_init_complete() const {
-    while (!init_complete_.load(std::memory_order_acquire)) {
-        SPIN_WAIT_HINT();
-    }
 }
 
 void SchedulerContext::bind_runtime(PTO2Runtime *rt) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -101,10 +101,6 @@ public:
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
 
-    // Block until the first scheduler thread has finished one-time PTO2 init.
-    // Called by the orchestrator thread in device-orch mode.
-    void wait_init_complete() const;
-
 private:
     // =========================================================================
     // State
@@ -178,10 +174,6 @@ private:
 
     // Platform AICore-register base array (set by AicpuExecutor before init()).
     uint64_t regs_{0};
-
-    // --- One-time init coordination ---
-    std::atomic<bool> init_claimed_{false};
-    std::atomic<bool> init_complete_{false};
 
     // =========================================================================
     // Core management (scheduler_cold_path.cpp)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -497,33 +497,6 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
-    // One-time init: assign perf buffers (one thread does it; others wait).
-    // l2_swimlane_aicpu_init / l2_swimlane_aicpu_init_phase already ran eagerly in
-    // SchedulerContext::init() so the orchestrator thread can read the
-    // promoted g_l2_swimlane_level before caching it on rt->orchestrator. Only
-    // dump_tensor / pmu init remain dispatch-time because they depend on
-    // handshake-derived core IDs / counts.
-    if (!init_claimed_.exchange(true, std::memory_order_acq_rel)) {
-        LOG_INFO_V0("Thread %d: doing one-time init", thread_idx);
-
-#if PTO2_PROFILING
-        if (is_dump_args_enabled()) {
-            dump_args_init(orch_to_sched_ ? aicpu_thread_num_ : sched_thread_num_);
-        }
-        if (is_pmu_enabled()) {
-            pmu_aicpu_init(physical_core_ids_, cores_total_num_);
-            LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
-        }
-#endif
-
-        LOG_INFO_V0("Thread %d: one-time init done", thread_idx);
-        init_complete_.store(true, std::memory_order_release);
-    } else {
-        while (!init_complete_.load(std::memory_order_acquire)) {
-            SPIN_WAIT_HINT();
-        }
-    }
-
     LOG_INFO_V0("Thread %d: PTO2 dispatch starting with %d cores", thread_idx, tracker.core_num());
     int32_t cur_thread_completed = 0;
     // Non-zero once a scheduler-hang timeout latches; returned in place of the


### PR DESCRIPTION
## Summary

Consolidate the `dump_args` / `pmu` / `dep_gen` profiling-subsystem buffer init
out of the dispatch-loop one-time-init block (CAS-guarded across scheduler
threads) into the single-threaded `SchedulerContext::init()` cold path, matching
the existing `l2_swimlane` convention. Applied to **both a2a3 and a5** in
lockstep so the runtimes don't drift. Resolves #1120.

- `dump_args_init` / `pmu_aicpu_init` / `dep_gen_aicpu_init` now run once in
  `init()` after `handshake_all_cores` / `assign_cores_to_threads`
  (`pmu_aicpu_init` needs `physical_core_ids_` / `cores_total_num_`). The three
  `*_set_orch_thread_idx` setters (swimlane / dep_gen / scope_stats) stay on the
  orchestrator thread.
- Delete the one-time-init block, the `init_claimed_` / `init_complete_`
  (a2a3: `pto2_*`) atomics, and `wait_*init_complete()`, removing a cross-thread
  handshake from the orchestrator critical path. `init()` being single-threaded
  makes the run-once guarantee structural — no CAS needed.
- Update the dep_gen header pre-conditions (the initial pop touches only
  instance 0's free_queue, so it no longer depends on the orchestrator thread
  index) and the RUNTIME_LOGIC startup-sync docs.

Code-health / consistency cleanup; no behavior change.

## Testing

- **a2a3 onboard** (via `task-submit`, `--platform a2a3`) — dfx profiling smoke:
  - `dfx/pmu` (`--enable-pmu 1`) → PASS, `pmu.csv` produced
  - `dfx/dep_gen` + `dfx/dep_gen_chain` (`--enable-dep-gen`) → PASS, `deps.json` produced
  - `dfx/tensor_dump` (`--dump-args 1`) → PASS
  - `dfx/l2_swimlane` + `_mixed` (`--enable-l2-swimlane 4`) → PASS (scheduler-phase capture + overhead analysis)
- **a5sim** — `dfx/dep_gen/test_dep_gen` default case → PASS.
- **Build** — both a2a3 and a5 build cleanly for `*sim` (host) and `onboard`
  (CCEC cross-compile: AICPU + AICore + Host).
- **Not a regression** — `a5sim dfx/dep_gen/test_dep_gen_chain` fails on a
  pre-existing sim host-side `DepGenCollector` multi-case lifecycle issue
  (`init`/`finalize` not paired across CASES). Reproduced identically on
  unmodified `main` (this refactor git-stashed away), so it is independent of
  this change; single-default-case runs pass.