### PR TITLE
bench: add qwen3_14b_decode to tensormap_and_ringbuffer benchmark set

### DIFF
--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -39,6 +39,7 @@ declare -A TMR_EXAMPLE_CASES=(
     [paged_attention_unroll_manual_scope]="Case1,Case2"
     [batch_paged_attention]="Case1"
     [spmd_paged_attention]="Case1,Case2"
+    [qwen3_14b_decode]="StressBatch16Seq3500"
 )
 TMR_EXAMPLE_ORDER=(
     alternating_matmul_add
@@ -47,6 +48,7 @@ TMR_EXAMPLE_ORDER=(
     paged_attention_unroll_manual_scope
     batch_paged_attention
     spmd_paged_attention
+    qwen3_14b_decode
 )
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Add the `qwen3_14b_decode` 2-layer SceneTestCase (#1088) to the
`tensormap_and_ringbuffer` benchmark set in `tools/benchmark_rounds.sh`.

- `TMR_EXAMPLE_CASES`: `[qwen3_14b_decode]="StressBatch16Seq3500"` — the
  case's only regime (BATCH=16, MAX_SEQ=5500, decode seq_len=3500).
- `TMR_EXAMPLE_ORDER`: appended `qwen3_14b_decode` so it runs last.

## Why

The case lives under `examples/a2a3/tensormap_and_ringbuffer/` and passes
deterministically on a2a3 device (per its README), but was not part of the
benchmark sweep. `benchmark_rounds.sh` resolves examples by searching
`tests/st/` first, then `examples/`, so the example dir is picked up
automatically.

## Test

`tools/benchmark_rounds.sh` is config-only; no behavior change to runtime
or kernels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)