### PR TITLE
Fix: clear callable registries in Worker.close() to fully release nanobind handles

### DIFF
--- a/python/simpler/worker.py
+++ b/python/simpler/worker.py
@@ -3967,6 +3967,18 @@ class Worker:
             self._next_level_workers.clear()
             self._next_level_worker_ids.clear()
 
+        # Drop the Worker-held references to registered callables. These dicts
+        # pin ChipCallable/CoreCallable nanobind instances (and, via identity
+        # state, their payloads); if a closed Worker is kept alive past
+        # interpreter exit — e.g. a failing test's traceback pins the frame's
+        # `worker` local — any surviving instance prevents nanobind from
+        # unloading its module and triggers a leak dump at shutdown. Guard with
+        # _registry_lock, mirroring every other mutation of these three dicts.
+        with self._registry_lock:
+            self._callable_registry.clear()
+            self._identity_registry.clear()
+            self._live_handles.clear()
+
         self._initialized = False
 
     def __enter__(self) -> Worker:

--- a/tests/ut/py/test_worker/test_host_worker.py
+++ b/tests/ut/py/test_worker/test_host_worker.py
@@ -168,6 +168,23 @@ class TestLifecycle:
         with pytest.raises(TypeError, match="level 2 only supports ChipCallable"):
             hw.register(lambda args: None)
 
+    def test_close_releases_registered_callables(self):
+        # close() must drop every Worker-held reference to registered callables.
+        # A ChipCallable is a nanobind instance; if close() leaves it in one of
+        # the registries, a closed Worker kept alive past interpreter exit (e.g.
+        # a failing test's traceback pinning the frame's `worker` local) keeps
+        # the instance live, which blocks nanobind's module unload and prints a
+        # leak dump at shutdown.
+        hw = Worker(level=3, num_sub_workers=0)
+        hw.init()
+        handle = hw.register(_unique_chip_callable(1))
+        assert _slot_for(hw, handle) in hw._callable_registry
+        assert hw._identity_registry and hw._live_handles
+        hw.close()
+        assert hw._callable_registry == {}
+        assert hw._identity_registry == {}
+        assert hw._live_handles == {}
+
     def test_prepare_python_fn_after_init_before_start_succeeds(self):
         # init() allocates mailboxes but does not fork children. Python
         # callables prepared in this window still land in the startup


### PR DESCRIPTION
## Summary

Follow-up to #1222 (already merged). #1222 dropped `self._chip_worker` in the L2 `close()` branch, removing the leaked `_ChipWorker` instance — but `Worker.close()` still left the **Worker-level callable bookkeeping** populated: `_callable_registry`, `_identity_registry`, and `_live_handles` keep the registered `ChipCallable` (and its child `CoreCallable`) nanobind instances alive on **both** the L2 and L≥3 teardown paths.

As long as *any* nanobind instance survives, nanobind cannot unload its module, so the shutdown leak dump still fires when a closed `Worker` is pinned past interpreter exit (a failing pytest case whose traceback references the frame's `worker` local).

This PR clears all three registries in the shared tail of `close()` (covers L2 and L≥3), so a closed `Worker` retains no callable handles.

## Root-cause verification (real nanobind dumps)

Reproduced on `examples/workers/l2/vector_add` (`a2a3sim`): run register/init/run/close, then keep the closed `worker` alive to interpreter exit (the way a failing test's traceback pins it) and read nanobind's `Py_AtExit` leak check on stderr.

### Before #1222 (buggy)

```
nanobind: leaked 2 instances!
 - leaked instance 0x... of type "_task_interface.ChipCallable"
 - leaked instance 0x... of type "_task_interface._ChipWorker"
nanobind: leaked 15 types!
 - leaked type "_task_interface._ChipWorker"
 - leaked type "_task_interface.ChipCallable"
 - ... skipped remainder
nanobind: leaked 165 functions!
 - ... skipped remainder
nanobind: this is likely caused by a reference counting issue in the binding code.
See https://nanobind.readthedocs.io/en/latest/refleaks.html
```

### After #1222 only (`_chip_worker = None`) — dump still printed

```
nanobind: leaked 1 instances!
 - leaked instance 0x... of type "_task_interface.ChipCallable"
nanobind: leaked 15 types!
 - leaked type "_task_interface._ChipWorker"
nanobind: leaked 165 functions!
nanobind: this is likely caused by a reference counting issue in the binding code.
```

`_ChipWorker` is gone, but the retained `ChipCallable` still blocks module unload, so the noisy `15 types / 165 functions` dump remains.

### With this PR (also clear the registries) — dump gone

```
(zero `nanobind: leaked` lines on stderr)
```

Root cause confirmed with a probe: after `close()`, the registry still held the callable —
```
after close(): _chip_worker = None
after close(): _callable_registry = {0: ChipCallable(func_name="vector_add_orchestration", ...)}
```

> Note: this box's nanobind has leak-warnings compiled off at normal exit; the dumps above were forced by immortalizing the pinned `worker` (an equivalent of a retained traceback surviving `Py_FinalizeEx`), matching the CI-observed symptom in #1221.

## Testing

- [x] New unit test `TestLifecycle::test_close_releases_registered_callables` registers a `ChipCallable`, closes, and asserts all three registries are empty. Fails without this change; passes with it.
- [x] `tests/ut/py/test_worker/test_host_worker.py::TestLifecycle` — 43 passed.
- [x] `examples/workers/l2/vector_add` on `a2a3sim` — golden check passes, zero nanobind leak output at exit.

Related: #1221, #1222.