### PR TITLE
Fix: add mandatory arg_index to l3_l2_orch_comm test

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/l3_l2_orch_comm_stream/l3_l2_orch_comm_stream.py
+++ b/examples/a2a3/tensormap_and_ringbuffer/l3_l2_orch_comm_stream/l3_l2_orch_comm_stream.py
@@ -66,7 +66,7 @@ def _build_chip_callable(platform: str) -> ChipCallable:
         signature=[],
         func_name="l3_l2_orch_comm_orchestration",
         binary=orch,
-        children=[(0, CoreCallable.build(signature=[D.IN, D.OUT], binary=aiv))],
+        children=[(0, CoreCallable.build(signature=[D.IN, D.OUT], arg_index=[0, 1], binary=aiv))],
     )
 
 

--- a/tests/st/a5/tensormap_and_ringbuffer/l3_l2_orch_comm/test_l3_l2_orch_comm.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/l3_l2_orch_comm/test_l3_l2_orch_comm.py
@@ -67,7 +67,7 @@ def _build_chip_callable(platform: str) -> ChipCallable:
         signature=[],
         func_name="l3_l2_orch_comm_orchestration",
         binary=orch,
-        children=[(0, CoreCallable.build(signature=[D.IN, D.OUT], binary=aiv))],
+        children=[(0, CoreCallable.build(signature=[D.IN, D.OUT], arg_index=[0, 1], binary=aiv))],
     )
 
 


### PR DESCRIPTION
## Summary

Fixes the `st-sim-a5` breakage on `main`: `test_l3_l2_orch_comm.py` calls `CoreCallable.build` without the mandatory `arg_index` introduced by #1123, so it raises at build time and fails on every PR merging against current main.

- Declares `arg_index=[0, 1]` for `signature=[D.IN, D.OUT]` — the explicit per-slot payload mapping every other migrated incore already uses.
- Root cause: #1015 (which added this test) merged after #1123's ~250-site arg_index sweep without reconciling. See #1170 for the full analysis.

## Testing

- [ ] `st-sim-a5` (the failing job) — relying on CI; the omitted argument is the sole cause and the value matches the `signature=[D.IN, D.OUT]` ordering.

Fixes #1170