### PR TITLE
Refactor: drop AICPU cache invalidate/flush on a5 (coherent with DMA/HBM)

### DIFF
--- a/docs/dfx/device-phases.md
+++ b/docs/dfx/device-phases.md
@@ -26,7 +26,7 @@ run-wall `{start, end}` pair used, generalized to `N` pairs.
 | `ConfigValidate` | (inside `GraphBuild`, orch thread) `config_func()` + arg-count validate |
 | `ArenaWire` | (inside `GraphBuild`, orch thread) attach the prebuilt runtime arena + wire device pointers |
 | `SmReset` | (inside `GraphBuild`, orch thread) SM/ring reset + finalize + bind, up to releasing the scheduler threads |
-| `PostOrch` | last-thread teardown (`deinit`: cache-invalidate + scheduler-state reset) after the run completes — stamped only on the thread that finishes last, so it is the real teardown tail, strictly after `sched` |
+| `PostOrch` | last-thread teardown after the run completes — a2a3 deinit invalidates host-DMA/SDMA-published state before reset; a5 resets scheduler state without cache invalidation. Stamped only on the thread that finishes last, so it is the real teardown tail, strictly after `sched`. |
 | `OrchWindow` | orchestrator thread's submit window (the former device-log `orch_start/end`) |
 | `SchedWindow` | scheduler thread's dispatch window (the former device-log `sched_start/end`) |
 

--- a/docs/hardware/cache-coherency.md
+++ b/docs/hardware/cache-coherency.md
@@ -1,10 +1,12 @@
 # Cache Coherency (GM ↔ AICore/AICPU)
 
 This page is the authoritative reference for **when to insert a cache
-operation** on Ascend onboard hardware. The coherency model is shared
-across the chip generations supported in this repo (a2a3, a5); cycle
-costs and a few code-path examples below are sampled on a2a3 unless
-stated otherwise. Misapplying these rules either leaks stale data
+operation** on Ascend onboard hardware. The coherency model differs
+between chip generations supported in this repo: a2a3 requires AICPU
+cache maintenance for host-DMA and SDMA-published GM, while a5 AICPU
+loads are coherent with DMA/HBM and do not need those invalidates.
+Cycle costs and a few code-path examples below are sampled on a2a3
+unless stated otherwise. Misapplying these rules either leaks stale data
 (correctness bug) or burns a `dsb sy` per record on a hot path (perf
 bug — see PR #863 lineage). Read it before touching any code that
 writes `dc civac`, `dc cvac`, `cache_invalidate_range`, or any `dcci`
@@ -13,15 +15,15 @@ on AICore.
 ## Who shares GM, and with what consistency
 
 GM (HBM) is read and written by four parties on Ascend onboard. Their
-relationship to **AICPU's data cache** is **not symmetric** — that
-asymmetry is the entire reason this page exists.
+relationship to **AICPU's data cache** is **not symmetric** on a2a3,
+and a5 has a stronger DMA/HBM coherency model:
 
-| Writer | AICPU sees write automatically? | AICPU must invalidate before read? |
-| ------ | ------------------------------- | ---------------------------------- |
-| AICPU itself | Yes (own cache) | No |
-| **AICore** (AIC / AIV / MIX) | **Yes** | **No** |
-| Host DMA (`rtMemcpy` from host RAM) | No | **Yes** |
-| SDMA engine (device-side DMA) | No (assumed) | **Yes** (until hardware confirms otherwise) |
+| Writer | a2a3: AICPU sees write automatically? | a2a3: AICPU must invalidate before read? | a5: AICPU must invalidate before read? |
+| ------ | ------------------------------------- | ---------------------------------------- | -------------------------------------- |
+| AICPU itself | Yes (own cache) | No | No |
+| **AICore** (AIC / AIV / MIX) | **Yes** | **No** | **No** |
+| Host DMA (`rtMemcpy` from host RAM) | No | **Yes** | **No** |
+| SDMA engine (device-side DMA) | No (assumed) | **Yes** | **No** |
 
 Likewise, **AICore's own cache is non-coherent with GM** in the other
 direction: AICore-side writes stay in its data cache until explicitly
@@ -37,12 +39,13 @@ and what code lives on each side.
 | Primitive | Side | Purpose | Cost (rough, a2a3 / DAV_3510) |
 | --------- | ---- | ------- | ----------------------------- |
 | `dcci` (`__attribute__((aicore))` intrinsic) | AICore | Push a cache line out to GM (clean+invalidate). Required after AICore stores that AICPU or peer AICore must read. | 1 cache line per call + a following `dsb` to commit ordering. |
-| `cache_invalidate_range(addr, size)` (`src/{a2a3,a5}/platform/onboard/aicpu/cache_ops.cpp`) | AICPU | `dc civac` + `dsb sy` + `isb` over a byte range. Required before AICPU reads GM that **a non-coherent writer** (host DMA, SDMA) most recently published. | `dsb sy` dominates (tens to hundreds of cycles, fixed regardless of range). |
+| `cache_invalidate_range(addr, size)` (`src/a2a3/platform/onboard/aicpu/cache_ops.cpp`) | AICPU | `dc civac` + `dsb sy` + `isb` over a byte range. Required on a2a3 before AICPU reads GM that **a non-coherent writer** (host DMA, SDMA) most recently published. | `dsb sy` dominates (tens to hundreds of cycles, fixed regardless of range). |
 
 `cache_invalidate_range` is the protocol-correct primitive for the
-**host-DMA → AICPU** case. It was introduced in PR #204 specifically
-for `Runtime` struct hand-off where the host writes via `rtMemcpy` and
-AICPU reads. **It is NOT the right primitive for AICore → AICPU.**
+**host-DMA → AICPU** case on a2a3. It was introduced in PR #204
+specifically for `Runtime` struct hand-off where the host writes via
+`rtMemcpy` and AICPU reads. **It is NOT the right primitive for
+AICore → AICPU, and it is not required for a5 DMA/HBM reads.**
 
 ### `dcci` is whole-cache-line: no parallel sub-line writes
 
@@ -124,9 +127,9 @@ is `rmb()` (for load-load ordering against a prior COND read) plus
 making sure the AICore side does `dcci` before signaling. The cache
 invalidate itself is not needed on this path.
 
-## The "host DMA → AICPU" path: AICPU MUST invalidate
+## The "host DMA → AICPU" path: a2a3 MUST invalidate, a5 does not
 
-When the host writes via `rtMemcpy`, the AICPU cache is not snooped.
+On a2a3, when the host writes via `rtMemcpy`, the AICPU cache is not snooped.
 A cached value from a previous round survives the DMA write, so the
 next AICPU load returns stale data. The original PR #204 fix was:
 
@@ -135,18 +138,16 @@ next AICPU load returns stale data. The original PR #204 fix was:
 cache_invalidate_range(runtime, sizeof(Runtime));  // before reading host-written Runtime
 ```
 
-This is **necessary** and must not be removed. It is the
-load-bearing usage of `cache_invalidate_range` in this repo.
+This is **necessary on a2a3** and must not be removed there. It is the
+load-bearing usage of `cache_invalidate_range` in the a2a3 runtime.
 
-Same protocol applies to anything else the host DMAs into a GM region
-that AICPU subsequently reads.
+On a5, host DMA writes to GM are coherent with AICPU reads, so the
+matching runtime hand-off code does not call `cache_invalidate_range`.
 
-## The "SDMA → AICPU" path: treat as non-coherent until proven otherwise
+## The "SDMA → AICPU" path: a2a3 is conservative, a5 is coherent
 
-SDMA is a separate device-side DMA engine. It writes GM but is not
-known to snoop AICPU's data cache. SDMA backend code currently lives
-only under the a2a3 runtime tree, but the principle applies to any
-chip generation that exposes SDMA. Current runtime code (see
+SDMA is a separate device-side DMA engine. On a2a3 it writes GM but is
+not known to snoop AICPU's data cache. Current a2a3 runtime code (see
 `src/a2a3/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h`
 and the SDMA-engine async-wait completion path in
 `runtime/pto_async_wait.h` / `runtime/scheduler/pto_scheduler.h`)
@@ -154,10 +155,8 @@ and the SDMA-engine async-wait completion path in
 on the conservative assumption that SDMA is not in AICPU's coherency
 domain.
 
-If a hardware confirmation lifts that assumption — i.e. SDMA writes
-become snooped — these invalidates can be removed using the same
-reasoning as the AICore case. Until that confirmation exists, **leave
-them in place**.
+On a5, SDMA writes are coherent with AICPU reads, so the matching a5
+SDMA completion helpers do not invalidate or flush cache lines.
 
 ## Quick decision table
 
@@ -165,12 +164,14 @@ When you are about to insert a cache operation, ask in order:
 
 1. Who actually wrote the bytes I'm reading? Look at the producer
    code, not the address.
-2. Is the producer in the AICPU coherency domain (AICPU itself or
-   AICore)? If yes → no invalidate. If no (host, SDMA) → invalidate.
-3. For AICore writes specifically, does the producer already `dcci`
+2. Is this a5? If yes → no AICPU invalidate/flush for GM reads written
+   by host DMA, SDMA, AICPU, or AICore.
+3. On a2a3, is the producer in the AICPU coherency domain (AICPU itself
+   or AICore)? If yes → no invalidate. If no (host, SDMA) → invalidate.
+4. For AICore writes specifically, does the producer already `dcci`
    before signaling? If not, fix that instead of papering over it
    with an AICPU-side invalidate.
-4. Did I just read a completion flag (COND / mailbox / counter) from
+5. Did I just read a completion flag (COND / mailbox / counter) from
    a different memory type (Device-nGnRE MMIO) before this load? If
    yes, and there is no data/address dependency between that read and
    this one, insert `rmb()` between them — coherency does not imply
@@ -184,8 +185,8 @@ forever once they ship.
 
 ## Related code
 
-- `src/{a2a3,a5}/platform/onboard/aicpu/cache_ops.cpp` — `cache_invalidate_range` implementation (`dc civac` / `dsb sy` / `isb`).
-- `src/{a2a3,a5}/platform/sim/aicpu/cache_ops.cpp` — sim no-op.
+- `src/a2a3/platform/onboard/aicpu/cache_ops.cpp` — `cache_invalidate_range` implementation (`dc civac` / `dsb sy` / `isb`).
+- `src/a2a3/platform/sim/aicpu/cache_ops.cpp` — sim no-op.
 - AICore-side `dcci` usage lives in the L2 swimlane / PMU AICore collectors and any kernel that publishes to a GM slot AICPU reads.
 
 ## Related docs

--- a/docs/hardware/chip-architecture.md
+++ b/docs/hardware/chip-architecture.md
@@ -216,7 +216,8 @@ A complete `Worker::run()` call traverses all three tiers:
    - writes the AICPU start register to signal "go"
 
 2. AICPU (.so running on the chip)
-   - cache_invalidate_range on the Runtime header   (host DMA wrote it)
+   - a2a3: cache_invalidate_range on the Runtime header (host DMA wrote it)
+   - a5: read the coherent Runtime header directly
    - reads task graph + buffer pointers
    - for each ready task, picks an idle AICore unit (AIC or AIV)
    - writes task descriptor to that unit over the on-chip bus

--- a/src/a5/platform/shared/aicpu/pmu_collector_aicpu.cpp
+++ b/src/a5/platform/shared/aicpu/pmu_collector_aicpu.cpp
@@ -288,7 +288,6 @@ void pmu_aicpu_complete_record(
         return;
     }
     PmuRecord *slot = &ring->dual_issue_slots[reg_task_id % PLATFORM_PMU_AICORE_RING_SIZE];
-    cache_invalidate_range(slot, sizeof(PmuRecord));
 
     if (static_cast<uint32_t>(slot->task_id) != reg_task_id) {
         // AICore hasn't published this slot yet — hard invariant violation,

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -1134,38 +1134,8 @@ int AicpuExecutor::run(Runtime *runtime) {
     return 0;
 }
 
-void AicpuExecutor::deinit(Runtime *runtime) {
+void AicpuExecutor::deinit(Runtime * /*runtime*/) {
     // === Exit cleanup: reset all inter-round state ===
-
-    // 1. Invalidate AICPU cache for Runtime address range.
-    //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
-    //    bypasses this cache. Invalidating now ensures next round reads from HBM.
-    //    Invalidate exactly the uploaded prefix (offsetof(tasks) + populated
-    //    tasks): the device buffer is allocated at that size (see
-    //    runtime_device_copy_size / init_runtime_args), so invalidating
-    //    sizeof(Runtime) would iterate cache lines past the allocation into
-    //    unrelated memory. A short invalidate is also sufficient — every run
-    //    reads only tasks[0..next_task_id) for its OWN next_task_id (get_task()
-    //    bounds-checks), and the H2D DMA wrote exactly that, so no run ever
-    //    observes a task line beyond its own prefix. cache_invalidate_range
-    //    rounds the end up to a 64-byte line, covering a partial trailing line.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winvalid-offsetof"
-    const size_t runtime_prefix_bytes =
-        offsetof(Runtime, tasks) + static_cast<size_t>(runtime->get_task_count()) * sizeof(Task);
-#pragma GCC diagnostic pop
-    cache_invalidate_range(runtime, runtime_prefix_bytes);
-    if (runtime->get_tensor_info_storage() != nullptr && runtime->get_tensor_info_storage_bytes() > 0) {
-        cache_invalidate_range(
-            runtime->get_tensor_info_storage(), static_cast<size_t>(runtime->get_tensor_info_storage_bytes())
-        );
-    }
-    if (runtime->get_tensor_allocation_storage() != nullptr && runtime->get_tensor_allocation_storage_bytes() > 0) {
-        cache_invalidate_range(
-            runtime->get_tensor_allocation_storage(),
-            static_cast<size_t>(runtime->get_tensor_allocation_storage_bytes())
-        );
-    }
 
     // === Existing reset logic ===
     ready_count_aic_.store(0, std::memory_order_release);

--- a/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/aicpu/aicpu_executor.cpp
@@ -779,13 +779,7 @@ int32_t AicpuExecutor::run(Runtime *runtime) {
     return run_rc;
 }
 
-void AicpuExecutor::deinit(Runtime *runtime) {
-    // 1. Invalidate AICPU cache for the device-copied Runtime range (`dev`).
-    //    Next round's Host DMA (rtMemcpy) writes fresh bytes to HBM but
-    //    bypasses this cache. Invalidating now ensures next round reads from
-    //    HBM. Only `dev` is uploaded, so only `dev` needs invalidation.
-    cache_invalidate_range(runtime, sizeof(runtime->dev));
-
+void AicpuExecutor::deinit(Runtime * /*runtime*/) {
     // Reset all SchedulerContext-owned state in one place.
     sched_ctx_.deinit();
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/backend/sdma/sdma_completion_scheduler.h
@@ -32,17 +32,12 @@ struct SdmaEventRecord {
 static_assert(sizeof(SdmaEventRecord) == 16, "SDMA event record ABI drift");
 static_assert(offsetof(SdmaEventRecord, sq_tail) == 4, "SDMA event record ABI drift");
 
-inline uintptr_t sdma_completion_cache_line(const volatile void *addr) {
-    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
-}
-
 inline CompletionPollResult poll_sdma_event_record(uint64_t record_addr) {
     if (record_addr == 0) {
         return {CompletionPollState::FAILED, PTO2_ERROR_ASYNC_COMPLETION_INVALID};
     }
     volatile SdmaEventRecord *record =
         reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
-    cache_invalidate_range(reinterpret_cast<const void *>(sdma_completion_cache_line(record)), PTO2_ALIGN_SIZE);
     uint32_t flag = __atomic_load_n(&record->flag, __ATOMIC_ACQUIRE);
     return {flag != 0 ? CompletionPollState::READY : CompletionPollState::PENDING, PTO2_ERROR_NONE};
 }
@@ -51,19 +46,16 @@ inline void retire_sdma_event_record(uint64_t record_addr) {
     if (record_addr == 0) return;
     volatile SdmaEventRecord *record =
         reinterpret_cast<volatile SdmaEventRecord *>(static_cast<uintptr_t>(record_addr));
-    cache_invalidate_range(reinterpret_cast<const void *>(sdma_completion_cache_line(record)), PTO2_ALIGN_SIZE);
     uint32_t completed_tail = __atomic_load_n(&record->sq_tail, __ATOMIC_ACQUIRE);
     uint64_t channel_info_addr = __atomic_load_n(&record->channel_info, __ATOMIC_ACQUIRE);
 
     volatile uint64_t *record_head = reinterpret_cast<volatile uint64_t *>(record);
     __atomic_store_n(record_head, 0ULL, __ATOMIC_RELEASE);
-    cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(record_head)), sizeof(uint64_t));
 
     if (channel_info_addr == 0) return;
     uint64_t packed = (static_cast<uint64_t>(completed_tail) << 32) | static_cast<uint64_t>(completed_tail);
     volatile uint64_t *channel_info = reinterpret_cast<volatile uint64_t *>(static_cast<uintptr_t>(channel_info_addr));
     __atomic_store_n(channel_info, packed, __ATOMIC_RELEASE);
-    cache_flush_range(const_cast<const void *>(reinterpret_cast<volatile void *>(channel_info)), sizeof(uint64_t));
 }
 
 #endif  // SRC_A5_RUNTIME_TENSORMAP_AND_RINGBUFFER_RUNTIME_BACKEND_SDMA_SDMA_COMPLETION_SCHEDULER_H_

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_async_wait.h
@@ -34,10 +34,6 @@ inline constexpr int32_t MAX_ASYNC_WAITS = 64;
 // functions in aicore_completion_mailbox.h. This file only holds the
 // application layer: translating drained messages into wait-list state.
 
-inline uintptr_t mailbox_cache_line(const volatile void *addr) {
-    return reinterpret_cast<uintptr_t>(addr) & ~(uintptr_t(PTO2_ALIGN_SIZE) - 1u);
-}
-
 struct CompletionCondition;
 
 using CompletionPollFn = CompletionPollResult (*)(const CompletionCondition &);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -152,10 +152,11 @@ struct Task {
  *
  * Adding a field here grows the device image; adding a field to Runtime's
  * host-only tail does not. Keep it standard-layout (static_assert below) so the
- * rtMemcpy is well-defined. alignas(64) makes sizeof a multiple of the cache
- * line so the per-run cache_invalidate_range(runtime, sizeof(dev)) never rounds
- * into a neighbouring line (the leading Handshake is already 64-aligned, but the
- * explicit alignas keeps the property if fields are ever reordered).
+ * rtMemcpy is well-defined. alignas(64) keeps sizeof a multiple of the cache
+ * line so the device-copied image starts and ends on cache-line boundaries and
+ * never shares a line with Runtime's host-only tail (the leading Handshake is
+ * already 64-aligned, but the explicit alignas keeps the property if fields are
+ * ever reordered).
  */
 struct alignas(64) DeviceRuntimeLaunchDesc {
     // Handshake buffers for AICPU-AICore communication
@@ -340,7 +341,7 @@ static_assert(
 );
 static_assert(
     sizeof(DeviceRuntimeLaunchDesc) % 64 == 0,
-    "DeviceRuntimeLaunchDesc size must be a multiple of 64 so cache_invalidate_range(sizeof(dev)) "
+    "DeviceRuntimeLaunchDesc size must be a multiple of 64 so the device-copied image "
     "stays cache-line aligned"
 );
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/pto_scheduler.h
@@ -1307,17 +1307,9 @@ inline AsyncPollResult AsyncWaitList::poll_and_complete(
 
     for (int32_t i = count - 1; i >= 0; --i) {
         AsyncWaitEntry &entry = entries[i];
-        uintptr_t last_invalidated_counter_line = static_cast<uintptr_t>(-1);
         for (int32_t c = 0; c < entry.condition_count; c++) {
             CompletionCondition &cond = entry.conditions[c];
             if (cond.satisfied) continue;
-            if (cond.completion_type == COMPLETION_TYPE_COUNTER && cond.counter_addr != nullptr) {
-                uintptr_t counter_line = mailbox_cache_line(cond.counter_addr);
-                if (counter_line != last_invalidated_counter_line) {
-                    cache_invalidate_range(reinterpret_cast<const void *>(counter_line), sizeof(uint32_t));
-                    last_invalidated_counter_line = counter_line;
-                }
-            }
             CompletionPollResult poll = cond.test();
             if (poll.state == CompletionPollState::FAILED) {
                 result.error_code = poll.error_code;


### PR DESCRIPTION
## What

Removes the explicit AICPU data-cache `cache_invalidate_range` (DC CIVAC)
and `cache_flush_range` (DC CVAC) calls on **a5 only**.

## Why

Per hardware guidance, the a5 AICPU data cache is **coherent** with the
DMA/HBM path, so the manual invalidate/flush that a3 requires is
unnecessary on a5. Memory *ordering* is still guaranteed by the existing
`acquire`/`release` atomics on the shared flags — only the manual
*coherence* ops are dropped.

This PR is an **experiment to confirm a5 CI stays green** without these ops.

## Changes (a5 only)

- Remove `cache_invalidate_range` from both `deinit` paths (host_build_graph
  + tensormap `aicpu_executor.cpp`); the now-unused `runtime` param is marked.
- Drop the counter-line invalidate loop in the tensormap scheduler
  async-wait poll (`pto_scheduler.h`).
- Drop invalidate/flush around the SDMA completion record read/retire
  (`sdma_completion_scheduler.h`); `__ATOMIC_ACQUIRE`/`RELEASE` keep ordering.
- Drop the PMU collector's per-record invalidate (`pmu_collector_aicpu.cpp`);
  `rmb()`/`wmb()` barriers are retained.
- Update `DeviceRuntimeLaunchDesc` doc comment + `static_assert` that
  justified the 64B alignment solely by the removed invalidate. Alignment is
  **retained** (clean `rtMemcpy`, avoid sharing a line with the host-only tail).

## Out of scope / intentionally untouched

- Shared `common/platform/onboard/aicpu/cache_ops.cpp` — a3 still uses it.
- `src/a5/platform/include/aicpu/platform_regs.h` declarations — kept so the
  a5/a3 platform API stays parallel; simply uncalled on a5 now.
- a2a3 call sites — unchanged.

## Verification

- Built all 4 platforms × 2 runtimes (`a5sim`, `a5`, `a2a3sim`, `a2a3`) with
  `-Werror` — all pass. a2a3 built to confirm no shared-file breakage.
- Relying on CI to validate a5 correctness on real silicon without the ops.

## Risk

If a5's AICPU cache turns out **not** fully coherent in some path (SDMA
completion, PMU staging ring, mailbox counters), this would surface as
sporadic stale reads. Flagging the SDMA/PMU/mailbox sites specifically for
hardware-team review.