### PR TITLE
perf(runtime): reset slot_state at submit, drop the per-boot per-slot init loop

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -424,6 +424,20 @@ static bool prepare_task(
     out->task = &orch->sm_header->rings[ring_id].task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->rings[ring_id].task_payloads[out->alloc_result.slot];
 
+    // Reset the fanout/fanin bookkeeping for this reuse. The allocator only
+    // returns a slot whose previous occupant is CONSUMED and quiescent (alloc
+    // spins until last_task_alive passes it; in-order reclaim + acquire load),
+    // and the slot is not published to any scheduler thread until the
+    // wiring.queue.push at the end of submit_task_common — so this reset is
+    // race-free. Doing it here (not relying on the scheduler's eager
+    // reset-after-CONSUMED, which only covers the contiguously-reclaimed tail)
+    // makes every reused slot self-clean, which lets the per-boot SM init skip
+    // its O(window) per-slot loop. bind_ring is slot-invariant but cheap to
+    // re-assert on the already-dirtied cache line.
+    out->slot_state->bind_ring(ring_id);
+    out->slot_state->reset_for_reuse();
+    out->slot_state->fanin_count = 0;
+
     out->payload->prefetch(args.tensor_count(), args.scalar_count());
 
     // Re-bind payload/task pointers each submit. Value is per-slot constant

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -175,22 +175,10 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
     header->sched_stall_task_id.store(-1, std::memory_order_relaxed);
     header->sched_stall_core.store(-1, std::memory_order_relaxed);
 
-    // Per-ring slot_states reset. Previously lived in
-    // PTO2SchedulerState::RingSchedState::init(), but it writes into
-    // ring->slot_states[] which is SM-side storage — keeping it here lets
-    // host-side prebuilt-arena init skip all SM dereferences.
-    // bind_ring() pins the ring_id (slot-invariant after this point);
-    // reset_for_reuse() prepares dynamic fanout/refcount fields so the first
-    // submit doesn't need an explicit reset.
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        auto &ring = header->rings[r];
-        for (uint64_t i = 0; i < task_window_sizes[r]; i++) {
-            ring.slot_states[i].bind_ring(static_cast<uint8_t>(r));
-            ring.slot_states[i].reset_for_reuse();
-            ring.slot_states[i].fanin_count = 0;
-            ring.slot_states[i].active_mask = ActiveMask{};
-        }
-    }
+    // No per-slot loop: prepare_task resets each slot when it allocates it, and
+    // the scheduler only scans submitted task_ids [last_task_alive,
+    // current_task_index), so unsubmitted slots are never read. Per-boot reset
+    // is just the header fields above; per-slot state is set lazily at submit.
 }
 
 // =============================================================================

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -432,6 +432,20 @@ static bool prepare_task(
     out->task = &orch->sm_header->rings[ring_id].task_descriptors[out->alloc_result.slot];
     out->payload = &orch->sm_header->rings[ring_id].task_payloads[out->alloc_result.slot];
 
+    // Reset the fanout/fanin bookkeeping for this reuse. The allocator only
+    // returns a slot whose previous occupant is CONSUMED and quiescent (alloc
+    // spins until last_task_alive passes it; in-order reclaim + acquire load),
+    // and the slot is not published to any scheduler thread until the
+    // wiring.queue.push at the end of submit_task_common — so this reset is
+    // race-free. Doing it here (not relying on the scheduler's eager
+    // reset-after-CONSUMED, which only covers the contiguously-reclaimed tail)
+    // makes every reused slot self-clean, which lets the per-boot SM init skip
+    // its O(window) per-slot loop. bind_ring is slot-invariant but cheap to
+    // re-assert on the already-dirtied cache line.
+    out->slot_state->bind_ring(ring_id);
+    out->slot_state->reset_for_reuse();
+    out->slot_state->fanin_count = 0;
+
     prefetch_payload(out->payload, args.tensor_count(), args.scalar_count());
 
     // Re-bind payload/task pointers each submit. Value is per-slot constant

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/pto_shared_memory.cpp
@@ -175,22 +175,10 @@ void PTO2SharedMemoryHandle::init_header_per_ring(
     header->sched_stall_task_id.store(-1, std::memory_order_relaxed);
     header->sched_stall_core.store(-1, std::memory_order_relaxed);
 
-    // Per-ring slot_states reset. Previously lived in
-    // PTO2SchedulerState::RingSchedState::init(), but it writes into
-    // ring->slot_states[] which is SM-side storage — keeping it here lets
-    // host-side prebuilt-arena init skip all SM dereferences.
-    // bind_ring() pins the ring_id (slot-invariant after this point);
-    // reset_for_reuse() prepares dynamic fanout/refcount fields so the first
-    // submit doesn't need an explicit reset.
-    for (int r = 0; r < PTO2_MAX_RING_DEPTH; r++) {
-        auto &ring = header->rings[r];
-        for (uint64_t i = 0; i < task_window_sizes[r]; i++) {
-            ring.slot_states[i].bind_ring(static_cast<uint8_t>(r));
-            ring.slot_states[i].reset_for_reuse();
-            ring.slot_states[i].fanin_count = 0;
-            ring.slot_states[i].active_mask = ActiveMask{};
-        }
-    }
+    // No per-slot loop: prepare_task resets each slot when it allocates it, and
+    // the scheduler only scans submitted task_ids [last_task_alive,
+    // current_task_index), so unsubmitted slots are never read. Per-boot reset
+    // is just the header fields above; per-slot state is set lazily at submit.
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

`init_per_ring` ran an `O(sum(task_window_sizes))` loop on **every** run that reset
every `slot_states[]` entry (`bind_ring` + `reset_for_reuse` + `fanin_count` +
`active_mask`). Those are slow AICPU writes into device SM; on a qwen3-14B decode
with a large ring window the device-phase `sm_reset` marker measured **~20 ms/step
— ~31% of the decode `device_wall`**.

The loop is redundant. The scheduler only ever scans **submitted** task_ids
`[last_task_alive, current_task_index)` — i.e. slots that have already been through
the orchestrator's `prepare_task`. So instead of priming the whole window at boot,
`prepare_task` resets the slot it just allocated.

### Change
- **`prepare_task()`** calls `bind_ring + reset_for_reuse + fanin_count=0` on the
  freshly-allocated slot. Race-free: `alloc()` only returns a slot whose previous
  occupant is **CONSUMED and quiescent** (it spins until `last_task_alive` passes
  it — in-order reclaim + acquire load), and the slot is not published to any
  scheduler thread until the `wiring.queue.push` at the end of `submit_task_common`.
  Crucially this does **not** rely on the scheduler's eager reset-after-CONSUMED
  (which only covers the contiguously-reclaimed tail `[old_last_alive, last_alive)`),
  so every reused slot is self-clean regardless of how a prior run left the pooled
  SM — closing the stale-`fanout_count` head-of-line wedge that a naive "skip the
  init loop on the device" hits on `batch_paged_attention`.
- **`init_header_per_ring`** drops the per-slot loop entirely; it now only resets
  the per-boot header flow-control / layout / error fields. Per-slot state is
  established lazily at submit time.

Cost moves from `O(window)` every run to `O(tasks actually submitted)`, and stays
on the device (no host DMA). Applied symmetrically to **a2a3 and a5**.

### Measured — same-device A/B (qwen3-14B, 3.5k-context decode, a2a3 onboard, `PTO2_RING_TASK_WINDOW=524288`, 19 decode steps)

Baseline = parent commit (per-boot per-slot loop) rebuilt and run on the **same
device** as the fix; both produce identical output tokens.

| device-wall phase | baseline | this PR | Δ |
| ----------------- | -------- | ------- | - |
| `sm_reset`        | 20,284 µs | **51.6 µs** | **−20,233 µs** |
| `orch`            | 21,437 µs | 21,563 µs | +126 µs (noise) |
| `sched`           | 44,460 µs | 44,508 µs | +48 µs (noise) |
| `Effective` (orch ∥ sched) | 44,461 µs | 44,508 µs | +47 µs |
| **`device_wall`** | **65,195 µs** | **45,009 µs** | **−20,186 µs (−31%)** |

The relocated reset does **not** resurface inside orchestration: `orch`/`sched`
are flat within run-to-run jitter. The reset went from `O(524288 slots/boot)` to
`O(tasks-actually-submitted)` on already-hot cache lines, so the full 31%
`device_wall` reduction is pure `sm_reset` collapse with **zero regression to the
orch/sched compute**. The residual ~52 µs `sm_reset` is the fixed, window-independent
256 KB AICore-completion-mailbox zeroing — flat at any window size.

## Testing
- [x] a2a3sim + a5sim build; `vector_example` golden **PASSES across 4 rounds** on both.
- [x] a2a3 onboard full `examples + tests/st` scene suite: **41 passed, 0 failed**
  (incl. `batch_paged_attention`, which a device-side init-skip wedged at 507018).
- [x] a2a3 onboard qwen3-14B 3.5k decode: same-device A/B above; output tokens
  identical to baseline.
