### PR TITLE
docs(skills): device-log triage, DFX-tools skill, rebuild footgun

### DIFF
--- a/.claude/rules/codestyle.md
+++ b/.claude/rules/codestyle.md
@@ -4,12 +4,14 @@
 2. Use `enum class` preferentially for basic enumeration usage. Use `enum` only when implementing bitmask patterns or when bitwise operations are required.
 
     **Good:**
+
     ```cpp
     enum class CoreType : int { AIC = 0, AIV = 1 };
     CoreType type = CoreType::AIC;
     ```
 
     **Bad (unless implementing bitmask):**
+
     ```cpp
     enum CoreType { AIC = 0, AIV = 1 };  // Avoid this for basic enums
     ```
@@ -18,6 +20,7 @@
 4. Avoid using pointer arithmetic with hardcoded offsets when `offsetof` is available.
 5. **Never use `std::this_thread::yield()` or `sched_yield()` in AICPU spin-wait loops.** On the Ascend AICPU, yielding to the OS scheduler introduces unacceptable latency for tight spin-waits (ticket locks, CAS retries, etc.). Use an empty loop body or a bare architecture hint (`__asm__ volatile("yield")`) instead.
 6. **For cross-platform/platform-isolation preprocessor blocks, place the `__aarch64__` branch first.** Use this ordering pattern:
+
     ```cpp
     #if defined(__aarch64__)
     // aarch64 path (must be first)
@@ -27,3 +30,13 @@
     // other platforms
     #endif
     ```
+
+7. **Never log on AICPU hot paths** (orchestrator / scheduler inner loops,
+   per-task or per-scope code such as `submit_task` / `begin_scope` / the
+   dispatch loop). AICPU `device_log` writes are expensive and serialize on the
+   single AICPU op; flooding them — e.g. one `LOG_*` per scope_begin or per task
+   — slows the op enough to trip the **op-execute timeout** (STARS/tsdaemon
+   `HandleTaskTimeout` kills `aicpu-sd`), which *masks the very behavior you were
+   trying to observe* and looks like a runtime hang. Gate any diagnostic to a
+   high-water-mark (log only on a new max), a sample interval, or the
+   cold/stall path — never unconditionally per iteration.

--- a/.claude/rules/running-onboard.md
+++ b/.claude/rules/running-onboard.md
@@ -116,6 +116,69 @@ task-submit --device auto --device-num 1 \
 Sim variants (`a2a3sim`, `a5sim`) pass the precheck unconditionally — they
 are silicon-agnostic. The precheck is purely about onboard invocations.
 
+## Device logs: redirect them out of the shared default
+
+The AICPU/CCECPU device log (where `report_deadlock`, `HandleTaskTimeout`,
+stall diagnostics, AICore faults, and the `PTO2_PROFILING` Total/Orch/Sched
+markers land — the ground truth behind a host-side `507018`) defaults to:
+
+```text
+~/ascend/log/debug/device-<id>/device-<pid>_<timestamp>.log
+```
+
+That directory is **shared across every user/process on the box**, so finding
+*your* run's log means guessing by pid/timestamp and racing other writers.
+`ASCEND_PROCESS_LOG_PATH` redirects it to a directory you control.
+
+**`export` and `--env` are equivalent** — `task-submit` inherits the caller's
+environment, so you do *not* need `--env`:
+
+```bash
+# these two are the same; the dir MUST exist first (the driver fopens, no mkdir)
+export ASCEND_PROCESS_LOG_PATH="$LOGDIR"   # then: task-submit --run "..."
+task-submit --env ASCEND_PROCESS_LOG_PATH="$LOGDIR" --run "..."
+```
+
+**Recommended: put the device log under the run's own output dir** so it is
+isolated from other users and co-located with that run's artifacts. For a
+simpler scene test the per-case root is `outputs/<case>_<ts>/`; for a JIT
+example it is `build_output/_jit_*/dfx_outputs/`. Make an `ascend/` subdir
+under it and point the var there:
+
+```bash
+LOGDIR="$PWD/outputs/<case>/ascend"   # or .../dfx_outputs/ascend
+mkdir -p "$LOGDIR"
+export ASCEND_PROCESS_LOG_PATH="$LOGDIR"
+task-submit --device auto --device-num 1 --run "python ... -d \$TASK_DEVICE"
+# this run's device log is now at $LOGDIR/device-<id>/device-*.log
+```
+
+Then read it directly (`$LOGDIR/device-*/device-*.log`) — no more `grep`-ing
+`~/ascend/log/debug/` and guessing which file is yours.
+
+## `507018` triage: classify the mechanism before concluding
+
+`507018` (and `507014` / `507899`) is a **generic host-side code** —
+`run_prepared failed` / `aclrtSynchronizeStreamWithTimeout failed`. Several
+*distinct* on-device mechanisms all surface as the same code. Do NOT call it a
+"deadlock" or "OOM" from the host error alone — **read the device log and grep
+for the signature that actually fired:**
+
+| device-log signature | mechanism | note |
+| -------------------- | --------- | ---- |
+| `FATAL: Task Allocator Deadlock` / `Provable head-of-line` | ring/heap or dep-pool **deadlock** (alloc can't reclaim) | AICPU detector: 500ms backstop (`PTO2_ALLOC_DEADLOCK_TIMEOUT_CYCLES`) or immediate structural `head_blocked_on_scope_end`. Real capacity/scope deadlock. |
+| `Timeout (N cycles): producer/consumers ...` | **SPIN** wait on a specific producer/consumer | `pto_runtime2.cpp`. |
+| `HandleTaskTimeout` / `kill aicpu-sd` | **OS op-execute timeout** | STARS/tsdaemon, default 3s (`PLATFORM_OP_EXECUTE_TIMEOUT_US`). **A 3s kill ≠ deadlock** — the op was merely long or stalled. Raise this constant to measure true on-device duration. |
+| `log_stall_diagnostics` (cores idle + tasks `state=WAIT fanin 0/N` + `completed` frozen) | **forward-progress stall** | No dedicated detector — intermittent races (often contention-triggered) land here and are reaped only by the op-timeout above. |
+
+Decisive rule: **if a capacity/deadlock detector did NOT fire (counts of
+`Task Allocator Deadlock` / `Timeout (cycles)` are 0) and only
+`HandleTaskTimeout` did, it is NOT a proven deadlock or capacity bug** — it is a
+long/stalled op. A capacity exhaustion would trip its own detector; silence ⇒
+look for a race or just-too-slow, not "the ring is too small". For the
+device-side Total / Orch / Sched breakdown of a (completed) run, use
+`python -m simpler_setup.tools.device_log_timing` (see `simpler_setup/tools/README.md`).
+
 ## Anti-patterns
 
 - ❌ Bash `for i in $(seq 1 50); do pytest ... --device 8 & pytest ... --device 9 & wait; done`
@@ -129,6 +192,9 @@ are silicon-agnostic. The precheck is purely about onboard invocations.
 - ❌ Bypassing `onboard-arch-precheck` — the `--platform` mismatch failure
   modes are silent (look like real bugs) and burn hours of investigation
   time. Always run the gate.
+- ❌ Fishing your run's device log out of the shared `~/ascend/log/debug/`
+  by pid/timestamp guesswork. Set `ASCEND_PROCESS_LOG_PATH` to a per-run
+  dir up front (see "Device logs" above) so the log is isolated and known.
 
 ## Quick reference
 
@@ -140,5 +206,8 @@ are silicon-agnostic. The precheck is purely about onboard invocations.
 - **Wait for a submitted task** — `task-submit --wait <task-id>`
 - **Cancel pending** — `task-submit --cancel <task-id>`
 - **Per-die utilization + process table** — `npu-smi info`
+- **Redirect device log to the run's output** —
+  `mkdir -p <outdir>/ascend && export ASCEND_PROCESS_LOG_PATH=<outdir>/ascend`
+  (== `task-submit --env ASCEND_PROCESS_LOG_PATH=...`; dir must pre-exist)
 
 `task-submit --help` for the full surface.

--- a/.claude/skills/dfx-analyze/SKILL.md
+++ b/.claude/skills/dfx-analyze/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: dfx-analyze
+description: Analyze an onboard run's performance/scheduling/dependency/dump data using simpler's BUILT-IN DFX tools (simpler_setup.tools.*) instead of hand-rolling instrumentation. Use AFTER an onboard run when you need per-run device timing (Total/Orch/Sched), AICPU scheduler-overhead / Tail-OH breakdown, the task dependency graph, scope ring-fill peaks, or to inspect args dumps. These are simpler's own tools (shipped in the wheel), distinct from any cross-repo workload. Reach for this before writing custom timing/logging into the runtime.
+---
+
+# Analyze DFX data (simpler's own tools)
+
+simpler already ships end-user analysis CLIs under `simpler_setup.tools` —
+**use them; do not re-invent timing/instrumentation in the runtime.** Canonical
+reference (tool flags, examples, output paths): `simpler_setup/tools/README.md`.
+Per-DFX docs: `docs/dfx/` (`l2-timing.md`, `sched-overhead-model.md`,
+`l2-swimlane-profiling.md`, `scope-stats.md`, `dep_gen.md`, `args-dump.md`).
+
+## Pick the tool by question
+
+| You want… | Tool | Needs |
+| --------- | ---- | ----- |
+| Per-run **Total / Orch / Sched** device timing | `device_log_timing` | nothing extra — `PTO2_PROFILING` markers are in every device log (compile-time default on, **NOT** gated by swimlane) |
+| AICPU **scheduler overhead / Tail-OH / critical-path** breakdown | `sched_overhead_analysis` | a `--enable-l2-swimlane` (level≥3) run + `--enable-dep-gen` run |
+| Swimlane → **Perfetto** Chrome trace | `swimlane_converter` | `--enable-l2-swimlane` run (`--overhead` track needs deps.json too) |
+| Task **dependency graph** (text / HTML) | `deps_viewer` | `--enable-dep-gen` run → `deps.json` |
+| **Per-scope ring-fill peaks** (task_window / heap / tensormap) | `scope_stats_plot` | `--enable-scope-stats` run → `scope_stats.jsonl` |
+| Inspect / export **args dumps** | `dump_viewer` | `--enable-dump-tensor` run → `args_dump/` |
+
+## First reflex: Total/Orch/Sched needs nothing extra
+
+To answer "where did the time go / is this AICPU-orchestration bound", you do
+**not** need swimlane or custom logging — just run, then:
+
+```bash
+python -m simpler_setup.tools.device_log_timing -d <device_id>   # latest log for that die
+# or: --device-log <path/to/device-*.log>
+# prints per-round Total / Orch / Sched (us); Orch≈Sched≈Total ⇒ AICPU-bound.
+```
+
+Make the device log easy to find: redirect it under the run's output dir via
+`ASCEND_PROCESS_LOG_PATH` (see `.claude/rules/running-onboard.md` → "Device logs").
+
+## Where the inputs are written
+
+DFX artifacts land in the run's output dir with fixed filenames:
+
+- simpler scene tests (`tests/st`): `outputs/<case>_<ts>/` (the tools auto-pick
+  the latest by mtime when run from the dir holding `outputs/`).
+- JIT examples / pypto-lib: `build_output/_jit_*/dfx_outputs/`.
+
+## Don't
+
+- ❌ Hand-roll per-stage / submit-drain / per-scope timing in the runtime to get
+  numbers these tools already produce. If a tool is missing a metric, extend the
+  tool, not the hot path (and never log on AICPU hot paths — see
+  `codestyle.md` rule 7).

--- a/.claude/skills/multi-repo-setup/SKILL.md
+++ b/.claude/skills/multi-repo-setup/SKILL.md
@@ -127,6 +127,28 @@ source .venv/bin/activate
 pip install --no-build-isolation .   # needs PTO_ISA_ROOT set (Step 2.5)
 ```
 
+**Re-editing simpler later → the runtime `.so` may NOT recompile.** Non-editable
+`pip install .` (and `--force-reinstall`) rebuilds the *Python wheel* but can
+**silently skip the runtime build** (the runtime builder skips when outputs
+already exist), so a fresh C++ edit to `src/{arch}/runtime|platform/*` does not
+take effect — you keep running the old binary (real footgun: a runtime fix or
+diagnostic you added appears to do nothing). After editing simpler's C++, either
+verify the installed `.so` actually changed, or rebuild it via the cmake cache
+and sync to **both** load locations (`build/lib` AND the installed
+`.venv/.../simpler_setup/_assets/build/lib`):
+
+```bash
+BD=build/cache/{arch}/onboard/tensormap_and_ringbuffer/{aicpu|host|aicore}
+cmake --build "$BD" -j                       # incremental; recompiles changed .cpp
+SO="$BD/libaicpu_kernel.so"                   # or libhost_runtime.so / aicore_kernel.o
+for d in $(find .venv build/lib -path "*onboard*tensormap_and_ringbuffer*$(basename "$SO")"); do cp "$SO" "$d"; done
+strings "$SO" | grep '<your-marker>'          # confirm your change is in the binary
+```
+
+(CI/dev normally "use `-e .`" — editable rebuilds incrementally on reinstall; but
+multi-repo prefers non-editable to avoid the `_simpler_editable.pth` leak, so you
+must take the verify-or-cmake-build step above instead.)
+
 ### Either way: verify which simpler actually loaded
 
 A previous session may have left a user-site editable hook


### PR DESCRIPTION
## Summary

Doc/skill-only changes capturing onboard-debugging lessons (no code paths touched):

- **`.claude/rules/running-onboard.md`** — redirect the AICPU/CCECPU device log out
  of the shared `~/ascend/log/debug/` via `ASCEND_PROCESS_LOG_PATH` (`export` ≡
  `--env`); add a **`507018` triage table** so the generic host code is classified
  from the device log: deadlock-detect (`Task Allocator Deadlock`) vs SPIN-timeout
  (`Timeout (N cycles)`) vs OS op-timeout (`HandleTaskTimeout`, 3s) vs
  forward-progress stall (`log_stall_diagnostics`). "3s kill ≠ deadlock".
- **`.claude/skills/dfx-analyze/SKILL.md`** (new) — reach for simpler's built-in DFX
  tools (`device_log_timing`, `swimlane_converter`, `sched_overhead_analysis`,
  `deps_viewer`, `dump_viewer`) instead of hand-rolling timing/instrumentation in the
  runtime; points at `simpler_setup/tools/README.md`.
- **`.claude/rules/codestyle.md`** — rule #7: never log on AICPU hot paths (floods
  `device_log` → trips the op-timeout, masking the behavior under study).
- **`.claude/skills/multi-repo-setup/SKILL.md`** — footgun: a non-editable
  `pip install .` / `--force-reinstall` can silently skip the runtime `.so` rebuild;
  verify the built `.so` changed or `cmake --build` the cache + sync both load
  locations.

## Testing

- Documentation/skill files only — no build, sim, or hardware impact.