### PR TITLE
feat(dfx): subdivide graph_build prep into 3 RAII phases; SIMPLER_DEVICE_PROFILING gate; nested trace views

### DIFF
--- a/.claude/skills/benchmark/SKILL.md
+++ b/.claude/skills/benchmark/SKILL.md
@@ -236,10 +236,13 @@ tees the run and renders the Host/Device/Effective/Orch/Sched table with
 come from the markers (onboard and sim) — no CANN device log is read.
 
 For a per-stage breakdown of `Host`/`Device` (host `bind`/`runner_run`/`validate`
-plus the AICPU `preamble`/`so_load`/`graph_build`/`post_orch` subdivision), parse
-the `[STRACE]` markers with `simpler_setup/tools/strace_timing.py` — see
+plus the AICPU `preamble`/`so_load`/`graph_build`
+(`config_validate`/`arena_wire`/`sm_reset` prep sub-phases)/`post_orch`
+subdivision), parse the `[STRACE]` markers with
+`simpler_setup/tools/strace_timing.py` (add `--tree` for the nested view) — see
 [docs/dfx/host-trace.md](../../../docs/dfx/host-trace.md). Same `SIMPLER_PROFILING`
-gate, no extra flag.
+gate, no extra flag (set `SIMPLER_DEVICE_PROFILING=0` to drop only the device
+`clk=dev` markers).
 
 ### Single Mode
 

--- a/.claude/skills/dfx-analyze/SKILL.md
+++ b/.claude/skills/dfx-analyze/SKILL.md
@@ -32,6 +32,9 @@ python test_*.py -p <platform> -d <device> --rounds N --skip-golden > run.log 2>
 python -m simpler_setup.tools.strace_timing run.log --rounds-table
 # prints per-round Host / Device / Effective / Orch / Sched (us);
 # Orch≈Sched≈Effective ⇒ AICPU-bound. (Effective = orch∪sched window.)
+# --tree instead shows the nested span tree (device_wall → preamble/so_load/
+#   graph_build → config_validate/arena_wire/sm_reset prep + orch/sched → post_orch).
+# SIMPLER_DEVICE_PROFILING=0 drops the device clk=dev markers (host spans stay).
 ```
 
 For the per-thread `loops`/`tasks_scheduled` deep-dive (not in the markers),

--- a/.claude/skills/multi-repo-qwen-setup/SKILL.md
+++ b/.claude/skills/multi-repo-qwen-setup/SKILL.md
@@ -230,9 +230,12 @@ the child's `RunTiming`, so they never reach a return value.
 Simpler surfaces them instead as **`[STRACE]` host-trace markers** — one
 line per `run_prepared` stage
 (`bind`/`bind.args`/`bind.prebuilt`/`runner_run`/`validate`) plus the AICPU
-device-phase subdivision (`preamble`/`so_load`/`graph_build`/`post_orch`).
+device-phase subdivision (`preamble`/`so_load`/`graph_build` — with
+`config_validate`/`arena_wire`/`sm_reset` prep sub-phases — /`post_orch`,
+`orch`/`sched`).
 `strace_timing.py` groups by `(pid, inv)`, rebuilds each invocation's span
-tree from `depth`, and prints per-callable means; see
+tree from `depth`, and prints per-callable means (add `--tree` for the nested
+view); see
 [docs/dfx/host-trace.md](../../../docs/dfx/host-trace.md) for the marker
 grammar and span tree. The L3-side tensor-management ask is
 [pypto-serving #44](https://github.com/hw-native-sys/pypto-serving/issues/44).

--- a/docs/dfx/device-phases.md
+++ b/docs/dfx/device-phases.md
@@ -22,10 +22,21 @@ run-wall `{start, end}` pair used, generalized to `N` pairs.
 | `RunWall` | whole-run AICPU wall (the legacy `device_wall`, slot 0) |
 | `Preamble` | executor init + wait-for-init before orchestration |
 | `SoLoad` | orchestration-SO `dlopen` (real cost only on a first/changed callable; ~0 when cached) |
-| `GraphBuild` | `orchestrate()` — submit tasks (the scheduler dispatches concurrently) |
-| `PostOrch` | runtime-status read + last-thread cleanup after orchestration |
+| `GraphBuild` | `orchestrate()` — submit tasks (the scheduler dispatches concurrently). **A container** for the three prep sub-phases below plus the `OrchWindow`/`SchedWindow` work. |
+| `ConfigValidate` | (inside `GraphBuild`, orch thread) `config_func()` + arg-count validate |
+| `ArenaWire` | (inside `GraphBuild`, orch thread) attach the prebuilt runtime arena + wire device pointers |
+| `SmReset` | (inside `GraphBuild`, orch thread) SM/ring reset + finalize + bind, up to releasing the scheduler threads |
+| `PostOrch` | last-thread teardown (`deinit`: cache-invalidate + scheduler-state reset) after the run completes — stamped only on the thread that finishes last, so it is the real teardown tail, strictly after `sched` |
 | `OrchWindow` | orchestrator thread's submit window (the former device-log `orch_start/end`) |
 | `SchedWindow` | scheduler thread's dispatch window (the former device-log `sched_start/end`) |
+
+`ConfigValidate` / `ArenaWire` / `SmReset` break out the per-run prep the
+orchestrator thread does **inside `GraphBuild`, before the `OrchWindow` opens**
+(the scheduler threads spin-wait on `runtime_init_ready_` across this whole
+region). Before they existed this was an unattributed front-matter gap — on a
+qwen3-14B 3.5k decode step it is ~22 ms, ~31 % of the device wall. They are
+stamped only on the orchestrator thread (sched threads leave the slots unset; the
+host reducer ignores them).
 
 `OrchWindow` / `SchedWindow` replace the device-log `Orch` / `Sched` lines for
 everyday use: the orchestrator and each scheduler thread store their
@@ -57,8 +68,80 @@ deep-dive — see [l2-timing.md](l2-timing.md).
   `[STRACE]` marker nested under `run_prepared.runner_run.device_wall`
   (see [host-trace.md](host-trace.md)).
 
+### Gating: `SIMPLER_DEVICE_PROFILING` (host/device split)
+
+The device markers can be turned off independently of the host spans so a
+deployment can profile the two domains separately:
+
+* **Device** (`clk=dev` markers): the runtime env `SIMPLER_DEVICE_PROFILING`,
+  read once by `emit_device_phase_markers` in the host `c_api_shared`. `=0`
+  suppresses the whole device-phase emit; any other value (or unset) keeps it on
+  (**default on**). It does not affect the on-device stamping cost (cheap plain
+  stores) — only whether the host re-emits the readback as markers.
+* **Host** (`run_prepared` / `bind` / `runner_run` / `validate` spans): no new
+  knob — they ride the compile-time `SIMPLER_PROFILING` macro and the log level
+  (`LOG_INFO_V9`), so raising the log threshold drops them.
+
 `RunWall` is the whole on-NPU wall (the former `RunTiming.device_wall`); it is
 emitted as the `run_prepared.runner_run.device_wall` marker, not returned.
+
+### Reading the phases — they nest and overlap, don't sum them
+
+The phases are **not a flat partition** of the wall — they nest, and some run
+concurrently. Use each span's `ts` (device-domain start offset) + `dur` to see
+the structure, not the bare durations:
+
+```text
+device_wall (RunWall)                 ── time flows top → bottom (sequential) ──
+│
+├─ preamble                              init + wait-for-init
+│
+├─ graph_build  (CONTAINER):
+│    │
+│    ├─ config_validate   ┐
+│    ├─ arena_wire        │  prep (sequential, orch thread)
+│    ├─ sm_reset          ┘
+│    │
+│    └─ Effective         ← orch & sched run SIDE BY SIDE (concurrent):
+│         ┌──── orch (OrchWindow) ────┐   ┌──── sched (SchedWindow) ────┐
+│         │ orchestrator submits tasks│   │ scheduler dispatches/drains │
+│         └───────────────────────────┘   └─────────────────────────────┘
+│              (finishes first)                 (outlasts orch)
+│
+└─ post_orch                             last-thread teardown (deinit), after sched
+```
+
+The vertical axis is time: `preamble → graph_build → post_orch` are **sequential**
+(top to bottom), and inside `graph_build` the prep phases are sequential too. Only
+`orch` and `sched` are drawn **side by side** because they are **concurrent** — both
+start when the schedulers are released, and `sched` outlasts `orch` (the scheduler
+keeps dispatching after the orchestrator has submitted everything). `«Effective»`
+is **not a stamped marker** — `orch` and `sched` are the two real spans, and
+`strace_timing` derives `Effective = max(orch_end, sched_end) −
+min(orch_start, sched_start)` (their merged window).
+
+So:
+
+* `device_wall ≈ preamble + graph_build + post_orch` (left-to-right, sequential
+  — `post_orch` is the teardown tail after `graph_build` returns).
+* `graph_build ≈ prep + Effective`, where `prep = config_validate + arena_wire +
+  sm_reset` (sequential) and `Effective = orch ∪ sched` (the concurrent window).
+  You **cannot** add `orch + sched` — they overlap; use their union `Effective`.
+* `graph_build − Effective` ≈ `prep` — the front matter, now broken out. See
+  [l2-timing.md](l2-timing.md) for how the rounds-table reports `Effective`.
+* `post_orch` is stamped **only on the thread that finishes last** (gated on
+  `finished_`), so it captures just the `deinit` teardown. (An earlier version
+  stamped it on every thread; an orchestrator thread that finished submitting
+  early then sat idle waiting for the scheduler, and the cross-thread
+  `max(end) − min(start)` reduction absorbed that orch-waits-for-sched overlap
+  into `post_orch` — inflating it to tens of ms. It is now the real teardown.)
+
+**Worked example** — qwen3-14B, 3.5k-context **decode** step on a2a3 (per-step
+means): `device_wall` ≈ 71 ms, of which `graph_build` ≈ 71 ms (the container),
+`Effective` ≈ 49 ms (`orch` ≈ 25 ms started at +22 ms, `sched` ≈ 49 ms), so the
+~22 ms before the windows open — `config_validate + arena_wire + sm_reset` — is a
+fixed per-decode prep cost that is now directly visible instead of only inferable
+as `graph_build − Effective`.
 
 ### Sim
 

--- a/docs/dfx/host-trace.md
+++ b/docs/dfx/host-trace.md
@@ -48,12 +48,12 @@ run_prepared                                   (= host_wall)
 │  └─ run_prepared.bind.prebuilt    (prebuilt runtime-arena image build + upload)
 ├─ run_prepared.runner_run          (launch + blocking sync on the AICPU)
 │  └─ run_prepared.runner_run.device_wall      (whole on-NPU AICPU wall)
-│     └─ .{preamble,so_load,graph_build,post_orch,orch,sched}
+│     └─ .{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}
 │           device-domain (clk=dev): AICPU subdivision of the on-NPU wall
 └─ run_prepared.validate
 ```
 
-The `device_wall` + its `.{preamble,so_load,graph_build,post_orch,orch,sched}`
+The `device_wall` + its `.{preamble,so_load,graph_build,config_validate,arena_wire,sm_reset,post_orch,orch,sched}`
 spans are **device-domain**, tagged `clk=dev`. They are not host `steady_clock`
 spans: the AICPU stamps raw sys-counter cycles into a host-allocated buffer
 (whose address rides on `KernelArgs::device_wall_data_base`), the host reads it

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -11,7 +11,7 @@ no repo checkout required.
 
 - **[swimlane_converter](#swimlane_converter)** — perf JSON → Chrome Trace Event (Perfetto)
 - **[sched_overhead_analysis](#sched_overhead_analysis)** — scheduler overhead / Tail OH breakdown
-- **[strace_timing](#strace_timing)** — per-stage `run_prepared` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), or Perfetto JSON
+- **[strace_timing](#strace_timing)** — per-stage `run_prepared` breakdown (host + AICPU phases) from `[STRACE]` log markers → TPOT table, per-round table (`--rounds-table`), nested tree (`--tree`), or Perfetto JSON
 - **[dump_viewer](#dump_viewer)** — inspect / export args dumps (see [docs/args-dump.md](../../docs/dfx/args-dump.md) for full workflow)
 - **[deps_viewer](#deps_viewer)** — `deps.json` (dep_gen) → text or pan/zoom HTML dependency graph
 
@@ -195,7 +195,12 @@ python -m simpler_setup.tools.strace_timing path/to/log
 # Per-round Host/Device/Orch/Sched table (the benchmark/--rounds N view)
 python -m simpler_setup.tools.strace_timing path/to/log --rounds-table
 
-# Also emit a Chrome-trace / Perfetto JSON (lane = pid → host call tree)
+# Indented nested span tree per callable (run_prepared → bind / runner_run →
+# device_wall → preamble/config_validate/arena_wire/sm_reset/orch/sched/post_orch)
+python -m simpler_setup.tools.strace_timing path/to/log --tree
+
+# Also emit a Chrome-trace / Perfetto JSON (one named lane per invocation, with
+# separate host and device(clk=dev) tracks; nested by span containment)
 python -m simpler_setup.tools.strace_timing path/to/log --trace-out strace.json
 ```
 

--- a/simpler_setup/tools/strace_timing.py
+++ b/simpler_setup/tools/strace_timing.py
@@ -300,10 +300,55 @@ def print_rounds_table(buckets, stream=sys.stdout):
         print(msg, file=stream)
 
 
-def to_chrome_trace(invocations):
-    """Build a Chrome-trace event list: one ph:X per span, lane = pid."""
+def _bucket_label(buckets, hid):
+    """Short human label for an hid: 'decode' (busiest bucket) / 'prefill' (once) / hid prefix."""
+    if not buckets:
+        return hid[:8]
+    ordered = sorted(buckets.items(), key=lambda kv: len(kv[1]), reverse=True)
+    if hid == ordered[0][0] and len(ordered[0][1]) > 1:
+        return "decode"
+    if len(buckets.get(hid, [])) == 1:
+        return "prefill"
+    return hid[:8]
+
+
+def to_chrome_trace(invocations, buckets=None):
+    """Build a Chrome-trace / Perfetto event list with readable nested tracks.
+
+    Each invocation gets its own named process lane ("decode inv=3" /
+    "prefill inv=1"), and within it host spans and device (``clk=dev``) spans go
+    to two separate threads — because host ``ts`` is steady_clock while device
+    ``ts`` is a device-clock offset, the two are NOT on a common timeline and
+    must not share a track. Within each track the spans nest by their own
+    ``ts``/``dur`` (Perfetto renders containment as nested slices), and ``depth``
+    is carried so the structure is unambiguous.
+    """
     events = []
+    lane_map = {}
     for inv in invocations:
+        label = _bucket_label(buckets, inv.hid) if buckets else inv.hid[:8]
+        # One process lane per invocation; host vs device on separate tracks.
+        # Key by (pid, inv): `inv` is only unique within a pid, so distinct
+        # processes (L3 parent + L2 children) can share inv values — mapping the
+        # pair to a dense lane id keeps their lanes from merging in Perfetto.
+        key = (inv.pid, inv.inv)
+        if key not in lane_map:
+            lane_map[key] = len(lane_map) + 1
+        lane = lane_map[key]
+        host_tid, dev_tid = 0, 1
+        events.append(
+            {
+                "ph": "M",
+                "name": "process_name",
+                "pid": lane,
+                "tid": host_tid,
+                "args": {"name": f"{label} inv={inv.inv} (pid={inv.pid})"},
+            }
+        )
+        events.append({"ph": "M", "name": "thread_name", "pid": lane, "tid": host_tid, "args": {"name": "host"}})
+        events.append(
+            {"ph": "M", "name": "thread_name", "pid": lane, "tid": dev_tid, "args": {"name": "device (clk=dev)"}}
+        )
         for s in inv.spans:
             events.append(
                 {
@@ -311,12 +356,75 @@ def to_chrome_trace(invocations):
                     "ph": "X",
                     "ts": s.ts / 1000.0,  # Chrome trace ts is microseconds
                     "dur": s.dur / 1000.0,
-                    "pid": s.pid,
-                    "tid": s.tid,
+                    "pid": lane,
+                    "tid": dev_tid if s.is_device else host_tid,
                     "args": {"inv": s.inv, "hid": s.hid, "depth": s.depth, "attrs": s.attrs},
                 }
             )
     return {"traceEvents": events, "displayTimeUnit": "ms"}
+
+
+def _print_inv_tree(inv, stream=sys.stdout):
+    """Print one invocation's spans as a nested tree built from the dotted span
+    names (so e.g. ``run_prepared.bind.args`` nests under ``run_prepared.bind``),
+    NOT from depth+ts — host (steady_clock) and device (``clk=dev``) spans live
+    on different clocks, so timestamp containment across domains is meaningless;
+    the dotted name is the unambiguous parent link. Siblings are ordered by
+    ``ts``. Device spans are tagged ``[dev]``; durations are µs."""
+    by_name = {s.name: s for s in inv.spans}
+    # children[parent_name] = [child span...]; a span's parent is its name minus
+    # the last dotted segment (if that prefix is itself a known span).
+    children = {}
+    roots = []
+    for s in inv.spans:
+        parent = s.name.rsplit(".", 1)[0] if "." in s.name else None
+        if parent is not None and parent in by_name:
+            children.setdefault(parent, []).append(s)
+        else:
+            roots.append(s)
+
+    def emit(s, indent):
+        tag = " [dev]" if s.is_device else ""
+        leaf = s.name.rsplit(".", 1)[-1] if "." in s.name else s.name
+        stream.write(f"{'  ' * indent}{leaf:<22}{tag:>6}  {s.dur / 1000.0:>12.1f} us\n")
+        kids = sorted(children.get(s.name, []), key=lambda x: x.ts)
+        # orch and sched run concurrently (see docs/dfx/device-phases.md): render
+        # them on ONE line, left = orch, right = sched, under their merged window
+        # `Effective = orch ∪ sched`, instead of as two sequential-looking rows.
+        has_sched = any(k.name.rsplit(".", 1)[-1] == "sched" for k in kids)
+        has_orch = any(k.name.rsplit(".", 1)[-1] == "orch" for k in kids)
+        for c in kids:
+            cleaf = c.name.rsplit(".", 1)[-1]
+            if cleaf == "orch" and has_sched:
+                sched = next(k for k in kids if k.name.rsplit(".", 1)[-1] == "sched")
+                eff = (max(c.ts + c.dur, sched.ts + sched.dur) - min(c.ts, sched.ts)) / 1000.0
+                base = "  " * (indent + 1)
+                # Effective = the merged orch ∪ sched window, with the two
+                # concurrent children shown side by side on the indented line
+                # below it (see docs/dfx/device-phases.md).
+                stream.write(f"{base}{'Effective':<22} [dev]  {eff:>12.1f} us\n")
+                stream.write(f"{base}  orch {c.dur / 1000.0:.1f}  ∥  sched {sched.dur / 1000.0:.1f}   (concurrent)\n")
+            elif cleaf == "sched" and has_orch:
+                continue  # shown beside orch on the Effective line above
+            else:
+                emit(c, indent + 1)
+
+    for r in sorted(roots, key=lambda x: x.ts):
+        emit(r, 0)
+
+
+def print_tree(buckets, stream=sys.stdout):
+    """Per-callable, per-invocation indented tree of spans (the nested view)."""
+    if not buckets:
+        print("No [STRACE] markers found.", file=stream)
+        return
+    ordered = sorted(buckets.items(), key=lambda kv: len(kv[1]), reverse=True)
+    for hid, invs in ordered:
+        label = _bucket_label(buckets, hid)
+        print(f"callable hid={hid} ({label}) — {len(invs)} invocation(s)", file=stream)
+        # Show the first invocation's tree as representative (they share structure).
+        _print_inv_tree(invs[0], stream=stream)
+        print(file=stream)
 
 
 def main(argv=None):
@@ -330,6 +438,12 @@ def main(argv=None):
         action="store_true",
         help="print a per-round Host/Device/Orch/Sched table (the format tools/benchmark_rounds.sh "
         "parses) instead of the per-callable TPOT table",
+    )
+    ap.add_argument(
+        "--tree",
+        action="store_true",
+        help="print an indented nested span tree per callable (device_wall → sub-phases), "
+        "instead of the per-callable TPOT table",
     )
     args = ap.parse_args(argv)
 
@@ -345,12 +459,14 @@ def main(argv=None):
 
     if args.rounds_table:
         print_rounds_table(buckets)
+    elif args.tree:
+        print_tree(buckets)
     else:
         print_tpot_table(buckets)
 
     if args.trace_out:
         with open(args.trace_out, "w", encoding="utf-8") as f:
-            json.dump(to_chrome_trace(invocations), f)
+            json.dump(to_chrome_trace(invocations, buckets), f)
         print(f"Wrote Chrome trace: {args.trace_out} ({len(spans)} spans)")
 
     return 0

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -116,7 +116,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // (no C++ thread_local — see docs/dynamic-linking.md). Idempotent across the
     // concurrent exec threads (same base). Run-wall is stamped here.
     set_platform_phase_base(k_args->device_wall_data_base);
-    aicpu_phase_start(AicpuPhase::RunWall);
+    AicpuPhaseScope run_wall(AicpuPhase::RunWall);
 
     LOG_INFO_V0("%s", "simpler_aicpu_exec: Calling aicpu_execute with Runtime");
     int rc = aicpu_execute(runtime);
@@ -126,10 +126,8 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     }
     LOG_INFO_V0("%s", "simpler_aicpu_exec: aicpu_execute completed successfully");
 
-    // Run-wall: record this thread's end into its own slot (plain store).
-    // Host reduces max(end) - min(start) → ns (see wall-capture note above).
-    aicpu_phase_end(AicpuPhase::RunWall);
-
+    // Run-wall end is stamped by run_wall's destructor (covers the early return
+    // above too); host reduces max(end) - min(start) → ns.
     return rc;
 }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -240,11 +240,7 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
 
     // First/changed callable: this is the real orch-SO dlopen — the SoLoad phase.
     // RAII end-stamp so every return path below closes the phase.
-    struct SoLoadPhaseGuard {
-        ~SoLoadPhaseGuard() { aicpu_phase_end(AicpuPhase::SoLoad); }
-    };
-    aicpu_phase_start(AicpuPhase::SoLoad);
-    SoLoadPhaseGuard so_load_guard;
+    AicpuPhaseScope so_load_phase(AicpuPhase::SoLoad);
     LOG_INFO_V0("Thread %d: New orch SO detected (callable_id=%d), (re)loading", thread_idx, callable_id);
     if (entry.handle != nullptr) {
         dlclose(entry.handle);
@@ -409,72 +405,84 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return load_rc;
             }
-            OrchSoEntry &entry = orch_so_table_[callable_id];
-            void **p_handle = &entry.handle;
-            char *p_path = entry.path;
-            DeviceOrchestrationFunc *p_func = &entry.func;
-            DeviceOrchestrationBindRuntimeFunc *p_bind = &entry.bind;
-            DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
+            // graph_build front-matter phases (orch thread only); the scheduler
+            // threads spin-wait on runtime_init_ready_ across this whole region.
+            // Each sub-phase gets its own `{}` scope so the boundaries are
+            // visible and an early `return` still records the end via the guard
+            // dtor. The few values used past their phase (p_func / p_bind for the
+            // orch call below; rt / sm_ptr across phases) are declared out here.
+            DeviceOrchestrationFunc *p_func = nullptr;
+            DeviceOrchestrationBindRuntimeFunc *p_bind = nullptr;
+            void *sm_ptr = nullptr;
+            uint64_t sm_size = 0;
+            {
+                AicpuPhaseScope config_validate(AicpuPhase::ConfigValidate);
+                OrchSoEntry &entry = orch_so_table_[callable_id];
+                void **p_handle = &entry.handle;
+                char *p_path = entry.path;
+                p_func = &entry.func;
+                p_bind = &entry.bind;
+                DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
 
-            // Build the entry-arg once per run; both the config call below and
-            // the orchestration entry (consumed at orch_args_cached_) use it.
-            orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
+                // Build the entry-arg once per run; both the config call below and
+                // the orchestration entry (consumed at orch_args_cached_) use it.
+                orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
 
-            // Validate arg count on every run (reload or cache hit).
-            if (*p_config_func != nullptr) {
-                PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
-                LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
-                if (cfg.expected_arg_count > 0) {
-                    const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
-                    int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
-                    if (actual_arg_count < cfg.expected_arg_count) {
-                        LOG_ERROR(
-                            "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
-                            cfg.expected_arg_count
-                        );
-                        // Clean up cached state so a subsequent run does a full reload.
-                        if (*p_handle != nullptr) {
-                            dlclose(*p_handle);
-                            *p_handle = nullptr;
+                // Validate arg count on every run (reload or cache hit).
+                if (*p_config_func != nullptr) {
+                    PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
+                    LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
+                    if (cfg.expected_arg_count > 0) {
+                        const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
+                        int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
+                        if (actual_arg_count < cfg.expected_arg_count) {
+                            LOG_ERROR(
+                                "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
+                                cfg.expected_arg_count
+                            );
+                            // Clean up cached state so a subsequent run does a full reload.
+                            if (*p_handle != nullptr) {
+                                dlclose(*p_handle);
+                                *p_handle = nullptr;
+                            }
+                            if (p_path[0] != '\0') {
+                                unlink(p_path);
+                                p_path[0] = '\0';
+                            }
+                            *p_func = nullptr;
+                            *p_bind = nullptr;
+                            *p_config_func = nullptr;
+                            orch_so_table_[callable_id].in_use = false;
+                            // Unblock scheduler threads before returning so they don't spin forever.
+                            runtime_init_ready_.store(true, std::memory_order_release);
+                            return -1;
                         }
-                        if (p_path[0] != '\0') {
-                            unlink(p_path);
-                            p_path[0] = '\0';
-                        }
-                        *p_func = nullptr;
-                        *p_bind = nullptr;
-                        *p_config_func = nullptr;
-                        orch_so_table_[callable_id].in_use = false;
-                        // Unblock scheduler threads before returning so they don't spin forever.
-                        runtime_init_ready_.store(true, std::memory_order_release);
-                        return -1;
                     }
+                } else {
+                    LOG_INFO_V0("Thread %d: No config function, using defaults", thread_idx);
                 }
-            } else {
-                LOG_INFO_V0("Thread %d: No config function, using defaults", thread_idx);
-            }
 
-            // sm_handle / rt are bound to *this* run's memory and must be
-            // (re)created every run, regardless of whether the SO itself was
-            // reused above.
-            const ChipStorageTaskArgs &args = runtime->get_orch_args();
-            int32_t arg_count = args.tensor_count() + args.scalar_count();
-            LOG_INFO_V0("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
-            for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                const Tensor &t = args.tensor(i);
-                LOG_INFO_V0(
-                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
-                    static_cast<uint64_t>(t.buffer.addr), t.ndims, static_cast<unsigned>(t.dtype)
-                );
+                // sm_handle / rt are bound to *this* run's memory and must be
+                // (re)created every run, regardless of whether the SO itself was
+                // reused above.
+                const ChipStorageTaskArgs &args = runtime->get_orch_args();
+                int32_t arg_count = args.tensor_count() + args.scalar_count();
+                LOG_INFO_V0("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
+                for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
+                    const Tensor &t = args.tensor(i);
+                    LOG_INFO_V0(
+                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                        static_cast<uint64_t>(t.buffer.addr), t.ndims, static_cast<unsigned>(t.dtype)
+                    );
+                }
+                for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
+                    LOG_INFO_V0(
+                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                        static_cast<uint64_t>(args.scalar(i))
+                    );
+                }
+                sm_ptr = runtime->get_gm_sm_ptr();
             }
-            for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                LOG_INFO_V0(
-                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
-                    static_cast<uint64_t>(args.scalar(i))
-                );
-            }
-
-            void *sm_ptr = runtime->get_gm_sm_ptr();
 
             // Prebuilt-arena fast path. Host has pre-populated the entire
             // runtime arena (PTO2Runtime + orchestrator/scheduler/tensor_map
@@ -483,26 +491,29 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // wire arena-internal pointers to their device addresses, reset
             // the SM, and finalize the few device-only fields the host could
             // not know at image-build time.
-            void *prebuilt_arena = runtime->get_prebuilt_arena_base();
-            size_t off_runtime = runtime->get_prebuilt_runtime_offset();
-            if (prebuilt_arena == nullptr) {
-                LOG_ERROR("Thread %d: prebuilt_arena_base is null", thread_idx);
-                runtime_init_ready_.store(true, std::memory_order_release);
-                return -1;
-            }
-            runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
-            rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
+            {
+                AicpuPhaseScope arena_wire(AicpuPhase::ArenaWire);
+                void *prebuilt_arena = runtime->get_prebuilt_arena_base();
+                size_t off_runtime = runtime->get_prebuilt_runtime_offset();
+                if (prebuilt_arena == nullptr) {
+                    LOG_ERROR("Thread %d: prebuilt_arena_base is null", thread_idx);
+                    runtime_init_ready_.store(true, std::memory_order_release);
+                    return -1;
+                }
+                runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
+                rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
 
-            // Wire every arena-internal pointer field (host wrote host-mirror
-            // addresses; we overwrite them with device addresses).
-            runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
-            for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
-                LOG_INFO_V0(
-                    "Thread %d: Ring %d sizes: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%d", thread_idx, r,
-                    rt->prebuilt_layout.task_window_sizes[r], rt->prebuilt_layout.heap_sizes[r],
-                    rt->prebuilt_layout.dep_pool_capacities[r]
-                );
+                // Wire every arena-internal pointer field (host wrote host-mirror
+                // addresses; we overwrite them with device addresses).
+                runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
+                sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+                for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+                    LOG_INFO_V0(
+                        "Thread %d: Ring %d sizes: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%d", thread_idx, r,
+                        rt->prebuilt_layout.task_window_sizes[r], rt->prebuilt_layout.heap_sizes[r],
+                        rt->prebuilt_layout.dep_pool_capacities[r]
+                    );
+                }
             }
 
             // Reset SM state. setup_pointers + init_header_per_ring restore
@@ -510,44 +521,47 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // the per-slot ring->slot_states[] (bind_ring + reset_for_reuse +
             // fanin_count/active_mask zero — previously done inside
             // RingSchedState::init).
-            memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->init_per_ring(
-                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, rt->prebuilt_layout.heap_sizes
-                )) {
-                LOG_ERROR("Thread %d: sm_handle->init_per_ring failed", thread_idx);
-                rt = nullptr;
-                runtime_init_ready_.store(true, std::memory_order_release);
-                return -1;
-            }
-
-            // AICore completion mailbox lives in the arena; reset it each
-            // boot so stale completion notifications from a previous run do
-            // not leak.
-            memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
-
-            // Fill ops / core counts (host can't resolve s_runtime_ops's
-            // device address nor know the SchedulerContext's core fan-out).
-            runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
-#if PTO2_PROFILING
-            rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level();
             {
-                auto &orch = rt->orchestrator;
-                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                    auto &alloc = orch.rings[r].task_allocator;
-                    scope_stats_set_ring_capacity(
-                        r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacities[r]
-                    );
+                AicpuPhaseScope sm_reset(AicpuPhase::SmReset);
+                memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
+                if (!rt->sm_handle->init_per_ring(
+                        sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, rt->prebuilt_layout.heap_sizes
+                    )) {
+                    LOG_ERROR("Thread %d: sm_handle->init_per_ring failed", thread_idx);
+                    rt = nullptr;
+                    runtime_init_ready_.store(true, std::memory_order_release);
+                    return -1;
                 }
-                scope_stats_set_tensormap_capacity(orch.tensor_map.pool_capacity());
-            }
+
+                // AICore completion mailbox lives in the arena; reset it each
+                // boot so stale completion notifications from a previous run do
+                // not leak.
+                memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
+
+                // Fill ops / core counts (host can't resolve s_runtime_ops's
+                // device address nor know the SchedulerContext's core fan-out).
+                runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
+#if PTO2_PROFILING
+                rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level();
+                {
+                    auto &orch = rt->orchestrator;
+                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                        auto &alloc = orch.rings[r].task_allocator;
+                        scope_stats_set_ring_capacity(
+                            r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacities[r]
+                        );
+                    }
+                    scope_stats_set_tensormap_capacity(orch.tensor_map.pool_capacity());
+                }
 #endif
 
-            // With multi-ring, slot_states are per-ring inside the scheduler.
-            runtime->set_slot_states_ptr(nullptr);
+                // With multi-ring, slot_states are per-ring inside the scheduler.
+                runtime->set_slot_states_ptr(nullptr);
 
-            // Wire scheduler context to the newly created PTO2Runtime before
-            // releasing scheduler threads from runtime_init_ready_.
-            sched_ctx_.bind_runtime(rt);
+                // Wire scheduler context to the newly created PTO2Runtime before
+                // releasing scheduler threads from runtime_init_ready_.
+                sched_ctx_.bind_runtime(rt);
+            }
 
             runtime_init_ready_.store(true, std::memory_order_release);
 
@@ -844,33 +858,43 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
 
     LOG_INFO_V0("%s", "aicpu_execute: Starting AICPU kernel execution");
 
-    aicpu_phase_start(AicpuPhase::Preamble);
-    g_aicpu_executor.init(runtime);
-
-    while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
-        if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
-            LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
-            return -1;
+    // Each phase is bracketed by its own scope so the start/end boundaries are
+    // visible and an early `return` still records the end via the guard dtor.
+    // rc / runtime_rc are declared out here because they outlive their phase.
+    {
+        AicpuPhaseScope preamble(AicpuPhase::Preamble);
+        g_aicpu_executor.init(runtime);
+        while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
+            if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
+                LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
+                return -1;
+            }
         }
     }
-    aicpu_phase_end(AicpuPhase::Preamble);
 
-    aicpu_phase_start(AicpuPhase::GraphBuild);
-    int32_t rc = g_aicpu_executor.run(runtime);
-    aicpu_phase_end(AicpuPhase::GraphBuild);
+    int32_t rc = 0;
+    {
+        AicpuPhaseScope graph_build(AicpuPhase::GraphBuild);
+        rc = g_aicpu_executor.run(runtime);
+    }
     if (rc != 0) {
         LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
     }
 
-    aicpu_phase_start(AicpuPhase::PostOrch);
+    // PostOrch measures only the real teardown (deinit), and only on the last
+    // thread to finish. Stamping it on every thread would let an orchestrator
+    // thread that finished early (it submits then returns while the scheduler
+    // threads are still draining) open the window at its early exit, so the
+    // cross-thread max(end)-min(start) reduction would absorb the orch-waits-for-
+    // sched overlap into post_orch — inflating it well past the actual teardown.
+    // read_pto2_runtime_status is two atomic loads every thread needs, so it
+    // stays outside the scope.
     int32_t runtime_rc = read_pto2_runtime_status(runtime);
-
-    // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
+        AicpuPhaseScope post_orch(AicpuPhase::PostOrch);
         LOG_INFO_V0("aicpu_execute: Last thread finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
     }
-    aicpu_phase_end(AicpuPhase::PostOrch);
 
     if (runtime_rc != 0) {
         LOG_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -126,7 +126,7 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // (no C++ thread_local — see docs/dynamic-linking.md). Idempotent across the
     // concurrent exec threads (same base). Run-wall is stamped here.
     set_platform_phase_base(k_args->device_wall_data_base);
-    aicpu_phase_start(AicpuPhase::RunWall);
+    AicpuPhaseScope run_wall(AicpuPhase::RunWall);
 
     LOG_INFO_V0("%s", "simpler_aicpu_exec: Calling aicpu_execute with Runtime");
     int rc = aicpu_execute(runtime);
@@ -136,10 +136,8 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     }
     LOG_INFO_V0("%s", "simpler_aicpu_exec: aicpu_execute completed successfully");
 
-    // Run-wall: record this thread's end into its own slot (plain store).
-    // Host reduces max(end) - min(start) → ns (see wall-capture note above).
-    aicpu_phase_end(AicpuPhase::RunWall);
-
+    // Run-wall end is stamped by run_wall's destructor (covers the early return
+    // above too); host reduces max(end) - min(start) → ns.
     return rc;
 }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -242,11 +242,7 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
 
     // First/changed callable: this is the real orch-SO dlopen — the SoLoad phase.
     // RAII end-stamp so every return path below closes the phase.
-    struct SoLoadPhaseGuard {
-        ~SoLoadPhaseGuard() { aicpu_phase_end(AicpuPhase::SoLoad); }
-    };
-    aicpu_phase_start(AicpuPhase::SoLoad);
-    SoLoadPhaseGuard so_load_guard;
+    AicpuPhaseScope so_load_phase(AicpuPhase::SoLoad);
     LOG_INFO_V0("Thread %d: New orch SO detected (callable_id=%d), (re)loading", thread_idx, callable_id);
     if (entry.handle != nullptr) {
         dlclose(entry.handle);
@@ -406,72 +402,84 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return load_rc;
             }
-            OrchSoEntry &entry = orch_so_table_[callable_id];
-            void **p_handle = &entry.handle;
-            char *p_path = entry.path;
-            DeviceOrchestrationFunc *p_func = &entry.func;
-            DeviceOrchestrationBindRuntimeFunc *p_bind = &entry.bind;
-            DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
+            // graph_build front-matter phases (orch thread only); the scheduler
+            // threads spin-wait on runtime_init_ready_ across this whole region.
+            // Each sub-phase gets its own `{}` scope so the boundaries are
+            // visible and an early `return` still records the end via the guard
+            // dtor. The few values used past their phase (p_func / p_bind for the
+            // orch call below; rt / sm_ptr across phases) are declared out here.
+            DeviceOrchestrationFunc *p_func = nullptr;
+            DeviceOrchestrationBindRuntimeFunc *p_bind = nullptr;
+            void *sm_ptr = nullptr;
+            uint64_t sm_size = 0;
+            {
+                AicpuPhaseScope config_validate(AicpuPhase::ConfigValidate);
+                OrchSoEntry &entry = orch_so_table_[callable_id];
+                void **p_handle = &entry.handle;
+                char *p_path = entry.path;
+                p_func = &entry.func;
+                p_bind = &entry.bind;
+                DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
 
-            // Build the entry-arg once per run; both the config call below and
-            // the orchestration entry (consumed at orch_args_cached_) use it.
-            orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
+                // Build the entry-arg once per run; both the config call below and
+                // the orchestration entry (consumed at orch_args_cached_) use it.
+                orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
 
-            // Validate arg count on every run (reload or cache hit).
-            if (*p_config_func != nullptr) {
-                PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
-                LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
-                if (cfg.expected_arg_count > 0) {
-                    const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
-                    int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
-                    if (actual_arg_count < cfg.expected_arg_count) {
-                        LOG_ERROR(
-                            "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
-                            cfg.expected_arg_count
-                        );
-                        // Clean up cached state so a subsequent run does a full reload.
-                        if (*p_handle != nullptr) {
-                            dlclose(*p_handle);
-                            *p_handle = nullptr;
+                // Validate arg count on every run (reload or cache hit).
+                if (*p_config_func != nullptr) {
+                    PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
+                    LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
+                    if (cfg.expected_arg_count > 0) {
+                        const ChipStorageTaskArgs &args_validate = runtime->get_orch_args();
+                        int32_t actual_arg_count = args_validate.tensor_count() + args_validate.scalar_count();
+                        if (actual_arg_count < cfg.expected_arg_count) {
+                            LOG_ERROR(
+                                "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
+                                cfg.expected_arg_count
+                            );
+                            // Clean up cached state so a subsequent run does a full reload.
+                            if (*p_handle != nullptr) {
+                                dlclose(*p_handle);
+                                *p_handle = nullptr;
+                            }
+                            if (p_path[0] != '\0') {
+                                unlink(p_path);
+                                p_path[0] = '\0';
+                            }
+                            *p_func = nullptr;
+                            *p_bind = nullptr;
+                            *p_config_func = nullptr;
+                            orch_so_table_[callable_id].in_use = false;
+                            // Unblock scheduler threads before returning so they don't spin forever.
+                            runtime_init_ready_.store(true, std::memory_order_release);
+                            return -1;
                         }
-                        if (p_path[0] != '\0') {
-                            unlink(p_path);
-                            p_path[0] = '\0';
-                        }
-                        *p_func = nullptr;
-                        *p_bind = nullptr;
-                        *p_config_func = nullptr;
-                        orch_so_table_[callable_id].in_use = false;
-                        // Unblock scheduler threads before returning so they don't spin forever.
-                        runtime_init_ready_.store(true, std::memory_order_release);
-                        return -1;
                     }
+                } else {
+                    LOG_INFO_V0("Thread %d: No config function, using defaults", thread_idx);
                 }
-            } else {
-                LOG_INFO_V0("Thread %d: No config function, using defaults", thread_idx);
-            }
 
-            // sm_handle / rt are bound to *this* run's memory and must be
-            // (re)created every run, regardless of whether the SO itself was
-            // reused above.
-            const ChipStorageTaskArgs &args = runtime->get_orch_args();
-            int32_t arg_count = args.tensor_count() + args.scalar_count();
-            LOG_INFO_V0("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
-            for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
-                const Tensor &t = args.tensor(i);
-                LOG_INFO_V0(
-                    "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
-                    static_cast<uint64_t>(t.buffer.addr), t.ndims, static_cast<unsigned>(t.dtype)
-                );
+                // sm_handle / rt are bound to *this* run's memory and must be
+                // (re)created every run, regardless of whether the SO itself was
+                // reused above.
+                const ChipStorageTaskArgs &args = runtime->get_orch_args();
+                int32_t arg_count = args.tensor_count() + args.scalar_count();
+                LOG_INFO_V0("Thread %d: sm_ptr=%p, arg_count=%d", thread_idx, runtime->get_gm_sm_ptr(), arg_count);
+                for (int32_t i = 0; i < args.tensor_count() && i < 20; i++) {
+                    const Tensor &t = args.tensor(i);
+                    LOG_INFO_V0(
+                        "Thread %d: orch_args[%d] = TENSOR(data=0x%lx, ndims=%u, dtype=%u)", thread_idx, i,
+                        static_cast<uint64_t>(t.buffer.addr), t.ndims, static_cast<unsigned>(t.dtype)
+                    );
+                }
+                for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
+                    LOG_INFO_V0(
+                        "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
+                        static_cast<uint64_t>(args.scalar(i))
+                    );
+                }
+                sm_ptr = runtime->get_gm_sm_ptr();
             }
-            for (int32_t i = 0; i < args.scalar_count() && (args.tensor_count() + i) < 20; i++) {
-                LOG_INFO_V0(
-                    "Thread %d: orch_args[%d] = SCALAR(0x%lx)", thread_idx, args.tensor_count() + i,
-                    static_cast<uint64_t>(args.scalar(i))
-                );
-            }
-
-            void *sm_ptr = runtime->get_gm_sm_ptr();
 
             // Prebuilt-arena fast path. Host has pre-populated the entire
             // runtime arena (PTO2Runtime + orchestrator/scheduler/tensor_map
@@ -480,26 +488,29 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // wire arena-internal pointers to their device addresses, reset
             // the SM, and finalize the few device-only fields the host could
             // not know at image-build time.
-            void *prebuilt_arena = runtime->get_prebuilt_arena_base();
-            size_t off_runtime = runtime->get_prebuilt_runtime_offset();
-            if (prebuilt_arena == nullptr) {
-                LOG_ERROR("Thread %d: prebuilt_arena_base is null", thread_idx);
-                runtime_init_ready_.store(true, std::memory_order_release);
-                return -1;
-            }
-            runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
-            rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
+            {
+                AicpuPhaseScope arena_wire(AicpuPhase::ArenaWire);
+                void *prebuilt_arena = runtime->get_prebuilt_arena_base();
+                size_t off_runtime = runtime->get_prebuilt_runtime_offset();
+                if (prebuilt_arena == nullptr) {
+                    LOG_ERROR("Thread %d: prebuilt_arena_base is null", thread_idx);
+                    runtime_init_ready_.store(true, std::memory_order_release);
+                    return -1;
+                }
+                runtime_arena_.attach(prebuilt_arena, DeviceArena::kDefaultBaseAlign);
+                rt = reinterpret_cast<PTO2Runtime *>(static_cast<char *>(prebuilt_arena) + off_runtime);
 
-            // Wire every arena-internal pointer field (host wrote host-mirror
-            // addresses; we overwrite them with device addresses).
-            runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
-            uint64_t sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
-            for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
-                LOG_INFO_V0(
-                    "Thread %d: Ring %d sizes: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%d", thread_idx, r,
-                    rt->prebuilt_layout.task_window_sizes[r], rt->prebuilt_layout.heap_sizes[r],
-                    rt->prebuilt_layout.dep_pool_capacities[r]
-                );
+                // Wire every arena-internal pointer field (host wrote host-mirror
+                // addresses; we overwrite them with device addresses).
+                runtime_wire_arena_pointers(runtime_arena_, rt->prebuilt_layout, rt);
+                sm_size = PTO2SharedMemoryHandle::calculate_size_per_ring(rt->prebuilt_layout.task_window_sizes);
+                for (int r = 0; r < PTO2_MAX_RING_DEPTH; ++r) {
+                    LOG_INFO_V0(
+                        "Thread %d: Ring %d sizes: task_window=%" PRIu64 " heap=%" PRIu64 " dep_pool=%d", thread_idx, r,
+                        rt->prebuilt_layout.task_window_sizes[r], rt->prebuilt_layout.heap_sizes[r],
+                        rt->prebuilt_layout.dep_pool_capacities[r]
+                    );
+                }
             }
 
             // Reset SM state. setup_pointers + init_header_per_ring restore
@@ -507,45 +518,48 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             // the per-slot ring->slot_states[] (bind_ring + reset_for_reuse +
             // fanin_count/active_mask zero — previously done inside
             // RingSchedState::init).
-            memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
-            if (!rt->sm_handle->init_per_ring(
-                    sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, rt->prebuilt_layout.heap_sizes
-                )) {
-                LOG_ERROR("Thread %d: sm_handle->init_per_ring failed", thread_idx);
-                rt = nullptr;
-                runtime_init_ready_.store(true, std::memory_order_release);
-                return -1;
-            }
+            {
+                AicpuPhaseScope sm_reset(AicpuPhase::SmReset);
+                memset(rt->sm_handle, 0, sizeof(*rt->sm_handle));
+                if (!rt->sm_handle->init_per_ring(
+                        sm_ptr, sm_size, rt->prebuilt_layout.task_window_sizes, rt->prebuilt_layout.heap_sizes
+                    )) {
+                    LOG_ERROR("Thread %d: sm_handle->init_per_ring failed", thread_idx);
+                    rt = nullptr;
+                    runtime_init_ready_.store(true, std::memory_order_release);
+                    return -1;
+                }
 
-            // AICore completion mailbox lives in the arena; reset it each
-            // boot so stale completion notifications from a previous run do
-            // not leak.
-            memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
+                // AICore completion mailbox lives in the arena; reset it each
+                // boot so stale completion notifications from a previous run do
+                // not leak.
+                memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
 
-            // Fill ops / core counts (host can't resolve s_runtime_ops's
-            // device address nor know the SchedulerContext's core fan-out).
-            runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
+                // Fill ops / core counts (host can't resolve s_runtime_ops's
+                // device address nor know the SchedulerContext's core fan-out).
+                runtime_finalize_after_wire(rt, sched_ctx_.aic_count(), sched_ctx_.aiv_count());
 
 #if PTO2_PROFILING
-            rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level();
-            {
-                auto &orch = rt->orchestrator;
-                for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-                    auto &alloc = orch.rings[r].task_allocator;
-                    scope_stats_set_ring_capacity(
-                        r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacities[r]
-                    );
+                rt->orchestrator.l2_swimlane_level = get_l2_swimlane_level();
+                {
+                    auto &orch = rt->orchestrator;
+                    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+                        auto &alloc = orch.rings[r].task_allocator;
+                        scope_stats_set_ring_capacity(
+                            r, alloc.window_size(), alloc.heap_capacity(), rt->prebuilt_layout.dep_pool_capacities[r]
+                        );
+                    }
+                    scope_stats_set_tensormap_capacity(orch.tensor_map.pool_capacity());
                 }
-                scope_stats_set_tensormap_capacity(orch.tensor_map.pool_capacity());
-            }
 #endif
 
-            // With multi-ring, slot_states are per-ring inside the scheduler.
-            runtime->set_slot_states_ptr(nullptr);
+                // With multi-ring, slot_states are per-ring inside the scheduler.
+                runtime->set_slot_states_ptr(nullptr);
 
-            // Wire scheduler context to the newly created PTO2Runtime before
-            // releasing scheduler threads from runtime_init_ready_.
-            sched_ctx_.bind_runtime(rt);
+                // Wire scheduler context to the newly created PTO2Runtime before
+                // releasing scheduler threads from runtime_init_ready_.
+                sched_ctx_.bind_runtime(rt);
+            }
 
             runtime_init_ready_.store(true, std::memory_order_release);
 
@@ -839,33 +853,43 @@ extern "C" int32_t aicpu_execute(Runtime *runtime) {
 
     LOG_INFO_V0("%s", "aicpu_execute: Starting AICPU kernel execution");
 
-    aicpu_phase_start(AicpuPhase::Preamble);
-    g_aicpu_executor.init(runtime);
-
-    while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
-        if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
-            LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
-            return -1;
+    // Each phase is bracketed by its own scope so the start/end boundaries are
+    // visible and an early `return` still records the end via the guard dtor.
+    // rc / runtime_rc are declared out here because they outlive their phase.
+    {
+        AicpuPhaseScope preamble(AicpuPhase::Preamble);
+        g_aicpu_executor.init(runtime);
+        while (!g_aicpu_executor.init_done_.load(std::memory_order_acquire)) {
+            if (g_aicpu_executor.init_failed_.load(std::memory_order_acquire)) {
+                LOG_ERROR("%s", "aicpu_execute: Initialization failed, aborting execution");
+                return -1;
+            }
         }
     }
-    aicpu_phase_end(AicpuPhase::Preamble);
 
-    aicpu_phase_start(AicpuPhase::GraphBuild);
-    int32_t rc = g_aicpu_executor.run(runtime);
-    aicpu_phase_end(AicpuPhase::GraphBuild);
+    int32_t rc = 0;
+    {
+        AicpuPhaseScope graph_build(AicpuPhase::GraphBuild);
+        rc = g_aicpu_executor.run(runtime);
+    }
     if (rc != 0) {
         LOG_ERROR("aicpu_execute: Thread execution failed with rc=%d", rc);
     }
 
-    aicpu_phase_start(AicpuPhase::PostOrch);
+    // PostOrch measures only the real teardown (deinit), and only on the last
+    // thread to finish. Stamping it on every thread would let an orchestrator
+    // thread that finished early (it submits then returns while the scheduler
+    // threads are still draining) open the window at its early exit, so the
+    // cross-thread max(end)-min(start) reduction would absorb the orch-waits-for-
+    // sched overlap into post_orch — inflating it well past the actual teardown.
+    // read_runtime_status is two atomic loads every thread needs, so it stays
+    // outside the scope.
     int32_t runtime_rc = read_runtime_status(runtime);
-
-    // Last thread cleans up
     if (g_aicpu_executor.finished_.load(std::memory_order_acquire)) {
+        AicpuPhaseScope post_orch(AicpuPhase::PostOrch);
         LOG_INFO_V0("aicpu_execute: Last thread finished, cleaning up");
         g_aicpu_executor.deinit(runtime);
     }
-    aicpu_phase_end(AicpuPhase::PostOrch);
 
     if (runtime_rc != 0) {
         LOG_ERROR("aicpu_execute: PTO2 runtime failed with rc=%d", runtime_rc);

--- a/src/common/platform/include/aicpu/device_phase_aicpu.h
+++ b/src/common/platform/include/aicpu/device_phase_aicpu.h
@@ -90,4 +90,36 @@ inline void aicpu_phase_set_window(AicpuPhase phase, uint64_t start_cycle, uint6
     records[static_cast<int>(phase)].end_cycle = end_cycle;
 }
 
+/**
+ * RAII guard: stamp `phase`'s start on construction, end on destruction. The
+ * device analogue of the host `StraceScope` — but it only writes the per-thread
+ * cycle slot (no logging: the AICPU hot path must not log, per the codestyle
+ * rule; the host re-emits the readback as the marker). Bracket a phase region
+ * with its own `{}` scope so the start/end are visually obvious and every exit
+ * path (including an early `return`) records the end:
+ *
+ *     {
+ *         AicpuPhaseScope _g(AicpuPhase::ArenaWire);
+ *         ...                              // end stamped at the closing }
+ *     }
+ *
+ * Each AicpuPhase has its own fixed slot, so nested scopes (e.g. RunWall ⊃
+ * GraphBuild ⊃ SmReset, each its own guard) record independently and never
+ * interfere; a phase must still fire at most once per run (a second guard for
+ * the same phase would overwrite the slot).
+ */
+class AicpuPhaseScope {
+public:
+    explicit AicpuPhaseScope(AicpuPhase phase) :
+        phase_(phase) {
+        aicpu_phase_start(phase_);
+    }
+    ~AicpuPhaseScope() { aicpu_phase_end(phase_); }
+    AicpuPhaseScope(const AicpuPhaseScope &) = delete;
+    AicpuPhaseScope &operator=(const AicpuPhaseScope &) = delete;
+
+private:
+    AicpuPhase phase_;
+};
+
 #endif  // PLATFORM_AICPU_DEVICE_PHASE_AICPU_H_

--- a/src/common/platform/include/common/device_phase.h
+++ b/src/common/platform/include/common/device_phase.h
@@ -50,6 +50,12 @@ enum class AicpuPhase : uint32_t {
     PostOrch,     // AICore exec tail + drain after orchestration returns
     OrchWindow,   // orchestrator thread's submit window (former device-log orch_start/end)
     SchedWindow,  // scheduler thread's dispatch window (former device-log sched_start/end)
+    // graph_build front-matter sub-phases (orchestrator thread only, before the
+    // OrchWindow opens): the per-run prep the scheduler threads spin-wait on. New
+    // entries appended (not reordered) so existing slot indices stay stable.
+    ConfigValidate,  // config_func() + arg-count validate
+    ArenaWire,       // attach prebuilt runtime arena + wire device pointers
+    SmReset,         // SM/ring reset + finalize + bind, up to releasing the schedulers
     Count,
 };
 

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -35,6 +35,7 @@
 
 #include <chrono>
 #include <cstdlib>
+#include <cstring>
 #include <utility>
 #include <vector>
 
@@ -375,6 +376,20 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
     }
 }
 
+// Runtime gate for device-domain phase emission. SIMPLER_DEVICE_PROFILING=0
+// suppresses the device (clk=dev) markers so a deployment can profile host and
+// device independently; any other value (or unset) keeps them on. Host-side
+// [STRACE] spans are unaffected — they ride SIMPLER_PROFILING + the log level.
+// Read once and cached: getenv is not thread-safe against setenv, and the value
+// is a process-lifetime config knob.
+static bool device_profiling_enabled() {
+    static const bool enabled = [] {
+        const char *v = std::getenv("SIMPLER_DEVICE_PROFILING");
+        return v == nullptr || std::strcmp(v, "0") != 0;
+    }();
+    return enabled;
+}
+
 // Emit device-domain trace markers for the AICPU phases. RunWall (the whole
 // on-NPU wall, i.e. the former RunTiming.device_wall) is emitted at depth 2
 // under runner_run; its preamble/so_load/graph_build/post_orch subdivisions are
@@ -382,6 +397,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 // STRACE_DEV_SPAN_AT self-compiles to nothing when profiling is off, so no extra
 // gate is needed here.
 static void emit_device_phase_markers(DeviceRunnerBase *runner) {
+    if (!device_profiling_enabled()) return;
     const uint64_t run_wall_ns = runner->last_device_phase_ns(AicpuPhase::RunWall);
     if (run_wall_ns != 0) {
         STRACE_DEV_SPAN_AT("run_prepared.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);
@@ -394,10 +410,18 @@ static void emit_device_phase_markers(DeviceRunnerBase *runner) {
         {AicpuPhase::Preamble, "run_prepared.runner_run.device_wall.preamble"},
         {AicpuPhase::SoLoad, "run_prepared.runner_run.device_wall.so_load"},
         {AicpuPhase::GraphBuild, "run_prepared.runner_run.device_wall.graph_build"},
+        {AicpuPhase::ConfigValidate, "run_prepared.runner_run.device_wall.config_validate"},
+        {AicpuPhase::ArenaWire, "run_prepared.runner_run.device_wall.arena_wire"},
+        {AicpuPhase::SmReset, "run_prepared.runner_run.device_wall.sm_reset"},
         {AicpuPhase::PostOrch, "run_prepared.runner_run.device_wall.post_orch"},
         {AicpuPhase::OrchWindow, "run_prepared.runner_run.device_wall.orch"},
         {AicpuPhase::SchedWindow, "run_prepared.runner_run.device_wall.sched"},
     };
+    // RunWall is emitted above as device_wall; every other phase is in the table.
+    static_assert(
+        sizeof(kPhases) / sizeof(kPhases[0]) == NUM_AICPU_PHASES - 1,
+        "kPhases[] must list every AicpuPhase except RunWall — add the new phase here"
+    );
     for (const auto &p : kPhases) {
         const uint64_t ns = runner->last_device_phase_ns(p.phase);
         if (ns != 0) {

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -32,6 +32,8 @@
 #include <pthread.h>
 
 #include <chrono>
+#include <cstdlib>
+#include <cstring>
 #include <new>
 #include <utility>
 #include <vector>
@@ -335,10 +337,24 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
     }
 }
 
+// Runtime gate for device-domain phase emission. SIMPLER_DEVICE_PROFILING=0
+// suppresses the device (clk=dev) markers so a deployment can profile host and
+// device independently; any other value (or unset) keeps them on. Host-side
+// [STRACE] spans are unaffected — they ride SIMPLER_PROFILING + the log level.
+// Read once and cached (process-lifetime config knob).
+static bool device_profiling_enabled() {
+    static const bool enabled = [] {
+        const char *v = std::getenv("SIMPLER_DEVICE_PROFILING");
+        return v == nullptr || std::strcmp(v, "0") != 0;
+    }();
+    return enabled;
+}
+
 // Emit device-domain phase markers (RunWall + its 4 AICPU subdivisions),
 // mirroring the onboard c_api. Phases never stamped (0 ns) are skipped.
 // STRACE_DEV_SPAN_AT self-compiles to nothing when profiling is off.
 static void emit_device_phase_markers(SimDeviceRunnerBase *runner) {
+    if (!device_profiling_enabled()) return;
     const uint64_t run_wall_ns = runner->last_device_phase_ns(AicpuPhase::RunWall);
     if (run_wall_ns != 0) {
         STRACE_DEV_SPAN_AT("run_prepared.runner_run.device_wall", 0, static_cast<long long>(run_wall_ns), 2);
@@ -351,10 +367,18 @@ static void emit_device_phase_markers(SimDeviceRunnerBase *runner) {
         {AicpuPhase::Preamble, "run_prepared.runner_run.device_wall.preamble"},
         {AicpuPhase::SoLoad, "run_prepared.runner_run.device_wall.so_load"},
         {AicpuPhase::GraphBuild, "run_prepared.runner_run.device_wall.graph_build"},
+        {AicpuPhase::ConfigValidate, "run_prepared.runner_run.device_wall.config_validate"},
+        {AicpuPhase::ArenaWire, "run_prepared.runner_run.device_wall.arena_wire"},
+        {AicpuPhase::SmReset, "run_prepared.runner_run.device_wall.sm_reset"},
         {AicpuPhase::PostOrch, "run_prepared.runner_run.device_wall.post_orch"},
         {AicpuPhase::OrchWindow, "run_prepared.runner_run.device_wall.orch"},
         {AicpuPhase::SchedWindow, "run_prepared.runner_run.device_wall.sched"},
     };
+    // RunWall is emitted above as device_wall; every other phase is in the table.
+    static_assert(
+        sizeof(kPhases) / sizeof(kPhases[0]) == NUM_AICPU_PHASES - 1,
+        "kPhases[] must list every AicpuPhase except RunWall — add the new phase here"
+    );
     for (const auto &p : kPhases) {
         const uint64_t ns = runner->last_device_phase_ns(p.phase);
         if (ns != 0) {


### PR DESCRIPTION
## Summary

Follow-ups to the `[STRACE]` device-phase facility (#1177), driven by a real
qwen3-14B onboard profile: on a decode step ~22 ms (≈31 %) of the device wall sat
inside `graph_build`, **before** the orch/sched windows opened, with no phase.

### 1. Subdivide the `graph_build` front matter into 3 phases
The orchestrator-thread prep that runs before `OrchWindow` (while scheduler
threads spin-wait on `runtime_init_ready_`) is now broken out:

| phase | marker | covers |
| ----- | ------ | ------ |
| `ConfigValidate` | `…device_wall.config_validate` | `config_func()` + arg-count validate |
| `ArenaWire` | `…device_wall.arena_wire` | attach prebuilt runtime arena + wire device pointers |
| `SmReset` | `…device_wall.sm_reset` | SM/ring reset + finalize + bind, up to releasing the schedulers |

`NUM_AICPU_PHASES` auto-grows; the host `kPhases[]` tables (onboard + sim) gain
the names, guarded by `static_assert(sizeof(kPhases) == NUM_AICPU_PHASES-1)`.

Measured on a2a3 (qwen3-14B, 256-token prompt, decode): the prep is almost
entirely `sm_reset` (~21 ms) — `config_validate`/`arena_wire` are ~3 µs each —
i.e. the previously-invisible 22 ms is one concrete, optimizable target.

### 2. RAII for all AICPU phase stamping
A single `AicpuPhaseScope` guard (ctor stamps start, dtor stamps end) in
`device_phase_aicpu.h` — the device analogue of the host `StraceScope`, but it
only writes the per-thread cycle slot (no logging on the AICPU hot path). Every
phase now uses it via its own `{}` scope so the boundaries are visible and an
early `return` still records the end: `RunWall`, `Preamble`/`GraphBuild`/
`PostOrch`, `SoLoad`, plus the 3 new prep phases — across a2a3 and a5. Replaces
the bare `aicpu_phase_start/end` pairs and the one-off `SoLoadPhaseGuard`, and
fixes the latent miss where `RunWall` / `Preamble` early-return paths skipped
their end stamp. (`orch`/`sched` keep `aicpu_phase_set_window` — pre-measured.)

### 3. `SIMPLER_DEVICE_PROFILING` — host/device split
Runtime env read once in `emit_device_phase_markers` (onboard + sim). `=0`
suppresses the `clk=dev` device markers; unset/other keeps them on (default on).
Host spans are unchanged — they ride `SIMPLER_PROFILING` + the log level.

### 4. `strace_timing` readability
- **`--tree`**: indented nested span tree per callable (device spans tagged `[dev]`).
- **`--trace-out`** Perfetto JSON: one named lane per invocation keyed by
  `(pid, inv)` so distinct processes don't collide, with separate host and
  device(`clk=dev`) tracks.

Docs: `device-phases.md`, `host-trace.md`, `tools/README` updated.

## Testing
- [x] a2a3sim + a5sim build (`static_assert` holds).
- [x] sim: 3 phases emit, `--tree` nests correctly, `SIMPLER_DEVICE_PROFILING=0` drops device markers (host spans remain).
- [x] real a2a3: qwen3-14B 256-token decode — phases emit; `sm_reset` ≈ 21 ms isolated.
- [x] pyut green; clang-format(v21) + ruff + markdownlint clean.
