### PR TITLE
fix(runtime): improve task allocator deadlock diagnostics

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -96,10 +96,11 @@ public:
     void init(
         PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
         std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr,
-        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0
+        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, uint8_t ring_id = 0
     ) {
         descriptors_ = descriptors;
         slot_states_ = slot_states;
+        ring_id_ = ring_id;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
         current_index_ptr_ = current_index_ptr;
@@ -204,9 +205,10 @@ public:
                 }
                 if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
                     LOG_WARN(
-                        "[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
-                        local_task_id_ - last_alive, window_size_, heap_top_, heap_size_,
-                        blocked_on_heap ? "heap" : "task", spin_count
+                        "[TaskAllocator ring=%u] BLOCKED: tasks=%d/%d, heap_used=%" PRIu64 "/%" PRIu64
+                        ", heap_available=%" PRIu64 ", heap_cursor=%" PRIu64 ", on=%s, spins=%d",
+                        static_cast<unsigned>(ring_id_), local_task_id_ - last_alive, window_size_, heap_used_bytes(),
+                        heap_size_, heap_available(), heap_top_, blocked_on_heap ? "heap" : "task", spin_count
                     );
                 }
             }
@@ -256,6 +258,7 @@ private:
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
     // used by the deadlock detector to inspect the head task's state + fanout.
     PTO2TaskSlotState *slot_states_ = nullptr;
+    uint8_t ring_id_ = 0;
     int32_t window_size_ = 0;
     int32_t window_mask_ = 0;
     std::atomic<int32_t> *current_index_ptr_ = nullptr;
@@ -417,9 +420,9 @@ private:
 
         LOG_ERROR("========================================");
         if (heap_blocked) {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted! ring=%u", static_cast<unsigned>(ring_id_));
         } else {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full! ring=%u", static_cast<unsigned>(ring_id_));
         }
         LOG_ERROR("========================================");
         if (scope_gated) {
@@ -433,12 +436,12 @@ private:
             );
         }
         LOG_ERROR(
-            "  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)", local_task_id_, last_alive, active_tasks,
-            window_size_, 100.0 * active_tasks / window_size_
+            "  Task ring %u: current=%d, last_alive=%d, active=%d/%d (%.1f%%)", static_cast<unsigned>(ring_id_),
+            local_task_id_, last_alive, active_tasks, window_size_, 100.0 * active_tasks / window_size_
         );
         LOG_ERROR(
-            "  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", available=%" PRIu64, heap_top_, htail,
-            heap_size_, heap_available()
+            "  Heap ring %u: top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", used=%" PRIu64 ", available=%" PRIu64,
+            static_cast<unsigned>(ring_id_), heap_top_, htail, heap_size_, heap_used_bytes(), heap_available()
         );
         if (heap_blocked) {
             LOG_ERROR("  Requested:  %d bytes", requested_output_size);
@@ -461,13 +464,19 @@ private:
             LOG_ERROR("  2. Size the ring >= the scope's peak live-set (heap*2 may not be enough).");
         } else if (heap_blocked) {
             LOG_ERROR(
-                "  Increase heap (current: %" PRIu64 "); env PTO2_RING_HEAP=<pow2> (e.g. %" PRIu64 ")", heap_size_,
+                "  Increase heap (current: %" PRIu64 "); env PTO2_RING_HEAP=<bytes> (e.g. %" PRIu64 ")", heap_size_,
                 heap_size_ * 2
+            );
+            LOG_ERROR(
+                "  If one increase completes, it was under-provisioned; otherwise debug the stuck head consumer."
             );
         } else {
             LOG_ERROR(
                 "  Increase task window (current: %d); env PTO2_RING_TASK_WINDOW=<pow2> (e.g. %d)", window_size_,
                 active_tasks * 2
+            );
+            LOG_ERROR(
+                "  If one increase completes, it was under-provisioned; otherwise debug the stuck head consumer."
             );
         }
         LOG_ERROR("========================================");

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -301,7 +301,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
         orch->rings[r].task_allocator.init(
             task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
-            heap_sizes[r], orch_err, slot_states_dev
+            heap_sizes[r], orch_err, slot_states_dev, 0, static_cast<uint8_t>(r)
         );
         heap_offset += heap_sizes[r];
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -96,10 +96,11 @@ public:
     void init(
         PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
         std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr,
-        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0
+        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, uint8_t ring_id = 0
     ) {
         descriptors_ = descriptors;
         slot_states_ = slot_states;
+        ring_id_ = ring_id;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
         current_index_ptr_ = current_index_ptr;
@@ -204,9 +205,10 @@ public:
                 }
                 if (spin_count % PTO2_BLOCK_NOTIFY_INTERVAL == 0) {
                     LOG_WARN(
-                        "[TaskAllocator] BLOCKED: tasks=%d/%d, heap=%" PRIu64 "/%" PRIu64 ", on=%s, spins=%d",
-                        local_task_id_ - last_alive, window_size_, heap_top_, heap_size_,
-                        blocked_on_heap ? "heap" : "task", spin_count
+                        "[TaskAllocator ring=%u] BLOCKED: tasks=%d/%d, heap_used=%" PRIu64 "/%" PRIu64
+                        ", heap_available=%" PRIu64 ", heap_cursor=%" PRIu64 ", on=%s, spins=%d",
+                        static_cast<unsigned>(ring_id_), local_task_id_ - last_alive, window_size_, heap_used_bytes(),
+                        heap_size_, heap_available(), heap_top_, blocked_on_heap ? "heap" : "task", spin_count
                     );
                 }
             }
@@ -256,6 +258,7 @@ private:
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
     // used by the deadlock detector to inspect the head task's state + fanout.
     PTO2TaskSlotState *slot_states_ = nullptr;
+    uint8_t ring_id_ = 0;
     int32_t window_size_ = 0;
     int32_t window_mask_ = 0;
     std::atomic<int32_t> *current_index_ptr_ = nullptr;
@@ -417,9 +420,9 @@ private:
 
         LOG_ERROR("========================================");
         if (heap_blocked) {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted! ring=%u", static_cast<unsigned>(ring_id_));
         } else {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full! ring=%u", static_cast<unsigned>(ring_id_));
         }
         LOG_ERROR("========================================");
         if (scope_gated) {
@@ -433,12 +436,12 @@ private:
             );
         }
         LOG_ERROR(
-            "  Task ring:  current=%d, last_alive=%d, active=%d/%d (%.1f%%)", local_task_id_, last_alive, active_tasks,
-            window_size_, 100.0 * active_tasks / window_size_
+            "  Task ring %u: current=%d, last_alive=%d, active=%d/%d (%.1f%%)", static_cast<unsigned>(ring_id_),
+            local_task_id_, last_alive, active_tasks, window_size_, 100.0 * active_tasks / window_size_
         );
         LOG_ERROR(
-            "  Heap ring:  top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", available=%" PRIu64, heap_top_, htail,
-            heap_size_, heap_available()
+            "  Heap ring %u: top=%" PRIu64 ", tail=%" PRIu64 ", size=%" PRIu64 ", used=%" PRIu64 ", available=%" PRIu64,
+            static_cast<unsigned>(ring_id_), heap_top_, htail, heap_size_, heap_used_bytes(), heap_available()
         );
         if (heap_blocked) {
             LOG_ERROR("  Requested:  %d bytes", requested_output_size);
@@ -461,13 +464,19 @@ private:
             LOG_ERROR("  2. Size the ring >= the scope's peak live-set (heap*2 may not be enough).");
         } else if (heap_blocked) {
             LOG_ERROR(
-                "  Increase heap (current: %" PRIu64 "); env PTO2_RING_HEAP=<pow2> (e.g. %" PRIu64 ")", heap_size_,
+                "  Increase heap (current: %" PRIu64 "); env PTO2_RING_HEAP=<bytes> (e.g. %" PRIu64 ")", heap_size_,
                 heap_size_ * 2
+            );
+            LOG_ERROR(
+                "  If one increase completes, it was under-provisioned; otherwise debug the stuck head consumer."
             );
         } else {
             LOG_ERROR(
                 "  Increase task window (current: %d); env PTO2_RING_TASK_WINDOW=<pow2> (e.g. %d)", window_size_,
                 active_tasks * 2
+            );
+            LOG_ERROR(
+                "  If one increase completes, it was under-provisioned; otherwise debug the stuck head consumer."
             );
         }
         LOG_ERROR("========================================");

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -293,7 +293,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
         orch->rings[r].task_allocator.init(
             task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
-            heap_sizes[r], orch_err, slot_states_dev
+            heap_sizes[r], orch_err, slot_states_dev, 0, static_cast<uint8_t>(r)
         );
         heap_offset += heap_sizes[r];
 

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "utils/device_arena.h"
@@ -59,6 +60,13 @@ protected:
     }
 };
 
+static void
+add_runtime_output_arg(L0TaskArgs &args, std::vector<TensorCreateInfo> &create_infos, uint32_t float_count) {
+    uint32_t shape[] = {float_count};
+    create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+    args.add_output(create_infos.back());
+}
+
 TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     orch.begin_scope();
 
@@ -84,4 +92,53 @@ TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     // ref, low bits the consumer count. The duplicate explicit dep is deduped to a
     // single consumer, so this is scope + 1.
     EXPECT_EQ(producer_slot.fanout_count, PTO2_FANOUT_SCOPE_BIT + 1);
+}
+
+TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapState) {
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(8);
+
+    orch.begin_scope();
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), 1);
+
+    L0TaskArgs first_args;
+    add_runtime_output_arg(first_args, create_infos, 1024);  // 4096 bytes
+    TaskOutputTensors first = orch.submit_dummy_task(first_args);
+    ASSERT_TRUE(first.task_id().is_valid());
+
+    auto &ring = sm_handle->header->rings[1];
+    ring.fc.last_task_alive.store(1, std::memory_order_release);
+
+    L0TaskArgs wrap_args;
+    add_runtime_output_arg(wrap_args, create_infos, 1);  // wraps, packed to 1024 bytes
+    TaskOutputTensors wrapped = orch.submit_dummy_task(wrap_args);
+    ASSERT_TRUE(wrapped.task_id().is_valid());
+
+    L0TaskArgs fill_args;
+    add_runtime_output_arg(fill_args, create_infos, 512);  // 2048 bytes
+    TaskOutputTensors filled = orch.submit_dummy_task(fill_args);
+    ASSERT_TRUE(filled.task_id().is_valid());
+    ASSERT_EQ(orch.rings[1].task_allocator.heap_used_bytes(), 3072ULL);
+    ASSERT_EQ(orch.rings[1].task_allocator.heap_available(), 1024ULL);
+
+    auto &head = ring.get_slot_state_by_task_id(static_cast<int32_t>(wrapped.task_id().local()));
+    head.fanout_count = PTO2_FANOUT_SCOPE_BIT;
+    head.fanout_refcount.store(0, std::memory_order_release);
+    head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
+
+    L0TaskArgs blocked_args;
+    add_runtime_output_arg(blocked_args, create_infos, 1);
+    testing::internal::CaptureStderr();
+    TaskOutputTensors blocked = orch.submit_dummy_task(blocked_args);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(blocked.task_id().is_valid());
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
+    EXPECT_NE(log.find("FATAL: Task Allocator Deadlock - Heap Exhausted! ring=1"), std::string::npos);
+    EXPECT_NE(log.find("Heap ring 1:"), std::string::npos);
+    EXPECT_NE(log.find("used=3072"), std::string::npos);
+    EXPECT_NE(log.find("available=1024"), std::string::npos);
+    EXPECT_EQ(log.find("PTO2_RING_HEAP=<pow2>"), std::string::npos);
 }

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <cstdint>
+#include <string>
 #include <vector>
 
 #include "utils/device_arena.h"
@@ -59,6 +60,13 @@ protected:
     }
 };
 
+static void
+add_runtime_output_arg(L0TaskArgs &args, std::vector<TensorCreateInfo> &create_infos, uint32_t float_count) {
+    uint32_t shape[] = {float_count};
+    create_infos.emplace_back(shape, 1, DataType::FLOAT32);
+    args.add_output(create_infos.back());
+}
+
 TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     orch.begin_scope();
 
@@ -84,4 +92,53 @@ TEST_F(OrchestratorFaninTest, DuplicateExplicitProducerAddsOneFanin) {
     // ref, low bits the consumer count. The duplicate explicit dep is deduped to a
     // single consumer, so this is scope + 1.
     EXPECT_EQ(producer_slot.fanout_count, PTO2_FANOUT_SCOPE_BIT + 1);
+}
+
+TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapState) {
+    std::vector<TensorCreateInfo> create_infos;
+    create_infos.reserve(8);
+
+    orch.begin_scope();
+    orch.begin_scope();
+    ASSERT_EQ(orch.current_ring_id(), 1);
+
+    L0TaskArgs first_args;
+    add_runtime_output_arg(first_args, create_infos, 1024);  // 4096 bytes
+    TaskOutputTensors first = orch.submit_dummy_task(first_args);
+    ASSERT_TRUE(first.task_id().is_valid());
+
+    auto &ring = sm_handle->header->rings[1];
+    ring.fc.last_task_alive.store(1, std::memory_order_release);
+
+    L0TaskArgs wrap_args;
+    add_runtime_output_arg(wrap_args, create_infos, 1);  // wraps, packed to 1024 bytes
+    TaskOutputTensors wrapped = orch.submit_dummy_task(wrap_args);
+    ASSERT_TRUE(wrapped.task_id().is_valid());
+
+    L0TaskArgs fill_args;
+    add_runtime_output_arg(fill_args, create_infos, 512);  // 2048 bytes
+    TaskOutputTensors filled = orch.submit_dummy_task(fill_args);
+    ASSERT_TRUE(filled.task_id().is_valid());
+    ASSERT_EQ(orch.rings[1].task_allocator.heap_used_bytes(), 3072ULL);
+    ASSERT_EQ(orch.rings[1].task_allocator.heap_available(), 1024ULL);
+
+    auto &head = ring.get_slot_state_by_task_id(static_cast<int32_t>(wrapped.task_id().local()));
+    head.fanout_count = PTO2_FANOUT_SCOPE_BIT;
+    head.fanout_refcount.store(0, std::memory_order_release);
+    head.task_state.store(PTO2_TASK_COMPLETED, std::memory_order_release);
+
+    L0TaskArgs blocked_args;
+    add_runtime_output_arg(blocked_args, create_infos, 1);
+    testing::internal::CaptureStderr();
+    TaskOutputTensors blocked = orch.submit_dummy_task(blocked_args);
+    std::string log = testing::internal::GetCapturedStderr();
+
+    EXPECT_FALSE(blocked.task_id().is_valid());
+    EXPECT_TRUE(orch.fatal);
+    EXPECT_EQ(sm_handle->header->orch_error_code.load(std::memory_order_acquire), PTO2_ERROR_HEAP_RING_DEADLOCK);
+    EXPECT_NE(log.find("FATAL: Task Allocator Deadlock - Heap Exhausted! ring=1"), std::string::npos);
+    EXPECT_NE(log.find("Heap ring 1:"), std::string::npos);
+    EXPECT_NE(log.find("used=3072"), std::string::npos);
+    EXPECT_NE(log.find("available=1024"), std::string::npos);
+    EXPECT_EQ(log.find("PTO2_RING_HEAP=<pow2>"), std::string::npos);
 }


### PR DESCRIPTION
## Summary

Fix TaskAllocator deadlock diagnostics so heap-ring failures report the actual runtime state instead of misleading heap cursor values.

Previously, the blocked/deadlock logs printed `heap_top_` in a way that looked like heap usage, did not identify the affected ring, and suggested `PTO2_RING_HEAP=<pow2>` even though the runtime expects a byte size. This made issue #1133 hard to diagnose because the log could not clearly distinguish under-provisioned heap capacity from a stuck head consumer.

This change updates both a2a3 and a5 runtimes to:

- include the allocator ring id in blocked and fatal deadlock logs
- report real heap usage via `heap_used_bytes()`
- keep the heap cursor visible separately as `heap_cursor`
- include `used` and `available` in the heap-ring fatal report
- correct the heap sizing hint to `PTO2_RING_HEAP=<bytes>`
- add guidance for distinguishing under-provisioning from a stuck head consumer

The resulting fatal report now includes fields like:

```text
FATAL: Task Allocator Deadlock - Heap Exhausted! ring=1
Heap ring 1: top=..., tail=..., size=4096, used=3072, available=1024
```

## Tests

Added submit-path regression coverage for both a2a3 and a5. The tests trigger a heap-ring deadlock through submit_dummy_task() and verify that the captured log contains:

- FATAL: Task Allocator Deadlock - Heap Exhausted! ring=1
- Heap ring 1:
- used=3072
- available=1024

They also verify that the old misleading hint PTO2_RING_HEAP=<pow2> is no longer emitted.

### Validation run:

```shell
ctest -R '^(test_a2a3_orchestrator_fanin|test_a5_orchestrator_fanin)$' --output-on-failure
ctest -R '^(test_task_allocator|test_a5_task_allocator)$' --output-on-failure
task-submit ...
task-submit --device auto --device-num 1 ...
git diff --check
```