### PR TITLE
ci: read the pinned pto-isa commit from a committed pto_isa.pin

### DIFF
--- a/.github/actions/read-pto-isa/action.yml
+++ b/.github/actions/read-pto-isa/action.yml
@@ -1,0 +1,18 @@
+name: Read pinned pto-isa commit
+description: >-
+  Read the committed pto_isa.pin (the repo-root source of truth for the pinned
+  pto-isa revision) and export it as PTO_ISA_COMMIT for subsequent steps in the
+  calling job. Requires the repository to be checked out first.
+runs:
+  using: composite
+  steps:
+    - name: Read and validate pto_isa.pin
+      shell: bash
+      run: |
+        commit="$(tr -d '[:space:]' < pto_isa.pin)"
+        if ! printf '%s' "$commit" | grep -qE '^[0-9a-f]{40}$'; then
+          echo "::error file=pto_isa.pin::expected a 40-char hex commit, got '$commit'"
+          exit 1
+        fi
+        echo "PTO_ISA_COMMIT=$commit" >> "$GITHUB_ENV"
+        echo "pinned pto-isa: $commit"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Single source of truth for the pinned pto-isa revision. Drives BOTH the
-  # build (`pip install` threads it into build_runtimes.py via
-  # SIMPLER_PTO_ISA_COMMIT, so host_runtime.so embeds these pto-isa headers)
-  # and the run (scene tests check it out via `--pto-isa-commit`). Bump here to
-  # update both at once — never pin one without the other (issue #1067).
-  PTO_ISA_COMMIT: ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8
-
 jobs:
   # ---------- Pre-commit hooks (format, lint, clang-tidy) ----------
   pre-commit:
@@ -182,6 +174,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
+
       - name: Set up C++ compiler
         run: |
           if [[ "${{ runner.os }}" == "Linux" ]]; then
@@ -265,6 +260,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
 
       - name: Set up C++ compiler
         run: |
@@ -449,6 +447,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
+
       - name: Set up environment
         run: |
           source /usr/local/Ascend/cann/set_env.sh
@@ -533,6 +534,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
 
       - name: Set up environment
         run: |
@@ -649,6 +653,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
+
       - name: Set up environment
         run: |
           python3 -m venv --system-site-packages .venv
@@ -716,6 +723,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
 
       - name: Set up environment
         run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -18,9 +18,6 @@ concurrency:
   group: sanitizers-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  PTO_ISA_COMMIT: ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8
-
 jobs:
   sanitizer-sim:
     runs-on: ubuntu-latest
@@ -38,6 +35,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+
+      - name: Load pinned pto-isa commit
+        uses: ./.github/actions/read-pto-isa
 
       - name: Set up C++ compiler
         run: |

--- a/pto_isa.pin
+++ b/pto_isa.pin
@@ -1,0 +1,1 @@
+ddafa8da9c760ecd13fe9fe2833d6ee55fb20bd8


### PR DESCRIPTION
## Why

The pinned pto-isa revision lives only in workflow `env: PTO_ISA_COMMIT` literals (`ci.yml`, `sanitizers.yml`). Downstream consumers that pin this repo as a submodule — notably **pypto** — have no stable, machine-readable file to derive it from, so each re-declares its own pto-isa pin and they drift out of sync.

## What

- **`pto_isa.pin`** (new, repo root): the committed source of truth — a single 40-char pto-isa commit.
- **`.github/actions/read-pto-isa`** (new composite action): reads `pto_isa.pin`, validates it is a 40-char hex commit (fails early otherwise), and exports `PTO_ISA_COMMIT` for the calling job.
- Every job that needs the pin adds one line after checkout: `- uses: ./.github/actions/read-pto-isa` (six jobs in `ci.yml`, the sanitizer job in `sanitizers.yml`).
- The workflow-level `PTO_ISA_COMMIT` literals are removed — `pto_isa.pin` is now the only place the revision is declared, and the read+validate logic lives once in the composite action.

**No version change** — `pto_isa.pin` equals the previous pin (`ddafa8da…`). All existing `${{ env.PTO_ISA_COMMIT }}` / `${PTO_ISA_COMMIT}` references are unchanged; only their source moved from a literal to the file.

## Context

Upstream half of a cross-repo effort to keep pypto / pypto-lib / runtime pinning the same pto-isa. pypto's side (`toolchain/versions.env` SSOT) is in hw-native-sys/pypto#1851; a follow-up there derives pypto's pto-isa from `runtime/pto_isa.pin` once this lands.