### PR TITLE
Refactor: move HostApi out of Runtime into a shared explicit parameter

### DIFF
--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -48,6 +48,11 @@ namespace {
 struct OrchestrationRuntimeImpl {
     const OrchestrationRuntimeOps *ops;
     Runtime *runtime;
+    // Platform device-memory hooks. Host orchestration runs through the ops
+    // callbacks below, which need host_api but cannot take it as a parameter
+    // (fixed OrchestrationRuntimeOps ABI) — so it travels here, alongside the
+    // Runtime pointer, filled by bind_callable_to_runtime_impl.
+    const HostApi *host_api;
     struct TensorInfoBuilder *tensor_info_builder;
     struct TensorAllocationBuilder *tensor_allocation_builder;
 };
@@ -92,8 +97,22 @@ struct TensorAllocationBuilder {
     }
 };
 
+// Free every device buffer the orchestration recorded in the allocation
+// builder. Used on bind error paths: once tensor_pairs_ is cleared, the
+// finalize-time cleanup can no longer see these, so they must be freed here
+// or they leak.
+void free_tensor_allocations(const HostApi *api, const TensorAllocationBuilder &builder) {
+    for (const TensorAllocationInfo &allocation : builder.allocations) {
+        api->device_free(reinterpret_cast<void *>(static_cast<uintptr_t>(allocation.base_addr)));
+    }
+}
+
 Runtime *unwrap_runtime(OrchestrationRuntime *runtime) {
     return reinterpret_cast<OrchestrationRuntimeImpl *>(runtime)->runtime;
+}
+
+const HostApi *unwrap_host_api(OrchestrationRuntime *runtime) {
+    return reinterpret_cast<OrchestrationRuntimeImpl *>(runtime)->host_api;
 }
 
 TensorInfoBuilder *unwrap_tensor_info_builder(OrchestrationRuntime *runtime) {
@@ -139,18 +158,18 @@ int runtime_get_task_count(OrchestrationRuntime *runtime) { return unwrap_runtim
 void runtime_print_runtime(OrchestrationRuntime *runtime) { unwrap_runtime(runtime)->print_runtime(); }
 
 void *runtime_device_malloc(OrchestrationRuntime *runtime, size_t size) {
-    void *ptr = unwrap_runtime(runtime)->host_api.device_malloc(size);
+    void *ptr = unwrap_host_api(runtime)->device_malloc(size);
     unwrap_tensor_allocation_builder(runtime)->record_allocation(ptr, size);
     return ptr;
 }
 
 void runtime_device_free(OrchestrationRuntime *runtime, void *ptr) {
     unwrap_tensor_allocation_builder(runtime)->erase_allocation(ptr);
-    unwrap_runtime(runtime)->host_api.device_free(ptr);
+    unwrap_host_api(runtime)->device_free(ptr);
 }
 
 int runtime_copy_to_device(OrchestrationRuntime *runtime, void *dev_ptr, const void *host_ptr, size_t size) {
-    return unwrap_runtime(runtime)->host_api.copy_to_device(dev_ptr, host_ptr, size);
+    return unwrap_host_api(runtime)->copy_to_device(dev_ptr, host_ptr, size);
 }
 
 const OrchestrationRuntimeOps k_orchestration_runtime_ops = {
@@ -198,7 +217,7 @@ bool create_temp_so_file(const uint8_t *data, size_t size, std::string *out_path
     return true;
 }
 
-int upload_tensor_info_storage(Runtime *runtime, const TensorInfoBuilder &builder) {
+int upload_tensor_info_storage(Runtime *runtime, const HostApi *api, const TensorInfoBuilder &builder) {
     runtime->clear_tensor_info_storage();
     for (int task_id = 0; task_id < RUNTIME_MAX_TASKS; task_id++) {
         runtime->set_tensor_info_range(task_id, 0, 0);
@@ -225,16 +244,16 @@ int upload_tensor_info_storage(Runtime *runtime, const TensorInfoBuilder &builde
     }
 
     size_t tensor_info_bytes = compact_tensor_info.size() * sizeof(TensorInfo);
-    void *dev_tensor_info_storage = runtime->host_api.device_malloc(tensor_info_bytes);
+    void *dev_tensor_info_storage = api->device_malloc(tensor_info_bytes);
     if (dev_tensor_info_storage == nullptr) {
         LOG_ERROR("Failed to allocate tensor info storage (%zu bytes)", tensor_info_bytes);
         return -1;
     }
 
-    int rc = runtime->host_api.copy_to_device(dev_tensor_info_storage, compact_tensor_info.data(), tensor_info_bytes);
+    int rc = api->copy_to_device(dev_tensor_info_storage, compact_tensor_info.data(), tensor_info_bytes);
     if (rc != 0) {
         LOG_ERROR("Failed to copy tensor info storage to device: %d", rc);
-        runtime->host_api.device_free(dev_tensor_info_storage);
+        api->device_free(dev_tensor_info_storage);
         return rc;
     }
 
@@ -243,23 +262,23 @@ int upload_tensor_info_storage(Runtime *runtime, const TensorInfoBuilder &builde
     return 0;
 }
 
-int upload_tensor_allocation_storage(Runtime *runtime, const TensorAllocationBuilder &builder) {
+int upload_tensor_allocation_storage(Runtime *runtime, const HostApi *api, const TensorAllocationBuilder &builder) {
     runtime->clear_tensor_allocation_storage();
     if (builder.allocations.empty()) {
         return 0;
     }
 
     size_t allocation_bytes = builder.allocations.size() * sizeof(TensorAllocationInfo);
-    void *dev_allocation_storage = runtime->host_api.device_malloc(allocation_bytes);
+    void *dev_allocation_storage = api->device_malloc(allocation_bytes);
     if (dev_allocation_storage == nullptr) {
         LOG_ERROR("Failed to allocate tensor allocation storage (%zu bytes)", allocation_bytes);
         return -1;
     }
 
-    int rc = runtime->host_api.copy_to_device(dev_allocation_storage, builder.allocations.data(), allocation_bytes);
+    int rc = api->copy_to_device(dev_allocation_storage, builder.allocations.data(), allocation_bytes);
     if (rc != 0) {
         LOG_ERROR("Failed to copy tensor allocation storage to device: %d", rc);
-        runtime->host_api.device_free(dev_allocation_storage);
+        api->device_free(dev_allocation_storage);
         return rc;
     }
 
@@ -358,12 +377,16 @@ int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(c
  * CallableState for this run's callable_id).
  */
 int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
     const uint64_t * /*ring_dep_pool*/
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
     if (orch_args == nullptr) {
@@ -387,7 +410,7 @@ int bind_callable_to_runtime_impl(
     TensorInfoBuilder tensor_info_builder;
     TensorAllocationBuilder tensor_allocation_builder;
     OrchestrationRuntimeImpl orchestration_runtime = {
-        &k_orchestration_runtime_ops, runtime, &tensor_info_builder, &tensor_allocation_builder
+        &k_orchestration_runtime_ops, runtime, api, &tensor_info_builder, &tensor_allocation_builder
     };
 
     // hbg orch runs on the host, so it may legitimately need to dereference
@@ -401,24 +424,27 @@ int bind_callable_to_runtime_impl(
     int rc = orch_func(reinterpret_cast<OrchestrationRuntime *>(&orchestration_runtime), *orch_args);
     if (rc != 0) {
         LOG_ERROR("Orchestration function failed with code %d", rc);
+        free_tensor_allocations(api, tensor_allocation_builder);
         runtime->tensor_pairs_.clear();
         return rc;
     }
 
-    rc = upload_tensor_allocation_storage(runtime, tensor_allocation_builder);
+    rc = upload_tensor_allocation_storage(runtime, api, tensor_allocation_builder);
     if (rc != 0) {
         LOG_ERROR("Failed to upload tensor allocations: %d", rc);
+        free_tensor_allocations(api, tensor_allocation_builder);
         runtime->tensor_pairs_.clear();
         return rc;
     }
 
-    rc = upload_tensor_info_storage(runtime, tensor_info_builder);
+    rc = upload_tensor_info_storage(runtime, api, tensor_info_builder);
     if (rc != 0) {
         LOG_ERROR("Failed to upload tensor info storage: %d", rc);
         if (runtime->get_tensor_allocation_storage() != nullptr) {
-            runtime->host_api.device_free(runtime->get_tensor_allocation_storage());
+            api->device_free(runtime->get_tensor_allocation_storage());
             runtime->clear_tensor_allocation_storage();
         }
+        free_tensor_allocations(api, tensor_allocation_builder);
         runtime->tensor_pairs_.clear();
         return rc;
     }
@@ -438,9 +464,13 @@ int bind_callable_to_runtime_impl(
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime *runtime) {
+int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
 
@@ -454,7 +484,7 @@ int validate_runtime_impl(Runtime *runtime) {
 
     for (int i = 0; i < tensor_pair_count; i++) {
         const TensorPair &pair = tensor_pairs[i];
-        int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
+        int copy_rc = api->copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
         if (copy_rc != 0) {
             LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
             rc = copy_rc;
@@ -469,7 +499,7 @@ int validate_runtime_impl(Runtime *runtime) {
     // Cleanup device tensors
     LOG_INFO_V0("=== Cleaning Up ===");
     for (int i = 0; i < tensor_pair_count; i++) {
-        runtime->host_api.device_free(tensor_pairs[i].dev_ptr);
+        api->device_free(tensor_pairs[i].dev_ptr);
     }
     LOG_INFO_V0("Freed %d device tensors", tensor_pair_count);
 
@@ -488,11 +518,11 @@ int validate_runtime_impl(Runtime *runtime) {
     runtime->clear_registered_kernels();
 
     if (runtime->get_tensor_info_storage() != nullptr) {
-        runtime->host_api.device_free(runtime->get_tensor_info_storage());
+        api->device_free(runtime->get_tensor_info_storage());
         runtime->clear_tensor_info_storage();
     }
     if (runtime->get_tensor_allocation_storage() != nullptr) {
-        runtime->host_api.device_free(runtime->get_tensor_allocation_storage());
+        api->device_free(runtime->get_tensor_allocation_storage());
         runtime->clear_tensor_allocation_storage();
     }
 

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "common/core_type.h"
+#include "common/host_api.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
@@ -125,52 +126,6 @@ struct TensorPair {
     void *host_ptr;
     void *dev_ptr;
     size_t size;
-};
-
-/**
- * Host API function pointers for device memory operations.
- * Allows runtime to use pluggable device memory backends.
- */
-struct HostApi {
-    void *(*device_malloc)(size_t size);
-    void (*device_free)(void *dev_ptr);
-    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
-    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    // Device-side memset (zero-init pure OUTPUT buffers in lieu of an H2D
-    // copy-in). Unused by host_build_graph; present only so the platform
-    // layer can populate the same HostApi shape regardless of runtime variant.
-    int (*device_memset)(void *dev_ptr, int value, size_t size);
-    // PTO2 static-arena hooks. The host_build_graph runtime does not currently
-    // use these — the fields exist only so the platform layer's
-    // pto_runtime_c_api.cpp can populate the same HostApi struct regardless of
-    // which runtime variant it is built against. Unset for this variant; do
-    // not call. hbg-side callers pass runtime_arena_size == 0 (hbg has no
-    // prebuilt runtime arena).
-    int (*setup_static_arena)(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
-    void *(*acquire_pooled_gm_heap)();
-    void *(*acquire_pooled_gm_sm)();
-    void *(*acquire_pooled_runtime_arena)();
-    bool (*lookup_prebuilt_runtime_arena_cache)(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
-    );
-    void (*mark_prebuilt_runtime_arena_cached)(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
-        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
-    );
-    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
-    // `const ChipCallable *` (declared void* to avoid pulling task_interface
-    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
-    // total byte size, allocates device GM once, fixes up each child's
-    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
-    // dlopen function pointer), H2D's once, and returns the device-side
-    // address of the ChipCallable header. Pool-managed: identical buffer
-    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
-    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
-    // child_count() == 0. Caller computes child addrs as
-    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
-    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
-    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**
@@ -481,12 +436,8 @@ public:
     void clear_registered_kernels() { registered_kernel_count_ = 0; }
 
     // =========================================================================
-    // Host API (host-only, not copied to device)
+    // Host-only state (not copied to device)
     // =========================================================================
-
-    // Host API function pointers for device memory operations
-    // NOTE: Placed at end of class to avoid affecting device memory layout
-    HostApi host_api;
 
     // Per-callable_id dispatch. hbg orch runs on host, so AICPU never reads
     // `active_callable_id_`; the field exists for parity with the shared
@@ -501,7 +452,7 @@ public:
     // runtime_maker.cpp from orch_args at bind time; iterated in
     // validate_runtime_impl. Not read by AICPU/AICore — the device-side
     // Runtime image carries the std::vector control block as harmless
-    // garbage, identical to host_api above. No fixed cap.
+    // garbage. No fixed cap.
     std::vector<TensorPair> tensor_pairs_;
 };
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -246,7 +246,7 @@ static bool resolve_ring_config(
     return true;
 }
 
-static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
+static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PTO2SharedMemoryHeader *host_header) {
     if (runtime == nullptr || host_header == nullptr) {
         return 0;
     }
@@ -256,7 +256,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
         return 0;
     }
 
-    int hdr_rc = runtime->host_api.copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
+    int hdr_rc = api->copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
     if (hdr_rc != 0) {
         LOG_WARN("Failed to copy PTO2 header from device");
         return 0;
@@ -274,7 +274,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
  * on per-run argument values, so the simpler_register_callable / simpler_run split
  * lets us run this once per callable_id and amortize across runs.
  *
- * @param runtime   Pointer to pre-constructed Runtime (host_api populated)
+ * @param runtime   Pointer to pre-constructed Runtime
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
  * @return 0 on success, -1 on failure
  */
@@ -419,8 +419,8 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
 // staged device_args / tensor_pairs_ stay owned by the caller's Runtime, which
 // frees them in validate_runtime_impl.
 static bool stage_device_args(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, const ArgDirection *signature, int sig_count,
-    ChipStorageTaskArgs *out
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, const ArgDirection *signature,
+    int sig_count, ChipStorageTaskArgs *out
 ) {
     int tensor_count = orch_args->tensor_count();
     int scalar_count = orch_args->scalar_count();
@@ -439,7 +439,7 @@ static bool stage_device_args(
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.buffer.addr));
         size_t size = static_cast<size_t>(t.nbytes());
 
-        void *dev_ptr = runtime->host_api.device_malloc(size);
+        void *dev_ptr = api->device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return false;
@@ -453,14 +453,14 @@ static bool stage_device_args(
         // did not wire device_memset.
         bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
         int rc;
-        if (is_pure_output && runtime->host_api.device_memset != nullptr) {
-            rc = runtime->host_api.device_memset(dev_ptr, 0, size);
+        if (is_pure_output && api->device_memset != nullptr) {
+            rc = api->device_memset(dev_ptr, 0, size);
         } else {
-            rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+            rc = api->copy_to_device(dev_ptr, host_ptr, size);
         }
         if (rc != 0) {
             LOG_ERROR("Failed to stage tensor %d to device", i);
-            runtime->host_api.device_free(dev_ptr);
+            api->device_free(dev_ptr);
             return false;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
@@ -503,21 +503,22 @@ static void apply_orch_sched_env_flags(Runtime *runtime) {
 // reserve sequence on a throwaway host arena. Idempotent across runs — the
 // pools are owned by DeviceRunner and freed in DeviceRunner::finalize().
 static bool ensure_static_arenas(
-    Runtime *runtime, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, StaticArenaPtrs *out
+    Runtime *runtime, const HostApi *api, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes,
+    StaticArenaPtrs *out
 ) {
     DeviceArena sizing_arena;  // discarded; only its computed arena_size is read
     PTO2RuntimeArenaLayout layout =
         runtime_reserve_layout(sizing_arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
 
     int64_t t_setup_start = _now_ms();
-    if (runtime->host_api.setup_static_arena(sizes.total_heap, sizes.sm_size, layout.offsets.arena_size) != 0) {
+    if (api->setup_static_arena(sizes.total_heap, sizes.sm_size, layout.offsets.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return false;
     }
     int64_t t_setup_end = _now_ms();
 
     int64_t t_heap_start = _now_ms();
-    out->gm_heap = runtime->host_api.acquire_pooled_gm_heap();
+    out->gm_heap = api->acquire_pooled_gm_heap();
     int64_t t_heap_end = _now_ms();
     if (out->gm_heap == nullptr) {
         LOG_ERROR("Failed to acquire pooled GM heap");
@@ -525,7 +526,7 @@ static bool ensure_static_arenas(
     }
 
     int64_t t_sm_start = _now_ms();
-    out->gm_sm = runtime->host_api.acquire_pooled_gm_sm();
+    out->gm_sm = api->acquire_pooled_gm_sm();
     int64_t t_sm_end = _now_ms();
     if (out->gm_sm == nullptr) {
         LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
@@ -533,7 +534,7 @@ static bool ensure_static_arenas(
     }
     runtime->set_gm_sm_ptr(out->gm_sm);
 
-    out->runtime_arena_dev = runtime->host_api.acquire_pooled_runtime_arena();
+    out->runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (out->runtime_arena_dev == nullptr) {
         LOG_ERROR("Failed to acquire pooled runtime arena");
         return false;
@@ -589,13 +590,12 @@ static bool build_runtime_image(
 // rtMemcpy the host image into the pooled runtime-arena region, and record the
 // device base + runtime offset the AICPU reads before dereferencing the image.
 static bool bind_launch_state(
-    Runtime *runtime, const StaticArenaPtrs &ptrs, const DeviceArena &host_arena, const PTO2RuntimeArenaLayout &layout,
-    const ChipStorageTaskArgs &device_args
+    Runtime *runtime, const HostApi *api, const StaticArenaPtrs &ptrs, const DeviceArena &host_arena,
+    const PTO2RuntimeArenaLayout &layout, const ChipStorageTaskArgs &device_args
 ) {
     runtime->set_orch_args(device_args);
 
-    int rc_upload =
-        runtime->host_api.copy_to_device(ptrs.runtime_arena_dev, host_arena.base(), layout.offsets.arena_size);
+    int rc_upload = api->copy_to_device(ptrs.runtime_arena_dev, host_arena.base(), layout.offsets.arena_size);
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return false;
@@ -605,9 +605,10 @@ static bool bind_launch_state(
 }
 
 static int bind_cached_runtime_image(
-    Runtime *runtime, const PrebuiltRuntimeArenaCacheProbe &probe, const ChipStorageTaskArgs &device_args
+    Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe,
+    const ChipStorageTaskArgs &device_args
 ) {
-    if (runtime->host_api.lookup_prebuilt_runtime_arena_cache == nullptr) {
+    if (api->lookup_prebuilt_runtime_arena_cache == nullptr) {
         return 1;
     }
 
@@ -617,7 +618,7 @@ static int bind_cached_runtime_image(
     size_t runtime_off = 0;
     const void *cached_image = nullptr;
     size_t cached_image_size = 0;
-    bool cache_hit = runtime->host_api.lookup_prebuilt_runtime_arena_cache(
+    bool cache_hit = api->lookup_prebuilt_runtime_arena_cache(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), &gm_heap, &sm_ptr, &runtime_arena_dev,
         &runtime_off, &cached_image, &cached_image_size
     );
@@ -626,7 +627,7 @@ static int bind_cached_runtime_image(
     }
 
     runtime->set_orch_args(device_args);
-    int rc_upload = runtime->host_api.copy_to_device(runtime_arena_dev, cached_image, cached_image_size);
+    int rc_upload = api->copy_to_device(runtime_arena_dev, cached_image, cached_image_size);
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy cached prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;
@@ -637,13 +638,13 @@ static int bind_cached_runtime_image(
 }
 
 static void store_prebuilt_runtime_image(
-    Runtime *runtime, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
+    Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
     const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
-    if (runtime->host_api.mark_prebuilt_runtime_arena_cached == nullptr) {
+    if (api->mark_prebuilt_runtime_arena_cached == nullptr) {
         return;
     }
-    runtime->host_api.mark_prebuilt_runtime_arena_cached(
+    api->mark_prebuilt_runtime_arena_cached(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
         ptrs.runtime_arena_dev, layout.offsets.off_runtime, host_arena.base(), layout.offsets.arena_size
     );
@@ -664,16 +665,21 @@ static void store_prebuilt_runtime_image(
  * (build_runtime_image), and per-run args (stage_device_args) + launch publish
  * (bind_launch_state).
  *
- * @param runtime    Pointer to pre-constructed Runtime (host_api populated)
+ * @param runtime    Pointer to pre-constructed Runtime
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
 extern "C" int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
     if (orch_args == nullptr) {
@@ -700,7 +706,7 @@ extern "C" int bind_callable_to_runtime_impl(
     }
 
     ChipStorageTaskArgs device_args;
-    if (!stage_device_args(runtime, orch_args, signature, sig_count, &device_args)) {
+    if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &device_args)) {
         return -1;
     }
 
@@ -710,7 +716,7 @@ extern "C" int bind_callable_to_runtime_impl(
     {
         STRACE("simpler_run.bind.prebuilt");
         PrebuiltRuntimeArenaCacheProbe cache_probe = make_prebuilt_runtime_arena_cache_probe(sizing);
-        int cache_rc = bind_cached_runtime_image(runtime, cache_probe, device_args);
+        int cache_rc = bind_cached_runtime_image(runtime, api, cache_probe, device_args);
         if (cache_rc < 0) {
             return -1;
         }
@@ -721,7 +727,7 @@ extern "C" int bind_callable_to_runtime_impl(
             }
 
             StaticArenaPtrs ptrs;
-            if (!ensure_static_arenas(runtime, sizing, sizes, &ptrs)) {
+            if (!ensure_static_arenas(runtime, api, sizing, sizes, &ptrs)) {
                 return -1;
             }
 
@@ -731,10 +737,10 @@ extern "C" int bind_callable_to_runtime_impl(
                 return -1;
             }
 
-            if (!bind_launch_state(runtime, ptrs, host_arena, layout, device_args)) {
+            if (!bind_launch_state(runtime, api, ptrs, host_arena, layout, device_args)) {
                 return -1;
             }
-            store_prebuilt_runtime_image(runtime, cache_probe, ptrs, layout, host_arena);
+            store_prebuilt_runtime_image(runtime, api, cache_probe, ptrs, layout, host_arena);
         }
     }
     int64_t t_prebuilt_end = _now_ms();
@@ -759,9 +765,13 @@ extern "C" int bind_callable_to_runtime_impl(
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime) {
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
 
@@ -783,7 +793,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     PTO2SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
 
-    runtime_status = pto2_read_runtime_status(runtime, &host_header);
+    runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
@@ -856,7 +866,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
                 first_output_tensor = false;
             }
 
-            int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(pair.host_ptr, src_ptr, copy_size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;
@@ -870,7 +880,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO_V0("=== Cleaning Up ===");
     for (int i = 0; i < tensor_pair_count; i++) {
         if (tensor_pairs[i].dev_ptr != nullptr) {
-            runtime->host_api.device_free(tensor_pairs[i].dev_ptr);
+            api->device_free(tensor_pairs[i].dev_ptr);
         }
     }
     LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "common/core_type.h"
+#include "common/host_api.h"
 #include "common/l2_swimlane_profiling.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
@@ -114,62 +115,6 @@ struct TensorPair {
     // so the end-of-run D2H copy-back is skipped. OUTPUT/INOUT/unknown
     // keep the safe default of copying back.
     bool needs_copy_back = true;
-};
-
-/**
- * Host API function pointers for device memory operations.
- * Allows runtime to use pluggable device memory backends.
- */
-struct HostApi {
-    void *(*device_malloc)(size_t size);
-    void (*device_free)(void *dev_ptr);
-    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
-    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    // Set a device buffer to a byte value (device-side, no PCIe). Used to
-    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
-    // null on backends that don't wire it; callers must fall back to
-    // copy_to_device.
-    int (*device_memset)(void *dev_ptr, int value, size_t size);
-    // Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2 shared
-    // memory, trb prebuilt runtime arena) as three independent device
-    // allocations. `runtime_arena_size == 0` skips the third region (hbg
-    // path: hbg has no prebuilt runtime arena). Idempotent on identical
-    // sizes; returns 0 on success, -1 on allocation failure.
-    int (*setup_static_arena)(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
-    // Return the per-Worker pooled pointer for the PTO2 GM heap / shared
-    // memory / prebuilt runtime arena. setup_static_arena must have already
-    // committed the relevant region; the returned pointer is owned by the
-    // DeviceRunner and freed in `DeviceRunner::finalize()` — do NOT pass it
-    // to device_free or record it in `tensor_pairs_`.
-    //
-    // acquire_pooled_runtime_arena is trb-only — the runtime-arena region is
-    // only committed when setup_static_arena was invoked with
-    // runtime_arena_size > 0. Calling it on the hbg path
-    // (setup_static_arena(...,0)) returns nullptr (not undefined).
-    void *(*acquire_pooled_gm_heap)();
-    void *(*acquire_pooled_gm_sm)();
-    void *(*acquire_pooled_runtime_arena)();
-    bool (*lookup_prebuilt_runtime_arena_cache)(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
-    );
-    void (*mark_prebuilt_runtime_arena_cached)(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
-        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
-    );
-    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
-    // `const ChipCallable *` (declared void* to avoid pulling task_interface
-    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
-    // total byte size, allocates device GM once, fixes up each child's
-    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
-    // dlopen function pointer), H2D's once, and returns the device-side
-    // address of the ChipCallable header. Pool-managed: identical buffer
-    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
-    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
-    // child_count() == 0. Caller computes child addrs as
-    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
-    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
-    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**
@@ -364,12 +309,8 @@ public:
     Task *get_task(int) { return nullptr; }
 
     // =========================================================================
-    // Host API (host-only, not copied to device)
+    // Host-only state (not copied to device)
     // =========================================================================
-
-    // Host API function pointers for device memory operations. Host-only:
-    // lives in the tail after `dev`, so it is never part of the device copy.
-    HostApi host_api;
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -48,6 +48,11 @@ namespace {
 struct OrchestrationRuntimeImpl {
     const OrchestrationRuntimeOps *ops;
     Runtime *runtime;
+    // Platform device-memory hooks. Host orchestration runs through the ops
+    // callbacks below, which need host_api but cannot take it as a parameter
+    // (fixed OrchestrationRuntimeOps ABI) — so it travels here, alongside the
+    // Runtime pointer, filled by bind_callable_to_runtime_impl.
+    const HostApi *host_api;
     struct TensorInfoBuilder *tensor_info_builder;
     struct TensorAllocationBuilder *tensor_allocation_builder;
 };
@@ -92,8 +97,22 @@ struct TensorAllocationBuilder {
     }
 };
 
+// Free every device buffer the orchestration recorded in the allocation
+// builder. Used on bind error paths: once tensor_pairs_ is cleared, the
+// finalize-time cleanup can no longer see these, so they must be freed here
+// or they leak.
+void free_tensor_allocations(const HostApi *api, const TensorAllocationBuilder &builder) {
+    for (const TensorAllocationInfo &allocation : builder.allocations) {
+        api->device_free(reinterpret_cast<void *>(static_cast<uintptr_t>(allocation.base_addr)));
+    }
+}
+
 Runtime *unwrap_runtime(OrchestrationRuntime *runtime) {
     return reinterpret_cast<OrchestrationRuntimeImpl *>(runtime)->runtime;
+}
+
+const HostApi *unwrap_host_api(OrchestrationRuntime *runtime) {
+    return reinterpret_cast<OrchestrationRuntimeImpl *>(runtime)->host_api;
 }
 
 TensorInfoBuilder *unwrap_tensor_info_builder(OrchestrationRuntime *runtime) {
@@ -139,18 +158,18 @@ int runtime_get_task_count(OrchestrationRuntime *runtime) { return unwrap_runtim
 void runtime_print_runtime(OrchestrationRuntime *runtime) { unwrap_runtime(runtime)->print_runtime(); }
 
 void *runtime_device_malloc(OrchestrationRuntime *runtime, size_t size) {
-    void *ptr = unwrap_runtime(runtime)->host_api.device_malloc(size);
+    void *ptr = unwrap_host_api(runtime)->device_malloc(size);
     unwrap_tensor_allocation_builder(runtime)->record_allocation(ptr, size);
     return ptr;
 }
 
 void runtime_device_free(OrchestrationRuntime *runtime, void *ptr) {
     unwrap_tensor_allocation_builder(runtime)->erase_allocation(ptr);
-    unwrap_runtime(runtime)->host_api.device_free(ptr);
+    unwrap_host_api(runtime)->device_free(ptr);
 }
 
 int runtime_copy_to_device(OrchestrationRuntime *runtime, void *dev_ptr, const void *host_ptr, size_t size) {
-    return unwrap_runtime(runtime)->host_api.copy_to_device(dev_ptr, host_ptr, size);
+    return unwrap_host_api(runtime)->copy_to_device(dev_ptr, host_ptr, size);
 }
 
 const OrchestrationRuntimeOps k_orchestration_runtime_ops = {
@@ -198,7 +217,7 @@ bool create_temp_so_file(const uint8_t *data, size_t size, std::string *out_path
     return true;
 }
 
-int upload_tensor_info_storage(Runtime *runtime, const TensorInfoBuilder &builder) {
+int upload_tensor_info_storage(Runtime *runtime, const HostApi *api, const TensorInfoBuilder &builder) {
     runtime->clear_tensor_info_storage();
     for (int task_id = 0; task_id < RUNTIME_MAX_TASKS; task_id++) {
         runtime->set_tensor_info_range(task_id, 0, 0);
@@ -225,16 +244,16 @@ int upload_tensor_info_storage(Runtime *runtime, const TensorInfoBuilder &builde
     }
 
     size_t tensor_info_bytes = compact_tensor_info.size() * sizeof(TensorInfo);
-    void *dev_tensor_info_storage = runtime->host_api.device_malloc(tensor_info_bytes);
+    void *dev_tensor_info_storage = api->device_malloc(tensor_info_bytes);
     if (dev_tensor_info_storage == nullptr) {
         LOG_ERROR("Failed to allocate tensor info storage (%zu bytes)", tensor_info_bytes);
         return -1;
     }
 
-    int rc = runtime->host_api.copy_to_device(dev_tensor_info_storage, compact_tensor_info.data(), tensor_info_bytes);
+    int rc = api->copy_to_device(dev_tensor_info_storage, compact_tensor_info.data(), tensor_info_bytes);
     if (rc != 0) {
         LOG_ERROR("Failed to copy tensor info storage to device: %d", rc);
-        runtime->host_api.device_free(dev_tensor_info_storage);
+        api->device_free(dev_tensor_info_storage);
         return rc;
     }
 
@@ -243,23 +262,23 @@ int upload_tensor_info_storage(Runtime *runtime, const TensorInfoBuilder &builde
     return 0;
 }
 
-int upload_tensor_allocation_storage(Runtime *runtime, const TensorAllocationBuilder &builder) {
+int upload_tensor_allocation_storage(Runtime *runtime, const HostApi *api, const TensorAllocationBuilder &builder) {
     runtime->clear_tensor_allocation_storage();
     if (builder.allocations.empty()) {
         return 0;
     }
 
     size_t allocation_bytes = builder.allocations.size() * sizeof(TensorAllocationInfo);
-    void *dev_allocation_storage = runtime->host_api.device_malloc(allocation_bytes);
+    void *dev_allocation_storage = api->device_malloc(allocation_bytes);
     if (dev_allocation_storage == nullptr) {
         LOG_ERROR("Failed to allocate tensor allocation storage (%zu bytes)", allocation_bytes);
         return -1;
     }
 
-    int rc = runtime->host_api.copy_to_device(dev_allocation_storage, builder.allocations.data(), allocation_bytes);
+    int rc = api->copy_to_device(dev_allocation_storage, builder.allocations.data(), allocation_bytes);
     if (rc != 0) {
         LOG_ERROR("Failed to copy tensor allocation storage to device: %d", rc);
-        runtime->host_api.device_free(dev_allocation_storage);
+        api->device_free(dev_allocation_storage);
         return rc;
     }
 
@@ -358,12 +377,16 @@ int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(c
  * CallableState for this run's callable_id).
  */
 int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t * /*ring_task_window*/, const uint64_t * /*ring_heap*/,
     const uint64_t * /*ring_dep_pool*/
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
     if (orch_args == nullptr) {
@@ -387,7 +410,7 @@ int bind_callable_to_runtime_impl(
     TensorInfoBuilder tensor_info_builder;
     TensorAllocationBuilder tensor_allocation_builder;
     OrchestrationRuntimeImpl orchestration_runtime = {
-        &k_orchestration_runtime_ops, runtime, &tensor_info_builder, &tensor_allocation_builder
+        &k_orchestration_runtime_ops, runtime, api, &tensor_info_builder, &tensor_allocation_builder
     };
 
     // hbg orch runs on the host, so it may legitimately need to dereference
@@ -401,24 +424,27 @@ int bind_callable_to_runtime_impl(
     int rc = orch_func(reinterpret_cast<OrchestrationRuntime *>(&orchestration_runtime), *orch_args);
     if (rc != 0) {
         LOG_ERROR("Orchestration function failed with code %d", rc);
+        free_tensor_allocations(api, tensor_allocation_builder);
         runtime->tensor_pairs_.clear();
         return rc;
     }
 
-    rc = upload_tensor_allocation_storage(runtime, tensor_allocation_builder);
+    rc = upload_tensor_allocation_storage(runtime, api, tensor_allocation_builder);
     if (rc != 0) {
         LOG_ERROR("Failed to upload tensor allocations: %d", rc);
+        free_tensor_allocations(api, tensor_allocation_builder);
         runtime->tensor_pairs_.clear();
         return rc;
     }
 
-    rc = upload_tensor_info_storage(runtime, tensor_info_builder);
+    rc = upload_tensor_info_storage(runtime, api, tensor_info_builder);
     if (rc != 0) {
         LOG_ERROR("Failed to upload tensor info storage: %d", rc);
         if (runtime->get_tensor_allocation_storage() != nullptr) {
-            runtime->host_api.device_free(runtime->get_tensor_allocation_storage());
+            api->device_free(runtime->get_tensor_allocation_storage());
             runtime->clear_tensor_allocation_storage();
         }
+        free_tensor_allocations(api, tensor_allocation_builder);
         runtime->tensor_pairs_.clear();
         return rc;
     }
@@ -438,9 +464,13 @@ int bind_callable_to_runtime_impl(
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-int validate_runtime_impl(Runtime *runtime) {
+int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
 
@@ -454,7 +484,7 @@ int validate_runtime_impl(Runtime *runtime) {
 
     for (int i = 0; i < tensor_pair_count; i++) {
         const TensorPair &pair = tensor_pairs[i];
-        int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
+        int copy_rc = api->copy_from_device(pair.host_ptr, pair.dev_ptr, pair.size);
         if (copy_rc != 0) {
             LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
             rc = copy_rc;
@@ -469,7 +499,7 @@ int validate_runtime_impl(Runtime *runtime) {
     // Cleanup device tensors
     LOG_INFO_V0("=== Cleaning Up ===");
     for (int i = 0; i < tensor_pair_count; i++) {
-        runtime->host_api.device_free(tensor_pairs[i].dev_ptr);
+        api->device_free(tensor_pairs[i].dev_ptr);
     }
     LOG_INFO_V0("Freed %d device tensors", tensor_pair_count);
 
@@ -488,11 +518,11 @@ int validate_runtime_impl(Runtime *runtime) {
     runtime->clear_registered_kernels();
 
     if (runtime->get_tensor_info_storage() != nullptr) {
-        runtime->host_api.device_free(runtime->get_tensor_info_storage());
+        api->device_free(runtime->get_tensor_info_storage());
         runtime->clear_tensor_info_storage();
     }
     if (runtime->get_tensor_allocation_storage() != nullptr) {
-        runtime->host_api.device_free(runtime->get_tensor_allocation_storage());
+        api->device_free(runtime->get_tensor_allocation_storage());
         runtime->clear_tensor_allocation_storage();
     }
 

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "common/core_type.h"
+#include "common/host_api.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "tensor_info.h"
@@ -131,51 +132,6 @@ struct TensorPair {
     void *host_ptr;
     void *dev_ptr;
     size_t size;
-};
-
-/**
- * Host API function pointers for device memory operations.
- * Allows runtime to use pluggable device memory backends.
- */
-struct HostApi {
-    void *(*device_malloc)(size_t size);
-    void (*device_free)(void *dev_ptr);
-    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
-    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    // Device-side memset (zero-init pure OUTPUT buffers in lieu of an H2D
-    // copy-in). Unused by host_build_graph; present only so the platform
-    // layer can populate the same HostApi shape regardless of runtime variant.
-    int (*device_memset)(void *dev_ptr, int value, size_t size);
-    // PTO2 static-arena hooks. The host_build_graph runtime does not currently
-    // use these — the fields exist only so the platform layer's
-    // pto_runtime_c_api.cpp can populate the same HostApi struct regardless of
-    // which runtime variant it is built against. Unset for this variant; do
-    // not call.
-    int (*setup_static_arena)(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
-    void *(*acquire_pooled_gm_heap)();
-    void *(*acquire_pooled_gm_sm)();
-    void *(*acquire_pooled_runtime_arena)();
-    bool (*lookup_prebuilt_runtime_arena_cache)(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
-    );
-    void (*mark_prebuilt_runtime_arena_cached)(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
-        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
-    );
-    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
-    // `const ChipCallable *` (declared void* to avoid pulling task_interface
-    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
-    // total byte size, allocates device GM once, fixes up each child's
-    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
-    // dlopen function pointer), H2D's once, and returns the device-side
-    // address of the ChipCallable header. Pool-managed: identical buffer
-    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
-    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
-    // child_count() == 0. Caller computes child addrs as
-    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
-    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
-    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**
@@ -496,12 +452,8 @@ public:
     void clear_registered_kernels() { registered_kernel_count_ = 0; }
 
     // =========================================================================
-    // Host API (host-only, not copied to device)
+    // Host-only state (not copied to device)
     // =========================================================================
-
-    // Host API function pointers for device memory operations
-    // NOTE: Placed at end of class to avoid affecting device memory layout
-    HostApi host_api;
 
     // Per-callable_id dispatch. hbg orch runs on host, so AICPU never reads
     // `active_callable_id_`; the field exists for parity with the shared
@@ -516,7 +468,7 @@ public:
     // runtime_maker.cpp from orch_args at bind time; iterated in
     // validate_runtime_impl. Not read by AICPU/AICore — the device-side
     // Runtime image carries the std::vector control block as harmless
-    // garbage, identical to host_api above. No fixed cap.
+    // garbage. No fixed cap.
     std::vector<TensorPair> tensor_pairs_;
 };
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -246,7 +246,7 @@ static bool resolve_ring_config(
     return true;
 }
 
-static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader *host_header) {
+static int32_t pto2_read_runtime_status(Runtime *runtime, const HostApi *api, PTO2SharedMemoryHeader *host_header) {
     if (runtime == nullptr || host_header == nullptr) {
         return 0;
     }
@@ -256,7 +256,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
         return 0;
     }
 
-    int hdr_rc = runtime->host_api.copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
+    int hdr_rc = api->copy_from_device(host_header, pto2_sm, sizeof(PTO2SharedMemoryHeader));
     if (hdr_rc != 0) {
         LOG_WARN("Failed to copy PTO2 header from device");
         return 0;
@@ -274,7 +274,7 @@ static int32_t pto2_read_runtime_status(Runtime *runtime, PTO2SharedMemoryHeader
  * on per-run argument values, so the simpler_register_callable / simpler_run split
  * lets us run this once per callable_id and amortize across runs.
  *
- * @param runtime   Pointer to pre-constructed Runtime (host_api populated)
+ * @param runtime   Pointer to pre-constructed Runtime
  * @param callable  ChipCallable carrying the orch SO + child kernel binaries
  * @return 0 on success, -1 on failure
  */
@@ -419,8 +419,8 @@ static bool derive_arena_static_sizes(const ArenaSizingConfig &sizing, ArenaStat
 // staged device_args / tensor_pairs_ stay owned by the caller's Runtime, which
 // frees them in validate_runtime_impl.
 static bool stage_device_args(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, const ArgDirection *signature, int sig_count,
-    ChipStorageTaskArgs *out
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, const ArgDirection *signature,
+    int sig_count, ChipStorageTaskArgs *out
 ) {
     int tensor_count = orch_args->tensor_count();
     int scalar_count = orch_args->scalar_count();
@@ -439,7 +439,7 @@ static bool stage_device_args(
         void *host_ptr = reinterpret_cast<void *>(static_cast<uintptr_t>(t.buffer.addr));
         size_t size = static_cast<size_t>(t.nbytes());
 
-        void *dev_ptr = runtime->host_api.device_malloc(size);
+        void *dev_ptr = api->device_malloc(size);
         if (dev_ptr == nullptr) {
             LOG_ERROR("Failed to allocate device memory for tensor %d", i);
             return false;
@@ -453,14 +453,14 @@ static bool stage_device_args(
         // did not wire device_memset.
         bool is_pure_output = (signature != nullptr && i < sig_count && signature[i] == ArgDirection::OUT);
         int rc;
-        if (is_pure_output && runtime->host_api.device_memset != nullptr) {
-            rc = runtime->host_api.device_memset(dev_ptr, 0, size);
+        if (is_pure_output && api->device_memset != nullptr) {
+            rc = api->device_memset(dev_ptr, 0, size);
         } else {
-            rc = runtime->host_api.copy_to_device(dev_ptr, host_ptr, size);
+            rc = api->copy_to_device(dev_ptr, host_ptr, size);
         }
         if (rc != 0) {
             LOG_ERROR("Failed to stage tensor %d to device", i);
-            runtime->host_api.device_free(dev_ptr);
+            api->device_free(dev_ptr);
             return false;
         }
         // Read-only INPUT tensors are never written by the kernel, so there is
@@ -503,21 +503,22 @@ static void apply_orch_sched_env_flags(Runtime *runtime) {
 // reserve sequence on a throwaway host arena. Idempotent across runs — the
 // pools are owned by DeviceRunner and freed in DeviceRunner::finalize().
 static bool ensure_static_arenas(
-    Runtime *runtime, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes, StaticArenaPtrs *out
+    Runtime *runtime, const HostApi *api, const ArenaSizingConfig &sizing, const ArenaStaticSizes &sizes,
+    StaticArenaPtrs *out
 ) {
     DeviceArena sizing_arena;  // discarded; only its computed arena_size is read
     PTO2RuntimeArenaLayout layout =
         runtime_reserve_layout(sizing_arena, sizing.task_window_sizes, sizing.heap_sizes, sizing.dep_pool_capacities);
 
     int64_t t_setup_start = _now_ms();
-    if (runtime->host_api.setup_static_arena(sizes.total_heap, sizes.sm_size, layout.offsets.arena_size) != 0) {
+    if (api->setup_static_arena(sizes.total_heap, sizes.sm_size, layout.offsets.arena_size) != 0) {
         LOG_ERROR("Failed to setup pooled static arena");
         return false;
     }
     int64_t t_setup_end = _now_ms();
 
     int64_t t_heap_start = _now_ms();
-    out->gm_heap = runtime->host_api.acquire_pooled_gm_heap();
+    out->gm_heap = api->acquire_pooled_gm_heap();
     int64_t t_heap_end = _now_ms();
     if (out->gm_heap == nullptr) {
         LOG_ERROR("Failed to acquire pooled GM heap");
@@ -525,7 +526,7 @@ static bool ensure_static_arenas(
     }
 
     int64_t t_sm_start = _now_ms();
-    out->gm_sm = runtime->host_api.acquire_pooled_gm_sm();
+    out->gm_sm = api->acquire_pooled_gm_sm();
     int64_t t_sm_end = _now_ms();
     if (out->gm_sm == nullptr) {
         LOG_ERROR("Failed to acquire pooled PTO2 shared memory");
@@ -533,7 +534,7 @@ static bool ensure_static_arenas(
     }
     runtime->set_gm_sm_ptr(out->gm_sm);
 
-    out->runtime_arena_dev = runtime->host_api.acquire_pooled_runtime_arena();
+    out->runtime_arena_dev = api->acquire_pooled_runtime_arena();
     if (out->runtime_arena_dev == nullptr) {
         LOG_ERROR("Failed to acquire pooled runtime arena");
         return false;
@@ -589,13 +590,12 @@ static bool build_runtime_image(
 // rtMemcpy the host image into the pooled runtime-arena region, and record the
 // device base + runtime offset the AICPU reads before dereferencing the image.
 static bool bind_launch_state(
-    Runtime *runtime, const StaticArenaPtrs &ptrs, const DeviceArena &host_arena, const PTO2RuntimeArenaLayout &layout,
-    const ChipStorageTaskArgs &device_args
+    Runtime *runtime, const HostApi *api, const StaticArenaPtrs &ptrs, const DeviceArena &host_arena,
+    const PTO2RuntimeArenaLayout &layout, const ChipStorageTaskArgs &device_args
 ) {
     runtime->set_orch_args(device_args);
 
-    int rc_upload =
-        runtime->host_api.copy_to_device(ptrs.runtime_arena_dev, host_arena.base(), layout.offsets.arena_size);
+    int rc_upload = api->copy_to_device(ptrs.runtime_arena_dev, host_arena.base(), layout.offsets.arena_size);
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy prebuilt runtime arena to device (rc=%d)", rc_upload);
         return false;
@@ -605,9 +605,10 @@ static bool bind_launch_state(
 }
 
 static int bind_cached_runtime_image(
-    Runtime *runtime, const PrebuiltRuntimeArenaCacheProbe &probe, const ChipStorageTaskArgs &device_args
+    Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe,
+    const ChipStorageTaskArgs &device_args
 ) {
-    if (runtime->host_api.lookup_prebuilt_runtime_arena_cache == nullptr) {
+    if (api->lookup_prebuilt_runtime_arena_cache == nullptr) {
         return 1;
     }
 
@@ -617,7 +618,7 @@ static int bind_cached_runtime_image(
     size_t runtime_off = 0;
     const void *cached_image = nullptr;
     size_t cached_image_size = 0;
-    bool cache_hit = runtime->host_api.lookup_prebuilt_runtime_arena_cache(
+    bool cache_hit = api->lookup_prebuilt_runtime_arena_cache(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), &gm_heap, &sm_ptr, &runtime_arena_dev,
         &runtime_off, &cached_image, &cached_image_size
     );
@@ -626,7 +627,7 @@ static int bind_cached_runtime_image(
     }
 
     runtime->set_orch_args(device_args);
-    int rc_upload = runtime->host_api.copy_to_device(runtime_arena_dev, cached_image, cached_image_size);
+    int rc_upload = api->copy_to_device(runtime_arena_dev, cached_image, cached_image_size);
     if (rc_upload != 0) {
         LOG_ERROR("Failed to rtMemcpy cached prebuilt runtime arena to device (rc=%d)", rc_upload);
         return -1;
@@ -637,13 +638,13 @@ static int bind_cached_runtime_image(
 }
 
 static void store_prebuilt_runtime_image(
-    Runtime *runtime, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
+    Runtime *runtime, const HostApi *api, const PrebuiltRuntimeArenaCacheProbe &probe, const StaticArenaPtrs &ptrs,
     const PTO2RuntimeArenaLayout &layout, const DeviceArena &host_arena
 ) {
-    if (runtime->host_api.mark_prebuilt_runtime_arena_cached == nullptr) {
+    if (api->mark_prebuilt_runtime_arena_cached == nullptr) {
         return;
     }
-    runtime->host_api.mark_prebuilt_runtime_arena_cached(
+    api->mark_prebuilt_runtime_arena_cached(
         probe.hash, probe.serialized_key.data(), probe.serialized_key.size(), ptrs.gm_heap, ptrs.gm_sm,
         ptrs.runtime_arena_dev, layout.offsets.off_runtime, host_arena.base(), layout.offsets.arena_size
     );
@@ -664,16 +665,21 @@ static void store_prebuilt_runtime_image(
  * (build_runtime_image), and per-run args (stage_device_args) + launch publish
  * (bind_launch_state).
  *
- * @param runtime    Pointer to pre-constructed Runtime (host_api populated)
+ * @param runtime    Pointer to pre-constructed Runtime
  * @param orch_args  Separated tensor/scalar arguments for this run
  * @return 0 on success, -1 on failure
  */
 extern "C" int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
 ) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
     if (orch_args == nullptr) {
@@ -700,7 +706,7 @@ extern "C" int bind_callable_to_runtime_impl(
     }
 
     ChipStorageTaskArgs device_args;
-    if (!stage_device_args(runtime, orch_args, signature, sig_count, &device_args)) {
+    if (!stage_device_args(runtime, api, orch_args, signature, sig_count, &device_args)) {
         return -1;
     }
 
@@ -710,7 +716,7 @@ extern "C" int bind_callable_to_runtime_impl(
     {
         STRACE("simpler_run.bind.prebuilt");
         PrebuiltRuntimeArenaCacheProbe cache_probe = make_prebuilt_runtime_arena_cache_probe(sizing);
-        int cache_rc = bind_cached_runtime_image(runtime, cache_probe, device_args);
+        int cache_rc = bind_cached_runtime_image(runtime, api, cache_probe, device_args);
         if (cache_rc < 0) {
             return -1;
         }
@@ -721,7 +727,7 @@ extern "C" int bind_callable_to_runtime_impl(
             }
 
             StaticArenaPtrs ptrs;
-            if (!ensure_static_arenas(runtime, sizing, sizes, &ptrs)) {
+            if (!ensure_static_arenas(runtime, api, sizing, sizes, &ptrs)) {
                 return -1;
             }
 
@@ -731,10 +737,10 @@ extern "C" int bind_callable_to_runtime_impl(
                 return -1;
             }
 
-            if (!bind_launch_state(runtime, ptrs, host_arena, layout, device_args)) {
+            if (!bind_launch_state(runtime, api, ptrs, host_arena, layout, device_args)) {
                 return -1;
             }
-            store_prebuilt_runtime_image(runtime, cache_probe, ptrs, layout, host_arena);
+            store_prebuilt_runtime_image(runtime, api, cache_probe, ptrs, layout, host_arena);
         }
     }
     int64_t t_prebuilt_end = _now_ms();
@@ -759,9 +765,13 @@ extern "C" int bind_callable_to_runtime_impl(
  * @param runtime  Pointer to Runtime
  * @return 0 on success, -1 on failure
  */
-extern "C" int validate_runtime_impl(Runtime *runtime) {
+extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     if (runtime == nullptr) {
         LOG_ERROR("Runtime pointer is null");
+        return -1;
+    }
+    if (api == nullptr) {
+        LOG_ERROR("HostApi pointer is null");
         return -1;
     }
 
@@ -783,7 +793,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     PTO2SharedMemoryHeader host_header;
     memset(&host_header, 0, sizeof(host_header));
 
-    runtime_status = pto2_read_runtime_status(runtime, &host_header);
+    runtime_status = pto2_read_runtime_status(runtime, api, &host_header);
     if (runtime_status != 0) {
         int32_t orch_error_code = host_header.orch_error_code.load(std::memory_order_relaxed);
         int32_t sched_error_code = host_header.sched_error_code.load(std::memory_order_relaxed);
@@ -856,7 +866,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
                 first_output_tensor = false;
             }
 
-            int copy_rc = runtime->host_api.copy_from_device(pair.host_ptr, src_ptr, copy_size);
+            int copy_rc = api->copy_from_device(pair.host_ptr, src_ptr, copy_size);
             if (copy_rc != 0) {
                 LOG_ERROR("Failed to copy tensor %d from device: %d", i, copy_rc);
                 rc = copy_rc;
@@ -870,7 +880,7 @@ extern "C" int validate_runtime_impl(Runtime *runtime) {
     LOG_INFO_V0("=== Cleaning Up ===");
     for (int i = 0; i < tensor_pair_count; i++) {
         if (tensor_pairs[i].dev_ptr != nullptr) {
-            runtime->host_api.device_free(tensor_pairs[i].dev_ptr);
+            api->device_free(tensor_pairs[i].dev_ptr);
         }
     }
     LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -39,6 +39,7 @@
 #include <vector>
 
 #include "common/core_type.h"
+#include "common/host_api.h"
 #include "common/platform_config.h"
 #include "aicpu/platform_aicpu_affinity.h"  // MAX_GATE_THREADS (aicpu_allowed_cpus bound)
 #include "pto2_dispatch_payload.h"
@@ -122,62 +123,6 @@ struct TensorPair {
     // so the end-of-run D2H copy-back is skipped. OUTPUT/INOUT/unknown
     // keep the safe default of copying back.
     bool needs_copy_back = true;
-};
-
-/**
- * Host API function pointers for device memory operations.
- * Allows runtime to use pluggable device memory backends.
- */
-struct HostApi {
-    void *(*device_malloc)(size_t size);
-    void (*device_free)(void *dev_ptr);
-    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
-    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
-    // Set a device buffer to a byte value (device-side, no PCIe). Used to
-    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
-    // null on backends that don't wire it; callers must fall back to
-    // copy_to_device.
-    int (*device_memset)(void *dev_ptr, int value, size_t size);
-    // Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2 shared
-    // memory, trb prebuilt runtime arena) as three independent device
-    // allocations. `runtime_arena_size == 0` skips the third region (hbg
-    // path: hbg has no prebuilt runtime arena). Idempotent on identical
-    // sizes; returns 0 on success, -1 on allocation failure.
-    int (*setup_static_arena)(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
-    // Return the per-Worker pooled pointer for the PTO2 GM heap / shared
-    // memory / prebuilt runtime arena. setup_static_arena must have already
-    // committed the relevant region; the returned pointer is owned by the
-    // DeviceRunner and freed in `DeviceRunner::finalize()` — do NOT pass it
-    // to device_free or record it in `tensor_pairs_`.
-    //
-    // acquire_pooled_runtime_arena is trb-only — the runtime-arena region is
-    // only committed when setup_static_arena was invoked with
-    // runtime_arena_size > 0. Calling it on the hbg path
-    // (setup_static_arena(...,0)) returns nullptr (not undefined).
-    void *(*acquire_pooled_gm_heap)();
-    void *(*acquire_pooled_gm_sm)();
-    void *(*acquire_pooled_runtime_arena)();
-    bool (*lookup_prebuilt_runtime_arena_cache)(
-        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
-        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
-    );
-    void (*mark_prebuilt_runtime_arena_cached)(
-        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
-        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
-    );
-    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
-    // `const ChipCallable *` (declared void* to avoid pulling task_interface
-    // headers into runtime.h). DeviceRunner walks child_offsets_ to compute
-    // total byte size, allocates device GM once, fixes up each child's
-    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
-    // dlopen function pointer), H2D's once, and returns the device-side
-    // address of the ChipCallable header. Pool-managed: identical buffer
-    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
-    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
-    // child_count() == 0. Caller computes child addrs as
-    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
-    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
-    uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 
 /**
@@ -378,12 +323,8 @@ public:
     Task *get_task(int) { return nullptr; }
 
     // =========================================================================
-    // Host API (host-only, not copied to device)
+    // Host-only state (not copied to device)
     // =========================================================================
-
-    // Host API function pointers for device memory operations. Host-only:
-    // lives in the tail after `dev`, so it is never part of the device copy.
-    HostApi host_api;
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time, then iterated in

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+#ifndef COMMON_HOST_API_H_
+#define COMMON_HOST_API_H_
+
+#include <cstddef>
+#include <cstdint>
+
+/**
+ * Host API function pointers for device memory operations.
+ * Allows a runtime to use pluggable device-memory backends.
+ *
+ * This is a platform capability, not runtime state: it is populated once per
+ * simpler_run by the platform layer (onboard / sim c_api_shared.cpp) and passed
+ * explicitly into bind_callable_to_runtime_impl / validate_runtime_impl. Shared
+ * by every runtime variant (tensormap_and_ringbuffer / host_build_graph) and
+ * arch (a2a3 / a5) so the field set stays defined in exactly one place.
+ */
+struct HostApi {
+    void *(*device_malloc)(size_t size);
+    void (*device_free)(void *dev_ptr);
+    int (*copy_to_device)(void *dev_ptr, const void *host_ptr, size_t size);
+    int (*copy_from_device)(void *host_ptr, const void *dev_ptr, size_t size);
+    // Set a device buffer to a byte value (device-side, no PCIe). Used to
+    // zero-init pure OUTPUT buffers in lieu of an H2D copy-in. May be
+    // null on backends that don't wire it; callers must fall back to
+    // copy_to_device.
+    int (*device_memset)(void *dev_ptr, int value, size_t size);
+    // Commit the three per-Worker pooled regions (PTO2 GM heap, PTO2 shared
+    // memory, trb prebuilt runtime arena) as three independent device
+    // allocations. `runtime_arena_size == 0` skips the third region (hbg
+    // path: hbg has no prebuilt runtime arena). Idempotent on identical
+    // sizes; returns 0 on success, -1 on allocation failure.
+    int (*setup_static_arena)(size_t gm_heap_size, size_t gm_sm_size, size_t runtime_arena_size);
+    // Return the per-Worker pooled pointer for the PTO2 GM heap / shared
+    // memory / prebuilt runtime arena. setup_static_arena must have already
+    // committed the relevant region; the returned pointer is owned by the
+    // DeviceRunner and freed in `DeviceRunner::finalize()` — do NOT pass it
+    // to device_free or record it in `tensor_pairs_`.
+    //
+    // acquire_pooled_runtime_arena is trb-only — the runtime-arena region is
+    // only committed when setup_static_arena was invoked with
+    // runtime_arena_size > 0. Calling it on the hbg path
+    // (setup_static_arena(...,0)) returns nullptr (not undefined).
+    void *(*acquire_pooled_gm_heap)();
+    void *(*acquire_pooled_gm_sm)();
+    void *(*acquire_pooled_runtime_arena)();
+    // Prebuilt runtime-arena image cache (trb): look up a previously built
+    // image by content hash, returning its pooled device bases + image bytes on
+    // a hit; and record a freshly built image so a later run with the same key
+    // can skip the rebuild. Populated on the trb path; unused by hbg.
+    bool (*lookup_prebuilt_runtime_arena_cache)(
+        uint64_t hash, const void *key_data, size_t key_size, void **gm_heap_base, void **sm_base,
+        void **runtime_arena_base, size_t *runtime_off, const void **image_data, size_t *image_size
+    );
+    void (*mark_prebuilt_runtime_arena_cached)(
+        uint64_t hash, const void *key_data, size_t key_size, void *gm_heap_base, void *sm_base,
+        void *runtime_arena_base, size_t runtime_off, const void *image_data, size_t image_size
+    );
+    // Single-shot upload of the entire ChipCallable buffer. `callable` is a
+    // `const ChipCallable *` (declared void* to avoid pulling task_interface
+    // headers into this header). DeviceRunner walks child_offsets_ to compute
+    // total byte size, allocates device GM once, fixes up each child's
+    // resolved_addr_ in an internal host scratch (onboard: device addr; sim:
+    // dlopen function pointer), H2D's once, and returns the device-side
+    // address of the ChipCallable header. Pool-managed: identical buffer
+    // contents (FNV-1a 64-bit) hit the dedup cache; all chip buffers are
+    // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
+    // child_count() == 0. Caller computes child addrs as
+    //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
+    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
+    uint64_t (*upload_chip_callable_buffer)(const void *callable);
+};
+
+#endif  // COMMON_HOST_API_H_

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -57,10 +57,11 @@ extern "C" {
  * =========================================================================== */
 int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
 int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
 );
-int validate_runtime_impl(Runtime *runtime);
+int validate_runtime_impl(Runtime *runtime, const HostApi *api);
 
 /* ===========================================================================
  * Per-thread DeviceRunnerBase binding (set by simpler_register_callable / simpler_run)
@@ -73,7 +74,8 @@ static void create_runner_key() { pthread_key_create(&g_runner_key, nullptr); }
 static DeviceRunnerBase *current_runner() { return static_cast<DeviceRunnerBase *>(pthread_getspecific(g_runner_key)); }
 
 /* ===========================================================================
- * Internal device-memory functions (used via Runtime.host_api, NOT dlsym'd)
+ * Internal device-memory functions (wired into a HostApi and passed to the
+ * runtime impls, NOT dlsym'd)
  * =========================================================================== */
 
 static void *device_malloc(size_t size) {
@@ -493,18 +495,23 @@ int simpler_run(
         auto runtime_guard = RAIIScopeGuard([r]() {
             r->~Runtime();
         });
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.device_memset = device_memset;
-        r->host_api.setup_static_arena = setup_static_arena_wrapper;
-        r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
-        r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
-        r->host_api.acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper;
-        r->host_api.lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper;
-        r->host_api.mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper;
-        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
+        // Platform device-memory hooks. host_api is a platform capability, not
+        // runtime state — it lives here (local to simpler_run, covering the whole
+        // bind→run→validate span) and is passed explicitly into the runtime impls
+        // rather than stored on `Runtime`.
+        HostApi api{};
+        api.device_malloc = device_malloc;
+        api.device_free = device_free;
+        api.copy_to_device = copy_to_device;
+        api.copy_from_device = copy_from_device;
+        api.device_memset = device_memset;
+        api.setup_static_arena = setup_static_arena_wrapper;
+        api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
+        api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
+        api.acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper;
+        api.lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper;
+        api.mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper;
+        api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         {
             STRACE("simpler_run.bind");
@@ -522,13 +529,13 @@ int simpler_run(
 
             // Per-run binding (tensor args, GM heap, SM alloc)
             rc = bind_callable_to_runtime_impl(
-                r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
+                r, &api, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
                 bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
             );
         }
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
-            validate_runtime_impl(r);
+            validate_runtime_impl(r, &api);
             return rc;
         }
 
@@ -546,13 +553,13 @@ int simpler_run(
             rc = runner->run(*r, block_dim, aicpu_thread_num);
         }
         if (rc != 0) {
-            validate_runtime_impl(r);
+            validate_runtime_impl(r, &api);
             return rc;
         }
 
         {
             STRACE("simpler_run.validate");
-            rc = validate_runtime_impl(r);
+            rc = validate_runtime_impl(r, &api);
         }
         // Device-domain phase markers: the AICPU subdivision of the on-NPU wall
         // (device_wall + preamble/so_load/graph_build/post_orch/orch/sched).

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -52,10 +52,11 @@ extern "C" {
  * =========================================================================== */
 int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
 int bind_callable_to_runtime_impl(
-    Runtime *runtime, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr, const ArgDirection *signature,
-    int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
 );
-int validate_runtime_impl(Runtime *runtime);
+int validate_runtime_impl(Runtime *runtime, const HostApi *api);
 
 /* ===========================================================================
  * Per-thread DeviceRunner binding
@@ -70,7 +71,8 @@ static SimDeviceRunnerBase *current_runner() {
 }
 
 /* ===========================================================================
- * Internal device-memory functions (used via Runtime.host_api, NOT dlsym'd)
+ * Internal device-memory functions (wired into a HostApi and passed to the
+ * runtime impls, NOT dlsym'd)
  * =========================================================================== */
 
 static void *device_malloc(size_t size) {
@@ -444,18 +446,23 @@ int simpler_run(
             r->~Runtime();
         });
 
-        r->host_api.device_malloc = device_malloc;
-        r->host_api.device_free = device_free;
-        r->host_api.copy_to_device = copy_to_device;
-        r->host_api.copy_from_device = copy_from_device;
-        r->host_api.device_memset = device_memset;
-        r->host_api.setup_static_arena = setup_static_arena_wrapper;
-        r->host_api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
-        r->host_api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
-        r->host_api.acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper;
-        r->host_api.lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper;
-        r->host_api.mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper;
-        r->host_api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
+        // Platform device-memory hooks. host_api is a platform capability, not
+        // runtime state — it lives here (local to simpler_run, covering the whole
+        // bind→run→validate span) and is passed explicitly into the runtime impls
+        // rather than stored on `Runtime`.
+        HostApi api{};
+        api.device_malloc = device_malloc;
+        api.device_free = device_free;
+        api.copy_to_device = copy_to_device;
+        api.copy_from_device = copy_from_device;
+        api.device_memset = device_memset;
+        api.setup_static_arena = setup_static_arena_wrapper;
+        api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
+        api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
+        api.acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper;
+        api.lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper;
+        api.mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper;
+        api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
 
         auto bind_result = runner->bind_callable_to_runtime(*r, callable_id);
         int rc = bind_result.rc;
@@ -467,13 +474,13 @@ int simpler_run(
         {
             STRACE("simpler_run.bind");
             rc = bind_callable_to_runtime_impl(
-                r, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
+                r, &api, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
                 bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
             );
         }
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
-            validate_runtime_impl(r);
+            validate_runtime_impl(r, &api);
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
@@ -490,14 +497,14 @@ int simpler_run(
             rc = runner->run(*r, block_dim, aicpu_thread_num);
         }
         if (rc != 0) {
-            validate_runtime_impl(r);
+            validate_runtime_impl(r, &api);
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
         {
             STRACE("simpler_run.validate");
-            rc = validate_runtime_impl(r);
+            rc = validate_runtime_impl(r, &api);
         }
         pthread_setspecific(g_runner_key, nullptr);
         emit_device_phase_markers(runner);


### PR DESCRIPTION
## Summary

`HostApi` (the platform's host→device hooks: `device_malloc` / `copy_to_device` / `setup_static_arena` / …) is a **platform capability, not runtime state**. It was a `HostApi host_api;` member on `Runtime`, living in the host-only tail as "harmless garbage" that rides along with the object. Two problems:

1. **Pollutes `Runtime`** — #1216 already split `Runtime` into a device-copied `dev` + a host-only tail; moving `host_api` out leaves the tail as just `tensor_pairs_` / `registered_kernel_*`, so `Runtime` is closer to pure runtime state. This continues #1216's "make host/device and layer boundaries explicit in the type system" line.
2. **Four duplicate definitions** — `struct HostApi` was written verbatim in all four `runtime.h` (trb/hbg × a2a3/a5), kept in sync only by convention. Verified byte-identical, so merging is safe.

### Changes

- **New shared definition** `src/common/platform/include/common/host_api.h` (already on every runtime's + c_api's include path via the `common/…` prefix).
- **Removed** `struct HostApi` + the `HostApi host_api;` member from all four `runtime.h`; each now `#include "common/host_api.h"`.
- **Threaded `const HostApi *` explicitly** into `bind_callable_to_runtime_impl` and `validate_runtime_impl` (both forward decls + all four definitions); 74 `runtime->host_api.X` call sites → `api->X`.
- **`c_api_shared.cpp`** (onboard + sim): `simpler_run` builds a local `HostApi api` (covering the whole bind→run→validate span) and passes `&api` in, instead of stamping the fields onto the placement-new'd `Runtime`.
- **hbg wrinkle**: host orchestration runs through fixed-ABI `OrchestrationRuntimeOps` callbacks that can't take an extra param, so `OrchestrationRuntimeImpl` carries a `const HostApi *host_api;` the three device-memory callbacks read via a new `unwrap_host_api()` helper.

DIP is preserved — the `HostApi` interface still exists, it just no longer lives on `Runtime`.

## Not a device ABI change

`host_api` was never part of the device copy (host-only tail since #1216), so nothing that the AICPU/AICore read moves. Pure host-side refactor. (Onboard still run below as a conservative check, since `Runtime`'s host-side layout changed.)

## Testing

- [x] Build a2a3 + a5 clean (all 4 runtimes + sim/onboard platform)
- [x] sim ST — trb a2a3sim **30 passed/1 skipped**, a5sim **20**; hbg a2a3sim **10**, a5sim **7**
- [x] **a2a3 onboard** — trb **33 passed/1 skipped**, hbg **10 passed/2 skipped**
- [ ] a5 onboard — not run (this box is a2a3 silicon); covered by CI `st-onboard-a5`