### PR TITLE
Fix: release _ChipWorker handle in Worker.close() L2 branch

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -3915,6 +3915,7 @@ class Worker:
         if self.level == 2:
             if self._chip_worker:
                 self._chip_worker.finalize()
+                self._chip_worker = None
         else:
             if self._worker:
                 self._worker.close()


### PR DESCRIPTION
## Summary

- `Worker.close()` L2 branch called `self._chip_worker.finalize()` but never dropped the Python reference, leaving the `_ChipWorker` nanobind instance alive on the closed Worker.
- Set `self._chip_worker = None` after `finalize()`, mirroring the L>=3 branch (`self._worker = None`) and the error path (which already does this).

## Why

When a pytest case fails, pytest retains its traceback, which strongly references the failing frame's `worker` local and through it the `_ChipWorker` instance — surviving until interpreter exit, where nanobind's leak check fires:

```
nanobind: leaked instance ... of type "_task_interface._ChipWorker"
nanobind: leaked 15 types! / leaked 165 functions!
```

(nanobind dumps the whole types/functions list because it cannot cleanly unload the module while any one instance is live.) This is a benign teardown-ordering artifact, not a runtime C++ leak, but it is noisy in CI and masks future real refcount regressions. Dropping the handle on close releases the instance so it no longer outlives the module.

## Testing

- [x] Simulation tests pass — `examples/workers/l2/vector_add` on `a2a3sim` (exercises L2 register/init/run/close), no leak dump.
- [ ] Hardware tests pass (not run; teardown-only change, sim-covered).

Closes #1221