### PR TITLE
Refactor: remove per-task DeviceArgs from KernelArgs

### DIFF
--- a/docs/aicpu-kernel-launch-mechanisms.md
+++ b/docs/aicpu-kernel-launch-mechanisms.md
@@ -90,8 +90,57 @@ The dispatcher exports three symbols
 (`StaticTileFwkBackendKernelServer` +
 `DynTileFwkBackendKernelServerInit` +
 `DynTileFwkBackendKernelServer`) — see
-[`src/common/aicpu_dispatcher/`](../src/common/aicpu_dispatcher/) for
-the symbol-level contract.
+[`src/common/aicpu_loader/device/`](../src/common/aicpu_loader/device/)
+for the symbol-level contract.
+
+### Bootstrap ABI vs per-task launch ABI
+
+There are two similarly shaped but separate argument channels in the current
+onboard Path A implementation:
+
+1. **Dispatcher bootstrap private ABI.**
+   `LoadAicpuOp::BootstrapDispatcher()` builds a private argument blob for
+   `rtAicpuKernelLaunchExWithArgs(KERNEL_TYPE_AICPU_KFC, ...)` and writes a
+   `device_args_ptr` at offset 40. The dispatcher reads that pointer as an
+   extended `DeviceArgs` object carrying dispatcher SO bytes, inner runtime SO
+   bytes, and `device_id`. This ABI belongs only to bootstrap and is kept in
+   `src/common/aicpu_loader/{host,device}`.
+2. **AICPU per-task launch ABI.**
+   The per-task launch hands the front-less `KernelArgs` payload directly to
+   `rtsLaunchCpuKernel()` (`cpu_args.baseArgs.args = &kernel_args.args`,
+   `argsSize = sizeof(KernelArgs)`). There is no CANN launch front on this
+   path — `runtime_args` sits at offset 0 and the AICPU entry reads it directly.
+3. **Shared per-task `KernelArgs` payload.**
+   `src/{a2a3,a5}/platform/include/common/kernel_args.h` is front-less.
+   Runtime state is passed through `KernelArgs::runtime_args`,
+   profiling/logging fields, register tables, and `device_id`. AICore receives
+   only this payload through the host-owned device copy.
+
+Keep those channels distinct. The bootstrap ABI still uses the `DeviceArgs`
+name because the dispatcher really reads that structure. The platform per-task
+ABI passes only the front-less `KernelArgs` and carries no CANN launch front.
+
+The per-task launch buffer is exactly the front-less `KernelArgs`:
+
+```text
+KernelArgs + 0:  runtime_args
+KernelArgs + 8:  regs
+```
+
+An earlier revision wrapped this payload behind a 48-byte CANN launch front
+(`AicpuLaunchArgs`, an opaque pointer at offset 40 plus the payload at offset
+48) on the belief that `rtsLaunchCpuKernel` required it: removing the front had
+produced CANN `507018` on a2a3 onboard. That failure was traced to build
+skew — the AICPU inner SO and AICore `.o` had not been rebuilt against the
+moved offsets — not a CANN requirement. With a clean rebuild, passing the bare
+`KernelArgs` (`runtime_args` @ 0, `argsSize = sizeof(KernelArgs)`) is verified
+working on a2a3 onboard across HBG and TRB, so the front was removed.
+
+### Ownership boundaries
+
+- `LoadAicpuOp` still owns both dispatcher bootstrap registration and cached
+  per-task AICPU entry launches. Splitting those into separate loader objects
+  would be a larger lifecycle refactor.
 
 ## Method 3: Path B — `KERNEL_TYPE_AICPU_CUSTOM` (broken — #822)
 
@@ -209,11 +258,9 @@ above stays valid.
   the bug report with the diagnostic D2H recipe and CANN source
   pointers
 - PR #537 — the migration that attempted Path B
-- [`src/common/aicpu_dispatcher/`](../src/common/aicpu_dispatcher/) —
-  the dispatcher's three-symbol contract
-  (`StaticTileFwkBackendKernelServer` /
-  `DynTileFwkBackendKernelServerInit` /
-  `DynTileFwkBackendKernelServer`)
+- [`src/common/aicpu_loader/`](../src/common/aicpu_loader/) —
+  the dispatcher bootstrap, three-symbol device contract, and per-task
+  launch loader
 - [`tools/cann-examples/aicpu-kernel-launch/`](../tools/cann-examples/aicpu-kernel-launch/) —
   the standalone reference tool implementing Path A
 - [`tools/cann-examples/aicpu-device-query/`](../tools/cann-examples/aicpu-device-query/) —

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -34,15 +34,26 @@ Python process (ChipWorker)
     |
     +-- DeviceRunner (handle-based, one per ChipWorker)
     |     |
-    |     +-- rtMemcpy(aicpu_binary → device HBM)    ← NOT dlopen, binary blob upload
-    |     +-- rtRegisterAllKernel(aicore_binary)      ← CANN kernel registration
-    |     +-- rtAicpuKernelLaunchExWithArgs(...)       ← device-side execution
+    |     +-- LoadAicpuOp::BootstrapDispatcher()
+    |     |     |
+    |     |     +-- rtAicpuKernelLaunchExWithArgs(KERNEL_TYPE_AICPU_KFC)
+    |     |           dispatcher writes simpler_inner_<fp>_<device_id>.so
+    |     |
+    |     +-- LoadAicpuOp::Init()
+    |     |     |
+    |     |     +-- rtsBinaryLoadFromFile(...)       ← register preinstall runtime SO
+    |     |     +-- rtsFuncGetByName(...)            ← cache AICPU entry handles
+    |     |
+    |     +-- rtsLaunchCpuKernel(...)                ← per-task AICPU launches
+    |     +-- rtRegisterAllKernel(aicore_binary)     ← CANN kernel registration
     |
     +-- dlopen("libascend_hal.so", RTLD_NOW | RTLD_LOCAL)  ← CANN HAL (profiling only)
 ```
 
 Key difference: onboard does **not** dlopen AICPU/AICore as host-side SOs.
-They are binary blobs uploaded to device memory and executed by CANN runtime.
+The runtime AICPU SO is written once to the device preinstall path through
+the dispatcher bootstrap, then registered and launched by CANN runtime handles.
+AICore remains a CANN-registered binary blob.
 
 ## RTLD Flags and Rationale
 
@@ -240,18 +251,26 @@ Applies to all 4 runtime executors: a2a3 (hbg, tmr), a5 (hbg, tmr).
 | Resource | Caching | Lifecycle |
 | -------- | ------- | --------- |
 | Host runtime | `ChipWorker::lib_handle_` | Per-runtime-group: shared across tasks in same group |
-| AICPU binary | `AicpuSoInfo` in DeviceRunner | Per-runtime-group: uploaded to device HBM once, reused |
+| Dispatcher SO bytes | `DeviceRunnerBase::dispatcher_so_binary_` | Init-only: passed to `LoadAicpuOp::BootstrapDispatcher`, then cleared |
+| Runtime AICPU SO | Preinstall file `simpler_inner_<fp>_<device_id>.so` | Written once through dispatcher bootstrap, then registered via `rtsBinaryLoadFromFile` |
+| AICPU entry handles | `LoadAicpuOp` cached `rtFuncHandle`s | Per-runtime-group: reused by `rtsLaunchCpuKernel` on every task |
 | AICore binary | `rtRegisterAllKernel` handle | Per-run: registered each `launch_aicore_kernel()` call |
 | Kernel binaries | `func_id_to_addr_` (device GM addresses) | Per-task: uploaded to device GM, cached by func_id |
 | CANN HAL | `g_hal_handle` (file-scope static) | Process lifetime: loaded once for profiling, never closed |
 
 ### Key difference
 
-Onboard caches more aggressively — the DeviceRunner persists
-across tasks within a runtime group, and the AICPU binary stays in device memory. Simulation
-re-loads AICPU/AICore SOs every `run()` call because the SO's internal
-static state (`g_aicpu_executor`) must be fresh for each task when
+Onboard caches more aggressively. The `DeviceRunner` persists across tasks
+within a runtime group, the runtime AICPU SO is preinstalled once through the
+dispatcher bootstrap, and per-task launches reuse cached `rtFuncHandle`s.
+Simulation re-loads AICPU/AICore SOs every `run()` call because the SO's
+internal static state (`g_aicpu_executor`) must be fresh for each task when
 different tasks have different configurations.
+
+Onboard per-task launches pass the front-less `KernelArgs` payload directly to
+`rtsLaunchCpuKernel` with no CANN launch front: runtime state flows through
+`runtime_args` (at offset 0) and the other profiling/logging/register fields.
+AICore receives only a device copy of that same `KernelArgs` payload.
 
 ## Execution Lifecycle
 
@@ -302,13 +321,26 @@ device_worker_main(device_id)
     ChipWorker.init(device_id, bins)                    # Python wrapper
       ctypes.CDLL(libsimpler_log.so, RTLD_GLOBAL)       # once per process
       simpler_log_init(log_level, log_info_v)
-      _ChipWorker.init(host_path, aicpu_path, aicore_path, device_id)   # C++
+      _ChipWorker.init(host_path, aicpu_path, aicore_path,
+                       dispatcher_path, device_id)       # C++
         dlopen(host_runtime.so, RTLD_LOCAL)
         create_device_context()
-        simpler_init(ctx, device_id, aicpu*, aicpu_size, aicore*, aicore_size)
+        simpler_init(ctx, device_id,
+                     aicpu*, aicpu_size, aicore*, aicore_size,
+                     dispatcher*, dispatcher_size)
           dlog_setlevel(HostLogger.level())               sync CANN dlog before context open
           DeviceRunner::attach_current_thread(device_id)  rtSetDevice()
           DeviceRunner::set_executors(aicpu, aicore)
+          DeviceRunner::set_dispatcher_binary(dispatcher)
+          DeviceRunner::ensure_device_initialized()
+            rtStreamCreate(AICPU + AICore)
+            LoadAicpuOp::BootstrapDispatcher()
+              rtAicpuKernelLaunchExWithArgs(KERNEL_TYPE_AICPU_KFC)
+              dispatcher writes simpler_inner_<fp>_<device_id>.so
+            LoadAicpuOp::Init()
+              rtsBinaryLoadFromFile()
+              rtsFuncGetByName(simpler_aicpu_exec, ...)
+            init CANN runtime-launch compatibility payload
 
     for each callable:
         ChipWorker.prepare_callable(callable)   # returns opaque handle
@@ -321,8 +353,8 @@ device_worker_main(device_id)
               bind_prepared_callable_to_runtime()
               bind_prepared_to_runtime_impl()  rtMalloc, rtMemcpy to device
               DeviceRunner::run()
-                ensure_binaries_loaded()       rtMemcpy AICPU SO to HBM (once)
-                rtAicpuKernelLaunchExWithArgs() launch on device
+                ensure_binaries_loaded()       already done by init
+                rtsLaunchCpuKernel()           cached rtFuncHandle
                 rtStreamSynchronize()          wait for completion
                 launch_aicore_kernel()         rtRegisterAllKernel + rtKernelLaunch
               validate_runtime_impl()          rtMemcpy results back to host

--- a/docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
+++ b/docs/troubleshooting/a2a3-507899-aicpu-shared-so-fault.md
@@ -88,11 +88,12 @@ Make the staged SO names **per-device** so paired dies never touch the same
 file:
 
 - Dispatcher inner SO: `simpler_inner_<fp>_<device_id>.so`
-  (`src/common/aicpu_dispatcher/aicpu_dispatcher.cpp` `MakeInnerSoPath`,
-  `src/common/host/load_aicpu_op.cpp` `MakeInnerSoBasename`). The real
-  `device_id` (was hardcoded `0`) is threaded from `DeviceRunner` through
-  `BootstrapDispatcher` into both the host JSON reader name and the device-side
-  writer (`DeviceArgs.device_id`). Bootstrap cache keyed by `(fp, device_id)`.
+  (`src/common/aicpu_loader/device/aicpu_dispatcher.cpp` `MakeInnerSoPath`,
+  `src/common/aicpu_loader/host/load_aicpu_op.cpp`
+  `MakeInnerSoBasename`). The real `device_id` (was hardcoded `0`) is
+  threaded from `DeviceRunner` through `BootstrapDispatcher` into both the host
+  JSON reader name and the device-side writer (`DeviceArgs.device_id`).
+  Bootstrap cache keyed by `(fp, device_id)`.
 - AICPU executor orchestration SO: `libdevice_orch_<pid>_<cid>_<device_id>.so`
   (`create_orch_so_file`). `device_id` reaches the executor via a new
   `KernelArgs.device_id` field → `set_orch_device_id()` in `kernel.cpp` →

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -10,19 +10,22 @@
  */
 /**
  * @file kernel_args.h
- * @brief KernelArgs Structure - Shared between Host, AICPU, and AICore
+ * @brief KernelArgs payload - Shared between Host, AICPU, and AICore
  *
- * This structure is used to pass arguments to both AICPU and AICore kernels.
- * It contains pointers to device memory for arguments and runtime data.
+ * This structure is the Simpler runtime payload read by AICPU and AICore
+ * kernels. It contains pointers to device memory for runtime data, profiling
+ * buffers, and platform state.
  *
  * Platform Support:
  * - a2a3: Real hardware with CANN runtime compatibility
  * - a2a3sim: Host-based simulation using standard memory
  *
  * Memory Layout (a2a3):
- * This structure's layout is hardcoded in libaicpu_extend_kernels.so, which
- * expects specific offsets for deviceArgs fields. The unused[5] array provides
- * the required offset alignment for compatibility with the CANN runtime.
+ * This platform struct is the front-less per-task runtime payload, passed
+ * directly to the onboard AICPU launch (rtsLaunchCpuKernel) and copied to
+ * device memory for AICore — no CANN launch front is needed on this path.
+ * The bootstrap dispatcher has its own private KernelArgs/DeviceArgs ABI in
+ * src/common/aicpu_loader/device/aicpu_dispatcher.cpp.
  *
  * Memory Layout (a2a3sim):
  * For simulation, the layout is maintained for API compatibility, though
@@ -32,10 +35,10 @@
 #ifndef PLATFORM_COMMON_KERNEL_ARGS_H_
 #define PLATFORM_COMMON_KERNEL_ARGS_H_
 
+#include <cstddef>
 #include <cstdint>
 
 // Forward declarations
-class DeviceArgs;
 class Runtime;
 
 #ifdef __cplusplus
@@ -50,13 +53,12 @@ extern "C" {
 #endif
 
 /**
- * Kernel arguments structure
+ * Kernel arguments payload
  *
- * This structure is passed to AICPU kernels by the host.
+ * This structure is the payload passed to AICPU kernels by the host and copied
+ * to device memory for AICore kernels.
  *
  * Field Access Patterns:
- * - unused[5]: Padding for alignment with CANN runtime expectations
- * - device_args: Written by host, read by AICPU (contains aicpu_so_bin/aicpu_so_len)
  * - runtime_args: Written by host, read by AICPU (task runtime, includes
  *   handshake buffers)
  * - dump_data_base: Written by host, read by AICPU platform layer; zero when
@@ -73,31 +75,27 @@ extern "C" {
  * - bit2: PMU enabled
  * - bit3: dep_gen capture enabled
  *
- * Field Access Patterns:
- *       - AICPU: receives KernelArgs* via DynTileFwkBackendKernelServer
- *       - AICore: receives KernelArgs* via KERNEL_ENTRY
+ * Consumer paths:
+ *       - AICPU: receives this KernelArgs directly via rtsLaunchCpuKernel
+ *       - AICore: receives device KernelArgs* via KERNEL_ENTRY
  */
 struct KernelArgs {
-    uint64_t unused[5] = {0};                               // Alignment padding (required by CANN runtime offset)
-    DeviceArgs *device_args{nullptr};                       // Device arguments (AICPU reads, contains SO info)
     __may_used_by_aicore__ Runtime *runtime_args{nullptr};  // Task runtime in device memory
     uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
     uint64_t ffts_base_addr{0};                             // FFTS base address for AICore
     uint64_t dump_data_base{0};  // Dump shared memory base address; use explicit flags to detect enablement
-    uint64_t l2_swimlane_data_base{
-        0
-    };  // L2 swimlane shared memory base address; use explicit flags to detect enablement
+    // L2 swimlane shared memory base address; use explicit flags to detect enablement
+    uint64_t l2_swimlane_data_base{0};
     uint64_t pmu_data_base{0};          // PMU shared memory base address; use explicit flags to detect enablement
     uint64_t pmu_reg_addrs{0};          // Per-core PMU MMIO register base address array (onboard only; 0 on sim)
     uint64_t dep_gen_data_base{0};      // dep_gen shared memory base address; use explicit flags to detect enablement
     uint64_t scope_stats_data_base{0};  // ScopeStatsBuffer shared memory base; 0 when scope_stats is off.
                                         // Allocated by host's ScopeStatsCollector, read+written by AICPU's
                                         // scope_stats_collector via set_platform_scope_stats_base.
-    uint64_t l2_swimlane_aicore_rotation_table{
-        0
-    };  // Device ptr to a uint64_t[num_aicore] table holding each core's
-        // L2SwimlaneAicoreTaskBuffer address. AICore kernel entry indexes by block_idx
-        // and forwards into platform set/get state. 0 when L2 swimlane is off.
+    // Device ptr to a uint64_t[num_aicore] table holding each core's
+    // L2SwimlaneAicoreTaskBuffer address. AICore kernel entry indexes by block_idx
+    // and forwards into platform set/get state. 0 when L2 swimlane is off.
+    uint64_t l2_swimlane_aicore_rotation_table{0};
     uint32_t log_level{1};              // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
     uint32_t log_info_v{5};             // INFO verbosity threshold (0..9); default V5
     uint32_t enable_profiling_flag{0};  // Profiling umbrella bitmask; dump_tensor|l2_swimlane|pmu|dep_gen|scope_stats
@@ -105,8 +103,8 @@ struct KernelArgs {
 
     // Device pointer to the run-wall buffer the platform AICPU entry writes.
     // Allocated once and kept resident, reset each run. Onboard AICPU receives
-    // KernelArgs as a CANN-private copy (see rtAicpuKernelLaunchExWithArgs in
-    // launch_aicpu_kernel), so an inline field would be write-only from AICPU;
+    // KernelArgs as a CANN-private copy (see launch_aicpu_kernel), so an
+    // inline field would be write-only from AICPU;
     // the dedicated host-allocated buffer's address travels via this field.
     // Onboard layout: one { start_cycle, end_cycle } pair per launched AICPU
     // thread (PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH pairs, raw sys-counter
@@ -120,10 +118,11 @@ struct KernelArgs {
     // staged orchestration SO name (libdevice_orch_<pid>_<cid>_<device_id>.so):
     // paired a2a3 dies share the preinstall filesystem, and a content/pid-only
     // name risks a cross-die write/execute collision (see simpler_inner fix).
-    // Trailing field — keeps the CANN-fixed front offsets and AICore-read
-    // fields in place.
     uint32_t device_id{0};
 };
+
+static_assert(offsetof(KernelArgs, runtime_args) == 0, "KernelArgs::runtime_args offset drift");
+static_assert(offsetof(KernelArgs, regs) == 8, "KernelArgs::regs offset drift");
 
 #ifdef __cplusplus
 }

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -48,7 +48,7 @@ extern "C" int aicpu_prewarm_callable(Runtime *arg);
  * only writes this SO to the preinstall path — it does not dlsym this symbol
  * itself.
  *
- * @param arg Pointer to KernelArgs structure containing runtime_args
+ * @param arg Pointer to the front-less KernelArgs payload (runtime_args @ 0)
  * @return 0 on success, non-zero on error
  */
 extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *arg) {
@@ -60,8 +60,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
         return -1;
     }
 
-    // Extract Runtime from KernelArgs
-    auto k_args = (KernelArgs *)arg;
+    KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
     Runtime *runtime = k_args->runtime_args;
 
     if (runtime == nullptr) {
@@ -143,7 +142,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_prewarm_call
         return -1;
     }
 
-    auto k_args = (KernelArgs *)arg;
+    KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
     Runtime *runtime = k_args->runtime_args;
     if (runtime == nullptr) {
         LOG_ERROR("%s", "Invalid prewarm runtime_args: null pointer");

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -15,7 +15,6 @@
  * kernels on Ascend devices using CANN runtime APIs.
  *
  * Key Components:
- * - DeviceArgs: AICPU device argument structure
  * - KernelArgsHelper: Helper for managing kernel arguments with device memory
  * - DeviceRunner: kernel launching and execution
  */
@@ -45,7 +44,7 @@
 #include "common/unified_log.h"
 #include "utils/device_arena.h"
 #include "device_runner_base.h"     // common DeviceRunnerBase
-#include "device_runner_helpers.h"  // common DeviceArgs + KernelArgsHelper
+#include "device_runner_helpers.h"  // common KernelArgsHelper
 #include "host/function_cache.h"
 #include "host/memory_allocator.h"
 #include "host/l2_swimlane_collector.h"
@@ -186,7 +185,7 @@ private:
     // worker_count_, executor + dispatcher bytes, aicore_bin_handle_,
     // load_aicpu_op_, mem_alloc_, the three DeviceArenas + their cached
     // sizes, persistent AICPU/AICore streams, kernel_args_, device_wall_*,
-    // device_args_, binaries_loaded_) is inherited from `DeviceRunnerBase`.
+    // binaries_loaded_) is inherited from `DeviceRunnerBase`.
 
     // Group D state (`chip_callable_buffers_`, `callables_`,
     // `orch_so_dedup_`, `aicpu_seen_callable_ids_`, `aicpu_dlopen_total_`,

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -10,19 +10,22 @@
  */
 /**
  * @file kernel_args.h
- * @brief KernelArgs Structure - Shared between Host, AICPU, and AICore
+ * @brief KernelArgs payload - Shared between Host, AICPU, and AICore
  *
- * This structure is used to pass arguments to both AICPU and AICore kernels.
- * It contains pointers to device memory for arguments and runtime data.
+ * This structure is the Simpler runtime payload read by AICPU and AICore
+ * kernels. It contains pointers to device memory for runtime data, profiling
+ * buffers, and platform state.
  *
  * Platform Support:
  * - a5: Real hardware with CANN runtime compatibility
  * - a5sim: Host-based simulation using standard memory
  *
  * Memory Layout (a5):
- * This structure's layout is hardcoded in libaicpu_extend_kernels.so, which
- * expects specific offsets for deviceArgs fields. The unused[5] array provides
- * the required offset alignment for compatibility with the CANN runtime.
+ * This platform struct is the front-less per-task runtime payload, passed
+ * directly to the onboard AICPU launch (rtsLaunchCpuKernel) and copied to
+ * device memory for AICore — no CANN launch front is needed on this path.
+ * The bootstrap dispatcher has its own private KernelArgs/DeviceArgs ABI in
+ * src/common/aicpu_loader/device/aicpu_dispatcher.cpp.
  *
  * Memory Layout (a5sim):
  * For simulation, the layout is maintained for API compatibility, though
@@ -32,10 +35,10 @@
 #ifndef PLATFORM_COMMON_KERNEL_ARGS_H_
 #define PLATFORM_COMMON_KERNEL_ARGS_H_
 
+#include <cstddef>
 #include <cstdint>
 
 // Forward declarations
-class DeviceArgs;
 class Runtime;
 
 #ifdef __cplusplus
@@ -50,39 +53,34 @@ extern "C" {
 #endif
 
 /**
- * Kernel arguments structure
+ * Kernel arguments payload
  *
- * This structure is passed to AICPU kernels by the host.
+ * This structure is the payload passed to AICPU kernels by the host and copied
+ * to device memory for AICore kernels.
  *
  * Field Access Patterns:
- * - unused[5]: Padding for alignment with CANN runtime expectations
- * - device_args: Written by host, read by AICPU (contains aicpu_so_bin/aicpu_so_len)
  * - runtime_args: Written by host, read by AICPU (task runtime, includes
  *   handshake buffers)
  * - dep_gen_data_base: Written by host platform, read by AICPU platform layer;
  *   zero when dep_gen capture is unused
  *
- * Note: AICore kernels receive Runtime* directly, not KernelArgs
- *       - AICPU: accesses runtime_args->workers directly
- *       - AICore: receives Runtime* pointer with workers at offset 0
+ * Consumer paths:
+ *       - AICPU: receives this KernelArgs directly via rtsLaunchCpuKernel
+ *       - AICore: receives device KernelArgs* via KERNEL_ENTRY
  */
 struct KernelArgs {
-    uint64_t unused[5] = {0};                               // Alignment padding (required by CANN runtime offset)
-    DeviceArgs *device_args{nullptr};                       // Device arguments (AICPU reads, contains SO info)
     __may_used_by_aicore__ Runtime *runtime_args{nullptr};  // Task runtime in device memory
     uint64_t regs{0};                                       // Per-core register base address array (platform-specific)
     uint64_t dump_data_base{0};  // Dump shared memory base address; use explicit flags to detect enablement
-    uint64_t l2_swimlane_data_base{
-        0
-    };  // L2 swimlane shared memory base address; use explicit flags to detect enablement
+    // L2 swimlane shared memory base address; use explicit flags to detect enablement
+    uint64_t l2_swimlane_data_base{0};
     uint64_t pmu_data_base{0};      // PMU buffer base address (device memory); 0 = PMU disabled
     uint64_t dep_gen_data_base{0};  // dep_gen shared memory base address; use explicit flags to detect enablement
     // Profiling per-core address arrays (moved out of Handshake). Each *_addrs
     // field is a device pointer to uint64_t[num_aicore]. AICore KERNEL_ENTRY
     // indexes by block_idx and forwards into per-core platform state.
-    uint64_t l2_swimlane_aicore_rotation_table{
-        0
-    };  // L2SwimlaneActiveHead* per core (rotation channel); 0 when L2 swimlane is off
+    // L2SwimlaneActiveHead* per core (rotation channel); 0 when L2 swimlane is off
+    uint64_t l2_swimlane_aicore_rotation_table{0};
     uint64_t aicore_pmu_ring_addrs{0};  // PmuAicoreRing* per core; 0 when PMU is off
     uint64_t scope_stats_data_base{0};  // ScopeStatsBuffer device pointer; 0 when scope_stats is off.
                                         // a5 has no halHostRegister — host keeps a separate shadow and
@@ -99,8 +97,7 @@ struct KernelArgs {
     uint64_t device_wall_data_base{0};
     // ACL device ordinal. Pushed to the AICPU so the executor can suffix the
     // staged orchestration SO name (libdevice_orch_<pid>_<cid>_<device_id>.so),
-    // mirroring the per-device simpler_inner preinstall fix. Trailing field —
-    // keeps the CANN-fixed front offsets and AICore-read fields in place.
+    // mirroring the per-device simpler_inner preinstall fix.
     uint32_t device_id{0};
     // Opaque always-false guard read by the AICore SIMT meta anchor (AIV
     // KERNEL_ENTRY). The host never sets it non-zero; its only purpose is to be
@@ -109,6 +106,9 @@ struct KernelArgs {
     // still classifies the entry as SIMT. Keep it last (trailing field).
     uint32_t force_simt_anchor{0};
 };
+
+static_assert(offsetof(KernelArgs, runtime_args) == 0, "KernelArgs::runtime_args offset drift");
+static_assert(offsetof(KernelArgs, regs) == 8, "KernelArgs::regs offset drift");
 
 #ifdef __cplusplus
 }

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -48,7 +48,7 @@ extern "C" int aicpu_prewarm_callable(Runtime *arg);
  * only writes this SO to the preinstall path — it does not dlsym this symbol
  * itself.
  *
- * @param arg Pointer to KernelArgs structure containing runtime_args
+ * @param arg Pointer to the front-less KernelArgs payload (runtime_args @ 0)
  * @return 0 on success, non-zero on error
  */
 extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *arg) {
@@ -60,8 +60,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
         return -1;
     }
 
-    // Extract Runtime from KernelArgs
-    auto k_args = (KernelArgs *)arg;
+    KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
     Runtime *runtime = k_args->runtime_args;
 
     if (runtime == nullptr) {
@@ -153,7 +152,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_prewarm_call
         return -1;
     }
 
-    auto k_args = (KernelArgs *)arg;
+    KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
     Runtime *runtime = k_args->runtime_args;
     if (runtime == nullptr) {
         LOG_ERROR("%s", "Invalid prewarm runtime_args: null pointer");

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -15,7 +15,6 @@
  * kernels on Ascend devices using CANN runtime APIs.
  *
  * Key Components:
- * - DeviceArgs: AICPU device argument structure
  * - KernelArgsHelper: Helper for managing kernel arguments with device memory
  * - DeviceRunner: kernel launching and execution
  */
@@ -40,7 +39,7 @@
 #include "prepare_callable_common.h"
 #include "utils/device_arena.h"
 #include "device_runner_base.h"     // common DeviceRunnerBase
-#include "device_runner_helpers.h"  // common DeviceArgs + KernelArgsHelper
+#include "device_runner_helpers.h"  // common KernelArgsHelper
 #include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_swimlane_profiling.h"
@@ -56,7 +55,7 @@
 #include "aicpu_loader/host/load_aicpu_op.h"
 #include "runtime.h"
 
-// DeviceArgs + KernelArgsHelper are defined in
+// KernelArgsHelper is defined in
 // src/common/platform/onboard/host/device_runner_helpers.h (included above).
 
 /**
@@ -175,7 +174,7 @@ private:
     // worker_count_, executor + dispatcher bytes, aicore_bin_handle_,
     // load_aicpu_op_, mem_alloc_, the three DeviceArenas + their cached
     // sizes, persistent AICPU/AICore streams, kernel_args_, device_wall_*,
-    // device_args_, binaries_loaded_) is inherited from `DeviceRunnerBase`.
+    // binaries_loaded_) is inherited from `DeviceRunnerBase`.
 
     // Group D state (`chip_callable_buffers_`, `callables_`,
     // `orch_so_dedup_`, `aicpu_seen_callable_ids_`, `aicpu_dlopen_total_`,

--- a/src/common/aicpu_loader/README.md
+++ b/src/common/aicpu_loader/README.md
@@ -28,6 +28,28 @@ sibling of each runtime's host_runtime.so. A single process binding multiple
 runtimes can share one dispatcher SO on disk; the host process-level
 fingerprint cache deduplicates bootstrap calls by inner-SO Build-ID.
 
+## Argument ABI boundaries
+
+The dispatcher bootstrap uses a private `DeviceArgs` ABI. Host-side
+`LoadAicpuOp::BootstrapDispatcher()` writes a `device_args_ptr` into the
+bootstrap `KernelArgs` front slot at offset 40. The device-side dispatcher
+reads that pointer as an extended `DeviceArgs` object:
+
+```text
+DeviceArgs + 96:  aicpu_so_bin
+DeviceArgs + 104: aicpu_so_len
+DeviceArgs + 112: device_id
+DeviceArgs + 120: inner_so_bin
+DeviceArgs + 128: inner_so_len
+```
+
+This private bootstrap structure is distinct from the platform runtime
+`KernelArgs` payload used by per-task launches. Per-task AICPU launch passes
+the front-less `KernelArgs` payload directly to `rtsLaunchCpuKernel` (no CANN
+launch front): `runtime_args` is at offset 0, followed by profiling/logging
+fields, register tables, and `device_id`. AICore receives only the same
+front-less `KernelArgs` via a host-owned device copy.
+
 ## Exported entry points
 
 Three C-style symbols are exposed; `libaicpu_extend_kernels.so::SetTileFwkKernelMap`
@@ -38,7 +60,7 @@ dlsym's all three at load time, but only DynInit does real work:
 3. `DynTileFwkBackendKernelServer`          — stub
 
 See `aicpu_dispatcher.h` for the bootstrap protocol details (extended DeviceArgs
-with `inner_so_bin`/`inner_so_len`, FNV-1a content fingerprint).
+with `inner_so_bin`/`inner_so_len`, Build-ID-derived fingerprint).
 
 ## See also
 

--- a/src/common/aicpu_loader/host/load_aicpu_op.h
+++ b/src/common/aicpu_loader/host/load_aicpu_op.h
@@ -115,7 +115,7 @@ public:
      * @brief Launch a runtime SO entry point via rtsLaunchCpuKernel.
      *
      * @param stream       RTS stream
-     * @param k_args       Kernel arguments
+     * @param k_args       Front-less KernelArgs payload (runtime_args @ 0)
      * @param aicpu_num    Number of AICPU threads
      * @param func_name    Lookup key in func_handles_ (KernelNames::RunName)
      * @return 0 on success, error code on failure

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -287,20 +287,6 @@ int DeviceRunnerBase::ensure_binaries_loaded() {
     }
     LOG_INFO_V2("DeviceRunner: inner SO registered (runtime entry handles ready)");
 
-    // H2D the per-task DeviceArgs struct itself. device_args_.aicpu_so_bin/len
-    // stay zero — our own per-task AICPU code (launched via rtsLaunchCpuKernel
-    // against the cached rtFuncHandle on LoadAicpuOp) never reads them, and
-    // the dispatcher-bootstrap KernelArgs (KERNEL_TYPE_AICPU_KFC) builds its
-    // own DeviceArgs view inside BootstrapDispatcher rather than reading
-    // ours. The "load-bearing on a5" finding documented prior to #864/#870
-    // no longer reproduces against current HEAD — see PR removing
-    // AicpuSoInfo (CI on both archs green).
-    rc = kernel_args_.init_device_args(device_args_, mem_alloc_);
-    if (rc != 0) {
-        LOG_ERROR("init_device_args failed: %d", rc);
-        return rc;
-    }
-
     // Release host bytes — bootstrap is done. Per-task launches go through
     // the cached rtFuncHandle owned by LoadAicpuOp; dispatcher SO bytes are
     // never referenced again; the aicpu kernel SO's host buffer is no longer
@@ -738,10 +724,6 @@ int DeviceRunnerBase::finalize_common() {
         stream_aicore_ = nullptr;
     }
 
-    // Cleanup kernel args (deviceArgs); device-side KernelArgs + runtime args
-    // are released by runtime_args_cleanup RAII so they also unwind on errors.
-    capture(kernel_args_.finalize_device_args());
-
     // load_aicpu_op_ has no per-task host-side state to release —
     // rtsLaunchCpuKernel does not hand back any per-launch handle, and the
     // dispatcher itself was a transient libaicpu_extend_kernels dlopen.
@@ -994,11 +976,10 @@ int DeviceRunnerBase::sync_run_streams() {
 }
 
 void DeviceRunnerBase::read_device_wall_ns() {
-    // Pull the platform-level device wall (ns) back from the 8-byte
-    // device buffer that AICPU writes through via
-    // KernelArgs::device_wall_data_base. (We can't use the
-    // device_k_args_ shadow here — CANN's rtAicpuKernelLaunchExWithArgs
-    // copies KernelArgs into AICPU-private memory at launch, so AICPU's
+    // Pull the platform-level device wall (ns) back from the 8-byte device
+    // buffer that AICPU writes through via KernelArgs::device_wall_data_base.
+    // (We can't use the device_k_args_ shadow here — CANN copies the
+    // KernelArgs payload into AICPU-private memory at launch, so AICPU's
     // writes to its local copy don't propagate to device_k_args_.)
     // Failure path is a soft warn — wall stays zero.
     device_wall_ns_ = 0;

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -361,7 +361,7 @@ public:
      * bootstrap).
      *
      * @param stream       AICPU stream
-     * @param k_args       Kernel arguments
+     * @param k_args       Front-less KernelArgs payload (runtime_args @ 0)
      * @param kernel_name  Name of the kernel to launch (e.g.
      *                     `host::KernelNames::RunName`)
      * @param aicpu_num    Number of AICPU instances to launch
@@ -379,10 +379,8 @@ public:
      * manifested in CI as 207001 at `rtKernelLaunchWithHandleV2` with a
      * 507899 cascade at `rtStreamCreate`.
      *
-     * `k_args` reaches the AICore kernel through `rtArgsEx_t`; whether
-     * it is a host-resident or device-resident `KernelArgs` pointer is
-     * decided by the subclass's `run()` (a2a3 passes host; a5 passes
-     * device).
+     * `k_args` reaches the AICore kernel through `rtArgsEx_t` as a
+     * device-resident KernelArgs payload pointer.
      */
     int launch_aicore_kernel(rtStream_t stream, KernelArgs *k_args);
 
@@ -595,7 +593,6 @@ protected:
      * a5's `rtDeviceReset`). Everything else lives here:
      *
      *   - rtStreamDestroy for both persistent streams
-     *   - kernel_args_.finalize_device_args
      *   - aicore_bin_handle_ + binaries_loaded_ reset
      *   - chip_callable_buffers_ free + clear
      *   - orch_so_dedup_ free + clear
@@ -754,7 +751,6 @@ protected:
     // simpler_init, freed in the subclass `finalize()`.
     void *device_wall_dev_ptr_{nullptr};
     uint64_t device_wall_ns_{0};
-    DeviceArgs device_args_;
 
     // True after AICPU SO loaded; reset by the subclass's `finalize()`.
     bool binaries_loaded_{false};

--- a/src/common/platform/onboard/host/device_runner_helpers.cpp
+++ b/src/common/platform/onboard/host/device_runner_helpers.cpp
@@ -22,40 +22,6 @@
 
 #include "common/unified_log.h"
 
-int KernelArgsHelper::init_device_args(const DeviceArgs &host_device_args, MemoryAllocator &allocator) {
-    allocator_ = &allocator;
-
-    // Allocate device memory for device_args
-    if (args.device_args == nullptr) {
-        uint64_t device_args_size = sizeof(DeviceArgs);
-        void *device_args_dev = allocator_->alloc(device_args_size);
-        if (device_args_dev == nullptr) {
-            LOG_ERROR("Alloc for device_args failed");
-            return -1;
-        }
-        args.device_args = reinterpret_cast<DeviceArgs *>(device_args_dev);
-    }
-    // Copy host_device_args to device memory via device_args
-    int rc =
-        rtMemcpy(args.device_args, sizeof(DeviceArgs), &host_device_args, sizeof(DeviceArgs), RT_MEMCPY_HOST_TO_DEVICE);
-    if (rc != 0) {
-        LOG_ERROR("rtMemcpy failed: %d", rc);
-        allocator_->free(args.device_args);
-        args.device_args = nullptr;
-        return rc;
-    }
-    return 0;
-}
-
-int KernelArgsHelper::finalize_device_args() {
-    if (args.device_args != nullptr && allocator_ != nullptr) {
-        int rc = allocator_->free(args.device_args);
-        args.device_args = nullptr;
-        return rc;
-    }
-    return 0;
-}
-
 int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 

--- a/src/common/platform/onboard/host/device_runner_helpers.h
+++ b/src/common/platform/onboard/host/device_runner_helpers.h
@@ -17,10 +17,8 @@
  * the arch's own `device_runner.h` rather than being declared here.
  *
  * Current contents:
- *   - `DeviceArgs`: per-task AICPU device-args struct (offsets fixed by
- *     libaicpu_extend_kernels' ABI; layout identical on both archs).
  *   - `KernelArgsHelper`: host-side `KernelArgs` wrapper with device-memory
- *     management for the 3 H2D copies (`DeviceArgs`, `Runtime`, `KernelArgs`).
+ *     management for the H2D `Runtime` and `KernelArgs` copies.
  *
  * Future migrations (see `.docs/ONBOARD_HOST_COMMON_REFACTOR.md`):
  *   - `DeviceRunnerBase` (lifecycle + registration + profiling init).
@@ -35,23 +33,6 @@
 #include "common/kernel_args.h"  // arch-specific KernelArgs layout
 #include "host/memory_allocator.h"
 #include "runtime.h"
-
-/**
- * DeviceArgs structure for AICPU device arguments.
- *
- * Layout offsets are still nominally fixed by libaicpu_extend_kernels.so for
- * `aicpu_so_bin` / `aicpu_so_len` (at offsets 96 / 104), but per-task AICPU
- * launches go through `rtsLaunchCpuKernel` against the cached `rtFuncHandle`
- * on `LoadAicpuOp` — none of our code reads these fields. The fields are
- * kept (zero-initialized, never assigned) so the H2D struct layout matches
- * the historical contract on both archs; the runner-side `AicpuSoInfo`
- * allocation that used to back them was removed in PR #877.
- */
-struct DeviceArgs {
-    uint64_t unused[12] = {0};
-    uint64_t aicpu_so_bin{0};
-    uint64_t aicpu_so_len{0};
-};
 
 /**
  * Helper class for managing `KernelArgs` with device memory.
@@ -71,18 +52,6 @@ struct KernelArgsHelper {
     KernelArgs args;
     MemoryAllocator *allocator_{nullptr};
     KernelArgs *device_k_args_{nullptr};  // Device copy of KernelArgs for AICore
-
-    /**
-     * Initialize device arguments by allocating device memory and copying data.
-     *
-     * @param host_device_args  Host-side device arguments to copy.
-     * @param allocator         Memory allocator to use.
-     * @return 0 on success, error code on failure.
-     */
-    int init_device_args(const DeviceArgs &host_device_args, MemoryAllocator &allocator);
-
-    /** Free device memory allocated for device arguments. */
-    int finalize_device_args();
 
     /**
      * Initialize runtime arguments by allocating device memory and copying data.
@@ -111,9 +80,8 @@ struct KernelArgsHelper {
     /**
      * Implicit conversion operators for seamless use with runtime APIs.
      *
-     * These allow `KernelArgsHelper` to be used wherever `KernelArgs *` is
-     * expected, enabling transparent device memory management while
-     * maintaining API compatibility.
+     * These allow `KernelArgsHelper` to be used wherever a payload
+     * `KernelArgs *` is expected.
      */
     operator KernelArgs *() { return &args; }
     KernelArgs *operator&() { return &args; }


### PR DESCRIPTION
## Summary

This PR cleans up the platform runtime argument ABI by removing the historical
per-task `DeviceArgs` path from onboard AICPU launches.

The work follows the review discussion from PR #1089:
https://github.com/hw-native-sys/simpler/pull/1089#issuecomment-4777844855

After this PR, the onboard argument model is:

- **Bootstrap/load path:** still uses the private dispatcher `DeviceArgs` ABI
  inside `src/common/aicpu_loader/{host,device}`.
- **Per-task runtime path:** passes a front-less `KernelArgs *` directly to
  `rtsLaunchCpuKernel`.
- **AICPU runtime entry:** reads `KernelArgs::runtime_args` at offset 0.
- **AICore entry:** receives a device-side `KernelArgs *` carrying the same
  runtime/profiling/register payload.

This keeps the Path A bootstrap ABI separate from the per-task runtime ABI.

## Final Runtime Contract

Per-task AICPU launch now uses `KernelArgs` directly:

```cpp
cpu_args.baseArgs.args = k_args;
cpu_args.baseArgs.argsSize = sizeof(KernelArgs);
```

The AICPU entry treats the launch argument as:

```cpp
KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
Runtime *runtime = k_args->runtime_args;
```

There is no per-task `DeviceArgs`, no offset-40 compatibility pointer, and no
`AicpuLaunchArgs` / `CannRuntimeLaunchArgs` wrapper on this path.

## Changes

- Removed platform runtime `KernelArgs::device_args` from a2a3 and a5.
- Removed the old front padding from platform `KernelArgs`.
- Added static layout checks for the front-less payload:
  - `KernelArgs::runtime_args == 0`
  - `KernelArgs::regs == 8`
- Removed platform-side per-task `DeviceArgs` ownership from
  `KernelArgsHelper` and `DeviceRunnerBase`.
- Made `LoadAicpuOp::{LaunchBuiltInOp,AicpuKernelLaunch}` launch with
  `KernelArgs *` directly.
- Updated a2a3/a5 AICPU entries to read `KernelArgs *` directly.
- Kept AICore launch on the existing device-side `KernelArgs` copy.
- Updated prewarm and normal run launches to use the same front-less
  `KernelArgs` ABI.
- Updated project docs to describe the bootstrap/runtime ABI boundary.

## What Remains Intentionally Separate

The dispatcher bootstrap still has its private `DeviceArgs` ABI. That path is
used only by:

```text
rtAicpuKernelLaunchExWithArgs(..., libaicpu_extend_kernels.so, ...)
```

It carries dispatcher/runtime SO bytes during Path A bootstrap. It is not used
by per-task runtime launch.

## Verification

- `git diff --check origin/main...HEAD`
- `.venv/bin/pre-commit run --show-diff-on-failure --files ...`
- `PYTHONNOUSERSITE=1 CCACHE_DIR=/tmp/simpler-pr1131-ccache PTO_ISA_ROOT=/data/fangjingzhi/simpler_comm/build/pto-isa .venv/bin/python -m pip install --no-build-isolation -e .[test]`
- `git merge-tree --write-tree HEAD origin/main`

Earlier branch validation also covered a2a3 onboard HBG/TRB smoke coverage
after a clean rebuild. a5 onboard still depends on CI/hardware coverage.

## Risk

The main risk is ABI/layout mismatch between host, AICPU, and AICore after
making `KernelArgs` front-less.

Mitigations:

- Per-task AICPU launch passes `sizeof(KernelArgs)`.
- AICPU entry reads `KernelArgs *` directly.
- AICore continues to receive the device-side `KernelArgs *`.
- Static asserts pin the critical offsets.
- Docs now explicitly distinguish bootstrap `DeviceArgs` from per-task
  `KernelArgs`.
