### PR TITLE
fix(trb): read pack(1) ring overrides with memcpy to avoid unaligned load

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -173,6 +173,21 @@ static void apply_env_ring_values(
     }
 }
 
+// ring_task_window / ring_heap / ring_dep_pool point into the #pragma pack(1)
+// RuntimeEnv wire struct (call_config.h), so their uint64_t entries are only
+// byte-aligned — runtime_env sits at offset 28 in CallConfig (after 7 int32_t),
+// i.e. 4-byte but not 8-byte aligned. Reading them as `base[idx]` is an
+// unaligned 8-byte load: UB, and fatal under UBSan (-fsanitize=alignment). Copy
+// the bytes out instead. A null base means "no per-task overrides" -> 0 (unset).
+static uint64_t read_ring_override(const uint64_t *base, int idx) {
+    if (base == nullptr) {
+        return 0;
+    }
+    uint64_t value;
+    std::memcpy(&value, base + idx, sizeof(value));
+    return value;
+}
+
 // Each of ring_task_window / ring_heap / ring_dep_pool is a per-ring array of
 // PTO2_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
 // PTO2_RING_* env value > compile-time default. A "size all rings the same"
@@ -194,14 +209,17 @@ static bool resolve_ring_config(
     apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (ring_task_window != nullptr && ring_task_window[r] != 0) {
-            eff_task_window_sizes[r] = ring_task_window[r];
+        const uint64_t task_window_override = read_ring_override(ring_task_window, r);
+        const uint64_t heap_override = read_ring_override(ring_heap, r);
+        const uint64_t dep_pool_override = read_ring_override(ring_dep_pool, r);
+        if (task_window_override != 0) {
+            eff_task_window_sizes[r] = task_window_override;
         }
-        if (ring_heap != nullptr && ring_heap[r] != 0) {
-            eff_heap_sizes[r] = ring_heap[r];
+        if (heap_override != 0) {
+            eff_heap_sizes[r] = heap_override;
         }
-        if (ring_dep_pool != nullptr && ring_dep_pool[r] != 0) {
-            dep_pool_values[r] = ring_dep_pool[r];
+        if (dep_pool_override != 0) {
+            dep_pool_values[r] = dep_pool_override;
         }
 
         if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -173,6 +173,21 @@ static void apply_env_ring_values(
     }
 }
 
+// ring_task_window / ring_heap / ring_dep_pool point into the #pragma pack(1)
+// RuntimeEnv wire struct (call_config.h), so their uint64_t entries are only
+// byte-aligned — runtime_env sits at offset 28 in CallConfig (after 7 int32_t),
+// i.e. 4-byte but not 8-byte aligned. Reading them as `base[idx]` is an
+// unaligned 8-byte load: UB, and fatal under UBSan (-fsanitize=alignment). Copy
+// the bytes out instead. A null base means "no per-task overrides" -> 0 (unset).
+static uint64_t read_ring_override(const uint64_t *base, int idx) {
+    if (base == nullptr) {
+        return 0;
+    }
+    uint64_t value;
+    std::memcpy(&value, base + idx, sizeof(value));
+    return value;
+}
+
 // Each of ring_task_window / ring_heap / ring_dep_pool is a per-ring array of
 // PTO2_MAX_RING_DEPTH entries (0 = unset). Precedence per ring: per-task entry >
 // PTO2_RING_* env value > compile-time default. A "size all rings the same"
@@ -194,14 +209,17 @@ static bool resolve_ring_config(
     apply_env_ring_values("PTO2_RING_DEP_POOL", 4, static_cast<uint64_t>(INT32_MAX), false, dep_pool_values);
 
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        if (ring_task_window != nullptr && ring_task_window[r] != 0) {
-            eff_task_window_sizes[r] = ring_task_window[r];
+        const uint64_t task_window_override = read_ring_override(ring_task_window, r);
+        const uint64_t heap_override = read_ring_override(ring_heap, r);
+        const uint64_t dep_pool_override = read_ring_override(ring_dep_pool, r);
+        if (task_window_override != 0) {
+            eff_task_window_sizes[r] = task_window_override;
         }
-        if (ring_heap != nullptr && ring_heap[r] != 0) {
-            eff_heap_sizes[r] = ring_heap[r];
+        if (heap_override != 0) {
+            eff_heap_sizes[r] = heap_override;
         }
-        if (ring_dep_pool != nullptr && ring_dep_pool[r] != 0) {
-            dep_pool_values[r] = ring_dep_pool[r];
+        if (dep_pool_override != 0) {
+            dep_pool_values[r] = dep_pool_override;
         }
 
         if (eff_task_window_sizes[r] < 4 || eff_task_window_sizes[r] > static_cast<uint64_t>(INT32_MAX) ||


### PR DESCRIPTION
Fixes #1150.

## Goal

Fix the real **product-code** bug the nightly Sanitizers job caught: an unaligned `uint64_t` load (UB). This is the "solve the real problem" half; together with the sanitizer-tooling fixes in #1148 it makes the nightly ASAN job green.

## Problem

`resolve_ring_config` read the per-ring override arrays as aligned `uint64_t` loads:

```cpp
if (ring_task_window != nullptr && ring_task_window[r] != 0) { ... }   // unaligned load
```

Those pointers come from `chip_worker.cpp:327`, which unconditionally passes `config.runtime_env.ring_task_window` (and siblings). `runtime_env` is a **`#pragma pack(1)`** wire struct (`call_config.h`) at byte offset **28** in `CallConfig` (after 7× `int32_t`), so the `uint64_t` arrays are **4-byte but not 8-byte aligned** → unaligned 8-byte load → **UB**, fatal under UBSan:

```
runtime_maker.cpp:197: runtime error: load of misaligned address ...
  for type 'const uint64_t', which requires 8 byte alignment
```

Because `CallConfig` is `pack(1)` (alignment 1), each instance lands at an arbitrary address, so `base+28` is 8-aligned or not depending on the run — hence the nightly failed only **intermittently**.

## Fix

Read each entry with `memcpy` via a `read_ring_override()` helper — alignment-independent, and the wire layout (+ its `static_assert`s) is untouched. Null base still returns `0` ("no override"), so precedence semantics are unchanged. Applied identically to the a2a3 and a5 `runtime_maker` mirrors.

## Validation

- **Deterministic local repro**: a `CallConfig` placed at an 8-aligned address reproduces the exact UBSan error on the direct read under `g++-15 -fsanitize=alignment`; the `memcpy` path reads the same bytes with no error.
- **CI**: in the combined sanitizer run (closed draft #1153, this PR + #1148), `test_dedup_shared_so_independent_unregister` — which used to abort here — **PASSED**, with zero misaligned-load errors in the log.

## Relationship to #1148

The nightly ASAN leg had **two independent aborts**: this real UB, and a separate `__cxa_throw` sanitizer-tooling issue (fixed in #1148). **Both must merge for the job to be green.** This PR = the product-code fix; #1148 = the sanitizer harness.
