### PR TITLE
Refactor: make run consume-only; loading is solely a registration step

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -933,21 +933,12 @@ def _comm_base_handle(cw: ChipWorker) -> int:
     return int(handle)
 
 
-def _ensure_prepared(cw, registry, prepared, cid: int, *, lazy: bool, device_id: int) -> None:
+def _ensure_prepared(cw, registry, prepared, cid: int, *, device_id: int) -> None:
     if cid in prepared:
         return
     callable_obj = registry.get(cid)
     if callable_obj is None:
         raise RuntimeError(f"chip_process dev={device_id}: cid {cid} not in registry")
-    if lazy:
-        # Reaching the lazy branch means _CTRL_PREPARE prewarm did not run
-        # for this cid before the first TASK_READY; the child still does
-        # the work, but the resulting H2D + dlopen cost lands on the
-        # first task's latency.  Log so the gap is visible in stderr.
-        sys.stderr.write(
-            f"[chip_process pid={os.getpid()} dev={device_id}] WARN: lazy-prepare cid={cid}; prewarm path missed it\n"
-        )
-        sys.stderr.flush()
     cw._prepare_callable_at_slot(cid, callable_obj)
     prepared.add(cid)
 
@@ -975,10 +966,11 @@ def _run_chip_main_loop(  # noqa: PLR0912, PLR0913, PLR0915 -- unified TASK_READ
     Returning a non-zero code overrides the kernel's success.
 
     TASK_READY carries a callable digest. The child resolves it to a
-    target-local slot, prepares that slot once, then runs it. ``_CTRL_PREPARE``
-    is the explicit pre-warm path (parent pushes after init() to amortise the
-    first H2D upload); TASK_READY preserves the historical lazy-prepare safety
-    net when the digest mapping exists but prewarm was missed.
+    target-local slot and runs it. The slot must already be prepared via
+    ``_CTRL_PREPARE`` (the explicit registration path the parent pushes after
+    init() to stage the H2D upload + device-orch load); a TASK_READY for an
+    unprepared slot is a control-flow error and fails the task rather than
+    lazily preparing it.
     """
     prepared: set[int] = set()
     l3_l2_control_shms: list[SharedMemory] = []
@@ -995,7 +987,16 @@ def _run_chip_main_loop(  # noqa: PLR0912, PLR0913, PLR0915 -- unified TASK_READ
                 try:
                     if cid is None:
                         raise RuntimeError(f"callable hash {_format_digest(digest)} not registered")
-                    _ensure_prepared(cw, registry, prepared, cid, lazy=True, device_id=device_id)
+                    # Run only consumes a prepared slot — it never lazily
+                    # prepares. The callable must have been staged via
+                    # _CTRL_PREPARE first; reaching TASK_READY without it is a
+                    # control-flow bug, so fail loudly instead of masking the
+                    # missing-prepare with a first-task latency spike.
+                    if cid not in prepared:
+                        raise RuntimeError(
+                            f"chip_process dev={device_id}: cid {cid} not prepared before TASK_READY "
+                            f"(register via _CTRL_PREPARE first)"
+                        )
                     # Hand the mailbox bytes straight to C++ (zero-copy zero-decode):
                     # the blob layout is what `write_blob` already wrote, so re-parsing
                     # it in Python is N×40B of avoidable work and a permanent
@@ -1047,7 +1048,7 @@ def _run_chip_main_loop(  # noqa: PLR0912, PLR0913, PLR0915 -- unified TASK_READ
                             raise RuntimeError(
                                 f"prepare chip={device_id}: callable hash {_format_digest(digest)} not registered"
                             )
-                        _ensure_prepared(cw, registry, prepared, int(cid), lazy=False, device_id=device_id)
+                        _ensure_prepared(cw, registry, prepared, int(cid), device_id=device_id)
                     elif sub_cmd == _CTRL_REGISTER:
                         digest = _read_control_digest(buf)
                         payload_size = struct.unpack_from("Q", buf, _CTRL_OFF_ARG0)[0]

--- a/src/a2a3/platform/include/common/kernel_args.h
+++ b/src/a2a3/platform/include/common/kernel_args.h
@@ -158,7 +158,6 @@ struct InitArgs {
  */
 struct RegisterCallableArgs {
     int32_t active_callable_id{-1};                                  // orch_so_table_ slot
-    uint32_t register_new{0};                                        // 1 -> (re)dlopen, 0 -> reuse cached handle
     uint64_t dev_orch_so_addr{0};                                    // device address of the orch SO image
     uint64_t dev_orch_so_size{0};                                    // orch SO image size in bytes
     char device_orch_func_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME]{};    // entry symbol

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -189,7 +189,6 @@ int DeviceRunner::invoke_aicpu_register_callable(Runtime &runtime) {
     // memory, so the name pointers stay valid for the synchronous call).
     RegisterCallableArgs reg_args{};
     reg_args.active_callable_id = runtime.get_active_callable_id();
-    reg_args.register_new = runtime.register_new_callable_id() ? 1 : 0;
     reg_args.dev_orch_so_addr = runtime.get_dev_orch_so_addr();
     reg_args.dev_orch_so_size = runtime.get_dev_orch_so_size();
     const char *func_name = runtime.get_device_orch_func_name();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -150,14 +150,14 @@ struct AicpuExecutor {
 
     // ===== Methods =====
     int32_t init(Runtime *runtime);
-    // Core orch-SO (re)load, driven by the extracted descriptor values. Both
-    // the run-path Runtime* wrapper and the register_callable entry delegate
-    // here so neither has to know the other's argument source.
-    int32_t ensure_orch_so_loaded_core(
-        int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
-        const char *entry_symbol, const char *config_symbol, int32_t thread_idx
+    // (Re)load a callable's orchestration SO into orch_so_table_[callable_id].
+    // Register-only: the register_callable entry calls this to dlopen and
+    // populate the slot. The run path never loads — it consumes an already
+    // registered slot (see run()), so loading is solely a registration step.
+    int32_t load_orch_so(
+        int32_t callable_id, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size, const char *entry_symbol,
+        const char *config_symbol, int32_t thread_idx
     );
-    int32_t ensure_orch_so_loaded(Runtime *runtime, int32_t thread_idx);
     int32_t run(Runtime *runtime);
     void deinit(Runtime *runtime);
 
@@ -227,21 +227,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     return 0;
 }
 
-int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_idx) {
-    if (runtime == nullptr) {
-        LOG_ERROR("Thread %d: runtime is nullptr", thread_idx);
-        return -1;
-    }
-    return ensure_orch_so_loaded_core(
-        runtime->get_active_callable_id(), runtime->register_new_callable_id(), runtime->get_dev_orch_so_addr(),
-        runtime->get_dev_orch_so_size(), runtime->get_device_orch_func_name(), runtime->get_device_orch_config_name(),
-        thread_idx
-    );
-}
-
-int32_t AicpuExecutor::ensure_orch_so_loaded_core(
-    int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
-    const char *entry_symbol_in, const char *config_symbol_in, int32_t thread_idx
+int32_t AicpuExecutor::load_orch_so(
+    int32_t callable_id, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size, const char *entry_symbol_in,
+    const char *config_symbol_in, int32_t thread_idx
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR("Thread %d: invalid callable_id %d (limit=%d)", thread_idx, callable_id, MAX_REGISTERED_CALLABLE_IDS);
@@ -249,23 +237,13 @@ int32_t AicpuExecutor::ensure_orch_so_loaded_core(
     }
 
     OrchSoEntry &entry = orch_so_table_[callable_id];
-    const bool reload_so = register_new;
-    if (!reload_so) {
-        LOG_INFO_V0(
-            "Thread %d: Reusing cached orch SO handle=%p (callable_id=%d)", thread_idx, entry.handle, callable_id
-        );
-        if (entry.handle == nullptr || entry.func == nullptr) {
-            LOG_ERROR(
-                "Thread %d: reload=false but no cached SO handle/func for callable_id=%d", thread_idx, callable_id
-            );
-            return -1;
-        }
-        return 0;  // cached: no dlopen, SoLoad stays unstamped (~0)
-    }
 
-    // First/changed callable: this is the real orch-SO dlopen — the SoLoad phase.
-    // RAII end-stamp so every return path below closes the phase.
-    AicpuPhaseScope so_load_phase(AicpuPhase::SoLoad);
+    // Registration always (re)loads: the slot may have been reused after an
+    // unregister, so dlclose any stale handle before dlopen'ing the new SO.
+    // No AicpuPhase::SoLoad stamp here: that phase times the dlopen within a
+    // run_prepared launch, but loading now happens in the separate
+    // register_callable launch which has no phase buffer (the run-path SoLoad
+    // slot is simply 0 now that run never loads).
     LOG_INFO_V0("Thread %d: New orch SO detected (callable_id=%d), (re)loading", thread_idx, callable_id);
     if (entry.handle != nullptr) {
         dlclose(entry.handle);
@@ -415,8 +393,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // scope the per-callable dlopen / SO-table locals to this block.
         {
             // Per-callable_id dispatch: the orch SO state lives in
-            // `orch_so_table_[callable_id]` keyed by registration order;
-            // reload is governed by `register_new_callable_id_`.
+            // `orch_so_table_[callable_id]`, loaded once by the
+            // register_callable entry. The run path only consumes it — it never
+            // loads. A missing handle means run was reached without a prior
+            // successful registration, which is a caller/scheduling bug.
             const int32_t callable_id = runtime->get_active_callable_id();
             if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
                 LOG_ERROR(
@@ -425,10 +405,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
             }
-            int32_t load_rc = ensure_orch_so_loaded(runtime, thread_idx);
-            if (load_rc != 0) {
+            if (orch_so_table_[callable_id].handle == nullptr || orch_so_table_[callable_id].func == nullptr) {
+                LOG_ERROR(
+                    "Thread %d: callable_id=%d not registered (no orch SO loaded); register before run", thread_idx,
+                    callable_id
+                );
                 runtime_init_ready_.store(true, std::memory_order_release);
-                return load_rc;
+                return -1;
             }
             // graph_build front-matter phases (orch thread only); the scheduler
             // threads spin-wait on runtime_init_ready_ across this whole region.
@@ -443,8 +426,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             {
                 AicpuPhaseScope config_validate(AicpuPhase::ConfigValidate);
                 OrchSoEntry &entry = orch_so_table_[callable_id];
-                void **p_handle = &entry.handle;
-                char *p_path = entry.path;
                 p_func = &entry.func;
                 p_bind = &entry.bind;
                 DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
@@ -453,7 +434,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // the orchestration entry (consumed at orch_args_cached_) use it.
                 orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
 
-                // Validate arg count on every run (reload or cache hit).
+                // Validate arg count on every run against the registered SO.
                 if (*p_config_func != nullptr) {
                     PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                     LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
@@ -465,20 +446,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                                 "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
                                 cfg.expected_arg_count
                             );
-                            // Clean up cached state so a subsequent run does a full reload.
-                            if (*p_handle != nullptr) {
-                                dlclose(*p_handle);
-                                *p_handle = nullptr;
-                            }
-                            if (p_path[0] != '\0') {
-                                unlink(p_path);
-                                p_path[0] = '\0';
-                            }
-                            *p_func = nullptr;
-                            *p_bind = nullptr;
-                            *p_config_func = nullptr;
-                            orch_so_table_[callable_id].in_use = false;
-                            // Unblock scheduler threads before returning so they don't spin forever.
+                            // The registered SO is fine — these run args are
+                            // incompatible with it. Run only consumes the slot
+                            // (no reload), so leave the table intact and just
+                            // fail this run; unblock scheduler threads first so
+                            // they don't spin forever.
                             runtime_init_ready_.store(true, std::memory_order_release);
                             return -1;
                         }
@@ -787,7 +759,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         finished_.store(true, std::memory_order_release);
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
-        // alive for the next run's cache-hit reuse (see run() reload_so branch).
+        // alive — they are loaded once by register_callable and consumed by
+        // every subsequent run.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
             const int32_t callable_id = runtime->get_active_callable_id();
@@ -824,9 +797,9 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     serial_orch_sched_ = false;
 
     orch_args_cached_.reset();
-    // orch_so_table_ entries are intentionally preserved across deinit: the
-    // next run reuses cached handles when register_new_callable_id() returns
-    // false. The destructor releases them at process teardown.
+    // orch_so_table_ entries are intentionally preserved across deinit: they
+    // are loaded once by register_callable and consumed by every subsequent
+    // run. The destructor releases them at process teardown.
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
@@ -855,9 +828,9 @@ extern "C" int32_t aicpu_register_callable(const RegisterCallableArgs *args) {
     // `args` is the launch-arg payload CANN copies into the AICPU arg space
     // (same coherent channel exec reads KernelArgs fields from) — no HBM deref,
     // so unlike the old prewarm path there is no Runtime to cache-invalidate.
-    int32_t rc = g_aicpu_executor.ensure_orch_so_loaded_core(
-        args->active_callable_id, args->register_new != 0, args->dev_orch_so_addr, args->dev_orch_so_size,
-        args->device_orch_func_name, args->device_orch_config_name, /*thread_idx=*/0
+    int32_t rc = g_aicpu_executor.load_orch_so(
+        args->active_callable_id, args->dev_orch_so_addr, args->dev_orch_so_size, args->device_orch_func_name,
+        args->device_orch_config_name, /*thread_idx=*/0
     );
     if (rc != 0) {
         LOG_ERROR("aicpu_register_callable: SO load failed with rc=%d", rc);

--- a/src/a5/platform/include/common/kernel_args.h
+++ b/src/a5/platform/include/common/kernel_args.h
@@ -140,7 +140,6 @@ struct InitArgs {
  */
 struct RegisterCallableArgs {
     int32_t active_callable_id{-1};                                  // orch_so_table_ slot
-    uint32_t register_new{0};                                        // 1 -> (re)dlopen, 0 -> reuse cached handle
     uint64_t dev_orch_so_addr{0};                                    // device address of the orch SO image
     uint64_t dev_orch_so_size{0};                                    // orch SO image size in bytes
     char device_orch_func_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME]{};    // entry symbol

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -190,7 +190,6 @@ int DeviceRunner::invoke_aicpu_register_callable(Runtime &runtime) {
     // memory, so the name pointers stay valid for the synchronous call).
     RegisterCallableArgs reg_args{};
     reg_args.active_callable_id = runtime.get_active_callable_id();
-    reg_args.register_new = runtime.register_new_callable_id() ? 1 : 0;
     reg_args.dev_orch_so_addr = runtime.get_dev_orch_so_addr();
     reg_args.dev_orch_so_size = runtime.get_dev_orch_so_size();
     const char *func_name = runtime.get_device_orch_func_name();

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -152,14 +152,14 @@ struct AicpuExecutor {
 
     // ===== Methods =====
     int32_t init(Runtime *runtime);
-    // Core orch-SO (re)load, driven by the extracted descriptor values. Both
-    // the run-path Runtime* wrapper and the register_callable entry delegate
-    // here so neither has to know the other's argument source.
-    int32_t ensure_orch_so_loaded_core(
-        int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
-        const char *entry_symbol, const char *config_symbol, int32_t thread_idx
+    // (Re)load a callable's orchestration SO into orch_so_table_[callable_id].
+    // Register-only: the register_callable entry calls this to dlopen and
+    // populate the slot. The run path never loads — it consumes an already
+    // registered slot (see run()), so loading is solely a registration step.
+    int32_t load_orch_so(
+        int32_t callable_id, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size, const char *entry_symbol,
+        const char *config_symbol, int32_t thread_idx
     );
-    int32_t ensure_orch_so_loaded(Runtime *runtime, int32_t thread_idx);
     int32_t run(Runtime *runtime);
     void deinit(Runtime *runtime);
 
@@ -229,21 +229,9 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     return 0;
 }
 
-int32_t AicpuExecutor::ensure_orch_so_loaded(Runtime *runtime, int32_t thread_idx) {
-    if (runtime == nullptr) {
-        LOG_ERROR("Thread %d: runtime is nullptr", thread_idx);
-        return -1;
-    }
-    return ensure_orch_so_loaded_core(
-        runtime->get_active_callable_id(), runtime->register_new_callable_id(), runtime->get_dev_orch_so_addr(),
-        runtime->get_dev_orch_so_size(), runtime->get_device_orch_func_name(), runtime->get_device_orch_config_name(),
-        thread_idx
-    );
-}
-
-int32_t AicpuExecutor::ensure_orch_so_loaded_core(
-    int32_t callable_id, bool register_new, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size,
-    const char *entry_symbol_in, const char *config_symbol_in, int32_t thread_idx
+int32_t AicpuExecutor::load_orch_so(
+    int32_t callable_id, uint64_t dev_orch_so_addr, uint64_t dev_orch_so_size, const char *entry_symbol_in,
+    const char *config_symbol_in, int32_t thread_idx
 ) {
     if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
         LOG_ERROR("Thread %d: invalid callable_id %d (limit=%d)", thread_idx, callable_id, MAX_REGISTERED_CALLABLE_IDS);
@@ -251,23 +239,13 @@ int32_t AicpuExecutor::ensure_orch_so_loaded_core(
     }
 
     OrchSoEntry &entry = orch_so_table_[callable_id];
-    const bool reload_so = register_new;
-    if (!reload_so) {
-        LOG_INFO_V0(
-            "Thread %d: Reusing cached orch SO handle=%p (callable_id=%d)", thread_idx, entry.handle, callable_id
-        );
-        if (entry.handle == nullptr || entry.func == nullptr) {
-            LOG_ERROR(
-                "Thread %d: reload=false but no cached SO handle/func for callable_id=%d", thread_idx, callable_id
-            );
-            return -1;
-        }
-        return 0;  // cached: no dlopen, SoLoad stays unstamped (~0)
-    }
 
-    // First/changed callable: this is the real orch-SO dlopen — the SoLoad phase.
-    // RAII end-stamp so every return path below closes the phase.
-    AicpuPhaseScope so_load_phase(AicpuPhase::SoLoad);
+    // Registration always (re)loads: the slot may have been reused after an
+    // unregister, so dlclose any stale handle before dlopen'ing the new SO.
+    // No AicpuPhase::SoLoad stamp here: that phase times the dlopen within a
+    // run_prepared launch, but loading now happens in the separate
+    // register_callable launch which has no phase buffer (the run-path SoLoad
+    // slot is simply 0 now that run never loads).
     LOG_INFO_V0("Thread %d: New orch SO detected (callable_id=%d), (re)loading", thread_idx, callable_id);
     if (entry.handle != nullptr) {
         dlclose(entry.handle);
@@ -412,8 +390,10 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         // scope the per-callable dlopen / SO-table locals to this block.
         {
             // Per-callable_id dispatch: the orch SO state lives in
-            // `orch_so_table_[callable_id]` keyed by registration order;
-            // reload is governed by `register_new_callable_id_`.
+            // `orch_so_table_[callable_id]`, loaded once by the
+            // register_callable entry. The run path only consumes it — it never
+            // loads. A missing handle means run was reached without a prior
+            // successful registration, which is a caller/scheduling bug.
             const int32_t callable_id = runtime->get_active_callable_id();
             if (callable_id < 0 || callable_id >= MAX_REGISTERED_CALLABLE_IDS) {
                 LOG_ERROR(
@@ -422,10 +402,13 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 runtime_init_ready_.store(true, std::memory_order_release);
                 return -1;
             }
-            int32_t load_rc = ensure_orch_so_loaded(runtime, thread_idx);
-            if (load_rc != 0) {
+            if (orch_so_table_[callable_id].handle == nullptr || orch_so_table_[callable_id].func == nullptr) {
+                LOG_ERROR(
+                    "Thread %d: callable_id=%d not registered (no orch SO loaded); register before run", thread_idx,
+                    callable_id
+                );
                 runtime_init_ready_.store(true, std::memory_order_release);
-                return load_rc;
+                return -1;
             }
             // graph_build front-matter phases (orch thread only); the scheduler
             // threads spin-wait on runtime_init_ready_ across this whole region.
@@ -440,8 +423,6 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
             {
                 AicpuPhaseScope config_validate(AicpuPhase::ConfigValidate);
                 OrchSoEntry &entry = orch_so_table_[callable_id];
-                void **p_handle = &entry.handle;
-                char *p_path = entry.path;
                 p_func = &entry.func;
                 p_bind = &entry.bind;
                 DeviceOrchestrationConfigFunc *p_config_func = &entry.config_func;
@@ -450,7 +431,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                 // the orchestration entry (consumed at orch_args_cached_) use it.
                 orch_args_cached_.create_from_chip_args(runtime->get_orch_args());
 
-                // Validate arg count on every run (reload or cache hit).
+                // Validate arg count on every run against the registered SO.
                 if (*p_config_func != nullptr) {
                     PTO2OrchestrationConfig cfg = (*p_config_func)(orch_args_cached_);
                     LOG_INFO_V0("Thread %d: Config: expected_args=%d", thread_idx, cfg.expected_arg_count);
@@ -462,20 +443,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                                 "Thread %d: arg_count %d < expected %d", thread_idx, actual_arg_count,
                                 cfg.expected_arg_count
                             );
-                            // Clean up cached state so a subsequent run does a full reload.
-                            if (*p_handle != nullptr) {
-                                dlclose(*p_handle);
-                                *p_handle = nullptr;
-                            }
-                            if (p_path[0] != '\0') {
-                                unlink(p_path);
-                                p_path[0] = '\0';
-                            }
-                            *p_func = nullptr;
-                            *p_bind = nullptr;
-                            *p_config_func = nullptr;
-                            orch_so_table_[callable_id].in_use = false;
-                            // Unblock scheduler threads before returning so they don't spin forever.
+                            // The registered SO is fine — these run args are
+                            // incompatible with it. Run only consumes the slot
+                            // (no reload), so leave the table intact and just
+                            // fail this run; unblock scheduler threads first so
+                            // they don't spin forever.
                             runtime_init_ready_.store(true, std::memory_order_release);
                             return -1;
                         }
@@ -782,7 +754,8 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
         finished_.store(true, std::memory_order_release);
         // Destroy PTO2 runtime. sm_handle / rt are recreated every run so we
         // always tear them down here, but we keep the per-cid orch SO entries
-        // alive for the next run's cache-hit reuse (see run() reload_so branch).
+        // alive — they are loaded once by register_callable and consumed by
+        // every subsequent run.
         if (rt != nullptr) {
             // Clear g_current_runtime in this DSO and in the orchestration SO before destroying rt.
             const int32_t callable_id = runtime->get_active_callable_id();
@@ -819,9 +792,9 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     serial_orch_sched_ = false;
 
     orch_args_cached_.reset();
-    // orch_so_table_ entries are intentionally preserved across deinit: the
-    // next run reuses cached handles when register_new_callable_id() returns
-    // false. The destructor releases them at process teardown.
+    // orch_so_table_ entries are intentionally preserved across deinit: they
+    // are loaded once by register_callable and consumed by every subsequent
+    // run. The destructor releases them at process teardown.
 
     // Clear file-scope PTO2Runtime pointer (freed by orchestrator thread before deinit)
     rt = nullptr;
@@ -850,9 +823,9 @@ extern "C" int32_t aicpu_register_callable(const RegisterCallableArgs *args) {
     // `args` is the launch-arg payload CANN copies into the AICPU arg space
     // (same coherent channel exec reads KernelArgs fields from) — no HBM deref,
     // so unlike the old prewarm path there is no Runtime to cache-invalidate.
-    int32_t rc = g_aicpu_executor.ensure_orch_so_loaded_core(
-        args->active_callable_id, args->register_new != 0, args->dev_orch_so_addr, args->dev_orch_so_size,
-        args->device_orch_func_name, args->device_orch_config_name, /*thread_idx=*/0
+    int32_t rc = g_aicpu_executor.load_orch_so(
+        args->active_callable_id, args->dev_orch_so_addr, args->dev_orch_so_size, args->device_orch_func_name,
+        args->device_orch_config_name, /*thread_idx=*/0
     );
     if (rc != 0) {
         LOG_ERROR("aicpu_register_callable: SO load failed with rc=%d", rc);

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -647,12 +647,11 @@ int DeviceRunnerBase::aicpu_register_callable(int32_t callable_id) {
     }
 
     // Build the orch-SO descriptor straight from CallableState — no full
-    // Runtime H2D as the old prewarm path did. This is the registration
-    // launch, so the AICPU always (re)dlopens the SO (register_new = 1).
+    // Runtime H2D as the old prewarm path did. Registration always (re)dlopens
+    // the SO device-side, so there is no per-callable "new?" bit to carry.
     const CallableState &state = it->second;
     RegisterCallableArgs reg_args{};
     reg_args.active_callable_id = callable_id;
-    reg_args.register_new = 1;
     reg_args.dev_orch_so_addr = state.dev_orch_so_addr;
     reg_args.dev_orch_so_size = state.dev_orch_so_size;
     snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", state.func_name.c_str());

--- a/tests/ut/py/test_worker/test_ensure_prepared.py
+++ b/tests/ut/py/test_worker/test_ensure_prepared.py
@@ -8,11 +8,10 @@
 # -----------------------------------------------------------------------------------------------------------
 """Unit tests for the module-level ``_ensure_prepared`` helper.
 
-The two chip-child loops both rely on this helper to handle the
-``_CTRL_PREPARE`` prewarm path (``lazy=False``) and the ``_TASK_READY``
-safety-net path (``lazy=True``). The lazy branch is not reachable from a
-normal end-to-end run — it only fires when prewarm was skipped — so it
-must be exercised directly here.
+``_ensure_prepared`` is the ``_CTRL_PREPARE`` registration path: it stages a
+callable's slot exactly once. There is no lazy/run-time preparation — the run
+path (``_TASK_READY``) only consumes an already-prepared slot and raises if it
+is missing, so that behavior is covered by the chip-loop tests, not here.
 """
 
 from unittest.mock import MagicMock
@@ -22,30 +21,17 @@ from simpler.worker import _ensure_prepared
 
 
 class TestEnsurePrepared:
-    def test_lazy_warns_and_prepares(self, capsys):
-        cw = MagicMock()
-        callable_obj = object()
-        registry = {7: callable_obj}
-        prepared: set[int] = set()
-
-        _ensure_prepared(cw, registry, prepared, 7, lazy=True, device_id=3)
-
-        cw._prepare_callable_at_slot.assert_called_once_with(7, callable_obj)
-        assert prepared == {7}
-        err = capsys.readouterr().err
-        assert "WARN: lazy-prepare cid=7" in err
-        assert "dev=3" in err
-
-    def test_eager_does_not_warn(self, capsys):
+    def test_prepares_slot(self, capsys):
         cw = MagicMock()
         callable_obj = object()
         registry = {2: callable_obj}
         prepared: set[int] = set()
 
-        _ensure_prepared(cw, registry, prepared, 2, lazy=False, device_id=0)
+        _ensure_prepared(cw, registry, prepared, 2, device_id=0)
 
         cw._prepare_callable_at_slot.assert_called_once_with(2, callable_obj)
         assert prepared == {2}
+        # Preparation is a normal control-flow step now — no warning is emitted.
         assert capsys.readouterr().err == ""
 
     def test_already_prepared_short_circuits(self):
@@ -54,9 +40,9 @@ class TestEnsurePrepared:
         # slot preparation entirely.  Pass an empty registry to prove the
         # lookup never happens (otherwise registry.get would return None
         # and the helper would raise).
-        _ensure_prepared(cw, {}, {5}, 5, lazy=True, device_id=0)
+        _ensure_prepared(cw, {}, {5}, 5, device_id=0)
         cw._prepare_callable_at_slot.assert_not_called()
 
     def test_missing_cid_raises(self):
         with pytest.raises(RuntimeError, match="cid 9 not in registry"):
-            _ensure_prepared(MagicMock(), {}, set(), 9, lazy=False, device_id=0)
+            _ensure_prepared(MagicMock(), {}, set(), 9, device_id=0)


### PR DESCRIPTION
## Summary

Tightens the prepared-callable contract: a callable's orchestration SO is
loaded **exactly once at registration**, and `run()` only **consumes** the
already-loaded slot. This removes the lazy/run-time load fallback, so a run on
an unregistered callable fails loudly instead of silently `dlopen`'ing on the
first task's latency path.

Builds on #1201 (the register_callable / `simpler_aicpu_init` split).

## Changes

**Device (TMARB a2a3 + a5)**
- Replace `ensure_orch_so_loaded(Runtime*)` + its shared core with a
  register-only `load_orch_so()` that always (re)`dlopen`s — slot reuse after
  an unregister still needs the `dlclose`+`dlopen`. The run path no longer
  calls it: it checks `orch_so_table_[cid].handle` and errors if the slot was
  never registered.
- arg-count mismatch in `run` no longer tears the slot down to force a "next
  run reload" (there is no such reload now) — it fails the run and leaves the
  registered SO intact.
- Drop the now-unused `register_new` field from `RegisterCallableArgs` and its
  host/sim fillers; registration is unconditionally a (re)load.

**Python (`worker.py`)**
- `_ensure_prepared` loses its `lazy` parameter and warning; it is the
  `_CTRL_PREPARE` registration path only. `TASK_READY` now raises if the cid
  was not prepared first, instead of lazily preparing it.

**Tests**
- Rewrite `test_ensure_prepared` for the prepare-only signature.

## Testing

- [x] a2a3 + a5 build clean (rebased onto merged main)
- [x] Worker Python UT — 155 passed
- [x] Simulation — `prepared_callable` register→run passes (a2a3sim)
- [x] Hardware — a2a3 onboard passes: HBG + TMARB `prepared_callable` / `mixed_example` / `matmul` / `paged_attention`