### PR TITLE
fix(build): default local pto-isa to repository pin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,11 +38,11 @@ set(SIMPLER_PTO_CLONE_PROTOCOL "ssh" CACHE STRING
 
 # Override the pto-isa revision used when `build_runtimes.py` builds the
 # onboard a2a3 host runtime (which compiles the pto-isa SDMA headers into
-# host_runtime.so). Empty (default) preserves the original behavior and uses
-# the current checkout HEAD. Override at `pip install` time via
+# host_runtime.so). Empty (default) uses pto_isa.pin. Use latest/head/none to
+# explicitly track origin/HEAD. Override at `pip install` time via
 #   pip install --config-settings=cmake.define.SIMPLER_PTO_ISA_COMMIT=<sha> .
 set(SIMPLER_PTO_ISA_COMMIT "" CACHE STRING
-    "Override pto-isa commit for onboard a2a3 host build (empty/latest = HEAD)")
+    "Override pto-isa commit for onboard a2a3 host build (empty = pto_isa.pin; latest/head/none = HEAD)")
 
 # Compiler sanitizer for host-compiled targets (sim runtime/kernels and the
 # onboard host runtime). Default `none`. Preset (asan/ubsan/tsan) or a raw
@@ -52,7 +52,7 @@ set(SIMPLER_SANITIZER "none" CACHE STRING
     "Sanitizer for host targets during install (none/asan/ubsan/tsan)")
 
 # Pass --pto-isa-commit only when explicitly overridden; an empty cache var
-# leaves the flag off so build_runtimes uses the current checkout HEAD.
+# leaves the flag off so build_runtimes uses pto_isa.pin by default.
 if(NOT SIMPLER_PTO_ISA_COMMIT STREQUAL "")
     set(_pto_isa_commit_arg --pto-isa-commit "${SIMPLER_PTO_ISA_COMMIT}")
 endif()
@@ -75,4 +75,8 @@ if(SKBUILD_MODE)
     install(DIRECTORY ${CMAKE_SOURCE_DIR}/build/lib/
             DESTINATION simpler_setup/_assets/build/lib
             OPTIONAL)
+    if(EXISTS "${CMAKE_SOURCE_DIR}/pto_isa.pin")
+        install(FILES ${CMAKE_SOURCE_DIR}/pto_isa.pin
+                DESTINATION simpler_setup/_assets)
+    endif()
 endif()

--- a/conftest.py
+++ b/conftest.py
@@ -193,7 +193,10 @@ def pytest_addoption(parser):
         "--pto-isa-commit",
         action="store",
         default=None,
-        help=("Override the pto-isa revision before running tests. Default/latest: use the current checkout HEAD."),
+        help=(
+            "Override the pto-isa revision before running tests. "
+            "Default: use pto_isa.pin. Use latest/head/none to track origin/HEAD."
+        ),
     )
     parser.addoption(
         "--clone-protocol",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,13 +77,23 @@ It follows this order:
 
 1. If `PTO_ISA_ROOT` points to an existing directory, that directory wins.
    `simpler` treats it as user-managed and uses it as-is.
-2. If `PTO_ISA_ROOT` is not set, `simpler` uses the managed checkout at
-   `build/pto-isa`, cloning it on first use if necessary.
-3. If a concrete commit is requested and the managed checkout is being used,
-   `simpler` checks out that commit.
-4. If no commit is requested, or the requested value is `latest`, `head`, or
-   `none`, `simpler` keeps the existing HEAD/latest behavior and uses the
-   checkout's current HEAD.
+2. If the managed checkout is being used and `--pto-isa-commit` or the CMake
+   `SIMPLER_PTO_ISA_COMMIT` define supplies a value, that value wins.
+3. If no CLI/CMake value is supplied and `SIMPLER_PTO_ISA_COMMIT` is set in
+   the environment, that environment value wins.
+4. If no explicit value is requested, `simpler` checks out the commit recorded
+   in `pto_isa.pin`.
+5. If `pto_isa.pin` is missing, `simpler` warns and falls back to the latest
+   `origin/HEAD` behavior for downstream checkout compatibility.
+
+For explicit values in steps 2 and 3, a concrete SHA/tag/ref checks out that
+revision. The values `latest`, `head`, and `none` are explicit opt-outs from
+the pin and use `origin/HEAD`. For the CMake cache variable, the empty string is
+the default value and means "use `pto_isa.pin`"; use `latest`, `head`, or `none`
+for an explicit CMake opt-out.
+
+When the managed checkout is selected, `simpler` uses `build/pto-isa`, cloning
+it on first use if necessary.
 
 This is only the checkout selection order. The compatibility check later uses a
 separate commit lookup order so it can compare the installed runtime's recorded
@@ -115,9 +125,10 @@ python path/to/scene_test.py --platform a2a3 --pto-isa-commit "$PTO_ISA_COMMIT"
 ```
 
 `SIMPLER_PTO_ISA_COMMIT="$PTO_ISA_COMMIT"` can also provide the concrete commit
-when the CLI option is omitted. Leaving both unset preserves the current
-checkout HEAD behavior. For reproducible a2a3 onboard runs, prefer passing the
-same concrete commit at install time and run time.
+when the CLI option is omitted. Leaving both unset uses `pto_isa.pin`, so a
+plain local install and test run match the repository pin. To explicitly track
+the remote default branch instead, pass `--pto-isa-commit latest` or set
+`SIMPLER_PTO_ISA_COMMIT=latest`.
 
 For a2a3 onboard runtimes, `pip install` records the actual PTO-ISA git HEAD
 used to build `host_runtime.so` in `build/lib/pto_isa_build.json`. The recorded
@@ -135,8 +146,9 @@ comparison:
    HEAD.
 2. `PTO_ISA_ROOT`'s current git HEAD, when `PTO_ISA_ROOT` points to a git
    checkout and the recorded run-time commit is unavailable.
-3. A concrete `SIMPLER_PTO_ISA_COMMIT` value, as a fallback for cases where no
-   git checkout commit can be read.
+3. The resolved concrete request from `SIMPLER_PTO_ISA_COMMIT` or `pto_isa.pin`,
+   as a fallback for cases where no git checkout commit can be read. Explicit
+   `latest`/`head`/`none` without a readable git checkout remains unverifiable.
 
 If the build commit and run-time commit differ, `simpler` fails early on the
 host side before loading the runtime binary. The error reports both commits and

--- a/simpler_setup/build_runtimes.py
+++ b/simpler_setup/build_runtimes.py
@@ -92,8 +92,8 @@ def build_all(
             token list. Only host-compiled targets honor it; see
             BuildTarget.gen_cmake_args.
         pto_isa_commit: optional pto-isa commit override for the onboard a2a3
-            host build. None preserves the original behavior and uses the
-            current checkout HEAD.
+            host build. None uses pto_isa.pin; latest/head/none explicitly
+            tracks origin/HEAD.
     """
     # Override default paths to respect CLI args
     RuntimeBuilder._LIB_DIR = lib_dir
@@ -127,9 +127,9 @@ def build_all(
     # the fallback in RuntimeCompiler._init_a2a3. No-ops when PTO_ISA_ROOT
     # is already set. Skipped when only sim platforms are being built.
     #
-    # pto_isa_commit can override the current checkout HEAD used by the
-    # managed clone. The actual git HEAD used for this build is recorded after
-    # the runtime build completes and later compared with the run-time checkout.
+    # pto_isa_commit can override the repository pin used by the managed clone.
+    # The actual git HEAD used for this build is recorded after the runtime
+    # build completes and later compared with the run-time checkout.
     if "a2a3" in platforms:
         from simpler_setup.pto_isa import ensure_pto_isa_root  # noqa: PLC0415
 
@@ -250,7 +250,8 @@ def main():
         default=None,
         help=(
             "Override the pto-isa revision before building onboard "
-            "a2a3 host_runtime. Default/latest: use the current checkout HEAD."
+            "a2a3 host_runtime. Default: use pto_isa.pin. "
+            "Use latest/head/none to track origin/HEAD."
         ),
     )
     args = parser.parse_args()

--- a/simpler_setup/pto_isa.py
+++ b/simpler_setup/pto_isa.py
@@ -14,7 +14,10 @@ at compile time), `SceneTestCase.run_module` (pin via `-c`).
 
 Resolution order for ensure_pto_isa_root():
   1. PTO_ISA_ROOT environment variable (if set and points to a directory)
-  2. PROJECT_ROOT / build / pto-isa (auto-clone if missing)
+  2. Explicit commit argument / SIMPLER_PTO_ISA_COMMIT
+  3. PROJECT_ROOT / pto_isa.pin
+  4. PROJECT_ROOT / build / pto-isa at origin/HEAD when explicitly unpinned
+     or when the pin is missing
 
 Lock file under build/ serializes concurrent clones from parallel processes.
 """
@@ -23,6 +26,7 @@ import fcntl
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -35,17 +39,46 @@ logger = logging.getLogger(__name__)
 _PTO_ISA_HTTPS = "https://github.com/hw-native-sys/pto-isa.git"
 _PTO_ISA_SSH = "git@github.com:hw-native-sys/pto-isa.git"
 _UNPINNED_COMMIT_VALUES = {"", "head", "latest", "none"}
+_PTO_ISA_PIN_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+PTO_ISA_PIN_FILE = "pto_isa.pin"
 PTO_ISA_BUILD_METADATA = "pto_isa_build.json"
 _RUN_PTO_ISA_COMMIT_ENV = "SIMPLER_RUN_PTO_ISA_COMMIT"
 _RUN_PTO_ISA_ROOT_ENV = "SIMPLER_RUN_PTO_ISA_ROOT"
 
 
+def read_pto_isa_pin(pin_path: Optional[Path] = None) -> Optional[str]:
+    """Read the repository PTO-ISA pin, returning None only when absent/empty."""
+    path = pin_path or (PROJECT_ROOT / PTO_ISA_PIN_FILE)
+    try:
+        value = path.read_text().strip()
+    except FileNotFoundError:
+        logger.warning(
+            "pto_isa.pin not found at %s; falling back to latest pto-isa (origin/HEAD). "
+            "Local build may diverge from CI.",
+            path,
+        )
+        return None
+    except OSError as e:
+        raise RuntimeError(f"Failed to read PTO-ISA pin at {path}: {e}") from e
+
+    if not value:
+        logger.warning(
+            "pto_isa.pin at %s is empty; falling back to latest pto-isa (origin/HEAD). "
+            "Local build may diverge from CI.",
+            path,
+        )
+        return None
+    if not _PTO_ISA_PIN_RE.fullmatch(value):
+        raise RuntimeError(f"Invalid PTO-ISA pin at {path}: expected a 40-character hex SHA, got {value!r}")
+    return value
+
+
 def resolve_pto_isa_commit(commit: Optional[str] = None) -> Optional[str]:
     """Resolve the pto-isa revision requested for managed clones.
 
-    Explicit CLI/API values, or SIMPLER_PTO_ISA_COMMIT, request a concrete
-    revision. When no revision is requested, keep the original behavior and use
-    the current checkout HEAD. "latest", "head", or "none" also opt into HEAD.
+    Explicit CLI/API values win over SIMPLER_PTO_ISA_COMMIT. When neither is
+    provided, use pto_isa.pin. "latest", "head", "none", and an explicit empty
+    Python/API or environment value opt into the current remote HEAD behavior.
     """
     requested = commit if commit is not None else os.environ.get("SIMPLER_PTO_ISA_COMMIT")
     if requested is not None:
@@ -53,13 +86,13 @@ def resolve_pto_isa_commit(commit: Optional[str] = None) -> Optional[str]:
         if value.lower() in _UNPINNED_COMMIT_VALUES:
             return None
         return value
-    return None
+    return read_pto_isa_pin()
 
 
 def get_pto_isa_head(pto_isa_root: str) -> str:
     """Return the full git HEAD SHA for a PTO-ISA checkout, or empty if unknown."""
     try:
-        result = _run_git(["rev-parse", "HEAD"], cwd=Path(pto_isa_root), timeout=5)
+        result = _run_git_resilient(["rev-parse", "HEAD"], cwd=Path(pto_isa_root), timeout=5)
         return result.stdout.strip() if result.returncode == 0 else ""
     except Exception:  # noqa: BLE001
         return ""
@@ -223,6 +256,34 @@ def _run_git(
     )
 
 
+def _is_dubious_ownership_error(stderr: str) -> bool:
+    return "detected dubious ownership" in stderr and "safe.directory" in stderr
+
+
+def _run_git_with_safe_directory(
+    args: list, cwd: Path, timeout: int = 30, check: bool = False
+) -> subprocess.CompletedProcess:
+    return _run_git(["-c", f"safe.directory={cwd.resolve()}", *args], cwd=cwd, timeout=timeout, check=check)
+
+
+def _run_git_resilient(
+    args: list,
+    cwd: Path,
+    timeout: int = 30,
+    check: bool = False,
+    verbose: bool = False,
+) -> subprocess.CompletedProcess:
+    """Run git, retrying dubious-ownership failures with a per-command safe.directory."""
+    result = _run_git(args, cwd=cwd, timeout=timeout, check=False)
+    if result.returncode != 0 and _is_dubious_ownership_error(result.stderr):
+        if verbose:
+            logger.info(f"Using pto-isa safe.directory for {cwd}")
+        result = _run_git_with_safe_directory(args, cwd=cwd, timeout=timeout, check=False)
+    if check and result.returncode != 0:
+        raise subprocess.CalledProcessError(result.returncode, ["git", *args], result.stdout, result.stderr)
+    return result
+
+
 def _discard_incomplete_clone(target: Path, verbose: bool) -> None:
     """Remove `target` if it exists but isn't a usable clone.
 
@@ -299,20 +360,26 @@ def _clone(target: Path, commit: Optional[str], clone_protocol: str, verbose: bo
         return False
 
 
-def checkout_pto_isa_commit(clone_path: Path, commit: str, verbose: bool = False) -> None:
-    """Switch an existing clone to `commit` if it isn't already there (idempotent)."""
+def checkout_pto_isa_commit(clone_path: Path, commit: str, verbose: bool = False) -> bool:
+    """Switch an existing clone to `commit` if needed. Return False on failure."""
     try:
-        result = _run_git(["rev-parse", "--short", "HEAD"], cwd=clone_path, timeout=5)
-        current = result.stdout.strip() if result.returncode == 0 else ""
+        result = _run_git_resilient(["rev-parse", "--short", "HEAD"], cwd=clone_path, timeout=5, verbose=verbose)
+        if result.returncode != 0:
+            logger.warning(f"Failed to read pto-isa HEAD before checking out {commit}: {result.stderr}")
+            return False
+        current = result.stdout.strip()
         if current and not commit.startswith(current) and not current.startswith(commit):
             if verbose:
                 logger.info(f"pto-isa at {current}, checking out {commit}...")
-            _run_git(["fetch", "origin"], cwd=clone_path, timeout=120, check=True)
-            _run_git(["checkout", commit], cwd=clone_path, timeout=30, check=True)
+            _run_git_resilient(["fetch", "origin"], cwd=clone_path, timeout=120, check=True, verbose=verbose)
+            _run_git_resilient(["checkout", commit], cwd=clone_path, timeout=30, check=True, verbose=verbose)
+        return True
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         logger.warning(f"Failed to checkout pto-isa commit {commit}: {e.stderr if hasattr(e, 'stderr') else e}")
+        return False
     except Exception as e:  # noqa: BLE001
         logger.warning(f"Unexpected error checking out pto-isa commit {commit}: {e}")
+        return False
 
 
 def _update_to_latest(clone_path: Path, verbose: bool) -> None:
@@ -320,8 +387,8 @@ def _update_to_latest(clone_path: Path, verbose: bool) -> None:
     try:
         if verbose:
             logger.info("Updating pto-isa to latest...")
-        _run_git(["fetch", "origin"], cwd=clone_path, timeout=120, check=True)
-        _run_git(["reset", "--hard", "origin/HEAD"], cwd=clone_path, timeout=30, check=True)
+        _run_git_resilient(["fetch", "origin"], cwd=clone_path, timeout=120, check=True, verbose=verbose)
+        _run_git_resilient(["reset", "--hard", "origin/HEAD"], cwd=clone_path, timeout=30, check=True, verbose=verbose)
     except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
         logger.warning(f"Failed to update pto-isa to latest: {e.stderr if hasattr(e, 'stderr') else e}")
     except Exception as e:  # noqa: BLE001
@@ -339,12 +406,11 @@ def ensure_pto_isa_root(
     Args:
         commit: if provided, check out this revision after clone/in existing clone.
         clone_protocol: "ssh" (default) or "https".
-        update_if_exists: when `commit` is None and a clone already exists,
-            fetch origin and reset to origin/HEAD. Conftest passes True to
-            guarantee the local clone isn't stale (in particular, to ensure
-            any later `-c <commit>` request resolves to a real commit rather
-            than a missing object in an old clone). Lazy callers pass False
-            to avoid redundant network traffic since conftest already ran.
+        update_if_exists: when the resolved commit is None and a clone already
+            exists, fetch origin and reset to origin/HEAD. Conftest passes True
+            so explicit latest/head/none runs are refreshed up front. Lazy
+            callers pass False to avoid redundant network traffic since
+            conftest already ran.
         verbose: log progress via `logger.info` / `logger.warning`.
 
     Raises:
@@ -397,12 +463,13 @@ def _ensure_locked(
                 return None
             if verbose:
                 logger.info("pto-isa already cloned by another process")
-            if commit:
-                checkout_pto_isa_commit(clone_path, commit, verbose=verbose)
+            if commit and not checkout_pto_isa_commit(clone_path, commit, verbose=verbose):
+                return None
             elif update_if_exists:
                 _update_to_latest(clone_path, verbose=verbose)
     elif commit:
-        checkout_pto_isa_commit(clone_path, commit, verbose=verbose)
+        if not checkout_pto_isa_commit(clone_path, commit, verbose=verbose):
+            return None
     elif update_if_exists:
         _update_to_latest(clone_path, verbose=verbose)
 

--- a/simpler_setup/scene_test.py
+++ b/simpler_setup/scene_test.py
@@ -1375,7 +1375,10 @@ class SceneTestCase:
             "-c",
             "--pto-isa-commit",
             default=None,
-            help=("Override the PTO-ISA revision before running. Default/latest: use the current checkout HEAD."),
+            help=(
+                "Override the PTO-ISA revision before running. Default: use pto_isa.pin. "
+                "Use latest/head/none to track origin/HEAD."
+            ),
         )
         parser.add_argument(
             "--clone-protocol",

--- a/tests/ut/py/test_pto_isa.py
+++ b/tests/ut/py/test_pto_isa.py
@@ -10,10 +10,264 @@
 
 import json
 import os
+import subprocess
 
 import pytest
 
 from simpler_setup import pto_isa
+
+PIN_A = "a" * 40
+PIN_B = "b" * 40
+PIN_C = "c" * 40
+
+
+def test_read_pto_isa_pin_reads_valid_pin(tmp_path):
+    pin = tmp_path / "pto_isa.pin"
+    pin.write_text(f"{PIN_A}\n")
+
+    assert pto_isa.read_pto_isa_pin(pin) == PIN_A
+
+
+def test_read_pto_isa_pin_missing_warns_and_returns_none(tmp_path, caplog):
+    caplog.set_level("WARNING", logger="simpler_setup.pto_isa")
+
+    assert pto_isa.read_pto_isa_pin(tmp_path / "missing.pin") is None
+    assert "falling back to latest pto-isa" in caplog.text
+
+
+def test_read_pto_isa_pin_empty_warns_and_returns_none(tmp_path, caplog):
+    pin = tmp_path / "pto_isa.pin"
+    pin.write_text("\n")
+    caplog.set_level("WARNING", logger="simpler_setup.pto_isa")
+
+    assert pto_isa.read_pto_isa_pin(pin) is None
+    assert "is empty" in caplog.text
+
+
+def test_read_pto_isa_pin_rejects_invalid_content(tmp_path):
+    pin = tmp_path / "pto_isa.pin"
+    pin.write_text("not-a-sha\n")
+
+    with pytest.raises(RuntimeError, match="Invalid PTO-ISA pin"):
+        pto_isa.read_pto_isa_pin(pin)
+
+
+def test_resolve_pto_isa_commit_prefers_explicit_over_env_and_pin(monkeypatch):
+    monkeypatch.setenv("SIMPLER_PTO_ISA_COMMIT", PIN_B)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_C)
+
+    assert pto_isa.resolve_pto_isa_commit(PIN_A) == PIN_A
+
+
+def test_resolve_pto_isa_commit_prefers_env_over_pin(monkeypatch):
+    monkeypatch.setenv("SIMPLER_PTO_ISA_COMMIT", PIN_B)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_C)
+
+    assert pto_isa.resolve_pto_isa_commit() == PIN_B
+
+
+def test_resolve_pto_isa_commit_uses_pin_by_default(monkeypatch):
+    monkeypatch.delenv("SIMPLER_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_C)
+
+    assert pto_isa.resolve_pto_isa_commit() == PIN_C
+
+
+@pytest.mark.parametrize("value", ["latest", "head", "none", ""])
+def test_resolve_pto_isa_commit_explicit_unpinned_values_return_none(value, monkeypatch):
+    monkeypatch.setenv("SIMPLER_PTO_ISA_COMMIT", PIN_B)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_C)
+
+    assert pto_isa.resolve_pto_isa_commit(value) is None
+
+
+def test_resolve_pto_isa_commit_env_latest_overrides_pin(monkeypatch):
+    monkeypatch.setenv("SIMPLER_PTO_ISA_COMMIT", "latest")
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_C)
+
+    assert pto_isa.resolve_pto_isa_commit() is None
+
+
+def test_ensure_pto_isa_root_uses_pin_instead_of_latest_for_existing_clone(tmp_path, monkeypatch):
+    clone_path = tmp_path / "build" / "pto-isa"
+    (clone_path / "include").mkdir(parents=True)
+    checked_out = []
+    updated = []
+
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.delenv("SIMPLER_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
+    monkeypatch.setattr(
+        pto_isa,
+        "checkout_pto_isa_commit",
+        lambda path, commit, verbose=False: checked_out.append(commit) or True,
+    )
+    monkeypatch.setattr(pto_isa, "_update_to_latest", lambda path, verbose: updated.append(path))
+    monkeypatch.setattr(pto_isa, "_record_runtime_pto_isa", lambda root: None)
+
+    assert pto_isa.ensure_pto_isa_root(update_if_exists=True) == str(clone_path.resolve())
+    assert checked_out == [PIN_A]
+    assert updated == []
+
+
+def test_ensure_pto_isa_root_latest_still_updates_existing_clone(tmp_path, monkeypatch):
+    clone_path = tmp_path / "build" / "pto-isa"
+    (clone_path / "include").mkdir(parents=True)
+    checked_out = []
+    updated = []
+
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
+    monkeypatch.setattr(
+        pto_isa,
+        "checkout_pto_isa_commit",
+        lambda path, commit, verbose=False: checked_out.append(commit) or True,
+    )
+    monkeypatch.setattr(pto_isa, "_update_to_latest", lambda path, verbose: updated.append(path))
+    monkeypatch.setattr(pto_isa, "_record_runtime_pto_isa", lambda root: None)
+
+    assert pto_isa.ensure_pto_isa_root(commit="latest", update_if_exists=True) == str(clone_path.resolve())
+    assert checked_out == []
+    assert updated == [clone_path]
+
+
+def test_checkout_pto_isa_commit_rejects_non_git_clone(tmp_path, monkeypatch, caplog):
+    calls = []
+
+    def fake_run_git(args, cwd=None, timeout=30, check=False):
+        calls.append(args)
+        return subprocess.CompletedProcess(["git", *args], returncode=128, stdout="", stderr="not a git repo")
+
+    monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+    caplog.set_level("WARNING", logger="simpler_setup.pto_isa")
+
+    assert not pto_isa.checkout_pto_isa_commit(tmp_path, PIN_A)
+    assert calls == [["rev-parse", "--short", "HEAD"]]
+    assert "Failed to read pto-isa HEAD" in caplog.text
+
+
+def test_checkout_pto_isa_commit_marks_dubious_clone_safe_and_retries(tmp_path, monkeypatch):
+    calls = []
+    dubious = "fatal: detected dubious ownership in repository\nsafe.directory"
+    safe_arg = f"safe.directory={tmp_path.resolve()}"
+    normal_attempts = set()
+
+    def fake_run_git(args, cwd=None, timeout=30, check=False):
+        calls.append((args, cwd, check))
+        if (
+            args
+            in (
+                ["rev-parse", "--short", "HEAD"],
+                ["fetch", "origin"],
+                ["checkout", PIN_A],
+            )
+            and tuple(args) not in normal_attempts
+        ):
+            normal_attempts.add(tuple(args))
+            return subprocess.CompletedProcess(["git", *args], returncode=128, stdout="", stderr=dubious)
+        if args == ["-c", safe_arg, "rev-parse", "--short", "HEAD"]:
+            return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="bbbbbbb\n", stderr="")
+        return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+
+    assert pto_isa.checkout_pto_isa_commit(tmp_path, PIN_A)
+    assert calls == [
+        (["rev-parse", "--short", "HEAD"], tmp_path, False),
+        (["-c", safe_arg, "rev-parse", "--short", "HEAD"], tmp_path, False),
+        (["fetch", "origin"], tmp_path, False),
+        (["-c", safe_arg, "fetch", "origin"], tmp_path, False),
+        (["checkout", PIN_A], tmp_path, False),
+        (["-c", safe_arg, "checkout", PIN_A], tmp_path, False),
+    ]
+
+
+def test_get_pto_isa_head_retries_dubious_ownership(tmp_path, monkeypatch):
+    calls = []
+    dubious = "fatal: detected dubious ownership in repository\nsafe.directory"
+    safe_arg = f"safe.directory={tmp_path.resolve()}"
+
+    def fake_run_git(args, cwd=None, timeout=30, check=False):
+        calls.append((args, cwd, check))
+        if args == ["rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(["git", *args], returncode=128, stdout="", stderr=dubious)
+        if args == ["-c", safe_arg, "rev-parse", "HEAD"]:
+            return subprocess.CompletedProcess(["git", *args], returncode=0, stdout=f"{PIN_A}\n", stderr="")
+        return subprocess.CompletedProcess(["git", *args], returncode=1, stdout="", stderr="unexpected")
+
+    monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+
+    assert pto_isa.get_pto_isa_head(str(tmp_path)) == PIN_A
+    assert calls == [
+        (["rev-parse", "HEAD"], tmp_path, False),
+        (["-c", safe_arg, "rev-parse", "HEAD"], tmp_path, False),
+    ]
+
+
+def test_update_to_latest_retries_dubious_ownership(tmp_path, monkeypatch):
+    calls = []
+    dubious = "fatal: detected dubious ownership in repository\nsafe.directory"
+    safe_arg = f"safe.directory={tmp_path.resolve()}"
+    normal_attempts = set()
+
+    def fake_run_git(args, cwd=None, timeout=30, check=False):
+        calls.append((args, cwd, check))
+        if args in (["fetch", "origin"], ["reset", "--hard", "origin/HEAD"]) and tuple(args) not in normal_attempts:
+            normal_attempts.add(tuple(args))
+            return subprocess.CompletedProcess(["git", *args], returncode=128, stdout="", stderr=dubious)
+        return subprocess.CompletedProcess(["git", *args], returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pto_isa, "_run_git", fake_run_git)
+
+    pto_isa._update_to_latest(tmp_path, verbose=False)
+    assert calls == [
+        (["fetch", "origin"], tmp_path, False),
+        (["-c", safe_arg, "fetch", "origin"], tmp_path, False),
+        (["reset", "--hard", "origin/HEAD"], tmp_path, False),
+        (["-c", safe_arg, "reset", "--hard", "origin/HEAD"], tmp_path, False),
+    ]
+
+
+def test_ensure_pto_isa_root_rejects_existing_clone_when_pin_checkout_fails(tmp_path, monkeypatch):
+    clone_path = tmp_path / "build" / "pto-isa"
+    (clone_path / "include").mkdir(parents=True)
+    updated = []
+
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.delenv("SIMPLER_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
+    monkeypatch.setattr(pto_isa, "checkout_pto_isa_commit", lambda path, commit, verbose=False: False)
+    monkeypatch.setattr(pto_isa, "_update_to_latest", lambda path, verbose: updated.append(path))
+    monkeypatch.setattr(pto_isa, "_record_runtime_pto_isa", lambda root: None)
+
+    with pytest.raises(OSError, match="PTO-ISA not available"):
+        pto_isa.ensure_pto_isa_root(update_if_exists=True)
+    assert updated == []
+
+
+def test_ensure_pto_isa_root_rejects_clone_when_pin_checkout_fails_after_clone(tmp_path, monkeypatch):
+    clone_path = tmp_path / "build" / "pto-isa"
+    updated = []
+
+    def clone_then_fail(target, commit, clone_protocol, verbose):
+        (target / "include").mkdir(parents=True)
+        return False
+
+    monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
+    monkeypatch.delenv("SIMPLER_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: PIN_A)
+    monkeypatch.setattr(pto_isa, "get_pto_isa_clone_path", lambda: clone_path)
+    monkeypatch.setattr(pto_isa, "_clone", clone_then_fail)
+    monkeypatch.setattr(pto_isa, "checkout_pto_isa_commit", lambda path, commit, verbose=False: False)
+    monkeypatch.setattr(pto_isa, "_update_to_latest", lambda path, verbose: updated.append(path))
+    monkeypatch.setattr(pto_isa, "_record_runtime_pto_isa", lambda root: None)
+
+    with pytest.raises(OSError, match="PTO-ISA not available"):
+        pto_isa.ensure_pto_isa_root(update_if_exists=True)
+    assert updated == []
 
 
 def test_write_pto_isa_build_metadata_records_actual_head(tmp_path, monkeypatch):
@@ -49,6 +303,7 @@ def test_validate_runtime_pto_isa_rejects_when_run_commit_unavailable(tmp_path, 
     monkeypatch.delenv("SIMPLER_RUN_PTO_ISA_COMMIT", raising=False)
     monkeypatch.delenv("PTO_ISA_ROOT", raising=False)
     monkeypatch.delenv("SIMPLER_PTO_ISA_COMMIT", raising=False)
+    monkeypatch.setattr(pto_isa, "read_pto_isa_pin", lambda: None)
 
     with pytest.raises(RuntimeError, match="Cannot verify PTO-ISA runtime revision"):
         pto_isa.validate_runtime_pto_isa_compatible(tmp_path)


### PR DESCRIPTION
## Summary

Fix local PTO-ISA revision resolution so local build/test defaults to the repository pin in `pto_isa.pin`, matching CI behavior unless the user explicitly opts into another revision.

## Changes

- Add `read_pto_isa_pin()` and use `pto_isa.pin` as the default managed PTO-ISA commit.
- Preserve override precedence:
  - `PTO_ISA_ROOT` remains user-managed and wins as-is.
  - CLI/API/CMake `SIMPLER_PTO_ISA_COMMIT` overrides env and pin.
  - `SIMPLER_PTO_ISA_COMMIT` env overrides pin.
  - `pto_isa.pin` is the default fallback.
- Keep `latest`, `head`, and `none` as explicit opt-outs to `origin/HEAD`; Python/API/env empty values also opt out, while CMake uses `latest/head/none` because its empty cache value means the default pin.
- Make managed-clone concrete checkout failures fatal so an unreachable/typoed pin cannot silently proceed at `origin/HEAD`.
- Warn and fall back to latest when `pto_isa.pin` is missing or empty.
- Install `pto_isa.pin` into `simpler_setup/_assets` for installed layouts.
- Update CLI help text and getting-started docs.
- Add unit coverage for pin reading, precedence, explicit latest opt-out, failed pin checkout, and managed clone behavior.

## Validation

- `python -m pytest tests/ut/py/test_pto_isa.py`
- `python -m py_compile simpler_setup/pto_isa.py simpler_setup/build_runtimes.py simpler_setup/scene_test.py conftest.py tests/ut/py/test_pto_isa.py`
- `git diff --check`
- pre-commit hooks during commit:
  - `ruff check`
  - `ruff format`
  - `pyright`
  - `markdownlint-cli2`
  - other configured hooks

## Related

Fixes #1174
