### PR TITLE
Refactor: split trb Runtime into DeviceRuntimeLaunchDesc + host-only tail

### DIFF
--- a/src/a2a3/platform/onboard/aicpu/kernel.cpp
+++ b/src/a2a3/platform/onboard/aicpu/kernel.cpp
@@ -90,15 +90,15 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // OCCUPY and wrote it into Runtime; the device side only matches
     // sched_getcpu() against that table and exposes the table position as
     // exec_idx.
-    if (runtime->aicpu_allowed_cpu_count <= 0 || runtime->aicpu_launch_count <= 0) {
+    if (runtime->get_aicpu_allowed_cpu_count() <= 0 || runtime->get_aicpu_launch_count() <= 0) {
         LOG_ERROR(
             "AICPU affinity inputs missing: allowed_cpu_count=%d launch_count=%d (host probe must run before exec)",
-            runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+            runtime->get_aicpu_allowed_cpu_count(), runtime->get_aicpu_launch_count()
         );
         return -1;
     }
     if (!platform_aicpu_affinity_gate_filter(
-            runtime->aicpu_allowed_cpus, runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+            runtime->get_aicpu_allowed_cpus(), runtime->get_aicpu_allowed_cpu_count(), runtime->get_aicpu_launch_count()
         )) {
         LOG_INFO_V0("Thread dropped by filter affinity gate");
         return 0;

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -271,32 +271,33 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     {
         std::vector<pto::a2a3::AicpuLogicalCpu> user_cpus;
         std::vector<int32_t> allowed;
-        runtime.aicpu_allowed_cpu_count = 0;
-        runtime.aicpu_launch_count = 0;
+        runtime.set_aicpu_allowed_cpu_count(0);
+        runtime.set_aicpu_launch_count(0);
         if (!pto::a2a3::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
             LOG_ERROR("A2A3 AICPU topology probe failed; cannot configure affinity gate");
             return -1;
         }
-        if (!pto::a2a3::compute_allowed_cpus(user_cpus, runtime.aicpu_thread_num, allowed)) {
+        if (!pto::a2a3::compute_allowed_cpus(user_cpus, runtime.get_aicpu_thread_num(), allowed)) {
             LOG_ERROR(
                 "A2A3 AICPU topology has %zu user cpus, cannot fit %d active threads", user_cpus.size(),
-                runtime.aicpu_thread_num
+                runtime.get_aicpu_thread_num()
             );
             return -1;
         }
-        const size_t cap = sizeof(runtime.aicpu_allowed_cpus) / sizeof(runtime.aicpu_allowed_cpus[0]);
+        const size_t cap = runtime.aicpu_allowed_cpus_capacity();
         if (allowed.size() > cap) {
             LOG_ERROR("A2A3 compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
             return -1;
         }
+        int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
         for (size_t i = 0; i < allowed.size(); ++i)
-            runtime.aicpu_allowed_cpus[i] = allowed[i];
-        runtime.aicpu_allowed_cpu_count = static_cast<int32_t>(allowed.size());
+            allowed_cpus[i] = allowed[i];
+        runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
         int32_t launch_n = static_cast<int32_t>(user_cpus.size());
         if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
             launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
         }
-        runtime.aicpu_launch_count = launch_n;
+        runtime.set_aicpu_launch_count(launch_n);
 
         std::string dump;
         for (size_t i = 0; i < allowed.size(); ++i) {
@@ -306,7 +307,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         }
         LOG_INFO_V0(
             "A2A3 AICPU ALLOWED_CPUS = [%s] (active=%d, launch=%d, user_cpus=%zu)", dump.c_str(),
-            runtime.aicpu_thread_num, runtime.aicpu_launch_count, user_cpus.size()
+            runtime.get_aicpu_thread_num(), runtime.get_aicpu_launch_count(), user_cpus.size()
         );
     }
 
@@ -317,7 +318,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     // Initialize per-subsystem shared memory.
     if (enable_l2_swimlane_) {
-        rc = init_l2_swimlane(num_aicore, runtime.aicpu_thread_num, device_id_);
+        rc = init_l2_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_swimlane failed: %d", rc);
             return rc;
@@ -410,7 +411,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (enable_l2_swimlane_ && l2_swimlane_collector_.is_initialized()) {
         std::vector<CoreType> core_types(num_aicore);
         for (int i = 0; i < num_aicore; i++) {
-            core_types[i] = runtime.workers[i].core_type;
+            core_types[i] = runtime.get_workers()[i].core_type;
         }
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
@@ -435,7 +436,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
 
     LOG_INFO_V0("=== launch_aicpu_kernel %s ===", host::KernelNames::RunName);
-    int aicpu_launch_n = (runtime.aicpu_launch_count > 0) ? runtime.aicpu_launch_count : launch_aicpu_num;
+    int aicpu_launch_n = (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
@@ -830,7 +831,7 @@ int DeviceRunner::init_l2_swimlane(int num_aicore, int aicpu_thread_num, int dev
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.aicpu_thread_num;
+    int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);

--- a/src/a2a3/platform/sim/aicore/kernel.cpp
+++ b/src/a2a3/platform/sim/aicore/kernel.cpp
@@ -134,7 +134,7 @@ extern "C" void aicore_execute_wrapper(
     //   physical_core_id [block_dim..3*block_dim-1]    = AIV pairs
     //                                                    (AIV0_c0, AIV1_c0, AIV0_c1, AIV1_c1, ...)
     // This mirrors the runtime's CoreTracker cluster assignment.
-    uint32_t block_dim = static_cast<uint32_t>(runtime->worker_count) / PLATFORM_CORES_PER_BLOCKDIM;
+    uint32_t block_dim = static_cast<uint32_t>(runtime->get_worker_count()) / PLATFORM_CORES_PER_BLOCKDIM;
     uint32_t cluster_id;
     uint32_t subblock_id;
     if (core_type == CoreType::AIC) {

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -178,26 +178,17 @@ int DeviceRunner::ensure_binaries_loaded() {
     return 0;
 }
 
-int DeviceRunner::invoke_device_register(Runtime &runtime) {
+int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     if (aicpu_register_callable_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
         LOG_ERROR("Register-callable functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
     set_orch_device_id_func_(device_id_);
-    // Extract the orch-SO descriptor from the stamped Runtime into the small
-    // RegisterCallableArgs the renamed entry expects (sim shares process
-    // memory, so the name pointers stay valid for the synchronous call).
-    RegisterCallableArgs reg_args{};
-    reg_args.active_callable_id = runtime.get_active_callable_id();
-    reg_args.dev_orch_so_addr = runtime.get_dev_orch_so_addr();
-    reg_args.dev_orch_so_size = runtime.get_dev_orch_so_size();
-    const char *func_name = runtime.get_device_orch_func_name();
-    const char *config_name = runtime.get_device_orch_config_name();
-    snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", func_name ? func_name : "");
-    snprintf(
-        reg_args.device_orch_config_name, sizeof(reg_args.device_orch_config_name), "%s", config_name ? config_name : ""
-    );
-    return aicpu_register_callable_func_(&reg_args);
+    // The descriptor was assembled from CallableState by the base
+    // launch_device_register; sim shares process memory so the name pointers
+    // in reg_args stay valid for this synchronous call. The AICPU entry's C ABI
+    // takes void* and only reads the args, so the const_cast is safe.
+    return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
@@ -244,9 +235,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return -1;
     }
 
-    runtime.worker_count = num_aicore;
+    runtime.set_worker_count(num_aicore);
     worker_count_ = num_aicore;
-    runtime.aicpu_thread_num = launch_aicpu_num;
+    runtime.set_aicpu_thread_num(launch_aicpu_num);
 
     int num_aic = block_dim;
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
@@ -267,11 +258,12 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     }
     kernel_args_.enable_profiling_flag = enable_profiling_flag;
 
+    Handshake *workers = runtime.get_workers();
     for (int i = 0; i < num_aicore; i++) {
-        runtime.workers[i].aicpu_ready = 0;
-        runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].task = 0;
-        runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
+        workers[i].aicpu_ready = 0;
+        workers[i].aicore_done = 0;
+        workers[i].task = 0;
+        workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
     }
 
     LOG_DEBUG("Setting function_bin_addr for Tasks (Simulation)");
@@ -294,7 +286,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     last_runtime_ = &runtime;
 
     if (enable_l2_swimlane_) {
-        rc = init_l2_swimlane(num_aicore, runtime.aicpu_thread_num, device_id_);
+        rc = init_l2_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_swimlane failed: %d", rc);
             return rc;
@@ -304,7 +296,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         // workers[i].core_type via the (i < num_aic) rule at line ~240.
         std::vector<CoreType> core_types(num_aicore);
         for (int i = 0; i < num_aicore; i++) {
-            core_types[i] = runtime.workers[i].core_type;
+            core_types[i] = runtime.get_workers()[i].core_type;
         }
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
@@ -415,14 +407,12 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     LOG_INFO_V0("Allocated simulated PMU registers: %d cores x 0x%x bytes", num_aicore, SIM_REG_BLOCK_SIZE);
 
-    const bool needs_orch_device_id = runtime.register_new_callable_id();
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
-        (needs_orch_device_id && set_orch_device_id_func_ == nullptr) || set_platform_dump_base_func_ == nullptr ||
-        set_platform_phase_base_func_ == nullptr || set_dump_args_enabled_func_ == nullptr ||
-        set_platform_pmu_base_func_ == nullptr || set_platform_pmu_reg_addrs_func_ == nullptr ||
-        set_pmu_enabled_func_ == nullptr || set_platform_dep_gen_base_func_ == nullptr ||
-        set_dep_gen_enabled_func_ == nullptr || set_scope_stats_enabled_func_ == nullptr ||
-        set_platform_scope_stats_base_func_ == nullptr) {
+        set_platform_dump_base_func_ == nullptr || set_platform_phase_base_func_ == nullptr ||
+        set_dump_args_enabled_func_ == nullptr || set_platform_pmu_base_func_ == nullptr ||
+        set_platform_pmu_reg_addrs_func_ == nullptr || set_pmu_enabled_func_ == nullptr ||
+        set_platform_dep_gen_base_func_ == nullptr || set_dep_gen_enabled_func_ == nullptr ||
+        set_scope_stats_enabled_func_ == nullptr || set_platform_scope_stats_base_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
@@ -509,7 +499,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     LOG_INFO_V0("Launching %d AICore thread(s)", num_aicore);
     std::vector<std::thread> aicore_threads;
     for (int i = 0; i < num_aicore; i++) {
-        CoreType core_type = runtime.workers[i].core_type;
+        CoreType core_type = runtime.get_workers()[i].core_type;
         uint32_t physical_core_id = static_cast<uint32_t>(i);
         aicore_threads.push_back(create_thread([this, &runtime, i, core_type, physical_core_id]() {
             aicore_execute_func_(
@@ -726,7 +716,7 @@ int DeviceRunner::init_l2_swimlane(int num_aicore, int aicpu_thread_num, int dev
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.aicpu_thread_num;
+    int num_dump_threads = runtime.get_aicpu_thread_num();
 
     auto alloc_cb = [this](size_t size) -> void * {
         return mem_alloc_.alloc(size);

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -39,7 +39,7 @@ public:
 
 private:
     int ensure_binaries_loaded() override;
-    int invoke_device_register(Runtime &runtime) override;
+    int invoke_device_register(const RegisterCallableArgs &reg_args) override;
     void unload_executor_binaries();
 
     int init_l2_swimlane(int num_aicore, int aicpu_thread_num, int device_id);

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -232,3 +232,7 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
     }
     func_id_to_addr_[func_id] = addr;
 }
+
+// host_build_graph uploads the whole Runtime object (AICore reads tasks[] etc.
+// by offset), so the device copy size is the full struct.
+size_t runtime_device_copy_size(const Runtime &) { return sizeof(Runtime); }

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -264,6 +264,27 @@ public:
     Runtime();
 
     // =========================================================================
+    // Accessors for the launch/affinity fields.
+    //
+    // Mirror the trb Runtime's accessor surface (which forwards into its `dev`
+    // sub-struct) so the shared platform layer compiles against either variant.
+    // host_build_graph keeps these fields as flat public members, so the
+    // accessors just return them; layout and sizeof are unchanged.
+    // =========================================================================
+
+    int get_worker_count() const { return worker_count; }
+    void set_worker_count(int n) { worker_count = n; }
+    int get_aicpu_thread_num() const { return aicpu_thread_num; }
+    void set_aicpu_thread_num(int n) { aicpu_thread_num = n; }
+    Handshake *get_workers() { return workers; }
+    int32_t get_aicpu_allowed_cpu_count() const { return aicpu_allowed_cpu_count; }
+    void set_aicpu_allowed_cpu_count(int32_t n) { aicpu_allowed_cpu_count = n; }
+    int32_t get_aicpu_launch_count() const { return aicpu_launch_count; }
+    void set_aicpu_launch_count(int32_t n) { aicpu_launch_count = n; }
+    int32_t *get_aicpu_allowed_cpus() { return aicpu_allowed_cpus; }
+    size_t aicpu_allowed_cpus_capacity() const { return sizeof(aicpu_allowed_cpus) / sizeof(aicpu_allowed_cpus[0]); }
+
+    // =========================================================================
     // Task Management
     // =========================================================================
 
@@ -459,58 +480,14 @@ public:
     // NOTE: Placed at end of class to avoid affecting device memory layout
     HostApi host_api;
 
-    // Device orchestration SO metadata: device buffer pointer + size (host
-    // populates these via DeviceRunner::prepare_orch_so before launch).
-    // host_build_graph runtime variant currently does not load device
-    // orchestration SOs, but DeviceRunner is shared with the other variants
-    // and unconditionally writes these fields, so they must exist.
-    uint64_t dev_orch_so_addr_{0};
-    uint64_t dev_orch_so_size_{0};
-
     // Per-callable_id dispatch. hbg orch runs on host, so AICPU never reads
-    // `active_callable_id_`; the field exists for parity with the
-    // shared platform layer (DeviceRunner stamps it on every run).
+    // `active_callable_id_`; the field exists for parity with the shared
+    // platform layer (DeviceRunner stamps it on every run via
+    // set_active_callable_id).
     int32_t active_callable_id_{-1};
-    bool register_new_callable_id_{false};
 
-    // Device-orchestration entry/config symbol names (trb path). Always
-    // empty on this hbg variant — included for API parity so the shared
-    // platform layer can call set_device_orch_func_name unconditionally.
-    char device_orch_func_name_[64]{};
-    char device_orch_config_name_[64]{};
-
-    void set_device_orch_func_name(const char *name) {
-        device_orch_func_name_[0] = '\0';
-        if (name) {
-            strncpy(device_orch_func_name_, name, sizeof(device_orch_func_name_) - 1);
-            device_orch_func_name_[sizeof(device_orch_func_name_) - 1] = '\0';
-        }
-    }
-    const char *get_device_orch_func_name() const { return device_orch_func_name_; }
-    void set_device_orch_config_name(const char *name) {
-        device_orch_config_name_[0] = '\0';
-        if (name) {
-            strncpy(device_orch_config_name_, name, sizeof(device_orch_config_name_) - 1);
-            device_orch_config_name_[sizeof(device_orch_config_name_) - 1] = '\0';
-        }
-    }
-    const char *get_device_orch_config_name() const { return device_orch_config_name_; }
-
-    void set_dev_orch_so(uint64_t dev_addr, uint64_t size) {
-        dev_orch_so_addr_ = dev_addr;
-        dev_orch_so_size_ = size;
-    }
-    // hbg resolves orchestration on the host, so these stay zero; the getters
-    // exist only so the shared sim register-callable path compiles against this
-    // variant (it reads the descriptor but the AICPU entry is a no-op here).
-    uint64_t get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
-    uint64_t get_dev_orch_so_size() const { return dev_orch_so_size_; }
-    void set_active_callable_id(int32_t callable_id, bool is_new) {
-        active_callable_id_ = callable_id;
-        register_new_callable_id_ = is_new;
-    }
+    void set_active_callable_id(int32_t callable_id) { active_callable_id_ = callable_id; }
     int32_t get_active_callable_id() const { return active_callable_id_; }
-    bool register_new_callable_id() const { return register_new_callable_id_; }
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time; iterated in
@@ -519,5 +496,11 @@ public:
     // garbage, identical to host_api above. No fixed cap.
     std::vector<TensorPair> tensor_pairs_;
 };
+
+// Number of bytes of the Runtime image copied to the device. host_build_graph
+// uploads the whole object (AICore reads tasks[] etc. by offset), so this is
+// sizeof(Runtime). Mirrors the trb declaration so the shared
+// device_runner_helpers.cpp copy path is runtime-agnostic.
+size_t runtime_device_copy_size(const Runtime &rt);
 
 #endif  // SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -67,7 +67,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * @param core_type Core type (AIC or AIV)
  */
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int block_idx, CoreType core_type) {
-    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[block_idx]);
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->dev.workers[block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -203,11 +203,11 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     // Read execution parameters from runtime. The 0 → 1 fixup runs before the
     // sched_thread_num_ derivation so a zero input doesn't leave the scheduler
     // count at -1.
-    aicpu_thread_num_ = runtime->aicpu_thread_num;
+    aicpu_thread_num_ = runtime->dev.aicpu_thread_num;
     if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
     sched_thread_num_ = aicpu_thread_num_ - 1;
-    orch_to_sched_ = runtime->orch_to_sched;
-    serial_orch_sched_ = runtime->serial_orch_sched;
+    orch_to_sched_ = runtime->dev.orch_to_sched;
+    serial_orch_sched_ = runtime->dev.serial_orch_sched;
 
     if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
         LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
@@ -788,10 +788,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 }
 
 void AicpuExecutor::deinit(Runtime *runtime) {
-    // 1. Invalidate AICPU cache for Runtime address range.
-    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
-    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
-    cache_invalidate_range(runtime, sizeof(Runtime));
+    // 1. Invalidate AICPU cache for the device-copied Runtime range (`dev`).
+    //    Next round's Host DMA (rtMemcpy) writes fresh bytes to HBM but
+    //    bypasses this cache. Invalidating now ensures next round reads from
+    //    HBM. Only `dev` is uploaded, so only `dev` needs invalidation.
+    cache_invalidate_range(runtime, sizeof(runtime->dev));
 
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -620,7 +620,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
    once and returns the device address of the ChipCallable header.
 3. For each child, host computes
    `chip_dev + offsetof(ChipCallable, storage_) + callable->child_offset(i)`
-   and stores it in `Runtime.func_id_to_addr_[child_func_id(i)]`.
+   and stores it in `Runtime.dev.func_id_to_addr_[child_func_id(i)]`.
 4. When dispatching, the scheduler reads `func_id_to_addr_[fid]`, casts to
    `const CoreCallable*`, reads `resolved_addr_`, and copies that into
    `PTO2DispatchPayload.function_bin_addr`.

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -466,17 +466,17 @@ extern "C" int bind_callable_to_runtime_impl(
     {
         const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");
         if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
-            runtime->orch_to_sched = true;
+            runtime->dev.orch_to_sched = true;
         }
-        LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
+        LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->dev.orch_to_sched ? "enabled" : "disabled");
     }
 
     // Read serial orchestrator -> scheduler start gate from environment.
     {
         const char *env_val = std::getenv("PTO2_SERIAL_ORCH_SCHED");
-        runtime->serial_orch_sched = env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T');
+        runtime->dev.serial_orch_sched = env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T');
         LOG_INFO_V0(
-            "Serial orchestrator-to-scheduler start gate: %s", runtime->serial_orch_sched ? "enabled" : "disabled"
+            "Serial orchestrator-to-scheduler start gate: %s", runtime->dev.serial_orch_sched ? "enabled" : "disabled"
         );
     }
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -594,7 +594,7 @@ using L0TaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
 struct L2TaskArgs : Arg<CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS> {
     // Build from the executor's ChipStorageTaskArgs: each input becomes a
     // TensorRef pointing at src's Tensor, so `src` must outlive this (on the
-    // executor path src is runtime->orch_args_storage_, alive for the whole run).
+    // executor path src is runtime->dev.orch_args_storage_, alive for the whole run).
     void create_from_chip_args(const ChipStorageTaskArgs &src) {
         reset();
         for (int32_t i = 0; i < src.tensor_count(); ++i) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -29,11 +29,13 @@
 #ifndef SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
 #define SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
 
+#include <stddef.h>  // for offsetof
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>   // for fprintf, printf
 #include <string.h>  // for memset
 
+#include <type_traits>
 #include <vector>
 
 #include "common/core_type.h"
@@ -50,7 +52,6 @@
 #define RUNTIME_MAX_ARGS 128
 #define RUNTIME_MAX_WORKER 72  // 24 AIC + 48 AIV cores
 #define RUNTIME_MAX_FUNC_ID 1024
-#define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 4MB max for orchestration SO
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
 
 // Default ready queue shards: one shard per worker thread (total minus orchestrator)
@@ -176,18 +177,26 @@ struct Task {
 };
 
 // =============================================================================
-// Runtime Class
+// Device launch descriptor
 // =============================================================================
 
 /**
- * Runtime class for device execution and handshake control
+ * DeviceRuntimeLaunchDesc - the device-copied half of Runtime.
  *
- * This class manages AICPU-AICore communication through handshake buffers.
- * Task graph construction is handled by PTO2Runtime; this class only handles
- * execution control and device orchestration state.
+ * This is the ONLY part of Runtime that crosses the host->device boundary: the
+ * host fills it, `device_runner_helpers.cpp` rtMemcpy's exactly
+ * `sizeof(DeviceRuntimeLaunchDesc)` bytes from offset 0 of the Runtime image,
+ * and the AICPU/AICore read these fields back. It is the first member of
+ * Runtime (offsetof == 0), so the narrowed copy needs no offset arithmetic.
+ *
+ * Adding a field here grows the device image; adding a field to Runtime's
+ * host-only tail does not. Keep it standard-layout (static_assert below) so the
+ * rtMemcpy is well-defined. alignas(64) makes sizeof a multiple of the cache
+ * line so the per-run cache_invalidate_range(runtime, sizeof(dev)) never rounds
+ * into a neighbouring line (the leading Handshake is already 64-aligned, but the
+ * explicit alignas keeps the property if fields are ever reordered).
  */
-class Runtime {
-public:
+struct alignas(64) DeviceRuntimeLaunchDesc {
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
@@ -212,7 +221,6 @@ public:
     int32_t aicpu_launch_count;
 
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
-    // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
     // Orchestrator-to-scheduler transition control
@@ -227,13 +235,7 @@ public:
     // Controlled via PTO2_SERIAL_ORCH_SCHED environment variable.
     bool serial_orch_sched;
 
-private:
-    // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
-
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
-    void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
     void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
@@ -244,25 +246,69 @@ private:
     void *prebuilt_arena_base_;
     size_t prebuilt_runtime_offset_;
 
-    // Device orchestration SO (for dlopen on AICPU thread 3).
-    // The SO bytes themselves live in a separately-allocated device buffer
-    // owned by DeviceRunner; only the metadata below travels inside Runtime.
-    uint64_t dev_orch_so_addr_;
-    uint64_t dev_orch_so_size_;
     // Per-callable_id dispatch. AICPU dispatches via
-    // `orch_so_table_[active_callable_id_]`; `register_new_callable_id_`
-    // signals whether the host is delivering a freshly-registered
-    // callable_id (write+dlopen) or reusing an already-loaded one.
+    // `orch_so_table_[active_callable_id_]`.
     int32_t active_callable_id_;
-    bool register_new_callable_id_;
-    char device_orch_func_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME];
-    char device_orch_config_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME];
+};
+
+// =============================================================================
+// Runtime Class
+// =============================================================================
+
+/**
+ * Runtime class for device execution and handshake control
+ *
+ * This class manages AICPU-AICore communication through handshake buffers.
+ * Task graph construction is handled by PTO2Runtime; this class only handles
+ * execution control and device orchestration state.
+ *
+ * Layout: the device-read fields live in the first member `dev`
+ * (DeviceRuntimeLaunchDesc); everything below it is host-only and is never
+ * uploaded. The host/device boundary is therefore the `dev.` prefix, not a
+ * fragile field-ordering convention.
+ */
+class Runtime {
+public:
+    // The device-copied half. MUST stay the first member: device_runner_helpers
+    // copies sizeof(DeviceRuntimeLaunchDesc) bytes from offset 0.
+    DeviceRuntimeLaunchDesc dev;
+
+private:
+    // ---- host-only tail (never uploaded to device) ----
+
+    // Kernel binary tracking for cleanup
+    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
+    int registered_kernel_count_;
+
+    void *gm_heap_ptr_;  // GM heap for orchestrator output buffers (device); host-only bookkeeping
 
 public:
     /**
      * Constructor - zero-initialize all arrays
      */
     Runtime();
+
+    // =========================================================================
+    // Accessors for the device-copied fields in `dev`
+    //
+    // These exist with identical signatures on the host_build_graph Runtime so
+    // the shared platform layer (device_runner*.cpp, kernel.cpp) can compile
+    // against either variant. trb-only code reads `runtime->dev.X` directly.
+    // =========================================================================
+
+    int get_worker_count() const { return dev.worker_count; }
+    void set_worker_count(int n) { dev.worker_count = n; }
+    int get_aicpu_thread_num() const { return dev.aicpu_thread_num; }
+    void set_aicpu_thread_num(int n) { dev.aicpu_thread_num = n; }
+    Handshake *get_workers() { return dev.workers; }
+    int32_t get_aicpu_allowed_cpu_count() const { return dev.aicpu_allowed_cpu_count; }
+    void set_aicpu_allowed_cpu_count(int32_t n) { dev.aicpu_allowed_cpu_count = n; }
+    int32_t get_aicpu_launch_count() const { return dev.aicpu_launch_count; }
+    void set_aicpu_launch_count(int32_t n) { dev.aicpu_launch_count = n; }
+    int32_t *get_aicpu_allowed_cpus() { return dev.aicpu_allowed_cpus; }
+    size_t aicpu_allowed_cpus_capacity() const {
+        return sizeof(dev.aicpu_allowed_cpus) / sizeof(dev.aicpu_allowed_cpus[0]);
+    }
 
     // =========================================================================
     // Performance Profiling
@@ -290,21 +336,12 @@ public:
     void *get_prebuilt_arena_base() const;
     size_t get_prebuilt_runtime_offset() const;
 
-    // Device orchestration SO binary (for dlopen on AICPU thread 3)
-    void set_dev_orch_so(uint64_t dev_addr, uint64_t size);
-    uint64_t get_dev_orch_so_addr() const;
-    uint64_t get_dev_orch_so_size() const;
     // Per-callable_id dispatch. callable_id must be in
-    // [0, MAX_REGISTERED_CALLABLE_IDS); register_new_callable_id_ tells AICPU
-    // whether to (re)load the orch SO into orch_so_table_[callable_id] or
-    // reuse the cached entry.
-    void set_active_callable_id(int32_t callable_id, bool is_new);
+    // [0, MAX_REGISTERED_CALLABLE_IDS); the AICPU dispatches the orch SO via
+    // orch_so_table_[callable_id]. The SO itself is delivered to the AICPU at
+    // register time (RegisterCallableArgs), not through Runtime.
+    void set_active_callable_id(int32_t callable_id);
     int32_t get_active_callable_id() const;
-    bool register_new_callable_id() const;
-    void set_device_orch_func_name(const char *name);
-    const char *get_device_orch_func_name() const;
-    void set_device_orch_config_name(const char *name);
-    const char *get_device_orch_config_name() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
     void set_function_bin_addr(int func_id, uint64_t addr);
@@ -335,17 +372,47 @@ public:
     // Host API (host-only, not copied to device)
     // =========================================================================
 
-    // Host API function pointers for device memory operations
-    // NOTE: Placed at end of class to avoid affecting device memory layout
+    // Host API function pointers for device memory operations. Host-only:
+    // lives in the tail after `dev`, so it is never part of the device copy.
     HostApi host_api;
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in
-    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
-    // Runtime image carries the std::vector control block as harmless
-    // garbage, identical to host_api above. No fixed cap — grows with the
-    // chip-level entry-tensor count.
+    // validate_runtime_impl. Host-only (after `dev`): never uploaded.
     std::vector<TensorPair> tensor_pairs_;
 };
+
+// `dev` must be the first member so the narrowed H2D copy starts at offset 0.
+// Runtime is not standard-layout (std::vector member + mixed access), so guard
+// the offsetof against -Winvalid-offsetof; the offset itself is well-defined
+// for a first member.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
+static_assert(offsetof(Runtime, dev) == 0, "DeviceRuntimeLaunchDesc must be the first member of Runtime");
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+static_assert(
+    std::is_standard_layout_v<DeviceRuntimeLaunchDesc>,
+    "DeviceRuntimeLaunchDesc must be standard-layout: it is rtMemcpy'd to device"
+);
+static_assert(
+    std::is_trivially_copyable_v<DeviceRuntimeLaunchDesc>,
+    "DeviceRuntimeLaunchDesc must be trivially copyable: it is rtMemcpy'd to device"
+);
+static_assert(
+    sizeof(DeviceRuntimeLaunchDesc) % 64 == 0,
+    "DeviceRuntimeLaunchDesc size must be a multiple of 64 so cache_invalidate_range(sizeof(dev)) "
+    "stays cache-line aligned"
+);
+
+// Number of bytes of the Runtime image that must be copied to the device.
+// trb returns sizeof(DeviceRuntimeLaunchDesc) (only `dev` is device-read);
+// host_build_graph returns sizeof(Runtime) (its device image is the whole
+// object). Defined per-runtime so the shared device_runner_helpers.cpp copy
+// path stays runtime-agnostic.
+size_t runtime_device_copy_size(const Runtime &rt);
 
 #endif  // SRC_A2A3_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -689,8 +689,8 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 // Handshake with all AICore workers; discover core type and reg address.
 // =============================================================================
 int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
-    cores_total_num_ = runtime->worker_count;
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
+    cores_total_num_ = runtime->dev.worker_count;
 
     // Validate cores_total_num_ before using as array index
     if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
@@ -924,7 +924,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 // =============================================================================
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
     int32_t timeout_count = 0;
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake *hank = &all_handshakes[i];
@@ -967,7 +967,7 @@ int32_t SchedulerContext::init(
     // prior enabled launch's level can't leak into the phase-record gates in
     // scheduler_dispatch.
     if (is_l2_swimlane_enabled()) {
-        l2_swimlane_aicpu_init(runtime->worker_count);
+        l2_swimlane_aicpu_init(runtime->dev.worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
             // Sched-phase pool count must match the dump_args_init thread count
@@ -982,7 +982,7 @@ int32_t SchedulerContext::init(
             // Orchestration is always single-threaded, so orch-phase is one pool
             // (ordinal 0) in both modes — see record_orch_phase.
             const int orch_phase_threads = 1;
-            l2_swimlane_aicpu_init_phase(runtime->worker_count, sched_phase_threads, orch_phase_threads);
+            l2_swimlane_aicpu_init_phase(runtime->dev.worker_count, sched_phase_threads, orch_phase_threads);
         }
     } else {
         l2_swimlane_level_ = L2SwimlaneLevel::DISABLED;
@@ -1066,7 +1066,7 @@ int32_t SchedulerContext::init(
         }
     }
 
-    func_id_to_addr_ = runtime->func_id_to_addr_;
+    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
 
     return 0;
 }

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -774,7 +774,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
-    Handshake *hank = static_cast<Handshake *>(runtime->workers);
+    Handshake *hank = static_cast<Handshake *>(runtime->dev.workers);
     LOG_INFO_V0(
         "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
         static_cast<uint64_t>(header->rings[0].task_window_size)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -113,7 +113,7 @@ struct alignas(64) CoreExecState {
     uint64_t pending_dispatch_timestamp;  // offset 56: AICPU dispatch timestamp for pending task
 #else
     // --- Cold fields (init/diagnostics only, never in hot path) ---
-    int32_t worker_id;          // offset 48: index in runtime.workers[]
+    int32_t worker_id;          // offset 48: index in runtime.dev.workers[]
     uint32_t physical_core_id;  // offset 52: hardware physical core ID
     CoreType core_type;         // offset 56: AIC or AIV (enum class : int32_t)
     uint8_t pad2_[4];           // offset 60: pad to 64 bytes

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -29,106 +29,57 @@ Runtime::Runtime() {
     // NOTE: host_api is initialized in InitRuntime() (host-only code)
     // because the CApi functions don't exist when compiled for device.
 
-    // Initialize handshake buffers
-    memset(workers, 0, sizeof(workers));
-    worker_count = 0;
-    aicpu_thread_num = 1;
-    ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
-    aicpu_allowed_cpu_count = 0;
-    aicpu_launch_count = 0;
-    orch_to_sched = false;
-    serial_orch_sched = false;
-
-    // Initialize device orchestration state
-    gm_sm_ptr_ = nullptr;
-    gm_heap_ptr_ = nullptr;
-    slot_states_ptr_ = nullptr;
-    orch_args_storage_.clear();
-    prebuilt_arena_base_ = nullptr;
-    prebuilt_runtime_offset_ = 0;
-
-    // Initialize device orchestration SO binary
-    dev_orch_so_addr_ = 0;
-    dev_orch_so_size_ = 0;
-    active_callable_id_ = -1;
-    register_new_callable_id_ = false;
-    device_orch_func_name_[0] = '\0';
-    device_orch_config_name_[0] = '\0';
-
-    // Initialize kernel binary tracking
-    registered_kernel_count_ = 0;
-
-    // Initialize function address mapping
+    // Initialize the device-copied descriptor (`dev`).
+    memset(dev.workers, 0, sizeof(dev.workers));
+    dev.worker_count = 0;
+    dev.aicpu_thread_num = 1;
+    dev.ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+    memset(dev.aicpu_allowed_cpus, 0, sizeof(dev.aicpu_allowed_cpus));
+    dev.aicpu_allowed_cpu_count = 0;
+    dev.aicpu_launch_count = 0;
+    dev.orch_to_sched = false;
+    dev.serial_orch_sched = false;
+    dev.gm_sm_ptr_ = nullptr;
+    dev.slot_states_ptr_ = nullptr;
+    dev.orch_args_storage_.clear();
+    dev.prebuilt_arena_base_ = nullptr;
+    dev.prebuilt_runtime_offset_ = 0;
+    dev.active_callable_id_ = -1;
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
-        func_id_to_addr_[i] = 0;
+        dev.func_id_to_addr_[i] = 0;
     }
+
+    // Initialize host-only tail.
+    gm_heap_ptr_ = nullptr;
+    registered_kernel_count_ = 0;
 }
 
 // =============================================================================
 // Device orchestration
 // =============================================================================
 
-void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
+void *Runtime::get_gm_sm_ptr() const { return dev.gm_sm_ptr_; }
 void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
-const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
-void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
+const ChipStorageTaskArgs &Runtime::get_orch_args() const { return dev.orch_args_storage_; }
+void Runtime::set_gm_sm_ptr(void *p) { dev.gm_sm_ptr_ = p; }
 void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
-void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }
-void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
+void Runtime::set_slot_states_ptr(void *p) { dev.slot_states_ptr_ = p; }
+void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { dev.orch_args_storage_ = args; }
 
 void Runtime::set_prebuilt_arena(void *arena_base, size_t runtime_off) {
-    prebuilt_arena_base_ = arena_base;
-    prebuilt_runtime_offset_ = runtime_off;
+    dev.prebuilt_arena_base_ = arena_base;
+    dev.prebuilt_runtime_offset_ = runtime_off;
 }
-void *Runtime::get_prebuilt_arena_base() const { return prebuilt_arena_base_; }
-size_t Runtime::get_prebuilt_runtime_offset() const { return prebuilt_runtime_offset_; }
+void *Runtime::get_prebuilt_arena_base() const { return dev.prebuilt_arena_base_; }
+size_t Runtime::get_prebuilt_runtime_offset() const { return dev.prebuilt_runtime_offset_; }
 
-// Device orchestration SO metadata (bytes live in a separate device buffer
-// owned by DeviceRunner; only the address/size travels in Runtime).
-void Runtime::set_dev_orch_so(uint64_t dev_addr, uint64_t size) {
-    dev_orch_so_addr_ = dev_addr;
-    dev_orch_so_size_ = size;
-}
+void Runtime::set_active_callable_id(int32_t callable_id) { dev.active_callable_id_ = callable_id; }
 
-uint64_t Runtime::get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
-
-uint64_t Runtime::get_dev_orch_so_size() const { return dev_orch_so_size_; }
-
-void Runtime::set_active_callable_id(int32_t callable_id, bool is_new) {
-    active_callable_id_ = callable_id;
-    register_new_callable_id_ = is_new;
-}
-
-int32_t Runtime::get_active_callable_id() const { return active_callable_id_; }
-
-bool Runtime::register_new_callable_id() const { return register_new_callable_id_; }
-
-void Runtime::set_device_orch_func_name(const char *name) {
-    if (name == nullptr) {
-        device_orch_func_name_[0] = '\0';
-        return;
-    }
-    std::strncpy(device_orch_func_name_, name, RUNTIME_MAX_ORCH_SYMBOL_NAME - 1);
-    device_orch_func_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME - 1] = '\0';
-}
-
-const char *Runtime::get_device_orch_func_name() const { return device_orch_func_name_; }
-
-void Runtime::set_device_orch_config_name(const char *name) {
-    if (name == nullptr) {
-        device_orch_config_name_[0] = '\0';
-        return;
-    }
-    std::strncpy(device_orch_config_name_, name, RUNTIME_MAX_ORCH_SYMBOL_NAME - 1);
-    device_orch_config_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME - 1] = '\0';
-}
-
-const char *Runtime::get_device_orch_config_name() const { return device_orch_config_name_; }
+int32_t Runtime::get_active_callable_id() const { return dev.active_callable_id_; }
 
 uint64_t Runtime::get_function_bin_addr(int func_id) const {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
-    return func_id_to_addr_[func_id];
+    return dev.func_id_to_addr_[func_id];
 }
 
 void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
@@ -136,7 +87,7 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
         return;
     }
-    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+    if (addr != 0 && dev.func_id_to_addr_[func_id] == 0) {
         if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
             registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
         } else {
@@ -146,7 +97,7 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
             );
         }
     }
-    func_id_to_addr_[func_id] = addr;
+    dev.func_id_to_addr_[func_id] = addr;
 }
 
 void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
@@ -154,7 +105,7 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
         return;
     }
-    func_id_to_addr_[func_id] = addr;
+    dev.func_id_to_addr_[func_id] = addr;
 }
 
 int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
@@ -165,3 +116,7 @@ int Runtime::get_registered_kernel_func_id(int index) const {
 }
 
 void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }
+
+// trb's device image is just the `dev` descriptor (the rest of Runtime is
+// host-only). Mirrors the host_build_graph definition (= sizeof(Runtime)).
+size_t runtime_device_copy_size(const Runtime &) { return sizeof(DeviceRuntimeLaunchDesc); }

--- a/src/a5/platform/onboard/aicpu/kernel.cpp
+++ b/src/a5/platform/onboard/aicpu/kernel.cpp
@@ -101,15 +101,15 @@ extern "C" __attribute__((visibility("default"))) int simpler_aicpu_exec(void *a
     // and we'd silently return success without ever calling aicpu_execute.
     // That's a host-side bug; fail loud so it surfaces instead of
     // producing nothing at runtime.
-    if (runtime->aicpu_allowed_cpu_count <= 0 || runtime->aicpu_launch_count <= 0) {
+    if (runtime->get_aicpu_allowed_cpu_count() <= 0 || runtime->get_aicpu_launch_count() <= 0) {
         LOG_ERROR(
             "AICPU affinity inputs missing: allowed_cpu_count=%d launch_count=%d (host probe must run before exec)",
-            runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+            runtime->get_aicpu_allowed_cpu_count(), runtime->get_aicpu_launch_count()
         );
         return -1;
     }
     if (!platform_aicpu_affinity_gate_filter(
-            runtime->aicpu_allowed_cpus, runtime->aicpu_allowed_cpu_count, runtime->aicpu_launch_count
+            runtime->get_aicpu_allowed_cpus(), runtime->get_aicpu_allowed_cpu_count(), runtime->get_aicpu_launch_count()
         )) {
         LOG_INFO_V0("Thread dropped by filter affinity gate");
         return 0;

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -203,7 +203,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         std::vector<int32_t> allowed;
         const int32_t n_orch = 1;
         const int32_t n_sched = (launch_aicpu_num > 1) ? (launch_aicpu_num - n_orch) : 0;
-        runtime.aicpu_allowed_cpu_count = 0;
+        runtime.set_aicpu_allowed_cpu_count(0);
         if (n_sched > 0) {
             if (!pto::a5::probe_aicpu_topology(static_cast<uint32_t>(device_id_), user_cpus)) {
                 LOG_ERROR("AICPU topology probe failed; affinity gate will drop all threads");
@@ -215,14 +215,15 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
                 );
                 return -1;
             }
-            const size_t cap = sizeof(runtime.aicpu_allowed_cpus) / sizeof(runtime.aicpu_allowed_cpus[0]);
+            const size_t cap = runtime.aicpu_allowed_cpus_capacity();
             if (allowed.size() > cap) {
                 LOG_ERROR("compute_allowed_cpus returned %zu > cap %zu", allowed.size(), cap);
                 return -1;
             }
+            int32_t *allowed_cpus = runtime.get_aicpu_allowed_cpus();
             for (size_t i = 0; i < allowed.size(); ++i)
-                runtime.aicpu_allowed_cpus[i] = allowed[i];
-            runtime.aicpu_allowed_cpu_count = static_cast<int32_t>(allowed.size());
+                allowed_cpus[i] = allowed[i];
+            runtime.set_aicpu_allowed_cpu_count(static_cast<int32_t>(allowed.size()));
             // Launch one AICPU thread per OCCUPY-visible user cpu so CANN
             // spreads exactly across the user pool — over-subscription on a
             // SKU with fewer user cpus than the compile-time bound deadlocks
@@ -232,7 +233,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
             if (launch_n > PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH) {
                 launch_n = PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH;
             }
-            runtime.aicpu_launch_count = launch_n;
+            runtime.set_aicpu_launch_count(launch_n);
             std::string dump;
             for (size_t i = 0; i < allowed.size(); ++i) {
                 if (i) dump += ", ";
@@ -261,7 +262,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
 
     // Initialize per-subsystem shared memory.
     if (enable_l2_swimlane_) {
-        rc = init_l2_swimlane(num_aicore, runtime.aicpu_thread_num, device_id_);
+        rc = init_l2_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_swimlane failed: %d", rc);
             return rc;
@@ -335,7 +336,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     if (enable_l2_swimlane_ && l2_swimlane_collector_.is_initialized()) {
         std::vector<CoreType> core_types(num_aicore);
         for (int i = 0; i < num_aicore; i++) {
-            core_types[i] = runtime.workers[i].core_type;
+            core_types[i] = runtime.get_workers()[i].core_type;
         }
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
@@ -377,7 +378,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     // the probe was skipped (single-thread init / launch_aicpu_num == 1)
     // — over-launching to the compile-time bound on that path would
     // start 14 threads to do a 1-thread job and deadlock the device.
-    int aicpu_launch_n = (runtime.aicpu_launch_count > 0) ? runtime.aicpu_launch_count : launch_aicpu_num;
+    int aicpu_launch_n = (runtime.get_aicpu_launch_count() > 0) ? runtime.get_aicpu_launch_count() : launch_aicpu_num;
     rc = launch_aicpu_kernel(stream_aicpu_, &kernel_args_.args, host::KernelNames::RunName, aicpu_launch_n);
     if (rc != 0) {
         LOG_ERROR("launch_aicpu_kernel (main) failed: %d", rc);
@@ -770,7 +771,7 @@ int DeviceRunner::init_l2_swimlane(int num_aicore, int aicpu_thread_num, int dev
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.aicpu_thread_num;
+    int num_dump_threads = runtime.get_aicpu_thread_num();
 
     int rc = dump_collector_.initialize(
         num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_,

--- a/src/a5/platform/sim/aicore/kernel.cpp
+++ b/src/a5/platform/sim/aicore/kernel.cpp
@@ -165,7 +165,7 @@ extern "C" void aicore_execute_wrapper(
     //   physical_core_id [block_dim..3*block_dim-1]    = AIV pairs
     //                                                    (AIV0_c0, AIV1_c0, AIV0_c1, AIV1_c1, ...)
     // This mirrors the runtime's CoreTracker cluster assignment.
-    uint32_t block_dim = static_cast<uint32_t>(runtime->worker_count) / PLATFORM_CORES_PER_BLOCKDIM;
+    uint32_t block_dim = static_cast<uint32_t>(runtime->get_worker_count()) / PLATFORM_CORES_PER_BLOCKDIM;
     uint32_t cluster_id;
     uint32_t subblock_id;
     if (core_type == CoreType::AIC) {

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -179,26 +179,17 @@ int DeviceRunner::ensure_binaries_loaded() {
     return 0;
 }
 
-int DeviceRunner::invoke_device_register(Runtime &runtime) {
+int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     if (aicpu_register_callable_func_ == nullptr || set_orch_device_id_func_ == nullptr) {
         LOG_ERROR("Register-callable functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
     set_orch_device_id_func_(device_id_);
-    // Extract the orch-SO descriptor from the stamped Runtime into the small
-    // RegisterCallableArgs the renamed entry expects (sim shares process
-    // memory, so the name pointers stay valid for the synchronous call).
-    RegisterCallableArgs reg_args{};
-    reg_args.active_callable_id = runtime.get_active_callable_id();
-    reg_args.dev_orch_so_addr = runtime.get_dev_orch_so_addr();
-    reg_args.dev_orch_so_size = runtime.get_dev_orch_so_size();
-    const char *func_name = runtime.get_device_orch_func_name();
-    const char *config_name = runtime.get_device_orch_config_name();
-    snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", func_name ? func_name : "");
-    snprintf(
-        reg_args.device_orch_config_name, sizeof(reg_args.device_orch_config_name), "%s", config_name ? config_name : ""
-    );
-    return aicpu_register_callable_func_(&reg_args);
+    // The descriptor was assembled from CallableState by the base
+    // launch_device_register; sim shares process memory so the name pointers
+    // in reg_args stay valid for this synchronous call. The AICPU entry's C ABI
+    // takes void* and only reads the args, so the const_cast is safe.
+    return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
 int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
@@ -239,9 +230,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         return -1;
     }
 
-    runtime.worker_count = num_aicore;
+    runtime.set_worker_count(num_aicore);
     worker_count_ = num_aicore;
-    runtime.aicpu_thread_num = launch_aicpu_num;
+    runtime.set_aicpu_thread_num(launch_aicpu_num);
 
     int num_aic = block_dim;
     uint32_t enable_profiling_flag = PROFILING_FLAG_NONE;
@@ -261,11 +252,12 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         SET_PROFILING_FLAG(enable_profiling_flag, PROFILING_FLAG_SCOPE_STATS);
     }
 
+    Handshake *workers = runtime.get_workers();
     for (int i = 0; i < num_aicore; i++) {
-        runtime.workers[i].aicpu_ready = 0;
-        runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].task = 0;
-        runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
+        workers[i].aicpu_ready = 0;
+        workers[i].aicore_done = 0;
+        workers[i].task = 0;
+        workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
     }
     kernel_args_.enable_profiling_flag = enable_profiling_flag;
 
@@ -289,7 +281,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     last_runtime_ = &runtime;
 
     if (enable_l2_swimlane_) {
-        rc = init_l2_swimlane(num_aicore, runtime.aicpu_thread_num, device_id_);
+        rc = init_l2_swimlane(num_aicore, runtime.get_aicpu_thread_num(), device_id_);
         if (rc != 0) {
             LOG_ERROR("init_l2_swimlane failed: %d", rc);
             return rc;
@@ -298,7 +290,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         // emit path can label lanes without an AICPU record.
         std::vector<CoreType> core_types(num_aicore);
         for (int i = 0; i < num_aicore; i++) {
-            core_types[i] = runtime.workers[i].core_type;
+            core_types[i] = runtime.get_workers()[i].core_type;
         }
         l2_swimlane_collector_.set_core_types(core_types.data(), num_aicore);
     }
@@ -380,13 +372,12 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         "Allocated simulated registers: %d cores x 0x%x bytes (sparse: 3 pages)", num_aicore, SIM_REG_TOTAL_SIZE
     );
 
-    const bool needs_orch_device_id = runtime.register_new_callable_id();
     if (aicpu_execute_func_ == nullptr || aicore_execute_func_ == nullptr || set_platform_regs_func_ == nullptr ||
-        (needs_orch_device_id && set_orch_device_id_func_ == nullptr) || set_platform_dump_base_func_ == nullptr ||
-        set_platform_phase_base_func_ == nullptr || set_dump_args_enabled_func_ == nullptr ||
-        set_platform_pmu_base_func_ == nullptr || set_pmu_enabled_func_ == nullptr ||
-        set_platform_dep_gen_base_func_ == nullptr || set_dep_gen_enabled_func_ == nullptr ||
-        set_scope_stats_enabled_func_ == nullptr || set_platform_scope_stats_base_func_ == nullptr) {
+        set_platform_dump_base_func_ == nullptr || set_platform_phase_base_func_ == nullptr ||
+        set_dump_args_enabled_func_ == nullptr || set_platform_pmu_base_func_ == nullptr ||
+        set_pmu_enabled_func_ == nullptr || set_platform_dep_gen_base_func_ == nullptr ||
+        set_dep_gen_enabled_func_ == nullptr || set_scope_stats_enabled_func_ == nullptr ||
+        set_platform_scope_stats_base_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }
@@ -471,7 +462,7 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
     LOG_INFO_V0("Launching %d AICore thread(s)", num_aicore);
     std::vector<std::thread> aicore_threads;
     for (int i = 0; i < num_aicore; i++) {
-        CoreType core_type = runtime.workers[i].core_type;
+        CoreType core_type = runtime.get_workers()[i].core_type;
         uint32_t physical_core_id = static_cast<uint32_t>(i);
         aicore_threads.push_back(create_thread([this, &runtime, i, core_type, physical_core_id]() {
             aicore_execute_func_(
@@ -699,7 +690,7 @@ int DeviceRunner::init_l2_swimlane(int num_aicore, int aicpu_thread_num, int dev
 }
 
 int DeviceRunner::init_tensor_dump(Runtime &runtime, int device_id) {
-    int num_dump_threads = runtime.aicpu_thread_num;
+    int num_dump_threads = runtime.get_aicpu_thread_num();
 
     int rc = dump_collector_.initialize(
         num_dump_threads, device_id, prof_alloc_cb, /*register_cb=*/nullptr, prof_free_cb, output_prefix_,

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -40,7 +40,7 @@ public:
 
 private:
     int ensure_binaries_loaded() override;
-    int invoke_device_register(Runtime &runtime) override;
+    int invoke_device_register(const RegisterCallableArgs &reg_args) override;
     void unload_executor_binaries();
 
     int init_l2_swimlane(int num_aicore, int aicpu_thread_num, int device_id);

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -232,3 +232,7 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
     }
     func_id_to_addr_[func_id] = addr;
 }
+
+// host_build_graph uploads the whole Runtime object (AICore reads tasks[] etc.
+// by offset), so the device copy size is the full struct.
+size_t runtime_device_copy_size(const Runtime &) { return sizeof(Runtime); }

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -282,6 +282,27 @@ public:
     Runtime();
 
     // =========================================================================
+    // Accessors for the launch/affinity fields.
+    //
+    // Mirror the trb Runtime's accessor surface (which forwards into its `dev`
+    // sub-struct) so the shared platform layer compiles against either variant.
+    // host_build_graph keeps these fields as flat public members, so the
+    // accessors just return them; layout and sizeof are unchanged.
+    // =========================================================================
+
+    int get_worker_count() const { return worker_count; }
+    void set_worker_count(int n) { worker_count = n; }
+    int get_aicpu_thread_num() const { return aicpu_thread_num; }
+    void set_aicpu_thread_num(int n) { aicpu_thread_num = n; }
+    Handshake *get_workers() { return workers; }
+    int32_t get_aicpu_allowed_cpu_count() const { return aicpu_allowed_cpu_count; }
+    void set_aicpu_allowed_cpu_count(int32_t n) { aicpu_allowed_cpu_count = n; }
+    int32_t get_aicpu_launch_count() const { return aicpu_launch_count; }
+    void set_aicpu_launch_count(int32_t n) { aicpu_launch_count = n; }
+    int32_t *get_aicpu_allowed_cpus() { return aicpu_allowed_cpus; }
+    size_t aicpu_allowed_cpus_capacity() const { return sizeof(aicpu_allowed_cpus) / sizeof(aicpu_allowed_cpus[0]); }
+
+    // =========================================================================
     // Task Management
     // =========================================================================
 
@@ -474,53 +495,14 @@ public:
     // NOTE: Placed at end of class to avoid affecting device memory layout
     HostApi host_api;
 
-    // Device orchestration SO metadata (see a2a3 host_build_graph runtime.h).
-    uint64_t dev_orch_so_addr_{0};
-    uint64_t dev_orch_so_size_{0};
     // Per-callable_id dispatch. hbg orch runs on host, so AICPU never reads
-    // `active_callable_id_`; the field exists for parity with the
-    // shared platform layer (DeviceRunner stamps it on every run).
+    // `active_callable_id_`; the field exists for parity with the shared
+    // platform layer (DeviceRunner stamps it on every run via
+    // set_active_callable_id).
     int32_t active_callable_id_{-1};
-    bool register_new_callable_id_{false};
 
-    // Device-orchestration entry/config symbol names (trb path). Always
-    // empty on this hbg variant — included for API parity so the shared
-    // platform layer can call set_device_orch_func_name unconditionally.
-    char device_orch_func_name_[64]{};
-    char device_orch_config_name_[64]{};
-
-    void set_device_orch_func_name(const char *name) {
-        device_orch_func_name_[0] = '\0';
-        if (name) {
-            strncpy(device_orch_func_name_, name, sizeof(device_orch_func_name_) - 1);
-            device_orch_func_name_[sizeof(device_orch_func_name_) - 1] = '\0';
-        }
-    }
-    const char *get_device_orch_func_name() const { return device_orch_func_name_; }
-    void set_device_orch_config_name(const char *name) {
-        device_orch_config_name_[0] = '\0';
-        if (name) {
-            strncpy(device_orch_config_name_, name, sizeof(device_orch_config_name_) - 1);
-            device_orch_config_name_[sizeof(device_orch_config_name_) - 1] = '\0';
-        }
-    }
-    const char *get_device_orch_config_name() const { return device_orch_config_name_; }
-
-    void set_dev_orch_so(uint64_t dev_addr, uint64_t size) {
-        dev_orch_so_addr_ = dev_addr;
-        dev_orch_so_size_ = size;
-    }
-    // hbg resolves orchestration on the host, so these stay zero; the getters
-    // exist only so the shared sim register-callable path compiles against this
-    // variant (it reads the descriptor but the AICPU entry is a no-op here).
-    uint64_t get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
-    uint64_t get_dev_orch_so_size() const { return dev_orch_so_size_; }
-    void set_active_callable_id(int32_t callable_id, bool is_new) {
-        active_callable_id_ = callable_id;
-        register_new_callable_id_ = is_new;
-    }
+    void set_active_callable_id(int32_t callable_id) { active_callable_id_ = callable_id; }
     int32_t get_active_callable_id() const { return active_callable_id_; }
-    bool register_new_callable_id() const { return register_new_callable_id_; }
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time; iterated in
@@ -529,5 +511,11 @@ public:
     // garbage, identical to host_api above. No fixed cap.
     std::vector<TensorPair> tensor_pairs_;
 };
+
+// Number of bytes of the Runtime image copied to the device. host_build_graph
+// uploads the whole object (AICore reads tasks[] etc. by offset), so this is
+// sizeof(Runtime). Mirrors the trb declaration so the shared
+// device_runner_helpers.cpp copy path is runtime-agnostic.
+size_t runtime_device_copy_size(const Runtime &rt);
 
 #endif  // SRC_A5_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicore/aicore_executor.cpp
@@ -63,7 +63,7 @@ __aicore__ __attribute__((always_inline)) static void execute_task(__gm__ PTO2Di
  * @param core_type Core type (AIC or AIV)
  */
 __aicore__ __attribute__((weak)) void aicore_execute(__gm__ Runtime *runtime, int s_block_idx, CoreType core_type) {
-    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->workers[s_block_idx]);
+    __gm__ Handshake *my_hank = (__gm__ Handshake *)(&runtime->dev.workers[s_block_idx]);
 
     // Phase 1: Wait for AICPU initialization signal
     while (my_hank->aicpu_ready == 0) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -205,11 +205,11 @@ int32_t AicpuExecutor::init(Runtime *runtime) {
     // Read execution parameters from runtime. The 0 → 1 fixup runs before the
     // sched_thread_num_ derivation so a zero input doesn't leave the scheduler
     // count at -1.
-    aicpu_thread_num_ = runtime->aicpu_thread_num;
+    aicpu_thread_num_ = runtime->dev.aicpu_thread_num;
     if (aicpu_thread_num_ == 0) aicpu_thread_num_ = 1;
     sched_thread_num_ = aicpu_thread_num_ - 1;
-    orch_to_sched_ = runtime->orch_to_sched;
-    serial_orch_sched_ = runtime->serial_orch_sched;
+    orch_to_sched_ = runtime->dev.orch_to_sched;
+    serial_orch_sched_ = runtime->dev.serial_orch_sched;
 
     if (aicpu_thread_num_ < 1 || aicpu_thread_num_ > MAX_AICPU_THREADS) {
         LOG_ERROR("Invalid aicpu_thread_num: %d", aicpu_thread_num_);
@@ -783,10 +783,11 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
 }
 
 void AicpuExecutor::deinit(Runtime *runtime) {
-    // 1. Invalidate AICPU cache for Runtime address range.
-    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
-    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
-    cache_invalidate_range(runtime, sizeof(Runtime));
+    // 1. Invalidate AICPU cache for the device-copied Runtime range (`dev`).
+    //    Next round's Host DMA (rtMemcpy) writes fresh bytes to HBM but
+    //    bypasses this cache. Invalidating now ensures next round reads from
+    //    HBM. Only `dev` is uploaded, so only `dev` needs invalidation.
+    cache_invalidate_range(runtime, sizeof(runtime->dev));
 
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();

--- a/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/tensormap_and_ringbuffer/docs/RUNTIME_LOGIC.md
@@ -620,7 +620,7 @@ Built by the scheduler from `PTO2TaskDescriptor`:
    once and returns the device address of the ChipCallable header.
 3. For each child, host computes
    `chip_dev + offsetof(ChipCallable, storage_) + callable->child_offset(i)`
-   and stores it in `Runtime.func_id_to_addr_[child_func_id(i)]`.
+   and stores it in `Runtime.dev.func_id_to_addr_[child_func_id(i)]`.
 4. When dispatching, the scheduler reads `func_id_to_addr_[fid]`, casts to
    `const CoreCallable*`, reads `resolved_addr_`, and copies that into
    `PTO2DispatchPayload.function_bin_addr`.

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -462,17 +462,17 @@ extern "C" int bind_callable_to_runtime_impl(
     {
         const char *env_val = std::getenv("PTO2_ORCH_TO_SCHED");
         if (env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T')) {
-            runtime->orch_to_sched = true;
+            runtime->dev.orch_to_sched = true;
         }
-        LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->orch_to_sched ? "enabled" : "disabled");
+        LOG_INFO_V0("Orchestrator-to-scheduler transition: %s", runtime->dev.orch_to_sched ? "enabled" : "disabled");
     }
 
     // Read serial orchestrator -> scheduler start gate from environment.
     {
         const char *env_val = std::getenv("PTO2_SERIAL_ORCH_SCHED");
-        runtime->serial_orch_sched = env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T');
+        runtime->dev.serial_orch_sched = env_val && (env_val[0] == '1' || env_val[0] == 't' || env_val[0] == 'T');
         LOG_INFO_V0(
-            "Serial orchestrator-to-scheduler start gate: %s", runtime->serial_orch_sched ? "enabled" : "disabled"
+            "Serial orchestrator-to-scheduler start gate: %s", runtime->dev.serial_orch_sched ? "enabled" : "disabled"
         );
     }
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_types.h
@@ -582,7 +582,7 @@ using L0TaskArgs = Arg<MAX_TENSOR_ARGS, MAX_SCALAR_ARGS>;
 struct L2TaskArgs : Arg<CHIP_MAX_TENSOR_ARGS, CHIP_MAX_SCALAR_ARGS> {
     // Build from the executor's ChipStorageTaskArgs: each input becomes a
     // TensorRef pointing at src's Tensor, so `src` must outlive this (on the
-    // executor path src is runtime->orch_args_storage_, alive for the whole run).
+    // executor path src is runtime->dev.orch_args_storage_, alive for the whole run).
     void create_from_chip_args(const ChipStorageTaskArgs &src) {
         reset();
         for (int32_t i = 0; i < src.tensor_count(); ++i) {

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -29,11 +29,13 @@
 #ifndef SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
 #define SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_
 
+#include <stddef.h>  // for offsetof
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>   // for fprintf, printf
 #include <string.h>  // for memset
 
+#include <type_traits>
 #include <vector>
 
 #include "common/core_type.h"
@@ -49,7 +51,6 @@
 #define RUNTIME_MAX_ARGS 128
 #define RUNTIME_MAX_WORKER 108  // 36 AIC + 72 AIV cores
 #define RUNTIME_MAX_FUNC_ID 1024
-#define RUNTIME_MAX_ORCH_SO_SIZE (4 * 1024 * 1024)  // 4MB max for orchestration SO
 #define RUNTIME_MAX_ORCH_SYMBOL_NAME 64
 
 // Default ready queue shards: one shard per worker thread (total minus orchestrator)
@@ -184,18 +185,26 @@ struct Task {
 };
 
 // =============================================================================
-// Runtime Class
+// Device launch descriptor
 // =============================================================================
 
 /**
- * Runtime class for device execution and handshake control
+ * DeviceRuntimeLaunchDesc - the device-copied half of Runtime.
  *
- * This class manages AICPU-AICore communication through handshake buffers.
- * Task graph construction is handled by PTO2Runtime; this class only handles
- * execution control and device orchestration state.
+ * This is the ONLY part of Runtime that crosses the host->device boundary: the
+ * host fills it, `device_runner_helpers.cpp` rtMemcpy's exactly
+ * `sizeof(DeviceRuntimeLaunchDesc)` bytes from offset 0 of the Runtime image,
+ * and the AICPU/AICore read these fields back. It is the first member of
+ * Runtime (offsetof == 0), so the narrowed copy needs no offset arithmetic.
+ *
+ * Adding a field here grows the device image; adding a field to Runtime's
+ * host-only tail does not. Keep it standard-layout (static_assert below) so the
+ * rtMemcpy is well-defined. alignas(64) makes sizeof a multiple of the cache
+ * line so the per-run cache_invalidate_range(runtime, sizeof(dev)) never rounds
+ * into a neighbouring line (the leading Handshake is already 64-aligned, but the
+ * explicit alignas keeps the property if fields are ever reordered).
  */
-class Runtime {
-public:
+struct alignas(64) DeviceRuntimeLaunchDesc {
     // Handshake buffers for AICPU-AICore communication
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
@@ -226,7 +235,6 @@ public:
     int32_t aicpu_launch_count;
 
     // PTO2 integration: kernel_id -> GM function_bin_addr mapping
-    // NOTE: Made public for direct access from aicore code
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
     // Orchestrator-to-scheduler transition control
@@ -241,13 +249,7 @@ public:
     // Controlled via PTO2_SERIAL_ORCH_SCHED environment variable.
     bool serial_orch_sched;
 
-private:
-    // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
-
     void *gm_sm_ptr_;                        // GM pointer to PTO2 shared memory (device)
-    void *gm_heap_ptr_;                      // GM heap for orchestrator output buffers (device)
     void *slot_states_ptr_;                  // Pointer to PTO2TaskSlotState array (scheduler-private, for profiling)
     ChipStorageTaskArgs orch_args_storage_;  // Copy of args for device
 
@@ -258,25 +260,69 @@ private:
     void *prebuilt_arena_base_;
     size_t prebuilt_runtime_offset_;
 
-    // Device orchestration SO (for dlopen on AICPU thread 3).
-    // The SO bytes themselves live in a separately-allocated device buffer
-    // owned by DeviceRunner; only the metadata below travels inside Runtime.
-    uint64_t dev_orch_so_addr_;
-    uint64_t dev_orch_so_size_;
     // Per-callable_id dispatch. AICPU dispatches via
-    // `orch_so_table_[active_callable_id_]`; `register_new_callable_id_`
-    // signals whether the host is delivering a freshly-registered
-    // callable_id (write+dlopen) or reusing an already-loaded one.
+    // `orch_so_table_[active_callable_id_]`.
     int32_t active_callable_id_;
-    bool register_new_callable_id_;
-    char device_orch_func_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME];
-    char device_orch_config_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME];
+};
+
+// =============================================================================
+// Runtime Class
+// =============================================================================
+
+/**
+ * Runtime class for device execution and handshake control
+ *
+ * This class manages AICPU-AICore communication through handshake buffers.
+ * Task graph construction is handled by PTO2Runtime; this class only handles
+ * execution control and device orchestration state.
+ *
+ * Layout: the device-read fields live in the first member `dev`
+ * (DeviceRuntimeLaunchDesc); everything below it is host-only and is never
+ * uploaded. The host/device boundary is therefore the `dev.` prefix, not a
+ * fragile field-ordering convention.
+ */
+class Runtime {
+public:
+    // The device-copied half. MUST stay the first member: device_runner_helpers
+    // copies sizeof(DeviceRuntimeLaunchDesc) bytes from offset 0.
+    DeviceRuntimeLaunchDesc dev;
+
+private:
+    // ---- host-only tail (never uploaded to device) ----
+
+    // Kernel binary tracking for cleanup
+    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
+    int registered_kernel_count_;
+
+    void *gm_heap_ptr_;  // GM heap for orchestrator output buffers (device); host-only bookkeeping
 
 public:
     /**
      * Constructor - zero-initialize all arrays
      */
     Runtime();
+
+    // =========================================================================
+    // Accessors for the device-copied fields in `dev`
+    //
+    // These exist with identical signatures on the host_build_graph Runtime so
+    // the shared platform layer (device_runner*.cpp, kernel.cpp) can compile
+    // against either variant. trb-only code reads `runtime->dev.X` directly.
+    // =========================================================================
+
+    int get_worker_count() const { return dev.worker_count; }
+    void set_worker_count(int n) { dev.worker_count = n; }
+    int get_aicpu_thread_num() const { return dev.aicpu_thread_num; }
+    void set_aicpu_thread_num(int n) { dev.aicpu_thread_num = n; }
+    Handshake *get_workers() { return dev.workers; }
+    int32_t get_aicpu_allowed_cpu_count() const { return dev.aicpu_allowed_cpu_count; }
+    void set_aicpu_allowed_cpu_count(int32_t n) { dev.aicpu_allowed_cpu_count = n; }
+    int32_t get_aicpu_launch_count() const { return dev.aicpu_launch_count; }
+    void set_aicpu_launch_count(int32_t n) { dev.aicpu_launch_count = n; }
+    int32_t *get_aicpu_allowed_cpus() { return dev.aicpu_allowed_cpus; }
+    size_t aicpu_allowed_cpus_capacity() const {
+        return sizeof(dev.aicpu_allowed_cpus) / sizeof(dev.aicpu_allowed_cpus[0]);
+    }
 
     // =========================================================================
     // Performance Profiling
@@ -304,21 +350,12 @@ public:
     void *get_prebuilt_arena_base() const;
     size_t get_prebuilt_runtime_offset() const;
 
-    // Device orchestration SO binary (for dlopen on AICPU thread 3)
-    void set_dev_orch_so(uint64_t dev_addr, uint64_t size);
-    uint64_t get_dev_orch_so_addr() const;
-    uint64_t get_dev_orch_so_size() const;
     // Per-callable_id dispatch. callable_id must be in
-    // [0, MAX_REGISTERED_CALLABLE_IDS); register_new_callable_id_ tells AICPU
-    // whether to (re)load the orch SO into orch_so_table_[callable_id] or
-    // reuse the cached entry.
-    void set_active_callable_id(int32_t callable_id, bool is_new);
+    // [0, MAX_REGISTERED_CALLABLE_IDS); the AICPU dispatches the orch SO via
+    // orch_so_table_[callable_id]. The SO itself is delivered to the AICPU at
+    // register time (RegisterCallableArgs), not through Runtime.
+    void set_active_callable_id(int32_t callable_id);
     int32_t get_active_callable_id() const;
-    bool register_new_callable_id() const;
-    void set_device_orch_func_name(const char *name);
-    const char *get_device_orch_func_name() const;
-    void set_device_orch_config_name(const char *name);
-    const char *get_device_orch_config_name() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
     void set_function_bin_addr(int func_id, uint64_t addr);
@@ -349,17 +386,47 @@ public:
     // Host API (host-only, not copied to device)
     // =========================================================================
 
-    // Host API function pointers for device memory operations
-    // NOTE: Placed at end of class to avoid affecting device memory layout
+    // Host API function pointers for device memory operations. Host-only:
+    // lives in the tail after `dev`, so it is never part of the device copy.
     HostApi host_api;
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in
-    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
-    // Runtime image carries the std::vector control block as harmless
-    // garbage, identical to host_api above. No fixed cap — grows with the
-    // chip-level entry-tensor count.
+    // validate_runtime_impl. Host-only (after `dev`): never uploaded.
     std::vector<TensorPair> tensor_pairs_;
 };
+
+// `dev` must be the first member so the narrowed H2D copy starts at offset 0.
+// Runtime is not standard-layout (std::vector member + mixed access), so guard
+// the offsetof against -Winvalid-offsetof; the offset itself is well-defined
+// for a first member.
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif
+static_assert(offsetof(Runtime, dev) == 0, "DeviceRuntimeLaunchDesc must be the first member of Runtime");
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+static_assert(
+    std::is_standard_layout_v<DeviceRuntimeLaunchDesc>,
+    "DeviceRuntimeLaunchDesc must be standard-layout: it is rtMemcpy'd to device"
+);
+static_assert(
+    std::is_trivially_copyable_v<DeviceRuntimeLaunchDesc>,
+    "DeviceRuntimeLaunchDesc must be trivially copyable: it is rtMemcpy'd to device"
+);
+static_assert(
+    sizeof(DeviceRuntimeLaunchDesc) % 64 == 0,
+    "DeviceRuntimeLaunchDesc size must be a multiple of 64 so cache_invalidate_range(sizeof(dev)) "
+    "stays cache-line aligned"
+);
+
+// Number of bytes of the Runtime image that must be copied to the device.
+// trb returns sizeof(DeviceRuntimeLaunchDesc) (only `dev` is device-read);
+// host_build_graph returns sizeof(Runtime) (its device image is the whole
+// object). Defined per-runtime so the shared device_runner_helpers.cpp copy
+// path stays runtime-agnostic.
+size_t runtime_device_copy_size(const Runtime &rt);
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_RUNTIME_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_cold_path.cpp
@@ -693,8 +693,8 @@ int32_t SchedulerContext::shutdown(int32_t thread_idx) {
 // Handshake with all AICore workers; discover core type and reg address.
 // =============================================================================
 int32_t SchedulerContext::handshake_all_cores(Runtime *runtime) {
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
-    cores_total_num_ = runtime->worker_count;
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
+    cores_total_num_ = runtime->dev.worker_count;
 
     // Validate cores_total_num_ before using as array index
     if (cores_total_num_ == 0 || cores_total_num_ > RUNTIME_MAX_WORKER) {
@@ -927,7 +927,7 @@ void SchedulerContext::reassign_cores_for_all_threads() {
 // =============================================================================
 void SchedulerContext::emergency_shutdown(Runtime *runtime) {
     LOG_WARN("Emergency shutdown: sending exit signal to all initialized cores");
-    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->workers);
+    Handshake *all_handshakes = reinterpret_cast<Handshake *>(runtime->dev.workers);
     int32_t timeout_count = 0;
     for (int32_t i = 0; i < cores_total_num_; i++) {
         Handshake *hank = &all_handshakes[i];
@@ -973,7 +973,7 @@ int32_t SchedulerContext::init(
     // prior enabled launch's level can't leak into the phase-record gates in
     // scheduler_dispatch (`>= SCHED_PHASES`).
     if (is_l2_swimlane_enabled()) {
-        l2_swimlane_aicpu_init(runtime->worker_count);
+        l2_swimlane_aicpu_init(runtime->dev.worker_count);
         l2_swimlane_level_ = get_l2_swimlane_level();
         if (l2_swimlane_level_ >= L2SwimlaneLevel::SCHED_PHASES) {
             // When orchestrator phases merge into scheduler threads
@@ -993,7 +993,7 @@ int32_t SchedulerContext::init(
             // Orch phase is a single instance (PR #971 design), so the orch
             // pool count is always 1 regardless of orch_to_sched mode.
             const int orch_phase_threads = 1;
-            l2_swimlane_aicpu_init_phase(runtime->worker_count, sched_phase_threads, orch_phase_threads);
+            l2_swimlane_aicpu_init_phase(runtime->dev.worker_count, sched_phase_threads, orch_phase_threads);
         }
     } else {
         l2_swimlane_level_ = L2SwimlaneLevel::DISABLED;
@@ -1077,7 +1077,7 @@ int32_t SchedulerContext::init(
         }
     }
 
-    func_id_to_addr_ = runtime->func_id_to_addr_;
+    func_id_to_addr_ = runtime->dev.func_id_to_addr_;
 
     return 0;
 }

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -491,7 +491,7 @@ int32_t SchedulerContext::resolve_and_dispatch(Runtime *runtime, int32_t thread_
         static_cast<uint64_t>(header->rings[0].task_window_size)
     );
 
-    Handshake *hank = static_cast<Handshake *>(runtime->workers);
+    Handshake *hank = static_cast<Handshake *>(runtime->dev.workers);
     LOG_INFO_V0(
         "Thread %d: hank=%p, window_size=%lu", thread_idx, static_cast<void *>(hank),
         static_cast<uint64_t>(header->rings[0].task_window_size)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_types.h
@@ -114,7 +114,7 @@ struct alignas(64) CoreExecState {
     uint64_t pending_dispatch_timestamp;  // offset 56: AICPU dispatch timestamp for pending task
 #else
     // --- Cold fields (init/diagnostics only, never in hot path) ---
-    int32_t worker_id;          // offset 48: index in runtime.workers[]
+    int32_t worker_id;          // offset 48: index in runtime.dev.workers[]
     uint32_t physical_core_id;  // offset 52: hardware physical core ID
     CoreType core_type;         // offset 56: AIC or AIV (enum class : int32_t)
     uint8_t pad2_[4];           // offset 60: pad to 64 bytes

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -29,108 +29,57 @@ Runtime::Runtime() {
     // NOTE: host_api is initialized in InitRuntime() (host-only code)
     // because the CApi functions don't exist when compiled for device.
 
-    // Initialize handshake buffers
-    memset(workers, 0, sizeof(workers));
-    worker_count = 0;
-    aicpu_thread_num = 1;
-    ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
-    memset(aicpu_allowed_cpus, 0, sizeof(aicpu_allowed_cpus));
-    aicpu_allowed_cpu_count = 0;
-    aicpu_launch_count = 0;
-    orch_to_sched = false;
-    serial_orch_sched = false;
-
-    // Initialize profiling state
-
-    // Initialize device orchestration state
-    gm_sm_ptr_ = nullptr;
-    gm_heap_ptr_ = nullptr;
-    slot_states_ptr_ = nullptr;
-    orch_args_storage_.clear();
-    prebuilt_arena_base_ = nullptr;
-    prebuilt_runtime_offset_ = 0;
-
-    // Initialize device orchestration SO binary
-    dev_orch_so_addr_ = 0;
-    dev_orch_so_size_ = 0;
-    active_callable_id_ = -1;
-    register_new_callable_id_ = false;
-    device_orch_func_name_[0] = '\0';
-    device_orch_config_name_[0] = '\0';
-
-    // Initialize kernel binary tracking
-    registered_kernel_count_ = 0;
-
-    // Initialize function address mapping
+    // Initialize the device-copied descriptor (`dev`).
+    memset(dev.workers, 0, sizeof(dev.workers));
+    dev.worker_count = 0;
+    dev.aicpu_thread_num = 1;
+    dev.ready_queue_shards = RUNTIME_DEFAULT_READY_QUEUE_SHARDS;
+    memset(dev.aicpu_allowed_cpus, 0, sizeof(dev.aicpu_allowed_cpus));
+    dev.aicpu_allowed_cpu_count = 0;
+    dev.aicpu_launch_count = 0;
+    dev.orch_to_sched = false;
+    dev.serial_orch_sched = false;
+    dev.gm_sm_ptr_ = nullptr;
+    dev.slot_states_ptr_ = nullptr;
+    dev.orch_args_storage_.clear();
+    dev.prebuilt_arena_base_ = nullptr;
+    dev.prebuilt_runtime_offset_ = 0;
+    dev.active_callable_id_ = -1;
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
-        func_id_to_addr_[i] = 0;
+        dev.func_id_to_addr_[i] = 0;
     }
+
+    // Initialize host-only tail.
+    gm_heap_ptr_ = nullptr;
+    registered_kernel_count_ = 0;
 }
 
 // =============================================================================
 // Device orchestration
 // =============================================================================
 
-void *Runtime::get_gm_sm_ptr() const { return gm_sm_ptr_; }
+void *Runtime::get_gm_sm_ptr() const { return dev.gm_sm_ptr_; }
 void *Runtime::get_gm_heap_ptr() const { return gm_heap_ptr_; }
-const ChipStorageTaskArgs &Runtime::get_orch_args() const { return orch_args_storage_; }
-void Runtime::set_gm_sm_ptr(void *p) { gm_sm_ptr_ = p; }
+const ChipStorageTaskArgs &Runtime::get_orch_args() const { return dev.orch_args_storage_; }
+void Runtime::set_gm_sm_ptr(void *p) { dev.gm_sm_ptr_ = p; }
 void Runtime::set_gm_heap(void *p) { gm_heap_ptr_ = p; }
-void Runtime::set_slot_states_ptr(void *p) { slot_states_ptr_ = p; }
-void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { orch_args_storage_ = args; }
+void Runtime::set_slot_states_ptr(void *p) { dev.slot_states_ptr_ = p; }
+void Runtime::set_orch_args(const ChipStorageTaskArgs &args) { dev.orch_args_storage_ = args; }
 
 void Runtime::set_prebuilt_arena(void *arena_base, size_t runtime_off) {
-    prebuilt_arena_base_ = arena_base;
-    prebuilt_runtime_offset_ = runtime_off;
+    dev.prebuilt_arena_base_ = arena_base;
+    dev.prebuilt_runtime_offset_ = runtime_off;
 }
-void *Runtime::get_prebuilt_arena_base() const { return prebuilt_arena_base_; }
-size_t Runtime::get_prebuilt_runtime_offset() const { return prebuilt_runtime_offset_; }
+void *Runtime::get_prebuilt_arena_base() const { return dev.prebuilt_arena_base_; }
+size_t Runtime::get_prebuilt_runtime_offset() const { return dev.prebuilt_runtime_offset_; }
 
-// Device orchestration SO metadata (bytes live in a separate device buffer
-// owned by DeviceRunner; only the address/size travels in Runtime).
-void Runtime::set_dev_orch_so(uint64_t dev_addr, uint64_t size) {
-    dev_orch_so_addr_ = dev_addr;
-    dev_orch_so_size_ = size;
-}
+void Runtime::set_active_callable_id(int32_t callable_id) { dev.active_callable_id_ = callable_id; }
 
-uint64_t Runtime::get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
-
-uint64_t Runtime::get_dev_orch_so_size() const { return dev_orch_so_size_; }
-
-void Runtime::set_active_callable_id(int32_t callable_id, bool is_new) {
-    active_callable_id_ = callable_id;
-    register_new_callable_id_ = is_new;
-}
-
-int32_t Runtime::get_active_callable_id() const { return active_callable_id_; }
-
-bool Runtime::register_new_callable_id() const { return register_new_callable_id_; }
-
-void Runtime::set_device_orch_func_name(const char *name) {
-    if (name == nullptr) {
-        device_orch_func_name_[0] = '\0';
-        return;
-    }
-    std::strncpy(device_orch_func_name_, name, RUNTIME_MAX_ORCH_SYMBOL_NAME - 1);
-    device_orch_func_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME - 1] = '\0';
-}
-
-const char *Runtime::get_device_orch_func_name() const { return device_orch_func_name_; }
-
-void Runtime::set_device_orch_config_name(const char *name) {
-    if (name == nullptr) {
-        device_orch_config_name_[0] = '\0';
-        return;
-    }
-    std::strncpy(device_orch_config_name_, name, RUNTIME_MAX_ORCH_SYMBOL_NAME - 1);
-    device_orch_config_name_[RUNTIME_MAX_ORCH_SYMBOL_NAME - 1] = '\0';
-}
-
-const char *Runtime::get_device_orch_config_name() const { return device_orch_config_name_; }
+int32_t Runtime::get_active_callable_id() const { return dev.active_callable_id_; }
 
 uint64_t Runtime::get_function_bin_addr(int func_id) const {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return 0;
-    return func_id_to_addr_[func_id];
+    return dev.func_id_to_addr_[func_id];
 }
 
 void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
@@ -138,7 +87,7 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
         return;
     }
-    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
+    if (addr != 0 && dev.func_id_to_addr_[func_id] == 0) {
         if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
             registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
         } else {
@@ -148,7 +97,7 @@ void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
             );
         }
     }
-    func_id_to_addr_[func_id] = addr;
+    dev.func_id_to_addr_[func_id] = addr;
 }
 
 void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
@@ -156,7 +105,7 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
         return;
     }
-    func_id_to_addr_[func_id] = addr;
+    dev.func_id_to_addr_[func_id] = addr;
 }
 
 int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
@@ -167,3 +116,7 @@ int Runtime::get_registered_kernel_func_id(int index) const {
 }
 
 void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }
+
+// trb's device image is just the `dev` descriptor (the rest of Runtime is
+// host-only). Mirrors the host_build_graph definition (= sizeof(Runtime)).
+size_t runtime_device_copy_size(const Runtime &) { return sizeof(DeviceRuntimeLaunchDesc); }

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -523,13 +523,6 @@ int simpler_run(
             validate_runtime_impl(r);
             return rc;
         }
-        if (r->register_new_callable_id()) {
-            rc = runner->commit_device_register(r->get_active_callable_id());
-            if (rc != 0) {
-                validate_runtime_impl(r);
-                return rc;
-            }
-        }
 
         {
             STRACE("simpler_run.validate");

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -515,7 +515,9 @@ void DeviceRunnerBase::print_handshake_results() {
     // Allocate temporary buffer to read handshake data from device
     std::vector<Handshake> workers(worker_count_);
     size_t total_size = sizeof(Handshake) * worker_count_;
-    rtMemcpy(workers.data(), total_size, kernel_args_.args.runtime_args->workers, total_size, RT_MEMCPY_DEVICE_TO_HOST);
+    rtMemcpy(
+        workers.data(), total_size, kernel_args_.args.runtime_args->get_workers(), total_size, RT_MEMCPY_DEVICE_TO_HOST
+    );
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
     for (int i = 0; i < worker_count_; i++) {
@@ -582,11 +584,11 @@ uint64_t DeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *calla
     return chip_dev;
 }
 
-int DeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid, bool force_reload) {
-    // Registered-callable flow only: the SO bytes were already H2D'd at
-    // record_device_orch_callable time. Stamp dev_orch_so on the runtime and mark
-    // `is_new` based on whether the AICPU has committed a successful load
-    // for this cid since registration.
+int DeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid) {
+    // Registered-callable flow only: the orch SO was already H2D'd and
+    // dlopen'd device-side at record_device_orch_callable / launch_device_register
+    // time. All that remains for a run is to tell the AICPU which orch_so_table_
+    // slot to dispatch — the active callable_id.
     if (cid < 0) {
         LOG_ERROR("stamp_orch_so: invalid callable_id=%d", cid);
         return -1;
@@ -596,24 +598,7 @@ int DeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid, bool force_re
         LOG_ERROR("stamp_orch_so: callable_id=%d not registered", cid);
         return -1;
     }
-    const auto &state = it->second;
-    // hbg variant: orch SO never crosses the host/device boundary, so the
-    // AICPU does no per-cid dlopen. Skip orch_so_table_ bookkeeping and clear
-    // device-orch metadata.
-    if (state.host_dlopen_handle != nullptr) {
-        runtime.set_dev_orch_so(0, 0);
-        runtime.set_active_callable_id(cid, /*is_new=*/false);
-        return 0;
-    }
-    const bool needs_load = force_reload || (aicpu_seen_callable_ids_.count(cid) == 0);
-    runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
-    runtime.set_device_orch_func_name(state.func_name.c_str());
-    runtime.set_device_orch_config_name(state.config_name.c_str());
-    runtime.set_active_callable_id(cid, needs_load);
-    LOG_INFO_V0(
-        "Orch SO stamped cid=%d hash=0x%lx %zu bytes (needs_load=%d)", cid, state.hash, state.dev_orch_so_size,
-        needs_load ? 1 : 0
-    );
+    runtime.set_active_callable_id(cid);
     return 0;
 }
 
@@ -623,7 +608,7 @@ int DeviceRunnerBase::prepare_orch_so(Runtime &runtime) {
         LOG_ERROR("prepare_orch_so: no active callable_id; registered-callable flow required");
         return -1;
     }
-    return stamp_orch_so(runtime, cid, /*force_reload=*/false);
+    return stamp_orch_so(runtime, cid);
 }
 
 int DeviceRunnerBase::commit_device_register(int32_t cid) {
@@ -849,14 +834,12 @@ BindCallableResult DeviceRunnerBase::bind_callable_to_runtime(Runtime &runtime, 
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    runtime.set_device_orch_func_name(state.func_name.c_str());
-    runtime.set_device_orch_config_name(state.config_name.c_str());
-    // Stamp callable_id with is_new=false; prepare_orch_so refreshes the flag
-    // with the authoritative first_sighting answer right before launch.
-    runtime.set_active_callable_id(callable_id, /*is_new=*/false);
+    // Tell the AICPU which orch_so_table_ slot this run dispatches. The orch SO
+    // descriptor itself was delivered at register time via RegisterCallableArgs.
+    runtime.set_active_callable_id(callable_id);
     // hbg path: host_orch_func_ptr travels back to the c_api caller, which
     // hands it to bind_callable_to_runtime_impl. trb path: stays null and
-    // the device-side orch SO is resolved from the symbol names above.
+    // the device-side orch SO was resolved at register time.
     return {
         0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
         static_cast<int>(state.signature.size())
@@ -1120,17 +1103,18 @@ int DeviceRunnerBase::prepare_runtime_for_launch(Runtime &runtime, int block_dim
         return -1;
     }
 
-    runtime.worker_count = num_aicore;
+    runtime.set_worker_count(num_aicore);
     worker_count_ = num_aicore;  // Stored for print_handshake_results in destructor
-    runtime.aicpu_thread_num = launch_aicpu_num;
+    runtime.set_aicpu_thread_num(launch_aicpu_num);
 
     // First `block_dim` cores are AIC; remaining ~2/3 are AIV.
     int num_aic = block_dim;
+    Handshake *workers = runtime.get_workers();
     for (int i = 0; i < num_aicore; i++) {
-        runtime.workers[i].aicpu_ready = 0;
-        runtime.workers[i].aicore_done = 0;
-        runtime.workers[i].task = 0;
-        runtime.workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
+        workers[i].aicpu_ready = 0;
+        workers[i].aicore_done = 0;
+        workers[i].task = 0;
+        workers[i].core_type = (i < num_aic) ? CoreType::AIC : CoreType::AIV;
     }
 
     // Set function_bin_addr for all tasks: Runtime::func_id_to_addr_[] stores

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -349,10 +349,10 @@ public:
     /**
      * Device-orchestration callable registration used internally by
      * simpler_register_callable(): launches `simpler_aicpu_register_callable` with a
-     * RegisterCallableArgs descriptor so the AICPU (re)dlopens the callable's
+     * RegisterCallableArgs descriptor so the AICPU dlopens the callable's
      * orch SO. Host-orchestration callables are a no-op. On success, AICPU has
-     * populated orch_so_table_[callable_id] and first run can advertise
-     * register_new_callable_id_=false.
+     * populated orch_so_table_[callable_id] and subsequent runs only need to
+     * stamp the active callable_id.
      */
     int launch_device_register(int32_t callable_id);
 
@@ -581,8 +581,9 @@ protected:
     /**
      * Per-run Runtime setup: derives `num_aicore = block_dim *
      * cores_per_blockdim_`, range-checks against `RUNTIME_MAX_WORKER`,
-     * publishes `runtime.worker_count`, `worker_count_`,
-     * `runtime.aicpu_thread_num`, zero-initializes the handshake
+     * publishes `worker_count`, `worker_count_`,
+     * `aicpu_thread_num` (via the Runtime accessors), zero-initializes
+     * the handshake
      * worker array with AIC/AIV core typing (first `block_dim` cores
      * are AIC, remaining are AIV), and rewrites each task's
      * `function_bin_addr` from `runtime.get_function_bin_addr(func_id)
@@ -678,15 +679,16 @@ protected:
     int finalize_common();
 
     /**
-     * Stamp registered callable metadata onto a Runtime without committing
-     * host seen/counting state. The device-side load must complete before
-     * commit_device_register() is called.
+     * Stamp the active callable_id onto a Runtime so the AICPU knows which
+     * orch_so_table_ slot to dispatch. The orch SO itself was already delivered
+     * device-side at register time (launch_device_register), so nothing else
+     * needs rewriting per run.
      *
-     * @param runtime  Runtime whose device-SO metadata will be rewritten.
+     * @param runtime  Runtime whose active callable_id will be set.
      * @return 0 on success, non-zero on failure.
      */
     int prepare_orch_so(Runtime &runtime);
-    int stamp_orch_so(Runtime &runtime, int32_t callable_id, bool force_reload);
+    int stamp_orch_so(Runtime &runtime, int32_t callable_id);
 
     // ---- Group D state shared by both a2a3 and a5 -------------------------
     //

--- a/src/common/platform/onboard/host/device_runner_helpers.cpp
+++ b/src/common/platform/onboard/host/device_runner_helpers.cpp
@@ -25,8 +25,12 @@
 int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAllocator &allocator) {
     allocator_ = &allocator;
 
+    // Only the device-read prefix of Runtime crosses to the device: trb copies
+    // its `dev` descriptor (offset 0), hbg copies the whole object. Both start
+    // at &host_runtime; runtime_device_copy_size() picks the right length per
+    // runtime variant so this shared path stays runtime-agnostic.
+    const uint64_t runtime_size = runtime_device_copy_size(host_runtime);
     if (args.runtime_args == nullptr) {
-        uint64_t runtime_size = sizeof(Runtime);
         void *runtime_dev = allocator_->alloc(runtime_size);
         if (runtime_dev == nullptr) {
             LOG_ERROR("Alloc for runtime_args failed");
@@ -34,7 +38,7 @@ int KernelArgsHelper::init_runtime_args(const Runtime &host_runtime, MemoryAlloc
         }
         args.runtime_args = reinterpret_cast<Runtime *>(runtime_dev);
     }
-    int rc = rtMemcpy(args.runtime_args, sizeof(Runtime), &host_runtime, sizeof(Runtime), RT_MEMCPY_HOST_TO_DEVICE);
+    int rc = rtMemcpy(args.runtime_args, runtime_size, &host_runtime, runtime_size, RT_MEMCPY_HOST_TO_DEVICE);
     if (rc != 0) {
         LOG_ERROR("rtMemcpy for runtime failed: %d", rc);
         allocator_->free(args.runtime_args);

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -468,14 +468,6 @@ int simpler_run(
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
-        if (r->register_new_callable_id()) {
-            rc = runner->commit_device_register(r->get_active_callable_id());
-            if (rc != 0) {
-                validate_runtime_impl(r);
-                pthread_setspecific(g_runner_key, nullptr);
-                return rc;
-            }
-        }
 
         {
             STRACE("simpler_run.validate");

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -253,7 +253,10 @@ std::thread SimDeviceRunnerBase::l3_l2_create_service_thread(std::function<void(
     return create_thread(std::move(fn));
 }
 
-int SimDeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid, bool force_reload) {
+int SimDeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid) {
+    // Registered-callable flow only: the orch SO was already delivered to the
+    // sim AICPU at launch_device_register time. A run just needs the active
+    // callable_id so the AICPU dispatches the right orch_so_table_ slot.
     if (cid < 0) {
         LOG_ERROR("stamp_orch_so: invalid callable_id=%d", cid);
         return -1;
@@ -263,23 +266,7 @@ int SimDeviceRunnerBase::stamp_orch_so(Runtime &runtime, int32_t cid, bool force
         LOG_ERROR("stamp_orch_so: callable_id=%d not registered", cid);
         return -1;
     }
-    const auto &state = it->second;
-    // hbg: orch SO never crosses host/device — clear device-orch metadata
-    // and skip AICPU bookkeeping.
-    if (state.host_dlopen_handle != nullptr) {
-        runtime.set_dev_orch_so(0, 0);
-        runtime.set_active_callable_id(cid, /*is_new=*/false);
-        return 0;
-    }
-    const bool needs_load = force_reload || (aicpu_seen_callable_ids_.count(cid) == 0);
-    runtime.set_dev_orch_so(state.dev_orch_so_addr, state.dev_orch_so_size);
-    runtime.set_device_orch_func_name(state.func_name.c_str());
-    runtime.set_device_orch_config_name(state.config_name.c_str());
-    runtime.set_active_callable_id(cid, needs_load);
-    LOG_INFO_V0(
-        "Orch SO stamped cid=%d hash=0x%lx %zu bytes (needs_load=%d)", cid, state.hash, state.dev_orch_so_size,
-        needs_load ? 1 : 0
-    );
+    runtime.set_active_callable_id(cid);
     return 0;
 }
 
@@ -289,7 +276,7 @@ int SimDeviceRunnerBase::prepare_orch_so(Runtime &runtime) {
         LOG_ERROR("prepare_orch_so: no active callable_id; prepared-callable flow required");
         return -1;
     }
-    return stamp_orch_so(runtime, cid, /*force_reload=*/false);
+    return stamp_orch_so(runtime, cid);
 }
 
 int SimDeviceRunnerBase::commit_device_register(int32_t cid) {
@@ -325,11 +312,19 @@ int SimDeviceRunnerBase::launch_device_register(int32_t callable_id) {
         return rc;
     }
 
-    Runtime runtime;
-    rc = stamp_orch_so(runtime, callable_id, /*force_reload=*/true);
-    if (rc != 0) return rc;
+    // Build the orch-SO descriptor straight from CallableState — no throwaway
+    // Runtime + stamp round-trip. Mirrors the onboard launch_device_register.
+    const CallableState &state = it->second;
+    RegisterCallableArgs reg_args{};
+    reg_args.active_callable_id = callable_id;
+    reg_args.dev_orch_so_addr = state.dev_orch_so_addr;
+    reg_args.dev_orch_so_size = state.dev_orch_so_size;
+    snprintf(reg_args.device_orch_func_name, sizeof(reg_args.device_orch_func_name), "%s", state.func_name.c_str());
+    snprintf(
+        reg_args.device_orch_config_name, sizeof(reg_args.device_orch_config_name), "%s", state.config_name.c_str()
+    );
 
-    rc = invoke_device_register(runtime);
+    rc = invoke_device_register(reg_args);
     if (rc != 0) {
         LOG_ERROR("launch_device_register: invoke_device_register failed: %d", rc);
         return rc;
@@ -472,9 +467,9 @@ BindCallableResult SimDeviceRunnerBase::bind_callable_to_runtime(Runtime &runtim
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
-    runtime.set_device_orch_func_name(state.func_name.c_str());
-    runtime.set_device_orch_config_name(state.config_name.c_str());
-    runtime.set_active_callable_id(callable_id, /*is_new=*/false);
+    // The AICPU dispatches the orch SO via this callable_id; the SO descriptor
+    // was already delivered at launch_device_register time.
+    runtime.set_active_callable_id(callable_id);
     return {
         0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
         static_cast<int>(state.signature.size())
@@ -572,10 +567,11 @@ void SimDeviceRunnerBase::print_handshake_results() {
     }
 
     LOG_DEBUG("Handshake results for %d cores:", worker_count_);
+    Handshake *workers = last_runtime_->get_workers();
     for (int i = 0; i < worker_count_; i++) {
         LOG_DEBUG(
-            "  Core %d: aicore_done=%d aicpu_ready=%d task=%d", i, last_runtime_->workers[i].aicore_done,
-            last_runtime_->workers[i].aicpu_ready, last_runtime_->workers[i].task
+            "  Core %d: aicore_done=%d aicpu_ready=%d task=%d", i, workers[i].aicore_done, workers[i].aicpu_ready,
+            workers[i].task
         );
     }
 }

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -149,9 +149,12 @@ protected:
     // --- Helpers usable by subclass run() / finalize() -------------------
     int ensure_device_initialized();
     virtual int ensure_binaries_loaded() = 0;
-    virtual int invoke_device_register(Runtime &runtime) = 0;
+    // Hand the orch-SO descriptor to the sim AICPU register entry. Built
+    // directly from CallableState by launch_device_register — no Runtime
+    // round-trip.
+    virtual int invoke_device_register(const RegisterCallableArgs &reg_args) = 0;
     int prepare_orch_so(Runtime &runtime);
-    int stamp_orch_so(Runtime &runtime, int32_t callable_id, bool force_reload);
+    int stamp_orch_so(Runtime &runtime, int32_t callable_id);
 
     // Bulk-free the shared callable / chip-callable / orch-SO state. Subclass
     // finalize() calls this before mem_alloc_.finalize(). Idempotent.

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -213,7 +213,7 @@ int simpler_run(
  *
  * AICPU-side dlopen state in `orch_so_table_[callable_id]` is NOT released by
  * this call. It is reclaimed lazily when the cid is reused (the next
- * `register_new_callable_id()` triggers `dlclose` + reload), or at process
+ * `launch_device_register` triggers `dlclose` + reload), or at process
  * exit. Long-running processes that register / unregister cids without ever
  * reusing them will hold the AICPU SO handle until shutdown.
  *

--- a/tests/ut/cpp/CMakeLists.txt
+++ b/tests/ut/cpp/CMakeLists.txt
@@ -371,6 +371,12 @@ set_tests_properties(test_chip_callable_upload_immutable PROPERTIES LABELS "no_h
 # ---------------------------------------------------------------------------
 add_common_utils_test(test_elf_build_id common/test_elf_build_id.cpp)
 add_common_utils_test(test_runtime_orch_so common/test_runtime_orch_so.cpp)
+# RegisterCallableArgs lives in the arch platform headers (identical across
+# arches); pull in a2a3's so `common/kernel_args.h` resolves for this no-hardware
+# POD-shape test.
+target_include_directories(test_runtime_orch_so PRIVATE
+    ${CMAKE_SOURCE_DIR}/../../../src/a2a3/platform/include
+)
 add_common_utils_test(test_device_arena common/test_device_arena.cpp)
 add_common_utils_test(test_l3_l2_orch_comm common/test_l3_l2_orch_comm.cpp)
 add_executable(test_l3_l2_orch_endpoint

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
@@ -31,7 +31,7 @@ public:
 
 private:
     int ensure_binaries_loaded() override { return 0; }
-    int invoke_device_register(Runtime &) override { return 0; }
+    int invoke_device_register(const RegisterCallableArgs &) override { return 0; }
 };
 
 L3L2OrchCommResponse

--- a/tests/ut/cpp/common/test_runtime_orch_so.cpp
+++ b/tests/ut/cpp/common/test_runtime_orch_so.cpp
@@ -8,65 +8,50 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-// Ensures the Runtime device-orchestration SO accessors round-trip correctly
-// on the tensormap_and_ringbuffer variant. This is the only variant that ships
-// both `set_dev_orch_so` / three getters (a2a3 + a5 share the implementation).
-//
-// We do NOT construct a full Runtime here — its ctor drags in the entire
-// runtime shim surface. Instead we directly test the pieces that matter to
-// the SO cache contract by default-initializing the fields and calling the
-// setter / getters via placement-new onto a zeroed buffer.
+// The orch-SO descriptor (device address/size + entry/config symbol names) is
+// carried to the AICPU register entry in a RegisterCallableArgs POD, no longer
+// stashed on Runtime. These tests pin that POD's shape — default-empty and a
+// round-trip of the fields the host fills from CallableState in
+// launch_device_register.
 
 #include <cstdint>
 #include <cstring>
+#include <string>
 
 #include <gtest/gtest.h>
 
-// Stub for pto2_ring_buffer internal assertion hook referenced transitively
-// by task_args.h include chain. Kept inline to avoid pulling the stubs layer.
-[[noreturn]] void assert_impl(const char *, const char *, int) { std::abort(); }
+#include "common/kernel_args.h"
 
-// Include runtime.cpp-compatible header set. The runtime constructor lives in
-// shared/runtime.cpp; to avoid link dependencies we only exercise the
-// getter/setter via a minimal sub-struct. This mirrors the memory layout of
-// Runtime's orch-SO fields exactly.
-struct DevOrchSoFields {
-    uint64_t dev_orch_so_addr_;
-    uint64_t dev_orch_so_size_;
-    bool has_new_orch_so_;
-
-    void set_dev_orch_so(uint64_t addr, uint64_t size, bool is_new) {
-        dev_orch_so_addr_ = addr;
-        dev_orch_so_size_ = size;
-        has_new_orch_so_ = is_new;
-    }
-    uint64_t get_dev_orch_so_addr() const { return dev_orch_so_addr_; }
-    uint64_t get_dev_orch_so_size() const { return dev_orch_so_size_; }
-    bool has_new_orch_so() const { return has_new_orch_so_; }
-};
-
-TEST(RuntimeOrchSo, DefaultIsEmpty) {
-    DevOrchSoFields f{};
-    EXPECT_EQ(f.get_dev_orch_so_addr(), 0u);
-    EXPECT_EQ(f.get_dev_orch_so_size(), 0u);
-    EXPECT_FALSE(f.has_new_orch_so());
+TEST(RegisterCallableArgs, DefaultIsEmpty) {
+    RegisterCallableArgs args{};
+    EXPECT_EQ(args.active_callable_id, -1);
+    EXPECT_EQ(args.dev_orch_so_addr, 0u);
+    EXPECT_EQ(args.dev_orch_so_size, 0u);
+    EXPECT_EQ(args.device_orch_func_name[0], '\0');
+    EXPECT_EQ(args.device_orch_config_name[0], '\0');
 }
 
-TEST(RuntimeOrchSo, SetRoundTrips) {
-    DevOrchSoFields f{};
-    f.set_dev_orch_so(0xdeadbeefULL, 4096, /*is_new=*/true);
-    EXPECT_EQ(f.get_dev_orch_so_addr(), 0xdeadbeefULL);
-    EXPECT_EQ(f.get_dev_orch_so_size(), 4096u);
-    EXPECT_TRUE(f.has_new_orch_so());
+TEST(RegisterCallableArgs, FieldsRoundTrip) {
+    RegisterCallableArgs args{};
+    args.active_callable_id = 3;
+    args.dev_orch_so_addr = 0xdeadbeefULL;
+    args.dev_orch_so_size = 4096;
+    snprintf(args.device_orch_func_name, sizeof(args.device_orch_func_name), "%s", "orch_entry");
+    snprintf(args.device_orch_config_name, sizeof(args.device_orch_config_name), "%s", "orch_config");
 
-    f.set_dev_orch_so(0xdeadbeefULL, 4096, /*is_new=*/false);  // same buffer, cache hit
-    EXPECT_FALSE(f.has_new_orch_so());
-    EXPECT_EQ(f.get_dev_orch_so_addr(), 0xdeadbeefULL);
+    EXPECT_EQ(args.active_callable_id, 3);
+    EXPECT_EQ(args.dev_orch_so_addr, 0xdeadbeefULL);
+    EXPECT_EQ(args.dev_orch_so_size, 4096u);
+    EXPECT_STREQ(args.device_orch_func_name, "orch_entry");
+    EXPECT_STREQ(args.device_orch_config_name, "orch_config");
 }
 
-TEST(RuntimeOrchSo, ZeroSizeMeansNoSO) {
-    DevOrchSoFields f{};
-    f.set_dev_orch_so(0, 0, false);
-    EXPECT_EQ(f.get_dev_orch_so_size(), 0u);
-    EXPECT_FALSE(f.has_new_orch_so());
+TEST(RegisterCallableArgs, SymbolNamesAreBounded) {
+    // The host fills the symbol names via snprintf with sizeof(field); a name at
+    // or past the bound must stay NUL-terminated inside the fixed array.
+    RegisterCallableArgs args{};
+    std::string long_name(INIT_ARGS_MAX_ORCH_SYMBOL_NAME * 2, 'x');
+    snprintf(args.device_orch_func_name, sizeof(args.device_orch_func_name), "%s", long_name.c_str());
+    EXPECT_EQ(args.device_orch_func_name[INIT_ARGS_MAX_ORCH_SYMBOL_NAME - 1], '\0');
+    EXPECT_EQ(std::strlen(args.device_orch_func_name), static_cast<size_t>(INIT_ARGS_MAX_ORCH_SYMBOL_NAME - 1));
 }


### PR DESCRIPTION
## Summary

Make the host/device boundary of the `tensormap_and_ringbuffer` (trb) `Runtime` explicit in the type system instead of resting on a field-ordering convention, and drop the register-only fields that the `RegisterCallableArgs` hand-off (#1201/#1203/#1207) already superseded.

- **Device-read fields move into a named first member `DeviceRuntimeLaunchDesc dev`** (offset 0); host-only state (`host_api`, `tensor_pairs_`, `gm_heap_ptr_`, kernel-cleanup tracking) stays in the tail and is no longer uploaded. `static_assert`s pin `offsetof(Runtime,dev)==0` and `is_standard_layout_v<DeviceRuntimeLaunchDesc>`.
- **Narrowed H2D copy + cache invalidate**: the per-run `rtMemcpy` and the AICPU `cache_invalidate_range` go from `sizeof(Runtime)` (~34KB) to `sizeof(dev)`, via a per-runtime `runtime_device_copy_size()` free function (hbg returns `sizeof(Runtime)` — full object — so its behavior is unchanged).
- **Shared platform layer compiles against both runtimes**: `device_runner*.cpp` / `kernel.cpp` are built once per (arch, runtime), so they go through new same-signature accessors present on both the trb (forward into `dev.*`) and hbg (flat) `Runtime`; trb-only device code (`aicore_executor`, `scheduler/*`, `aicpu_executor`, `runtime_maker`) reads `runtime->dev.X` directly.
- **Dropped the register-only dead weight**: `dev_orch_so_addr_/size_`, `device_orch_func_name_/config_name_`, `register_new_callable_id_` are gone from trb `Runtime` (and the parity copies from hbg). The sim register path builds `RegisterCallableArgs` straight from `CallableState` (mirroring onboard) instead of round-tripping through a throwaway `Runtime`; the dead post-run `register_new_callable_id()` commit gate is removed; `set_active_callable_id` loses its `is_new` param and `stamp_orch_so` collapses to setting the active callable_id.
- `test_runtime_orch_so.cpp` now pins the `RegisterCallableArgs` POD shape (the new descriptor carrier) instead of the deleted `Runtime` field stubs.

No `Runtime` ABI assumption beyond `offsetof(Runtime,dev)==0` (asserted); hbg `Runtime` layout and copy size are unchanged.

## Testing

- [x] Simulation tests pass — a2a3sim + a5sim `prepared_callable` + `orch_so_cache` (trb), plus hbg `prepared_callable` regression
- [x] Hardware tests pass — a2a3 onboard `prepared_callable` (dlopen-count exactly-once) + `orch_so_cache` + `dummy_task` + `mixed_example`; hbg a2a3 onboard `prepared_callable`
- [x] Builds clean for a2a3 + a5, sim + onboard, trb + hbg

> Note: the cpput suite's final link currently fails on this box due to a pre-existing `libgtest.a` C++ ABI skew (reproduces on untouched tests); the rewritten `test_runtime_orch_so.cpp` object compiles cleanly.