### PR TITLE
perf(runtime): drop the per-run per-core memset in scheduler deinit

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1079,9 +1079,16 @@ void SchedulerContext::deinit() {
         core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
     }
 
-    // Clear per-core dispatch payloads
-    memset(payload_per_core_, 0, sizeof(payload_per_core_));
-    memset(deferred_slab_per_core_, 0, sizeof(deferred_slab_per_core_));
+    // No per-core memset of payload_per_core_ / deferred_slab_per_core_ here
+    // (~300 KB across all cores). Both are fully re-initialized at dispatch
+    // before they can be read: dispatch_task sets deferred_slab->count = 0 /
+    // error_code = NONE and build_payload() overwrites every payload field
+    // (function addr, args[], contexts, not_ready) on the exact [core][buf_idx]
+    // about to run. The consumer side cannot reach a stale slot either: the
+    // drain only services a core's running_reg_task_id, and the loop above
+    // already reset every core_exec_states_[].running/pending_reg_task_id to
+    // AICPU_TASK_INVALID — so no FIN for an undispatched slot is processed, and
+    // the count-gated consumer never reads entries[] past the fresh count.
 
     // Reset sync-start drain coordination — a previous run that aborted mid-drain
     // would otherwise leave dirty pending/elected/ack state for the next reuse.

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -1090,9 +1090,16 @@ void SchedulerContext::deinit() {
         core_exec_states_[i].pending_reg_task_id = AICPU_TASK_INVALID;
     }
 
-    // Clear per-core dispatch payloads
-    memset(payload_per_core_, 0, sizeof(payload_per_core_));
-    memset(deferred_slab_per_core_, 0, sizeof(deferred_slab_per_core_));
+    // No per-core memset of payload_per_core_ / deferred_slab_per_core_ here
+    // (~300 KB across all cores). Both are fully re-initialized at dispatch
+    // before they can be read: dispatch_task sets deferred_slab->count = 0 /
+    // error_code = NONE and build_payload() overwrites every payload field
+    // (function addr, args[], contexts, not_ready) on the exact [core][buf_idx]
+    // about to run. The consumer side cannot reach a stale slot either: the
+    // drain only services a core's running_reg_task_id, and the loop above
+    // already reset every core_exec_states_[].running/pending_reg_task_id to
+    // AICPU_TASK_INVALID — so no FIN for an undispatched slot is processed, and
+    // the count-gated consumer never reads entries[] past the fresh count.
 
     // Reset sync-start drain coordination — a previous run that aborted mid-drain
     // would otherwise leave dirty pending/elected/ack state for the next reuse.


### PR DESCRIPTION
## Summary

`SchedulerContext::deinit()` ran two per-core `memset`s on **every** run —
`payload_per_core_` (72 KB) and `deferred_slab_per_core_` (225 KB), ~300 KB
total. At a large ring window this dominated the `post_orch` teardown phase
(~64 µs/decode step — the largest fixed cost outside the orch/sched window once
#1208 and the mailbox-memset removal shrank the others).

Both buffers are **fully re-initialized at dispatch** before they can be read,
so the per-run zeroing is redundant.

### Why it's safe
- **`deferred_slab_per_core_`** — `dispatch_task()` sets `deferred_slab->count = 0`
  and `error_code = PTO2_ERROR_NONE` on the exact `[core][buf_idx]` about to run.
  The AICore producer only writes `entries[0..count)` and the FIN-thread consumer
  only reads `entries[0..count)` (count-gated), so a prior run's stale entries are
  unreachable. The consumer also can't touch a slot for an *undispatched* task:
  the drain services only a core's `running_reg_task_id`, and `deinit` already
  resets every `core_exec_states_[].running/pending_reg_task_id` to
  `AICPU_TASK_INVALID` (the scalar loop retained directly above).
- **`payload_per_core_`** — `build_payload()` overwrites every field the AICore
  reads (function addr, `args[]`, local/global context, the `not_ready`
  handshake) on every dispatch; there is no read-before-write of any field.

### Kept
- The `init()`-side memsets (one-shot cold-start init, not per-run).
- `cache_invalidate_range(runtime)` in the executor — correctness (next round's
  host DMA must be read fresh from HBM).

Applied symmetrically to **a2a3 and a5**. Same principle as the mailbox no-zero
change (#1208): the per-dispatch reset is the real initializer; the per-boot bulk
zero is belt-and-suspenders.

### Measured (qwen3-14B 3.5k decode, a2a3 onboard, `PTO2_RING_TASK_WINDOW=524288`, 19 steps)
| device-wall phase | before | after |
| ----------------- | ------ | ----- |
| `post_orch` | ~64.7 µs | **~8.9 µs** |

Output tokens identical to the memset build. (`sm_reset` is still ~45 µs on this
branch because it is based off pre-#1208 main; #1208 removes that one separately.)

## Testing
- [x] a2a3 onboard dispatch→FIN→drain paths across pooled-arena reuse —
  `async_notify_demo`, `deferred_notify_demo`, `sdma_async_completion_demo`,
  `paged_attention`, `multi_round_paged_attention`, `batch_paged_attention`:
  **6/6 pass**.
- [x] qwen3-14B 3.5k decode: `post_orch` ~64.7 µs → ~8.9 µs; output tokens identical.

Builds on the same structural insight as #1208.
