### PR TITLE
Bug fix non-deterministic AICPU affinity gate keeping cross-NUMA threads

### DIFF
--- a/src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
+++ b/src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp
@@ -26,7 +26,10 @@ static constexpr int32_t CPUS_PER_CLUSTER = 4;
 // threads and never approaches this bound.
 static constexpr int32_t MAX_GATE_THREADS = 16;
 
-static std::atomic<uint64_t> s_cpumask{0};
+// Bit i is set once thread-slot i has written its s_thread_cpu[] report. Keyed
+// on the reporting slot (not the cpu) so the barrier still reaches
+// total_launched when two unpinned threads share a cpu (sim).
+static std::atomic<uint64_t> s_done_mask{0};
 static std::atomic<int32_t> s_reported{0};
 static std::atomic<int32_t> s_gate_init{0};
 static std::atomic<int32_t> s_gate_ready{0};
@@ -44,17 +47,28 @@ static inline int32_t popcount64(uint64_t v) { return __builtin_popcountll(stati
 
 bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched) {
     tl_exec_idx = -1;
+
+    // Bound-check both inputs against the static slot buffers (s_thread_cpu[],
+    // s_thread_survive[], both MAX_GATE_THREADS) before any indexing. Without
+    // this, total_launched > MAX_GATE_THREADS makes the classifier loop read
+    // s_thread_cpu[tid] and write s_thread_survive[tid] out of bounds; a
+    // negative count would bypass the bounds checks entirely. Mirrors the
+    // validation in platform_aicpu_affinity_gate_filter().
+    if (total_launched <= 0 || total_launched > MAX_GATE_THREADS || logical_count < 0) {
+        LOG_ERROR(
+            "AICPU affinity gate: invalid config logical_count=%d total_launched=%d (max=%d) — dropping all threads",
+            logical_count, total_launched, MAX_GATE_THREADS
+        );
+        return false;
+    }
     if (logical_count >= total_launched) {
         // No over-launch (unreachable for a2a3, where logical < total always):
         // every thread survives. Leave tl_exec_idx = -1 so no run-wall slot is
-        // claimed on this degenerate path — and, crucially, do NOT touch
-        // s_reported here: this early return has no barrier/cleanup to reset
-        // it, so incrementing it would leak state into the next launch
-        // (s_reported is reset only by the full path's last-thread cleanup).
+        // claimed on this degenerate path.
         return true;
     }
 
-    // Assign thread index
+    // Assign this thread a reporting slot.
     int32_t idx = s_reported.fetch_add(1, std::memory_order_acq_rel);
 
     // Report CPU
@@ -65,21 +79,20 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
 #else
     int32_t cpu = -1;
 #endif
-
-    int32_t normalized_cpu = -1;
-    if (cpu >= 0) {
-        if (cpu < 63) {
-            s_cpumask.fetch_or(1ULL << cpu, std::memory_order_release);
-        }
-        normalized_cpu = cpu % AICPU_CORES_PER_CHIP;
-    }
+    int32_t normalized_cpu = (cpu >= 0) ? cpu % AICPU_CORES_PER_CHIP : -1;
     if (idx < MAX_GATE_THREADS) {
         s_thread_cpu[idx] = normalized_cpu;
     }
 
-    // Barrier: wait until all total_launched threads have reported
-    while (popcount64(s_cpumask.load(std::memory_order_acquire)) < total_launched &&
-           s_reported.load(std::memory_order_acquire) < total_launched) {}
+    // Barrier: publish this slot (the release pairs with the acquire load below
+    // so the s_thread_cpu[] write above is visible), then wait until every slot
+    // has reported. The old barrier released on s_reported, which is bumped
+    // *before* the write, so the classifier below could run on half-written or
+    // stale slots and non-deterministically keep cluster #0.
+    if (idx < 64) {
+        s_done_mask.fetch_or(1ULL << idx, std::memory_order_release);
+    }
+    while (popcount64(s_done_mask.load(std::memory_order_acquire)) < total_launched) {}
 
     // CAS winner does cluster classification
     int32_t expected = 0;
@@ -140,15 +153,10 @@ bool platform_aicpu_affinity_gate(int32_t logical_count, int32_t total_launched)
     bool survive = (idx < total_launched) ? s_thread_survive[idx] : false;
 
     // Last thread resets state for next invocation
-    int32_t finished = s_reported.load(std::memory_order_acquire);
-    (void)finished;
-    // Reset is deferred: the statics persist but are re-initialized by the CAS winner
-    // on next call. We reset the atomics after all threads have read their result.
-    // Use a second atomic counter for cleanup.
     static std::atomic<int32_t> s_cleanup{0};
     int32_t cleanup_idx = s_cleanup.fetch_add(1, std::memory_order_acq_rel);
     if (cleanup_idx + 1 == total_launched) {
-        s_cpumask.store(0, std::memory_order_release);
+        s_done_mask.store(0, std::memory_order_release);
         s_reported.store(0, std::memory_order_release);
         s_gate_init.store(0, std::memory_order_release);
         s_gate_ready.store(0, std::memory_order_release);


### PR DESCRIPTION
### Summary

`platform_aicpu_affinity_gate` (the legacy gate in
`src/common/platform/onboard/aicpu/platform_aicpu_affinity.cpp`) could
non-deterministically keep AICPU threads in the wrong CPU cluster, causing a
severe throughput regression from NUMA-domain crossing. This fixes the gate's
barrier so the survivor selection always runs on complete data.

This PR is based of this Issue #1045 and will solve it in a much less intrusive solution compared to these PRs #1046 & #1119

### Background

On a2a3 silicon the AICPU has two clusters of 4 cores each:

- **Cluster 0** — cpus `0–3` (`0` and `1` reserved for the OS)
- **Cluster 1** — cpus `4–7`

CANN over-launches `PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH` (6) threads and
the gate must keep exactly `aicpu_thread_num` (4: 3 schedulers + 1 orchestrator).
**All 4 survivors must land in cluster 1** — if any survivor sits in cluster #0,
every cross-cluster access pays a NUMA penalty and throughput collapses.

### Root cause

Each thread reports its cpu into `s_thread_cpu[idx]`, then one CAS-winner
classifies the reports by cluster and picks the survivors. The barrier between
"report" and "classify" was the bug:

```cpp
int32_t idx = s_reported.fetch_add(1, ...);   // bumped at entry, BEFORE the cpu write
...
s_thread_cpu[idx] = normalized_cpu;            // the actual report
// barrier released as soon as everyone had *entered*:
while (popcount(cpumask) < total && s_reported < total) {}
```

`s_reported` is incremented at function entry — before the thread writes its cpu
report. So the barrier could open as soon as all threads had *entered* the
function, while one or more `s_thread_cpu[]` slots were still unwritten (or held
stale values from a previous launch). The CAS-winner then classified on
half-written data, miscounted the clusters, and either fell back to the
arrival-order cutoff or kept the wrong cluster — non-deterministically keeping
cluster 0 threads. The selection logic itself was correct; it was simply being
fed an incomplete table.

### Fix

Replace the entry-counter barrier with a per-slot "done" mask that is published
**after** the report is written:

```cpp
s_thread_cpu[idx] = normalized_cpu;
// publish AFTER the write; release pairs with the acquire load below
s_done_mask.fetch_or(1ULL << idx, std::memory_order_release);
while (popcount64(s_done_mask.load(std::memory_order_acquire)) < total_launched) {}
```

- The bit is set **after** `s_thread_cpu[idx]` is written, and the
  release/acquire pair guarantees every report is visible before the classifier
  runs → the gate always sees the complete table and deterministically keeps
  cluster 1.
- The mask is keyed on the **reporting slot `idx`**, not the cpu, so it still
  reaches `total_launched` in the sim path, where unpinned host threads can share
  a cpu (a cpu-keyed `popcount` barrier would deadlock there).

The cluster-classification algorithm, the unexpected-topology fallback, and the
`tl_exec_idx` run-wall-slot contract are unchanged — only the barrier was
touched.

### Testing

Verified onboard on a2a3: the 4 surviving AICPU threads now consistently land on
cpus `4–7` (cluster 1) across repeated runs, eliminating the intermittent
NUMA-crossing slowdown.