### PR TITLE
docs(skill): add multi-repo-qwen-setup + reorganize multi-repo-setup

### DIFF
--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -1,0 +1,313 @@
+---
+name: multi-repo-qwen-setup
+description: Concrete qwen3-14B guide on NPU against the current worktree's simpler. Points at simpler's own in-repo qwen3_14b_decode example (zero cross-repo), then covers the two cross-repo paths — the pypto-serving runner (prefill/decode TPOT) and the pypto-lib decode_layer kernel (scheduler-overhead DFX). Defers cross-repo clone/install to multi-repo-setup, then gives the exact run commands (batch-1 and batch-16), the prefill ring/timeout gotchas that otherwise surface as 507018, how to read the per-token timing layers, and the kernel-level overhead-analysis flow. Invoke when running qwen3 on simpler, measuring decode/prefill TPOT, reproducing a qwen3 perf number, running qwen3 decode_layer overhead analysis, or chasing a 507018 on the qwen3 path.
+---
+
+# Qwen3-14B on NPU: setup + TPOT / overhead measurement
+
+This skill is the **qwen3-specific concrete guide**. It first points at
+simpler's own in-repo qwen3 example (the zero-cross-repo path), then covers
+the two cross-repo paths against the worktree's simpler: the **pypto-serving
+runner** (prefill/decode TPOT) and the **pypto-lib `decode_layer` kernel**
+(scheduler-overhead DFX). For the cross-repo paths it gives the exact run
+commands, the prefill ring/timeout gotchas, and how to read per-token timing
+— distilled from real runs plus each upstream repo's own docs — sitting on
+top of [`multi-repo-setup`](../multi-repo-setup/SKILL.md), which owns the
+generic repo-graph + clone + install steps this skill does not repeat.
+
+## Three ways to run qwen3 — pick by what you're measuring
+
+There are **three distinct qwen3 entry points with different invocation
+styles**. They measure different things; don't confuse them:
+
+| aspect | Path 0 (in-repo) | Path A (serving) | Path B (decode_layer) |
+| ------ | ---------------- | ---------------- | --------------------- |
+| repo | simpler (this) | pypto-serving | pypto-lib |
+| entry | qwen3_14b_decode | npu_generate.py | decode_layer.py |
+| cross-repo? | no | yes | yes |
+| measures | 2-layer decode correctness/timing | end-to-end TPOT | layer sched overhead |
+| see | this section | sections 2-5 | section 6 |
+
+- **Path 0 — in-repo example (simpler itself, NO cross-repo).** Start here
+  if you just want qwen3 decode running on simpler. simpler ships a
+  self-contained SceneTestCase at
+  `examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/` — a fused chunk
+  of **two** Qwen3-14B decode layers (harvested pypto codegen: 8 AIC + 27
+  AIV + orchestration, golden in `simpler_setup/goldens/qwen3_14b_decode.py`).
+  No pypto / pypto-lib / JIT descent — it builds and runs like any simpler
+  example. Onboard rules still apply (per-die lock + `onboard-arch-precheck`):
+
+  ```bash
+  .claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
+  task-submit --device auto --device-num 1 --run "\
+    python -m pytest examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode \
+      --platform a2a3 --device \$TASK_DEVICE"
+  # standalone: python .../qwen3_14b_decode/test_qwen3_14b_decode.py -p a2a3 -d \$TASK_DEVICE
+  ```
+
+  This is **not** a cross-repo path, so the rest of this skill (§1 setup,
+  §2–§6) does not apply to it — run it like any other example/scene test
+  (see the example's own `README.md`). It's listed here only so you know it
+  exists before reaching for the heavier cross-repo paths below.
+- **Path A — serving runner (pypto-serving).** Full engine: builds an
+  `Engine` and runs `generate` over a prompt. Entry
+  `examples/model/qwen3_14b/npu_generate.py`, flags `--model-dir --prompt
+  --max-seq-len --max-new-tokens --num-layers-override --profile[-verbose]`.
+  Measures **end-to-end prefill/decode TPOT** for the whole model; read via
+  the `--profile` report + `device_log_timing` (§2–§5). Use it to reproduce
+  a serving perf number or chase a serving `507018`.
+- **Path B — `decode_layer` kernel (pypto-lib).** A single JIT case for one
+  decode layer, not the engine. Entry
+  `models/qwen3/14b/decode_layer.py`, flags `-p <platform> -d <device>`,
+  run in two rounds (`--no-dep-gen --enable-l2-swimlane`). Measures **one
+  layer's scheduler overhead** (Orch/Sched breakdown); read via
+  `sched_overhead_analysis` / `swimlane_converter` (§6). Use it to dig into
+  per-layer scheduling cost / the overhead model.
+
+Path 0 needs no setup beyond simpler itself. **The cross-repo paths A and B**
+(everything from §1 on) share only the §1 setup and the onboard rules — their
+run commands, flags, and analysis tools are otherwise entirely different.
+
+For Path A, `pypto-serving`'s `cpu_generate.py` is the torch reference, and
+`npu_generate.py` is single-prompt (**batch-1**); there is no `npu_stress.py`
+upstream — the batch-16 + `--prefill-on-cpu` harness lives in a private
+`opt-qwen3` fork (§3 shows the batch-N driver).
+
+## 1. Setup (cross-repo paths A & B only) — defer to multi-repo-setup
+
+Run [`multi-repo-setup`](../multi-repo-setup/SKILL.md) first — it clones
+pto-isa / pypto / pypto-lib / **pypto-serving** under `build/`, exports the
+toolchain env, and installs the simpler you want (worktree or main). Its
+Step 5 hands off to each external repo's own skills/docs; read those for
+anything this skill doesn't cover:
+
+- **Path A** — `build/pypto-serving/.claude/skills/` (if present) and its
+  `README.md` (engine config, model-dir layout, weights conversion).
+- **Path B** — `build/pypto-lib/.claude/skills/` / `README.md` and the
+  `decode_layer.py` docstring / `--help` (case flags, golden data).
+
+Then, from the worktree, the qwen runs assume this env:
+
+```bash
+source .venv/bin/activate
+eval "$(pypto-setup --export)"            # PTOAS_ROOT, ASCEND_HOME_PATH, gcc-15, PATH
+export PTO_ISA_ROOT="$PWD/build/pto-isa"  # needed to build the simpler runtime
+PY="$PWD/.venv/bin/python"
+```
+
+Verify the loaded simpler is the worktree's (not a user-site `.pth` shadow):
+`python -c "import simpler; print(simpler.__file__)"`.
+
+## 2. Path A — serving runner: decode (batch-1)
+
+*Path A (§2–§5) drives the **pypto-serving** `npu_generate.py` runner.*
+
+Onboard work MUST hold an exclusive die — wrap in `task-submit` and pass the
+[`onboard-arch-precheck`](../onboard-arch-precheck/SKILL.md) gate. Contention
+inflates every timing number, so a clean exclusive run is mandatory for perf.
+
+```bash
+.claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
+task-submit --timeout 2400 --max-time 2400 --device auto --device-num 1 --run "\
+  SIMPLER_CHIP_TIMING=1 $PY build/pypto-serving/examples/model/qwen3_14b/npu_generate.py \
+    --model-dir <QWEN3_14B_DIR> --prompt 'Huawei is' \
+    --platform a2a3 --device-id \$TASK_DEVICE \
+    --max-seq-len 4096 --max-new-tokens 32 \
+    --num-layers-override 40 --profile-verbose"
+```
+
+- `--num-layers-override 40` = full model; `--profile[-verbose]` prints the
+  timing report (`api.run_decode` per-step = end-to-end TPOT, `kernel.decode_layer`
+  host wall, per-step layer breakdown).
+- Decode dispatches through the **L3 `DistributedWorker`**, which forks a
+  **chip-child (L2)** that runs `run_prepared`. The per-step timing lives at
+  **L2**: `run_prepared` computes both host (`host_wall`) and device
+  (`device_wall` = the fused-decode orchestrator wall, ~33 ms — nonzero) plus
+  the device orch/sched markers. The L3 parent's `Worker.run` returns
+  `RunTiming(python_wall, 0)` — its `device_wall=0` is **expected** (L3 is a
+  dispatcher with no device wall of its own) and is **not** the source you
+  read. Read L2 instead (next section).
+
+## 3. Run decode (batch-16)
+
+`npu_generate.py` is single-prompt. For batch-N, build the same engine but call
+`engine.generate_batch(model_id, [prompt]*N, config)` — a ~30-line driver that
+reuses `npu_generate`'s `_TimingCollector` / `InstallProfiling` /
+`InstallThroughputMeter` and swaps the final `generate_result` for
+`generate_batch`. The engine is already configured `max_batch_size=16`.
+
+## 4. Prefill on NPU — the two gotchas (else 507018)
+
+Batch-16 256-token × 40-layer prefill on NPU is heavy. Two independent
+failures both surface as the generic `507018`/`507046` — **read the device
+log to tell them apart**:
+
+1. **Heap-exhausted deadlock** (default 256 MB ring): the open prefill scope's
+   live-set exceeds one ring → device log prints
+   `FATAL: Task Allocator Deadlock - Heap Exhausted! ... Provable head-of-line`.
+   Fix: raise the ring. batch-1 needs just over 256 MB; batch-16 needs the
+   prefill config `PTO2_RING_HEAP=4294967296 PTO2_RING_TASK_WINDOW=131072
+   PTO2_RING_DEP_POOL=131072` (heap, task-window, and dep-pool all scale with
+   batch; default `task_window=16384` also overflows at batch-16).
+2. **Op-execute timeout** (slow/contended prefill): device log prints
+   `HandleTaskTimeout ... timeOut:<N>` and kills `aicpu-sd`. The compiled
+   defaults (`PLATFORM_OP_EXECUTE_TIMEOUT_US`=45 s,
+   `PLATFORM_STREAM_SYNC_TIMEOUT_MS`=50 s — raised in #1175) clear a ~16.7 s
+   clean batch-16 prefill with margin, so a clean exclusive run does **not**
+   need an override. You only hit this on a **contended** box, where prefill
+   stretches past 45 s. In that case **raise the timeouts at runtime via the
+   env overrides — no rebuild, no header edit:**
+
+   ```bash
+   # add to the task-submit --run, before the python call:
+   export PTO2_OP_EXECUTE_TIMEOUT_US=120000000  # 120 s
+   export PTO2_STREAM_SYNC_TIMEOUT_MS=130000    # 130 s (must exceed op-execute)
+   ```
+
+   The runtime reads these and overrides the compiled defaults
+   (`resolve_runtime_timeout_config`, wrapped by `resolve_onboard_timeout_config`).
+   The override is **only accepted if the ordering holds**:
+   `scheduler (10 s) < op_execute < stream_sync`, and `stream_sync` must clear
+   the scheduler-arming guard (scheduler + 1.5 s) — otherwise the **whole
+   override set is dropped** and the 45 s / 50 s defaults stand. `120 s / 130 s`
+   satisfies all three. Pair with a long `task-submit --timeout`. A clean
+   exclusive die runs batch-16 256-prefill in ~16.7 s; a contended box can
+   blow past any timeout — prefer holding the die exclusively over chasing
+   ever-larger timeouts.
+
+(The private fork sidesteps both with `--prefill-on-cpu` — CPU prefill, NPU
+decode only — which `npu_generate.py` does not have.)
+
+## 5. Read the per-token timing layers
+
+Redirect the CANN device log out of the shared default, then parse it:
+
+```bash
+# add to the task-submit --run, before the python call:
+export ASCEND_PROCESS_LOG_PATH="$PWD/build/pypto-serving/build_output/ascend"
+mkdir -p "$ASCEND_PROCESS_LOG_PATH"
+# after the run (local, no device):
+$PY -m simpler_setup.tools.device_log_timing \
+    --device-log "$ASCEND_PROCESS_LOG_PATH/device-*/device-*.log"
+```
+
+`device_log_timing` reports per-round **Total / Orch / Sched** from the
+`PTO2_PROFILING` markers (on by default, no swimlane needed). Round 0 is the
+prefill; the rest are decode steps. **Total ≈ on-device kernel makespan** =
+the "kernel run time" layer.
+
+For layers ②③④ — the host↔device and bind/validate spans — parse the
+`[STRACE]` host-trace markers with `strace_timing.py` (landed in
+[simpler #1177](https://github.com/hw-native-sys/simpler/pull/1177)). The
+markers are emitted at `LOG_INFO_V9` under `PTO2_PROFILING` (no new flag),
+so the same log captured above carries them:
+
+```bash
+# TPOT table (per-callable; decode = most-invoked hid bucket):
+$PY -m simpler_setup.tools.strace_timing \
+    "$ASCEND_PROCESS_LOG_PATH/device-*/device-*.log"
+# also emit a Perfetto/Chrome-trace JSON (L3 parent + each L2 child = a lane):
+$PY -m simpler_setup.tools.strace_timing \
+    "$ASCEND_PROCESS_LOG_PATH/device-*/device-*.log" --trace-out strace.json
+```
+
+The full per-token decomposition (what each layer means / how to get it):
+
+| layer | = | source |
+| ----- | - | ------ |
+| ① kernel run time | makespan | `device_log_timing` Total |
+| ② device init/finalize | `device_wall − makespan` | `strace_timing` (`[STRACE]` markers) |
+| ③ host↔device handshake | `runner_run − device_wall` | `strace_timing` (`runner_run` span) |
+| ④ attach+bind+validate | `host_wall − runner_run` | `strace_timing` (`bind`/`validate` spans) |
+| ⑤ python/executor wrap | `end-to-end − host_wall` | `npu_generate --profile` |
+
+②③④ come from the **L2 chip-child** `run_prepared`'s `host_wall` /
+`runner_run` / `device_wall`. `host_wall` and `device_wall` are already
+computed there (and `device_wall` is nonzero, ~33 ms — it is the L2 orchestrator
+wall, *not* the L3 parent's `RunTiming.device_wall=0`); the L3 parent drops
+the child's `RunTiming`, so they never reach a return value.
+
+Simpler surfaces them instead as **`[STRACE]` host-trace markers** — one
+line per `run_prepared` stage
+(`bind`/`bind.args`/`bind.prebuilt`/`runner_run`/`validate`) plus the AICPU
+device-phase subdivision (`preamble`/`so_load`/`graph_build`/`post_orch`).
+`strace_timing.py` groups by `(pid, inv)`, rebuilds each invocation's span
+tree from `depth`, and prints per-callable means; see
+[docs/dfx/host-trace.md](../../../docs/dfx/host-trace.md) for the marker
+grammar and span tree. The L3-side tensor-management ask is
+[pypto-serving #44](https://github.com/hw-native-sys/pypto-serving/issues/44).
+
+## 6. Path B — `decode_layer` kernel: scheduler-overhead DFX
+
+*Path B is a different repo (**pypto-lib**) and a different entry point
+than §2–§5 — a single JIT kernel case, not the serving engine.*
+
+Path A above measures end-to-end TPOT through the serving runner. Path B
+instead digs into the **scheduler overhead** of the qwen3 decode kernel
+itself: run `build/pypto-lib/models/qwen3/14b/decode_layer.py` in two
+rounds and feed both into simpler's overhead tools. Onboard rules apply
+(per-die lock + `onboard-arch-precheck`).
+
+```bash
+.claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1
+cd "$PWD/build/pypto-lib/models/qwen3/14b"
+# Round 1 — dep_gen (topology); Round 2 — swimlane (clean timing). NEVER co-run:
+# dep_gen perturbs the timing the overhead analysis reads.
+task-submit --device auto --device-num 1 --run "python decode_layer.py -p a2a3 -d \$TASK_DEVICE"
+task-submit --device auto --device-num 1 --run "python decode_layer.py -p a2a3 -d \$TASK_DEVICE --no-dep-gen --enable-l2-swimlane"
+```
+
+Both write to `build_output/_jit_*/dfx_outputs/` (`deps.json` from round 1,
+`l2_swimlane_records.json` from round 2). Analyze from the simpler worktree
+(its `simpler_setup/tools` wins by cwd precedence):
+
+```bash
+# ROUND1_DIR / ROUND2_DIR are the two build_output/_jit_*/dfx_outputs/ dirs above.
+$PY -m simpler_setup.tools.sched_overhead_analysis \
+    --l2-swimlane-records-json "ROUND2_DIR/l2_swimlane_records.json" \
+    --deps-json "ROUND1_DIR/deps.json"
+# Visual: add the Overhead Analysis track to the Perfetto trace
+$PY -m simpler_setup.tools.swimlane_converter "ROUND2_DIR/l2_swimlane_records.json" \
+    --deps-json "ROUND1_DIR/deps.json" --overhead -o swimlane.json
+```
+
+See [docs/dfx/sched-overhead-model.md](../../../docs/dfx/sched-overhead-model.md)
+for what the report and the overhead tracks mean.
+
+## 7. When you change simpler C++ (instrumentation)
+
+Timeouts no longer need this — use the §4 env overrides. But for *code*
+changes (new instrumentation, log lines), `pip install` may skip the runtime
+`.so` rebuild. Rebuild + sync explicitly (same `find`-based copy as
+[`multi-repo-setup`](../multi-repo-setup/SKILL.md) Step 3 — arch-parametrized
+and python-version-agnostic, so it works on a2a3 / a5 and any venv layout):
+
+```bash
+ARCH=a2a3   # or a5
+BD="build/cache/$ARCH/onboard/tensormap_and_ringbuffer/host"
+cmake --build "$BD" -j"$(nproc)"
+SO="$BD/libhost_runtime.so"
+# sync to every load location (build/lib AND the installed venv), no hardcoded
+# python version — the glob matches whatever site-packages path exists:
+for d in $(find .venv build/lib -path "*onboard*tensormap_and_ringbuffer*$(basename "$SO")"); do
+  cp -f "$SO" "$d"
+done
+strings "$SO" | grep -m1 '<your-new-log-string>'   # confirm it baked in
+```
+
+(`.venv/lib64` is a symlink to `lib`, so the `find` covers both.) Host-side
+instrumentation lives in the **host** lib; only that target needs rebuilding.
+
+## Anti-patterns
+
+- ❌ Comparing TPOT across runs on a contended box — contention inflates
+  prefill (50 s+ vs 16.7 s) and decode spikes. Hold the die exclusively.
+- ❌ Reading `507018` as "simpler bug" without the device log — it masks a
+  heap deadlock, an op-timeout, and a forward-progress stall.
+- ❌ Editing `platform_config.h` to raise timeouts — use the `PTO2_OP_EXECUTE_TIMEOUT_US`
+  / `PTO2_STREAM_SYNC_TIMEOUT_MS` env overrides (§4) instead; no rebuild, and it
+  doesn't change the default for everyone else.
+- ❌ Setting the timeout env but breaking the ordering (`stream_sync` ≤ `op_execute`,
+  or `op_execute` ≤ scheduler 10 s, or `stream_sync` not clearing scheduler + 1.5 s
+  guard) — the **whole override set is dropped** and you debug the unchanged 45 s /
+  50 s defaults.

--- a/.claude/skills/multi-repo-setup/SKILL.md
+++ b/.claude/skills/multi-repo-setup/SKILL.md
@@ -1,17 +1,24 @@
 ---
 name: multi-repo-setup
-description: Set up a cross-repo investigation when a workload from another repo (pypto, pypto-lib, etc.) needs to be run, especially when you want to swap in simpler-main HEAD or the current worktree's simpler instead of the version that repo pins. Clones-or-updates each external repo every invocation so stale local clones don't lie about CI parity. MUST invoke before chasing "X doesn't work on simpler" reports where X lives outside this repo.
+description: Set up a cross-repo investigation when a workload from another repo (pypto, pypto-lib, pypto-serving, etc.) needs to be run, especially when you want to swap in simpler-main HEAD or the current worktree's simpler instead of the version that repo pins. Documents the repo graph (who imports who), clones-or-updates each external repo every invocation so stale local clones don't lie about CI parity, and points at each repo's own skills/docs for workload-specific steps. MUST invoke before chasing "X doesn't work on simpler" reports where X lives outside this repo.
 ---
 
 # Multi-Repo Investigation Setup
 
-The skill lives in the simpler repo, so `$PWD` when you invoke it is
-already a simpler worktree — nothing to clone for simpler itself.
+This skill answers one question: **given a workload that lives in another
+repo, how do the repos relate, and how do I clone + set up each one so the
+workload runs against the simpler I want?** It stops at "the repos are
+installed and the workload's own entry point is reachable" — for what to
+*run* and how to read its output, defer to that repo's own skills/docs
+(see [Step 5](#step-5-hand-off-to-each-repos-own-skillsdocs)) or, for the
+qwen3 workload specifically, to
+[`multi-repo-qwen-setup`](../multi-repo-qwen-setup/SKILL.md).
 
-Every other repo gets cloned-or-updated to a canonical local path each
-time. The default is to follow each repo's own pinning. Simpler dev
-often diverges from that to swap in either simpler-main HEAD or the
-current worktree.
+The skill lives in the simpler repo, so `$PWD` when you invoke it is
+already a simpler worktree — nothing to clone for simpler itself. Every
+other repo gets cloned-or-updated to a canonical local path each time. The
+default is to follow each repo's own pinning. Simpler dev often diverges
+from that to swap in either simpler-main HEAD or the current worktree.
 
 ## When to invoke
 
@@ -24,7 +31,7 @@ Invoke before:
 Skip for work that stays inside `simpler/` (its own pytest, examples,
 unit tests).
 
-## Step 1: The repo graph (URLs)
+## Step 1: The repo graph (who imports who)
 
 For an Ascend workload investigation, the cast is usually some subset
 of these. `simpler` is `$PWD` — the other repos are cloned under the
@@ -32,13 +39,20 @@ worktree's **`build/`** (gitignored, so they never get committed and stay
 co-located with the simpler you're testing). `$BUILD` =
 `$(git rev-parse --show-toplevel)/build` (Step 2 defines it).
 
-| repo | role | GitHub URL | local clone |
-| ---- | ---- | ---------- | ----------- |
-| simpler | host runtime + DFX (this repo) | <https://github.com/hw-native-sys/simpler> | `$PWD` (the current worktree) |
-| pypto | compiler + Python frontend; vendors a simpler submodule at `runtime/` | <https://github.com/hw-native-sys/pypto> | `$BUILD/pypto` |
-| pypto-lib | model workloads (qwen3, deepseek, etc.) — imports pypto + simpler | <https://github.com/hw-native-sys/pypto-lib> | `$BUILD/pypto-lib` |
-| pto-isa | ISA spec; sets `PTO_ISA_ROOT` (required to BUILD the simpler runtime) | <https://github.com/hw-native-sys/pto-isa> | `$BUILD/pto-isa` |
-| PTOAS | `ptoas` assembler — **provided globally**, no clone | (on dev box / CI) | `/usr/local/bin/ptoas-bin` via `pypto-setup` |
+| repo | role | imports | GitHub URL | local clone |
+| ---- | ---- | ------- | ---------- | ----------- |
+| simpler | host runtime + DFX (this repo) | — | <https://github.com/hw-native-sys/simpler> | `$PWD` (the current worktree) |
+| pto-isa | ISA spec; sets `PTO_ISA_ROOT` (required to BUILD the simpler runtime) | — | <https://github.com/hw-native-sys/pto-isa> | `$BUILD/pto-isa` |
+| pypto | compiler + Python frontend; vendors a simpler submodule at `runtime/` | simpler | <https://github.com/hw-native-sys/pypto> | `$BUILD/pypto` |
+| pypto-lib | model kernels (qwen3, deepseek, etc.) | pypto + simpler | <https://github.com/hw-native-sys/pypto-lib> | `$BUILD/pypto-lib` |
+| pypto-serving | serving stack + standalone model runners (qwen3 `npu_generate.py`) | pypto-lib + pypto + simpler | <https://github.com/hw-native-sys/pypto-serving> | `$BUILD/pypto-serving` |
+| PTOAS | `ptoas` assembler — **provided globally**, no clone | — | (on dev box / CI) | `/usr/local/bin/ptoas-bin` via `pypto-setup` |
+
+The import chain is a stack: **pto-isa** (build-time spec) → **simpler**
+(runtime) → **pypto** (compiler, vendors simpler) → **pypto-lib** (kernels)
+→ **pypto-serving** (serving + runners). A change low in the stack
+(simpler) can break anything above it; that's why Step 3 lets you pin which
+simpler the whole stack sees.
 
 Drop rows your investigation doesn't need. Add rows for ad-hoc repos in
 the same format.
@@ -65,10 +79,11 @@ ensure_repo() {
   git -C "$dir" submodule update --init --recursive --depth 1
 }
 
-ensure_repo https://github.com/hw-native-sys/pypto      "$BUILD/pypto"
-ensure_repo https://github.com/hw-native-sys/pypto-lib  "$BUILD/pypto-lib"
-ensure_repo https://github.com/hw-native-sys/pto-isa    "$BUILD/pto-isa"
-# add more as needed
+ensure_repo https://github.com/hw-native-sys/pto-isa        "$BUILD/pto-isa"
+ensure_repo https://github.com/hw-native-sys/pypto          "$BUILD/pypto"
+ensure_repo https://github.com/hw-native-sys/pypto-lib      "$BUILD/pypto-lib"
+ensure_repo https://github.com/hw-native-sys/pypto-serving  "$BUILD/pypto-serving"
+# add more as needed; drop rows your investigation doesn't touch
 ```
 
 Notes:
@@ -178,10 +193,13 @@ without reinstall. Editable installs leak the `_simpler_editable.pth`
 hook into user-site, which survives sessions and shadows the next
 venv install. Non-editable installs don't.
 
-## Step 4: Install pypto / pypto-lib
+## Step 4: Install the compiler / kernel / serving layers
 
-For pypto, plain install too — let pypto's vendored `runtime/` stay
-unbuilt because you've already provided simpler via Step 3:
+Install only the layers your workload imports (the Step 1 chain). For each,
+prefer plain `--no-build-isolation` install and let the vendored simpler
+stay unbuilt — you've already provided simpler via Step 3.
+
+### pypto (compiler)
 
 ```bash
 pip install --no-build-isolation "$BUILD/pypto"
@@ -189,58 +207,57 @@ pip install --no-build-isolation "$BUILD/pypto"
 # overwrite the simpler you installed in Step 3 with pypto's older pin.
 ```
 
-pypto-lib is import-only (no install). Set `PYTHONPATH` and run
-scripts out of its tree directly:
+### pypto-lib (kernels) — import-only
 
 ```bash
-export PYTHONPATH="$BUILD/pypto-lib"
+export PYTHONPATH="$BUILD/pypto-lib"   # no install; run scripts out of its tree
 ```
 
-Re-verify the loaded simpler after every install — pypto's install can
+### pypto-serving (serving + runners)
+
+Install or `PYTHONPATH`-import per that repo's README (see Step 5). Its
+qwen3 runner is the entry point the
+[`multi-repo-qwen-setup`](../multi-repo-qwen-setup/SKILL.md)
+skill drives.
+
+Re-verify the loaded simpler after every install — an install can
 re-resolve dependencies in ways that change what wins.
 
-## Worked example: qwen3 decode_layer onboard (a2a3) + DFX
+## Step 5: Hand off to each repo's own skills/docs
 
-End-to-end, assuming Steps 1–4 done (repos in `$BUILD`, env from Step 2.5,
-worktree simpler installed). The case is
-`$BUILD/pypto-lib/models/qwen3/14b/decode_layer.py`. Onboard runs MUST hold a
-per-die lock (see `.claude/rules/running-onboard.md`) and pass the
-`onboard-arch-precheck` gate.
+This skill gets the repos cloned, the toolchain env exported, and the
+simpler-of-your-choice installed. **What to run inside each repo — its
+test entry points, flags, golden-data setup, DFX knobs — is documented in
+that repo, not here.** After Step 4, for each external repo you're using,
+consult, in this order:
 
-```bash
-.claude/skills/onboard-arch-precheck/check.sh a2a3 || exit 1   # refuse wrong-arch BEFORE locking
-cd "$BUILD/pypto-lib/models/qwen3/14b"
-# Round 1 — dep_gen (topology) ; Round 2 — swimlane (clean timing). NEVER co-run:
-# dep_gen perturbs the timing the overhead analysis reads.
-task-submit --device auto --device-num 1 --run "python decode_layer.py -p a2a3 -d \$TASK_DEVICE"
-task-submit --device auto --device-num 1 --run "python decode_layer.py -p a2a3 -d \$TASK_DEVICE --no-dep-gen --enable-l2-swimlane"
-```
-
-Both write to `build_output/_jit_*/dfx_outputs/` (`deps.json` from round 1,
-`l2_swimlane_records.json` from round 2). Then analyze from the simpler worktree
-(its `simpler_setup/tools` wins by cwd precedence):
+1. **That repo's `.claude/skills/`** (if it has one) — task-specific
+   workflows maintained by that repo's owners.
+2. **That repo's top-level `README.md`** and any `docs/` — setup and
+   run recipes.
+3. **The workload script's own docstring / `--help`** — often the most
+   precise statement of intent and flags.
 
 ```bash
-# ROUND1_DIR / ROUND2_DIR are the two build_output/_jit_*/dfx_outputs/ dirs above.
-python -m simpler_setup.tools.sched_overhead_analysis \
-    --l2-swimlane-records-json "ROUND2_DIR/l2_swimlane_records.json" \
-    --deps-json "ROUND1_DIR/deps.json"
-# Visual: add the Overhead Analysis track to the Perfetto trace
-python -m simpler_setup.tools.swimlane_converter "ROUND2_DIR/l2_swimlane_records.json" \
-    --deps-json "ROUND1_DIR/deps.json" --overhead -o swimlane.json
+ls "$BUILD/<repo>/.claude/skills" 2>/dev/null   # repo-owned skills, if any
+sed -n '1,40p' "$BUILD/<repo>/README.md"        # repo setup/run recipe
+python "$BUILD/<repo>/<workload>.py" --help      # the script's own contract
 ```
 
-See [docs/dfx/sched-overhead-model.md](../../../docs/dfx/sched-overhead-model.md)
-for what the report and the 8 overhead tracks mean.
+Do not duplicate those instructions into simpler's skills — link to them.
+The one exception maintained here is the qwen3 workload, whose cross-repo
+timing/ring/timeout gotchas are simpler-specific enough to warrant the
+dedicated [`multi-repo-qwen-setup`](../multi-repo-qwen-setup/SKILL.md)
+skill.
 
-## Step 5: If the workload fails — start with "is it CI-gated?"
+## Step 6: If the workload fails — start with "is it CI-gated?"
 
 The most informative first check is whether the workload is gated by
 that repo's CI workflow.
 
 | case | meaning | how to triage |
 | ---- | ------- | ------------- |
-| **CI-gated** | the repo's CI runs this exact script today; it was passing as of the last green CI run | A failure now usually points at a **recent code change** — your in-flight simpler changes, or a commit landed in pypto / pypto-lib since the last CI run. Bisect against `origin/main` of each repo. |
+| **CI-gated** | the repo's CI runs this exact script today; it was passing as of the last green CI run | A failure now usually points at a **recent code change** — your in-flight simpler changes, or a commit landed in pypto / pypto-lib / pypto-serving since the last CI run. Bisect against `origin/main` of each repo. |
 | **not CI-gated** | the script is in the repo but no workflow invokes it | Read the docstring first. Files like this are often "intent" / "EXPECTED / INTENT program" / experimental drafts — they may be documented as expected-to-fail. Treat as workload bug, not simpler bug, unless proven otherwise. |
 
 Quick check:
@@ -279,13 +296,18 @@ grep "completed=" "$LOG" | head -1
 ```
 
 If the same task hangs across every retry on every chip, it's the
-workload (or your code change), not chip contention.
+workload (or your code change), not chip contention. For the full
+`507018` mechanism-classification table (deadlock vs op-timeout vs
+stall), see [`.claude/rules/running-onboard.md`](../../rules/running-onboard.md).
 
 ## Anti-patterns
 
 - ❌ **Trusting an existing local clone without `git fetch`**. Your
   clone is whatever you last fetched, possibly weeks behind. Step 2
   exists precisely to make this not a thing.
+- ❌ **Re-documenting another repo's run steps here**. Link to that
+  repo's own `.claude/skills/` / README (Step 5) — duplicated steps go
+  stale the moment that repo moves.
 - ❌ **Using `-e` "just to be safe"**. Editable installs leak a
   user-site finder hook that survives sessions and shadows the next
   venv install. Plain install is the default; reach for `-e` only
@@ -293,7 +315,7 @@ workload (or your code change), not chip contention.
 - ❌ **Blaming chip contention before reading the device log**. The
   device log either shows the contention signature (sibling-die cores
   with `cond_reg_state=ack` from another owner) or it doesn't.
-- ❌ **Treating any failing workload as "simpler broke it"**. Step 5's
+- ❌ **Treating any failing workload as "simpler broke it"**. Step 6's
   CI-gate check separates "your simpler change broke a CI case" (real)
   from "this file was always expected to fail" (not your problem).
 - ❌ **Skipping `.claude/rules/running-onboard.md`** on onboard


### PR DESCRIPTION
## Summary

Splits the cross-repo qwen3 work into two focused, non-overlapping skills.

**`multi-repo-setup`** — the repo-relationship + per-repo setup/run skill:

- documents the import stack (`pto-isa → simpler → pypto → pypto-lib →
  pypto-serving`) with an explicit `imports` column;
- adds **pypto-serving** as a first-class repo (clone + install layer);
- new **Step 5 "hand off to each repo's own skills/docs"** — points at
  `build/<repo>/.claude/skills/` + README instead of duplicating each
  repo's run steps (so they can't go stale here).

**`multi-repo-qwen-setup`** (renamed from `multi-repo-qwen-serving-setup`)
— the concrete qwen3 guide, framed up front as **two distinct paths**:

- **Path A — pypto-serving runner** (`npu_generate.py`): batch-1 / batch-16
  prefill/decode TPOT, the prefill ring/timeout gotchas behind a generic
  `507018`, and the per-token timing layers;
- **Path B — pypto-lib `decode_layer` kernel** (`decode_layer.py`):
  scheduler-overhead DFX flow.

Step 1 defers clone/install to `multi-repo-setup`. Named
`multi-repo-qwen-setup` (not `-serving-setup`) since it spans both paths.

## Notes

- Rebased onto `main` after **#1177 merged**; the per-token timing section
  uses the now-landed `[STRACE]` markers + `strace_timing.py` /
  `docs/dfx/host-trace.md`.
- Timeout facts use the **post-#1175 compiled defaults** (`op_execute` 45 s
  / `stream_sync` 50 s / `scheduler` 10 s). A clean ~16.7 s batch-16 prefill
  no longer trips the op-timeout, so the `PTO2_OP_EXECUTE_TIMEOUT_US` /
  `PTO2_STREAM_SYNC_TIMEOUT_MS` env overrides are framed as
  **contended-box only**; breaking the `scheduler < op_execute <
  stream_sync` ordering drops the **whole** override set.
- §7 host-instrumentation rebuild uses an `$ARCH` variable + a
  python-version-agnostic `find`-based copy (resolves both bot review
  comments; matches `multi-repo-setup` Step 3).

## Testing

- [x] `markdownlint-cli2` (config `tests/lint/.markdownlint.yaml`) — 0 errors
- [x] `check-english-only` — passes
- [x] all cross-skill / doc relative links resolve (incl. now-present
      `docs/dfx/host-trace.md`)

Docs-only; no code paths touched.