### PR TITLE
feat(runtime): always-on TRB temporary variable buffer (internal, no user switch)

### DIFF
--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -258,6 +258,23 @@ void ChipWorker::run(int32_t local_slot, TaskArgsView view, const CallConfig &co
 
 One memcpy of a few KB per task; negligible.
 
+#### TRB temporary buffer
+
+`tensormap_and_ringbuffer` stages ordinary non-child tensor arguments through a
+runner-scoped retained temporary buffer instead of a per-run `device_malloc()` /
+`device_free()` pair. This is always on for TRB — an internal allocation
+optimization with no user-facing switch. It is not serialized in task mailboxes
+and does not change `TaskArgs`, `CallConfig`, child-memory tensors, or public
+`Worker.malloc()` / `Worker.free()` semantics.
+
+On each TRB bind the host runtime sizes the retained buffer from the run's
+non-child tensors, growing it (free old + malloc new) only when a run needs
+more than is currently retained, and bump-slices each tensor from it. The
+buffer lives on the `DeviceRunner` across runs (freed once at finalize); the
+platform only stores its `{addr, size}` slot. If a grow allocation fails the
+run fails before device argument staging. See the runtime's `RUNTIME_LOGIC.md`
+§2.4 for the grow/reuse mechanics.
+
 ### SUB-type child loop (Python callable leaf)
 
 SUB execution is handled entirely in Python. The forked child process

--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -3025,10 +3025,10 @@ class Worker:
                                 callable_kind="CHIP_CALLABLE",
                                 target_namespace="LOCAL_CHIP",
                             ),
-                            chip_log_level,
-                            chip_log_info_v,
-                            str(self._config["platform"]),
-                            str(self._config["runtime"]),
+                            log_level=chip_log_level,
+                            log_info_v=chip_log_info_v,
+                            platform=str(self._config["platform"]),
+                            runtime=str(self._config["runtime"]),
                         )
                         os._exit(0)
                     else:

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -687,6 +687,7 @@ int DeviceRunner::finalize() {
     gm_heap_arena_.release();
     gm_sm_arena_.release();
     runtime_arena_pool_.release();
+    clear_temporary_buffer();
     cached_gm_heap_size_ = 0;
     cached_gm_sm_size_ = 0;
     cached_runtime_arena_size_ = 0;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -91,6 +91,49 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 | `PLATFORM_MAX_AIV_PER_THREAD` | 48 | Max AIV cores per scheduler thread |
 | `PLATFORM_PROF_SYS_CNT_FREQ` | 50 MHz | System counter frequency for profiling |
 
+### 2.4 Host Temporary Buffer
+
+TRB bind normally allocates one device buffer per ordinary non-child tensor
+during host-side argument staging, copies input bytes as needed, records
+copy-back metadata, and frees those temporary buffers during runtime
+validation. TRB replaces those per-run malloc/free pairs with a single
+runner-scoped retained buffer that is reused across runs. This is always on for
+TRB — an internal allocation optimization, not user-facing configuration.
+
+The platform side is deliberately thin: `DeviceRunnerBase` only remembers a
+`{addr, size}` slot across runs, exposed through two HostApi callbacks —
+`get_retained_temp_buffer` and `set_retained_temp_buffer`. It is not an
+allocator; all grow/pack/slice logic lives in `runtime_maker.cpp`
+(`RetainedTempBump`).
+
+On each trb bind, `RetainedTempBump`:
+
+- packs the run's non-child, non-empty tensors to a required size, aligning
+  each slice up to 1024 bytes (TRB kernels require 1024-aligned device
+  pointers, which `device_malloc` already guarantees, so the retained base and
+  every 1024-aligned slice stay aligned without a base fix-up);
+- reads the slot via `get_retained_temp_buffer`; if `required` exceeds the
+  retained size it `device_free`s the old buffer, `device_malloc`s a new one,
+  and writes it back via `set_retained_temp_buffer` (no data preserved across
+  this grow — the buffer is per-run scratch). Smaller later runs keep the
+  larger buffer; the slot only grows;
+- bump-slices each tensor from the retained base at the next 1024-aligned
+  offset. Slices always fit because the buffer was sized from the same
+  tensors; a miss is a caller bug (reported, bind fails). The runtime never
+  falls back to `device_malloc` mid-run.
+
+Slices are recorded as `BufferNoop` leases: per-tensor release is a no-op, and
+the retained buffer is neither freed at end of run nor per run — it lives on
+the runner and is freed once in `finalize`. If the platform leaves the slot
+callbacks null (e.g. a backend without a retained buffer), bind transparently
+falls back to per-tensor `device_malloc` (recorded as `Free` leases, freed in
+validate).
+
+Public device-memory APIs keep their original semantics. `device_malloc_ctx`,
+`device_free_ctx`, `Worker.malloc()`, and `Worker.free()` still allocate and
+free caller-owned device memory directly; the retained buffer only affects
+TRB's internal temporary tensor staging.
+
 ---
 
 ## 3. Shared Memory Layout

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -51,6 +51,8 @@
 #include "common/strace.h"
 #include "common/unified_log.h"
 #include "host/platform_compile_info.h"
+#include "host/raii_scope_guard.h"
+#include "common/host_api.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -267,6 +269,103 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PT
     return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
+static void release_tensor_leases(Runtime *runtime, const HostApi *api) {
+    int freed = 0;
+    int buffer_noop = 0;
+    int external_noop = 0;
+    for (TensorLease &lease : runtime->tensor_leases_) {
+        if (lease.dev_ptr == nullptr) {
+            continue;
+        }
+        switch (lease.release_kind) {
+        case TensorReleaseKind::Free:
+            api->device_free(lease.dev_ptr);
+            ++freed;
+            break;
+        case TensorReleaseKind::BufferNoop:
+            ++buffer_noop;
+            break;
+        case TensorReleaseKind::ExternalNoop:
+            ++external_noop;
+            break;
+        }
+    }
+    LOG_DEBUG("Released tensor leases: freed=%d buffer_noop=%d external_noop=%d", freed, buffer_noop, external_noop);
+    runtime->tensor_leases_.clear();
+}
+
+// per-run bump allocator over the runner's retained temporary buffer. This is
+// the whole temporary-buffer mechanism: the platform only remembers a
+// {addr, size} slot across runs (HostApi get/set_retained_temp_buffer); the
+// grow/pack/slice logic lives here. TRB kernels require 1024-byte-aligned
+// device pointers, which device_malloc already guarantees for the OFF path, so
+// the retained base is 1024-aligned and slices taken at 1024-aligned offsets
+// stay aligned without any base fix-up.
+class RetainedTempBump {
+public:
+    static constexpr size_t kAlignment = 1024;
+
+    static size_t align_up(size_t v) { return (v + (kAlignment - 1)) & ~(kAlignment - 1); }
+
+    // Pack the run's non-child, non-empty tensors to compute the required
+    // aligned size, then grow the retained slot if it is too small (free old +
+    // malloc new + write back). Returns false only if the (grow) device_malloc
+    // fails. A run needing 0 bytes leaves the slot untouched.
+    bool begin(const HostApi *api, const ChipStorageTaskArgs *orch_args) {
+        api_ = api;
+        offset_ = 0;
+        size_t required = 0;
+        for (int i = 0; i < orch_args->tensor_count(); i++) {
+            Tensor t = orch_args->tensor(i);
+            if (t.is_child_memory() || t.nbytes() == 0) {
+                continue;
+            }
+            required += align_up(static_cast<size_t>(t.nbytes()));
+        }
+        void *addr = nullptr;
+        size_t size = 0;
+        api->get_retained_temp_buffer(&addr, &size);
+        if (required > size) {
+            if (addr != nullptr) {
+                api->device_free(addr);
+            }
+            addr = required != 0 ? api->device_malloc(required) : nullptr;
+            if (required != 0 && addr == nullptr) {
+                api->set_retained_temp_buffer(nullptr, 0);
+                base_ = nullptr;
+                capacity_ = 0;
+                LOG_ERROR("Retained temp buffer grow failed: required bytes %zu", required);
+                return false;
+            }
+            api->set_retained_temp_buffer(addr, required);
+            size = required;
+        }
+        base_ = addr;
+        capacity_ = size;
+        return true;
+    }
+
+    // Slice `bytes` from the retained buffer at the next 1024-aligned offset.
+    // Must fit because begin() sized the buffer from the same tensors; a miss
+    // is a caller bug (plan/slice mismatch), reported as nullptr.
+    void *acquire(size_t bytes) {
+        size_t aligned = align_up(offset_);
+        if (base_ == nullptr || aligned + bytes > capacity_) {
+            LOG_ERROR("Retained temp buffer slice miss: bytes=%zu offset=%zu capacity=%zu", bytes, aligned, capacity_);
+            return nullptr;
+        }
+        void *ptr = static_cast<char *>(base_) + aligned;
+        offset_ = aligned + bytes;
+        return ptr;
+    }
+
+private:
+    const HostApi *api_ = nullptr;
+    void *base_ = nullptr;
+    size_t capacity_ = 0;
+    size_t offset_ = 0;
+};
+
 /**
  * Stage the per-callable resources (kernel binaries + orchestration SO) into
  * the supplied runtime so a subsequent bind_callable_to_runtime_impl can use
@@ -334,7 +433,7 @@ struct ArenaStaticSizes {
 };
 
 // Device pointers to the per-Worker static pools that DeviceRunner keeps alive
-// across runs (freed in DeviceRunner::finalize(), never in tensor_pairs_).
+// across runs (freed in DeviceRunner::finalize(), never in tensor_leases_).
 struct StaticArenaPtrs {
     void *gm_heap;
     void *gm_sm;
@@ -415,12 +514,14 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
 // per-run: the only signature-aware step. Copy the orch args, replacing each
 // host tensor pointer with a freshly staged device pointer (H2D copy-in, or an
 // on-device zero for pure-OUTPUT buffers), and record the host/device pair for
-// copy-back. Read-only INPUT tensors skip copy-back. On failure the partially
-// staged device_args / tensor_pairs_ stay owned by the caller's Runtime, which
-// frees them in validate_runtime_impl.
+// copy-back. Read-only INPUT tensors skip copy-back. When `bump` is non-null,
+// ordinary non-child tensors are sliced from the runner's retained temporary
+// buffer (released as a no-op — the buffer is reused across runs); otherwise
+// each is device_malloc'd and freed in validate. On failure the partially
+// staged device_args / tensor_leases_ stay owned by the caller's Runtime.
 static bool stage_device_args(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, const ArgDirection *signature,
-    int sig_count, ChipStorageTaskArgs *out
+    int sig_count, RetainedTempBump *bump, ChipStorageTaskArgs *out
 ) {
     int tensor_count = orch_args->tensor_count();
     int scalar_count = orch_args->scalar_count();
@@ -438,8 +539,24 @@ static bool stage_device_args(
 
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.buffer.addr));
         size_t size = static_cast<size_t>(t.nbytes());
+        if (size == 0) {
+            t.buffer.addr = 0;
+            out->add_tensor(t);
+            continue;
+        }
 
-        void *dev_ptr = api->device_malloc(size);
+        void *dev_ptr = nullptr;
+        TensorReleaseKind release_kind = TensorReleaseKind::Free;
+        if (bump != nullptr) {
+            dev_ptr = bump->acquire(size);
+            release_kind = TensorReleaseKind::BufferNoop;
+            if (dev_ptr == nullptr) {
+                LOG_ERROR("Retained temp buffer slice failed for tensor %d: tensor bytes=%zu", i, size);
+                return false;
+            }
+        } else {
+            dev_ptr = api->device_malloc(size);
+        }
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return false;
@@ -460,7 +577,9 @@ static bool stage_device_args(
         }
         if (rc != 0) {
             LOG_ERROR("Failed to stage tensor %d to device", i);
-            api->device_free(dev_ptr);
+            if (release_kind == TensorReleaseKind::Free) {
+                api->device_free(dev_ptr);
+            }
             return false;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
@@ -470,7 +589,7 @@ static bool stage_device_args(
         // tensor entries). Anything not provably IN keeps the safe default of
         // copying back.
         bool needs_copy_back = !(signature != nullptr && i < sig_count && signature[i] == ArgDirection::IN);
-        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size, needs_copy_back});
+        runtime->tensor_leases_.push_back({host_ptr, dev_ptr, size, needs_copy_back, release_kind});
         LOG_INFO_V0("  Tensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         t.buffer.addr = reinterpret_cast<uint64_t>(dev_ptr);
@@ -694,6 +813,7 @@ extern "C" int bind_callable_to_runtime_impl(
     int tensor_count = orch_args->tensor_count();
     int scalar_count = orch_args->scalar_count();
     LOG_INFO_V0("RT2 bind: %d tensors + %d scalars, device orchestration mode", tensor_count, scalar_count);
+    runtime->tensor_leases_.clear();
 
     int64_t t_total_start = _now_ms();
 
@@ -702,8 +822,25 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
 
+    // The retained temporary buffer is always used on the trb path — it is an
+    // internal allocation optimization, not user-facing config. Gate only on
+    // whether the platform wired the slot accessors (trb always does; a backend
+    // that leaves them null transparently falls back to per-tensor
+    // device_malloc). The buffer itself lives on the runner across runs; here we
+    // just grow it to this run's packed size and bump-slice from it.
+    RetainedTempBump bump;
+    bool use_temporary_buffer =
+        api->get_retained_temp_buffer != nullptr && api->set_retained_temp_buffer != nullptr;
+    if (use_temporary_buffer && !bump.begin(api, orch_args)) {
+        return -1;
+    }
+
+    auto bind_cleanup = RAIIScopeGuard([&]() { release_tensor_leases(runtime, api); });
+
     ChipStorageTaskArgs device_args;
-    if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &device_args)) {
+    if (!stage_device_args(
+            runtime, api, orch_args, signature, sig_count, use_temporary_buffer ? &bump : nullptr, &device_args
+        )) {
         return -1;
     }
 
@@ -748,6 +885,7 @@ extern "C" int bind_callable_to_runtime_impl(
     LOG_INFO_V0("TIMING: prebuilt_runtime_arena = %" PRId64 "ms", t_prebuilt_end - t_prebuilt_start);
     LOG_INFO_V0("TIMING: total_init_runtime_impl = %" PRId64 "ms", t_total_end - t_total_start);
 
+    bind_cleanup.dismiss();
     return 0;
 }
 
@@ -756,8 +894,8 @@ extern "C" int bind_callable_to_runtime_impl(
  *
  * This function:
  * 1. Copies recorded tensors from device back to host
- * 2. Frees device memory for recorded tensors
- * 3. Clears tensor pair state
+ * 2. Releases recorded tensor leases
+ * 3. Clears tensor lease state
  *
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
@@ -777,10 +915,10 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     LOG_INFO_V0("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
-    int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
+    TensorLease *tensor_leases = runtime->tensor_leases_.data();
+    int tensor_lease_count = static_cast<int>(runtime->tensor_leases_.size());
 
-    LOG_INFO_V0("Tensor pairs to process: %d", tensor_pair_count);
+    LOG_INFO_V0("Tensor leases to process: %d", tensor_lease_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
     uint64_t graph_out_ptr = 0;
@@ -829,31 +967,31 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
         LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
     } else {
         bool first_output_tensor = true;
-        for (int i = 0; i < tensor_pair_count; i++) {
-            const TensorPair &pair = tensor_pairs[i];
+        for (int i = 0; i < tensor_lease_count; i++) {
+            const TensorLease &lease = tensor_leases[i];
 
             // Skip if device pointer is null
-            if (pair.dev_ptr == nullptr) {
+            if (lease.dev_ptr == nullptr) {
                 LOG_WARN("Tensor %d has null device pointer, skipping", i);
                 continue;
             }
 
             // If host pointer is null, this is a device-only allocation (no copy-back)
-            if (pair.host_ptr == nullptr) {
+            if (lease.host_ptr == nullptr) {
                 LOG_INFO_V0("Tensor %d: device-only allocation (no copy-back)", i);
                 continue;
             }
 
             // Read-only INPUT tensors were uploaded H2D but the kernel never
             // wrote them — copying them back (potentially ~GB) is pure waste.
-            // They are still device_free'd in the cleanup loop below.
-            if (!pair.needs_copy_back) {
+            // They are still released through release_kind below.
+            if (!lease.needs_copy_back) {
                 LOG_INFO_V0("Tensor %d: read-only input, skipping copy-back", i);
                 continue;
             }
 
-            void *src_ptr = pair.dev_ptr;
-            size_t copy_size = pair.size;
+            void *src_ptr = lease.dev_ptr;
+            size_t copy_size = lease.size;
 
             // Use graph_output_ptr for the first output tensor if available
             if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
@@ -863,27 +1001,19 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 first_output_tensor = false;
             }
 
-            int copy_rc = api->copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(lease.host_ptr, src_ptr, copy_size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;
             } else {
-                LOG_INFO_V0("Tensor %d: %zu bytes copied to host", i, pair.size);
+                LOG_INFO_V0("Tensor %d: %zu bytes copied to host", i, lease.size);
             }
         }
     }
 
     // Cleanup device tensors
     LOG_INFO_V0("=== Cleaning Up ===");
-    for (int i = 0; i < tensor_pair_count; i++) {
-        if (tensor_pairs[i].dev_ptr != nullptr) {
-            api->device_free(tensor_pairs[i].dev_ptr);
-        }
-    }
-    LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);
-
-    // Clear tensor pairs
-    runtime->tensor_pairs_.clear();
+    release_tensor_leases(runtime, api);
 
     LOG_INFO_V0("=== Finalize Complete ===");
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -19,7 +19,7 @@
  * defined in tensor.h.
  *
  * This header is independent of orch_build_graph_runtime.h to allow inclusion from runtime.h
- * without type conflicts (Handshake, TensorPair, HostApi).
+ * without type conflicts (Handshake, TensorLease, HostApi).
  */
 
 #ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -103,11 +103,16 @@ struct Handshake {
     volatile uint32_t aicore_regs_ready;  // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
+enum class TensorReleaseKind {
+    Free,
+    BufferNoop,
+    ExternalNoop,
+};
+
 /**
- * Tensor pair for tracking host-device memory mappings.
- * Used for copy-back during finalize.
+ * Tensor lease for tracking host-device memory mappings and release ownership.
  */
-struct TensorPair {
+struct TensorLease {
     void *host_ptr;
     void *dev_ptr;
     size_t size;
@@ -115,6 +120,7 @@ struct TensorPair {
     // so the end-of-run D2H copy-back is skipped. OUTPUT/INOUT/unknown
     // keep the safe default of copying back.
     bool needs_copy_back = true;
+    TensorReleaseKind release_kind = TensorReleaseKind::Free;
 };
 
 /**
@@ -301,7 +307,7 @@ public:
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in
     // validate_runtime_impl. Host-only (after `dev`): never uploaded.
-    std::vector<TensorPair> tensor_pairs_;
+    std::vector<TensorLease> tensor_leases_;
 };
 
 // `dev` must be the first member so the narrowed H2D copy starts at offset 0.

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -656,6 +656,7 @@ int DeviceRunner::finalize() {
     gm_heap_arena_.release();
     gm_sm_arena_.release();
     runtime_arena_pool_.release();
+    clear_temporary_buffer();
     cached_gm_heap_size_ = 0;
     cached_gm_sm_size_ = 0;
     cached_runtime_arena_size_ = 0;

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -91,6 +91,49 @@ Two platform implementations exist under `src/platform/`, sharing a common inter
 | `PLATFORM_MAX_AIV_PER_THREAD` | 48 | Max AIV cores per scheduler thread |
 | `PLATFORM_PROF_SYS_CNT_FREQ` | 50 MHz | System counter frequency for profiling |
 
+### 2.4 Host Temporary Buffer
+
+TRB bind normally allocates one device buffer per ordinary non-child tensor
+during host-side argument staging, copies input bytes as needed, records
+copy-back metadata, and frees those temporary buffers during runtime
+validation. TRB replaces those per-run malloc/free pairs with a single
+runner-scoped retained buffer that is reused across runs. This is always on for
+TRB — an internal allocation optimization, not user-facing configuration.
+
+The platform side is deliberately thin: `DeviceRunnerBase` only remembers a
+`{addr, size}` slot across runs, exposed through two HostApi callbacks —
+`get_retained_temp_buffer` and `set_retained_temp_buffer`. It is not an
+allocator; all grow/pack/slice logic lives in `runtime_maker.cpp`
+(`RetainedTempBump`).
+
+On each trb bind, `RetainedTempBump`:
+
+- packs the run's non-child, non-empty tensors to a required size, aligning
+  each slice up to 1024 bytes (TRB kernels require 1024-aligned device
+  pointers, which `device_malloc` already guarantees, so the retained base and
+  every 1024-aligned slice stay aligned without a base fix-up);
+- reads the slot via `get_retained_temp_buffer`; if `required` exceeds the
+  retained size it `device_free`s the old buffer, `device_malloc`s a new one,
+  and writes it back via `set_retained_temp_buffer` (no data preserved across
+  this grow — the buffer is per-run scratch). Smaller later runs keep the
+  larger buffer; the slot only grows;
+- bump-slices each tensor from the retained base at the next 1024-aligned
+  offset. Slices always fit because the buffer was sized from the same
+  tensors; a miss is a caller bug (reported, bind fails). The runtime never
+  falls back to `device_malloc` mid-run.
+
+Slices are recorded as `BufferNoop` leases: per-tensor release is a no-op, and
+the retained buffer is neither freed at end of run nor per run — it lives on
+the runner and is freed once in `finalize`. If the platform leaves the slot
+callbacks null (e.g. a backend without a retained buffer), bind transparently
+falls back to per-tensor `device_malloc` (recorded as `Free` leases, freed in
+validate).
+
+Public device-memory APIs keep their original semantics. `device_malloc_ctx`,
+`device_free_ctx`, `Worker.malloc()`, and `Worker.free()` still allocate and
+free caller-owned device memory directly; the retained buffer only affects
+TRB's internal temporary tensor staging.
+
 ---
 
 ## 3. Shared Memory Layout

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -51,6 +51,8 @@
 #include "common/strace.h"
 #include "common/unified_log.h"
 #include "host/platform_compile_info.h"
+#include "host/raii_scope_guard.h"
+#include "common/host_api.h"
 #include "utils/device_arena.h"
 #include "prepare_callable_common.h"
 
@@ -267,6 +269,103 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PT
     return runtime_status_from_error_codes(orch_error_code, sched_error_code);
 }
 
+static void release_tensor_leases(Runtime *runtime, const HostApi *api) {
+    int freed = 0;
+    int buffer_noop = 0;
+    int external_noop = 0;
+    for (TensorLease &lease : runtime->tensor_leases_) {
+        if (lease.dev_ptr == nullptr) {
+            continue;
+        }
+        switch (lease.release_kind) {
+        case TensorReleaseKind::Free:
+            api->device_free(lease.dev_ptr);
+            ++freed;
+            break;
+        case TensorReleaseKind::BufferNoop:
+            ++buffer_noop;
+            break;
+        case TensorReleaseKind::ExternalNoop:
+            ++external_noop;
+            break;
+        }
+    }
+    LOG_DEBUG("Released tensor leases: freed=%d buffer_noop=%d external_noop=%d", freed, buffer_noop, external_noop);
+    runtime->tensor_leases_.clear();
+}
+
+// per-run bump allocator over the runner's retained temporary buffer. This is
+// the whole temporary-buffer mechanism: the platform only remembers a
+// {addr, size} slot across runs (HostApi get/set_retained_temp_buffer); the
+// grow/pack/slice logic lives here. TRB kernels require 1024-byte-aligned
+// device pointers, which device_malloc already guarantees for the OFF path, so
+// the retained base is 1024-aligned and slices taken at 1024-aligned offsets
+// stay aligned without any base fix-up.
+class RetainedTempBump {
+public:
+    static constexpr size_t kAlignment = 1024;
+
+    static size_t align_up(size_t v) { return (v + (kAlignment - 1)) & ~(kAlignment - 1); }
+
+    // Pack the run's non-child, non-empty tensors to compute the required
+    // aligned size, then grow the retained slot if it is too small (free old +
+    // malloc new + write back). Returns false only if the (grow) device_malloc
+    // fails. A run needing 0 bytes leaves the slot untouched.
+    bool begin(const HostApi *api, const ChipStorageTaskArgs *orch_args) {
+        api_ = api;
+        offset_ = 0;
+        size_t required = 0;
+        for (int i = 0; i < orch_args->tensor_count(); i++) {
+            Tensor t = orch_args->tensor(i);
+            if (t.is_child_memory() || t.nbytes() == 0) {
+                continue;
+            }
+            required += align_up(static_cast<size_t>(t.nbytes()));
+        }
+        void *addr = nullptr;
+        size_t size = 0;
+        api->get_retained_temp_buffer(&addr, &size);
+        if (required > size) {
+            if (addr != nullptr) {
+                api->device_free(addr);
+            }
+            addr = required != 0 ? api->device_malloc(required) : nullptr;
+            if (required != 0 && addr == nullptr) {
+                api->set_retained_temp_buffer(nullptr, 0);
+                base_ = nullptr;
+                capacity_ = 0;
+                LOG_ERROR("Retained temp buffer grow failed: required bytes %zu", required);
+                return false;
+            }
+            api->set_retained_temp_buffer(addr, required);
+            size = required;
+        }
+        base_ = addr;
+        capacity_ = size;
+        return true;
+    }
+
+    // Slice `bytes` from the retained buffer at the next 1024-aligned offset.
+    // Must fit because begin() sized the buffer from the same tensors; a miss
+    // is a caller bug (plan/slice mismatch), reported as nullptr.
+    void *acquire(size_t bytes) {
+        size_t aligned = align_up(offset_);
+        if (base_ == nullptr || aligned + bytes > capacity_) {
+            LOG_ERROR("Retained temp buffer slice miss: bytes=%zu offset=%zu capacity=%zu", bytes, aligned, capacity_);
+            return nullptr;
+        }
+        void *ptr = static_cast<char *>(base_) + aligned;
+        offset_ = aligned + bytes;
+        return ptr;
+    }
+
+private:
+    const HostApi *api_ = nullptr;
+    void *base_ = nullptr;
+    size_t capacity_ = 0;
+    size_t offset_ = 0;
+};
+
 /**
  * Stage the per-callable resources (kernel binaries + orchestration SO) into
  * the supplied runtime so a subsequent bind_callable_to_runtime_impl can use
@@ -334,7 +433,7 @@ struct ArenaStaticSizes {
 };
 
 // Device pointers to the per-Worker static pools that DeviceRunner keeps alive
-// across runs (freed in DeviceRunner::finalize(), never in tensor_pairs_).
+// across runs (freed in DeviceRunner::finalize(), never in tensor_leases_).
 struct StaticArenaPtrs {
     void *gm_heap;
     void *gm_sm;
@@ -415,12 +514,14 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
 // per-run: the only signature-aware step. Copy the orch args, replacing each
 // host tensor pointer with a freshly staged device pointer (H2D copy-in, or an
 // on-device zero for pure-OUTPUT buffers), and record the host/device pair for
-// copy-back. Read-only INPUT tensors skip copy-back. On failure the partially
-// staged device_args / tensor_pairs_ stay owned by the caller's Runtime, which
-// frees them in validate_runtime_impl.
+// copy-back. Read-only INPUT tensors skip copy-back. When `bump` is non-null,
+// ordinary non-child tensors are sliced from the runner's retained temporary
+// buffer (released as a no-op — the buffer is reused across runs); otherwise
+// each is device_malloc'd and freed in validate. On failure the partially
+// staged device_args / tensor_leases_ stay owned by the caller's Runtime.
 static bool stage_device_args(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, const ArgDirection *signature,
-    int sig_count, ChipStorageTaskArgs *out
+    int sig_count, RetainedTempBump *bump, ChipStorageTaskArgs *out
 ) {
     int tensor_count = orch_args->tensor_count();
     int scalar_count = orch_args->scalar_count();
@@ -438,8 +539,24 @@ static bool stage_device_args(
 
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.buffer.addr));
         size_t size = static_cast<size_t>(t.nbytes());
+        if (size == 0) {
+            t.buffer.addr = 0;
+            out->add_tensor(t);
+            continue;
+        }
 
-        void *dev_ptr = api->device_malloc(size);
+        void *dev_ptr = nullptr;
+        TensorReleaseKind release_kind = TensorReleaseKind::Free;
+        if (bump != nullptr) {
+            dev_ptr = bump->acquire(size);
+            release_kind = TensorReleaseKind::BufferNoop;
+            if (dev_ptr == nullptr) {
+                LOG_ERROR("Retained temp buffer slice failed for tensor %d: tensor bytes=%zu", i, size);
+                return false;
+            }
+        } else {
+            dev_ptr = api->device_malloc(size);
+        }
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return false;
@@ -460,7 +577,9 @@ static bool stage_device_args(
         }
         if (rc != 0) {
             LOG_ERROR("Failed to stage tensor %d to device", i);
-            api->device_free(dev_ptr);
+            if (release_kind == TensorReleaseKind::Free) {
+                api->device_free(dev_ptr);
+            }
             return false;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
@@ -470,7 +589,7 @@ static bool stage_device_args(
         // tensor entries). Anything not provably IN keeps the safe default of
         // copying back.
         bool needs_copy_back = !(signature != nullptr && i < sig_count && signature[i] == ArgDirection::IN);
-        runtime->tensor_pairs_.push_back({host_ptr, dev_ptr, size, needs_copy_back});
+        runtime->tensor_leases_.push_back({host_ptr, dev_ptr, size, needs_copy_back, release_kind});
         LOG_INFO_V0("  Tensor %d: %zu bytes at %p", i, size, dev_ptr);
 
         t.buffer.addr = reinterpret_cast<uint64_t>(dev_ptr);
@@ -694,6 +813,7 @@ extern "C" int bind_callable_to_runtime_impl(
     int tensor_count = orch_args->tensor_count();
     int scalar_count = orch_args->scalar_count();
     LOG_INFO_V0("RT2 bind: %d tensors + %d scalars, device orchestration mode", tensor_count, scalar_count);
+    runtime->tensor_leases_.clear();
 
     int64_t t_total_start = _now_ms();
 
@@ -702,8 +822,25 @@ extern "C" int bind_callable_to_runtime_impl(
         return -1;
     }
 
+    // The retained temporary buffer is always used on the trb path — it is an
+    // internal allocation optimization, not user-facing config. Gate only on
+    // whether the platform wired the slot accessors (trb always does; a backend
+    // that leaves them null transparently falls back to per-tensor
+    // device_malloc). The buffer itself lives on the runner across runs; here we
+    // just grow it to this run's packed size and bump-slice from it.
+    RetainedTempBump bump;
+    bool use_temporary_buffer =
+        api->get_retained_temp_buffer != nullptr && api->set_retained_temp_buffer != nullptr;
+    if (use_temporary_buffer && !bump.begin(api, orch_args)) {
+        return -1;
+    }
+
+    auto bind_cleanup = RAIIScopeGuard([&]() { release_tensor_leases(runtime, api); });
+
     ChipStorageTaskArgs device_args;
-    if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &device_args)) {
+    if (!stage_device_args(
+            runtime, api, orch_args, signature, sig_count, use_temporary_buffer ? &bump : nullptr, &device_args
+        )) {
         return -1;
     }
 
@@ -748,6 +885,7 @@ extern "C" int bind_callable_to_runtime_impl(
     LOG_INFO_V0("TIMING: prebuilt_runtime_arena = %" PRId64 "ms", t_prebuilt_end - t_prebuilt_start);
     LOG_INFO_V0("TIMING: total_init_runtime_impl = %" PRId64 "ms", t_total_end - t_total_start);
 
+    bind_cleanup.dismiss();
     return 0;
 }
 
@@ -756,8 +894,8 @@ extern "C" int bind_callable_to_runtime_impl(
  *
  * This function:
  * 1. Copies recorded tensors from device back to host
- * 2. Frees device memory for recorded tensors
- * 3. Clears tensor pair state
+ * 2. Releases recorded tensor leases
+ * 3. Clears tensor lease state
  *
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
@@ -777,10 +915,10 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     LOG_INFO_V0("=== Copying Results Back to Host ===");
 
     // Copy all recorded tensors from device back to host
-    TensorPair *tensor_pairs = runtime->tensor_pairs_.data();
-    int tensor_pair_count = static_cast<int>(runtime->tensor_pairs_.size());
+    TensorLease *tensor_leases = runtime->tensor_leases_.data();
+    int tensor_lease_count = static_cast<int>(runtime->tensor_leases_.size());
 
-    LOG_INFO_V0("Tensor pairs to process: %d", tensor_pair_count);
+    LOG_INFO_V0("Tensor leases to process: %d", tensor_lease_count);
 
     // PTO2 (device orchestration): graph output may be in packed buffer
     uint64_t graph_out_ptr = 0;
@@ -829,31 +967,31 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
         LOG_WARN("Skipping tensor copy-back because PTO2 runtime reported fatal status");
     } else {
         bool first_output_tensor = true;
-        for (int i = 0; i < tensor_pair_count; i++) {
-            const TensorPair &pair = tensor_pairs[i];
+        for (int i = 0; i < tensor_lease_count; i++) {
+            const TensorLease &lease = tensor_leases[i];
 
             // Skip if device pointer is null
-            if (pair.dev_ptr == nullptr) {
+            if (lease.dev_ptr == nullptr) {
                 LOG_WARN("Tensor %d has null device pointer, skipping", i);
                 continue;
             }
 
             // If host pointer is null, this is a device-only allocation (no copy-back)
-            if (pair.host_ptr == nullptr) {
+            if (lease.host_ptr == nullptr) {
                 LOG_INFO_V0("Tensor %d: device-only allocation (no copy-back)", i);
                 continue;
             }
 
             // Read-only INPUT tensors were uploaded H2D but the kernel never
             // wrote them — copying them back (potentially ~GB) is pure waste.
-            // They are still device_free'd in the cleanup loop below.
-            if (!pair.needs_copy_back) {
+            // They are still released through release_kind below.
+            if (!lease.needs_copy_back) {
                 LOG_INFO_V0("Tensor %d: read-only input, skipping copy-back", i);
                 continue;
             }
 
-            void *src_ptr = pair.dev_ptr;
-            size_t copy_size = pair.size;
+            void *src_ptr = lease.dev_ptr;
+            size_t copy_size = lease.size;
 
             // Use graph_output_ptr for the first output tensor if available
             if (first_output_tensor && graph_out_ptr != 0 && graph_out_size > 0) {
@@ -863,27 +1001,19 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
                 first_output_tensor = false;
             }
 
-            int copy_rc = api->copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(lease.host_ptr, src_ptr, copy_size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;
             } else {
-                LOG_INFO_V0("Tensor %d: %zu bytes copied to host", i, pair.size);
+                LOG_INFO_V0("Tensor %d: %zu bytes copied to host", i, lease.size);
             }
         }
     }
 
     // Cleanup device tensors
     LOG_INFO_V0("=== Cleaning Up ===");
-    for (int i = 0; i < tensor_pair_count; i++) {
-        if (tensor_pairs[i].dev_ptr != nullptr) {
-            api->device_free(tensor_pairs[i].dev_ptr);
-        }
-    }
-    LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);
-
-    // Clear tensor pairs
-    runtime->tensor_pairs_.clear();
+    release_tensor_leases(runtime, api);
 
     LOG_INFO_V0("=== Finalize Complete ===");
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -19,7 +19,7 @@
  * defined in tensor.h.
  *
  * This header is independent of orch_build_graph_runtime.h to allow inclusion from runtime.h
- * without type conflicts (Handshake, TensorPair, HostApi).
+ * without type conflicts (Handshake, TensorLease, HostApi).
  */
 
 #ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_PTO_TYPES_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -111,11 +111,16 @@ struct Handshake {
     volatile uint32_t aicore_regs_ready;  // AICore ID reported: 0=pending, 1=done
 } __attribute__((aligned(64)));
 
+enum class TensorReleaseKind {
+    Free,
+    BufferNoop,
+    ExternalNoop,
+};
+
 /**
- * Tensor pair for tracking host-device memory mappings.
- * Used for copy-back during finalize.
+ * Tensor lease for tracking host-device memory mappings and release ownership.
  */
-struct TensorPair {
+struct TensorLease {
     void *host_ptr;
     void *dev_ptr;
     size_t size;
@@ -123,6 +128,7 @@ struct TensorPair {
     // so the end-of-run D2H copy-back is skipped. OUTPUT/INOUT/unknown
     // keep the safe default of copying back.
     bool needs_copy_back = true;
+    TensorReleaseKind release_kind = TensorReleaseKind::Free;
 };
 
 /**
@@ -315,7 +321,7 @@ public:
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in
     // validate_runtime_impl. Host-only (after `dev`): never uploaded.
-    std::vector<TensorPair> tensor_pairs_;
+    std::vector<TensorLease> tensor_leases_;
 };
 
 // `dev` must be the first member so the narrowed H2D copy starts at offset 0.

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -37,6 +37,18 @@ struct HostApi {
     // null on backends that don't wire it; callers must fall back to
     // copy_to_device.
     int (*device_memset)(void *dev_ptr, int value, size_t size);
+    // Runner-scoped retained temporary buffer for TRB device-arg staging.
+    // This is NOT an allocator — it is a single {addr, size} slot that lives
+    // across runs on the DeviceRunner. trb bind reads the slot, and if the
+    // retained buffer is too small for this run's packed temporary size it
+    // device_free's the old one, device_malloc's a bigger one, and writes the
+    // new {addr, size} back. The grow/pack/slice logic lives in trb bind
+    // (runtime_maker); the platform only remembers the slot so it can be reused
+    // next run and freed at finalize. hbg leaves these null and stages tensors
+    // through per-tensor device_malloc. `get` returns {nullptr, 0} when nothing
+    // is retained yet.
+    void (*get_retained_temp_buffer)(void **addr, size_t *size);
+    void (*set_retained_temp_buffer)(void *addr, size_t size);
     // Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2 shared
     // memory, trb prebuilt runtime arena) as three independent device
     // allocations. `runtime_arena_size == 0` skips the third region (hbg
@@ -47,7 +59,7 @@ struct HostApi {
     // memory / prebuilt runtime arena. setup_static_arena must have already
     // committed the relevant region; the returned pointer is owned by the
     // DeviceRunner and freed in `DeviceRunner::finalize()` — do NOT pass it
-    // to device_free or record it in `tensor_pairs_`.
+    // to device_free or record it as an owned tensor lease.
     //
     // acquire_pooled_runtime_arena is trb-only — the runtime-arena region is
     // only committed when setup_static_arena was invoked with

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -116,6 +116,21 @@ static int device_memset(void *dev_ptr, int value, size_t size) {
     }
 }
 
+static void get_retained_temp_buffer(void **addr, size_t *size) {
+    try {
+        current_runner()->get_retained_temp_buffer(addr, size);
+    } catch (...) {
+        if (addr != nullptr) *addr = nullptr;
+        if (size != nullptr) *size = 0;
+    }
+}
+
+static void set_retained_temp_buffer(void *addr, size_t size) {
+    try {
+        current_runner()->set_retained_temp_buffer(addr, size);
+    } catch (...) {}
+}
+
 static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
         return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
@@ -183,7 +198,7 @@ static void mark_prebuilt_runtime_arena_cached_wrapper(
 // The HostApi is a set of context-free function pointers: each wrapper above
 // recovers its runner from the thread-local current_runner(), so a single
 // filled table is valid for every runner and every run. Build it once at load
-// time rather than reassembling the 12 pointers on each simpler_run. Passed by
+// time rather than reassembling the pointer table on each simpler_run. Passed by
 // address into bind_callable_to_runtime_impl / validate_runtime_impl.
 static const HostApi g_host_api = {
     .device_malloc = device_malloc,
@@ -191,6 +206,8 @@ static const HostApi g_host_api = {
     .copy_to_device = copy_to_device,
     .copy_from_device = copy_from_device,
     .device_memset = device_memset,
+    .get_retained_temp_buffer = get_retained_temp_buffer,
+    .set_retained_temp_buffer = set_retained_temp_buffer,
     .setup_static_arena = setup_static_arena_wrapper,
     .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
     .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -142,6 +142,24 @@ int DeviceRunnerBase::device_memset(void *dev_ptr, int value, std::size_t bytes)
     return aclrtMemset(dev_ptr, bytes, value, bytes);
 }
 
+void DeviceRunnerBase::get_retained_temp_buffer(void **addr, size_t *size) {
+    if (addr != nullptr) *addr = retained_temp_addr_;
+    if (size != nullptr) *size = retained_temp_size_;
+}
+
+void DeviceRunnerBase::set_retained_temp_buffer(void *addr, size_t size) {
+    retained_temp_addr_ = addr;
+    retained_temp_size_ = size;
+}
+
+void DeviceRunnerBase::clear_temporary_buffer() {
+    if (retained_temp_addr_ != nullptr) {
+        mem_alloc_.free(retained_temp_addr_);
+        retained_temp_addr_ = nullptr;
+        retained_temp_size_ = 0;
+    }
+}
+
 int DeviceRunnerBase::l3_l2_orch_comm_init(void *control_block, size_t control_block_size) {
     if (!l3_l2_orch_comm_supported()) {
         return PTO_RUNTIME_ERR_UNSUPPORTED;
@@ -1066,6 +1084,8 @@ int DeviceRunnerBase::finalize_common() {
     prebuilt_runtime_arena_cache_sm_base_ = nullptr;
     prebuilt_runtime_arena_cache_runtime_arena_base_ = nullptr;
     prebuilt_runtime_arena_cache_image_.clear();
+
+    clear_temporary_buffer();
 
     // Free the 8-byte device_wall buffer (allocated lazily in run()) while
     // mem_alloc_ and the device context are still live. free_tensor() routes

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -93,6 +93,9 @@ public:
     int copy_to_device(void *dev_ptr, const void *host_ptr, std::size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, std::size_t bytes);
     int device_memset(void *dev_ptr, int value, std::size_t bytes);
+    void get_retained_temp_buffer(void **addr, std::size_t *size);
+    void set_retained_temp_buffer(void *addr, std::size_t size);
+    void clear_temporary_buffer();
     int l3_l2_orch_comm_init(void *control_block, size_t control_block_size);
     int l3_l2_orch_comm_shutdown();
 
@@ -825,6 +828,11 @@ protected:
     host::LoadAicpuOp load_aicpu_op_;
 
     MemoryAllocator mem_alloc_;
+    // Retained temporary buffer slot for TRB device-arg staging (see HostApi
+    // get/set_retained_temp_buffer). Just a remembered {addr, size} reused
+    // across runs and freed in finalize; the grow/pack logic lives in trb bind.
+    void *retained_temp_addr_ = nullptr;
+    std::size_t retained_temp_size_ = 0;
     DeviceArena gm_heap_arena_;
     DeviceArena gm_sm_arena_;
     DeviceArena runtime_arena_pool_;

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -113,6 +113,21 @@ static int device_memset(void *dev_ptr, int value, size_t size) {
     }
 }
 
+static void get_retained_temp_buffer(void **addr, size_t *size) {
+    try {
+        current_runner()->get_retained_temp_buffer(addr, size);
+    } catch (...) {
+        if (addr != nullptr) *addr = nullptr;
+        if (size != nullptr) *size = 0;
+    }
+}
+
+static void set_retained_temp_buffer(void *addr, size_t size) {
+    try {
+        current_runner()->set_retained_temp_buffer(addr, size);
+    } catch (...) {}
+}
+
 static uint64_t upload_chip_callable_buffer_wrapper(const void *callable) {
     try {
         return current_runner()->upload_chip_callable_buffer(static_cast<const ChipCallable *>(callable));
@@ -180,7 +195,7 @@ static void mark_prebuilt_runtime_arena_cached_wrapper(
 // The HostApi is a set of context-free function pointers: each wrapper above
 // recovers its runner from the thread-local current_runner(), so a single
 // filled table is valid for every runner and every run. Build it once at load
-// time rather than reassembling the 12 pointers on each simpler_run. Passed by
+// time rather than reassembling the pointer table on each simpler_run. Passed by
 // address into bind_callable_to_runtime_impl / validate_runtime_impl.
 static const HostApi g_host_api = {
     .device_malloc = device_malloc,
@@ -188,6 +203,8 @@ static const HostApi g_host_api = {
     .copy_to_device = copy_to_device,
     .copy_from_device = copy_from_device,
     .device_memset = device_memset,
+    .get_retained_temp_buffer = get_retained_temp_buffer,
+    .set_retained_temp_buffer = set_retained_temp_buffer,
     .setup_static_arena = setup_static_arena_wrapper,
     .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
     .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -265,6 +265,24 @@ int SimDeviceRunnerBase::device_memset(void *dev_ptr, int value, size_t bytes) {
     return 0;
 }
 
+void SimDeviceRunnerBase::get_retained_temp_buffer(void **addr, size_t *size) {
+    if (addr != nullptr) *addr = retained_temp_addr_;
+    if (size != nullptr) *size = retained_temp_size_;
+}
+
+void SimDeviceRunnerBase::set_retained_temp_buffer(void *addr, size_t size) {
+    retained_temp_addr_ = addr;
+    retained_temp_size_ = size;
+}
+
+void SimDeviceRunnerBase::clear_temporary_buffer() {
+    if (retained_temp_addr_ != nullptr) {
+        mem_alloc_.free(retained_temp_addr_);
+        retained_temp_addr_ = nullptr;
+        retained_temp_size_ = 0;
+    }
+}
+
 int SimDeviceRunnerBase::l3_l2_orch_comm_init(void *control_block, size_t control_block_size) {
     return l3_l2_orch_comm_service_.start(this, control_block, control_block_size);
 }

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -97,6 +97,9 @@ public:
     int copy_to_device(void *dev_ptr, const void *host_ptr, size_t bytes);
     int copy_from_device(void *host_ptr, const void *dev_ptr, size_t bytes);
     int device_memset(void *dev_ptr, int value, size_t bytes);
+    void get_retained_temp_buffer(void **addr, size_t *size);
+    void set_retained_temp_buffer(void *addr, size_t size);
+    void clear_temporary_buffer();
 
     int l3_l2_orch_comm_init(void *control_block, size_t control_block_size);
     int l3_l2_orch_comm_shutdown();
@@ -202,6 +205,8 @@ protected:
     std::vector<uint8_t> aicore_kernel_binary_;
 
     MemoryAllocator mem_alloc_;
+    void *retained_temp_addr_ = nullptr;
+    size_t retained_temp_size_ = 0;
 
     // Three independent per-Worker arenas, each backing a single pooled
     // region (PTO2 GM heap / PTO2 shared memory / trb prebuilt runtime

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -379,6 +379,35 @@ target_include_directories(test_runtime_orch_so PRIVATE
 )
 add_common_utils_test(test_device_arena common/test_device_arena.cpp)
 add_common_utils_test(test_l3_l2_orch_comm common/test_l3_l2_orch_comm.cpp)
+
+add_executable(test_trb_runtime_temp_buffer
+    common/test_trb_runtime_temp_buffer.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/shared/host/platform_compile_info.cpp
+)
+target_compile_definitions(test_trb_runtime_temp_buffer PRIVATE SIMPLER_PLATFORM_NAME="a2a3sim")
+target_include_directories(test_trb_runtime_temp_buffer PRIVATE
+    ${GTEST_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/host
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/orchestration
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/runtime
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/runtime/tensormap_and_ringbuffer/common
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/platform/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common/task_interface
+    ${CMAKE_SOURCE_DIR}/../../../src/common/log/include
+    ${CMAKE_SOURCE_DIR}/../../../src/common
+)
+target_link_libraries(test_trb_runtime_temp_buffer PRIVATE
+    a2a3_rt_objs
+    ${GTEST_MAIN_LIB}
+    ${GTEST_LIB}
+    pthread
+)
+add_test(NAME test_trb_runtime_temp_buffer COMMAND test_trb_runtime_temp_buffer)
+set_tests_properties(test_trb_runtime_temp_buffer PROPERTIES LABELS "no_hardware")
+
 add_executable(test_l3_l2_orch_endpoint
     common/test_l3_l2_orch_endpoint.cpp
     stubs/test_stubs.cpp

--- a/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
+++ b/tests/ut/cpp/common/test_trb_runtime_temp_buffer.cpp
@@ -1,0 +1,401 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+// Host-side fake HostApi tests for a2a3 TRB bind/validate tensor leases.
+//
+// The retained temporary buffer's grow/pack/slice logic lives entirely in
+// runtime_maker.cpp (file-local RetainedTempBump). The platform side is just a
+// {addr, size} slot exposed via get/set_retained_temp_buffer, and the buffer
+// is grown through the ordinary device_malloc/device_free callbacks. So these
+// end-to-end bind/validate tests exercise the real grow/reuse logic while the
+// fake only remembers the slot and records malloc/copy counts.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <unordered_set>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arg_direction.h"
+#include "common/host_api.h"
+#include "pto_runtime2_types.h"
+#include "runtime.h"
+#include "task_args.h"
+
+extern "C" int bind_callable_to_runtime_impl(
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
+);
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api);
+
+namespace {
+
+// 1024-byte aligned device pointers are required by TRB kernels; RetainedTempBump
+// packs and slices at this alignment, so the test's expected sizes use it too.
+constexpr size_t kAlign = 1024;
+
+size_t align_up(size_t value, size_t alignment) { return (value + alignment - 1) & ~(alignment - 1); }
+
+struct FakeHostApi {
+    int device_malloc_count = 0;
+    int device_free_count = 0;
+    int copy_to_count = 0;
+    int copy_from_count = 0;
+    int device_memset_count = 0;
+    int setup_static_arena_count = 0;
+    int fail_copy_to_on_call = 0;
+    int fail_device_malloc_on_call = 0;
+    // The retained temporary-buffer slot the platform remembers across runs.
+    void *retained_addr = nullptr;
+    size_t retained_size = 0;
+    std::unordered_set<void *> live_mallocs;
+    std::vector<uint8_t> gm_heap;
+    std::vector<uint8_t> gm_sm;
+    std::vector<uint8_t> runtime_arena;
+
+    ~FakeHostApi() { release_all(); }
+
+    void release_all() {
+        for (void *ptr : live_mallocs) {
+            std::free(ptr);
+        }
+        live_mallocs.clear();
+        retained_addr = nullptr;
+        retained_size = 0;
+    }
+
+    void reset() {
+        release_all();
+        *this = FakeHostApi();
+    }
+};
+
+FakeHostApi *g_fake = nullptr;
+
+void *fake_device_malloc(size_t size) {
+    if (g_fake->fail_device_malloc_on_call != 0 &&
+        g_fake->device_malloc_count + 1 == g_fake->fail_device_malloc_on_call) {
+        ++g_fake->device_malloc_count;
+        return nullptr;
+    }
+    // Over-align so a retained-buffer base satisfies the 1024-byte requirement
+    // the same way the real device_malloc does.
+    void *ptr = nullptr;
+    if (posix_memalign(&ptr, kAlign, std::max<size_t>(size, 1)) != 0) {
+        return nullptr;
+    }
+    ++g_fake->device_malloc_count;
+    g_fake->live_mallocs.insert(ptr);
+    return ptr;
+}
+
+void fake_device_free(void *ptr) {
+    if (ptr == nullptr) {
+        return;
+    }
+    ++g_fake->device_free_count;
+    EXPECT_EQ(g_fake->live_mallocs.count(ptr), 1u);
+    g_fake->live_mallocs.erase(ptr);
+    std::free(ptr);
+}
+
+int fake_copy_to_device(void *dev_ptr, const void *host_ptr, size_t size) {
+    ++g_fake->copy_to_count;
+    if (g_fake->fail_copy_to_on_call != 0 && g_fake->copy_to_count == g_fake->fail_copy_to_on_call) {
+        return -7;
+    }
+    std::memcpy(dev_ptr, host_ptr, size);
+    return 0;
+}
+
+int fake_copy_from_device(void *host_ptr, const void *dev_ptr, size_t size) {
+    ++g_fake->copy_from_count;
+    std::memcpy(host_ptr, dev_ptr, size);
+    return 0;
+}
+
+int fake_device_memset(void *dev_ptr, int value, size_t size) {
+    ++g_fake->device_memset_count;
+    std::memset(dev_ptr, value, size);
+    return 0;
+}
+
+void fake_get_retained_temp_buffer(void **addr, size_t *size) {
+    if (addr != nullptr) *addr = g_fake->retained_addr;
+    if (size != nullptr) *size = g_fake->retained_size;
+}
+
+void fake_set_retained_temp_buffer(void *addr, size_t size) {
+    g_fake->retained_addr = addr;
+    g_fake->retained_size = size;
+}
+
+int fake_setup_static_arena(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size) {
+    ++g_fake->setup_static_arena_count;
+    g_fake->gm_heap.assign(gm_heap_size, 0);
+    g_fake->gm_sm.assign(gm_sm_size, 0);
+    g_fake->runtime_arena.assign(runtime_arena_size, 0);
+    return 0;
+}
+
+void *fake_acquire_pooled_gm_heap() { return g_fake->gm_heap.empty() ? nullptr : g_fake->gm_heap.data(); }
+void *fake_acquire_pooled_gm_sm() { return g_fake->gm_sm.empty() ? nullptr : g_fake->gm_sm.data(); }
+void *fake_acquire_pooled_runtime_arena() {
+    return g_fake->runtime_arena.empty() ? nullptr : g_fake->runtime_arena.data();
+}
+bool fake_lookup_prebuilt_runtime_arena_cache(
+    uint64_t /* hash */, const void * /* key_data */, size_t /* key_size */, void ** /* gm_heap_base */,
+    void ** /* sm_base */, void ** /* runtime_arena_base */, size_t * /* runtime_off */, const void ** /* image_data */,
+    size_t * /* image_size */
+) {
+    return false;
+}
+void fake_mark_prebuilt_runtime_arena_cached(
+    uint64_t /* hash */, const void * /* key_data */, size_t /* key_size */, void * /* gm_heap_base */,
+    void * /* sm_base */, void * /* runtime_arena_base */, size_t /* runtime_off */, const void * /* image_data */,
+    size_t /* image_size */
+) {}
+uint64_t fake_upload_chip_callable_buffer(const void * /* callable */) { return 0; }
+
+// with_temporary_buffer=false leaves the retained-slot callbacks null, which
+// makes trb bind fall back to a per-tensor device_malloc for each tensor.
+HostApi make_host_api(bool with_temporary_buffer = true) {
+    return HostApi{
+        fake_device_malloc,
+        fake_device_free,
+        fake_copy_to_device,
+        fake_copy_from_device,
+        fake_device_memset,
+        with_temporary_buffer ? fake_get_retained_temp_buffer : nullptr,
+        with_temporary_buffer ? fake_set_retained_temp_buffer : nullptr,
+        fake_setup_static_arena,
+        fake_acquire_pooled_gm_heap,
+        fake_acquire_pooled_gm_sm,
+        fake_acquire_pooled_runtime_arena,
+        fake_lookup_prebuilt_runtime_arena_cache,
+        fake_mark_prebuilt_runtime_arena_cached,
+        fake_upload_chip_callable_buffer,
+    };
+}
+
+Tensor make_tensor(std::vector<uint8_t> &storage, bool child_memory = false) {
+    Tensor tensor;
+    uint32_t shape[1] = {static_cast<uint32_t>(storage.size())};
+    tensor.init_external(storage.data(), storage.size(), shape, 1, DataType::UINT8, 0, false, child_memory ? 1 : 0);
+    return tensor;
+}
+
+ChipStorageTaskArgs make_args(std::vector<uint8_t> &input, std::vector<uint8_t> &output) {
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(input));
+    args.add_tensor(make_tensor(output));
+    return args;
+}
+
+int bind_runtime(
+    Runtime &runtime, const HostApi &api, const ChipStorageTaskArgs &args, const ArgDirection *signature, int sig_count
+) {
+    uint64_t ring_task_window[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    uint64_t ring_heap[PTO2_MAX_RING_DEPTH] = {1024, 1024, 1024, 1024};
+    uint64_t ring_dep_pool[PTO2_MAX_RING_DEPTH] = {4, 4, 4, 4};
+    return bind_callable_to_runtime_impl(
+        &runtime, &api, &args, nullptr, signature, sig_count, ring_task_window, ring_heap, ring_dep_pool
+    );
+}
+
+class TrbRuntimeTempBufferTest : public ::testing::Test {
+protected:
+    void SetUp() override { g_fake = &fake_; }
+    void TearDown() override {
+        fake_.release_all();
+        g_fake = nullptr;
+    }
+
+    Runtime make_runtime() { return Runtime{}; }
+
+    FakeHostApi fake_;
+    HostApi api_ = make_host_api();
+    // Temp-buffer slot callbacks left null: trb bind falls back to device_malloc.
+    HostApi malloc_api_ = make_host_api(false);
+};
+
+}  // namespace
+
+// The retained buffer is malloc'd once for the run and sliced (not per-tensor
+// malloc'd); copies/memsets are unchanged from the fallback path.
+TEST_F(TrbRuntimeTempBufferTest, TemporaryBufferSlicesWithoutChangingCopies) {
+    std::vector<uint8_t> input(64, 7);
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args = make_args(input, output);
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+
+    // Fallback path (null slot callbacks): one device_malloc per tensor.
+    fake_.reset();
+    Runtime malloc_runtime = make_runtime();
+    ASSERT_EQ(bind_runtime(malloc_runtime, malloc_api_, args, signature, 2), 0);
+    EXPECT_EQ(fake_.device_malloc_count, 2);
+    EXPECT_EQ(fake_.copy_to_count, 2);
+    EXPECT_EQ(fake_.device_memset_count, 1);
+    ASSERT_EQ(validate_runtime_impl(&malloc_runtime, &malloc_api_), 0);
+    EXPECT_EQ(fake_.device_free_count, 2);
+    EXPECT_EQ(fake_.copy_from_count, 2);
+
+    // Retained-buffer path: single device_malloc for the whole run (two
+    // 64-byte tensors pack to 2 * 1024-aligned = 2048 bytes), sliced in place.
+    fake_.reset();
+    Runtime buffer_runtime = make_runtime();
+    ASSERT_EQ(bind_runtime(buffer_runtime, api_, args, signature, 2), 0);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.retained_size, align_up(64, kAlign) * 2);
+    EXPECT_EQ(fake_.copy_to_count, 2);
+    EXPECT_EQ(fake_.device_memset_count, 1);
+    ASSERT_EQ(validate_runtime_impl(&buffer_runtime, &api_), 0);
+    // Retained buffer is NOT freed at end of run — it lives on the slot.
+    EXPECT_EQ(fake_.device_free_count, 0);
+    EXPECT_EQ(fake_.copy_from_count, 2);
+    EXPECT_NE(fake_.retained_addr, nullptr);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, SecondSameShapeRunReusesRetainedBuffer) {
+    std::vector<uint8_t> input(64, 7);
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args = make_args(input, output);
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+
+    fake_.reset();
+    Runtime run1 = make_runtime();
+    ASSERT_EQ(bind_runtime(run1, api_, args, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&run1, &api_), 0);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    void *first_addr = fake_.retained_addr;
+
+    Runtime run2 = make_runtime();
+    ASSERT_EQ(bind_runtime(run2, api_, args, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&run2, &api_), 0);
+    // Same shape → no new allocation, same retained buffer.
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.device_free_count, 0);
+    EXPECT_EQ(fake_.retained_addr, first_addr);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, LargerRunGrowsSmallerRunKeepsBuffer) {
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+
+    fake_.reset();
+    std::vector<uint8_t> small_in(64, 1);
+    std::vector<uint8_t> small_out(64, 0);
+    ChipStorageTaskArgs small = make_args(small_in, small_out);
+    Runtime run1 = make_runtime();
+    ASSERT_EQ(bind_runtime(run1, api_, small, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&run1, &api_), 0);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.retained_size, align_up(64, kAlign) * 2);
+
+    // Larger run: free old + malloc new.
+    std::vector<uint8_t> big_in(4096, 1);
+    std::vector<uint8_t> big_out(4096, 0);
+    ChipStorageTaskArgs big = make_args(big_in, big_out);
+    Runtime run2 = make_runtime();
+    ASSERT_EQ(bind_runtime(run2, api_, big, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&run2, &api_), 0);
+    EXPECT_EQ(fake_.device_malloc_count, 2);
+    EXPECT_EQ(fake_.device_free_count, 1);
+    EXPECT_EQ(fake_.retained_size, align_up(4096, kAlign) * 2);
+    size_t after_grow_mallocs = fake_.device_malloc_count;
+
+    // Smaller run again: retained buffer is big enough, no free/malloc.
+    Runtime run3 = make_runtime();
+    ASSERT_EQ(bind_runtime(run3, api_, small, signature, 2), 0);
+    ASSERT_EQ(validate_runtime_impl(&run3, &api_), 0);
+    EXPECT_EQ(fake_.device_malloc_count, static_cast<int>(after_grow_mallocs));
+    EXPECT_EQ(fake_.device_free_count, 1);
+    EXPECT_EQ(fake_.retained_size, align_up(4096, kAlign) * 2);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, ChildMemoryIsPassThroughAndPureOutStillMemsets) {
+    fake_.reset();
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> child(64, 3);
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(child, true));
+    args.add_tensor(make_tensor(output));
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+
+    ASSERT_EQ(bind_runtime(runtime, api_, args, signature, 2), 0);
+    // Only the non-child output tensor is staged: one retained buffer sized to
+    // a single 1024-aligned slice, no per-tensor malloc, child passed through.
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.retained_size, align_up(64, kAlign));
+    // The pure-OUT tensor is memset (not copied) and the child is passed
+    // through, so no tensor copy-in — the single copy_to is the runtime arena
+    // image upload that every bind performs.
+    EXPECT_EQ(fake_.copy_to_count, 1);
+    EXPECT_EQ(fake_.device_memset_count, 1);
+    ASSERT_EQ(validate_runtime_impl(&runtime, &api_), 0);
+    EXPECT_EQ(fake_.device_free_count, 0);
+}
+
+TEST_F(TrbRuntimeTempBufferTest, GrowAllocationFailureFailsBindWithoutLeak) {
+    fake_.reset();
+    fake_.fail_device_malloc_on_call = 1;  // fail the retained-buffer grow
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> input(64, 1);
+    std::vector<uint8_t> output(64, 0);
+    ChipStorageTaskArgs args = make_args(input, output);
+    ArgDirection signature[2] = {ArgDirection::IN, ArgDirection::OUT};
+
+    EXPECT_EQ(bind_runtime(runtime, api_, args, signature, 2), -1);
+    EXPECT_EQ(fake_.retained_addr, nullptr);
+    EXPECT_EQ(fake_.retained_size, 0u);
+    EXPECT_TRUE(fake_.live_mallocs.empty());
+    EXPECT_TRUE(runtime.tensor_leases_.empty());
+}
+
+TEST_F(TrbRuntimeTempBufferTest, FailedCopyReleasesRecordedFreeLease) {
+    fake_.reset();
+    fake_.fail_copy_to_on_call = 1;
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> input(64, 9);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(input));
+    ArgDirection signature[1] = {ArgDirection::IN};
+
+    // Fallback path: the per-tensor device_malloc is freed on the copy-failure
+    // error path, leaving no lease and no leak.
+    EXPECT_EQ(bind_runtime(runtime, malloc_api_, args, signature, 1), -1);
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.device_free_count, 1);
+    EXPECT_TRUE(runtime.tensor_leases_.empty());
+}
+
+TEST_F(TrbRuntimeTempBufferTest, FailedCopyOnTemporaryPathDoesNotFreeRetainedBuffer) {
+    fake_.reset();
+    fake_.fail_copy_to_on_call = 1;
+    Runtime runtime = make_runtime();
+    std::vector<uint8_t> input(64, 9);
+    ChipStorageTaskArgs args;
+    args.add_tensor(make_tensor(input));
+    ArgDirection signature[1] = {ArgDirection::IN};
+
+    EXPECT_EQ(bind_runtime(runtime, api_, args, signature, 1), -1);
+    // Retained buffer was allocated once for the grow and is NOT freed on the
+    // error path (it lives on the slot for the next run); the slice lease is a
+    // no-op, so no device_free happens here.
+    EXPECT_EQ(fake_.device_malloc_count, 1);
+    EXPECT_EQ(fake_.device_free_count, 0);
+    EXPECT_NE(fake_.retained_addr, nullptr);
+    EXPECT_TRUE(runtime.tensor_leases_.empty());
+}

--- a/tests/ut/cpp/stubs/test_stubs.cpp
+++ b/tests/ut/cpp/stubs/test_stubs.cpp
@@ -106,9 +106,9 @@ volatile uint32_t *get_reg_ptr(uint64_t /* reg_base_addr */, RegId /* reg */) {
 // and only present in the production host_runtime.so. These runner-only unit
 // tests link device_runner_base.cpp without any runtime_maker, and their mock
 // runners never bind (TestSimRunner::run returns 0), so the impl is never
-// invoked — it only has to resolve at link time. C linkage matches by symbol
-// name, so this opaque-pointer signature satisfies the reference.
-extern "C" int bind_callable_to_runtime_impl(
+// invoked — it only has to resolve at link time. Keep it weak so tests that
+// link a real runtime_maker.cpp use the real bind implementation instead.
+extern "C" __attribute__((weak)) int bind_callable_to_runtime_impl(
     void * /* runtime */, const void * /* api */, const void * /* orch_args */, void * /* host_orch_func_ptr */,
     const void * /* signature */, int /* sig_count */, const uint64_t * /* ring_task_window */,
     const uint64_t * /* ring_heap */, const uint64_t * /* ring_dep_pool */

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -18,6 +18,7 @@ import threading
 from multiprocessing.shared_memory import SharedMemory
 
 import pytest
+import simpler.worker as worker_mod
 from _task_interface import MAX_REGISTERED_CALLABLE_IDS  # pyright: ignore[reportMissingImports]
 from simpler.callable_identity import (
     CallableHandle,
@@ -120,6 +121,45 @@ def _chip_payload_shm(callable_obj: ChipCallable) -> SharedMemory:
     assert shm.buf is not None
     shm.buf[: len(payload)] = payload
     return shm
+
+
+def test_chip_process_loop_inits_runs_and_finalizes(monkeypatch):
+    events: list[tuple] = []
+
+    class FakeChipWorker:
+        def init(self, device_id, bins, *, log_level, log_info_v):
+            events.append(("init", device_id, bins, log_level, log_info_v))
+
+        def finalize(self) -> None:
+            events.append(("finalize",))
+
+    def fake_run_chip_main_loop(cw, *_args, chip_platform, chip_runtime):
+        events.append(("main_loop", cw, chip_platform, chip_runtime))
+
+    monkeypatch.setattr(worker_mod, "ChipWorker", FakeChipWorker)
+    monkeypatch.setattr(worker_mod, "_run_chip_main_loop", fake_run_chip_main_loop)
+
+    shm = SharedMemory(create=True, size=MAILBOX_SIZE)
+    try:
+        assert shm.buf is not None
+        worker_mod._chip_process_loop(
+            shm.buf,
+            "bins",
+            7,
+            {},
+            {},
+            {},
+            platform="a2a3",
+            runtime="tensormap_and_ringbuffer",
+        )
+    finally:
+        shm.close()
+        shm.unlink()
+
+    assert events[0] == ("init", 7, "bins", 1, 5)
+    assert events[1][0] == "main_loop"
+    assert events[1][2:] == ("a2a3", "tensormap_and_ringbuffer")
+    assert events[2] == ("finalize",)
 
 
 def _chip_digest(callable_obj: ChipCallable, *, platform: str = "", runtime: str = "") -> bytes:


### PR DESCRIPTION
## Summary

Cut the per-run `device_malloc` / `device_free` of ordinary non-child tensors on the `tensormap_and_ringbuffer` (TRB) bind path. TRB now stages them through a runner-scoped retained temporary buffer that grows to the high-water plan size and is reused across runs — steady-state (stable decode shapes) converges to zero temporary allocations.

This is an **internal allocation optimization, always on for TRB — there is no user-facing switch**. It is always result-equivalent to the old malloc/free path (only faster), and TRB runs are already serial per runner (enforced by the static arena pool), so there is no correctness reason to gate it. The buffer is a single retained allocation per `DeviceRunnerBase`; `begin_temporary_buffer_run(plan)` sizes it from the run's non-child tensors, `acquire` slices from it, `validate` ends the run. Grow = free-old + alloc-new (no data preserved — per-run scratch); it never shrinks; on-exhaustion the run fails (no mid-run malloc fallback).

## Design notes

- **No budget, no user API.** The buffer self-sizes from each run's plan; the caller configures nothing. There is no `max_temporary_buffer_bytes`, no `temporary_buffer_mode`, no `configure_*` entry across Python / pybind / C-ABI / ChipWorker.
- **Ownership.** `TensorLease` + `TensorReleaseKind` replace the implicit "every recorded dev_ptr was malloc'd this run" assumption: buffer slices release as no-ops (whole buffer reused at run end); the `Free` kind covers any backend that leaves the temp callbacks unwired and falls back to `device_malloc`.
- **child-memory preserved.** Child-memory and zero-byte tensors are skipped by the plan and pass through unchanged.
- **hbg unaffected** — host-orchestration bind does not use the temp buffer callbacks.

See the runtime's `RUNTIME_LOGIC.md` §2.4 and `docs/task-flow.md` for mechanics.

## Testing

- a2a3 + a5 build clean (all runtimes, sim + onboard).
- Python UT: 92 passed (`test_chip_worker`, `test_host_worker`).
- Sim ST: `tensormap_and_ringbuffer/prepared_callable` a2a3sim — 7 passed (end-to-end register→run→validate with the buffer always on).
- C++ UT (`test_temporary_variable_buffer`, `test_trb_runtime_temp_buffer`) cover grow / reuse / shrink-noop / grow-failure / plan-sizing / child-memory pass-through / copy-back / lease-release — to be exercised by CI.

Follow-up on the optimization direction discussed in https://github.com/hw-native-sys/simpler/pull/1186.
