### PR TITLE
Refactor: split per-device invariants into a one-shot AICPU init entry

### DIFF
--- a/docs/aicpu-kernel-launch-mechanisms.md
+++ b/docs/aicpu-kernel-launch-mechanisms.md
@@ -110,11 +110,22 @@ onboard Path A implementation:
    `rtsLaunchCpuKernel()` (`cpu_args.baseArgs.args = &kernel_args.args`,
    `argsSize = sizeof(KernelArgs)`). There is no CANN launch front on this
    path — `runtime_args` sits at offset 0 and the AICPU entry reads it directly.
+   Two sibling entries reuse the same launch mechanism with their own, smaller
+   payloads instead of `KernelArgs`:
+   - `simpler_aicpu_init` takes an `InitArgs` (device id + log config), launched
+     once per device at `ensure_device_initialized` time. It latches the
+     per-device invariants into the resident AICPU SO globals, so `exec` and
+     `register_callable` no longer re-push them.
+   - `simpler_aicpu_register_callable` takes a `RegisterCallableArgs` (orch-SO
+     descriptor extracted from `Runtime`), launched per callable on the
+     device-orchestration prepare path so the AICPU (re)dlopens its orch SO. hbg
+     is a no-op (host-side orchestration).
 3. **Shared per-task `KernelArgs` payload.**
    `src/{a2a3,a5}/platform/include/common/kernel_args.h` is front-less.
-   Runtime state is passed through `KernelArgs::runtime_args`,
-   profiling/logging fields, register tables, and `device_id`. AICore receives
-   only this payload through the host-owned device copy.
+   Runtime state is passed through `KernelArgs::runtime_args`, profiling buffer
+   bases, and register tables. AICore receives only this payload through the
+   host-owned device copy. Per-device invariants (device id, log config) are NOT
+   on `KernelArgs` — they travel once via `InitArgs`.
 
 Keep those channels distinct. The bootstrap ABI still uses the `DeviceArgs`
 name because the dispatcher really reads that structure. The platform per-task

--- a/docs/callable-identity-registration.md
+++ b/docs/callable-identity-registration.md
@@ -59,11 +59,14 @@ materialization. A successful registration installs the target-local
 state before the first dispatch, `prepare_callable()` also prewarms that state
 before returning success.
 
-For `tensormap_and_ringbuffer`, prewarm runs a private AICPU entry,
-`simpler_aicpu_prewarm_callable`, after the orchestration SO bytes and child
-kernel addresses have already been staged. The AICPU prewarm may materialize
-the orchestration SO into a temporary file, `dlopen` it, resolve the
-entry/config/bind symbols, and populate `orch_so_table_[callable_id]`. It must
+For `tensormap_and_ringbuffer`, this prepare-ahead step runs a private AICPU
+entry, `simpler_aicpu_register_callable`, after the orchestration SO bytes and
+child kernel addresses have already been staged. The host passes a small
+`RegisterCallableArgs` descriptor (callable id, orch-SO device address/size,
+entry/config symbol names) extracted from the staged `CallableState` — not a
+full `Runtime`. The AICPU entry may materialize the orchestration SO into a
+temporary file, `dlopen` it, resolve the entry/config/bind symbols, and
+populate `orch_so_table_[callable_id]`. It must
 stop before any real task execution: it does not call the orchestration entry,
 does not configure runtime arguments from user task inputs, does not create a
 `PTO2Runtime`, does not enter runtime scopes, and does not submit scheduler or

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -41,6 +41,12 @@
 // Forward declarations
 class Runtime;
 
+// Symbol-name capacity for the device orchestration entry/config functions.
+// Must match RUNTIME_MAX_ORCH_SYMBOL_NAME in the runtime's runtime.h; a
+// static_assert in the TMARB AICPU executor (where both headers are visible)
+// enforces the equality.
+#define INIT_ARGS_MAX_ORCH_SYMBOL_NAME 64
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -96,8 +102,6 @@ struct KernelArgs {
     // L2SwimlaneAicoreTaskBuffer address. AICore kernel entry indexes by block_idx
     // and forwards into platform set/get state. 0 when L2 swimlane is off.
     uint64_t l2_swimlane_aicore_rotation_table{0};
-    uint32_t log_level{1};              // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
-    uint32_t log_info_v{5};             // INFO verbosity threshold (0..9); default V5
     uint32_t enable_profiling_flag{0};  // Profiling umbrella bitmask; dump_tensor|l2_swimlane|pmu|dep_gen|scope_stats
     uint32_t _pad{0};                   // Alignment padding
 
@@ -123,6 +127,43 @@ struct KernelArgs {
 
 static_assert(offsetof(KernelArgs, runtime_args) == 0, "KernelArgs::runtime_args offset drift");
 static_assert(offsetof(KernelArgs, regs) == 8, "KernelArgs::regs offset drift");
+
+/**
+ * InitArgs - per-device one-shot invariants
+ *
+ * Uploaded once at worker init via the `simpler_aicpu_init` entry, before any
+ * register_callable/exec launch. Carries the values that are fixed for the
+ * lifetime of the device context, so they no longer ride on the per-run
+ * KernelArgs: the AICPU platform globals (orch device id, log verbosity) are
+ * latched once into the resident AICPU SO and survive every subsequent
+ * per-task launch.
+ *
+ * `regs` / `pmu_reg_addrs` are intentionally NOT here — they back per-core
+ * register tables consumed on the per-run AICore path and stay in KernelArgs.
+ */
+struct InitArgs {
+    uint32_t device_id{0};   // ACL device ordinal -> set_orch_device_id
+    uint32_t log_level{1};   // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
+    uint32_t log_info_v{5};  // INFO verbosity threshold (0..9); default V5
+};
+
+/**
+ * RegisterCallableArgs - device orchestration SO registration payload
+ *
+ * Uploaded by the host register_callable path via `simpler_aicpu_register_callable`.
+ * Carries only the orchestration-SO descriptor the AICPU executor needs to
+ * (re)dlopen a callable's device-orch SO — extracted from Runtime so the
+ * register path no longer H2D's a full Runtime. On hbg this is all-zero
+ * (host-side orchestration; no device dlopen) and the entry is a no-op.
+ */
+struct RegisterCallableArgs {
+    int32_t active_callable_id{-1};                                  // orch_so_table_ slot
+    uint32_t register_new{0};                                        // 1 -> (re)dlopen, 0 -> reuse cached handle
+    uint64_t dev_orch_so_addr{0};                                    // device address of the orch SO image
+    uint64_t dev_orch_so_size{0};                                    // orch SO image size in bytes
+    char device_orch_func_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME]{};    // entry symbol
+    char device_orch_config_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME]{};  // config symbol
+};
 
 #ifdef __cplusplus
 }

--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -37,7 +37,7 @@
 
 // Forward declaration of aicpu_execute (implemented in aicpu_executor.cpp)
 extern "C" int aicpu_execute(Runtime *arg);
-extern "C" int aicpu_prewarm_callable(Runtime *arg);
+extern "C" int aicpu_register_callable(const RegisterCallableArgs *arg);
 
 /**
  * AICPU kernel main execution entry point.
@@ -53,9 +53,8 @@ extern "C" int aicpu_prewarm_callable(Runtime *arg);
  * @return 0 on success, non-zero on error
  */
 extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *arg) {
-    // Snapshot CANN log severity. Idempotent across the concurrent exec
-    // threads — same snapshot value.
-    init_log_switch();
+    // Log severity was snapshot once by simpler_aicpu_init at worker init; the
+    // resident SO keeps it across launches, so exec does not re-snapshot.
     if (arg == nullptr) {
         LOG_ERROR("%s", "Invalid kernel arguments: null pointer");
         return -1;
@@ -69,16 +68,10 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
         return -1;
     }
 
-    // Push host-published log config into device globals.
-    set_log_level(static_cast<int>(k_args->log_level));
-    set_log_info_v(static_cast<int>(k_args->log_info_v));
-
-    // Store platform regs before calling aicpu_execute
-    // Dump enable is an execution control flag propagated via handshake.
-    // The dump base address is only the backing storage location.
+    // Per-device invariants (log config, orch device id) were latched once by
+    // simpler_aicpu_init at worker init; only the per-run register tables and
+    // profiling-buffer bases are pushed here.
     set_platform_regs(k_args->regs);
-    // Device ordinal for per-device orchestration-SO naming in the executor.
-    set_orch_device_id(static_cast<int>(k_args->device_id));
     set_platform_dump_base(k_args->dump_data_base);
     set_dump_args_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_swimlane_base(k_args->l2_swimlane_data_base);
@@ -131,30 +124,48 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     return rc;
 }
 
-extern "C" __attribute__((visibility("default"))) int simpler_aicpu_prewarm_callable(void *arg) {
+/**
+ * AICPU per-device init entry point.
+ *
+ * Launched once at worker init (before any register_callable / exec), this
+ * latches the per-device invariants — log config and orchestration device id —
+ * into the resident AICPU SO globals. Because the inner SO stays dlopen'd in
+ * the AICPU OS process across launches, these globals survive every subsequent
+ * per-task launch, so exec / register_callable no longer re-push them.
+ *
+ * @param arg Pointer to an InitArgs payload
+ * @return 0 on success, non-zero on error
+ */
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_init(void *arg) {
     init_log_switch();
     if (arg == nullptr) {
-        LOG_ERROR("%s", "Invalid prewarm kernel arguments: null pointer");
+        LOG_ERROR("%s", "Invalid init kernel arguments: null pointer");
         return -1;
     }
 
-    KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
-    Runtime *runtime = k_args->runtime_args;
-    if (runtime == nullptr) {
-        LOG_ERROR("%s", "Invalid prewarm runtime_args: null pointer");
+    InitArgs *init_args = reinterpret_cast<InitArgs *>(arg);
+    set_log_level(static_cast<int>(init_args->log_level));
+    set_log_info_v(static_cast<int>(init_args->log_info_v));
+    set_orch_device_id(static_cast<int>(init_args->device_id));
+
+    LOG_INFO_V0("%s", "simpler_aicpu_init: per-device invariants latched");
+    return 0;
+}
+
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_register_callable(void *arg) {
+    if (arg == nullptr) {
+        LOG_ERROR("%s", "Invalid register_callable kernel arguments: null pointer");
         return -1;
     }
 
-    set_log_level(static_cast<int>(k_args->log_level));
-    set_log_info_v(static_cast<int>(k_args->log_info_v));
-    set_orch_device_id(static_cast<int>(k_args->device_id));
+    RegisterCallableArgs *reg_args = reinterpret_cast<RegisterCallableArgs *>(arg);
 
-    LOG_INFO_V0("%s", "simpler_aicpu_prewarm_callable: prewarming callable");
-    int rc = aicpu_prewarm_callable(runtime);
+    LOG_INFO_V0("%s", "simpler_aicpu_register_callable: registering callable");
+    int rc = aicpu_register_callable(reg_args);
     if (rc != 0) {
-        LOG_ERROR("simpler_aicpu_prewarm_callable: prewarm failed with rc=%d", rc);
+        LOG_ERROR("simpler_aicpu_register_callable: registration failed with rc=%d", rc);
         return rc;
     }
-    LOG_INFO_V0("%s", "simpler_aicpu_prewarm_callable: prewarm completed");
+    LOG_INFO_V0("%s", "simpler_aicpu_register_callable: registration completed");
     return 0;
 }

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -94,7 +94,7 @@ int DeviceRunner::ensure_binaries_loaded() {
         };
 
         if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_))) return -1;
-        load_optional_sym("aicpu_prewarm_callable", reinterpret_cast<void **>(&aicpu_prewarm_func_));
+        load_optional_sym("aicpu_register_callable", reinterpret_cast<void **>(&aicpu_register_callable_func_));
         if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_))) return -1;
         load_optional_sym("set_orch_device_id", reinterpret_cast<void **>(&set_orch_device_id_func_));
         if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_))) return -1;
@@ -178,13 +178,27 @@ int DeviceRunner::ensure_binaries_loaded() {
     return 0;
 }
 
-int DeviceRunner::invoke_aicpu_prewarm(Runtime &runtime) {
-    if (aicpu_prewarm_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
-        LOG_ERROR("Prewarm functions not loaded. Call ensure_binaries_loaded first.");
+int DeviceRunner::invoke_aicpu_register_callable(Runtime &runtime) {
+    if (aicpu_register_callable_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
+        LOG_ERROR("Register-callable functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
     set_orch_device_id_func_(device_id_);
-    return aicpu_prewarm_func_(&runtime);
+    // Extract the orch-SO descriptor from the stamped Runtime into the small
+    // RegisterCallableArgs the renamed entry expects (sim shares process
+    // memory, so the name pointers stay valid for the synchronous call).
+    RegisterCallableArgs reg_args{};
+    reg_args.active_callable_id = runtime.get_active_callable_id();
+    reg_args.register_new = runtime.register_new_callable_id() ? 1 : 0;
+    reg_args.dev_orch_so_addr = runtime.get_dev_orch_so_addr();
+    reg_args.dev_orch_so_size = runtime.get_dev_orch_so_size();
+    const char *func_name = runtime.get_device_orch_func_name();
+    const char *config_name = runtime.get_device_orch_config_name();
+    snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", func_name ? func_name : "");
+    snprintf(
+        reg_args.device_orch_config_name, sizeof(reg_args.device_orch_config_name), "%s", config_name ? config_name : ""
+    );
+    return aicpu_register_callable_func_(&reg_args);
 }
 
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
@@ -613,7 +627,7 @@ void DeviceRunner::unload_executor_binaries() {
         dlclose(aicpu_so_handle_);
         aicpu_so_handle_ = nullptr;
         aicpu_execute_func_ = nullptr;
-        aicpu_prewarm_func_ = nullptr;
+        aicpu_register_callable_func_ = nullptr;
         set_platform_regs_func_ = nullptr;
         set_orch_device_id_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -39,7 +39,7 @@ public:
 
 private:
     int ensure_binaries_loaded() override;
-    int invoke_aicpu_prewarm(Runtime &runtime) override;
+    int invoke_aicpu_register_callable(Runtime &runtime) override;
     void unload_executor_binaries();
 
     int init_l2_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
@@ -55,7 +55,7 @@ private:
     // a2a3 sim's dlsym'd function-pointer table. Loaded once via
     // ensure_binaries_loaded(), nulled on unload_executor_binaries().
     int (*aicpu_execute_func_)(Runtime *){nullptr};
-    int (*aicpu_prewarm_func_)(Runtime *){nullptr};
+    int (*aicpu_register_callable_func_)(const RegisterCallableArgs *){nullptr};
     void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t, uint32_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_orch_device_id_func_)(int){nullptr};

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -22,6 +22,7 @@
 #include "aicpu/pmu_collector_aicpu.h"
 #include "aicpu/tensor_dump_aicpu.h"
 #include "callable.h"
+#include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
@@ -1307,10 +1308,10 @@ void AicpuExecutor::diagnose_stuck_state(
 
 // ===== Public Entry Point =====
 
-extern "C" int aicpu_prewarm_callable(Runtime *runtime) {
+extern "C" int aicpu_register_callable(const RegisterCallableArgs *args) {
     // host_build_graph resolves orchestration on the host during prepare.
-    // There is no AICPU orch_so_table_ state to prewarm.
-    (void)runtime;
+    // There is no AICPU orch_so_table_ state to register.
+    (void)args;
     return 0;
 }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -500,6 +500,11 @@ public:
         dev_orch_so_addr_ = dev_addr;
         dev_orch_so_size_ = size;
     }
+    // hbg resolves orchestration on the host, so these stay zero; the getters
+    // exist only so the shared sim register-callable path compiles against this
+    // variant (it reads the descriptor but the AICPU entry is a no-op here).
+    uint64_t get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
+    uint64_t get_dev_orch_so_size() const { return dev_orch_so_size_; }
     void set_active_callable_id(int32_t callable_id, bool is_new) {
         active_callable_id_ = callable_id;
         register_new_callable_id_ = is_new;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -26,6 +26,7 @@
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/orch_so_file.h"
 #include "callable_protocol.h"
+#include "common/kernel_args.h"
 #include "pto2_dispatch_payload.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -149,6 +150,13 @@ struct AicpuExecutor {
 
     // ===== Methods =====
     int32_t init(Runtime *runtime);
+    // Core orch-SO (re)load, driven by the extracted descriptor values. Both
+    // the run-path Runtime* wrapper and the register_callable entry delegate
+    // here so neither has to know the other's argument source.
+    int32_t ensure_orch_so_loaded_core(
+        int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
+        const char *entry_symbol, const char *config_symbol, int32_t thread_idx
+    );
     int32_t ensure_orch_so_loaded(Runtime *runtime, int32_t thread_idx);
     int32_t run(Runtime *runtime);
     void deinit(Runtime *runtime);
@@ -167,6 +175,14 @@ struct AicpuExecutor {
 };
 
 static AicpuExecutor g_aicpu_executor;
+
+// The register_callable payload mirrors the runtime's orch symbol-name
+// capacity; keep the two in lockstep so a name that fits in Runtime also fits
+// in RegisterCallableArgs.
+static_assert(
+    INIT_ARGS_MAX_ORCH_SYMBOL_NAME == RUNTIME_MAX_ORCH_SYMBOL_NAME,
+    "RegisterCallableArgs orch-symbol capacity must match RUNTIME_MAX_ORCH_SYMBOL_NAME"
+);
 
 // ===== AicpuExecutor Method Implementations =====
 
@@ -216,15 +232,24 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
         LOG_ERROR("Thread %d: runtime is nullptr", thread_idx);
         return -1;
     }
+    return ensure_orch_so_loaded_core(
+        runtime->get_active_callable_id(), runtime->register_new_callable_id(), runtime->get_dev_orch_so_addr(),
+        runtime->get_dev_orch_so_size(), runtime->get_device_orch_func_name(), runtime->get_device_orch_config_name(),
+        thread_idx
+    );
+}
 
-    const int32_t callable_id = runtime->get_active_callable_id();
+int32_t AicpuExecutor::ensure_orch_so_loaded_core(
+    int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
+    const char *entry_symbol_in, const char *config_symbol_in, int32_t thread_idx
+) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR("Thread %d: invalid callable_id %d (limit=%d)", thread_idx, callable_id, MAX_REGISTERED_CALLABLE_IDS);
         return -1;
     }
 
     OrchSoEntry &entry = orch_so_table_[callable_id];
-    const bool reload_so = runtime->register_new_callable_id();
+    const bool reload_so = register_new;
     if (!reload_so) {
         LOG_INFO_V0(
             "Thread %d: Reusing cached orch SO handle=%p (callable_id=%d)", thread_idx, entry.handle, callable_id
@@ -251,8 +276,8 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
     }
     entry = OrchSoEntry{};
 
-    const void *so_data = reinterpret_cast<const void *>(runtime->get_dev_orch_so_addr());
-    size_t so_size = runtime->get_dev_orch_so_size();
+    const void *so_data = reinterpret_cast<const void *>(dev_orch_so_addr);
+    size_t so_size = dev_orch_so_size;
     if (so_data == nullptr || so_size == 0) {
         LOG_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
         return -1;
@@ -302,11 +327,11 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
     // libdevice_orch_<pid>_<cid>.so files when worker children exit via os._exit.
     unlink(so_path);
 
-    const char *entry_symbol = runtime->get_device_orch_func_name();
+    const char *entry_symbol = entry_symbol_in;
     if (entry_symbol == nullptr || entry_symbol[0] == '\0') {
         entry_symbol = DEFAULT_ORCH_ENTRY_SYMBOL;
     }
-    const char *config_symbol = runtime->get_device_orch_config_name();
+    const char *config_symbol = config_symbol_in;
     if (config_symbol == nullptr || config_symbol[0] == '\0') {
         config_symbol = DEFAULT_ORCH_CONFIG_SYMBOL;
     }
@@ -822,18 +847,23 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
 // ===== Public Entry Point =====
 
-extern "C" int32_t aicpu_prewarm_callable(Runtime *runtime) {
-    if (runtime == nullptr) {
-        LOG_ERROR("%s", "aicpu_prewarm_callable: null Runtime pointer");
+extern "C" int32_t aicpu_register_callable(const RegisterCallableArgs *args) {
+    if (args == nullptr) {
+        LOG_ERROR("%s", "aicpu_register_callable: null RegisterCallableArgs pointer");
         return -1;
     }
-    int32_t rc = g_aicpu_executor.ensure_orch_so_loaded(runtime, /*thread_idx=*/0);
-    cache_invalidate_range(runtime, sizeof(Runtime));
+    // `args` is the launch-arg payload CANN copies into the AICPU arg space
+    // (same coherent channel exec reads KernelArgs fields from) — no HBM deref,
+    // so unlike the old prewarm path there is no Runtime to cache-invalidate.
+    int32_t rc = g_aicpu_executor.ensure_orch_so_loaded_core(
+        args->active_callable_id, args->register_new != 0, args->dev_orch_so_addr, args->dev_orch_so_size,
+        args->device_orch_func_name, args->device_orch_config_name, /*thread_idx=*/0
+    );
     if (rc != 0) {
-        LOG_ERROR("aicpu_prewarm_callable: SO load failed with rc=%d", rc);
+        LOG_ERROR("aicpu_register_callable: SO load failed with rc=%d", rc);
         return rc;
     }
-    LOG_INFO_V0("aicpu_prewarm_callable: completed for callable_id=%d", runtime->get_active_callable_id());
+    LOG_INFO_V0("aicpu_register_callable: completed for callable_id=%d", args->active_callable_id);
     return 0;
 }
 

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -41,6 +41,12 @@
 // Forward declarations
 class Runtime;
 
+// Symbol-name capacity for the device orchestration entry/config functions.
+// Must match RUNTIME_MAX_ORCH_SYMBOL_NAME in the runtime's runtime.h; a
+// static_assert in the TMARB AICPU executor (where both headers are visible)
+// enforces the equality.
+#define INIT_ARGS_MAX_ORCH_SYMBOL_NAME 64
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -85,8 +91,6 @@ struct KernelArgs {
     uint64_t scope_stats_data_base{0};  // ScopeStatsBuffer device pointer; 0 when scope_stats is off.
                                         // a5 has no halHostRegister — host keeps a separate shadow and
                                         // refreshes it via rtMemcpy DEVICE_TO_HOST at dump time.
-    uint32_t log_level{1};              // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
-    uint32_t log_info_v{5};             // INFO verbosity threshold (0..9); default V5
     uint32_t enable_profiling_flag{0};  // Profiling umbrella bitmask; dump_tensor|l2_swimlane|pmu|dep_gen|scope_stats
     uint32_t _pad{0};                   // Alignment padding
 
@@ -95,10 +99,6 @@ struct KernelArgs {
     // See the a2a3 kernel_args.h for the full design rationale (CANN's
     // AICPU args copy makes inline fields write-only).
     uint64_t device_wall_data_base{0};
-    // ACL device ordinal. Pushed to the AICPU so the executor can suffix the
-    // staged orchestration SO name (libdevice_orch_<pid>_<cid>_<device_id>.so),
-    // mirroring the per-device simpler_inner preinstall fix.
-    uint32_t device_id{0};
     // Opaque always-false guard read by the AICore SIMT meta anchor (AIV
     // KERNEL_ENTRY). The host never sets it non-zero; its only purpose is to be
     // a runtime-valued condition the compiler cannot constant-fold, so the
@@ -109,6 +109,43 @@ struct KernelArgs {
 
 static_assert(offsetof(KernelArgs, runtime_args) == 0, "KernelArgs::runtime_args offset drift");
 static_assert(offsetof(KernelArgs, regs) == 8, "KernelArgs::regs offset drift");
+
+/**
+ * InitArgs - per-device one-shot invariants
+ *
+ * Uploaded once at worker init via the `simpler_aicpu_init` entry, before any
+ * register_callable/exec launch. Carries the values fixed for the lifetime of
+ * the device context (orch device id, log config) so they no longer ride on
+ * the per-run KernelArgs: latched once into the resident AICPU SO globals and
+ * surviving every subsequent per-task launch.
+ *
+ * `regs` is intentionally NOT here — on a5 the per-core register table is also
+ * read by the AICore KERNEL_ENTRY off the per-run device KernelArgs copy, so it
+ * stays in KernelArgs.
+ */
+struct InitArgs {
+    uint32_t device_id{0};   // ACL device ordinal -> set_orch_device_id
+    uint32_t log_level{1};   // Severity floor: 0=DEBUG, 1=INFO, 2=WARN, 3=ERROR, 4=NUL
+    uint32_t log_info_v{5};  // INFO verbosity threshold (0..9); default V5
+};
+
+/**
+ * RegisterCallableArgs - device orchestration SO registration payload
+ *
+ * Uploaded by the host register_callable path via `simpler_aicpu_register_callable`.
+ * Carries only the orchestration-SO descriptor the AICPU executor needs to
+ * (re)dlopen a callable's device-orch SO — extracted from Runtime so the
+ * register path no longer H2D's a full Runtime. On hbg this is all-zero
+ * (host-side orchestration; no device dlopen) and the entry is a no-op.
+ */
+struct RegisterCallableArgs {
+    int32_t active_callable_id{-1};                                  // orch_so_table_ slot
+    uint32_t register_new{0};                                        // 1 -> (re)dlopen, 0 -> reuse cached handle
+    uint64_t dev_orch_so_addr{0};                                    // device address of the orch SO image
+    uint64_t dev_orch_so_size{0};                                    // orch SO image size in bytes
+    char device_orch_func_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME]{};    // entry symbol
+    char device_orch_config_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME]{};  // config symbol
+};
 
 #ifdef __cplusplus
 }

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -37,7 +37,7 @@
 
 // Forward declaration of aicpu_execute (implemented in aicpu_executor.cpp)
 extern "C" int aicpu_execute(Runtime *arg);
-extern "C" int aicpu_prewarm_callable(Runtime *arg);
+extern "C" int aicpu_register_callable(const RegisterCallableArgs *arg);
 
 /**
  * AICPU kernel main execution entry point.
@@ -53,9 +53,8 @@ extern "C" int aicpu_prewarm_callable(Runtime *arg);
  * @return 0 on success, non-zero on error
  */
 extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *arg) {
-    // Snapshot CANN log severity. Idempotent across the concurrent exec
-    // threads — same snapshot value.
-    init_log_switch();
+    // Log severity was snapshot once by simpler_aicpu_init at worker init; the
+    // resident SO keeps it across launches, so exec does not re-snapshot.
     if (arg == nullptr) {
         LOG_ERROR("%s", "Invalid kernel arguments: null pointer");
         return -1;
@@ -69,17 +68,12 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
         return -1;
     }
 
-    // Push host-published log config into device globals.
-    set_log_level(static_cast<int>(k_args->log_level));
-    set_log_info_v(static_cast<int>(k_args->log_info_v));
-
-    // Store platform regs before calling aicpu_execute. Profiling enable
-    // bits live on KernelArgs::enable_profiling_flag now (no longer
-    // mirrored into Handshake), so decode the umbrella bitmask once and
-    // hand it to the existing platform-state setters.
+    // Per-device invariants (log config, orch device id) were latched once by
+    // simpler_aicpu_init at worker init. Profiling enable bits live on
+    // KernelArgs::enable_profiling_flag now (no longer mirrored into
+    // Handshake), so decode the umbrella bitmask once and hand it to the
+    // existing platform-state setters.
     set_platform_regs(k_args->regs);
-    // Device ordinal for per-device orchestration-SO naming in the executor.
-    set_orch_device_id(static_cast<int>(k_args->device_id));
     set_platform_dump_base(k_args->dump_data_base);
     set_dump_args_enabled(GET_PROFILING_FLAG(k_args->enable_profiling_flag, PROFILING_FLAG_DUMP_TENSOR));
     set_platform_l2_swimlane_base(k_args->l2_swimlane_data_base);
@@ -141,30 +135,48 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     return rc;
 }
 
-extern "C" __attribute__((visibility("default"))) int simpler_aicpu_prewarm_callable(void *arg) {
+/**
+ * AICPU per-device init entry point.
+ *
+ * Launched once at worker init (before any register_callable / exec), this
+ * latches the per-device invariants — log config and orchestration device id —
+ * into the resident AICPU SO globals. Because the inner SO stays dlopen'd in
+ * the AICPU OS process across launches, these globals survive every subsequent
+ * per-task launch, so exec / register_callable no longer re-push them.
+ *
+ * @param arg Pointer to an InitArgs payload
+ * @return 0 on success, non-zero on error
+ */
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_init(void *arg) {
     init_log_switch();
     if (arg == nullptr) {
-        LOG_ERROR("%s", "Invalid prewarm kernel arguments: null pointer");
+        LOG_ERROR("%s", "Invalid init kernel arguments: null pointer");
         return -1;
     }
 
-    KernelArgs *k_args = reinterpret_cast<KernelArgs *>(arg);
-    Runtime *runtime = k_args->runtime_args;
-    if (runtime == nullptr) {
-        LOG_ERROR("%s", "Invalid prewarm runtime_args: null pointer");
+    InitArgs *init_args = reinterpret_cast<InitArgs *>(arg);
+    set_log_level(static_cast<int>(init_args->log_level));
+    set_log_info_v(static_cast<int>(init_args->log_info_v));
+    set_orch_device_id(static_cast<int>(init_args->device_id));
+
+    LOG_INFO_V0("%s", "simpler_aicpu_init: per-device invariants latched");
+    return 0;
+}
+
+extern "C" __attribute__((visibility("default"))) int simpler_aicpu_register_callable(void *arg) {
+    if (arg == nullptr) {
+        LOG_ERROR("%s", "Invalid register_callable kernel arguments: null pointer");
         return -1;
     }
 
-    set_log_level(static_cast<int>(k_args->log_level));
-    set_log_info_v(static_cast<int>(k_args->log_info_v));
-    set_orch_device_id(static_cast<int>(k_args->device_id));
+    RegisterCallableArgs *reg_args = reinterpret_cast<RegisterCallableArgs *>(arg);
 
-    LOG_INFO_V0("%s", "simpler_aicpu_prewarm_callable: prewarming callable");
-    int rc = aicpu_prewarm_callable(runtime);
+    LOG_INFO_V0("%s", "simpler_aicpu_register_callable: registering callable");
+    int rc = aicpu_register_callable(reg_args);
     if (rc != 0) {
-        LOG_ERROR("simpler_aicpu_prewarm_callable: prewarm failed with rc=%d", rc);
+        LOG_ERROR("simpler_aicpu_register_callable: registration failed with rc=%d", rc);
         return rc;
     }
-    LOG_INFO_V0("%s", "simpler_aicpu_prewarm_callable: prewarm completed");
+    LOG_INFO_V0("%s", "simpler_aicpu_register_callable: registration completed");
     return 0;
 }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -105,7 +105,7 @@ int DeviceRunner::ensure_binaries_loaded() {
         };
 
         if (!load_sym("aicpu_execute", reinterpret_cast<void **>(&aicpu_execute_func_))) return -1;
-        load_optional_sym("aicpu_prewarm_callable", reinterpret_cast<void **>(&aicpu_prewarm_func_));
+        load_optional_sym("aicpu_register_callable", reinterpret_cast<void **>(&aicpu_register_callable_func_));
         if (!load_sym("set_platform_regs", reinterpret_cast<void **>(&set_platform_regs_func_))) return -1;
         load_optional_sym("set_orch_device_id", reinterpret_cast<void **>(&set_orch_device_id_func_));
         if (!load_sym("set_platform_dump_base", reinterpret_cast<void **>(&set_platform_dump_base_func_))) return -1;
@@ -179,13 +179,27 @@ int DeviceRunner::ensure_binaries_loaded() {
     return 0;
 }
 
-int DeviceRunner::invoke_aicpu_prewarm(Runtime &runtime) {
-    if (aicpu_prewarm_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
-        LOG_ERROR("Prewarm functions not loaded. Call ensure_binaries_loaded first.");
+int DeviceRunner::invoke_aicpu_register_callable(Runtime &runtime) {
+    if (aicpu_register_callable_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
+        LOG_ERROR("Register-callable functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
     set_orch_device_id_func_(device_id_);
-    return aicpu_prewarm_func_(&runtime);
+    // Extract the orch-SO descriptor from the stamped Runtime into the small
+    // RegisterCallableArgs the renamed entry expects (sim shares process
+    // memory, so the name pointers stay valid for the synchronous call).
+    RegisterCallableArgs reg_args{};
+    reg_args.active_callable_id = runtime.get_active_callable_id();
+    reg_args.register_new = runtime.register_new_callable_id() ? 1 : 0;
+    reg_args.dev_orch_so_addr = runtime.get_dev_orch_so_addr();
+    reg_args.dev_orch_so_size = runtime.get_dev_orch_so_size();
+    const char *func_name = runtime.get_device_orch_func_name();
+    const char *config_name = runtime.get_device_orch_config_name();
+    snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", func_name ? func_name : "");
+    snprintf(
+        reg_args.device_orch_config_name, sizeof(reg_args.device_orch_config_name), "%s", config_name ? config_name : ""
+    );
+    return aicpu_register_callable_func_(&reg_args);
 }
 
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
@@ -572,7 +586,7 @@ void DeviceRunner::unload_executor_binaries() {
         dlclose(aicpu_so_handle_);
         aicpu_so_handle_ = nullptr;
         aicpu_execute_func_ = nullptr;
-        aicpu_prewarm_func_ = nullptr;
+        aicpu_register_callable_func_ = nullptr;
         set_platform_regs_func_ = nullptr;
         set_orch_device_id_func_ = nullptr;
         set_platform_dump_base_func_ = nullptr;

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -40,7 +40,7 @@ public:
 
 private:
     int ensure_binaries_loaded() override;
-    int invoke_aicpu_prewarm(Runtime &runtime) override;
+    int invoke_aicpu_register_callable(Runtime &runtime) override;
     void unload_executor_binaries();
 
     int init_l2_swimlane(int num_aicore, int aicpu_thread_num, int device_id);
@@ -57,7 +57,7 @@ private:
     // a5 sim's dlsym'd function-pointer table. Loaded once via
     // ensure_binaries_loaded(), nulled on unload_executor_binaries().
     int (*aicpu_execute_func_)(Runtime *){nullptr};
-    int (*aicpu_prewarm_func_)(Runtime *){nullptr};
+    int (*aicpu_register_callable_func_)(const RegisterCallableArgs *){nullptr};
     void (*aicore_execute_func_)(Runtime *, int, CoreType, uint32_t, uint64_t, uint32_t, uint64_t, uint64_t){nullptr};
     void (*set_platform_regs_func_)(uint64_t){nullptr};
     void (*set_orch_device_id_func_)(int){nullptr};

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -22,6 +22,7 @@
 #include "aicpu/tensor_dump_aicpu.h"
 #include "aicpu/platform_regs.h"
 #include "callable.h"
+#include "common/kernel_args.h"
 #include "common/memory_barrier.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
@@ -1302,10 +1303,10 @@ void AicpuExecutor::diagnose_stuck_state(
 
 // ===== Public Entry Point =====
 
-extern "C" int aicpu_prewarm_callable(Runtime *runtime) {
+extern "C" int aicpu_register_callable(const RegisterCallableArgs *args) {
     // host_build_graph resolves orchestration on the host during prepare.
-    // There is no AICPU orch_so_table_ state to prewarm.
-    (void)runtime;
+    // There is no AICPU orch_so_table_ state to register.
+    (void)args;
     return 0;
 }
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -510,6 +510,11 @@ public:
         dev_orch_so_addr_ = dev_addr;
         dev_orch_so_size_ = size;
     }
+    // hbg resolves orchestration on the host, so these stay zero; the getters
+    // exist only so the shared sim register-callable path compiles against this
+    // variant (it reads the descriptor but the AICPU entry is a no-op here).
+    uint64_t get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
+    uint64_t get_dev_orch_so_size() const { return dev_orch_so_size_; }
     void set_active_callable_id(int32_t callable_id, bool is_new) {
         active_callable_id_ = callable_id;
         register_new_callable_id_ = is_new;

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -27,6 +27,7 @@
 #include "aicpu/orch_so_file.h"
 #include "aicpu/platform_aicpu_affinity.h"
 #include "callable_protocol.h"
+#include "common/kernel_args.h"
 #include "pto2_dispatch_payload.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -151,6 +152,13 @@ struct AicpuExecutor {
 
     // ===== Methods =====
     int32_t init(Runtime *runtime);
+    // Core orch-SO (re)load, driven by the extracted descriptor values. Both
+    // the run-path Runtime* wrapper and the register_callable entry delegate
+    // here so neither has to know the other's argument source.
+    int32_t ensure_orch_so_loaded_core(
+        int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
+        const char *entry_symbol, const char *config_symbol, int32_t thread_idx
+    );
     int32_t ensure_orch_so_loaded(Runtime *runtime, int32_t thread_idx);
     int32_t run(Runtime *runtime);
     void deinit(Runtime *runtime);
@@ -169,6 +177,14 @@ struct AicpuExecutor {
 };
 
 static AicpuExecutor g_aicpu_executor;
+
+// The register_callable payload mirrors the runtime's orch symbol-name
+// capacity; keep the two in lockstep so a name that fits in Runtime also fits
+// in RegisterCallableArgs.
+static_assert(
+    INIT_ARGS_MAX_ORCH_SYMBOL_NAME == RUNTIME_MAX_ORCH_SYMBOL_NAME,
+    "RegisterCallableArgs orch-symbol capacity must match RUNTIME_MAX_ORCH_SYMBOL_NAME"
+);
 
 // ===== AicpuExecutor Method Implementations =====
 
@@ -218,15 +234,24 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
         LOG_ERROR("Thread %d: runtime is nullptr", thread_idx);
         return -1;
     }
+    return ensure_orch_so_loaded_core(
+        runtime->get_active_callable_id(), runtime->register_new_callable_id(), runtime->get_dev_orch_so_addr(),
+        runtime->get_dev_orch_so_size(), runtime->get_device_orch_func_name(), runtime->get_device_orch_config_name(),
+        thread_idx
+    );
+}
 
-    const int32_t callable_id = runtime->get_active_callable_id();
+int32_t AicpuExecutor::ensure_orch_so_loaded_core(
+    int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
+    const char *entry_symbol_in, const char *config_symbol_in, int32_t thread_idx
+) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR("Thread %d: invalid callable_id %d (limit=%d)", thread_idx, callable_id, MAX_REGISTERED_CALLABLE_IDS);
         return -1;
     }
 
     OrchSoEntry &entry = orch_so_table_[callable_id];
-    const bool reload_so = runtime->register_new_callable_id();
+    const bool reload_so = register_new;
     if (!reload_so) {
         LOG_INFO_V0(
             "Thread %d: Reusing cached orch SO handle=%p (callable_id=%d)", thread_idx, entry.handle, callable_id
@@ -252,8 +277,8 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
     }
     entry = OrchSoEntry{};
 
-    const void *so_data = reinterpret_cast<const void *>(runtime->get_dev_orch_so_addr());
-    size_t so_size = runtime->get_dev_orch_so_size();
+    const void *so_data = reinterpret_cast<const void *>(dev_orch_so_addr);
+    size_t so_size = dev_orch_so_size;
     if (so_data == nullptr || so_size == 0) {
         LOG_ERROR("Thread %d: Device orchestration SO not set", thread_idx);
         return -1;
@@ -301,11 +326,11 @@ int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_id
 
     unlink(so_path);
 
-    const char *entry_symbol = runtime->get_device_orch_func_name();
+    const char *entry_symbol = entry_symbol_in;
     if (entry_symbol == nullptr || entry_symbol[0] == '\0') {
         entry_symbol = DEFAULT_ORCH_ENTRY_SYMBOL;
     }
-    const char *config_symbol = runtime->get_device_orch_config_name();
+    const char *config_symbol = config_symbol_in;
     if (config_symbol == nullptr || config_symbol[0] == '\0') {
         config_symbol = DEFAULT_ORCH_CONFIG_SYMBOL;
     }
@@ -817,18 +842,23 @@ void AicpuExecutor::deinit(Runtime *runtime) {
 
 // ===== Public Entry Point =====
 
-extern "C" int32_t aicpu_prewarm_callable(Runtime *runtime) {
-    if (runtime == nullptr) {
-        LOG_ERROR("%s", "aicpu_prewarm_callable: null Runtime pointer");
+extern "C" int32_t aicpu_register_callable(const RegisterCallableArgs *args) {
+    if (args == nullptr) {
+        LOG_ERROR("%s", "aicpu_register_callable: null RegisterCallableArgs pointer");
         return -1;
     }
-    int32_t rc = g_aicpu_executor.ensure_orch_so_loaded(runtime, /*thread_idx=*/0);
-    cache_invalidate_range(runtime, sizeof(Runtime));
+    // `args` is the launch-arg payload CANN copies into the AICPU arg space
+    // (same coherent channel exec reads KernelArgs fields from) — no HBM deref,
+    // so unlike the old prewarm path there is no Runtime to cache-invalidate.
+    int32_t rc = g_aicpu_executor.ensure_orch_so_loaded_core(
+        args->active_callable_id, args->register_new != 0, args->dev_orch_so_addr, args->dev_orch_so_size,
+        args->device_orch_func_name, args->device_orch_config_name, /*thread_idx=*/0
+    );
     if (rc != 0) {
-        LOG_ERROR("aicpu_prewarm_callable: SO load failed with rc=%d", rc);
+        LOG_ERROR("aicpu_register_callable: SO load failed with rc=%d", rc);
         return rc;
     }
-    LOG_INFO_V0("aicpu_prewarm_callable: completed for callable_id=%d", runtime->get_active_callable_id());
+    LOG_INFO_V0("aicpu_register_callable: completed for callable_id=%d", args->active_callable_id);
     return 0;
 }
 

--- a/src/common/aicpu_loader/host/load_aicpu_op.cpp
+++ b/src/common/aicpu_loader/host/load_aicpu_op.cpp
@@ -264,7 +264,8 @@ bool LoadAicpuOp::GenerateAicpuOpJson(const std::string &json_path, const std::s
     };
     std::vector<AicpuOpConfig> op_configs = {
         make_cfg(KernelNames::RunName),
-        make_cfg(KernelNames::PrewarmName),
+        make_cfg(KernelNames::InitName),
+        make_cfg(KernelNames::RegisterCallableName),
     };
     json_file << "{\n";
     for (size_t i = 0; i < op_configs.size(); ++i) {
@@ -349,7 +350,7 @@ int LoadAicpuOp::Init() {
     }
     LOG_INFO_V2("LoadAicpuOp: Loaded inner SO via JSON, handle=%p", binary_handle_);
 
-    const char *symbol_names[] = {KernelNames::RunName, KernelNames::PrewarmName};
+    const char *symbol_names[] = {KernelNames::RunName, KernelNames::InitName, KernelNames::RegisterCallableName};
     for (const char *name : symbol_names) {
         std::string lookup_name = MakeUniqueOpType(name, inner_fp_);
         rtFuncHandle func_handle = nullptr;
@@ -370,10 +371,16 @@ int LoadAicpuOp::Init() {
     return 0;
 }
 
-int LoadAicpuOp::AicpuKernelLaunch(rtFuncHandle func_handle, rtStream_t stream, KernelArgs *k_args, int aicpu_num) {
+int LoadAicpuOp::AicpuKernelLaunch(
+    rtFuncHandle func_handle, rtStream_t stream, void *args, size_t args_size, int aicpu_num
+) {
+    if (args == nullptr || args_size == 0) {
+        LOG_ERROR("AicpuKernelLaunch: invalid arguments (args is null or args_size is 0)");
+        return -1;
+    }
     rtCpuKernelArgs_t cpu_args = {};
-    cpu_args.baseArgs.args = k_args;
-    cpu_args.baseArgs.argsSize = sizeof(KernelArgs);
+    cpu_args.baseArgs.args = args;
+    cpu_args.baseArgs.argsSize = args_size;
 
     rtKernelLaunchCfg_t kernelLaunchCfg = {nullptr, 0U};
     auto launchKernelAttr = std::make_unique<rtLaunchKernelAttr_t>();
@@ -388,13 +395,15 @@ int LoadAicpuOp::AicpuKernelLaunch(rtFuncHandle func_handle, rtStream_t stream, 
     return 0;
 }
 
-int LoadAicpuOp::LaunchBuiltInOp(rtStream_t stream, KernelArgs *k_args, int aicpu_num, const std::string &func_name) {
+int LoadAicpuOp::LaunchBuiltInOp(
+    rtStream_t stream, void *args, size_t args_size, int aicpu_num, const std::string &func_name
+) {
     auto it = func_handles_.find(func_name);
     if (it == func_handles_.end()) {
         LOG_ERROR("Function not found: %s", func_name.c_str());
         return -1;
     }
-    return AicpuKernelLaunch(it->second, stream, k_args, aicpu_num);
+    return AicpuKernelLaunch(it->second, stream, args, args_size, aicpu_num);
 }
 
 }  // namespace host

--- a/src/common/aicpu_loader/host/load_aicpu_op.h
+++ b/src/common/aicpu_loader/host/load_aicpu_op.h
@@ -27,8 +27,9 @@
  *   2. Init (per-DeviceRunner): JSON-registers the runtime SO via
  *      `rtsBinaryLoadFromFile` (cpuKernelMode=0, kernelSo points at the
  *      preinstall basename), then resolves runtime SO entry points such as
- *      `simpler_aicpu_exec` and `simpler_aicpu_prewarm_callable` to
- *      `rtFuncHandle`s via `rtsFuncGetByName`. JSON is per-process
+ *      `simpler_aicpu_exec`, `simpler_aicpu_init`, and
+ *      `simpler_aicpu_register_callable` to `rtFuncHandle`s via
+ *      `rtsFuncGetByName`. JSON is per-process
  *      (`/tmp/simpler_inner_<fp>_<pid>.json`) so concurrent multi-chip /
  *      multi-worker tests don't race on a shared file.
  *
@@ -115,12 +116,14 @@ public:
      * @brief Launch a runtime SO entry point via rtsLaunchCpuKernel.
      *
      * @param stream       RTS stream
-     * @param k_args       Front-less KernelArgs payload (runtime_args @ 0)
+     * @param args         Launch-arg payload (KernelArgs for exec, InitArgs for
+     *                     init, RegisterCallableArgs for register_callable)
+     * @param args_size    Size of the payload in bytes
      * @param aicpu_num    Number of AICPU threads
-     * @param func_name    Lookup key in func_handles_ (KernelNames::RunName)
+     * @param func_name    Lookup key in func_handles_ (KernelNames::*)
      * @return 0 on success, error code on failure
      */
-    int LaunchBuiltInOp(rtStream_t stream, KernelArgs *k_args, int aicpu_num, const std::string &func_name);
+    int LaunchBuiltInOp(rtStream_t stream, void *args, size_t args_size, int aicpu_num, const std::string &func_name);
 
 private:
     void *binary_handle_ = nullptr;
@@ -131,14 +134,15 @@ private:
     std::string inner_so_basename_;
 
     bool GenerateAicpuOpJson(const std::string &json_path, const std::string &kernel_so);
-    int AicpuKernelLaunch(rtFuncHandle func_handle, rtStream_t stream, KernelArgs *k_args, int aicpu_num);
+    int AicpuKernelLaunch(rtFuncHandle func_handle, rtStream_t stream, void *args, size_t args_size, int aicpu_num);
 };
 
 // Runtime SO's actual exported symbol name. Looked up via the runtime SO's
 // own JSON registration (no dispatcher hop at runtime).
 namespace KernelNames {
-constexpr const char *RunName = "simpler_aicpu_exec";  // multi-threaded exec
-constexpr const char *PrewarmName = "simpler_aicpu_prewarm_callable";
+constexpr const char *RunName = "simpler_aicpu_exec";   // multi-threaded exec
+constexpr const char *InitName = "simpler_aicpu_init";  // per-device one-shot invariants
+constexpr const char *RegisterCallableName = "simpler_aicpu_register_callable";
 }  // namespace KernelNames
 
 }  // namespace host

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -347,7 +347,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
 
         // hbg's prepare_callable_impl populates host_dlopen_handle; trb's
         // leaves it null and fills orch_so_data + func_name/config_name.
-        bool needs_aicpu_prewarm = false;
+        bool needs_aicpu_register = false;
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->register_callable_host_orch(
                 callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
@@ -361,10 +361,10 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
                 artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc != 0) return rc;
-            needs_aicpu_prewarm = true;
+            needs_aicpu_register = true;
         }
-        if (needs_aicpu_prewarm) {
-            rc = runner->prewarm_callable(callable_id);
+        if (needs_aicpu_register) {
+            rc = runner->aicpu_register_callable(callable_id);
             if (rc != 0) {
                 runner->unregister_callable(callable_id);
                 return rc;

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -349,7 +349,43 @@ int DeviceRunnerBase::ensure_device_initialized() {
         LOG_INFO_V0("DeviceRunner: device=%d set, streams created", device_id_);
     }
 
-    return ensure_binaries_loaded();
+    rc = ensure_binaries_loaded();
+    if (rc != 0) return rc;
+
+    return ensure_aicpu_init_launched();
+}
+
+int DeviceRunnerBase::ensure_aicpu_init_launched() {
+    // Per-device one-shot: latch the invariants (orch device id, log config)
+    // into the resident AICPU SO globals via simpler_aicpu_init, so exec /
+    // register_callable launches no longer carry them. The inner SO stays
+    // dlopen'd across launches, so a single init holds for the runner's life.
+    if (aicpu_init_launched_) {
+        return 0;
+    }
+
+    InitArgs init_args{};
+    init_args.device_id = static_cast<uint32_t>(device_id_);
+    init_args.log_level = static_cast<uint32_t>(HostLogger::get_instance().level());
+    init_args.log_info_v = static_cast<uint32_t>(HostLogger::get_instance().info_v());
+
+    LOG_INFO_V0("=== launch_aicpu_payload %s ===", host::KernelNames::InitName);
+    int rc = launch_aicpu_payload(
+        stream_aicpu_, &init_args, sizeof(init_args), host::KernelNames::InitName, /*aicpu_num=*/1
+    );
+    if (rc != 0) {
+        LOG_ERROR("ensure_aicpu_init_launched: launch_aicpu_payload failed: %d", rc);
+        return rc;
+    }
+
+    rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
+    if (rc != 0) {
+        LOG_ERROR("ensure_aicpu_init_launched: stream sync failed: %d (device_id=%d)", rc, device_id_);
+        return rc;
+    }
+
+    aicpu_init_launched_ = true;
+    return 0;
 }
 
 int DeviceRunnerBase::ensure_binaries_loaded() {
@@ -594,10 +630,10 @@ int DeviceRunnerBase::commit_aicpu_callable_load(int32_t cid) {
     return 0;
 }
 
-int DeviceRunnerBase::prewarm_callable(int32_t callable_id) {
+int DeviceRunnerBase::aicpu_register_callable(int32_t callable_id) {
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
-        LOG_ERROR("prewarm_callable: callable_id=%d not registered", callable_id);
+        LOG_ERROR("aicpu_register_callable: callable_id=%d not registered", callable_id);
         return -1;
     }
     if (it->second.host_dlopen_handle != nullptr) {
@@ -606,37 +642,43 @@ int DeviceRunnerBase::prewarm_callable(int32_t callable_id) {
 
     int rc = ensure_device_initialized();
     if (rc != 0) {
-        LOG_ERROR("prewarm_callable: ensure_device_initialized failed: %d", rc);
+        LOG_ERROR("aicpu_register_callable: ensure_device_initialized failed: %d", rc);
         return rc;
     }
 
-    Runtime runtime;
-    rc = stamp_orch_so(runtime, callable_id, /*force_reload=*/true);
-    if (rc != 0) return rc;
+    // Build the orch-SO descriptor straight from CallableState — no full
+    // Runtime H2D as the old prewarm path did. This is the registration
+    // launch, so the AICPU always (re)dlopens the SO (register_new = 1).
+    const CallableState &state = it->second;
+    RegisterCallableArgs reg_args{};
+    reg_args.active_callable_id = callable_id;
+    reg_args.register_new = 1;
+    reg_args.dev_orch_so_addr = state.dev_orch_so_addr;
+    reg_args.dev_orch_so_size = state.dev_orch_so_size;
+    snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", state.func_name.c_str());
+    snprintf(
+        reg_args.device_orch_config_name, sizeof(reg_args.device_orch_config_name), "%s", state.config_name.c_str()
+    );
 
-    rc = init_runtime_args_with_metadata(runtime);
-    if (rc != 0) return rc;
-    auto runtime_args_cleanup = RAIIScopeGuard([this]() {
-        kernel_args_.finalize_runtime_args();
-    });
-
-    LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::PrewarmName);
-    rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::PrewarmName, /*aicpu_num=*/1);
+    LOG_INFO_V0("=== launch_aicpu_payload %s ===", host::KernelNames::RegisterCallableName);
+    rc = launch_aicpu_payload(
+        stream_aicpu_, &reg_args, sizeof(reg_args), host::KernelNames::RegisterCallableName, /*aicpu_num=*/1
+    );
     if (rc != 0) {
-        LOG_ERROR("prewarm_callable: launch_aicpu_kernel failed: %d", rc);
+        LOG_ERROR("aicpu_register_callable: launch_aicpu_payload failed: %d", rc);
         return rc;
     }
 
     rc = aclrtSynchronizeStreamWithTimeout(stream_aicpu_, PLATFORM_STREAM_SYNC_TIMEOUT_MS);
     if (rc == ACL_ERROR_RT_STREAM_SYNC_TIMEOUT) {
         LOG_ERROR(
-            "prewarm_callable: stream sync timeout timeout_ms=%d device_id=%d", PLATFORM_STREAM_SYNC_TIMEOUT_MS,
+            "aicpu_register_callable: stream sync timeout timeout_ms=%d device_id=%d", PLATFORM_STREAM_SYNC_TIMEOUT_MS,
             device_id_
         );
         return rc;
     }
     if (rc != 0) {
-        LOG_ERROR("prewarm_callable: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
+        LOG_ERROR("aicpu_register_callable: aclrtSynchronizeStreamWithTimeout failed: %d", rc);
         return rc;
     }
 
@@ -815,7 +857,13 @@ int DeviceRunnerBase::launch_aicpu_kernel(
     // exported symbol (simpler_aicpu_exec). LaunchBuiltInOp dispatches via
     // rtsLaunchCpuKernel on the cached rtFuncHandle resolved by
     // LoadAicpuOp::Init at first-time bootstrap.
-    return load_aicpu_op_.LaunchBuiltInOp(stream, k_args, aicpu_num, kernel_name);
+    return load_aicpu_op_.LaunchBuiltInOp(stream, k_args, sizeof(KernelArgs), aicpu_num, kernel_name);
+}
+
+int DeviceRunnerBase::launch_aicpu_payload(
+    rtStream_t stream, void *args, size_t args_size, const char *kernel_name, int aicpu_num
+) {
+    return load_aicpu_op_.LaunchBuiltInOp(stream, args, args_size, aicpu_num, kernel_name);
 }
 
 int DeviceRunnerBase::finalize_common() {
@@ -864,6 +912,10 @@ int DeviceRunnerBase::finalize_common() {
     // releases its device-side state when the device context tears down.
     aicore_bin_handle_ = nullptr;
     binaries_loaded_ = false;
+    // The inner AICPU SO is unloaded with the binaries above, so its latched
+    // globals are gone too — clear the one-shot guard so a reused runner
+    // re-launches simpler_aicpu_init after the next ensure_binaries_loaded().
+    aicpu_init_launched_ = false;
 
     // Release any chip callable buffers uploaded via upload_chip_callable_buffer.
     // Pool semantics mirror per-fid binaries: never freed until finalize.
@@ -1167,14 +1219,9 @@ int DeviceRunnerBase::init_runtime_args_with_metadata(Runtime &runtime) {
         LOG_ERROR("init_runtime_args failed: %d", rc);
         return rc;
     }
-    // Publish log config to AICPU via KernelArgs (severity floor + INFO verbosity).
-    // HostLogger is the single source of truth for log config (seeded by
-    // libsimpler_log.so via simpler_log_init before host_runtime.so was even
-    // dlopen'd). Read it directly when populating KernelArgs.
-    kernel_args_.args.log_level = static_cast<uint32_t>(HostLogger::get_instance().level());
-    kernel_args_.args.log_info_v = static_cast<uint32_t>(HostLogger::get_instance().info_v());
-    // Device ordinal for the AICPU executor's per-device orchestration-SO name.
-    kernel_args_.args.device_id = static_cast<uint32_t>(device_id_);
+    // Log config and device ordinal are no longer published per-run on
+    // KernelArgs — they were latched once into the AICPU SO globals by
+    // simpler_aicpu_init (ensure_aicpu_init_launched) at device init.
     return 0;
 }
 

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -347,12 +347,14 @@ public:
     size_t host_dlopen_count() const { return host_dlopen_total_; }
 
     /**
-     * Device-orchestration callable prewarm used internally by
-     * prepare_callable(). Host-orchestration callables are a no-op.
-     * On success, AICPU has populated orch_so_table_[callable_id] and
-     * first run can advertise register_new_callable_id_=false.
+     * Device-orchestration callable registration used internally by
+     * prepare_callable(): launches `simpler_aicpu_register_callable` with a
+     * RegisterCallableArgs descriptor so the AICPU (re)dlopens the callable's
+     * orch SO. Host-orchestration callables are a no-op. On success, AICPU has
+     * populated orch_so_table_[callable_id] and first run can advertise
+     * register_new_callable_id_=false.
      */
-    int prewarm_callable(int32_t callable_id);
+    int aicpu_register_callable(int32_t callable_id);
 
     /**
      * Commit host-side AICPU seen/counting state after a device-side SO load
@@ -409,6 +411,20 @@ public:
      * @return 0 on success, error code on failure
      */
     int launch_aicpu_kernel(rtStream_t stream, KernelArgs *k_args, const char *kernel_name, int aicpu_num);
+
+    /**
+     * Launch an AICPU entry with an arbitrary launch-arg payload. Used by the
+     * non-exec entries whose payload is not KernelArgs: `simpler_aicpu_init`
+     * (InitArgs) and `simpler_aicpu_register_callable` (RegisterCallableArgs).
+     *
+     * @param stream       AICPU stream
+     * @param args         Payload pointer (host memory; CANN copies it in)
+     * @param args_size    Payload size in bytes
+     * @param kernel_name  Name of the kernel to launch
+     * @param aicpu_num    Number of AICPU instances to launch
+     * @return 0 on success, error code on failure
+     */
+    int launch_aicpu_payload(rtStream_t stream, void *args, size_t args_size, const char *kernel_name, int aicpu_num);
 
     /**
      * Launch an AICore kernel. Lazy-registers the kernel binary
@@ -492,6 +508,16 @@ protected:
      * @return 0 on success, error code on failure.
      */
     int ensure_binaries_loaded();
+
+    /**
+     * Per-device one-shot launch of `simpler_aicpu_init`, latching the
+     * invariants (orch device id, log config) into the resident AICPU SO
+     * globals. Idempotent via `aicpu_init_launched_`; called from
+     * `ensure_device_initialized()` after the binaries are loaded.
+     *
+     * @return 0 on success, error code on failure.
+     */
+    int ensure_aicpu_init_launched();
 
     /**
      * Query the maximum block_dim the stream can host.
@@ -802,6 +828,8 @@ protected:
 
     // True after AICPU SO loaded; reset by the subclass's `finalize()`.
     bool binaries_loaded_{false};
+    // Per-device one-shot guard for the simpler_aicpu_init launch.
+    bool aicpu_init_launched_{false};
 
     // Shared diagnostics collectors. Each subclass initializes its own
     // (a2a3 wraps `halHostRegister`/`Unregister` callbacks, a5 uses

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -305,7 +305,7 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
             kernel_addrs.emplace_back(c.func_id, c.device_addr);
         }
 
-        bool needs_aicpu_prewarm = false;
+        bool needs_aicpu_register = false;
         if (artifacts.host_dlopen_handle != nullptr) {
             rc = runner->register_callable_host_orch(
                 callable_id, artifacts.host_dlopen_handle, artifacts.host_orch_func_ptr, std::move(kernel_addrs),
@@ -320,11 +320,11 @@ int prepare_callable(DeviceContextHandle ctx, int32_t callable_id, const void *c
                 artifacts.config_name.c_str(), std::move(kernel_addrs), std::move(artifacts.signature)
             );
             if (rc == 0) {
-                needs_aicpu_prewarm = true;
+                needs_aicpu_register = true;
             }
         }
-        if (rc == 0 && needs_aicpu_prewarm) {
-            rc = runner->prewarm_callable(callable_id);
+        if (rc == 0 && needs_aicpu_register) {
+            rc = runner->aicpu_register_callable(callable_id);
             if (rc != 0) {
                 runner->unregister_callable(callable_id);
             }

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -309,10 +309,10 @@ int SimDeviceRunnerBase::commit_aicpu_callable_load(int32_t cid) {
     return 0;
 }
 
-int SimDeviceRunnerBase::prewarm_callable(int32_t callable_id) {
+int SimDeviceRunnerBase::aicpu_register_callable(int32_t callable_id) {
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
-        LOG_ERROR("prewarm_callable: callable_id=%d not registered", callable_id);
+        LOG_ERROR("aicpu_register_callable: callable_id=%d not registered", callable_id);
         return -1;
     }
     if (it->second.host_dlopen_handle != nullptr) {
@@ -321,7 +321,7 @@ int SimDeviceRunnerBase::prewarm_callable(int32_t callable_id) {
 
     int rc = ensure_device_initialized();
     if (rc != 0) {
-        LOG_ERROR("prewarm_callable: ensure_device_initialized failed: %d", rc);
+        LOG_ERROR("aicpu_register_callable: ensure_device_initialized failed: %d", rc);
         return rc;
     }
 
@@ -329,9 +329,9 @@ int SimDeviceRunnerBase::prewarm_callable(int32_t callable_id) {
     rc = stamp_orch_so(runtime, callable_id, /*force_reload=*/true);
     if (rc != 0) return rc;
 
-    rc = invoke_aicpu_prewarm(runtime);
+    rc = invoke_aicpu_register_callable(runtime);
     if (rc != 0) {
-        LOG_ERROR("prewarm_callable: invoke_aicpu_prewarm failed: %d", rc);
+        LOG_ERROR("aicpu_register_callable: invoke_aicpu_register_callable failed: %d", rc);
         return rc;
     }
 

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -102,7 +102,7 @@ public:
     bool has_callable(int32_t callable_id) const;
     BindCallableResult bind_callable_to_runtime(Runtime &runtime, int32_t callable_id);
     uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
-    int prewarm_callable(int32_t callable_id);
+    int aicpu_register_callable(int32_t callable_id);
     int commit_aicpu_callable_load(int32_t callable_id);
 
     void print_handshake_results();
@@ -149,7 +149,7 @@ protected:
     // --- Helpers usable by subclass run() / finalize() -------------------
     int ensure_device_initialized();
     virtual int ensure_binaries_loaded() = 0;
-    virtual int invoke_aicpu_prewarm(Runtime &runtime) = 0;
+    virtual int invoke_aicpu_register_callable(Runtime &runtime) = 0;
     int prepare_orch_so(Runtime &runtime);
     int stamp_orch_so(Runtime &runtime, int32_t callable_id, bool force_reload);
 

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
@@ -31,7 +31,7 @@ public:
 
 private:
     int ensure_binaries_loaded() override { return 0; }
-    int invoke_aicpu_prewarm(Runtime &) override { return 0; }
+    int invoke_aicpu_register_callable(Runtime &) override { return 0; }
 };
 
 L3L2OrchCommResponse


### PR DESCRIPTION
## Summary

Per-device-fixed values rode on **every** per-task `KernelArgs` launch even
though they never change across runs. This lifts them into a single
worker-init-time AICPU entry and slims the callable-registration payload so it
no longer ships a full `Runtime`.

- **New `InitArgs` + `simpler_aicpu_init`** — `{ device_id, log_level, log_info_v }`
  launched once per device from `ensure_device_initialized()`. It latches these
  into the resident AICPU SO globals, so `exec` / `register_callable` no longer
  re-push them. The corresponding setters are removed from `simpler_aicpu_exec`
  and the fields dropped from `KernelArgs`. `regs` / `pmu_reg_addrs` / `ffts`
  stay per-run (a5 AICore still reads `regs` off the device `KernelArgs` copy).
- **`prewarm` → `register_callable` end to end** —
  `simpler_aicpu_prewarm_callable` → `simpler_aicpu_register_callable`,
  `aicpu_prewarm_callable` → `aicpu_register_callable`, host `prewarm_callable`
  → `aicpu_register_callable`, `KernelNames::PrewarmName` →
  `RegisterCallableName`, plus new `InitName`.
- **New `RegisterCallableArgs`** carrying only the orch-SO descriptor extracted
  from `Runtime` (callable id, dev SO addr/size, entry/config symbol names), so
  the register path no longer H2D's a full `Runtime`. `ensure_orch_so_loaded`
  is refactored into a core taking those values; the run-path `Runtime*`
  wrapper and the register entry both delegate to it.
- **Launch path generalized to `void* + size`** so the three entries
  (exec / init / register_callable) share one mechanism; all three symbols are
  registered in the inner-SO JSON.
- `hbg` variants are no-ops (host-side orchestration); the two missing
  `dev_orch_so` getters are added to `hbg` `Runtime` so the shared sim path
  compiles.

## Testing

- [x] a2a3 + a5 build clean (onboard + sim, both runtimes), incl. post-clang-format
- [x] Simulation tests pass (a2a3sim + a5sim; register-path and exec-path, both runtimes)
- [x] Hardware tests pass — full a2a3 onboard sweep via task-submit: HBG 10 passed/2 skipped, TMARB 33 passed/1 skipped