### PR TITLE
fix(build): link librt for shm_open on glibc < 2.34

### DIFF
--- a/python/bindings/CMakeLists.txt
+++ b/python/bindings/CMakeLists.txt
@@ -49,6 +49,13 @@ target_include_directories(_task_interface PRIVATE
 
 target_link_libraries(_task_interface PRIVATE ${CMAKE_DL_LIBS} pthread)
 
+# POSIX shm_open / shm_unlink (used by worker_manager.cpp broadcast_register) live
+# in librt on glibc < 2.34 and in libSystem on macOS. glibc 2.34+ folded librt
+# into libc, so -lrt is a no-op there but harmless (and required for older glibc).
+if(UNIX AND NOT APPLE)
+    target_link_libraries(_task_interface PRIVATE rt)
+endif()
+
 if(SKBUILD_MODE)
     install(TARGETS _task_interface DESTINATION .)
 else()

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -183,6 +183,10 @@ function(add_hierarchical_test name src)
         ${GTEST_LIB}
         pthread
     )
+    # worker_manager.cpp uses shm_open/shm_unlink; librt on glibc < 2.34, libSystem on macOS.
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(${name} PRIVATE rt)
+    endif()
     add_test(NAME ${name} COMMAND ${name})
 endfunction()
 


### PR DESCRIPTION
_task_interface binding and hierarchical ut objects compile worker_manager.cpp, which uses shm_open/shm_unlink in broadcast_register. These symbols live in librt on glibc < 2.34 (e.g. 2.31 / Ubuntu 20.04), causing undefined-reference link errors. glibc 2.34+ folded librt into libc, so -lrt is a no-op there.

The two sim/host host_runtime targets already link rt; this fixes the two remaining build paths that were missed.