### PR TITLE
test(st): drop a5 from runtime_fatal_codes onboard coverage

### DIFF
--- a/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
+++ b/tests/st/runtime_fatal_codes/test_runtime_fatal_codes.py
@@ -282,7 +282,7 @@ def test_fatal_code_surfaces_on_sim(st_platform, st_device_ids, case_name, monke
         worker.close()
 
 
-@pytest.mark.platforms(["a2a3", "a5"])
+@pytest.mark.platforms(["a2a3"])
 @pytest.mark.device_count(1)
 @pytest.mark.runtime(RUNTIME)
 @pytest.mark.timeout(90)  # hang cases hold a core ~15-20 s; bound a wedge


### PR DESCRIPTION
The onboard device-error test (`test_device_error_class_reaches_host_log`) now runs on `a2a3` only; `a5` is taken offline.

The sim test (`a5sim`/`a2a3sim`) is unchanged.