### PR TITLE
ci(sanitizers): capture reports through aborts + fix __cxa_throw preload

### DIFF
--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -13,6 +13,9 @@ name: Sanitizers
 on:
   schedule:
     - cron: "0 18 * * *"  # 02:00 Beijing
+  # Manual trigger so a flaky nightly can be re-run on demand to confirm it
+  # reproduces (and now that reports are captured, to inspect the stack).
+  workflow_dispatch:
 
 concurrency:
   group: sanitizers-${{ github.ref }}
@@ -67,8 +70,32 @@ jobs:
         run: |
           # Sim unifies host compilation on g++-15, so preload g++-15's runtime.
           LIB=$(g++-15 -print-file-name=lib${{ matrix.sanitizer }}.so)
+          # Also preload g++-15's libstdc++. ASan resolves its __cxa_throw
+          # interceptor at init via dlsym(RTLD_NEXT, ...); the runtime is dlopen'd
+          # into a plain C Python where libstdc++ is not yet mapped, so that
+          # lookup returns null and the first C++ throw from the runtime aborts
+          # with "CHECK failed: ... real___cxa_throw != 0" (seen on the prewarm
+          # rollback test, which throws by design). Mapping libstdc++ up front
+          # makes the real symbol resolvable. Must be g++-15's, matching $LIB.
+          LIBSTDCXX=$(g++-15 -print-file-name=libstdc++.so)
           ARCH=$(echo "${{ matrix.platform }}" | sed 's/sim$//')
           PC="tests/st/$ARCH/tensormap_and_ringbuffer/prepared_callable"
+          # Why the report needs explicit capture: pytest's default fd-capture
+          # buffers each test's stdout/stderr in memory and prints it at test
+          # teardown. A sanitizer abort (abort_on_error=1) kills the process
+          # mid-test, so teardown never runs and that buffer is discarded —
+          # leaving only the parent's faulthandler "Fatal Python error: Aborted"
+          # with no sanitizer stack (that line survives because faulthandler
+          # holds the original fd). Two fixes, below:
+          #   1. `log_path` routes each process's sanitizer report to a per-pid
+          #      file, written at report time independent of fd capture, so it
+          #      survives the abort. Forked chip children (worker.py os.fork)
+          #      inherit the env and get their own files; uploaded as an artifact.
+          #   2. pytest `-s` disables capture so the report also reaches the live
+          #      job log inline (and recovers non-sanitizer abort/assert messages,
+          #      which never go to log_path).
+          LOGDIR="$GITHUB_WORKSPACE/sanitizer-logs"
+          mkdir -p "$LOGDIR"
           # dlopen_count tests are excluded everywhere: they assert exact dlopen
           # accounting that the sanitizers perturb by interposing dlopen.
           if [ "${{ matrix.sanitizer }}" = "tsan" ]; then
@@ -82,7 +109,7 @@ jobs:
             TARGETS="$PC"
             MAXPAR=1
             KFILTER="not dlopen_count"
-            export TSAN_OPTIONS=halt_on_error=0:exitcode=0
+            export TSAN_OPTIONS=halt_on_error=0:exitcode=0:log_path="$LOGDIR/tsan"
           else
             # ASAN (~1.7x) + UBSan. Like TSAN, the chip-fork L3 cases
             # (dynamic_register is all level=3) livelock on the 4-vCPU runner
@@ -93,10 +120,22 @@ jobs:
             TARGETS="$PC"
             MAXPAR=2
             KFILTER="not parallel_broadcast and not dlopen_count"
-            export ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1
-            export UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+            export ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1:log_path="$LOGDIR/asan"
+            export UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1:log_path="$LOGDIR/ubsan"
           fi
-          LD_PRELOAD="$LIB" pytest $TARGETS --platform ${{ matrix.platform }} \
+          # -s (no capture) so the report/abort message also reaches the live
+          # job log inline, not just the uploaded per-pid file.
+          LD_PRELOAD="$LIB $LIBSTDCXX" pytest $TARGETS --platform ${{ matrix.platform }} \
             --device 0-7 --max-parallel "$MAXPAR" -k "$KFILTER" \
-            --sanitizer ${{ matrix.sanitizer }} -v --pto-session-timeout 600 \
+            --sanitizer ${{ matrix.sanitizer }} -v -s --pto-session-timeout 600 \
             --pto-isa-commit ${{ env.PTO_ISA_COMMIT }} --clone-protocol https --require-pto-isa
+
+      - name: Upload sanitizer logs (${{ matrix.sanitizer }}, ${{ matrix.platform }})
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sanitizer-logs-${{ matrix.sanitizer }}-${{ matrix.platform }}
+          path: sanitizer-logs/
+          # ASAN writes a file only on error, so a clean run leaves the dir
+          # empty — don't fail the upload (or the job) over that.
+          if-no-files-found: ignore

--- a/docs/sanitizers.md
+++ b/docs/sanitizers.md
@@ -77,8 +77,11 @@ pip install --no-build-isolation --config-settings=cmake.define.SIMPLER_SANITIZE
 
 # 2. Run, preloading the matching runtime. Sim unifies on g++-15, so preload
 #    g++-15's runtime — plain g++'s would mismatch the kernels' ABI (see
-#    invariant 1) and fail at load.
-LD_PRELOAD=$(g++-15 -print-file-name=libasan.so) \
+#    invariant 1) and fail at load. Preload g++-15's libstdc++ too, or ASan
+#    can't resolve its __cxa_throw interceptor (libstdc++ isn't mapped into the
+#    plain C Python when ASan inits) and the first C++ throw from the runtime
+#    aborts with "CHECK failed: ... real___cxa_throw != 0".
+LD_PRELOAD="$(g++-15 -print-file-name=libasan.so) $(g++-15 -print-file-name=libstdc++.so)" \
 ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1 \
 UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
 pytest examples tests/st --platform a2a3sim --sanitizer asan -v
@@ -94,6 +97,27 @@ pytest examples tests/st --platform a2a3sim --sanitizer tsan -v
 
 `detect_leaks=0` is recommended initially — LSan false-positives on the device
 custom arenas until suppressions are added (see the scope investigation).
+
+Capturing the report through an abort: pytest's default fd-capture buffers a
+test's output in memory and prints it only at teardown. A sanitizer abort
+(`abort_on_error=1`) kills the process mid-test, so teardown never runs and the
+buffer is discarded — the job log shows only `Fatal Python error: Aborted` with
+no sanitizer stack. Two ways to recover it, used together:
+
+- `log_path` writes each process's report to a per-pid file at report time,
+  independent of fd capture, so it survives the abort. Forked chip children
+  (`worker.py` `os.fork`) inherit the env and get their own files.
+- pytest `-s` (`--capture=no`) sends output straight to the real stderr fd, so
+  the report — and any non-sanitizer abort/assert message, which never reaches
+  `log_path` — also appears inline.
+
+```bash
+ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:halt_on_error=1:log_path=/tmp/asan \
+... pytest ... -s        # report lands in /tmp/asan.$PID (per process) and on the console
+```
+
+The nightly `Sanitizers` workflow does both and uploads the files as a
+`sanitizer-logs-<sanitizer>-<platform>` artifact.
 
 ## Presets
 


### PR DESCRIPTION
## Goal

Two **sanitizer-tooling** fixes that, together with the code fix in #1151, get the nightly **Sanitizers** ASAN job green. This PR touches only the sanitizer harness (`sanitizers.yml` + `docs/sanitizers.md`) — no product code.

This is the "make the sanitizer usable + self-reporting" half:
- **discovery** — make a sanitizer abort actually show its report;
- **tooling fix** — stop the harness from spuriously aborting on a C++ throw.

## 1. Capture the report through an abort

A sanitizer abort (`abort_on_error=1`) kills the process mid-test. pytest's default fd-capture buffers the test's output in memory and only prints it at teardown — which never runs — so the report is discarded, leaving only `Fatal Python error: Aborted` with no stack.

Fix two ways (complementary — validated below that each catches a leg the other misses):
- `log_path` on `ASAN/UBSAN/TSAN_OPTIONS` → per-pid report file, written at report time independent of fd capture (forked chip children inherit the env), uploaded as a `sanitizer-logs-<sanitizer>-<platform>` artifact (`if-no-files-found: ignore`).
- pytest `-s` → no capture, so the report (and non-sanitizer abort/assert messages, which never reach `log_path`) also lands inline.

## 2. Fix the `__cxa_throw` preload abort

`asan, a5sim` (and `a2a3sim` once it gets past the alignment bug) aborted with:

```
AddressSanitizer: CHECK failed: asan_interceptors.cpp:470 "((real___cxa_throw)) != (0)"
```

ASan resolves its `__cxa_throw` interceptor at init via `dlsym(RTLD_NEXT, ...)`. The instrumented runtime is `dlopen`'d into a plain C Python where **libstdc++ isn't yet mapped**, so the lookup returns null and the **first C++ throw** from the runtime aborts. The `test_prewarm_failure_rolls_back_registration` test throws by design (missing AICPU orch entry), so it tripped this every time it ran. Fix: **also preload g++-15's libstdc++** so the real symbol is resolvable.

Also adds `workflow_dispatch` for on-demand re-runs.

## Validation

Ran the Sanitizers workflow on a throwaway branch combining this PR + #1151 (closed draft #1153). All four legs green; the asan a2a3sim leg:

```
test_dedup_shared_so_independent_unregister      PASSED   ← #1151 (alignment)
test_prewarm_failure_rolls_back_registration     PASSED   ← this PR (libstdc++ preload)
test_run                                         PASSED
======================= 3 passed, 4 deselected in 30.91s
```

## Relationship to #1151

The nightly ASAN leg had **two independent aborts**: the `__cxa_throw` tooling issue (this PR) and a real UB — an unaligned `uint64_t` load (#1151). **Both must merge for the job to be green**; neither alone suffices. This PR = tooling/discovery; #1151 = the product-code fix.
