### PR TITLE
Add: name the exhausted ring in task-allocator deadlock dump

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -415,6 +415,18 @@ static bool prepare_task(
 
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
+        // The allocator named its ring_id; add the live scope depth it can't see.
+        // ring_id saturates at PTO2_MAX_RING_DEPTH-1, so deeper scopes all collapse
+        // onto the last ring -- print scope_depth to disambiguate which one.
+        // scope_stack_top is a 0-based top index; +1 matches the scope_depth
+        // convention in check_scope_can_accept_task. Snapshot it for a single
+        // consistent read (orchestrator is single-threaded, so no race).
+        const int32_t scope_top = orch->scope_stack_top;
+        LOG_ERROR(
+            "Stuck scope: scope_depth=%d -> ring=%d (PTO2_MAX_RING_DEPTH=%d)%s", scope_top + 1, ring_id,
+            PTO2_MAX_RING_DEPTH,
+            scope_top >= PTO2_MAX_RING_DEPTH ? " [ring saturated: deeper scopes share this ring]" : ""
+        );
         orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -96,9 +96,10 @@ public:
     void init(
         PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
         std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr,
-        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0
+        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, int32_t ring_id = 0
     ) {
         descriptors_ = descriptors;
+        ring_id_ = ring_id;
         slot_states_ = slot_states;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
@@ -251,6 +252,11 @@ public:
     }
 
 private:
+    // --- Identity ---
+    // This allocator's ring index (scope depth, saturated at PTO2_MAX_RING_DEPTH-1).
+    // Set once at init() so the deadlock dump can name which ring exhausted.
+    int32_t ring_id_ = 0;
+
     // --- Task Ring ---
     PTO2TaskDescriptor *descriptors_ = nullptr;
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
@@ -417,9 +423,9 @@ private:
 
         LOG_ERROR("========================================");
         if (heap_blocked) {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted! (ring=%d)", ring_id_);
         } else {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full! (ring=%d)", ring_id_);
         }
         LOG_ERROR("========================================");
         if (scope_gated) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -301,7 +301,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
         orch->rings[r].task_allocator.init(
             task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
-            heap_sizes[r], orch_err, slot_states_dev
+            heap_sizes[r], orch_err, slot_states_dev, /*initial_local_task_id=*/0, /*ring_id=*/r
         );
         heap_offset += heap_sizes[r];
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -423,6 +423,18 @@ static bool prepare_task(
 
     out->alloc_result = allocator.alloc(total_output_size);
     if (out->alloc_result.failed()) {
+        // The allocator named its ring_id; add the live scope depth it can't see.
+        // ring_id saturates at PTO2_MAX_RING_DEPTH-1, so deeper scopes all collapse
+        // onto the last ring -- print scope_depth to disambiguate which one.
+        // scope_stack_top is a 0-based top index; +1 matches the scope_depth
+        // convention in check_scope_can_accept_task. Snapshot it for a single
+        // consistent read (orchestrator is single-threaded, so no race).
+        const int32_t scope_top = orch->scope_stack_top;
+        LOG_ERROR(
+            "Stuck scope: scope_depth=%d -> ring=%d (PTO2_MAX_RING_DEPTH=%d)%s", scope_top + 1, ring_id,
+            PTO2_MAX_RING_DEPTH,
+            scope_top >= PTO2_MAX_RING_DEPTH ? " [ring saturated: deeper scopes share this ring]" : ""
+        );
         orch_mark_fatal(orch, PTO2_ERROR_HEAP_RING_DEADLOCK);
         return false;
     }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -96,9 +96,10 @@ public:
     void init(
         PTO2TaskDescriptor *descriptors, int32_t window_size, std::atomic<int32_t> *current_index_ptr,
         std::atomic<int32_t> *last_alive_ptr, void *heap_base, uint64_t heap_size, std::atomic<int32_t> *error_code_ptr,
-        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0
+        PTO2TaskSlotState *slot_states = nullptr, int32_t initial_local_task_id = 0, int32_t ring_id = 0
     ) {
         descriptors_ = descriptors;
+        ring_id_ = ring_id;
         slot_states_ = slot_states;
         window_size_ = window_size;
         window_mask_ = window_size - 1;
@@ -251,6 +252,11 @@ public:
     }
 
 private:
+    // --- Identity ---
+    // This allocator's ring index (scope depth, saturated at PTO2_MAX_RING_DEPTH-1).
+    // Set once at init() so the deadlock dump can name which ring exhausted.
+    int32_t ring_id_ = 0;
+
     // --- Task Ring ---
     PTO2TaskDescriptor *descriptors_ = nullptr;
     // Parallel to descriptors_, indexed by task_id & window_mask_. Read-only here,
@@ -417,9 +423,9 @@ private:
 
         LOG_ERROR("========================================");
         if (heap_blocked) {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Heap Exhausted! (ring=%d)", ring_id_);
         } else {
-            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full!");
+            LOG_ERROR("FATAL: Task Allocator Deadlock - Task Ring Full! (ring=%d)", ring_id_);
         }
         LOG_ERROR("========================================");
         if (scope_gated) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -293,7 +293,7 @@ bool PTO2OrchestratorState::init_data_from_layout(
 
         orch->rings[r].task_allocator.init(
             task_descs_dev, static_cast<int32_t>(task_window_sizes[r]), cur_idx_dev, last_alive_dev, ring_heap_base,
-            heap_sizes[r], orch_err, slot_states_dev
+            heap_sizes[r], orch_err, slot_states_dev, /*initial_local_task_id=*/0, /*ring_id=*/r
         );
         heap_offset += heap_sizes[r];
 


### PR DESCRIPTION
## Summary

The task-allocator deadlock dump (`report_deadlock`) reported the task
ring / heap ring counters and the head task, but never **which** of the
`PTO2_MAX_RING_DEPTH` (=4) rings actually exhausted. The allocator is a
depth-agnostic component that never learned its own ring index, and the
live scope depth lives one level up in the orchestrator — so the most
actionable piece ("which scope's ring is stuck") was missing.

This wires that identity through, each layer printing what it owns:

- **Allocator names its own ring.** `PTO2TaskAllocator` gains a
  `ring_id_` member, stamped once at `init()` from the per-ring init
  loop (`r`). The FATAL header now reads
  `... Heap Exhausted! (ring=N)` / `... Task Ring Full! (ring=N)`.
- **Orchestrator adds the live scope depth.** On the failed-alloc path
  in `prepare_task`, log `scope_stack_top` alongside `ring_id` right
  before `orch_mark_fatal`. Because `ring_id` saturates at
  `PTO2_MAX_RING_DEPTH-1`, deeper scopes collapse onto the last ring;
  `scope_depth` disambiguates which one.

No new global, include cycle, or orchestrator pointer in the allocator —
the allocator stays unit-testable in isolation. Applied symmetrically to
a2a3 and a5.

Resulting dump:

```
FATAL: Task Allocator Deadlock - Heap Exhausted! (ring=3)
  Task ring:  ...
  Heap ring:  ...
  Head task 0: state=1, consumers=464/464, scope_released=0
Stuck scope: scope_depth=3 -> ring=3 (PTO2_MAX_RING_DEPTH=4)
```

This sharpens the `FATAL: Task Allocator Deadlock` signature already
referenced in the 507018-triage table.

## Testing

- [x] All touched files compile (a2a3 + a5 objects build clean)
- [ ] cpput unit tests (`tests/ut/cpp`) — blocked locally by a
  pre-existing gtest ABI/link issue on this box (unrelated to this
  change); relying on CI to exercise them
- [ ] Hardware tests (N/A — diagnostic log string only, no behavior change)

The `LOG_ERROR` sits on the terminal failed-alloc/deadlock cold path
(fired once, immediately before the fatal abort), so it does not violate
the "no logging on AICPU hot paths" rule.