### PR TITLE
feat(runtime): add serial orch sched gate

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -22,9 +22,11 @@ Optional benchmark arguments forwarded to `tools/benchmark_rounds.sh`:
 /benchmark
 /benchmark -d 4 -n 50
 /benchmark -d 4 -d 6
+/benchmark --serial-orch-sched
 ```
 
-Extra arguments (`-n`, `-r`, etc.) are forwarded to `tools/benchmark_rounds.sh`.
+Extra arguments (`-n`, `-r`, `--serial-orch-sched`, etc.) are forwarded to
+`tools/benchmark_rounds.sh`.
 
 ### Device arguments (`-d`)
 
@@ -113,6 +115,10 @@ WORKTREE_ABS="/home/user/simpler/tmp/worktree_baseline_20260331_102302"
 ```bash
 ./tools/benchmark_rounds.sh $BENCH_ARGS -r "$RUNTIME" 2>&1 | tee "tmp/benchmark_${TIMESTAMP}.txt"
 ```
+
+Use `--serial-orch-sched` to run each case once in the default overlapped mode
+and once with `PTO2_SERIAL_ORCH_SCHED=1`, then emit serial-vs-parallel
+Delta/Change tables.
 
 ### Compare Mode
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -114,6 +114,7 @@ struct OrchSoEntry {
 struct AicpuExecutor {
     int32_t sched_thread_num_;
     bool orch_to_sched_{false};
+    bool serial_orch_sched_{false};
 
     // ===== Thread management state =====
     std::atomic<int32_t> thread_idx_{0};
@@ -190,6 +191,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
     sched_thread_num_ = aicpu_thread_num_ - 1;
     orch_to_sched_ = runtime->orch_to_sched;
+    serial_orch_sched_ = runtime->serial_orch_sched;
 
     if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
         LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
@@ -717,6 +719,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             LOG_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
         } else {
             sched_ctx_.bind_runtime(rt);
+            if (serial_orch_sched_) {
+                sched_ctx_.wait_for_orchestration_done_before_dispatch(runtime, thread_idx);
+            }
             int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
             if (completed < 0) {
                 LOG_ERROR("Thread %d: Scheduler failed with rc=%d", thread_idx, completed);
@@ -777,6 +782,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     aicpu_thread_num_ = 0;
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
+    serial_orch_sched_ = false;
 
     orch_args_cached_.reset();
     // orch_so_table_ entries are intentionally preserved across deinit: the

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -629,17 +629,18 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 
 1. **Host** compiles the orchestration source into a shared library (`.so`)
 2. The SO binary is embedded into `Runtime.device_orch_so_storage_[]` and copied to device
-3. **AICPU Thread 3** writes the SO to a temp file, calls `dlopen`
+3. The orchestrator thread writes the SO to a temp file, calls `dlopen`
 4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
 5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. Thread 3 creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
+6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
 7. After orchestration completes: `dlclose`, delete temp file
 
 ### 10.3 Thread Startup Synchronization
 
 | Flag | Set by | Waited by | Purpose |
 | ---- | ------ | --------- | ------- |
-| `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
+| `runtime_init_ready_` | Orchestrator thread | Scheduler threads | Runtime and SM handle initialized |
+| `orchestrator_done_` | Orchestrator thread | Scheduler threads when `PTO2_SERIAL_ORCH_SCHED=1` | Full task graph built |
 
 Profiling-subsystem init (`dump_args` / `pmu` / `dep_gen` / `l2_swimlane`) runs
 once in `SchedulerContext::init()` on the single-threaded cold path, before any
@@ -648,9 +649,19 @@ handshake.
 
 Startup sequence:
 
-1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
+1. Orchestrator thread: create SM handle + runtime → set `runtime_init_ready_`
 2. Scheduler threads: wait for `runtime_init_ready_` → enter main loop
-3. Thread 3: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
+3. Orchestrator thread: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
+
+With `PTO2_SERIAL_ORCH_SCHED=1`, scheduler threads still wait for
+`runtime_init_ready_` first, then additionally wait for `orchestrator_done_`
+before entering `resolve_and_dispatch()`. The default is off, preserving the
+current overlapped orch/sched pipeline. Serial mode is intended for measurement
+and debugging. During the serial wait, scheduler thread 0 may drain deferred
+wiring records to prevent bounded wiring-queue backpressure, but it does not
+dispatch AICore work until `orchestrator_done_` is set. Large graphs may still
+require larger task-ring, heap, or dependency-pool capacity because no task
+execution/reclaim happens during graph build.
 
 ---
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -471,6 +471,15 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
     }
 
+    // Read serial orchestrator -> scheduler start gate from environment.
+    {
+        const char *env_val = std::getenv("PTO2_SERIAL_ORCH_SCHED");
+        runtime->serial_orch_sched = env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T');
+        LOG_INFO_V0(
+            "Serial orchestrator-to-scheduler start gate: %s", runtime->serial_orch_sched ? "enabled" : "disabled"
+        );
+    }
+
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena all live in a single backing allocation;
     // setup_static_arena reserves the three regions and commits in one shot.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -221,6 +221,12 @@ public:
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
 
+    // Serial orchestrator -> scheduler start control.
+    // When true, scheduler threads wait until orchestration has fully built the
+    // task graph before entering resolve_and_dispatch().
+    // Controlled via PTO2_SERIAL_ORCH_SCHED environment variable.
+    bool serial_orch_sched;
+
 private:
     // Kernel binary tracking for cleanup
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -74,7 +74,7 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
         return LoopAction::BREAK_LOOP;
     }
 
-    bool orch_done = orchestrator_done_;
+    bool orch_done = orchestrator_done_.load(std::memory_order_acquire);
     if (!orch_done) return LoopAction::NONE;
 
     task_count = total_tasks_;
@@ -963,7 +963,7 @@ int32_t SchedulerContext::init(
     completed_tasks_.store(0, std::memory_order_release);
 
     // Device orchestration: the orchestrator thread flips this when the graph is built.
-    orchestrator_done_ = false;
+    orchestrator_done_.store(false, std::memory_order_release);
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
@@ -1011,7 +1011,7 @@ void SchedulerContext::deinit() {
     // Reset task counters and orchestrator state
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
-    orchestrator_done_ = false;
+    orchestrator_done_.store(false, std::memory_order_release);
 
     // Reset core transition state
     transition_requested_.store(false, std::memory_order_release);
@@ -1042,6 +1042,25 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
     sched_ = &rt->scheduler;
 }
 
+void SchedulerContext::wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx) {
+    while (!orchestration_done() && !completed_.load(std::memory_order_acquire)) {
+        if (thread_idx == 0 && sched_ != nullptr) {
+            // Use the wiring subsystem's normal batch/backoff policy while
+            // waiting. This still honors orch_needs_drain/producer_blocked
+            // signals without force-draining an empty queue every spin.
+            int wired = sched_->drain_wiring_queue(/*force_drain=*/false);
+            if (wired > 0) {
+                continue;
+            }
+        }
+        if (sched_ != nullptr && sched_->sm_header != nullptr &&
+            check_idle_fatal_error(thread_idx, sched_->sm_header, runtime) == LoopAction::BREAK_LOOP) {
+            break;
+        }
+        SPIN_WAIT_HINT();
+    }
+}
+
 // =============================================================================
 // Post-orchestration bookkeeping. Runs on the orchestrator thread once the
 // build phase finishes; folds inline-completed tasks, flips orchestrator_done_,
@@ -1069,7 +1088,7 @@ void SchedulerContext::on_orchestration_done(
         rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
 #endif
     }
-    orchestrator_done_ = true;
+    orchestrator_done_.store(true, std::memory_order_release);
 
     // Check for fatal error from orchestration; if so, shut down immediately.
     int32_t orch_err = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -94,6 +94,11 @@ public:
     // mode where rt is created by the orchestrator thread after init().
     void bind_runtime(PTO2Runtime *rt);
 
+    // Serial orch->sched mode pre-dispatch wait. Thread 0 may drain deferred
+    // wiring to keep the bounded wiring queue from back-pressuring orchestration,
+    // but no AICore dispatch happens before orchestrator_done_.
+    void wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx);
+
     // =========================================================================
     // State queries / external synchronization points
     // =========================================================================
@@ -102,6 +107,7 @@ public:
     int32_t aiv_count() const { return aiv_count_; }
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+    bool orchestration_done() const { return orchestrator_done_.load(std::memory_order_relaxed); }
 
 private:
     // =========================================================================
@@ -142,8 +148,7 @@ private:
     std::atomic<int32_t> completed_tasks_{0};
     int32_t total_tasks_{0};
     // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
-    // volatile prevents the compiler from hoisting the load out of spin loops.
-    volatile bool orchestrator_done_{false};
+    std::atomic<bool> orchestrator_done_{false};
     std::atomic<bool> completed_{false};
     uint64_t *func_id_to_addr_{nullptr};
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -1029,7 +1029,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // Phase 3: Drain wiring queue (thread 0 only)
         int wired = 0;
         if (thread_idx == 0) {
-            wired = sched_->drain_wiring_queue(orchestrator_done_);
+            wired = sched_->drain_wiring_queue(orchestrator_done_.load(std::memory_order_relaxed));
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -38,6 +38,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     orch_to_sched = false;
+    serial_orch_sched = false;
 
     // Initialize device orchestration state
     gm_sm_ptr_ = nullptr;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -114,6 +114,7 @@ struct OrchSoEntry {
 struct AicpuExecutor {
     int32_t sched_thread_num_;
     bool orch_to_sched_{false};
+    bool serial_orch_sched_{false};
 
     // ===== Thread management state =====
     std::atomic<int32_t> thread_idx_{0};
@@ -192,6 +193,7 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
     sched_thread_num_ = aicpu_thread_num_ - 1;
     orch_to_sched_ = runtime->orch_to_sched;
+    serial_orch_sched_ = runtime->serial_orch_sched;
 
     if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
         LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
@@ -712,6 +714,9 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             LOG_ERROR("Thread %d: rt is null after orchestrator error, skipping dispatch", thread_idx);
         } else {
             sched_ctx_.bind_runtime(rt);
+            if (serial_orch_sched_) {
+                sched_ctx_.wait_for_orchestration_done_before_dispatch(runtime, thread_idx);
+            }
             int32_t completed = sched_ctx_.resolve_and_dispatch(runtime, thread_idx);
             if (completed < 0) {
                 LOG_ERROR("Thread %d: Scheduler failed with rc=%d", thread_idx, completed);
@@ -772,6 +777,7 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     aicpu_thread_num_ = 0;
     sched_thread_num_ = 0;
     orch_to_sched_ = false;
+    serial_orch_sched_ = false;
 
     orch_args_cached_.reset();
     // orch_so_table_ entries are intentionally preserved across deinit: the

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -629,17 +629,18 @@ Built by the scheduler from `PTO2TaskDescriptor`:
 
 1. **Host** compiles the orchestration source into a shared library (`.so`)
 2. The SO binary is embedded into `Runtime.device_orch_so_storage_[]` and copied to device
-3. **AICPU Thread 3** writes the SO to a temp file, calls `dlopen`
+3. The orchestrator thread writes the SO to a temp file, calls `dlopen`
 4. `dlsym("aicpu_orchestration_config")` returns configuration (expected arg count)
 5. `dlsym("aicpu_orchestration_entry")` returns the orchestration function pointer
-6. Thread 3 creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
+6. The orchestrator thread creates a `PTO2Runtime`, calls the orchestration function within a `PTO2_SCOPE`
 7. After orchestration completes: `dlclose`, delete temp file
 
 ### 10.3 Thread Startup Synchronization
 
 | Flag | Set by | Waited by | Purpose |
 | ---- | ------ | --------- | ------- |
-| `runtime_init_ready_` | Thread 3 | Threads 0-2 | Runtime and SM handle initialized |
+| `runtime_init_ready_` | Orchestrator thread | Scheduler threads | Runtime and SM handle initialized |
+| `orchestrator_done_` | Orchestrator thread | Scheduler threads when `PTO2_SERIAL_ORCH_SCHED=1` | Full task graph built |
 
 Profiling-subsystem init (`dump_args` / `pmu` / `dep_gen` / `l2_swimlane`) runs
 once in `SchedulerContext::init()` on the single-threaded cold path, before any
@@ -648,9 +649,19 @@ handshake.
 
 Startup sequence:
 
-1. Thread 3: create SM handle + runtime → set `runtime_init_ready_`
+1. Orchestrator thread: create SM handle + runtime → set `runtime_init_ready_`
 2. Scheduler threads: wait for `runtime_init_ready_` → enter main loop
-3. Thread 3: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
+3. Orchestrator thread: configure orchestrator-scheduler pointers → call orchestration function → set `orchestrator_done_`
+
+With `PTO2_SERIAL_ORCH_SCHED=1`, scheduler threads still wait for
+`runtime_init_ready_` first, then additionally wait for `orchestrator_done_`
+before entering `resolve_and_dispatch()`. The default is off, preserving the
+current overlapped orch/sched pipeline. Serial mode is intended for measurement
+and debugging. During the serial wait, scheduler thread 0 may drain deferred
+wiring records to prevent bounded wiring-queue backpressure, but it does not
+dispatch AICore work until `orchestrator_done_` is set. Large graphs may still
+require larger task-ring, heap, or dependency-pool capacity because no task
+execution/reclaim happens during graph build.
 
 ---
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -467,6 +467,15 @@ extern "C" int bind_callable_to_runtime_impl(
         LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
     }
 
+    // Read serial orchestrator -> scheduler start gate from environment.
+    {
+        const char *env_val = std::getenv("PTO2_SERIAL_ORCH_SCHED");
+        runtime->serial_orch_sched = env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T');
+        LOG_INFO_V0(
+            "Serial orchestrator-to-scheduler start gate: %s", runtime->serial_orch_sched ? "enabled" : "disabled"
+        );
+    }
+
     // Lay out the per-Worker static device arena. GM heap, PTO2 shared memory,
     // and the prebuilt runtime arena all live in a single backing allocation;
     // setup_static_arena reserves the three regions and commits in one shot.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -235,6 +235,12 @@ public:
     // Controlled via PTO2_ORCH_TO_SCHED environment variable.
     bool orch_to_sched;
 
+    // Serial orchestrator -> scheduler start control.
+    // When true, scheduler threads wait until orchestration has fully built the
+    // task graph before entering resolve_and_dispatch().
+    // Controlled via PTO2_SERIAL_ORCH_SCHED environment variable.
+    bool serial_orch_sched;
+
 private:
     // Kernel binary tracking for cleanup
     int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -74,7 +74,7 @@ LoopAction SchedulerContext::handle_orchestrator_exit(
         return LoopAction::BREAK_LOOP;
     }
 
-    bool orch_done = orchestrator_done_;
+    bool orch_done = orchestrator_done_.load(std::memory_order_acquire);
     if (!orch_done) return LoopAction::NONE;
 
     task_count = total_tasks_;
@@ -974,7 +974,7 @@ int32_t SchedulerContext::init(
     completed_tasks_.store(0, std::memory_order_release);
 
     // Device orchestration: the orchestrator thread flips this when the graph is built.
-    orchestrator_done_ = false;
+    orchestrator_done_.store(false, std::memory_order_release);
 
     // Clear per-core dispatch payloads
     memset(payload_per_core_, 0, sizeof(payload_per_core_));
@@ -1022,7 +1022,7 @@ void SchedulerContext::deinit() {
     // Reset task counters and orchestrator state
     completed_tasks_.store(0, std::memory_order_release);
     total_tasks_ = 0;
-    orchestrator_done_ = false;
+    orchestrator_done_.store(false, std::memory_order_release);
 
     // Reset core transition state
     transition_requested_.store(false, std::memory_order_release);
@@ -1053,6 +1053,25 @@ void SchedulerContext::bind_runtime(PTO2Runtime *rt) {
     sched_ = &rt->scheduler;
 }
 
+void SchedulerContext::wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx) {
+    while (!orchestration_done() && !completed_.load(std::memory_order_acquire)) {
+        if (thread_idx == 0 && sched_ != nullptr) {
+            // Use the wiring subsystem's normal batch/backoff policy while
+            // waiting. This still honors orch_needs_drain/producer_blocked
+            // signals without force-draining an empty queue every spin.
+            int wired = sched_->drain_wiring_queue(/*force_drain=*/false);
+            if (wired > 0) {
+                continue;
+            }
+        }
+        if (sched_ != nullptr && sched_->sm_header != nullptr &&
+            check_idle_fatal_error(thread_idx, sched_->sm_header, runtime) == LoopAction::BREAK_LOOP) {
+            break;
+        }
+        SPIN_WAIT_HINT();
+    }
+}
+
 // =============================================================================
 // Post-orchestration bookkeeping. Runs on the orchestrator thread once the
 // build phase finishes; folds inline-completed tasks, flips orchestrator_done_,
@@ -1078,7 +1097,7 @@ void SchedulerContext::on_orchestration_done(
         rt->scheduler.tasks_completed.fetch_add(inline_completed, std::memory_order_relaxed);
 #endif
     }
-    orchestrator_done_ = true;
+    orchestrator_done_.store(true, std::memory_order_release);
 
     // Check for fatal error from orchestration; if so, shut down immediately.
     int32_t orch_err = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_context.h
@@ -92,6 +92,11 @@ public:
     // mode where rt is created by the orchestrator thread after init().
     void bind_runtime(PTO2Runtime *rt);
 
+    // Serial orch->sched mode pre-dispatch wait. Thread 0 may drain deferred
+    // wiring to keep the bounded wiring queue from back-pressuring orchestration,
+    // but no AICore dispatch happens before orchestrator_done_.
+    void wait_for_orchestration_done_before_dispatch(Runtime *runtime, int32_t thread_idx);
+
     // =========================================================================
     // State queries / external synchronization points
     // =========================================================================
@@ -100,6 +105,7 @@ public:
     int32_t aiv_count() const { return aiv_count_; }
     bool is_completed() const { return completed_.load(std::memory_order_acquire); }
     int32_t completed_tasks_count() const { return completed_tasks_.load(std::memory_order_acquire); }
+    bool orchestration_done() const { return orchestrator_done_.load(std::memory_order_relaxed); }
 
 private:
     // =========================================================================
@@ -140,8 +146,7 @@ private:
     std::atomic<int32_t> completed_tasks_{0};
     int32_t total_tasks_{0};
     // Device orchestration: set by last orchestrator when graph is built; schedulers poll it.
-    // volatile prevents the compiler from hoisting the load out of spin loops.
-    volatile bool orchestrator_done_{false};
+    std::atomic<bool> orchestrator_done_{false};
     std::atomic<bool> completed_{false};
     uint64_t *func_id_to_addr_{nullptr};
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -736,7 +736,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         // Phase 3: Drain wiring queue (thread 0 only)
         int wired = 0;
         if (thread_idx == 0) {
-            wired = sched_->drain_wiring_queue(orchestrator_done_);
+            wired = sched_->drain_wiring_queue(orchestrator_done_.load(std::memory_order_relaxed));
             if (wired > 0) {
                 made_progress = true;
 #if PTO2_SCHED_PROFILING

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -38,6 +38,7 @@ Runtime::Runtime() {
     aicpu_allowed_cpu_count = 0;
     aicpu_launch_count = 0;
     orch_to_sched = false;
+    serial_orch_sched = false;
 
     // Initialize profiling state
 

--- a/tools/benchmark_rounds.sh
+++ b/tools/benchmark_rounds.sh
@@ -18,7 +18,7 @@
 #   - Sched     run_prepared.runner_run.device_wall.sched span
 #
 # Usage:
-#   ./tools/benchmark_rounds.sh [-p <platform>] [-d <device>] [-n <rounds>] [-r <runtime>]
+#   ./tools/benchmark_rounds.sh [-p <platform>] [-d <device>] [-n <rounds>] [-r <runtime>] [--serial-orch-sched]
 #
 # Edit the EXAMPLE_CASES map below to control which examples and cases to run.
 
@@ -49,6 +49,7 @@ ROUNDS=100
 PLATFORM=a2a3
 RUNTIME=tensormap_and_ringbuffer
 VERBOSE=0
+SERIAL_ORCH_SCHED=0
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -73,12 +74,16 @@ while [[ $# -gt 0 ]]; do
             VERBOSE=1
             shift
             ;;
+        --serial-orch-sched)
+            SERIAL_ORCH_SCHED=1
+            shift
+            ;;
         --help|-h)
             cat <<'USAGE'
 benchmark_rounds.sh — run all examples and report per-round timing from [STRACE] markers
 
 Usage:
-  ./tools/benchmark_rounds.sh [-p <platform>] [-d <device>] [-n <rounds>] [-r <runtime>] [-v]
+  ./tools/benchmark_rounds.sh [-p <platform>] [-d <device>] [-n <rounds>] [-r <runtime>] [-v] [--serial-orch-sched]
 
 Options:
   -p, --platform Platform to run on (default: a2a3)
@@ -86,6 +91,9 @@ Options:
   -n, --rounds   Override number of rounds for each example (default: 100)
   -r, --runtime  Runtime to benchmark: tensormap_and_ringbuffer (default)
   -v, --verbose  Save detailed test_*.py output to a timestamped log file
+  --serial-orch-sched
+                 Run each case twice: default parallel mode, then serial
+                 orch->sched mode with PTO2_SERIAL_ORCH_SCHED=1.
   -h, --help     Show this help
 
 All other options are passed through to the underlying `python test_*.py`
@@ -179,16 +187,19 @@ parse_timing() {
 }
 
 # ---------------------------------------------------------------------------
-# run_bench <example> <example_dir> [case_name]
+# run_bench <example> <example_dir> [case_name] [mode]
 #   Run one benchmark invocation (via `python test_*.py`) and parse timing
 #   from the [STRACE] markers in its stderr. Skips the example if it has no
 #   test_*.py. Sets global PASS / FAIL counters.
 # ---------------------------------------------------------------------------
 run_bench() {
     local example="$1" example_dir="$2" case_name="${3:-}"
+    local mode="${4:-parallel}"
 
     if [[ -n "$case_name" ]]; then
-        echo "  ---- $case_name ----"
+        echo "  ---- $case_name [$mode] ----"
+    else
+        echo "  ---- $mode ----"
     fi
 
     local fw_stdout_file
@@ -219,7 +230,12 @@ run_bench() {
     # Run example, capturing stdout+stderr — the [STRACE] markers are on stderr.
     vlog "Running: ${run_cmd[*]}"
     local rc=0
-    "${run_cmd[@]}" > "$fw_stdout_file" 2>&1 || rc=$?
+    if [[ "$mode" == "serial" ]]; then
+        vlog "Environment: PTO2_SERIAL_ORCH_SCHED=1"
+        PTO2_SERIAL_ORCH_SCHED=1 "${run_cmd[@]}" > "$fw_stdout_file" 2>&1 || rc=$?
+    else
+        "${run_cmd[@]}" > "$fw_stdout_file" 2>&1 || rc=$?
+    fi
     if [[ -n "$VERBOSE_LOG" && -s "$fw_stdout_file" ]]; then
         cat "$fw_stdout_file" >> "$VERBOSE_LOG"
     fi
@@ -263,6 +279,7 @@ run_bench() {
     fi
 
     SUMMARY_NAMES+=("$label")
+    SUMMARY_MODE+=("$mode")
     SUMMARY_HOST+=("$avg_host")
     SUMMARY_DEVICE+=("$avg_device")
     SUMMARY_EFFECTIVE+=("$avg_effective")
@@ -278,6 +295,7 @@ FAIL=0
 
 # Summary collection arrays
 SUMMARY_NAMES=()
+SUMMARY_MODE=()
 SUMMARY_HOST=()
 SUMMARY_DEVICE=()
 SUMMARY_EFFECTIVE=()
@@ -322,11 +340,17 @@ for example in "${EXAMPLE_ORDER[@]}"; do
     fi
 
     if [[ -z "${case_list:-}" ]]; then
-        run_bench "$example" "$EXAMPLE_DIR"
+        run_bench "$example" "$EXAMPLE_DIR" "" "parallel"
+        if [[ $SERIAL_ORCH_SCHED -eq 1 ]]; then
+            run_bench "$example" "$EXAMPLE_DIR" "" "serial"
+        fi
     else
         IFS=',' read -ra cases <<< "$case_list"
         for c in "${cases[@]}"; do
-            run_bench "$example" "$EXAMPLE_DIR" "$c"
+            run_bench "$example" "$EXAMPLE_DIR" "$c" "parallel"
+            if [[ $SERIAL_ORCH_SCHED -eq 1 ]]; then
+                run_bench "$example" "$EXAMPLE_DIR" "$c" "serial"
+            fi
         done
     fi
 done
@@ -351,8 +375,8 @@ if [[ ${#SUMMARY_NAMES[@]} -gt 0 ]]; then
     echo "================================================================"
     echo ""
 
-    _hdr=$(printf "  %-40s" "Example")
-    _sep=$(printf "  %-40s" "----------------------------------------")
+    _hdr=$(printf "  %-40s  %-8s" "Example" "Mode")
+    _sep=$(printf "  %-40s  %-8s" "----------------------------------------" "--------")
     if [[ $_has_host      -eq 1 ]]; then _hdr=$(printf "%s  %12s" "$_hdr" "Host (us)");      _sep=$(printf "%s  %12s" "$_sep" "------------"); fi
     if [[ $_has_device    -eq 1 ]]; then _hdr=$(printf "%s  %12s" "$_hdr" "Device (us)");    _sep=$(printf "%s  %12s" "$_sep" "------------"); fi
     if [[ $_has_effective -eq 1 ]]; then _hdr=$(printf "%s  %14s" "$_hdr" "Effective (us)"); _sep=$(printf "%s  %14s" "$_sep" "--------------"); fi
@@ -363,6 +387,7 @@ if [[ ${#SUMMARY_NAMES[@]} -gt 0 ]]; then
 
     for _i in "${!SUMMARY_NAMES[@]}"; do
         _row=$(printf "  %-40s" "${SUMMARY_NAMES[$_i]}")
+        _row=$(printf "%s  %-8s" "$_row" "${SUMMARY_MODE[$_i]}")
         if [[ $_has_host      -eq 1 ]]; then _row=$(printf "%s  %12s" "$_row" "${SUMMARY_HOST[$_i]}");      fi
         if [[ $_has_device    -eq 1 ]]; then _row=$(printf "%s  %12s" "$_row" "${SUMMARY_DEVICE[$_i]}");    fi
         if [[ $_has_effective -eq 1 ]]; then _row=$(printf "%s  %14s" "$_row" "${SUMMARY_EFFECTIVE[$_i]}"); fi
@@ -370,6 +395,46 @@ if [[ ${#SUMMARY_NAMES[@]} -gt 0 ]]; then
         if [[ $_has_sched     -eq 1 ]]; then _row=$(printf "%s  %12s" "$_row" "${SUMMARY_SCHED[$_i]}");     fi
         echo "$_row"
     done
+
+    if [[ $SERIAL_ORCH_SCHED -eq 1 ]]; then
+        echo ""
+        echo "================================================================"
+        echo "  Serial vs Parallel Delta ($RUNTIME)"
+        echo "================================================================"
+        echo ""
+        printf "  %-40s  %-8s  %12s  %12s  %12s  %12s\n" \
+            "Example" "Metric" "Parallel" "Serial" "Delta" "Change (%)"
+        printf "  %-40s  %-8s  %12s  %12s  %12s  %12s\n" \
+            "----------------------------------------" "--------" "------------" "------------" "------------" "------------"
+
+        print_delta_row() {
+            local name="$1" metric="$2" base="$3" serial="$4"
+            [[ "$base" == "-" || "$serial" == "-" ]] && return
+            awk -v name="$name" -v metric="$metric" -v base="$base" -v serial="$serial" '
+                BEGIN {
+                    delta = serial - base
+                    change = (base == 0) ? 0 : delta * 100.0 / base
+                    printf "  %-40s  %-8s  %12.1f  %12.1f  %+12.1f  %+12.2f\n", name, metric, base, serial, delta, change
+                }'
+        }
+
+        for _i in "${!SUMMARY_NAMES[@]}"; do
+            [[ "${SUMMARY_MODE[$_i]}" == "serial" ]] || continue
+            _base_idx=""
+            for _j in "${!SUMMARY_NAMES[@]}"; do
+                if [[ "${SUMMARY_NAMES[$_j]}" == "${SUMMARY_NAMES[$_i]}" && "${SUMMARY_MODE[$_j]}" == "parallel" ]]; then
+                    _base_idx="$_j"
+                    break
+                fi
+            done
+            [[ -n "$_base_idx" ]] || continue
+            print_delta_row "${SUMMARY_NAMES[$_i]}" "Host"   "${SUMMARY_HOST[$_base_idx]}"   "${SUMMARY_HOST[$_i]}"
+            print_delta_row "${SUMMARY_NAMES[$_i]}" "Device" "${SUMMARY_DEVICE[$_base_idx]}" "${SUMMARY_DEVICE[$_i]}"
+            print_delta_row "${SUMMARY_NAMES[$_i]}" "Effective" "${SUMMARY_EFFECTIVE[$_base_idx]}" "${SUMMARY_EFFECTIVE[$_i]}"
+            print_delta_row "${SUMMARY_NAMES[$_i]}" "Orch"      "${SUMMARY_ORCH[$_base_idx]}"      "${SUMMARY_ORCH[$_i]}"
+            print_delta_row "${SUMMARY_NAMES[$_i]}" "Sched"     "${SUMMARY_SCHED[$_base_idx]}"     "${SUMMARY_SCHED[$_i]}"
+        done
+    fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #1164.

This adds an opt-in PTO2 serial orchestrator-to-scheduler start gate for the
`tensormap_and_ringbuffer` runtime on both `a2a3` and `a5`.

Default behavior remains unchanged: schedulers still use the existing overlapped
orch/sched pipeline unless `PTO2_SERIAL_ORCH_SCHED=1` is set.

## Changes

- Add `Runtime::serial_orch_sched`, wired from the host-side
  `PTO2_SERIAL_ORCH_SCHED` environment variable.
- Make AICPU scheduler threads wait for `orchestrator_done_` before
  `resolve_and_dispatch()` when serial mode is enabled.
- Keep scheduler thread 0 draining deferred wiring records during the serial
  wait so the bounded wiring queue does not back-pressure orchestration before
  `orchestrator_done_`.
- Change `orchestrator_done_` from `volatile bool` to `std::atomic<bool>` with
  acquire/release accesses.
- Add `tools/benchmark_rounds.sh --serial-orch-sched`, which runs each case in
  default `parallel` mode and serial mode, then prints serial-vs-parallel delta
  tables.
- Update runtime and benchmark docs.

## Verification

Build/static checks:

- `bash -n tools/benchmark_rounds.sh`
- `./tools/benchmark_rounds.sh --help`
- `git diff --check`
- `cmake --build build/ut_cpp --target a2a3_rt_objs`
- `cmake --build build/ut_cpp --target a5_rt_objs`
- `cmake --build build/cp310-cp310-linux_aarch64 --target build_runtimes`

Runtime smoke tests:

- `a2a3sim` `spmd_basic Case1` with `PTO2_SERIAL_ORCH_SCHED=1`: passed,
  device log confirmed `orch_end <= sched_start`.
- `a5sim` `spmd_basic Case1` with `PTO2_SERIAL_ORCH_SCHED=1`: passed,
  device log confirmed `orch_end <= sched_start`.
- `a2a3` onboard `spmd_basic Case1` with `PTO2_SERIAL_ORCH_SCHED=1`: passed,
  device log confirmed `orch_end <= sched_start`.

Benchmark integration:

- `tools/benchmark_rounds.sh -p a2a3 -n 1 --serial-orch-sched` emitted
  `[parallel]` / `[serial]` passes, `Performance Summary`, and
  `Serial vs Parallel Delta`.

Notes from the full a2a3 benchmark run:

- `spmd_paged_attention` failed in both parallel and serial modes with the
  existing onboard `507018` failure noted in the test source, so it is not a
  serial-gate regression.
- `batch_paged_attention Case1` serial mode exhausted the default 256MiB ring
  heap during full graph build. It passed with `PTO2_RING_HEAP=536870912`, which
  matches the expected serial-mode resource-capacity tradeoff.
