### PR TITLE
Fix: include L2-swimlane setters in sim DeviceRunner readiness guard

### DIFF
--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -426,7 +426,9 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         set_dump_args_enabled_func_ == nullptr || set_platform_pmu_base_func_ == nullptr ||
         set_platform_pmu_reg_addrs_func_ == nullptr || set_pmu_enabled_func_ == nullptr ||
         set_platform_dep_gen_base_func_ == nullptr || set_dep_gen_enabled_func_ == nullptr ||
-        set_scope_stats_enabled_func_ == nullptr || set_platform_scope_stats_base_func_ == nullptr) {
+        set_scope_stats_enabled_func_ == nullptr || set_platform_scope_stats_base_func_ == nullptr ||
+        set_platform_l2_swimlane_base_func_ == nullptr ||
+        set_platform_l2_swimlane_aicore_rotation_table_func_ == nullptr || set_l2_swimlane_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -391,7 +391,8 @@ int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
         set_dump_args_enabled_func_ == nullptr || set_platform_pmu_base_func_ == nullptr ||
         set_pmu_enabled_func_ == nullptr || set_platform_dep_gen_base_func_ == nullptr ||
         set_dep_gen_enabled_func_ == nullptr || set_scope_stats_enabled_func_ == nullptr ||
-        set_platform_scope_stats_base_func_ == nullptr) {
+        set_platform_scope_stats_base_func_ == nullptr || set_platform_l2_swimlane_base_func_ == nullptr ||
+        set_l2_swimlane_enabled_func_ == nullptr) {
         LOG_ERROR("Executor functions not loaded. Call ensure_binaries_loaded first.");
         return -1;
     }


### PR DESCRIPTION
## Summary

`DeviceRunner::run` (sim) calls the L2-swimlane setter function pointers unconditionally, but the "Executor functions not loaded" readiness guard that null-checks the sibling `set_*` pointers omitted them. If a future AICPU `.so` were missing those symbols, `dlsym` would leave them null and the guard would pass, then the unconditional call would dereference a null function pointer instead of returning the clean "not loaded" error.

This adds the swimlane setters to the guard so the whole set is checked together:
- **a2a3**: `set_platform_l2_swimlane_base` / `_aicore_rotation_table` / `_enabled` (3)
- **a5**: `set_platform_l2_swimlane_base` / `_enabled` (2 — a5 has no rotation-table setter; it neither declares nor calls one)

Latent only — the setters are loaded by the same `dlsym` batch as their already-checked siblings, so in practice they are never null. Pre-existing (surfaced by CodeRabbit on #1216); the guard should simply cover every pointer it guards.

## Testing

- [x] a2a3sim + a5sim build clean
- [x] a2a3sim `dummy_task` + a5sim `prepared_callable` smoke pass (L2-swimlane-enabled path)

Sim-only change (this guard lives in the sim `DeviceRunner`); onboard is unaffected.