### PR TITLE
refactor(runtime): move orch_device_id into aicpu_device_config, out of platform_regs

### DIFF
--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -66,17 +66,6 @@ void set_platform_pmu_reg_addrs(uint64_t pmu_regs);
  */
 uint64_t get_platform_pmu_reg_addrs();
 
-/**
- * Set the ACL device ordinal. Latched once per device by simpler_aicpu_init
- * (from InitArgs.device_id) into this resident-SO global; the executor reads it
- * to make the staged orchestration SO filename unique per device so paired dies
- * sharing the preinstall filesystem never collide.
- */
-void set_orch_device_id(int device_id);
-
-/** Get the ACL device ordinal set for the current run (0 if unset). */
-int get_orch_device_id();
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/a2a3/platform/shared/aicpu/platform_regs.cpp
+++ b/src/a2a3/platform/shared/aicpu/platform_regs.cpp
@@ -37,7 +37,6 @@
 
 static uint64_t g_platform_regs = 0;
 static uint64_t g_platform_pmu_reg_addrs = 0;
-static int g_orch_device_id = 0;
 
 void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
@@ -46,10 +45,6 @@ uint64_t get_platform_regs() { return g_platform_regs; }
 void set_platform_pmu_reg_addrs(uint64_t pmu_regs) { g_platform_pmu_reg_addrs = pmu_regs; }
 
 uint64_t get_platform_pmu_reg_addrs() { return g_platform_pmu_reg_addrs; }
-
-void set_orch_device_id(int device_id) { g_orch_device_id = device_id; }
-
-int get_orch_device_id() { return g_orch_device_id; }
 
 volatile uint32_t *get_reg_ptr(uint64_t reg_base_addr, RegId reg) {
     return reinterpret_cast<volatile uint32_t *>(reg_base_addr + reg_offset(reg));

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -45,6 +45,7 @@
 #include "common/unified_log.h"
 
 // Register-based communication
+#include "aicpu/aicpu_device_config.h"
 #include "aicpu/platform_aicpu_affinity.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -57,17 +57,6 @@ void set_platform_regs(uint64_t regs);
  */
 uint64_t get_platform_regs();
 
-/**
- * Set the ACL device ordinal. Latched once per device by simpler_aicpu_init
- * (from InitArgs.device_id) into this resident-SO global; the executor reads it
- * to make the staged orchestration SO filename unique per device so paired dies
- * sharing the preinstall filesystem never collide.
- */
-void set_orch_device_id(int device_id);
-
-/** Get the ACL device ordinal set for the current run (0 if unset). */
-int get_orch_device_id();
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/a5/platform/shared/aicpu/platform_regs.cpp
+++ b/src/a5/platform/shared/aicpu/platform_regs.cpp
@@ -26,15 +26,10 @@
 #include "spin_hint.h"
 
 static uint64_t g_platform_regs = 0;
-static int g_orch_device_id = 0;
 
 void set_platform_regs(uint64_t regs) { g_platform_regs = regs; }
 
 uint64_t get_platform_regs() { return g_platform_regs; }
-
-void set_orch_device_id(int device_id) { g_orch_device_id = device_id; }
-
-int get_orch_device_id() { return g_orch_device_id; }
 
 void platform_init_aicore_regs(uint64_t reg_addr) {
     // Initialize task dispatch register to idle state

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -46,6 +46,7 @@
 #include "common/unified_log.h"
 
 // Register-based communication
+#include "aicpu/aicpu_device_config.h"
 #include "aicpu/platform_regs.h"
 #include "common/platform_config.h"
 

--- a/src/common/platform/include/aicpu/aicpu_device_config.h
+++ b/src/common/platform/include/aicpu/aicpu_device_config.h
@@ -29,6 +29,17 @@ extern "C" {
 #endif
 
 /**
+ * Set the ACL device ordinal. Latched once per device by simpler_aicpu_init
+ * (from InitArgs.device_id) into this resident-SO global; the AICPU executor
+ * reads it to make the staged orchestration SO filename unique per device so
+ * paired dies sharing the preinstall filesystem never collide.
+ */
+void set_orch_device_id(int device_id);
+
+/** Get the ACL device ordinal set for the current run (0 if unset). */
+int get_orch_device_id();
+
+/**
  * Set the AICPU scheduler no-progress watchdog timeout (ms). Latched once per
  * device by simpler_aicpu_init (from InitArgs.scheduler_timeout_ms); read by
  * the scheduler dispatch loop each run. 0 means "no override" — the scheduler

--- a/src/common/platform/shared/aicpu/aicpu_device_config.cpp
+++ b/src/common/platform/shared/aicpu/aicpu_device_config.cpp
@@ -11,10 +11,15 @@
 #include "aicpu/aicpu_device_config.h"
 
 namespace {
-// Latched once per device by simpler_aicpu_init; survives every per-task launch
+// Latched once per device by simpler_aicpu_init; survive every per-task launch
 // because the AICPU inner SO stays dlopen'd for the runner's life.
+int g_orch_device_id = 0;
 int g_scheduler_timeout_ms = 0;
 }  // namespace
+
+void set_orch_device_id(int device_id) { g_orch_device_id = device_id; }
+
+int get_orch_device_id() { return g_orch_device_id; }
 
 void set_scheduler_timeout_ms(int timeout_ms) { g_scheduler_timeout_ms = timeout_ms; }
 


### PR DESCRIPTION
## What

Follow-up cleanup to #1223. `orch_device_id` (the ACL device ordinal) is latched once per device by `simpler_aicpu_init` (from `InitArgs.device_id`) and read by the AICPU executor (`create_orch_so_file(..., get_orch_device_id(), ...)`) to make the staged orchestration-SO filename unique per device.

It is a **per-device, run-invariant** knob — the exact same category as `scheduler_timeout` (moved in #1223) — and has nothing to do with per-core register addressing. It lived in `platform_regs` only for historical reasons. #1223 introduced `aicpu_device_config` as the dedicated home for per-device AICPU config latched by `simpler_aicpu_init`; this finishes the job by moving `orch_device_id` there too, so `platform_regs` is left **strictly** for per-core register access.

## How

- `aicpu_device_config.{h,cpp}`: add `set/get_orch_device_id` + the `g_orch_device_id` global, alongside `set/get_scheduler_timeout_ms`.
- `platform_regs.{h,cpp}` (a5 + a2a3): remove them.
- `aicpu_executor.cpp` (a5 + a2a3): include `aicpu/aicpu_device_config.h` for the `get_orch_device_id` consumer (keeps `platform_regs.h` — still uses `get_platform_regs`).
- `kernel.cpp` (latch) and sim `device_runner` (dlsym `set_orch_device_id`): **unchanged** — the symbol name is identical, only its defining TU moved (same AICPU SO; sim dlsym still resolves it).

**No behavior change.** `platform_regs` now holds only register-addressing state.

## Test

- All four quadrants (onboard/sim × a5/a2a3) build clean.
- `runtime_fatal_codes::scheduler_timeout` — which exercises the `register_callable` → `load_orch_so` → `create_orch_so_file(get_orch_device_id())` consumer path — passes on a5sim + a2a3sim.

Onboard hardware runs still recommended before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)