### PR TITLE
Gate residual orch/scheduler PMU & dep_gen enable() calls under PTO2_PROFILING (a2a3 + a5)

### DIFF
--- a/docs/investigations/2026-06-orch-profiling-enable-gates-hot-path.md
+++ b/docs/investigations/2026-06-orch-profiling-enable-gates-hot-path.md
@@ -1,0 +1,133 @@
+# Gating the two residual profiling `enable()` calls left on the orch/scheduler hot path
+
+**Date**: 2026-06-25
+**Verdict**: applied (gated under the **existing** `PTO2_PROFILING`); magnitude
+deliberately **not** measured; a new `PTO_PROFILING` macro was rejected.
+
+## Question
+
+Profiling must not slow the orchestration/scheduler flow it instruments. The
+runtime off switch (`is_*_enabled()` returning `false`) is not free: even when
+off, each gate is a live `if (xxx_enable())` on the hot path. Proposal: let
+production inference and perf-measurement runs shed that residual cost.
+
+Why the residual cost is non-zero: each gate is an O(1) global-bool read
+(`return g_enable_pmu;`), but `is_pmu_enabled()`, `is_dep_gen_enabled()`, … are
+`extern "C"` / weak symbols defined in a **different translation unit** from the
+scheduler loop. The compiler **cannot inline or hoist them**, so each "off"
+check is still a real `bl`/`ret` — once per scheduler iteration, once per task
+submit.
+
+This is already acknowledged in-tree: a2a3 `scheduler_dispatch.cpp` caches the
+PMU gate at function scope with the comment *"is_pmu_enabled() is extern "C" and
+the compiler cannot hoist it across the dispatch loop on its own"* — the team
+already treats the call cost as real enough to hand-hoist once.
+
+The answer is to move the toggle from run time to **compile time** via the
+existing `PTO2_PROFILING` macro, giving two regimes from one switch:
+
+- **Default build (`PTO2_PROFILING=1`)** keeps the full runtime toggle —
+  profiling stays available and can be turned on/off dynamically, behavior
+  unchanged.
+- **Perf-measurement and production inference builds (`PTO2_PROFILING=0`)**
+  compile the gates *out entirely* — no branch, no call, no residual `if` — so
+  the hot path runs at its best, paying nothing for an observation feature it
+  isn't using.
+
+The original report was that these gates make orchestration "much slower" and
+proposed wrapping them in a compile macro so production inference can drop them.
+
+## What was tried
+
+Swept every `is_*_enabled()` call site across both arches
+(`is_pmu_enabled`, `is_dep_gen_enabled`, `is_dump_args_enabled`,
+`is_scope_stats_enabled`, `is_l2_swimlane_enabled`) and classified each as
+gated/ungated by `PTO2_PROFILING`. Findings:
+
+- The existing `PTO2_PROFILING` compile macro
+  (`src/common/task_interface/profiling_config.h`, default `1`) already wraps
+  the **vast majority** of gates — `is_dump_args_enabled`,
+  `is_scope_stats_enabled`, and most `is_pmu_enabled` sites compile out at
+  `PTO2_PROFILING=0`.
+- Exactly **two** hot-path sites per arch were ungated:
+  1. `is_pmu_enabled()` in `scheduler_dispatch.cpp` — a2a3 already cached it
+     once at function scope; a5 re-called it **per scheduler main-loop
+     iteration**. The value is loop-invariant (PMU is latched once at kernel
+     entry via `kernel.cpp`'s `set_pmu_enabled`), so a5 was also hoisted to
+     function scope for parity. This gate is **load-bearing**: `pmu_active`
+     feeds `dispatch_ready_tasks(...)` and forces single-issue dispatch.
+  2. `is_dep_gen_enabled()` in `pto_orchestrator.cpp::submit_task_common` —
+     once per task submission.
+
+Fix applied (issue #1146): gate both, both arches, under the **existing**
+`PTO2_PROFILING`. A new `PTO_PROFILING` macro was rejected — it would only
+duplicate `PTO2_PROFILING`. For the load-bearing PMU site the call is replaced,
+not deleted, so the value stays well-defined when profiling is compiled out:
+
+```cpp
+#if PTO2_PROFILING
+    const bool pmu_active = is_pmu_enabled();
+#else
+    // PMU is definitionally off when profiling is compiled out; hard-set false
+    // so dispatch keeps its overlapping (non-single-issue) fast path.
+    constexpr bool pmu_active = false;
+#endif
+```
+
+The `dep_gen` per-task capture wraps the whole `if (is_dep_gen_enabled()) { ... }`
+block in `#if PTO2_PROFILING / #endif`. To keep the subsystem internally
+consistent, the **three remaining cold `dep_gen` sites** were folded under the
+same macro: `dep_gen_aicpu_init` (`scheduler_cold_path.cpp`, one-time boot) and
+`dep_gen_aicpu_set_orch_thread_idx` / `dep_gen_aicpu_flush` (`aicpu_executor.cpp`,
+once per orch thread). Gating only the per-task capture would leave a half-on
+state at `PTO2_PROFILING=0` — buffer init + an empty flush, but no records —
+which is worse than a clean compile-out. This supersedes the previous in-tree
+comment that dep_gen was "gated independently of `PTO2_PROFILING`"; that comment
+was updated in the same change.
+
+## Result
+
+The two hot-path gates plus the whole dep_gen subsystem (init / set_idx / flush)
+gated under `PTO2_PROFILING`, both arches, plus the a5 PMU gate hoisted to
+function scope to match a2a3 — no behavioral change at the default
+`PTO2_PROFILING=1`. All touched translation units (`scheduler_dispatch.cpp`,
+`pto_orchestrator.cpp`, `scheduler_cold_path.cpp`, `aicpu_executor.cpp`)
+`-fsyntax-only` clean under `PTO2_PROFILING=1` **and** `PTO2_PROFILING=0`.
+
+**Magnitude is unmeasured.** No AICPU scheduler profile was taken. "Much
+slower" is mechanism-true (one non-inlinable call per iteration / per submit)
+but quantitatively unverified. The strongest existing evidence the cost is real
+is the in-tree hand-hoist of the PMU gate; that is an argument, not a number.
+
+## Why not (now)
+
+- **No new macro.** Reusing `PTO2_PROFILING` avoids a duplicate config
+  permutation (see `.claude/rules/env-macro-gating.md`).
+- **No benchmark.** The change is a zero-risk compile-out at the default build,
+  so it shipped without first quantifying the win. If anyone needs to justify
+  it harder, profile before claiming a number.
+- **The `PTO2_PROFILING=0` + dep_gen-enabled combo is given up on purpose.**
+  Gating the whole dep_gen subsystem means a `=0` build can no longer capture
+  dep graphs. That combo is exercised by nothing today — the only `=0` CI leg
+  (`profiling-flags-smoke / pto2-off`) runs `vector_example`, which never
+  enables dep_gen — and `=0` is the production-inference build where dep_gen (a
+  diagnostic) is unwanted anyway. A `=1` build still toggles dep_gen at runtime
+  via the host SubmitTrace flag exactly as before.
+
+## When to reconsider
+
+- If an AICPU scheduler profile shows either gate as a non-trivial slice of the
+  dispatch loop / submit path, that turns the "unmeasured" caveat into a real
+  number — record it here.
+- If a real need appears for capturing dep graphs in a `PTO2_PROFILING=0`
+  build, the dep_gen subsystem would have to be split back out from
+  `PTO2_PROFILING` onto its own gate (host-driven, as it was before this
+  change).
+
+## References
+
+- Issue [#1146](https://github.com/hw-native-sys/simpler/issues/1146) — the
+  code-health issue this implements. Related: #1103.
+- `docs/.../tensormap_and_ringbuffer/docs/profiling_levels.md` — the
+  `PTO2_PROFILING` macro hierarchy and defaults.
+- `.claude/rules/env-macro-gating.md` — why no new macro was added.

--- a/docs/investigations/README.md
+++ b/docs/investigations/README.md
@@ -84,6 +84,7 @@ that ...".
 
 Newest first.
 
+- [2026-06 — Gating the two residual profiling enable() calls on the orch/scheduler hot path](2026-06-orch-profiling-enable-gates-hot-path.md) — gated under existing `PTO2_PROFILING`; magnitude unmeasured, no new macro
 - [2026-06 — Replacing COND with GM+dcci for AICore→AICPU notification](2026-06-cond-vs-gm-notification.md)
 - [2026-06 — Letting AICore directly read or write the SPR MMIO window](2026-06-aicore-mmio-to-spr.md)
 - [2026-06 — PA-unroll 207001: an op-timeout-window issue fixed by #1035, not a launch-order bug](2026-06-pa-unroll-207001-optimeout-window.md)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -539,6 +539,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             }
 #endif
 
+#if PTO2_PROFILING
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
             // record the per-thread ready_queue index before any submit_task fires
             // inside orch_func_.
@@ -546,7 +547,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
             }
 
-#if PTO2_PROFILING
             // scope_stats streams scope_end records off the orchestrator thread:
             // record the per-thread ready_queue index. No-op (writer shared
             // state null) when scope_stats is disabled; the current buffer is
@@ -565,12 +565,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             (*p_func)(orch_args_cached_);
             rt_scope_end(rt);
 
+#if PTO2_PROFILING
             // Flush the (potentially partially-filled) DepGenBuffer so the host
             // collector can pick it up before this orchestrator thread joins.
             if (is_dep_gen_enabled()) {
                 dep_gen_aicpu_flush();
             }
-#if PTO2_PROFILING
             // Push the partially-filled scope_stats buffer so the host gets the
             // final scope_end records. Idempotent / no-op when disabled.
             scope_stats_aicpu_flush_buffers();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -698,6 +698,7 @@ static TaskOutputTensors submit_task_common(
     // these records offline to reconstruct the complete dep graph — the sole
     // source of truth for fanout now that the swimlane hot path no longer
     // records it.
+#if PTO2_PROFILING
     if (is_dep_gen_enabled()) {
         const void *tensor_ptrs[MAX_TENSOR_ARGS];
         // TensorArgType is `enum class : int32_t` (4 bytes); the on-disk record
@@ -726,6 +727,7 @@ static TaskOutputTensors submit_task_common(
             args.launch_spec.block_num(), kernel_ids_capture
         );
     }
+#endif
 
     PTO2FaninBuilder fanin_builder(orch, orch->rings[ring_id].fanin_pool, next_fanin_seen_epoch(orch));
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -917,14 +917,15 @@ int32_t SchedulerContext::init(
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
         LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
     }
-#endif
-    // dep_gen is host-driven (SubmitTrace) and gated independently of
-    // PTO2_PROFILING. init() only pops the initial buffer from instance 0's
-    // free_queue; the orchestrator thread still records its idx via
+    // dep_gen is host-driven (SubmitTrace) — runtime-gated by the host flag —
+    // and compiles out with the other profiling subsystems at PTO2_PROFILING=0.
+    // init() only pops the initial buffer from instance 0's free_queue; the
+    // orchestrator thread still records its idx via
     // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
     if (is_dep_gen_enabled()) {
         dep_gen_aicpu_init();
     }
+#endif
 
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -809,7 +809,13 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
     // pollute per-task PMU counters, so skip the PENDING pre-load phase.
     // Cached at function scope: is_pmu_enabled() is extern "C" and the
     // compiler cannot hoist it across the dispatch loop on its own.
+#if PTO2_PROFILING
     const bool pmu_active = is_pmu_enabled();
+#else
+    // PMU is definitionally off when profiling is compiled out; hard-set false
+    // so dispatch keeps its overlapping (non-single-issue) fast path.
+    constexpr bool pmu_active = false;
+#endif
 
 #if PTO2_PROFILING
     l2_swimlane.sched_start_ts = get_sys_cnt_aicpu();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -540,7 +540,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // state null) when scope_stats is disabled; the current buffer is
             // popped lazily on the first scope_end append.
             scope_stats_aicpu_set_orch_thread_idx(thread_idx);
-#endif
 
             // dep_gen plugs into the orchestrator thread (single-instance subsystem):
             // record the per-thread ready_queue index before any submit_task fires
@@ -548,6 +547,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             if (is_dep_gen_enabled()) {
                 dep_gen_aicpu_set_orch_thread_idx(thread_idx);
             }
+#endif
 
 #if PTO2_PROFILING
             orch_cycle_start = get_sys_cnt_aicpu();
@@ -560,12 +560,12 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             (*p_func)(orch_args_cached_);
             rt_scope_end(rt);
 
+#if PTO2_PROFILING
             // Flush the (potentially partially-filled) DepGenBuffer so the host
             // collector can pick it up before this orchestrator thread joins.
             if (is_dep_gen_enabled()) {
                 dep_gen_aicpu_flush();
             }
-#if PTO2_PROFILING
             // Push the partially-filled scope_stats buffer so the host gets the
             // final scope_end records. Idempotent / no-op when disabled.
             scope_stats_aicpu_flush_buffers();

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -703,6 +703,7 @@ static TaskOutputTensors submit_task_common(
     // these records offline to reconstruct the complete dep graph — the sole
     // source of truth for fanout now that the swimlane hot path no longer
     // records it.
+#if PTO2_PROFILING
     if (is_dep_gen_enabled()) {
         const void *tensor_ptrs[MAX_TENSOR_ARGS];
         // TensorArgType is `enum class : int32_t` (4 bytes); the on-disk record
@@ -731,6 +732,7 @@ static TaskOutputTensors submit_task_common(
             args.launch_spec.core_num(), kernel_ids_capture
         );
     }
+#endif
 
     PTO2FaninBuilder fanin_builder(orch, orch->rings[ring_id].fanin_pool, next_fanin_seen_epoch(orch));
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -928,14 +928,15 @@ int32_t SchedulerContext::init(
         pmu_aicpu_init(physical_core_ids_, cores_total_num_);
         LOG_INFO_V0("PMU profiling started on %d cores", cores_total_num_);
     }
-#endif
-    // dep_gen is host-driven (SubmitTrace) and gated independently of
-    // PTO2_PROFILING. init() only pops the initial buffer from instance 0's
-    // free_queue; the orchestrator thread still records its idx via
+    // dep_gen is host-driven (SubmitTrace) — runtime-gated by the host flag —
+    // and compiles out with the other profiling subsystems at PTO2_PROFILING=0.
+    // init() only pops the initial buffer from instance 0's free_queue; the
+    // orchestrator thread still records its idx via
     // dep_gen_aicpu_set_orch_thread_idx() before the first record_submit.
     if (is_dep_gen_enabled()) {
         dep_gen_aicpu_init();
     }
+#endif
 
     // Initialize task counters. Task count comes from PTO2 shared memory.
     if (runtime->get_gm_sm_ptr()) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -522,6 +522,19 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
     bool cores_released = false;
 
+    // PMU runs require single-issue dispatch — overlapping in-flight tasks
+    // pollute per-task PMU counters. Cached at function scope (parity with
+    // a2a3): is_pmu_enabled() is extern "C" and the compiler cannot hoist it
+    // across the dispatch loop on its own, and the value is loop-invariant
+    // (PMU is latched once at kernel entry).
+#if PTO2_PROFILING
+    const bool pmu_active = is_pmu_enabled();
+#else
+    // PMU is definitionally off when profiling is compiled out; hard-set false
+    // so dispatch keeps its overlapping (non-single-issue) fast path.
+    constexpr bool pmu_active = false;
+#endif
+
 #if PTO2_PROFILING
     l2_swimlane.sched_start_ts = get_sys_cnt_aicpu();
 #endif
@@ -810,7 +823,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
 
         // Phase 4: MIX-strict-priority dispatch with phase-split and
         // cross-thread idle gating. See dispatch_ready_tasks for the policy.
-        const bool pmu_active = is_pmu_enabled();
+        // pmu_active is cached at function scope above (loop-invariant).
         dispatch_ready_tasks(runtime, thread_idx, tracker, local_bufs, pmu_active, made_progress, try_pushed);
 
 #if PTO2_PROFILING


### PR DESCRIPTION
## What

Closes #1146.

Two profiling `enable()` gates leaked onto the orchestrator/scheduler hot path uncovered by `PTO2_PROFILING`:

1. **`is_pmu_enabled()`** — once per scheduler main-loop iteration (`scheduler_dispatch.cpp`).
2. **`is_dep_gen_enabled()`** — once per task submission in `submit_task_common` (`pto_orchestrator.cpp`).

Both predicates are `extern "C"`/weak symbols defined in a separate translation unit from the scheduler loop, so the compiler can neither inline nor hoist them — each is a real `bl`/`ret` on the hot path even when profiling is off. Most other gates were already inside `#if PTO2_PROFILING`; these two were the residual.

## How

Gate both sites, both arches (a2a3 + a5), under the **existing** `PTO2_PROFILING` macro — **no new macro** (would duplicate `PTO2_PROFILING`).

- The PMU site is **load-bearing** (`pmu_active` feeds `dispatch_ready_tasks` and forces single-issue dispatch), so it is hard-set to `constexpr bool pmu_active = false` under `#if !PTO2_PROFILING` rather than dropped — PMU is definitionally off when profiling is compiled out, which keeps the overlapping fast path. The a5 read was additionally **hoisted to function scope** (it was re-called every scheduler loop iteration) to match a2a3; the value is loop-invariant (PMU latched once at kernel entry).
- **dep_gen is gated as a whole subsystem.** The per-task capture (`record_submit`) *and* the three cold sites — `dep_gen_aicpu_init` (`scheduler_cold_path.cpp`) and `set_orch_thread_idx` / `flush` (`aicpu_executor.cpp`) — are all folded under `#if PTO2_PROFILING`. Gating only the per-task capture would leave a half-on state at `=0` (buffer init + empty flush, no records); gating the whole subsystem compiles it out cleanly. The prior in-tree "dep_gen gated independently of PTO2_PROFILING" comment was updated accordingly.

## Scope notes

- Default build (`PTO2_PROFILING=1`) behavior is **unchanged**; a `=1` build still toggles dep_gen at runtime via the host SubmitTrace flag exactly as before.
- The `PTO2_PROFILING=0` + dep_gen-enabled combo is given up on purpose: nothing exercises it today (the only `=0` CI leg `profiling-flags-smoke / pto2-off` runs `vector_example`, which never enables dep_gen), and `=0` is the production-inference build where dep_gen (a diagnostic) is unwanted.
- **Magnitude unmeasured** — the cost is mechanism-true (one non-inlinable call per iteration/submit) but no AICPU scheduler profile was taken. Full analysis in `docs/investigations/2026-06-orch-profiling-enable-gates-hot-path.md`.

## Test

All touched translation units (`scheduler_dispatch.cpp`, `pto_orchestrator.cpp`, `scheduler_cold_path.cpp`, `aicpu_executor.cpp`) `-fsyntax-only` clean under `PTO2_PROFILING=1` **and** `PTO2_PROFILING=0` (a2a3 + a5).