### PR TITLE
fix(runtime): size scope_tasks_cap from the runtime window

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -466,10 +466,10 @@ static bool prepare_task(
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         // scope_tasks lives in the per-Worker arena (single backing allocation),
-        // so realloc is not legal. Capacity == PTO2_SCOPE_TASKS_CAP ==
-        // PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH, the total in-flight slot
-        // budget — hitting it means every ring is saturated, so no further push
-        // could succeed regardless of buffer growth.
+        // so realloc is not legal. Capacity is the total in-flight slot budget
+        // (sum of the per-ring task windows; see reserve_layout) — hitting it means
+        // every ring is saturated, so no further push could succeed regardless of
+        // buffer growth.
         orch->report_fatal(
             PTO2_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
             "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -237,7 +237,22 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
     const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
     PTO2OrchestratorLayout layout{};
-    layout.scope_tasks_cap = PTO2_SCOPE_TASKS_CAP;
+    // scope_tasks holds every task in the open scope across all rings, so its cap
+    // is the real in-flight budget = sum of the (runtime) per-ring windows. Using
+    // the compile-time PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when
+    // ring_task_window was enlarged past the default (premature SCOPE_TASKS_OVERFLOW)
+    // and over-allocated it when shrunk. See issue #1188.
+    //
+    // Accumulate in int64: each window is validated <= INT32_MAX individually, but
+    // the sum of PTO2_MAX_RING_DEPTH windows can exceed it — a bare int32 sum would
+    // wrap to a negative/undersized cap. Bound the result before narrowing.
+    int64_t scope_tasks_cap = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        always_assert(task_window_sizes[r] > 0);
+        scope_tasks_cap += task_window_sizes[r];
+    }
+    always_assert(scope_tasks_cap <= std::numeric_limits<int32_t>::max());
+    layout.scope_tasks_cap = static_cast<int32_t>(scope_tasks_cap);
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         layout.dep_pool_capacities[r] = dep_pool_capacities[r];

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -471,10 +471,10 @@ static bool prepare_task(
 static void scope_tasks_push(PTO2OrchestratorState *orch, PTO2TaskSlotState *task_slot_state) {
     if (orch->scope_tasks_size >= orch->scope_tasks_capacity) {
         // scope_tasks lives in the per-Worker arena (single backing allocation),
-        // so realloc is not legal. Capacity == PTO2_SCOPE_TASKS_CAP ==
-        // PTO2_TASK_WINDOW_SIZE × PTO2_MAX_RING_DEPTH, the total in-flight slot
-        // budget — hitting it means every ring is saturated, so no further push
-        // could succeed regardless of buffer growth.
+        // so realloc is not legal. Capacity is the total in-flight slot budget
+        // (sum of the per-ring task windows; see reserve_layout) — hitting it means
+        // every ring is saturated, so no further push could succeed regardless of
+        // buffer growth.
         orch->report_fatal(
             PTO2_ERROR_SCOPE_TASKS_OVERFLOW, __FUNCTION__,
             "scope_tasks buffer saturated at %d entries (all rings full)", orch->scope_tasks_capacity

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_runtime2_init.cpp
@@ -229,7 +229,22 @@ PTO2OrchestratorLayout PTO2OrchestratorState::reserve_layout(
     const int32_t dep_pool_capacities[PTO2_MAX_RING_DEPTH]
 ) {
     PTO2OrchestratorLayout layout{};
-    layout.scope_tasks_cap = PTO2_SCOPE_TASKS_CAP;
+    // scope_tasks holds every task in the open scope across all rings, so its cap
+    // is the real in-flight budget = sum of the (runtime) per-ring windows. Using
+    // the compile-time PTO2_SCOPE_TASKS_CAP instead under-sized the buffer when
+    // ring_task_window was enlarged past the default (premature SCOPE_TASKS_OVERFLOW)
+    // and over-allocated it when shrunk. See issue #1188.
+    //
+    // Accumulate in int64: each window is validated <= INT32_MAX individually, but
+    // the sum of PTO2_MAX_RING_DEPTH windows can exceed it — a bare int32 sum would
+    // wrap to a negative/undersized cap. Bound the result before narrowing.
+    int64_t scope_tasks_cap = 0;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
+        always_assert(task_window_sizes[r] > 0);
+        scope_tasks_cap += task_window_sizes[r];
+    }
+    always_assert(scope_tasks_cap <= std::numeric_limits<int32_t>::max());
+    layout.scope_tasks_cap = static_cast<int32_t>(scope_tasks_cap);
     layout.scope_stack_capacity = PTO2_MAX_SCOPE_DEPTH;
     for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
         layout.dep_pool_capacities[r] = dep_pool_capacities[r];

--- a/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a2a3/test_orchestrator_fanin.cpp
@@ -142,3 +142,36 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     EXPECT_NE(log.find("available=1024"), std::string::npos);
     EXPECT_EQ(log.find("PTO2_RING_HEAP=<pow2>"), std::string::npos);
 }
+
+// Regression for issue #1188: scope_tasks_cap must equal the real in-flight budget
+// (sum of the runtime per-ring windows), not the compile-time PTO2_SCOPE_TASKS_CAP.
+// reserve_layout only computes offsets, so no commit()/backing is needed here.
+TEST(OrchestratorLayoutScopeTasksCap, FollowsRuntimeWindowSum) {
+    auto cap_for = [](const int32_t windows[PTO2_MAX_RING_DEPTH]) {
+        DeviceArena arena;
+        int32_t cap = PTO2OrchestratorState::reserve_layout(arena, windows).scope_tasks_cap;
+        arena.release();
+        return cap;
+    };
+
+    int32_t windows[PTO2_MAX_RING_DEPTH];
+
+    // Default window: cap == the old compile-time value (no behavior change).
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+        windows[r] = PTO2_TASK_WINDOW_SIZE;
+    EXPECT_EQ(cap_for(windows), PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
+
+    // Shrunk window: cap shrinks to the real budget (no over-allocation).
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+        windows[r] = 4;
+    EXPECT_EQ(cap_for(windows), 4 * PTO2_MAX_RING_DEPTH);
+
+    // Enlarged window past the compile default: cap grows to match the rings, so a
+    // large scope no longer hits a premature SCOPE_TASKS_OVERFLOW (the bug fixed).
+    const int32_t big = PTO2_TASK_WINDOW_SIZE * 2;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+        windows[r] = big;
+    EXPECT_EQ(cap_for(windows), big * PTO2_MAX_RING_DEPTH);
+    EXPECT_GT(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
+}

--- a/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
+++ b/tests/ut/cpp/a5/test_orchestrator_fanin.cpp
@@ -142,3 +142,36 @@ TEST_F(OrchestratorFaninTest, SubmitPathHeapDeadlockLogReportsRingAndRealHeapSta
     EXPECT_NE(log.find("available=1024"), std::string::npos);
     EXPECT_EQ(log.find("PTO2_RING_HEAP=<pow2>"), std::string::npos);
 }
+
+// Regression for issue #1188: scope_tasks_cap must equal the real in-flight budget
+// (sum of the runtime per-ring windows), not the compile-time PTO2_SCOPE_TASKS_CAP.
+// reserve_layout only computes offsets, so no commit()/backing is needed here.
+TEST(OrchestratorLayoutScopeTasksCap, FollowsRuntimeWindowSum) {
+    auto cap_for = [](const int32_t windows[PTO2_MAX_RING_DEPTH]) {
+        DeviceArena arena;
+        int32_t cap = PTO2OrchestratorState::reserve_layout(arena, windows).scope_tasks_cap;
+        arena.release();
+        return cap;
+    };
+
+    int32_t windows[PTO2_MAX_RING_DEPTH];
+
+    // Default window: cap == the old compile-time value (no behavior change).
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+        windows[r] = PTO2_TASK_WINDOW_SIZE;
+    EXPECT_EQ(cap_for(windows), PTO2_TASK_WINDOW_SIZE * PTO2_MAX_RING_DEPTH);
+    EXPECT_EQ(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
+
+    // Shrunk window: cap shrinks to the real budget (no over-allocation).
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+        windows[r] = 4;
+    EXPECT_EQ(cap_for(windows), 4 * PTO2_MAX_RING_DEPTH);
+
+    // Enlarged window past the compile default: cap grows to match the rings, so a
+    // large scope no longer hits a premature SCOPE_TASKS_OVERFLOW (the bug fixed).
+    const int32_t big = PTO2_TASK_WINDOW_SIZE * 2;
+    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++)
+        windows[r] = big;
+    EXPECT_EQ(cap_for(windows), big * PTO2_MAX_RING_DEPTH);
+    EXPECT_GT(cap_for(windows), PTO2_SCOPE_TASKS_CAP);
+}


### PR DESCRIPTION
## What

`scope_tasks` is one buffer that tracks every task in the open scope across all
rings; its cap should equal the in-flight slot budget. But
`PTO2OrchestratorState::reserve_layout` set `scope_tasks_cap` from the
**compile-time** `PTO2_SCOPE_TASKS_CAP` (= `PTO2_TASK_WINDOW_SIZE * MAX_RING_DEPTH`
= 65536), ignoring the per-ring `task_window_sizes[]` it already receives (and
uses to size the rings, tensor map, and fanin buffers).

`ring_task_window` is validated only as "power of 2 in `[4, INT32_MAX]`"
(`call_config.h:89`) — **no clamp to the compile default** — so:

- **Enlarged window (the bug):** `ring_task_window = 32768` → rings hold
  `4 * 32768 = 131072` in-flight tasks, but `scope_tasks_cap` stays 65536. A scope
  that submits > 65536 tasks (which the enlarged rings allow) hits a
  **premature/false `SCOPE_TASKS_OVERFLOW` (10)** even though the rings have room —
  the enlarged window silently fails to deliver its capacity.
- **Shrunk window:** the 65536-entry buffer is over-allocated.

## Fix

Derive `scope_tasks_cap = sum(task_window_sizes)` from the runtime windows the
function already has, so it always equals the real in-flight budget. The default
window is unchanged (still 65536); an enlarged window grows the cap to match the
rings, a shrunk one shrinks it. Applied to a2a3 and a5.

## Test

- `tests/ut/cpp/{a2a3,a5}/test_orchestrator_fanin.cpp`: new
  `OrchestratorLayoutScopeTasksCap.FollowsRuntimeWindowSum` asserts the cap tracks
  the windows (default `== PTO2_SCOPE_TASKS_CAP`, shrunk smaller, enlarged larger).
- Rebuilt the runtime; `batch_paged_attention` passes on a2a3sim (default window →
  cap unchanged, no regression). cpput compiles (local link hits the pre-existing
  gtest-ABI issue; CI runs it).

Closes #1188.