### PR TITLE
fix(a5/profiling): defer collector device-buffer member publish past rollback guard (#1085)

### DIFF
--- a/src/a5/platform/shared/host/dep_gen_collector.cpp
+++ b/src/a5/platform/shared/host/dep_gen_collector.cpp
@@ -115,23 +115,26 @@ int DepGenCollector::init(
     // free_queue contents) to device.
     profiling_copy_to_device(shm_dev_local, shm_host_local, shm_size);
 
+    LOG_INFO_V0(
+        "DepGen collector initialized: %d threads, SHM=0x%lx (records held in memory until replay)", num_threads,
+        reinterpret_cast<unsigned long>(shm_dev_local)
+    );
+    guard.commit();
+    // Publish members + memory context only after the rollback guard is
+    // disarmed; initialized_ is published last. set_memory_context copy-assigns
+    // std::function members and can throw std::bad_alloc, so keeping it (and the
+    // initialized_ store) before commit would let the guard free the shm/buffers
+    // on unwind while initialized_ is already true — finalize() would then skip
+    // its !initialized_ early-return and double-free what the guard released.
+    // start(tf) gates on shm_host_ (published by set_memory_context), so this is
+    // the moment the collector becomes startable.
     shm_dev_ = shm_dev_local;
     shm_size_ = shm_size;
-    initialized_ = true;
-
-    // Re-set_memory_context now that the shm region is ready. start(tf) gates
-    // on shm_host_ being non-null, so this is the moment the collector
-    // becomes startable.
     set_memory_context(
         alloc_cb, register_cb, free_cb, profiling_copy_to_device_for_ops, profiling_copy_from_device_for_ops,
         shm_dev_local, shm_host_local, shm_size, device_id
     );
-
-    LOG_INFO_V0(
-        "DepGen collector initialized: %d threads, SHM=0x%lx (records held in memory until replay)", num_threads,
-        reinterpret_cast<unsigned long>(shm_dev_)
-    );
-    guard.commit();
+    initialized_ = true;
     return 0;
 }
 

--- a/src/a5/platform/shared/host/l2_swimlane_collector.cpp
+++ b/src/a5/platform/shared/host/l2_swimlane_collector.cpp
@@ -243,15 +243,19 @@ int L2SwimlaneCollector::initialize(
     // direct access to `&ac_state->head` device addresses, no
     // host-to-device translation needed). AICore reads
     // rotation_table[block_idx] at kernel entry.
+    // Held in a local and published to aicore_ring_addr_table_dev_ only after
+    // guard.commit() (see end of this function). The alloc registers the buffer
+    // in the rollback guard, so a later init failure frees it via
+    // release_all_owned; assigning the member here would leave it dangling.
+    void *rotation_table_dev = nullptr;
     {
         size_t table_bytes = static_cast<size_t>(num_aicore) * sizeof(uint64_t);
         void *rotation_table_host = nullptr;
-        void *rotation_table_dev = alloc_paired_buffer(table_bytes, &rotation_table_host);
+        rotation_table_dev = alloc_paired_buffer(table_bytes, &rotation_table_host);
         if (rotation_table_dev == nullptr) {
             LOG_ERROR("Failed to allocate l2_swimlane_aicore_rotation_table (rotation) table (%zu bytes)", table_bytes);
             return -1;
         }
-        aicore_ring_addr_table_dev_ = rotation_table_dev;
     }
 
     // Step 6: Initialize per-thread phase pools — both sched and orch. Each
@@ -346,14 +350,12 @@ int L2SwimlaneCollector::initialize(
     // kernel_args.l2_swimlane_data_base (read back via get_l2_swimlane_setup_device_ptr()).
     LOG_DEBUG("L2 swimlane device base = 0x%lx", reinterpret_cast<uint64_t>(perf_dev_ptr));
 
-    perf_shared_mem_dev_ = perf_dev_ptr;
-    // Refresh memory context with the now-known SHM tuple. start(tf) (inherited)
-    // gates on shm_host_, so this is the moment the collector becomes startable.
-    set_memory_context(
-        alloc_cb, register_cb, free_cb, profiling_copy_to_device_for_ops, profiling_copy_from_device_for_ops,
-        perf_dev_ptr, perf_host_ptr, total_size, device_id
-    );
-
+    // Reserve the per-core / per-thread record vectors while the rollback guard
+    // is still armed, so a std::bad_alloc here unwinds through the guard and
+    // frees every buffer. Publication of the device pointers and the memory
+    // context is deferred to after commit (below): otherwise a throw here would
+    // leave perf_shared_mem_dev_ dangling and shm_host_ non-null, which would
+    // make is_initialized() report true and finalize() double-free.
     collected_perf_records_.assign(num_aicore_, {});
     collected_aicore_records_.assign(num_aicore_, {});
     collected_sched_phase_records_.assign(PLATFORM_MAX_AICPU_THREADS, {});
@@ -361,6 +363,17 @@ int L2SwimlaneCollector::initialize(
 
     LOG_INFO_V0("Performance profiling initialized (dynamic buffer mode)");
     guard.commit();
+    // Publish device-buffer members + memory context only after the rollback
+    // guard is disarmed: on a failed init they stay nullptr / shm_host_ stays
+    // null, so is_initialized() is false and finalize() never frees buffers the
+    // guard already freed. set_memory_context publishes shm_host_; start(tf)
+    // gates on it, so this is the moment the collector becomes startable.
+    perf_shared_mem_dev_ = perf_dev_ptr;
+    aicore_ring_addr_table_dev_ = rotation_table_dev;
+    set_memory_context(
+        alloc_cb, register_cb, free_cb, profiling_copy_to_device_for_ops, profiling_copy_from_device_for_ops,
+        perf_dev_ptr, perf_host_ptr, total_size, device_id
+    );
     return 0;
 }
 

--- a/src/a5/platform/shared/host/pmu_collector.cpp
+++ b/src/a5/platform/shared/host/pmu_collector.cpp
@@ -99,14 +99,20 @@ int PmuCollector::init(
     // table is filled fully by the host. AICore resolves its own PMU MMIO
     // base at kernel entry from `KernelArgs::regs[get_physical_core_id()]`,
     // so no separate PMU reg-address table is needed.
-    aicore_rings_dev_.assign(num_cores, nullptr);
+    // Held in locals and published to the aicore_rings_dev_ / aicore_ring_addrs_*
+    // members only after guard.commit() (see end of this function). The table
+    // alloc registers in the rollback guard and each ring is added via
+    // add_direct_ptr, so a later init failure frees them; assigning the members
+    // here would leave them dangling at freed memory.
+    std::vector<void *> aicore_rings_dev_local(num_cores, nullptr);
     size_t table_size = static_cast<size_t>(num_cores) * sizeof(uint64_t);
-    aicore_ring_addrs_dev_ = alloc_paired_buffer(table_size, &aicore_ring_addrs_host_);
-    if (aicore_ring_addrs_dev_ == nullptr) {
+    void *ring_addrs_host_local = nullptr;
+    void *ring_addrs_dev_local = alloc_paired_buffer(table_size, &ring_addrs_host_local);
+    if (ring_addrs_dev_local == nullptr) {
         LOG_ERROR("PmuCollector: failed to allocate aicore ring address table (%zu bytes)", table_size);
         return -1;
     }
-    std::memset(aicore_ring_addrs_host_, 0, table_size);
+    std::memset(ring_addrs_host_local, 0, table_size);
 
     // ---- Allocate per-core PmuBuffers; populate free_queues + recycled pool ----
     const size_t buf_size = sizeof(PmuBuffer);
@@ -120,10 +126,10 @@ int PmuCollector::init(
             LOG_ERROR("PmuCollector: failed to allocate PmuAicoreRing for core %d", c);
             return -1;
         }
-        aicore_rings_dev_[c] = ring_dev;
+        aicore_rings_dev_local[c] = ring_dev;
         guard.add_direct_ptr(ring_dev);
         state->aicore_ring_ptr = reinterpret_cast<uint64_t>(ring_dev);
-        reinterpret_cast<uint64_t *>(aicore_ring_addrs_host_)[c] = reinterpret_cast<uint64_t>(ring_dev);
+        reinterpret_cast<uint64_t *>(ring_addrs_host_local)[c] = reinterpret_cast<uint64_t>(ring_dev);
 
         for (int b = 0; b < PLATFORM_PMU_BUFFERS_PER_CORE; b++) {
             void *host_ptr = nullptr;
@@ -145,7 +151,7 @@ int PmuCollector::init(
     }
 
     // Push the populated ring address table to device.
-    profiling_copy_to_device(aicore_ring_addrs_dev_, aicore_ring_addrs_host_, table_size);
+    profiling_copy_to_device(ring_addrs_dev_local, ring_addrs_host_local, table_size);
 
     // Push the entire initialized shm region (header + BufferStates +
     // free_queue contents) to device.
@@ -170,22 +176,27 @@ int PmuCollector::init(
         csv_header_ = std::move(header);
     }
 
-    initialized_ = true;
+    LOG_INFO_V0(
+        "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
+        num_threads, reinterpret_cast<unsigned long>(shm_dev_local), csv_path_.c_str()
+    );
+    guard.commit();
+    // Publish device-buffer members, the shm/memory context, and the
+    // initialized_ flag only after the rollback guard is disarmed. On a failed
+    // init they stay at their defaults — initialized_ stays false, so
+    // is_initialized() reports false and finalize() never runs against buffers
+    // the guard already freed. set_memory_context also publishes shm_host_;
+    // start(tf) gates on it, so this is the moment the collector becomes
+    // startable. initialized_ is published last, once everything else is set.
+    aicore_rings_dev_ = std::move(aicore_rings_dev_local);
+    aicore_ring_addrs_dev_ = ring_addrs_dev_local;
+    aicore_ring_addrs_host_ = ring_addrs_host_local;
     shm_dev_ = shm_dev_local;
-
-    // Re-set_memory_context now that the shm region is ready. start(tf)
-    // gates on shm_host_ being non-null, so this is the moment the
-    // collector becomes startable.
     set_memory_context(
         alloc_cb, register_cb, free_cb, profiling_copy_to_device_for_ops, profiling_copy_from_device_for_ops,
         shm_dev_local, shm_host_local, shm_size, device_id
     );
-
-    LOG_INFO_V0(
-        "PMU collector initialized: %d cores, %d threads, SHM=0x%lx, CSV=%s (opened on first record)", num_cores,
-        num_threads, reinterpret_cast<unsigned long>(shm_dev_), csv_path_.c_str()
-    );
-    guard.commit();
+    initialized_ = true;
     return 0;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1085.

The a5 `L2SwimlaneCollector`, `PmuCollector`, and `DepGenCollector`
published device-buffer **members**, the memory context, and/or the
`initialized_` flag mid-`init()` while the `InitRollbackGuard` was still
armed. A later init failure frees those buffers on unwind (via
`release_all_owned` / the guard's `direct_ptrs_`), leaving the collector
pointing at freed memory with its "initialized" gate already set — so
`finalize()` skips its `!initialized_` early-return and double-frees /
UAFs what the guard released.

The failure is low-probability (the throwing call is a `std::bad_alloc`
from a `std::vector::assign` or from `set_memory_context` copy-assigning
its `std::function` members), but it is a real exception-safety hole, not
just a latent footgun.

## Fix (issue option 1, scoped to `src/a5/`)

Route the device buffers through locals and publish them, the memory
context, and the init gate to their members only **after**
`guard.commit()`, with the init gate published **last**. A failed init
then leaves the members at their defaults and the gate false, so
`finalize()` is a no-op.

- **l2_swimlane** — rotation table → `aicore_ring_addr_table_dev_`,
  `perf_shared_mem_dev_`, and `set_memory_context`.
- **pmu** — ring-address table dev ptr + paired host shadow + per-core
  ring vector (`aicore_ring_addrs_dev_` / `aicore_ring_addrs_host_` /
  `aicore_rings_dev_`), `shm_dev_`, `set_memory_context`, then
  `initialized_` last.
- **dep_gen** — `shm_dev_` / `shm_size_`, `set_memory_context`, then
  `initialized_` last. dep_gen has no dangling-member problem (its only
  buffer member is set after the last fail-return), but it published
  `initialized_` before commit with a throwing `set_memory_context` in
  between — the same `finalize()` double-free class — so it is hardened
  the same way to satisfy #1085's "apply uniformly across the a5
  collectors" ask.

The `guard.commit()` → publish window contains no return or throwing
call, so the success path is behaviorally identical.

## Scope check

- **a2a3** is unaffected — its collectors use no `InitRollbackGuard`, so
  a failed init leaks rather than dangles (separate, pre-existing,
  lower-severity concern).
- The shared **`src/common/`** collectors that *do* use the guard
  (`tensor_dump_collector`, `scope_stats_collector`) are already safe by
  construction: their buffer member / init gate is published after the
  last fail-return or with no rollback-able call between the publish and
  `guard.commit()`.

## Testing

Builds clean; CI (incl. `st-onboard-a5`) green. No regression test
added: the UB is reached only via an allocation-failure unwind that is
impractical to trigger deterministically (per discipline.md's "test
impractical" exception), so the fix is verified by inspection as an
equivalent transform on the success path.
