### PR TITLE
fix(dfx): collapse SPMD dependency arrows to anchor rows

### DIFF
--- a/docs/dfx/l2-swimlane-profiling.md
+++ b/docs/dfx/l2-swimlane-profiling.md
@@ -456,6 +456,30 @@ Flow events: 0 (no deps.json — re-run dep_gen and pass --deps-json to add arro
 That's the rerun breadcrumb — keep an eye on it, it's the signal
 that something dropped on the way from dep_gen to converter.
 
+**SPMD dependency arrows.** For logical tasks with `block_num > 1`,
+dependency / `hb_violation` flows connect via **anchor pairing** on
+physical core lanes — there is no dedicated `SPMD (block-level)` track.
+
+SPMD tasks use the minimum-`core_id` subtask row per `core_type` as the
+dependency anchor; MIX-type SPMD tasks pick the minimum separately for
+AIC and AIV.
+
+Non-SPMD tasks (including MIX multi-slot kernels with `block_num == 1`)
+keep every subtask row as an endpoint (N×N pairing unchanged).
+
+For each logical `(pred, succ)` edge from `deps.json`, the converter
+emits flows between the Cartesian product of pred/succ anchor rows
+(`|pred_anchors| × |succ_anchors|`), not a per-subtask crossbar.
+
+**SPMD lane labels.** Logical SPMD tasks append `_spmd` before the
+`(rXtY)` suffix unless the function name already contains `spmd`
+(case-insensitive), e.g. `v_proj_spmd(r2t10)` vs `SPMD_WRITE_AIV(t0)`.
+
+Flow events carry `input_task_count` / `output_task_count` (SPMD
+`block_num`) to annotate fan degree. These arrows visualize **block-level**
+`deps.json` edges on representative subtasks — they do **not** imply
+runtime per-instance dependency resolution.
+
 **What you do NOT need to script:**
 
 - Pairing input shape / RNG seed across the two launches — `deps.json`
@@ -481,7 +505,10 @@ What the swimlane shows:
   `dep_gen` run is available, `swimlane_converter` emits flow events
   so Perfetto draws arrows between predecessor and successor tasks
   — see [§3.5](#35-dependency-arrows-from-dep_gen). Without
-  `deps.json` the trace is correct but unarrowed.
+  `deps.json` the trace is correct but unarrowed. For SPMD tasks,
+  dependency arrows use the minimum-`core_id` subtask row per
+  `core_type` as the anchor; MIX-type SPMD tasks pick the
+  minimum-`core_id` subtask separately for AIC and AIV.
 - **Scheduler-loop time decomposition.** Per-iteration AICPU
   phase records show how long the scheduler spent in each of
   its two work phases (complete / dispatch); idle is recovered

--- a/simpler_setup/tools/README.md
+++ b/simpler_setup/tools/README.md
@@ -62,6 +62,27 @@ python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane
 > alongside the perf JSON (and `--deps-json` isn't passed), the trace
 > still renders but has no arrows; the converter prints a warning.
 
+### SPMD dependency visualization
+
+For SPMD logical tasks (`block_num > 1` in `deps.json`), dependency
+arrows anchor on representative subtask rows on physical core lanes
+(not a dedicated block-level track). SPMD tasks use the minimum-`core_id`
+subtask row per `core_type` as the dependency anchor; MIX-type SPMD
+tasks pick the minimum separately for AIC and AIV. See
+[docs/dfx/l2-swimlane-profiling.md §3.5](../../docs/dfx/l2-swimlane-profiling.md#35-dependency-arrows-from-dep_gen).
+
+Each logical `(pred, succ)` edge emits flows for the Cartesian product
+of pred/succ anchor rows (`|pred_anchors| × |succ_anchors|`), not a
+per-subtask crossbar.
+
+SPMD lane labels append `_spmd` before `(rXtY)` unless the function
+name already contains `spmd` (case-insensitive), e.g.
+`v_proj_spmd(r2t10)` vs `SPMD_WRITE_AIV(t0)`.
+
+With `-v`, the converter prints
+`dependency arrows anchor on min core_id subtask per core_type` when
+SPMD tasks are present.
+
 ### Command-Line Options
 
 | Option | Short | Description |

--- a/simpler_setup/tools/swimlane_converter.py
+++ b/simpler_setup/tools/swimlane_converter.py
@@ -19,6 +19,9 @@ Usage:
     python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json -o out.json
     python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json -k kernel_config.py
     python -m simpler_setup.tools.swimlane_converter outputs/<case>_<ts>/l2_swimlane_records.json -v
+
+SPMD (block_num>1): dependency flows use min core_id anchors per core_type
+on physical lanes; see docs/dfx/l2-swimlane-profiling.md §3.5.
 """
 
 import argparse
@@ -49,7 +52,7 @@ def _func_id_to_letter(func_id):
     return str(n) + "_" + "".join(reversed(letters))
 
 
-def _task_display_name(func_id, func_id_to_name, tdisp):
+def _task_display_name(func_id, func_id_to_name, tdisp, *, spmd=False):
     """Build the swimlane event label for a task.
 
     Naming, in priority order:
@@ -58,16 +61,26 @@ def _task_display_name(func_id, func_id_to_name, tdisp):
         every lane is an anonymous ``task(...)`` distinguished only by id.
       - a name mapping exists for the func_id: ``<name>(rXtY)``.
       - otherwise: ``func_<letter>(rXtY)`` (resolved id, but no name map entry).
+
+    SPMD logical tasks append ``_spmd`` before the ``(rXtY)`` suffix unless the
+    name already contains ``spmd`` (case-insensitive), e.g.
+    ``fa_fused_aic_spmd(r2t18)``.
     """
     try:
         resolved = int(func_id) >= 0
     except (TypeError, ValueError):
         resolved = False
     if not resolved:
-        return f"task({tdisp})"
-    if func_id_to_name and str(func_id) in func_id_to_name:
-        return f"{func_id_to_name[str(func_id)]}({tdisp})"
-    return f"func_{_func_id_to_letter(func_id)}({tdisp})"
+        label = f"task({tdisp})"
+    elif func_id_to_name and str(func_id) in func_id_to_name:
+        label = f"{func_id_to_name[str(func_id)]}({tdisp})"
+    else:
+        label = f"func_{_func_id_to_letter(func_id)}({tdisp})"
+    if spmd and "(" in label:
+        base, rest = label.split("(", 1)
+        if "spmd" not in base.lower():
+            return f"{base}_spmd({rest}"
+    return label
 
 
 def normalize_pto2_task_id_int(v):
@@ -457,6 +470,141 @@ def load_deps_kernel_map(deps_path):
             continue
         kmap[tid] = [int(k) for k in kids]
     return kmap if kmap else None
+
+
+def load_deps_block_map(deps_path):
+    """Build a ``task_id → block_num`` map from deps.json's ``tasks[]``.
+
+    Returns:
+        dict[int, int] mapping ``task_id_raw → block_num``, or ``None`` if
+        the file is missing / unreadable / lacks the field. Entries without
+        ``block_num`` default to 1 (non-SPMD).
+    """
+    deps_path = Path(deps_path)
+    if not deps_path.exists():
+        return None
+    try:
+        with deps_path.open() as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+    tasks = data.get("tasks")
+    if not isinstance(tasks, list):
+        return None
+    bmap: dict[int, int] = {}
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        tid = normalize_pto2_task_id_int(task.get("task_id"))
+        if tid is None:
+            continue
+        try:
+            block_num = int(task.get("block_num", 1))
+        except (TypeError, ValueError):
+            block_num = 1
+        block_num = max(block_num, 1)
+        bmap[tid] = block_num
+    return bmap if bmap else None
+
+
+def _identify_spmd_task_ids(task_map, deps_block_map=None):
+    """Return task_ids whose dependency flow endpoints collapse to one subtask row."""
+    spmd_ids: set[int] = set()
+    if deps_block_map:
+        for tid, block_num in deps_block_map.items():
+            if block_num > 1:
+                spmd_ids.add(tid)
+    for tid, recs in task_map.items():
+        if tid in spmd_ids or len(recs) <= 1:
+            continue
+        if deps_block_map and tid in deps_block_map:
+            continue  # authoritative — don't second-guess block_num==1
+        core_types = {r.get("core_type") for r in recs}
+        if len(core_types) == 1:
+            spmd_ids.add(tid)
+    return spmd_ids
+
+
+def _dependency_flow_anchor_rows(task_id, task_map, spmd_task_ids):
+    """Dependency anchor rows: all subtask rows for non-SPMD; min core_id per core_type for SPMD."""
+    recs = task_map.get(task_id, [])
+    if not recs:
+        return []
+    if task_id not in spmd_task_ids:
+        return recs
+    by_type: dict[str, dict] = {}
+    for row in recs:
+        core_type = row.get("core_type") or "unknown"
+        prev = by_type.get(core_type)
+        if prev is None or row["core_id"] < prev["core_id"]:
+            by_type[core_type] = row
+    return list(by_type.values())
+
+
+def _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids):
+    """(pred_row, succ_row) pairs for one logical dependency edge."""
+    pred_rows = _dependency_flow_anchor_rows(pred_id, task_map, spmd_task_ids)
+    succ_rows = _dependency_flow_anchor_rows(succ_id, task_map, spmd_task_ids)
+    if not pred_rows or not succ_rows:
+        return []
+    return [(pred_row, succ_row) for pred_row in pred_rows for succ_row in succ_rows]
+
+
+def _dependency_task_fan_count(task_id, spmd_task_ids, task_map, deps_block_map=None):
+    """Logical subtask count for dependency metadata (SPMD block_num, else 1)."""
+    if task_id in spmd_task_ids:
+        if deps_block_map and task_id in deps_block_map:
+            return deps_block_map[task_id]
+        return len(task_map[task_id])
+    return 1
+
+
+def _append_dependency_flow_pair(  # noqa: PLR0913
+    events,
+    flow_id,
+    flow_name,
+    src_pid,
+    src_tid,
+    src_ts,
+    src_event_id,
+    dst_pid,
+    dst_tid,
+    dst_ts,
+    dst_event_id,
+    *,
+    input_task_count=1,
+    output_task_count=1,
+):
+    flow_s = {
+        "cat": "flow",
+        "id": flow_id,
+        "name": flow_name,
+        "ph": "s",
+        "pid": src_pid,
+        "tid": src_tid,
+        "ts": src_ts,
+        "input_task_count": input_task_count,
+        "output_task_count": output_task_count,
+    }
+    if src_event_id is not None:
+        flow_s["bind_id"] = src_event_id
+    events.append(flow_s)
+
+    flow_f = {
+        "cat": "flow",
+        "id": flow_id,
+        "name": flow_name,
+        "ph": "f",
+        "pid": dst_pid,
+        "tid": dst_tid,
+        "ts": dst_ts,
+        "bp": "e",
+        "input_task_count": input_task_count,
+        "output_task_count": output_task_count,
+    }
+    if dst_event_id is not None:
+        flow_f["bind_id"] = dst_event_id
+    events.append(flow_f)
 
 
 def resolve_func_id_from_kernel_map(task_id, core_type, kernel_map):
@@ -865,6 +1013,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     orchestrator_name=None,
     deps_edges=None,
     deps_kernel_map=None,
+    deps_block_map=None,
     emit_overhead=False,
 ):
     """Generate Chrome Trace Event Format JSON from task data.
@@ -883,10 +1032,10 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         core_to_thread: Optional list mapping core_id (index) to scheduler thread index (-1 = unassigned)
 
     Generates processes in the trace:
-        - pid=4 "Worker View": start_time_us to end_time_us (kernel execution)
-        - pid=3 "Scheduler View": dispatch_time_us to finish_time_us (AICPU perspective)
+        - pid=1 "AICPU Orchestrator": orchestrator phase bars (l2_swimlane_level >= 4)
         - pid=2 "AICPU Scheduler": scheduler phase bars (l2_swimlane_level >= 3)
-        - pid=1 "AICPU Orchestrator": orchestrator phase bars or summary (l2_swimlane_level >= 4)
+        - pid=3 "Scheduler View": dispatch_time_us to finish_time_us (AICPU perspective)
+        - pid=4 "Worker View": per-subtask kernel execution on physical cores
     """
     if verbose:
         print("Generating Chrome Trace JSON...")
@@ -928,8 +1077,13 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     #   pid=1  AICPU Orchestrator  (submits tasks — earliest)
     #   pid=2  AICPU Scheduler     (pops ready, dispatches, completes)
     #   pid=3  Scheduler View      (AICPU-eye view of each worker's dispatch→finish)
-    #   pid=4  Worker View         (physical AIC/AIV + DUMMY virtual workers — latest)
+    #   pid=4  Worker View         (physical AIC/AIV execution rows)
     # sort_index intentionally equals pid so JSON ordering is self-evident.
+    task_map: dict[int, list] = defaultdict(list)
+    for t in tasks:
+        task_map[t["task_id"]].append(t)
+    spmd_task_ids = _identify_spmd_task_ids(task_map, deps_block_map)
+
     events.append({"args": {"name": "Worker View"}, "cat": "__metadata", "name": "process_name", "ph": "M", "pid": 4})
     events.append({"args": {"sort_index": 4}, "cat": "__metadata", "name": "process_sort_index", "ph": "M", "pid": 4})
 
@@ -990,7 +1144,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
         # deps.json the id stays -1 and the lane is named task(rXtY).
         func_id = task["func_id"]
         tdisp = format_task_display(task["task_id"])
-        task_name = _task_display_name(func_id, func_id_to_name, tdisp)
+        task_name = _task_display_name(func_id, func_id_to_name, tdisp, spmd=task["task_id"] in spmd_task_ids)
 
         # fanout (consumers) / fanin (producers) hints from deps.json — the device
         # hot path no longer carries them. Each leads with the degree (count) so
@@ -1134,7 +1288,7 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
             # resolved the func_id; see _task_display_name).
             func_id = task["func_id"]
             tdisp = format_task_display(task["task_id"])
-            task_name = _task_display_name(func_id, func_id_to_name, tdisp)
+            task_name = _task_display_name(func_id, func_id_to_name, tdisp, spmd=task["task_id"] in spmd_task_ids)
 
             events.append(
                 {
@@ -1161,87 +1315,66 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
     # Flow events (Flow events "s" and "f" for dependencies). Edges come from
     # deps.json (dep_gen replay); without one we emit no flow events at all,
     # since the device hot path no longer carries fanout (PR #863).
-    # Edges where the predecessor's end_time outlives the successor's start_time
-    # are flagged as happens-before violations and emitted with a distinct flow
-    # name so Perfetto colors them differently from clean dependency arrows.
-    task_map: dict[int, list] = defaultdict(list)
-    for t in tasks:
-        task_map[t["task_id"]].append(t)
+    # SPMD logical tasks anchor dependency arrows on the min-core_id subtask
+    # row per core_type (AIC and AIV separately when both are present).
     flow_id = 0
     hb_violation_count = 0
+    deps_flow_count = 0
     edges_by_pred = deps_edges or {}
+    flow_epsilon = 0.01
 
-    for task in tasks:
-        src_tid = core_to_tid[task["core_id"]]
-        src_ts_end = task["end_time_us"]
-        # Get event ID for source task
-        src_event_id = task_to_event_id[(task["task_id"], task["core_id"])]
-        # Flow start timestamp (at end of source task, slightly before)
-        # Use a small offset (0.01 us) for visual clarity
-        flow_start_us = src_ts_end - 0.01
+    for pred_id, succ_ids in edges_by_pred.items():
+        if pred_id not in task_map:
+            continue
 
-        for succ_task_id in edges_by_pred.get(task["task_id"], []):
-            if succ_task_id not in task_map:
+        for succ_id in succ_ids:
+            if succ_id not in task_map:
                 if verbose:
                     print(
-                        f"Warning: Task {format_task_display(task['task_id'])} (raw {task['task_id']}) "
-                        f"references non-existent successor {format_task_display(succ_task_id)} (raw {succ_task_id})"
+                        f"Warning: Task {format_task_display(pred_id)} (raw {pred_id}) "
+                        f"references non-existent successor {format_task_display(succ_id)} (raw {succ_id})"
                     )
                 continue
 
-            for succ_task in task_map[succ_task_id]:
-                dst_tid = core_to_tid[succ_task["core_id"]]
-                # Land the dependency arrow at the consumer's `receive_time` —
-                # the instant AICore saw the dispatch signal on DATA_MAIN_BASE.
-                # The gap between this anchor and the kernel's `start_time` is
-                # the per-task local_setup (dcci + ack), now visible as the
-                # "setup" sub-bar PR #1004 adds. Fall back to start_time for
-                # captures without v3 receive_time (older swimlane records or
-                # AICPU-only joins).
-                dst_ts_start = succ_task.get("receive_time_us") or succ_task["start_time_us"]
-                dst_event_id = task_to_event_id[(succ_task["task_id"], succ_task["core_id"])]
+            row_pairs = _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids)
+            if not row_pairs:
+                continue
 
-                # Happens-before violation: producer outlived consumer's
-                # receive. Real time order broke the data dependency the graph
-                # asserted; the runtime got away with it (consumer presumably
-                # re-read fresh data) but it's a smell — surface it.
-                hb_violated = src_ts_end > dst_ts_start
+            output_task_count = _dependency_task_fan_count(pred_id, spmd_task_ids, task_map, deps_block_map)
+            input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
+            for pred_row, succ_row in row_pairs:
+                src_ts_end = pred_row["end_time_us"] - flow_epsilon
+                dst_ts_start = succ_row.get("receive_time_us") or succ_row["start_time_us"]
+                hb_violated = (src_ts_end + flow_epsilon) > dst_ts_start
                 flow_name = "hb_violation" if hb_violated else "dependency"
                 if hb_violated:
                     hb_violation_count += 1
-
-                # Flow start event (at end of source task)
-                events.append(
-                    {
-                        "cat": "flow",
-                        "id": flow_id,
-                        "name": flow_name,
-                        "ph": "s",
-                        "pid": 4,
-                        "tid": src_tid,
-                        "ts": flow_start_us,
-                        "bind_id": src_event_id,
-                    }
-                )
-                # Flow finish event (at start of destination task)
-                events.append(
-                    {
-                        "cat": "flow",
-                        "id": flow_id,
-                        "name": flow_name,
-                        "ph": "f",
-                        "pid": 4,
-                        "tid": dst_tid,
-                        "ts": dst_ts_start,
-                        "bp": "e",
-                        "bind_id": dst_event_id,
-                    }
+                _append_dependency_flow_pair(
+                    events,
+                    flow_id,
+                    flow_name,
+                    4,
+                    core_to_tid[pred_row["core_id"]],
+                    src_ts_end,
+                    task_to_event_id.get((pred_id, pred_row["core_id"])),
+                    4,
+                    core_to_tid[succ_row["core_id"]],
+                    dst_ts_start,
+                    task_to_event_id.get((succ_id, succ_row["core_id"])),
+                    input_task_count=input_task_count,
+                    output_task_count=output_task_count,
                 )
                 flow_id += 1
+                deps_flow_count += 1
 
     if verbose:
         if deps_edges is not None:
-            print(f"  Flow events: {flow_id} edges (source: deps.json)")
+            print(f"  Dependency flow events: {deps_flow_count} edges (source: deps.json)")
+            if spmd_task_ids:
+                print(
+                    f"  SPMD tasks: {len(spmd_task_ids)} logical task(s); "
+                    "dependency arrows anchor on min core_id subtask per core_type"
+                )
         else:
             print("  Flow events: 0 (no deps.json — re-run dep_gen and pass --deps-json to add arrows)")
         if hb_violation_count > 0:
@@ -1674,63 +1807,52 @@ def generate_chrome_trace_json(  # noqa: PLR0912, PLR0913, PLR0915
                             }
                         )
 
-    # Scheduler View fanout arrows (duplicate Worker View flow events using AICPU timestamps)
+    # Scheduler View dependency mirror (AICPU timestamps).
     if has_aicpu_data:
-        for task in tasks:
-            src_finish_us = task.get("finish_time_us", 0)
-            # 0us is valid for the first task; keep it for dependency visualization.
-            if src_finish_us < 0:
+        for pred_id, succ_ids in edges_by_pred.items():
+            if pred_id not in task_map:
                 continue
 
-            src_tid = task_to_aicpu_tid.get((task["task_id"], task["core_id"]), core_to_tid[task["core_id"]])
-            src_aicpu_eid = task_to_aicpu_event_id.get((task["task_id"], task["core_id"]))
-
-            for succ_task_id in edges_by_pred.get(task["task_id"], []):
-                if succ_task_id not in task_map:
+            for succ_id in succ_ids:
+                if succ_id not in task_map:
                     continue
 
-                for succ_task in task_map[succ_task_id]:
-                    dst_dispatch_us = succ_task.get("dispatch_time_us", 0)
-                    if dst_dispatch_us < 0:
+                row_pairs = _dependency_flow_row_pairs(pred_id, succ_id, task_map, spmd_task_ids)
+                if not row_pairs:
+                    continue
+
+                output_task_count = _dependency_task_fan_count(pred_id, spmd_task_ids, task_map, deps_block_map)
+                input_task_count = _dependency_task_fan_count(succ_id, spmd_task_ids, task_map, deps_block_map)
+                for pred_row, succ_row in row_pairs:
+                    src_finish_us = pred_row.get("finish_time_us", 0)
+                    dst_dispatch_us = succ_row.get("dispatch_time_us", 0)
+                    dst_finish_us = succ_row.get("finish_time_us", 0)
+                    # Skip when AICPU timestamps are missing or zero (matches Scheduler
+                    # View bar emission, which rejects finish_us <= 0).
+                    if src_finish_us <= 0 or dst_dispatch_us < 0 or dst_finish_us <= 0:
                         continue
-
-                    dst_tid = task_to_aicpu_tid.get(
-                        (succ_task["task_id"], succ_task["core_id"]), core_to_tid[succ_task["core_id"]]
-                    )
-                    dst_aicpu_eid = task_to_aicpu_event_id.get((succ_task["task_id"], succ_task["core_id"]))
-
-                    # Mirror the AICore-view HB-violation classification using
-                    # the AICPU dispatch/finish timestamps.
-                    aicpu_hb_violated = src_finish_us > dst_dispatch_us
+                    src_ts = src_finish_us - flow_epsilon
+                    aicpu_hb_violated = (src_ts + flow_epsilon) > dst_dispatch_us
                     aicpu_flow_name = "hb_violation" if aicpu_hb_violated else "dependency"
-
-                    flow_s = {
-                        "cat": "flow",
-                        "id": flow_id,
-                        "name": aicpu_flow_name,
-                        "ph": "s",
-                        "pid": 3,
-                        "tid": src_tid,
-                        "ts": src_finish_us - 0.01,
-                    }
-                    if src_aicpu_eid is not None:
-                        flow_s["bind_id"] = src_aicpu_eid
-                    events.append(flow_s)
-
-                    flow_f = {
-                        "cat": "flow",
-                        "id": flow_id,
-                        "name": aicpu_flow_name,
-                        "ph": "f",
-                        "pid": 3,
-                        "tid": dst_tid,
-                        "ts": dst_dispatch_us,
-                        "bp": "e",
-                    }
-                    if dst_aicpu_eid is not None:
-                        flow_f["bind_id"] = dst_aicpu_eid
-                    events.append(flow_f)
-
+                    _append_dependency_flow_pair(
+                        events,
+                        flow_id,
+                        aicpu_flow_name,
+                        3,
+                        task_to_aicpu_tid.get(
+                            (pred_row["task_id"], pred_row["core_id"]), core_to_tid[pred_row["core_id"]]
+                        ),
+                        src_ts,
+                        task_to_aicpu_event_id.get((pred_row["task_id"], pred_row["core_id"])),
+                        3,
+                        task_to_aicpu_tid.get(
+                            (succ_row["task_id"], succ_row["core_id"]), core_to_tid[succ_row["core_id"]]
+                        ),
+                        dst_dispatch_us,
+                        task_to_aicpu_event_id.get((succ_row["task_id"], succ_row["core_id"])),
+                        input_task_count=input_task_count,
+                        output_task_count=output_task_count,
+                    )
                     flow_id += 1
 
     # Complete-phase flow arrows. The complete phase wraps the AICPU's
@@ -2319,6 +2441,7 @@ def main():
         # the real kernel name. Optional — pre-schema deps.json without
         # kernel_ids and AICPU_TIMING+ runs both leave this at None.
         deps_kernel_map = load_deps_kernel_map(deps_path)
+        deps_block_map = load_deps_block_map(deps_path)
         if deps_edges is not None:
             if args.verbose:
                 print(f"  Using deps.json edges ({sum(len(v) for v in deps_edges.values())} total) from {deps_path}")
@@ -2342,6 +2465,7 @@ def main():
             core_to_thread=data.get("core_to_thread"),
             deps_edges=deps_edges,
             deps_kernel_map=deps_kernel_map,
+            deps_block_map=deps_block_map,
             emit_overhead=args.overhead,
         )
         if args.overhead and deps_edges is None:

--- a/tests/ut/py/test_swimlane_converter.py
+++ b/tests/ut/py/test_swimlane_converter.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import json
+
+from simpler_setup.tools import swimlane_converter as sc
+
+
+def _task_row(task_id, core_id, core_type="aiv", *, dispatch=10.0, start=11.0, end=20.0, receive=10.5):
+    return {
+        "task_id": task_id,
+        "func_id": 0,
+        "core_id": core_id,
+        "core_type": core_type,
+        "start_time_us": start,
+        "end_time_us": end,
+        "duration_us": end - start,
+        "dispatch_time_us": dispatch,
+        "finish_time_us": end + 1.0,
+        "receive_time_us": receive,
+        "local_setup_us": start - receive,
+    }
+
+
+def _count_dependency_flow_starts(trace_path, *, pid, tid=None):
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    return sum(
+        1
+        for e in events
+        if e.get("cat") == "flow"
+        and e.get("name") in ("dependency", "hb_violation")
+        and e.get("ph") == "s"
+        and e.get("pid") == pid
+        and (tid is None or e.get("tid") == tid)
+    )
+
+
+def _first_worker_dependency_flow(trace_path):
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    flow_id = next(
+        e["id"]
+        for e in events
+        if e.get("cat") == "flow"
+        and e.get("name") in ("dependency", "hb_violation")
+        and e.get("ph") == "s"
+        and e.get("pid") == 4
+    )
+    return [e for e in events if e.get("cat") == "flow" and e.get("id") == flow_id and e.get("pid") == 4]
+
+
+def _first_scheduler_dependency_flow(trace_path):
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    flow_id = next(
+        e["id"]
+        for e in events
+        if e.get("cat") == "flow"
+        and e.get("name") in ("dependency", "hb_violation")
+        and e.get("ph") == "s"
+        and e.get("pid") == 3
+    )
+    return [e for e in events if e.get("cat") == "flow" and e.get("id") == flow_id and e.get("pid") == 3]
+
+
+def _worker_flow_finish_tids(trace_path):
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    return {
+        e["tid"]
+        for e in events
+        if e.get("cat") == "flow"
+        and e.get("name") in ("dependency", "hb_violation")
+        and e.get("ph") == "f"
+        and e.get("pid") == 4
+    }
+
+
+def _has_spmd_block_level_track(trace_path):
+    with open(trace_path) as f:
+        events = json.load(f)["traceEvents"]
+    return any(
+        e.get("ph") == "M" and e.get("name") == "thread_name" and e.get("args", {}).get("name") == "SPMD (block-level)"
+        for e in events
+    )
+
+
+def _core_tid(core_id):
+    return 10000 + core_id * 10
+
+
+def _generate_trace(tasks, deps_edges, deps_block_map, tmp_path):
+    out = tmp_path / "trace.json"
+    sc.generate_chrome_trace_json(
+        tasks,
+        str(out),
+        deps_edges=deps_edges,
+        deps_block_map=deps_block_map,
+    )
+    return out
+
+
+def test_spmd_pred_routes_dependency_to_min_core_subtask(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [
+        _task_row(pred_id, core_id, dispatch=10.0 + core_id, start=11.0 + core_id, end=20.0 + core_id)
+        for core_id in range(4)
+    ]
+    tasks.append(_task_row(succ_id, 10))
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 4, succ_id: 1}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 1
+    assert _count_dependency_flow_starts(out, pid=3) == 1
+    assert not _has_spmd_block_level_track(out)
+    flow = _first_worker_dependency_flow(out)
+    assert flow[0]["output_task_count"] == 4
+    assert flow[0]["input_task_count"] == 1
+    assert flow[0]["tid"] == _core_tid(0)
+    sched_flow = _first_scheduler_dependency_flow(out)
+    assert sched_flow[0]["output_task_count"] == 4
+    assert sched_flow[0]["input_task_count"] == 1
+    assert sched_flow[0]["ts"] == tasks[0]["finish_time_us"] - 0.01
+    assert sched_flow[1]["ts"] == tasks[4]["dispatch_time_us"]
+
+
+def test_spmd_succ_routes_dependency_to_min_core_subtask(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [_task_row(pred_id, 0)]
+    tasks.extend(
+        _task_row(
+            succ_id, core_id, dispatch=20.0 + core_id, start=21.0 + core_id, end=30.0 + core_id, receive=20.5 + core_id
+        )
+        for core_id in range(4)
+    )
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 1, succ_id: 4}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 1
+    flow = _first_worker_dependency_flow(out)
+    assert flow[0]["output_task_count"] == 1
+    assert flow[0]["input_task_count"] == 4
+    assert flow[1]["tid"] == _core_tid(0)
+    assert flow[1]["ts"] == tasks[1]["receive_time_us"]
+
+
+def test_spmd_to_spmd_one_edge_on_min_core_subtask(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [_task_row(pred_id, core_id, dispatch=10.0 + core_id) for core_id in range(4)]
+    tasks.extend(_task_row(succ_id, core_id, dispatch=30.0 + core_id) for core_id in range(4))
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 4, succ_id: 4}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 1
+    assert not _has_spmd_block_level_track(out)
+    flow = _first_worker_dependency_flow(out)
+    assert flow[0]["output_task_count"] == 4
+    assert flow[0]["input_task_count"] == 4
+
+
+def test_spmd_mix_to_mix_uses_anchor_cartesian_product(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [
+        _task_row(pred_id, 0, "aic", dispatch=10.0, start=11.0, end=20.0),
+        _task_row(pred_id, 1, "aiv", dispatch=10.1, start=11.1, end=20.1),
+        _task_row(pred_id, 3, "aiv", dispatch=10.3, start=11.3, end=20.3),
+        _task_row(succ_id, 4, "aic", dispatch=30.0, start=31.0, end=40.0, receive=30.5),
+        _task_row(succ_id, 5, "aiv", dispatch=30.1, start=31.1, end=40.1, receive=30.6),
+        _task_row(succ_id, 7, "aiv", dispatch=30.3, start=31.3, end=40.3, receive=30.8),
+    ]
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 3, succ_id: 3}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 4
+    finish_tids = _worker_flow_finish_tids(out)
+    assert finish_tids == {_core_tid(4), _core_tid(5)}
+
+
+def test_spmd_aiv_only_pred_connects_to_mix_spmd_succ_both_anchors(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [
+        _task_row(pred_id, 24, "aiv", dispatch=10.0, start=11.0, end=20.0),
+        _task_row(pred_id, 30, "aiv", dispatch=10.3, start=11.3, end=20.3),
+        _task_row(succ_id, 0, "aic", dispatch=30.0, start=31.0, end=40.0, receive=30.5),
+        _task_row(succ_id, 24, "aiv", dispatch=30.1, start=31.1, end=40.1, receive=30.6),
+        _task_row(succ_id, 27, "aiv", dispatch=30.3, start=31.3, end=40.3, receive=30.8),
+    ]
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 16, succ_id: 24}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 2
+    assert _worker_flow_finish_tids(out) == {_core_tid(0), _core_tid(24)}
+
+
+def test_mix_keeps_worker_view_dependency_flows(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [
+        _task_row(pred_id, 0, "aic", dispatch=10.0, start=11.0, end=20.0, receive=10.5),
+        _task_row(pred_id, 1, "aiv", dispatch=10.1, start=11.1, end=20.1, receive=10.6),
+        _task_row(pred_id, 2, "aiv", dispatch=10.2, start=11.2, end=20.2, receive=10.7),
+        _task_row(succ_id, 3, "aic", dispatch=30.0, start=31.0, end=40.0, receive=30.5),
+        _task_row(succ_id, 4, "aiv", dispatch=30.1, start=31.1, end=40.1, receive=30.6),
+        _task_row(succ_id, 5, "aiv", dispatch=30.2, start=31.2, end=40.2, receive=30.7),
+    ]
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 1, succ_id: 1}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 9
+    assert not _has_spmd_block_level_track(out)
+    with open(out) as f:
+        mix_flows = [
+            e
+            for e in json.load(f)["traceEvents"]
+            if e.get("cat") == "flow"
+            and e.get("name") in ("dependency", "hb_violation")
+            and e.get("ph") == "s"
+            and e.get("pid") == 4
+        ]
+    assert all(e["output_task_count"] == 1 and e["input_task_count"] == 1 for e in mix_flows)
+
+
+def test_spmd_fallback_without_block_map(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [_task_row(pred_id, core_id, dispatch=10.0 + core_id) for core_id in range(3)]
+    tasks.append(_task_row(succ_id, 10))
+    deps_edges = {pred_id: [succ_id]}
+
+    out = _generate_trace(tasks, deps_edges, None, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 1
+    flow = _first_worker_dependency_flow(out)
+    assert flow[0]["tid"] == _core_tid(0)
+
+
+def test_dependency_flow_anchor_rows_picks_min_core_per_type():
+    task_map = {
+        1: [
+            _task_row(1, 5, "aiv"),
+            _task_row(1, 0, "aiv"),
+            _task_row(1, 2, "aic"),
+            _task_row(1, 7, "aic"),
+        ]
+    }
+    rows = sc._dependency_flow_anchor_rows(1, task_map, {1})
+    assert len(rows) == 2
+    by_type = {r["core_type"]: r["core_id"] for r in rows}
+    assert by_type == {"aic": 2, "aiv": 0}
+
+
+def test_identify_spmd_task_ids_respects_authoritative_block_num_one():
+    task_map = {
+        1: [_task_row(1, 0), _task_row(1, 1), _task_row(1, 2)],
+        2: [_task_row(2, 0), _task_row(2, 1)],
+    }
+    deps_block_map = {1: 1, 2: 4}
+    spmd_ids = sc._identify_spmd_task_ids(task_map, deps_block_map)
+    assert spmd_ids == {2}
+
+
+def test_spmd_task_display_name_suffix():
+    assert sc._task_display_name(16, {"16": "fa_fused_aic"}, "r2t18", spmd=True) == "fa_fused_aic_spmd(r2t18)"
+    assert sc._task_display_name(16, {"16": "fa_fused_aic"}, "r2t18", spmd=False) == "fa_fused_aic(r2t18)"
+    assert sc._task_display_name(-1, {}, "r2t18", spmd=True) == "task_spmd(r2t18)"
+    assert sc._task_display_name(0, {"0": "spmd_write_aiv"}, "t0", spmd=True) == "spmd_write_aiv(t0)"
+    assert sc._task_display_name(0, {"0": "SPMDKernel"}, "t0", spmd=True) == "SPMDKernel(t0)"
+
+
+def test_spmd_cross_type_single_anchor_pair(tmp_path):
+    pred_id = 100
+    succ_id = 200
+    tasks = [_task_row(pred_id, core_id, "aic", dispatch=10.0 + core_id) for core_id in range(1, 9, 3)]
+    tasks.extend(_task_row(succ_id, core_id, "aiv", dispatch=30.0 + core_id) for core_id in range(24, 40, 2))
+    deps_edges = {pred_id: [succ_id]}
+    deps_block_map = {pred_id: 8, succ_id: 16}
+
+    out = _generate_trace(tasks, deps_edges, deps_block_map, tmp_path)
+    assert _count_dependency_flow_starts(out, pid=4) == 1


### PR DESCRIPTION
Replace per-subtask N×N crossbar flows with min core_id anchors per core_type on physical lanes, annotate fan degree on flow events, and document the block-level visualization semantics in l2-swimlane-profiling.

close #1049 