### PR TITLE
perf(runtime): drop the 256KB per-boot mailbox memset; keep head/tail/seq monotonic

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -530,10 +530,18 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     return -1;
                 }
 
-                // AICore completion mailbox lives in the arena; reset it each
-                // boot so stale completion notifications from a previous run do
-                // not leak.
-                memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
+                // AICore completion mailbox lives in the pooled arena, so its
+                // head/tail/seq survive across runs and stay monotonic. We do
+                // NOT zero entries[] (256 KB): try_pop only reads a slot whose
+                // seq matches the exact current ticket, and a producer writes
+                // all payload before release-storing seq, so a prior run's stale
+                // seq can never false-match a fresh ticket. The only per-boot
+                // need is to discard any messages an error-aborted prior run
+                // left undrained (head > tail) so the new consumer starts empty;
+                // single-threaded here (no producers yet), tail := head does it.
+                rt->aicore_mailbox->tail.store(
+                    rt->aicore_mailbox->head.load(std::memory_order_acquire), std::memory_order_release
+                );
 
                 // Fill ops / core counts (host can't resolve s_runtime_ops's
                 // device address nor know the SchedulerContext's core fan-out).

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -527,10 +527,18 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
                     return -1;
                 }
 
-                // AICore completion mailbox lives in the arena; reset it each
-                // boot so stale completion notifications from a previous run do
-                // not leak.
-                memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));
+                // AICore completion mailbox lives in the pooled arena, so its
+                // head/tail/seq survive across runs and stay monotonic. We do
+                // NOT zero entries[] (256 KB): try_pop only reads a slot whose
+                // seq matches the exact current ticket, and a producer writes
+                // all payload before release-storing seq, so a prior run's stale
+                // seq can never false-match a fresh ticket. The only per-boot
+                // need is to discard any messages an error-aborted prior run
+                // left undrained (head > tail) so the new consumer starts empty;
+                // single-threaded here (no producers yet), tail := head does it.
+                rt->aicore_mailbox->tail.store(
+                    rt->aicore_mailbox->head.load(std::memory_order_acquire), std::memory_order_release
+                );
 
                 // Fill ops / core counts (host can't resolve s_runtime_ops's
                 // device address nor know the SchedulerContext's core fan-out).

--- a/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a2a3/test_aicore_completion_mailbox.cpp
@@ -332,3 +332,77 @@ TEST(AICoreCompletionMailbox, ProducerInterleavedWithDrain) {
 
     destroy_mailbox(mb);
 }
+
+// =============================================================================
+// Cross-run reuse without zeroing entries[]. The pooled-arena fast path keeps
+// the mailbox's head/tail/seq monotonic across boots and resets per-boot with
+// tail := head (NOT a 256KB memset). This pins down the two invariants that
+// makes safe:
+//   1. After a full capacity wrap every slot holds a STALE seq from a prior
+//      generation; a fresh push's release-store of the new (larger) seq must be
+//      the only value try_pop accepts — the stale seq must never false-match.
+//   2. tail := head discards messages an error-aborted prior run left undrained
+//      (head > tail) so the next consumer starts empty.
+// =============================================================================
+
+TEST(AICoreCompletionMailbox, MonotonicSeqSurvivesCapacityWrapWithoutZeroing) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    // Drive head/tail one full capacity past the wrap point so every physical
+    // slot has been published once and now carries a stale seq in [1, CAPACITY].
+    // Each push is drained immediately so the ring never reports full.
+    PTO2TaskId token = make_token(7);
+    AICoreCompletionMsgView msg;
+    for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY + 17; i++) {
+        ASSERT_TRUE(
+            mb->try_push_condition(token, /*addr=*/i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+        );
+        ASSERT_TRUE(mb->try_pop(msg));
+        EXPECT_EQ(msg.addr, i);
+    }
+    ASSERT_FALSE(mb->try_pop(msg));  // drained: tail == head
+
+    // Slot 0 now physically holds seq=1 (from the very first push). The next
+    // push reuses it but publishes seq = head+1 (well past CAPACITY). try_pop
+    // must accept only that fresh value — proving stale seq cannot be replayed.
+    const uint64_t addr_after_wrap = 0xABCD1234ull;
+    ASSERT_TRUE(
+        mb->try_push_condition(token, addr_after_wrap, /*expected=*/3, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+    );
+    ASSERT_TRUE(mb->try_pop(msg));
+    EXPECT_EQ(msg.addr, addr_after_wrap);
+    EXPECT_EQ(msg.expected_value, 3u);
+    ASSERT_FALSE(mb->try_pop(msg));
+
+    destroy_mailbox(mb);
+}
+
+TEST(AICoreCompletionMailbox, TailEqualsHeadDiscardsUndrainedLeftovers) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    // Simulate a prior run that pushed messages but aborted before draining
+    // them all (error path): head advances, tail lags.
+    PTO2TaskId token = make_token(11);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_TRUE(mb->try_push_condition(
+            token, /*addr=*/static_cast<uint64_t>(i), /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+        ));
+    }
+    ASSERT_TRUE(mb->has_pending());
+
+    // Per-boot reset performed by the executor: tail := head (single-threaded,
+    // no producers running). The leftovers are discarded, not replayed.
+    mb->tail.store(mb->head.load(std::memory_order_acquire), std::memory_order_release);
+    EXPECT_FALSE(mb->has_pending());
+    AICoreCompletionMsgView msg;
+    EXPECT_FALSE(mb->try_pop(msg));
+
+    // The channel is fully usable afterward: a fresh push drains cleanly with
+    // its own seq, unaffected by the discarded generation.
+    ASSERT_TRUE(mb->try_push_normal_done(token, /*slot_state_addr=*/0xFEEDull));
+    ASSERT_TRUE(mb->try_pop(msg));
+    EXPECT_EQ(msg.kind, MSG_KIND_TASK_NORMAL_DONE);
+    EXPECT_EQ(msg.addr, 0xFEEDull);
+
+    destroy_mailbox(mb);
+}

--- a/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
+++ b/tests/ut/cpp/a5/test_aicore_completion_mailbox.cpp
@@ -297,3 +297,77 @@ TEST(A5AICoreCompletionMailbox, ProducerInterleavedWithDrain) {
 
     destroy_mailbox(mb);
 }
+
+// =============================================================================
+// Cross-run reuse without zeroing entries[]. The pooled-arena fast path keeps
+// the mailbox's head/tail/seq monotonic across boots and resets per-boot with
+// tail := head (NOT a 256KB memset). This pins down the two invariants that
+// makes safe:
+//   1. After a full capacity wrap every slot holds a STALE seq from a prior
+//      generation; a fresh push's release-store of the new (larger) seq must be
+//      the only value try_pop accepts — the stale seq must never false-match.
+//   2. tail := head discards messages an error-aborted prior run left undrained
+//      (head > tail) so the next consumer starts empty.
+// =============================================================================
+
+TEST(A5AICoreCompletionMailbox, MonotonicSeqSurvivesCapacityWrapWithoutZeroing) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    // Drive head/tail one full capacity past the wrap point so every physical
+    // slot has been published once and now carries a stale seq in [1, CAPACITY].
+    // Each push is drained immediately so the ring never reports full.
+    PTO2TaskId token = make_token(7);
+    AICoreCompletionMsgView msg;
+    for (uint64_t i = 0; i < AICORE_COMPLETION_MAILBOX_CAPACITY + 17; i++) {
+        ASSERT_TRUE(
+            mb->try_push_condition(token, /*addr=*/i, /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+        );
+        ASSERT_TRUE(mb->try_pop(msg));
+        EXPECT_EQ(msg.addr, i);
+    }
+    ASSERT_FALSE(mb->try_pop(msg));  // drained: tail == head
+
+    // Slot 0 now physically holds seq=1 (from the very first push). The next
+    // push reuses it but publishes seq = head+1 (well past CAPACITY). try_pop
+    // must accept only that fresh value — proving stale seq cannot be replayed.
+    const uint64_t addr_after_wrap = 0xABCD1234ull;
+    ASSERT_TRUE(
+        mb->try_push_condition(token, addr_after_wrap, /*expected=*/3, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER)
+    );
+    ASSERT_TRUE(mb->try_pop(msg));
+    EXPECT_EQ(msg.addr, addr_after_wrap);
+    EXPECT_EQ(msg.expected_value, 3u);
+    ASSERT_FALSE(mb->try_pop(msg));
+
+    destroy_mailbox(mb);
+}
+
+TEST(A5AICoreCompletionMailbox, TailEqualsHeadDiscardsUndrainedLeftovers) {
+    AICoreCompletionMailbox *mb = fresh_mailbox();
+
+    // Simulate a prior run that pushed messages but aborted before draining
+    // them all (error path): head advances, tail lags.
+    PTO2TaskId token = make_token(11);
+    for (int i = 0; i < 5; i++) {
+        ASSERT_TRUE(mb->try_push_condition(
+            token, /*addr=*/static_cast<uint64_t>(i), /*expected=*/0, COMPLETION_ENGINE_SDMA, COMPLETION_TYPE_COUNTER
+        ));
+    }
+    ASSERT_TRUE(mb->has_pending());
+
+    // Per-boot reset performed by the executor: tail := head (single-threaded,
+    // no producers running). The leftovers are discarded, not replayed.
+    mb->tail.store(mb->head.load(std::memory_order_acquire), std::memory_order_release);
+    EXPECT_FALSE(mb->has_pending());
+    AICoreCompletionMsgView msg;
+    EXPECT_FALSE(mb->try_pop(msg));
+
+    // The channel is fully usable afterward: a fresh push drains cleanly with
+    // its own seq, unaffected by the discarded generation.
+    ASSERT_TRUE(mb->try_push_normal_done(token, /*slot_state_addr=*/0xFEEDull));
+    ASSERT_TRUE(mb->try_pop(msg));
+    EXPECT_EQ(msg.kind, MSG_KIND_TASK_NORMAL_DONE);
+    EXPECT_EQ(msg.addr, 0xFEEDull);
+
+    destroy_mailbox(mb);
+}


### PR DESCRIPTION
## Summary

The AICore completion mailbox lives in the **pooled** runtime arena (never freed
across runs by `DeviceRunner`), yet every boot zeroed the whole struct in the
`SmReset` phase — a `4096 × 64 B = 256 KB` `memset`. At a large ring window that
cost **~52 µs/run** on the AICPU; it was the residual `sm_reset` after #1199 (the
part that does **not** scale with ring window).

That memset was only load-bearing because it *also* reset `head`/`tail` to 0,
which restarts expected `seq` tickets at 1, 2, 3… and lets a prior run's stale
per-slot `seq` collide with a fresh ticket. There is no other reason to touch
`entries[]`:

- `try_pop` reads a slot's payload **only after** its `seq` matches the exact
  current ticket (`seq == t + 1`), and a producer writes all payload fields
  **before** the release-store of `seq`. So a stale `seq` from a prior generation
  is structurally unreachable through the gate.
- No code walks `entries[]` outside that gate (verified across a2a3 + a5 — only
  `try_push`/`try_pop` touch it; no print/validate/DFX scan).

### Change
Keep `head`/`tail`/`seq` **monotonic across runs** so the only matching `seq` for
ticket `t` is the current generation's — the collision can't happen. The sole
per-boot need is to discard any messages an **error-aborted** prior run left
undrained (`head > tail`), which is a 16-byte `tail := head` (single-threaded at
boot, no producers running yet). Applied symmetrically to **a2a3 and a5**.

```cpp
// was: memset(rt->aicore_mailbox, 0, sizeof(*rt->aicore_mailbox));  // 256 KB
rt->aicore_mailbox->tail.store(
    rt->aicore_mailbox->head.load(std::memory_order_acquire), std::memory_order_release);
```

First boot is still genuinely zeroed once by the host-side init
(`runtime_init_data_from_layout`), so the monotonic chain starts clean.

### Measured (qwen3-14B 3.5k decode, a2a3 onboard, `PTO2_RING_TASK_WINDOW=524288`, 19 steps)
| device-wall phase | before | after |
| ----------------- | ------ | ----- |
| `sm_reset` | 51.5 µs | **2.5 µs** |
| `orch` | 21,563 µs | 21,702 µs (noise) |
| `sched` | 44,508 µs | 44,446 µs (noise) |
| `device_wall` | 45,009 µs | 44,891 µs |

Output tokens byte-identical to the memset build.

## Testing
- [x] **New cpp UT ×2 (a2a3 + a5)** pinning the invariants — both pass:
  - `MonotonicSeqSurvivesCapacityWrapWithoutZeroing`: after a full 4096-capacity
    wrap (every slot carries a stale `seq`), a fresh push's larger `seq` is the
    only value `try_pop` accepts.
  - `TailEqualsHeadDiscardsUndrainedLeftovers`: `tail := head` drops an aborted
    run's pending messages; channel fully usable afterward.
- [x] Full `test_aicore_completion_mailbox` suite: **9 + 9 pass** (a2a3 + a5).
- [x] a2a3 onboard async/mailbox paths — `async_notify`, `deferred_notify`,
  `sdma_async_completion`, `paged_attention`, `multi_round_paged_attention`,
  `batch_paged_attention`: **6/6 pass** (live cross-run pooled-arena reuse with
  real mailbox traffic).
- [x] qwen3-14B 3.5k decode onboard: boot-cost drop above; output tokens identical.
