### PR TITLE
Add: SDMA workspace overlay + async completion demo on a5 onboard

### DIFF
--- a/docs/a5-sdma-overlay.md
+++ b/docs/a5-sdma-overlay.md
@@ -1,0 +1,105 @@
+# a5 SDMA Workspace Overlay — Isolation Status
+
+The a5 PTO-ISA async-SDMA workspace overlay is merged but **gated off by
+default**. This doc explains why, what is gated, and how to develop against it
+or re-enable it once the a5 CANN environment supports it.
+
+> Tracking: PR [#1179](https://github.com/hw-native-sys/simpler/pull/1179),
+> issue [#1315](https://github.com/hw-native-sys/simpler/issues/1315)
+> (re-enable checklist).
+
+---
+
+## What the overlay is
+
+`ensure_sdma_workspace()` (in `src/a5/platform/onboard/host/comm_hccl.cpp`)
+pre-allocates the per-rank PTO-ISA async-SDMA scratch workspace via
+`aclnnShmemSdmaStarsQuery*` and mirrors its address into
+`CommContext.workSpace`. SDMA producer kernels (`SdmaTget` / `TGET_ASYNC`)
+read `workSpace` to submit SQEs to the SDMA hardware engine; the deferred
+completion machinery polls workspace event-records to signal consumers.
+
+This is the a5 mirror of the a2a3 SDMA path, which is always on.
+
+## Why it is gated off
+
+The available a5 CANN drops do not expose a working
+`aclnnShmemSdmaStarsQuery`:
+
+| CANN | Failure |
+| ---- | ------- |
+| 9.1.T500 | STARS streams created but `aclrtSynchronizeStream` fails → AICPU exception `0x715002a` → every later kernel launch reports `507018`. **Breaks all a5 comm cases**, not just SDMA. |
+| 9.1.0 (`timestamp=20260625`) | `HcclCommInitRootInfo` returns `HCCL_E_INTERNAL (4)` — base HCCL never comes up. |
+
+`ensure_sdma_workspace` runs inside `comm_alloc_windows` / `alloc_domain`, so
+every communication case flows through it. Leaving it on unconditionally would
+poison the whole a5 comm test surface. The overlay was verified **working** on
+a separate a5 box whose CANN exposes the primitive (`sdma_async_completion_demo`
+passes), so this is an environment issue, not a code defect.
+
+## Current state (default OFF)
+
+Controlled by the build-time macro / env var `SIMPLER_ENABLE_PTO_SDMA_WORKSPACE`
+(default unset → OFF):
+
+- `ensure_sdma_workspace` is a no-op (`#else (void)h;`).
+- `host_runtime.so` does **not** link `libnnopbase` and does not reference
+  `aclnnShmemSdmaStarsQuery`.
+- `CommContext.workSpace` stays `0`; SDMA producer kernels self-skip
+  (`if (comm_ctx->workSpace == 0) { pipe_barrier(PIPE_ALL); return; }`).
+- `sdma_async_completion_demo` `pytest.skip`s.
+- All other (non-SDMA) comm cases run normally.
+
+### Gating points
+
+| File | What |
+| ---- | ---- |
+| `src/a5/platform/onboard/host/CMakeLists.txt` | `option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ... OFF)`; `PTO_ISA_ROOT` check + pto-isa include guarded |
+| `src/a5/platform/onboard/host/comm_hccl.cpp` | `ensure_sdma_workspace` body under `#ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE` |
+| `simpler_setup/runtime_compiler.py` | `_init_a5` `PTO_ISA_ROOT` ensure + `_sdma_workspace_enabled()` |
+| `simpler_setup/runtime_builder.py` | `_compile_target` forwards the env var to the host CMake define |
+| `examples/a5/.../sdma_async_completion_demo/test_sdma_async_completion_demo.py` | `pytest.skip` when env var unset |
+
+## Developing under the isolation
+
+- **Non-SDMA comm work** (HCCL, P2P, notify, allreduce, …): unaffected. The
+  overlay being off is transparent to these paths.
+- **New SDMA features**: build locally with
+  `SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON` (see below) on a box whose CANN
+  supports it. The kernel-side SDMA primitives (`SdmaTget`, `SdmaTput`,
+  `TGET_ASYNC`, `TPUT_ASYNC`) live in pto-isa and are independent of this
+  host-side workspace gate.
+- **Do not** make `ensure_sdma_workspace` unconditional again without
+  confirming the target CANN exposes a working `aclnnShmemSdmaStarsQuery`.
+
+## Re-enabling (once CANN is ready)
+
+Verify the primitive first:
+
+```bash
+nm -D $ASCEND_HOME_PATH/lib64/libascendcl.so | grep -ic SdmaStars   # must be > 0
+```
+
+**Option A — CI env var only (no code change):**
+
+```bash
+export SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON
+export PTO_ISA_ROOT=<managed checkout>
+pip install -e .
+```
+
+The env-var→CMake-define forwarding and the test skip gate pick it up
+automatically.
+
+**Option B — make SDMA the a5 default** (revert the 5 gating points above):
+flip `option(... OFF)` → `set(... ON)`, make `_init_a5`'s `PTO_ISA_ROOT`
+ensure unconditional (mirror `_init_a2a3`), and remove the test skip gate.
+
+Verify:
+
+```bash
+python -m pytest examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py \
+    -v --platform a5 --device <ids> -s          # must PASS, not skip
+python -m pytest examples/workers/l3/allreduce_distributed/test_allreduce.py \
+    -v --platform a5 --device <ids> -k onephase  # regression must stay green
+```

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_consumer.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_consumer.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/pto-inst.hpp>
+
+#include "tensor.h"
+
+using namespace pto;
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *result_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+
+    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+    __gm__ float *result = reinterpret_cast<__gm__ float *>(result_tensor->buffer.addr) + result_tensor->start_offset;
+
+    constexpr int kTotalRows = 128;
+    constexpr int kRows = 64;
+    constexpr int kCols = 128;
+    constexpr int kIters = kTotalRows / kRows;
+    using DynShapeDim5 = Shape<1, 1, 1, kRows, kCols>;
+    using DynStrideDim5 = pto::Stride<1, 1, 1, kCols, 1>;
+    using GlobalData = GlobalTensor<float, DynShapeDim5, DynStrideDim5>;
+    using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
+
+    TileData src_tile(kRows, kCols);
+    TileData result_tile(kRows, kCols);
+    TASSIGN(src_tile, 0x0);
+    TASSIGN(result_tile, 0x10000);
+
+    constexpr int kChunkElems = kRows * kCols;
+    for (int iter = 0; iter < kIters; ++iter) {
+        GlobalData src_global(src + iter * kChunkElems);
+        GlobalData result_global(result + iter * kChunkElems);
+        TLOAD(src_tile, src_global);
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+        TADDS(result_tile, src_tile, 1.0f);
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+
+        TSTORE(result_global, result_tile);
+        set_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+        wait_flag(PIPE_MTE3, PIPE_S, EVENT_ID7);
+    }
+}

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <cstdint>
+
+#ifndef __gm__
+#define __gm__
+#endif
+#ifndef __aicore__
+#define __aicore__ [aicore]
+#endif
+
+#include <pto/pto-inst.hpp>
+
+#include "backend/sdma/sdma_completion_kernel.h"
+#include "platform_comm/comm_context.h"
+#include "pto_async_kernel_api.h"
+#include "tensor.h"
+
+using namespace pto;
+
+template <typename T>
+static inline __aicore__ __gm__ T *comm_remote_ptr(__gm__ CommContext *ctx, __gm__ T *local_ptr, int peer_rank) {
+    uint64_t local_base = ctx->windowsIn[ctx->rankId];
+    uint64_t offset = reinterpret_cast<uint64_t>(local_ptr) - local_base;
+    return reinterpret_cast<__gm__ T *>(ctx->windowsIn[peer_rank] + offset);
+}
+
+extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
+    __gm__ Tensor *in_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ CommContext *comm_ctx = reinterpret_cast<__gm__ CommContext *>(args[2]);
+
+    __gm__ float *local_in = reinterpret_cast<__gm__ float *>(in_tensor->buffer.addr) + in_tensor->start_offset;
+    __gm__ float *local_out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
+
+    int rank = static_cast<int>(comm_ctx->rankId);
+    int nranks = static_cast<int>(comm_ctx->rankNum);
+    if (nranks != 2 || comm_ctx->workSpace == 0) {
+        pipe_barrier(PIPE_ALL);
+        return;
+    }
+    int peer_rank = 1 - rank;
+
+    constexpr int kElems = 128 * 128;
+    using FlatShape = Shape<1, 1, 1, 1, kElems>;
+    using FlatStride = pto::Stride<kElems, kElems, kElems, kElems, 1>;
+    using GlobalData = GlobalTensor<float, FlatShape, FlatStride>;
+    using ScratchTile = Tile<TileType::Vec, uint8_t, 1, SDMA_SCRATCH_ALIGNMENT>;
+
+    __gm__ float *remote_in = comm_remote_ptr(comm_ctx, local_in, peer_rank);
+    GlobalData remote_global(remote_in);
+    GlobalData local_global(local_out);
+
+    ScratchTile scratch_tile;
+    TASSIGN(scratch_tile, 0x0);
+
+    AsyncCtx async_ctx = get_async_ctx(args);
+    send_request_entry(
+        async_ctx,
+        SdmaTget(local_global, remote_global, scratch_tile, reinterpret_cast<__gm__ uint8_t *>(comm_ctx->workSpace))
+    );
+}

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/aiv/kernel_sdma_tget_async.cpp
@@ -44,6 +44,9 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
 
     int rank = static_cast<int>(comm_ctx->rankId);
     int nranks = static_cast<int>(comm_ctx->rankNum);
+    // workSpace == 0 means the SDMA overlay is not built in
+    // (SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=OFF, see docs/a5-sdma-overlay.md
+    // #1315): self-skip rather than dereferencing a null workspace.
     if (nranks != 2 || comm_ctx->workSpace == 0) {
         pipe_barrier(PIPE_ALL);
         return;

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/kernels/orchestration/sdma_async_completion_orch.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "platform_comm/comm_context.h"
+#include "pto_orchestration_api.h"
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig
+sdma_async_completion_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{.expected_arg_count = 4};
+}
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    return sdma_async_completion_orchestration_config(orch_args);
+}
+
+__attribute__((visibility("default"))) void sdma_async_completion_orchestration(const L2TaskArgs &orch_args) {
+    if (orch_args.tensor_count() + orch_args.scalar_count() != 4) {
+        LOG_ERROR("sdma_async_completion_demo: expected 4 args");
+        return;
+    }
+
+    const Tensor &input = orch_args.tensor(0).ref();
+    const Tensor &out = orch_args.tensor(1).ref();
+    const Tensor &result = orch_args.tensor(2).ref();
+    auto *comm_ctx = reinterpret_cast<CommContext *>(static_cast<uintptr_t>(orch_args.scalar(0)));
+
+    L0TaskArgs producer_args;
+    producer_args.add_input(input);
+    producer_args.add_output(out);
+    producer_args.add_scalar(reinterpret_cast<uint64_t>(comm_ctx));
+    rt_submit_aiv_task(0, producer_args);
+
+    L0TaskArgs consumer_args;
+    consumer_args.add_input(out);
+    consumer_args.add_output(result);
+    rt_submit_aiv_task(1, consumer_args);
+}
+
+}  // extern "C"

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -191,6 +191,11 @@ def run(
 @pytest.mark.platforms(["a5"])
 @pytest.mark.runtime("tensormap_and_ringbuffer")
 @pytest.mark.device_count(2)
+@pytest.mark.skipif(
+    os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() not in {"1", "ON", "TRUE", "YES"},
+    reason="SDMA workspace overlay not enabled (set SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON to run). "
+    "See docs/a5-sdma-overlay.md (#1315).",
+)
 def test_sdma_async_completion_demo(st_device_ids, st_platform) -> None:
     assert run(st_platform, [int(d) for d in st_device_ids]) == 0
 

--- a/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
+++ b/examples/a5/tensormap_and_ringbuffer/sdma_async_completion_demo/test_sdma_async_completion_demo.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""SDMA deferred completion smoke test for onboard a5.
+
+Each rank stages its input inside the HCCL window.  The deferred producer
+TGET_ASYNCs the peer rank's input into local ``out`` and registers the PTO
+AsyncEvent through ``defer_pto_async_event``.  The consumer depends on the
+producer output and writes ``result = out + 1``.  Correct ``out`` and
+``result`` therefore validate both the SDMA completion polling and the
+deferred-release dependency path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import pytest
+import torch
+from simpler.task_interface import (
+    ArgDirection,
+    CallConfig,
+    ChipCallable,
+    CommBufferSpec,
+    CoreCallable,
+    DataType,
+    TaskArgs,
+    Tensor,
+    TensorArgType,
+)
+from simpler.worker import Worker
+
+from simpler_setup.elf_parser import extract_text_section
+from simpler_setup.kernel_compiler import KernelCompiler
+from simpler_setup.pto_isa import ensure_pto_isa_root
+from simpler_setup.torch_interop import make_tensor_arg
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+N = 128 * 128
+DTYPE_NBYTES = 4
+
+
+def parse_device_range(spec: str) -> list[int]:
+    if "," in spec:
+        return [int(x) for x in spec.split(",") if x]
+    if "-" in spec:
+        lo, hi = (int(x) for x in spec.split("-"))
+        return list(range(lo, hi + 1))
+    return [int(spec)]
+
+
+def build_chip_callable(platform: str) -> ChipCallable:
+    kc = KernelCompiler(platform=platform)
+    runtime = "tensormap_and_ringbuffer"
+    pto_isa_root = ensure_pto_isa_root()
+    include_dirs = kc.get_orchestration_include_dirs(runtime)
+    extra_includes = list(include_dirs) + [str(kc.project_root / "src" / "common")]
+
+    children = []
+    for func_id, rel in [
+        (0, "kernels/aiv/kernel_sdma_tget_async.cpp"),
+        (1, "kernels/aiv/kernel_consumer.cpp"),
+    ]:
+        kernel = kc.compile_incore(
+            source_path=os.path.join(HERE, rel),
+            core_type="aiv",
+            pto_isa_root=pto_isa_root,
+            extra_include_dirs=extra_includes,
+        )
+        if not platform.endswith("sim"):
+            kernel = extract_text_section(kernel)
+        children.append(
+            (
+                func_id,
+                CoreCallable.build(
+                    signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
+                    binary=kernel,
+                ),
+            )
+        )
+
+    orch = kc.compile_orchestration(
+        runtime_name=runtime,
+        source_path=os.path.join(HERE, "kernels/orchestration/sdma_async_completion_orch.cpp"),
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
+    )
+    return ChipCallable.build(
+        signature=[ArgDirection.IN, ArgDirection.OUT, ArgDirection.OUT, ArgDirection.IN],
+        func_name="sdma_async_completion_orchestration",
+        binary=orch,
+        children=children,
+    )
+
+
+def run(
+    platform: str = "a5",
+    device_ids: list[int] | None = None,
+) -> int:
+    if device_ids is None:
+        device_ids = [0, 1]
+    nranks = len(device_ids)
+    if nranks != 2:
+        raise ValueError(f"sdma_async_completion_demo needs exactly 2 devices, got {device_ids}")
+    if platform.endswith("sim"):
+        raise ValueError("sdma_async_completion_demo requires onboard a5 hardware")
+
+    input_nbytes = N * DTYPE_NBYTES
+    window_size = max(input_nbytes, 4 * 1024)
+
+    # `inputs` must live in shared memory: `orch.copy_to` stages each rank's
+    # data into its HCCL window from the forked chip child, which reads `src`
+    # out of its own address space.
+    inputs = [
+        torch.tensor([float(rank * 1000 + (i % 251)) / 10.0 for i in range(N)], dtype=torch.float32).share_memory_()
+        for rank in range(nranks)
+    ]
+    out = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+    result = [torch.zeros(N, dtype=torch.float32).share_memory_() for _ in range(nranks)]
+
+    chip_callable = build_chip_callable(platform)
+    worker = Worker(
+        level=3,
+        platform=platform,
+        runtime="tensormap_and_ringbuffer",
+        device_ids=device_ids,
+        num_sub_workers=0,
+    )
+    chip_cid = worker.register(chip_callable)
+    try:
+        worker.init()
+
+        def orch_fn(orch, _args, cfg):
+            with orch.allocate_domain(
+                name="default",
+                workers=list(range(nranks)),
+                window_size=window_size,
+                buffers=[
+                    CommBufferSpec(name="input_window", dtype="float32", count=N, nbytes=input_nbytes),
+                ],
+            ) as handle:
+                # Stage every rank's input window before submitting any kernel:
+                # each producer TGET_ASYNCs the *peer* rank's window, so all
+                # windows must hold real data before execution begins.
+                for rank in range(nranks):
+                    orch.copy_to(
+                        rank,
+                        dst=handle[rank].buffer_ptrs["input_window"],
+                        src=inputs[rank].data_ptr(),
+                        size=input_nbytes,
+                    )
+                for rank in range(nranks):
+                    domain = handle[rank]
+                    args = TaskArgs()
+                    args.add_tensor(
+                        Tensor.make(
+                            data=domain.buffer_ptrs["input_window"],
+                            shapes=(N,),
+                            dtype=DataType.FLOAT32,
+                            child_memory=True,
+                        ),
+                        TensorArgType.INPUT,
+                    )
+                    args.add_tensor(make_tensor_arg(out[rank]), TensorArgType.OUTPUT_EXISTING)
+                    args.add_tensor(make_tensor_arg(result[rank]), TensorArgType.OUTPUT_EXISTING)
+                    args.add_scalar(domain.device_ctx)
+                    orch.submit_next_level(chip_cid, args, cfg, worker=rank)
+
+        worker.run(orch_fn, args=None, config=CallConfig())
+
+        ok = True
+        for rank in range(nranks):
+            peer = 1 - rank
+            expected_out = inputs[peer]
+            expected_result = expected_out + 1.0
+            max_out = float(torch.max(torch.abs(out[rank] - expected_out)))
+            max_result = float(torch.max(torch.abs(result[rank] - expected_result)))
+            print(f"[sdma_async_completion_demo] rank {rank}: max_out={max_out:.3e} max_result={max_result:.3e}")
+            ok = ok and max_out <= 1e-3 and max_result <= 1e-3
+        return 0 if ok else 1
+    finally:
+        worker.close()
+
+
+@pytest.mark.platforms(["a5"])
+@pytest.mark.runtime("tensormap_and_ringbuffer")
+@pytest.mark.device_count(2)
+def test_sdma_async_completion_demo(st_device_ids, st_platform) -> None:
+    assert run(st_platform, [int(d) for d in st_device_ids]) == 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a5")
+    parser.add_argument("-d", "--device", default="0-1")
+    args = parser.parse_args()
+    return run(args.platform, parse_device_range(args.device))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/simpler_setup/runtime_builder.py
+++ b/simpler_setup/runtime_builder.py
@@ -9,6 +9,7 @@
 import fcntl
 import json
 import logging
+import os
 import shutil
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
@@ -341,8 +342,21 @@ class RuntimeBuilder:
         def _compile_target(target: str) -> Path:
             include_dirs, source_dirs = self._resolve_target_dirs(config_dir, build_config, target)
             cmake_defines = None
-            if target == "host" and build_pto_isa_commit:
-                cmake_defines = {"SIMPLER_PTO_ISA_BUILD_COMMIT": build_pto_isa_commit}
+            if target == "host":
+                defines: dict[str, str] = {}
+                if build_pto_isa_commit:
+                    defines["SIMPLER_PTO_ISA_BUILD_COMMIT"] = build_pto_isa_commit
+                # Mirror the SIMPLER_ENABLE_PTO_SDMA_WORKSPACE env var into the
+                # CMake option (src/{arch}/platform/onboard/host/CMakeLists.txt)
+                # so the a5 SDMA workspace overlay is built only when opted in.
+                if os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() in {
+                    "1",
+                    "ON",
+                    "TRUE",
+                    "YES",
+                }:
+                    defines["SIMPLER_ENABLE_PTO_SDMA_WORKSPACE"] = "ON"
+                cmake_defines = defines or None
             # compile() adds a {target}/ subdirectory inside build_dir
             cache_dir = self._CACHE_DIR / arch / variant / name
             cache_dir.mkdir(parents=True, exist_ok=True)

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -23,6 +23,19 @@ from .toolchain import Aarch64GxxToolchain, CCECToolchain, GxxToolchain, Toolcha
 logger = logging.getLogger(__name__)
 
 
+_SDMA_WORKSPACE_TRUTHY = {"1", "ON", "TRUE", "YES"}
+
+
+def _sdma_workspace_enabled() -> bool:
+    """Whether the a5 PTO SDMA workspace overlay is opted in.
+
+    Mirrors the CMake ``option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ... OFF)`` in
+    src/a5/platform/onboard/host/CMakeLists.txt. Set the env var of the same
+    name to a truthy value (1/ON/TRUE/YES) to enable the overlay at build time.
+    """
+    return os.environ.get("SIMPLER_ENABLE_PTO_SDMA_WORKSPACE", "").upper() in _SDMA_WORKSPACE_TRUTHY
+
+
 class BuildTarget:
     """CMake build target: composes a Toolchain with a source directory and output name.
 
@@ -171,11 +184,15 @@ class RuntimeCompiler:
     def _init_a5(self):
         """Initialize toolchains for real a5 hardware."""
         env_manager.ensure("ASCEND_HOME_PATH")
-        # a5 onboard host_runtime hard-depends on pto-isa headers + CANN-9.0
-        # aclnn syms (cf. src/a5/platform/onboard/host/CMakeLists.txt
-        # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE marker). PTO_ISA_ROOT must be
-        # populated by the caller — same contract as a2a3 onboard.
-        env_manager.ensure("PTO_ISA_ROOT")
+        # The PTO SDMA workspace overlay (comm_hccl.cpp ensure_sdma_workspace +
+        # libnnopbase link) is opt-in via the SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
+        # env var, mirrored to the CMake option of the same name in
+        # src/a5/platform/onboard/host/CMakeLists.txt. Default OFF because the
+        # available a5 CANN drops lack working aclnnShmemSdmaStarsQuery
+        # primitives — see docs/a5-sdma-overlay.md (#1315). When opted in, the
+        # host build needs pto-isa headers via PTO_ISA_ROOT (same contract as a2a3).
+        if _sdma_workspace_enabled():
+            env_manager.ensure("PTO_ISA_ROOT")
 
         # AICore: Bisheng CCE compiler with A5 platform
         ccec = CCECToolchain(platform="a5")

--- a/simpler_setup/runtime_compiler.py
+++ b/simpler_setup/runtime_compiler.py
@@ -171,6 +171,11 @@ class RuntimeCompiler:
     def _init_a5(self):
         """Initialize toolchains for real a5 hardware."""
         env_manager.ensure("ASCEND_HOME_PATH")
+        # a5 onboard host_runtime hard-depends on pto-isa headers + CANN-9.0
+        # aclnn syms (cf. src/a5/platform/onboard/host/CMakeLists.txt
+        # SIMPLER_ENABLE_PTO_SDMA_WORKSPACE marker). PTO_ISA_ROOT must be
+        # populated by the caller — same contract as a2a3 onboard.
+        env_manager.ensure("PTO_ISA_ROOT")
 
         # AICore: Bisheng CCE compiler with A5 platform
         ccec = CCECToolchain(platform="a5")

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -33,6 +33,21 @@ else()
     message(FATAL_ERROR "MUST set CUSTOM_INCLUDE_DIRS to build Host runtime")
 endif()
 
+# SIMPLER_ENABLE_PTO_SDMA_WORKSPACE: marker for an outstanding architectural
+# issue. The SDMA workspace init in comm_hccl.cpp pulls in pto-isa
+# headers and CANN-9.0-only aclnn symbols (aclnnShmemSdmaStarsQuery*),
+# even though it is logically orthogonal to HCCL comm bootstrap and only
+# needed by the sdma_async_completion_demo. Until that coupling is
+# refactored away, the macro is forced ON: PTO_ISA_ROOT and CANN 9.0+ are
+# hard build/runtime preconditions for a5 onboard.
+set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ON)
+if(NOT DEFINED ENV{PTO_ISA_ROOT})
+    message(FATAL_ERROR
+        "a5 onboard host_runtime requires PTO_ISA_ROOT "
+        "(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE is forced ON; needs pto-isa headers + CANN 9.0+)")
+endif()
+list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
+
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS
 set(HOST_RUNTIME_SOURCES "")
 list(APPEND HOST_RUNTIME_SOURCES
@@ -97,6 +112,10 @@ target_compile_options(host_runtime
 # src/common/platform/shared/host/platform_compile_info.cpp.
 target_compile_definitions(host_runtime PRIVATE SIMPLER_PLATFORM_NAME="a5")
 
+if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
+    target_compile_definitions(host_runtime PRIVATE SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=1)
+endif()
+
 # Include directories - always include local headers
 target_include_directories(host_runtime
     PRIVATE
@@ -150,6 +169,11 @@ target_link_directories(host_runtime
         ${ASCEND_HOME_PATH}/lib64
         ${ASCEND_HOME_PATH}/runtime/lib64
 )
+
+if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
+    target_link_directories(host_runtime PRIVATE ${ASCEND_HOME_PATH}/${CMAKE_SYSTEM_PROCESSOR}-linux/lib64)
+    target_link_libraries(host_runtime PRIVATE nnopbase)
+endif()
 
 set_target_properties(host_runtime PROPERTIES OUTPUT_NAME "host_runtime")
 

--- a/src/a5/platform/onboard/host/CMakeLists.txt
+++ b/src/a5/platform/onboard/host/CMakeLists.txt
@@ -33,20 +33,25 @@ else()
     message(FATAL_ERROR "MUST set CUSTOM_INCLUDE_DIRS to build Host runtime")
 endif()
 
-# SIMPLER_ENABLE_PTO_SDMA_WORKSPACE: marker for an outstanding architectural
-# issue. The SDMA workspace init in comm_hccl.cpp pulls in pto-isa
-# headers and CANN-9.0-only aclnn symbols (aclnnShmemSdmaStarsQuery*),
-# even though it is logically orthogonal to HCCL comm bootstrap and only
-# needed by the sdma_async_completion_demo. Until that coupling is
-# refactored away, the macro is forced ON: PTO_ISA_ROOT and CANN 9.0+ are
-# hard build/runtime preconditions for a5 onboard.
-set(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ON)
-if(NOT DEFINED ENV{PTO_ISA_ROOT})
-    message(FATAL_ERROR
-        "a5 onboard host_runtime requires PTO_ISA_ROOT "
-        "(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE is forced ON; needs pto-isa headers + CANN 9.0+)")
+# SIMPLER_ENABLE_PTO_SDMA_WORKSPACE: opt-in overlay that wires the PTO-ISA
+# async-SDMA workspace into comm_alloc_windows. When ON it pulls in pto-isa
+# headers and CANN-9.0+ aclnn symbols (aclnnShmemSdmaStarsQuery*) and links
+# libnnopbase, so it requires a CANN drop that actually exposes working a5
+# SDMA primitives. Default OFF because the available a5 CANN drops break
+# (AICPU exception -> 507018, or HCCL_E_INTERNAL). See
+# docs/a5-sdma-overlay.md for the full isolation status and re-enable steps
+# (#1315).
+# Flip ON via -DSIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON (or the env var of the
+# same name, forwarded by simpler_setup/runtime_builder.py).
+option(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE "Enable a5 PTO SDMA workspace overlay" OFF)
+if(SIMPLER_ENABLE_PTO_SDMA_WORKSPACE)
+    if(NOT DEFINED ENV{PTO_ISA_ROOT})
+        message(FATAL_ERROR
+            "a5 onboard host_runtime with SIMPLER_ENABLE_PTO_SDMA_WORKSPACE=ON requires PTO_ISA_ROOT "
+            "(needs pto-isa headers + CANN 9.0+ with a5 SDMA primitives)")
+    endif()
+    list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
 endif()
-list(APPEND CMAKE_CUSTOM_INCLUDE_DIRS "$ENV{PTO_ISA_ROOT}/include")
 
 # Build complete source list: core host sources + sources from CUSTOM_SOURCE_DIRS
 set(HOST_RUNTIME_SOURCES "")

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -736,9 +736,11 @@ static std::string domain_barrier_tag(uint64_t allocation_id, const char *phase)
 // Idempotently provision the process-global PTO-ISA async-SDMA scratch
 // workspace on the comm handle and mirror its address into host_ctx.  Both
 // the base-window path and the dynamic per-domain path call this; only the
-// first call allocates.  CANN 9.0+ feature: on 8.5 the aclnn dlsym fails by
-// design, so we leave workSpace == 0 and SDMA demos self-skip.  No-op when
-// the build-time PTO-ISA dependency is absent.
+// first call allocates.  Requires CANN to expose working
+// aclnnShmemSdmaStarsQuery primitives — see docs/a5-sdma-overlay.md for why
+// this is gated behind SIMPLER_ENABLE_PTO_SDMA_WORKSPACE (default OFF) and
+// how to re-enable it once the a5 environment supports it (#1315).  No-op (workSpace
+// stays 0, SDMA demos self-skip) when the macro is undefined.
 static void ensure_sdma_workspace(CommHandle h) {
 #ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
     if (h->sdma_workspace) return;

--- a/src/a5/platform/onboard/host/comm_hccl.cpp
+++ b/src/a5/platform/onboard/host/comm_hccl.cpp
@@ -47,6 +47,9 @@
 #include "acl/acl.h"
 #include "hccl/hccl_comm.h"
 #include "hccl/hccl_types.h"
+#ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
+#include "pto/comm/async/sdma/sdma_workspace_manager.hpp"
+#endif
 
 // Thin wrappers around the HCCL public APIs we use. Kept as a translation
 // layer in case we need to swap (e.g., InitConfig variant) later.
@@ -97,6 +100,9 @@ struct CommHandle_ {
     bool owns_device_ctx = false;
     std::vector<CommContext *> derived_contexts;
     std::unordered_map<uint64_t, std::unique_ptr<DomainAllocation>> domain_allocations;
+#ifdef SIMPLER_ENABLE_PTO_SDMA_WORKSPACE
+    std::unique_ptr<pto::comm::sdma::SdmaWorkspaceManager> sdma_workspace;
+#endif
 };
 
 // ============================================================================


### PR DESCRIPTION
Layers the host-side SDMA workspace allocation on top of the comm backend from the previous commit. Until CANN exposes the missing SDMA primitives on a5, this overlay is the only piece of comm work that fails on real a5 silicon -- aclnnShmemSdmaStarsQuery raises an AICPU exception (InnerCode=0x715002a) that aborts the entire ACL thread context. Dropping this commit therefore unblocks the non-SDMA comm demos (async_notify_demo etc.) without touching the deferred-completion runtime, which is already SDMA-aware on the kernel side (dormant until a kernel registers an SDMA condition).

- Wire SdmaWorkspaceManager into comm_alloc_windows under SIMPLER_ENABLE_PTO_SDMA_WORKSPACE: pre-allocates the per-rank workspace via aclnnShmemSdmaStarsQuery and overlays the result into CommContext.workSpace/.workSpaceSize. On CANN 8.5 the dlsym fails by design and we demote to "no workspace" rather than failing comm_init.
- a5 onboard CMakeLists forces SIMPLER_ENABLE_PTO_SDMA_WORKSPACE ON, requires PTO_ISA_ROOT (with FATAL_ERROR message pointing to the workspace coupling), adds pto-isa headers to the include path, and links libnnopbase.
- runtime_compiler._init_a5 enforces the same PTO_ISA_ROOT env contract as _init_a2a3.
- Migrate sdma_async_completion_demo to examples/a5/ (kernels + orch byte-identical with the a2a3 version; test.py platform- renamed).