### PR TITLE
Add: L2 input window support to L3-L2 message queue

### DIFF
--- a/docs/hardware/cache-coherency.md
+++ b/docs/hardware/cache-coherency.md
@@ -39,7 +39,7 @@ and what code lives on each side.
 | Primitive | Side | Purpose | Cost (rough, a2a3 / DAV_3510) |
 | --------- | ---- | ------- | ----------------------------- |
 | `dcci` (`__attribute__((aicore))` intrinsic) | AICore | Push a cache line out to GM (clean+invalidate). Required after AICore stores that AICPU or peer AICore must read. | 1 cache line per call + a following `dsb` to commit ordering. |
-| `cache_invalidate_range(addr, size)` (`src/a2a3/platform/onboard/aicpu/cache_ops.cpp`) | AICPU | `dc civac` + `dsb sy` + `isb` over a byte range. Required on a2a3 before AICPU reads GM that **a non-coherent writer** (host DMA, SDMA) most recently published. | `dsb sy` dominates (tens to hundreds of cycles, fixed regardless of range). |
+| `cache_invalidate_range(addr, size)` (`src/common/platform/include/aicpu/cache_maintenance.h`) | AICPU | `dc civac` + `dsb sy` + `isb` over a byte range on onboard builds; sim builds keep it a no-op. Required on a2a3 before AICPU reads GM that **a non-coherent writer** (host DMA, SDMA) most recently published. | `dsb sy` dominates (tens to hundreds of cycles, fixed regardless of range). |
 
 `cache_invalidate_range` is the protocol-correct primitive for the
 **host-DMA → AICPU** case on a2a3. It was introduced in PR #204
@@ -185,8 +185,9 @@ forever once they ship.
 
 ## Related code
 
-- `src/a2a3/platform/onboard/aicpu/cache_ops.cpp` — `cache_invalidate_range` implementation (`dc civac` / `dsb sy` / `isb`).
-- `src/a2a3/platform/sim/aicpu/cache_ops.cpp` — sim no-op.
+- `src/common/platform/include/aicpu/cache_maintenance.h` — public cache-maintenance wrappers.
+- `src/common/platform/onboard/aicpu/cache_ops.cpp` — onboard implementation (`dc civac` / `dsb sy` / `isb`).
+- `src/common/platform/sim/aicpu/cache_ops.cpp` — sim no-op.
 - AICore-side `dcci` usage lives in the L2 swimlane / PMU AICore collectors and any kernel that publishes to a GM slot AICPU reads.
 
 ## Related docs

--- a/docs/l3-l2-message-queue.md
+++ b/docs/l3-l2-message-queue.md
@@ -82,9 +82,11 @@ message = queue.output.dequeue_into(host_output, timeout=timeout_s)
 `try_peek()` and `try_dequeue_into(buffer)` are the non-blocking forms. They
 return `None` when no output message is available.
 
-The L3 buffer arguments currently must be runtime-managed tensors returned by
-`orch.alloc(...)`. Ordinary Python `bytes`, `bytearray`, and private tensors
-are rejected before shared queue state is modified. Zero-byte messages use
+The L3 buffer arguments may be runtime-managed tensors returned by
+`orch.alloc(...)` or ordinary contiguous Python byte buffers such as `bytes`
+and `bytearray`. Runtime-managed tensors use the direct registered-buffer path.
+Ordinary host buffers are staged through an internal registered scratch buffer
+before shared queue state is modified. Zero-byte messages use
 `buffer_or_none=None` and `nbytes=0`.
 
 L3 requests graceful shutdown by publishing an input-side `STOP` descriptor:
@@ -121,6 +123,21 @@ if (queue.error().kind != L3L2QueueErrorKind::NONE) {
 }
 ```
 
+The default endpoint constructor allows one active L2 input handle at a time.
+L2 can opt into an input window with local endpoint configuration:
+
+```cpp
+L3L2QueueEndpoint queue(
+    desc,
+    queue_args,
+    L3L2QueueEndpointConfig{.max_l2_input_inflight = 4}
+);
+```
+
+`max_l2_input_inflight` is not part of L3 queue creation and does not change
+the queue layout or the shared ABI. The valid range is `1 <= N <= depth`.
+Invalid config reports `BAD_ARGUMENT` without setting the L2 abort flag.
+
 L2 consumes input messages from `queue.input()` and publishes outputs through
 `queue.output()`:
 
@@ -153,6 +170,12 @@ while (true) {
 `queue.output().try_reserve(nbytes, &reservation)` are non-blocking. A `false`
 return can mean ordinary no-progress, validation failure, or poison; check
 `queue.error().kind` to distinguish ordinary no-progress from terminal error.
+
+With `max_l2_input_inflight > 1`, L2 may acquire several DATA or ERROR inputs
+before releasing earlier ones. `release(handle)` then marks the input logically
+complete; the queue physically advances the shared input head only for the
+completed FIFO prefix. This lets L2 publish outputs in an application-defined
+order while keeping the input descriptor and payload release protocol FIFO.
 
 ## 2. Layout
 
@@ -298,23 +321,51 @@ same handle. The caller may read the payload with `read_into(handle, buffer)`
 before releasing it. Releasing the wrong handle is an ownership error and
 poisons the queue.
 
-On L2 input, `peek()` returns one active input handle. L2 must not call
-`peek()` again before releasing that handle. L2 must not release an input until
-all AICore work that reads the input payload has completed.
+On L2 input, the default endpoint constructor keeps one active input handle.
+L2 must not call `peek()` again before releasing that handle. This is
+equivalent to `max_l2_input_inflight = 1` and preserves the base queue
+behavior.
+
+When L2 constructs the endpoint with
+`L3L2QueueEndpointConfig{.max_l2_input_inflight = N}`, it may hold up to `N`
+active DATA or ERROR input handles. DATA and ERROR both count against the
+window because either may carry payload bytes that remain owned by L2
+application code. STOP does not count against the window.
+
+In window mode, `release(handle)` is logical completion: the application is
+declaring that no future L2 code or in-flight AICore task will read that input
+payload. The queue then physically releases only the completed FIFO prefix. If
+input 2 is released before input 1, input 2 remains physically owned until
+input 1 is also released.
 
 On L2 output, `reserve()` returns one active output reservation. L2 fills the
 reserved payload span, then calls `publish(reservation, opcode)`. Publishing an
 unknown, stale, already-published, or cross-queue reservation is an ownership
 error and poisons the queue.
 
-The base queue supports at most one active L2 input handle and one active L2
-output reservation. It does not provide a multi-input L2 window.
+The queue supports at most one active L2 output reservation. The input window
+does not introduce multiple concurrent output reservations; output ordering and
+output cardinality remain application-defined.
 
 ## 6. STOP Semantics
 
-`STOP` is an input descriptor with no payload. It follows normal FIFO ordering:
-L2 observes and releases messages before `STOP`, then releases `STOP` and
-returns from the persistent run.
+`STOP` is an input descriptor with no payload. It is acquired through
+`queue.input().peek()` / `try_peek()` like DATA and ERROR, and the user must
+release the STOP handle.
+
+With the default single-input endpoint, L2 observes and releases messages
+before STOP, then releases STOP and returns from the persistent run.
+
+With an input window, STOP may be acquired while earlier DATA or ERROR inputs
+are still active. After STOP is acquired, the input queue enters draining mode
+and does not acquire later DATA or ERROR descriptors. Earlier active inputs may
+still produce outputs, and L2 may still use `queue.output().reserve()` and
+`queue.output().publish()` while draining. STOP is physically released only
+after all earlier active inputs are physically released.
+
+`queue.input().drained()` returns true only after STOP has been physically
+released. Persistent L2 code should return only after `drained()` is true and
+after it has published all outputs required by its own payload protocol.
 
 After L3 successfully publishes `STOP`, the input queue rejects further input
 messages locally without poisoning. L3 may still dequeue output messages that
@@ -324,6 +375,9 @@ L2 publishes before returning.
 It does not wait for L2 exit and does not drain outputs. Applications that need
 all outputs must keep dequeuing until their own protocol-level final condition
 is satisfied before returning from the L3 orchestration function.
+
+If L2 observes a published input descriptor after STOP, that descriptor is
+invalid shared state and poisons the queue with `INVALID_DESCRIPTOR`.
 
 ## 7. Error Handling
 
@@ -357,7 +411,25 @@ set the local abort flag.
 
 After poison, normal queue operations reject. Cleanup remains valid.
 
-## 8. Platform Support
+## 8. Example
+
+The example lives at:
+
+```text
+examples/workers/l3/l3_l2_message_queue/
+```
+
+It uses `L3L2QueueEndpointConfig{.max_l2_input_inflight = 4}` and a PTO-ISA
+AIV kernel. L3 sends an initial pair of DATA inputs, drains the outputs that
+the persistent L2 run publishes for them, then sends another pair of DATA
+inputs followed by STOP. L2 acquires multiple inputs before releasing the
+earlier ones, publishes outputs in a different order from input acquisition,
+emits multiple outputs for one input, combines two inputs into one output
+during STOP drain, and returns only after `queue.input().drained()`.
+Application request IDs and output kinds are carried in the payload headers;
+the transport sequence number is not used as a request ID.
+
+## 9. Platform Support
 
 The message queue uses the existing L3-L2 orchestration communication region,
 payload, and counter primitives.

--- a/docs/l3-l2-message-queue.md
+++ b/docs/l3-l2-message-queue.md
@@ -117,26 +117,26 @@ L3L2QueueArgs queue_args{
     counter_bytes,
 };
 
-L3L2QueueEndpoint queue(desc, queue_args);
+L3L2QueueEndpoint<> queue(desc, queue_args);
 if (queue.error().kind != L3L2QueueErrorKind::NONE) {
     return;
 }
 ```
 
-The default endpoint constructor allows one active L2 input handle at a time.
-L2 can opt into an input window with local endpoint configuration:
+The default endpoint allows one active L2 DATA/ERROR input handle at a time.
+L2 can opt into a larger input window with a compile-time endpoint structure
+parameter:
 
 ```cpp
-L3L2QueueEndpoint queue(
-    desc,
-    queue_args,
-    L3L2QueueEndpointConfig{.max_l2_input_inflight = 4}
-);
+L3L2QueueEndpoint<4> queue(desc, queue_args);
 ```
 
-`max_l2_input_inflight` is not part of L3 queue creation and does not change
-the queue layout or the shared ABI. The valid range is `1 <= N <= depth`.
-Invalid config reports `BAD_ARGUMENT` without setting the L2 abort flag.
+The template argument is not part of L3 queue creation and does not change the
+queue layout or the shared ABI. The valid range is `1 <= MaxInflight <= depth`.
+Invalid template/layout combinations report `BAD_ARGUMENT` without setting the
+L2 abort flag. STOP does not count against `MaxInflight`; the endpoint keeps
+one extra active-entry slot so a STOP handle can remain pending behind earlier
+DATA/ERROR handles.
 
 L2 consumes input messages from `queue.input()` and publishes outputs through
 `queue.output()`:
@@ -171,11 +171,12 @@ while (true) {
 return can mean ordinary no-progress, validation failure, or poison; check
 `queue.error().kind` to distinguish ordinary no-progress from terminal error.
 
-With `max_l2_input_inflight > 1`, L2 may acquire several DATA or ERROR inputs
-before releasing earlier ones. `release(handle)` then marks the input logically
-complete; the queue physically advances the shared input head only for the
-completed FIFO prefix. This lets L2 publish outputs in an application-defined
-order while keeping the input descriptor and payload release protocol FIFO.
+With `L3L2QueueEndpoint<N>` where `N > 1`, L2 may acquire several DATA or
+ERROR inputs before releasing earlier ones. `release(handle)` then marks the
+input logically complete; the queue physically advances the shared input head
+only for the completed FIFO prefix. This lets L2 publish outputs in an
+application-defined order while keeping the input descriptor and payload
+release protocol FIFO.
 
 ## 2. Layout
 
@@ -321,16 +322,15 @@ same handle. The caller may read the payload with `read_into(handle, buffer)`
 before releasing it. Releasing the wrong handle is an ownership error and
 poisons the queue.
 
-On L2 input, the default endpoint constructor keeps one active input handle.
-L2 must not call `peek()` again before releasing that handle. This is
-equivalent to `max_l2_input_inflight = 1` and preserves the base queue
-behavior.
+On L2 input, `L3L2QueueEndpoint<>` keeps one active DATA/ERROR input handle.
+L2 must not call `peek()` again before releasing that handle, except that STOP
+may also be acquired into the endpoint's extra STOP slot.
 
-When L2 constructs the endpoint with
-`L3L2QueueEndpointConfig{.max_l2_input_inflight = N}`, it may hold up to `N`
-active DATA or ERROR input handles. DATA and ERROR both count against the
-window because either may carry payload bytes that remain owned by L2
-application code. STOP does not count against the window.
+When L2 constructs `L3L2QueueEndpoint<N>`, it may hold up to `N` active DATA
+or ERROR input handles. DATA and ERROR both count against the window because
+either may carry payload bytes that remain owned by L2 application code. STOP
+does not count against the DATA/ERROR window, but it is still normal FIFO
+content and is released only by the completed prefix.
 
 In window mode, `release(handle)` is logical completion: the application is
 declaring that no future L2 code or in-flight AICore task will read that input
@@ -419,15 +419,19 @@ The example lives at:
 examples/workers/l3/l3_l2_message_queue/
 ```
 
-It uses `L3L2QueueEndpointConfig{.max_l2_input_inflight = 4}` and a PTO-ISA
-AIV kernel. L3 sends an initial pair of DATA inputs, drains the outputs that
-the persistent L2 run publishes for them, then sends another pair of DATA
-inputs followed by STOP. L2 acquires multiple inputs before releasing the
-earlier ones, publishes outputs in a different order from input acquisition,
-emits multiple outputs for one input, combines two inputs into one output
-during STOP drain, and returns only after `queue.input().drained()`.
+It uses `L3L2QueueEndpoint<4>` and a PTO-ISA AIV kernel. L3 sends an initial
+pair of DATA inputs, drains the outputs that the persistent L2 run publishes
+for them, then sends another pair of DATA inputs followed by STOP. L2 acquires
+multiple inputs before releasing the earlier ones, publishes outputs in a
+different order from input acquisition, emits multiple outputs for one input,
+combines two inputs into one output during STOP drain, and returns only after
+`queue.input().drained()`.
 Application request IDs and output kinds are carried in the payload headers;
 the transport sequence number is not used as a request ID.
+
+Data-plane routing between L3 Python and an L2 host service is intentionally
+deferred. That needs a separate design for L2 host-service routing, registered
+host tensors, and possible IPC virtual-address mapping.
 
 ## 9. Platform Support
 

--- a/docs/l3-l2-message-queue.md
+++ b/docs/l3-l2-message-queue.md
@@ -144,7 +144,7 @@ L2 consumes input messages from `queue.input()` and publishes outputs through
 ```cpp
 while (true) {
     L3L2QueueInputHandle input{};
-    if (!queue.input().peek(timeout_ns, &input)) {
+    if (!queue.input().peek(timeout_ns, input)) {
         return;
     }
 
@@ -154,7 +154,7 @@ while (true) {
     }
 
     L3L2QueueOutputReservation output{};
-    if (!queue.output().reserve(input.payload_nbytes, timeout_ns, &output)) {
+    if (!queue.output().reserve(input.payload_nbytes, timeout_ns, output)) {
         return;
     }
 
@@ -166,8 +166,8 @@ while (true) {
 }
 ```
 
-`queue.input().try_peek(&input)` and
-`queue.output().try_reserve(nbytes, &reservation)` are non-blocking. A `false`
+`queue.input().try_peek(input)` and
+`queue.output().try_reserve(nbytes, reservation)` are non-blocking. A `false`
 return can mean ordinary no-progress, validation failure, or poison; check
 `queue.error().kind` to distinguish ordinary no-progress from terminal error.
 

--- a/docs/l3-l2-orch-comm.md
+++ b/docs/l3-l2-orch-comm.md
@@ -267,11 +267,9 @@ monotonic sequence or `Add` counters, because `EQ` can miss a target if the
 counter steps past it before the waiter observes the value. The primitive layer
 only applies the requested comparison.
 
-On onboard builds, correct payload/counter visibility depends on the endpoint
-cache maintenance helpers guarded by
-`L3_L2_ORCH_ENDPOINT_ENABLE_CACHE_MAINTENANCE`. Normal onboard orchestration
-builds define that macro through the toolchain; sim and non-aarch64 helper
-paths are no-ops. See
+On onboard builds, correct payload/counter visibility depends on the common
+`aicpu/cache_maintenance.h` helpers. The aarch64 path emits data-cache
+maintenance instructions; sim and non-aarch64 paths are no-ops. See
 [hardware/cache-coherency.md](hardware/cache-coherency.md).
 
 All waits must use finite timeouts. Unbounded waits hide protocol deadlocks.

--- a/docs/l3-l2-orch-comm.md
+++ b/docs/l3-l2-orch-comm.md
@@ -57,14 +57,14 @@ L3L2OrchEndpoint ep(desc);
 
 uint64_t data_ready_addr = 0;
 uint64_t completion_addr = 0;
-ep.counter_addr(data_ready_offset, &data_ready_addr);
-ep.counter_addr(completion_offset, &completion_addr);
+ep.counter_addr(data_ready_offset, data_ready_addr);
+ep.counter_addr(completion_offset, completion_addr);
 
 int32_t observed = 0;
 bool ok = ep.signal_wait(
-              data_ready_addr, seq, L3L2OrchWaitCmp::GE, timeout, &observed) &&
-          ep.payload_read(input_offset, input_nbytes, &input) &&
-          ep.payload_read(output_offset, output_nbytes, &output);
+              data_ready_addr, seq, L3L2OrchWaitCmp::GE, timeout, observed) &&
+          ep.payload_read(input_offset, input_nbytes, input) &&
+          ep.payload_read(output_offset, output_nbytes, output);
 
 // The wrapper combines gm_addr/nbytes with task-level dtype and shape.
 launch_aicore(input, output);
@@ -99,7 +99,7 @@ scalar[i + 5] = counter_bytes
 | Field | Meaning |
 | ----- | ------- |
 | `magic_version` | Descriptor ABI marker and version. |
-| `region_id` | Region identifier for diagnostics and region-scoped errors. |
+| `region_id` | Region identifier; `0` is reserved as invalid. |
 | `payload_base` | Base GM address of the payload byte range. |
 | `payload_bytes` | Size of the payload byte range. |
 | `counter_base` | Base GM address of the signal counter range. |
@@ -124,6 +124,9 @@ counter_base .. counter_base + counter_bytes - 1
 `counter_base` is 64-byte aligned, and `counter_bytes` is a multiple of
 `sizeof(int32_t)`. Counter addresses must be 4-byte aligned and inside the
 registered counter range. The payload and counter ranges do not overlap.
+`payload_base == 0` and `counter_base == 0` are not validity sentinels; only
+the range sizes, alignment, overflow, overlap, and reserved `region_id == 0`
+checks determine descriptor validity.
 
 ## 3. Control Path
 
@@ -186,9 +189,9 @@ addresses:
 
 ```cpp
 ep.signal_notify(counter_addr, value, L3L2OrchNotifyOp::Set);
-ep.signal_test(counter_addr, cmp_value, L3L2OrchWaitCmp::GE, &result);
+ep.signal_test(counter_addr, cmp_value, L3L2OrchWaitCmp::GE, result);
 ep.signal_wait(
-    counter_addr, cmp_value, L3L2OrchWaitCmp::GE, timeout, &observed);
+    counter_addr, cmp_value, L3L2OrchWaitCmp::GE, timeout, observed);
 ```
 
 `NotifyOp` supports:
@@ -251,8 +254,8 @@ L3:
 
 L2:
   signal_wait(data_ready_addr, seq, GE)
-  payload_read(input_offset, input_nbytes, &input_view)
-  payload_read(output_offset, output_nbytes, &output_view)
+  payload_read(input_offset, input_nbytes, input_view)
+  payload_read(output_offset, output_nbytes, output_view)
   submit AICore(input_view, output_view)
   wait for AICore completion
   signal_notify(completion_addr, seq, Set)

--- a/examples/workers/l3/l3_l2_message_queue/kernels/aiv/kernel_queue_transform.cpp
+++ b/examples/workers/l3/l3_l2_message_queue/kernels/aiv/kernel_queue_transform.cpp
@@ -27,12 +27,21 @@ using namespace pto;
 #define __aicore__ [aicore]  // NOLINT(whitespace/braces)
 #endif
 
+enum InputWindowOp : uint64_t {
+    ADD_SCALAR = 1,
+    ADD_TILES = 2,
+};
+
 extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ int64_t *args) {
-    __gm__ Tensor *src_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
-    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
-    __gm__ float *src = reinterpret_cast<__gm__ float *>(src_tensor->buffer.addr) + src_tensor->start_offset;
+    __gm__ Tensor *first_tensor = reinterpret_cast<__gm__ Tensor *>(args[0]);
+    __gm__ Tensor *second_tensor = reinterpret_cast<__gm__ Tensor *>(args[1]);
+    __gm__ Tensor *out_tensor = reinterpret_cast<__gm__ Tensor *>(args[2]);
+    uint64_t op = static_cast<uint64_t>(args[3]);
+    float scalar = from_u64<float>(static_cast<uint64_t>(args[4]));
+
+    __gm__ float *first = reinterpret_cast<__gm__ float *>(first_tensor->buffer.addr) + first_tensor->start_offset;
+    __gm__ float *second = reinterpret_cast<__gm__ float *>(second_tensor->buffer.addr) + second_tensor->start_offset;
     __gm__ float *out = reinterpret_cast<__gm__ float *>(out_tensor->buffer.addr) + out_tensor->start_offset;
-    float scalar = from_u64<float>(static_cast<uint64_t>(args[2]));
 
     constexpr int kRows = 128;
     constexpr int kCols = 128;
@@ -41,21 +50,31 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     using GlobalData = GlobalTensor<float, DynShapeDim5, DynStrideDim5>;
     using TileData = Tile<TileType::Vec, float, kRows, kCols, BLayout::RowMajor, -1, -1>;
 
-    TileData src_tile(kRows, kCols);
-    TileData dst_tile(kRows, kCols);
-    TASSIGN(src_tile, 0x0);
-    TASSIGN(dst_tile, 0x10000);
+    TileData first_tile(kRows, kCols);
+    TileData second_tile(kRows, kCols);
+    TileData out_tile(kRows, kCols);
+    TASSIGN(first_tile, 0x0);
+    TASSIGN(second_tile, 0x10000);
+    TASSIGN(out_tile, 0x20000);
 
-    GlobalData src_global(src);
-    GlobalData dst_global(out);
+    GlobalData first_global(first);
+    GlobalData second_global(second);
+    GlobalData out_global(out);
 
-    TLOAD(src_tile, src_global);
+    TLOAD(first_tile, first_global);
+    if (op == ADD_TILES) {
+        TLOAD(second_tile, second_global);
+    }
     set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
     wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
-    TADDS(dst_tile, src_tile, scalar);
+    if (op == ADD_TILES) {
+        TADD(out_tile, first_tile, second_tile);
+    } else {
+        TADDS(out_tile, first_tile, scalar);
+    }
     set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
     wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
-    TSTORE(dst_global, dst_tile);
+    TSTORE(out_global, out_tile);
 
     pipe_sync();
 }

--- a/examples/workers/l3/l3_l2_message_queue/kernels/orchestration/l3_l2_message_queue_orch.cpp
+++ b/examples/workers/l3/l3_l2_message_queue/kernels/orchestration/l3_l2_message_queue_orch.cpp
@@ -10,19 +10,46 @@
  */
 
 #include <stdint.h>
+#include <string.h>
 
 #include "aicpu/l3_l2_message_queue.h"
 #include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
 
 namespace {
 
-constexpr uint32_t kTransformFuncId = 0;
-constexpr int kExpectedArgCount = 13;
+constexpr int kExpectedArgCount = 12;
+constexpr uint32_t kInputWindowComputeFuncId = 0;
 constexpr uint64_t kQueueTimeoutNs = 5000000000ULL;
-constexpr uint32_t kRows = 128;
-constexpr uint32_t kCols = 128;
-constexpr uint32_t kNumel = kRows * kCols;
-constexpr uint64_t kTensorBytes = static_cast<uint64_t>(kNumel) * sizeof(float);
+constexpr uint64_t kInputWindow = 4;
+constexpr uint64_t kInputHeaderBytes = 64;
+constexpr uint64_t kOutputHeaderBytes = 64;
+constexpr uint32_t kTileRows = 128;
+constexpr uint32_t kTileCols = 128;
+constexpr uint64_t kTileBytes = static_cast<uint64_t>(kTileRows) * kTileCols * sizeof(float);
+
+enum InputWindowOp : uint64_t {
+    ADD_SCALAR = 1,
+    ADD_TILES = 2,
+};
+
+// The queue seq is transport ordering only. Payload headers carry the
+// application-level request correlation needed for out-of-order and
+// many-to-one outputs in this example.
+struct InputHeader {
+    uint64_t request_id;
+    uint64_t mode;
+};
+
+struct OutputHeader {
+    uint64_t request_id;
+    uint64_t kind;
+    uint64_t aux;
+};
+
+struct ActiveRequest {
+    L3L2QueueInputHandle handle;
+    InputHeader header;
+};
 
 void report_queue_error(const L3L2QueueEndpoint &queue) {
     const L3L2QueueError &err = queue.error();
@@ -35,44 +62,165 @@ void report_queue_error(const L3L2QueueEndpoint &queue) {
 
 bool has_queue_error(const L3L2QueueEndpoint &queue) { return queue.error().kind != L3L2QueueErrorKind::NONE; }
 
-bool process_data_message(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &input, float scalar) {
-    if (input.payload_nbytes != kTensorBytes) {
-        rt_report_fatal(
-            PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue example expected %llu input bytes, got %llu",
-            static_cast<unsigned long long>(kTensorBytes), static_cast<unsigned long long>(input.payload_nbytes)
-        );
+bool parse_input_header(const L3L2QueueInputHandle &input, InputHeader *header) {
+    if (header == nullptr || input.payload_nbytes != kInputHeaderBytes + kTileBytes) {
         return false;
     }
+    memcpy(header, reinterpret_cast<const void *>(static_cast<uintptr_t>(input.payload.gm_addr)), sizeof(*header));
+    return true;
+}
 
+Tensor make_input_values_tensor(const L3L2QueueInputHandle &input) {
+    uint32_t shape[2] = {kTileRows, kTileCols};
+    void *values = reinterpret_cast<void *>(static_cast<uintptr_t>(input.payload.gm_addr + kInputHeaderBytes));
+    return make_tensor_external(values, shape, 2, DataType::FLOAT32);
+}
+
+bool publish_aiv_output(
+    L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &first, const L3L2QueueInputHandle &second,
+    uint64_t request_id, uint64_t kind, uint64_t aux, InputWindowOp op, float scalar
+) {
+    uint64_t nbytes = kOutputHeaderBytes + kTileBytes;
     L3L2QueueOutputReservation output{};
-    if (!queue.output().reserve(kTensorBytes, kQueueTimeoutNs, &output)) {
+    if (!queue.output().reserve(nbytes, kQueueTimeoutNs, &output)) {
         report_queue_error(queue);
         return false;
     }
-    uint32_t shape[2] = {kRows, kCols};
-    Tensor input_tensor = make_tensor_external(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(input.payload.gm_addr)), shape, 2, DataType::FLOAT32
-    );
-    Tensor output_tensor = make_tensor_external(
-        reinterpret_cast<void *>(static_cast<uintptr_t>(output.payload.gm_addr)), shape, 2, DataType::FLOAT32
-    );
+
+    OutputHeader header{request_id, kind, aux};
+    uint8_t *dst = reinterpret_cast<uint8_t *>(static_cast<uintptr_t>(output.payload.gm_addr));
+    memset(dst, 0, kOutputHeaderBytes);
+    memcpy(dst, &header, sizeof(header));
+    l3_l2_orch_endpoint_cache_flush_range(dst, kOutputHeaderBytes);
+
+    Tensor first_tensor = make_input_values_tensor(first);
+    Tensor second_tensor = make_input_values_tensor(second);
+    uint32_t output_shape[2] = {kTileRows, kTileCols};
+    Tensor output_tensor = make_tensor_external(dst + kOutputHeaderBytes, output_shape, 2, DataType::FLOAT32);
 
     L0TaskArgs params;
-    params.add_input(input_tensor);
+    params.add_input(first_tensor);
+    params.add_input(second_tensor);
     params.add_output(output_tensor);
-    params.add_scalar(scalar);
-    rt_submit_aiv_task(kTransformFuncId, params);
+    params.add_scalar(static_cast<uint64_t>(op));
+    params.add_scalar(to_u64<float>(scalar));
+    rt_submit_aiv_task(kInputWindowComputeFuncId, params);
 
-    uint32_t first_index[2] = {0, 0};
-    (void)get_tensor_data<float>(output_tensor, 2, first_index);
+    uint32_t first_output_index[2] = {0, 0};
+    (void)get_tensor_data<float>(output_tensor, 2, first_output_index);
+
     if (!queue.output().publish(output, L3L2QueueOpcode::DATA)) {
         report_queue_error(queue);
         return false;
     }
+    return true;
+}
+
+bool release_input(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &input) {
     if (!queue.input().release(input)) {
         report_queue_error(queue);
         return false;
     }
+    return true;
+}
+
+bool process_first_pair(L3L2QueueEndpoint &queue, ActiveRequest *active, const L3L2QueueInputHandle &input) {
+    active[1].handle = input;
+    if (!parse_input_header(input, &active[1].header) || active[0].header.request_id == 0) {
+        rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "invalid L3-L2 queue example request");
+        return false;
+    }
+    if (!publish_aiv_output(
+            queue, active[1].handle, active[1].handle, active[1].header.request_id, 20, 0, ADD_SCALAR, 20.0F
+        )) {
+        return false;
+    }
+    if (!release_input(queue, active[1].handle)) {
+        return false;
+    }
+    active[1] = {};
+    if (!publish_aiv_output(
+            queue, active[0].handle, active[0].handle, active[0].header.request_id, 10, 0, ADD_SCALAR, 10.0F
+        ) ||
+        !publish_aiv_output(
+            queue, active[0].handle, active[0].handle, active[0].header.request_id, 11, 0, ADD_SCALAR, 11.0F
+        )) {
+        return false;
+    }
+    if (!release_input(queue, active[0].handle)) {
+        return false;
+    }
+    active[0] = {};
+    return true;
+}
+
+bool remember_input_for_pair(ActiveRequest *active, const L3L2QueueInputHandle &input, const InputHeader &header) {
+    if (active[2].header.request_id == 0) {
+        active[2].handle = input;
+        active[2].header = header;
+        return true;
+    }
+    if (active[3].header.request_id == 0) {
+        active[3].handle = input;
+        active[3].header = header;
+        return true;
+    }
+    rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue example input window is full");
+    return false;
+}
+
+bool process_data_message(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &input, ActiveRequest *active) {
+    InputHeader header{};
+    if (!parse_input_header(input, &header)) {
+        rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "invalid L3-L2 queue example request");
+        return false;
+    }
+    if (header.mode == 1) {
+        if (active[0].header.request_id != 0) {
+            rt_report_fatal(
+                PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue example received mode=1 while a request is pending"
+            );
+            return false;
+        }
+        active[0].handle = input;
+        active[0].header = header;
+        return true;
+    }
+    if (header.mode == 2) {
+        return process_first_pair(queue, active, input);
+    }
+    if (header.mode == 3) {
+        return remember_input_for_pair(active, input, header);
+    }
+    rt_report_fatal(
+        PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue example unexpected mode=%llu",
+        static_cast<unsigned long long>(header.mode)
+    );
+    return false;
+}
+
+bool finish_pending_inputs(L3L2QueueEndpoint &queue, ActiveRequest *active) {
+    if (active[2].header.request_id == 0 && active[3].header.request_id == 0) {
+        return true;
+    }
+    if (active[2].header.request_id == 0 || active[3].header.request_id == 0) {
+        rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue example missing paired input");
+        return false;
+    }
+    if (!publish_aiv_output(
+            queue, active[2].handle, active[3].handle, active[2].header.request_id, 30, active[3].header.request_id,
+            ADD_TILES, 0.0F
+        )) {
+        return false;
+    }
+    if (!release_input(queue, active[2].handle)) {
+        return false;
+    }
+    active[2] = {};
+    if (!release_input(queue, active[3].handle)) {
+        return false;
+    }
+    active[3] = {};
     return true;
 }
 
@@ -94,22 +242,32 @@ __attribute__((visibility("default"))) void l3_l2_message_queue_orchestration(co
         orch_args.scalar(6), orch_args.scalar(7),  orch_args.scalar(8),
         orch_args.scalar(9), orch_args.scalar(10), orch_args.scalar(11),
     };
-    L3L2QueueEndpoint queue(desc, queue_args);
+    L3L2QueueEndpoint queue(desc, queue_args, L3L2QueueEndpointConfig{.max_l2_input_inflight = kInputWindow});
     if (has_queue_error(queue)) {
         report_queue_error(queue);
         return;
     }
 
-    const float scalar = from_u64<float>(orch_args.scalar(12));
+    ActiveRequest active[kInputWindow]{};
     for (;;) {
         L3L2QueueInputHandle input{};
         if (!queue.input().peek(kQueueTimeoutNs, &input)) {
-            report_queue_error(queue);
-            return;
+            if (has_queue_error(queue)) {
+                report_queue_error(queue);
+                return;
+            }
+            continue;
         }
         if (input.opcode == L3L2QueueOpcode::STOP) {
+            if (!finish_pending_inputs(queue, active)) {
+                return;
+            }
             if (!queue.input().release(input)) {
                 report_queue_error(queue);
+                return;
+            }
+            if (!queue.input().drained()) {
+                rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue example returned before drain");
             }
             return;
         }
@@ -120,7 +278,7 @@ __attribute__((visibility("default"))) void l3_l2_message_queue_orchestration(co
             );
             return;
         }
-        if (!process_data_message(queue, input, scalar)) {
+        if (!process_data_message(queue, input, active)) {
             return;
         }
     }

--- a/examples/workers/l3/l3_l2_message_queue/kernels/orchestration/l3_l2_message_queue_orch.cpp
+++ b/examples/workers/l3/l3_l2_message_queue/kernels/orchestration/l3_l2_message_queue_orch.cpp
@@ -84,7 +84,7 @@ bool publish_aiv_output(
 ) {
     uint64_t nbytes = kOutputHeaderBytes + kTileBytes;
     L3L2QueueOutputReservation output{};
-    if (!queue.output().reserve(nbytes, kQueueTimeoutNs, &output)) {
+    if (!queue.output().reserve(nbytes, kQueueTimeoutNs, output)) {
         report_queue_error(queue);
         return false;
     }
@@ -253,7 +253,7 @@ __attribute__((visibility("default"))) void l3_l2_message_queue_orchestration(co
     ActiveRequest active[kInputWindow]{};
     for (;;) {
         L3L2QueueInputHandle input{};
-        if (!queue.input().peek(kQueueTimeoutNs, &input)) {
+        if (!queue.input().peek(kQueueTimeoutNs, input)) {
             if (has_queue_error(queue)) {
                 report_queue_error(queue);
                 return;

--- a/examples/workers/l3/l3_l2_message_queue/kernels/orchestration/l3_l2_message_queue_orch.cpp
+++ b/examples/workers/l3/l3_l2_message_queue/kernels/orchestration/l3_l2_message_queue_orch.cpp
@@ -51,16 +51,18 @@ struct ActiveRequest {
     InputHeader header;
 };
 
-void report_queue_error(const L3L2QueueEndpoint &queue) {
+using QueueEndpoint = L3L2QueueEndpoint<kInputWindow>;
+
+void report_queue_error(const QueueEndpoint &queue) {
     const L3L2QueueError &err = queue.error();
     rt_report_fatal(
         PTO2_ERROR_EXPLICIT_ORCH_FATAL, "L3-L2 queue error op=%s kind=%u region=%llu msg=%s",
-        err.op ? err.op : "unknown", static_cast<unsigned>(err.kind), static_cast<unsigned long long>(err.region_id),
-        err.message ? err.message : "unknown"
+        l3_l2_queue_op_to_string(err.op), static_cast<unsigned>(err.kind),
+        static_cast<unsigned long long>(err.region_id), err.message
     );
 }
 
-bool has_queue_error(const L3L2QueueEndpoint &queue) { return queue.error().kind != L3L2QueueErrorKind::NONE; }
+bool has_queue_error(const QueueEndpoint &queue) { return queue.error().kind != L3L2QueueErrorKind::NONE; }
 
 bool parse_input_header(const L3L2QueueInputHandle &input, InputHeader *header) {
     if (header == nullptr || input.payload_nbytes != kInputHeaderBytes + kTileBytes) {
@@ -77,8 +79,8 @@ Tensor make_input_values_tensor(const L3L2QueueInputHandle &input) {
 }
 
 bool publish_aiv_output(
-    L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &first, const L3L2QueueInputHandle &second,
-    uint64_t request_id, uint64_t kind, uint64_t aux, InputWindowOp op, float scalar
+    QueueEndpoint &queue, const L3L2QueueInputHandle &first, const L3L2QueueInputHandle &second, uint64_t request_id,
+    uint64_t kind, uint64_t aux, InputWindowOp op, float scalar
 ) {
     uint64_t nbytes = kOutputHeaderBytes + kTileBytes;
     L3L2QueueOutputReservation output{};
@@ -91,7 +93,7 @@ bool publish_aiv_output(
     uint8_t *dst = reinterpret_cast<uint8_t *>(static_cast<uintptr_t>(output.payload.gm_addr));
     memset(dst, 0, kOutputHeaderBytes);
     memcpy(dst, &header, sizeof(header));
-    l3_l2_orch_endpoint_cache_flush_range(dst, kOutputHeaderBytes);
+    cache_flush_range(dst, kOutputHeaderBytes);
 
     Tensor first_tensor = make_input_values_tensor(first);
     Tensor second_tensor = make_input_values_tensor(second);
@@ -116,7 +118,7 @@ bool publish_aiv_output(
     return true;
 }
 
-bool release_input(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &input) {
+bool release_input(QueueEndpoint &queue, const L3L2QueueInputHandle &input) {
     if (!queue.input().release(input)) {
         report_queue_error(queue);
         return false;
@@ -124,7 +126,7 @@ bool release_input(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &input) 
     return true;
 }
 
-bool process_first_pair(L3L2QueueEndpoint &queue, ActiveRequest *active, const L3L2QueueInputHandle &input) {
+bool process_first_pair(QueueEndpoint &queue, ActiveRequest *active, const L3L2QueueInputHandle &input) {
     active[1].handle = input;
     if (!parse_input_header(input, &active[1].header) || active[0].header.request_id == 0) {
         rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "invalid L3-L2 queue example request");
@@ -169,7 +171,7 @@ bool remember_input_for_pair(ActiveRequest *active, const L3L2QueueInputHandle &
     return false;
 }
 
-bool process_data_message(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &input, ActiveRequest *active) {
+bool process_data_message(QueueEndpoint &queue, const L3L2QueueInputHandle &input, ActiveRequest *active) {
     InputHeader header{};
     if (!parse_input_header(input, &header)) {
         rt_report_fatal(PTO2_ERROR_EXPLICIT_ORCH_FATAL, "invalid L3-L2 queue example request");
@@ -199,7 +201,7 @@ bool process_data_message(L3L2QueueEndpoint &queue, const L3L2QueueInputHandle &
     return false;
 }
 
-bool finish_pending_inputs(L3L2QueueEndpoint &queue, ActiveRequest *active) {
+bool finish_pending_inputs(QueueEndpoint &queue, ActiveRequest *active) {
     if (active[2].header.request_id == 0 && active[3].header.request_id == 0) {
         return true;
     }
@@ -242,7 +244,7 @@ __attribute__((visibility("default"))) void l3_l2_message_queue_orchestration(co
         orch_args.scalar(6), orch_args.scalar(7),  orch_args.scalar(8),
         orch_args.scalar(9), orch_args.scalar(10), orch_args.scalar(11),
     };
-    L3L2QueueEndpoint queue(desc, queue_args, L3L2QueueEndpointConfig{.max_l2_input_inflight = kInputWindow});
+    QueueEndpoint queue(desc, queue_args);
     if (has_queue_error(queue)) {
         report_queue_error(queue);
         return;

--- a/examples/workers/l3/l3_l2_message_queue/test_l3_l2_message_queue.py
+++ b/examples/workers/l3/l3_l2_message_queue/test_l3_l2_message_queue.py
@@ -7,21 +7,20 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""L3-L2 message queue demo with ordinary host-buffer staging.
+"""L3-L2 message queue example with L2 input-window processing.
 
 This file is both a runnable example and a pytest scene-test entry.
 """
 
 from __future__ import annotations
 
-import ctypes
 import os
 import struct
 
 import pytest
 from simpler.l3_l2_message_queue import L3L2QueueOpcode
 from simpler.task_interface import ArgDirection as D
-from simpler.task_interface import CallConfig, ChipCallable, CoreCallable, TaskArgs, scalar_to_uint64
+from simpler.task_interface import CallConfig, ChipCallable, CoreCallable, TaskArgs
 from simpler.worker import Worker
 
 from simpler_setup.elf_parser import extract_text_section
@@ -33,15 +32,18 @@ _HERE = os.path.dirname(os.path.abspath(__file__))
 _ORCH_SRC = os.path.join(_HERE, "kernels", "orchestration", "l3_l2_message_queue_orch.cpp")
 _AIV_SRC = os.path.join(_HERE, "kernels", "aiv", "kernel_queue_transform.cpp")
 _TIMEOUT_S = 5.0
-_QUEUE_DEPTH = 4
-_ROUNDS = 3
-_ROWS = 128
-_COLS = 128
-_NUMEL = _ROWS * _COLS
-_NBYTES = _NUMEL * 4
-_INPUT_ARENA_BYTES = _NBYTES * _ROUNDS
-_OUTPUT_ARENA_BYTES = _NBYTES * _ROUNDS
-_SCALAR = ctypes.c_float(7.0)
+_QUEUE_DEPTH = 8
+_INPUT_ARENA_BYTES = 512 * 1024
+_OUTPUT_ARENA_BYTES = 512 * 1024
+_INPUT_HEADER = "<QQ"
+_OUTPUT_HEADER = "<QQQ"
+_INPUT_HEADER_BYTES = 64
+_OUTPUT_HEADER_BYTES = 64
+# The queue seq is transport ordering only. This example uses payload headers
+# for application-level request correlation and output kind metadata.
+_TILE_ROWS = 128
+_TILE_COLS = 128
+_TILE_ELEMS = _TILE_ROWS * _TILE_COLS
 
 
 def _build_core_callable(signature: list[D], binary: bytes) -> CoreCallable:
@@ -50,14 +52,17 @@ def _build_core_callable(signature: list[D], binary: bytes) -> CoreCallable:
     except ValueError as exc:
         if "arg_index" not in str(exc):
             raise
-        return CoreCallable.build(signature=signature, arg_index=list(range(len(signature))), binary=binary)
+        return CoreCallable.build(
+            signature=signature,
+            arg_index=list(range(len(signature))),
+            binary=binary,
+        )
 
 
 def _build_chip_callable(platform: str) -> ChipCallable:
     kc = KernelCompiler(platform=platform)
     pto_isa_root = ensure_pto_isa_root()
     inc_dirs = kc.get_orchestration_include_dirs(_RUNTIME)
-    extra_common = [str(kc.project_root / "src" / "common")]
 
     aiv = kc.compile_incore(
         _AIV_SRC,
@@ -71,39 +76,78 @@ def _build_chip_callable(platform: str) -> ChipCallable:
     orch = kc.compile_orchestration(
         runtime_name=_RUNTIME,
         source_path=_ORCH_SRC,
-        extra_include_dirs=extra_common,
+        extra_include_dirs=[str(kc.project_root / "src" / "common")],
     )
     return ChipCallable.build(
         signature=[],
         func_name="l3_l2_message_queue_orchestration",
         binary=orch,
-        children=[(0, _build_core_callable([D.IN, D.OUT], aiv))],
+        children=[(0, _build_core_callable([D.IN, D.IN, D.OUT], aiv))],
     )
 
 
-def _pack_tile(values: list[float]) -> bytes:
-    if len(values) != _NUMEL:
-        raise ValueError(f"L3-L2 queue example tile requires {_NUMEL} floats")
-    return struct.pack(f"<{_NUMEL}f", *values)
+def _pack_input(request_id: int, mode: int, values: list[float]) -> bytes:
+    header = struct.pack(_INPUT_HEADER, request_id, mode)
+    return header + bytes(_INPUT_HEADER_BYTES - len(header)) + struct.pack(f"<{len(values)}f", *values)
 
 
-def _unpack_tile(data: bytes | bytearray) -> tuple[float, ...]:
-    if len(data) != _NBYTES:
-        raise ValueError(f"L3-L2 queue example tile requires {_NBYTES} bytes")
-    return struct.unpack(f"<{_NUMEL}f", bytes(data))
+def _pack_output(request_id: int, kind: int, aux: int, values: list[float]) -> bytes:
+    header = struct.pack(_OUTPUT_HEADER, request_id, kind, aux)
+    return header + bytes(_OUTPUT_HEADER_BYTES - len(header)) + struct.pack(f"<{len(values)}f", *values)
 
 
-def _make_input_payload(round_idx: int) -> tuple[bytes, list[float]]:
-    values = [float(round_idx * 1000 + (i % 251)) / 16.0 for i in range(_NUMEL)]
-    expected = [value + float(_SCALAR.value) for value in values]
-    return _pack_tile(values), expected
+def _tile(base: float) -> list[float]:
+    return [base + float(i % _TILE_COLS) for i in range(_TILE_ELEMS)]
 
 
-def _assert_output_matches(data: bytes | bytearray, expected: list[float]) -> None:
-    values = _unpack_tile(data)
-    for i, want in enumerate(expected):
-        got = float(values[i])
-        assert abs(got - want) <= 1e-5, f"output[{i}] expected {want}, got {got}"
+def _add_scalar(values: list[float], scalar: float) -> list[float]:
+    return [value + scalar for value in values]
+
+
+def _add_tiles(left: list[float], right: list[float]) -> list[float]:
+    return [x + y for x, y in zip(left, right)]
+
+
+def _input_payloads() -> list[bytes]:
+    inputs = _input_tiles()
+    return [
+        _pack_input(101, 1, inputs[0]),
+        _pack_input(102, 2, inputs[1]),
+        _pack_input(103, 3, inputs[2]),
+        _pack_input(104, 3, inputs[3]),
+    ]
+
+
+def _expected_outputs() -> list[bytes]:
+    inputs = _input_tiles()
+    return [
+        _pack_output(102, 20, 0, _add_scalar(inputs[1], 20.0)),
+        _pack_output(101, 10, 0, _add_scalar(inputs[0], 10.0)),
+        _pack_output(101, 11, 0, _add_scalar(inputs[0], 11.0)),
+        _pack_output(103, 30, 104, _add_tiles(inputs[2], inputs[3])),
+    ]
+
+
+def _read_expected_outputs(queue, expected_outputs: list[bytes]) -> None:
+    for expected in expected_outputs:
+        message = queue.output.peek(timeout=_TIMEOUT_S)
+        assert message.opcode == L3L2QueueOpcode.DATA
+        assert message.payload_nbytes == len(expected)
+        assert _read_message_payload(queue, message) == expected
+        queue.output.release(message)
+
+
+def _input_tiles() -> list[list[float]]:
+    return [_tile(1.0), _tile(100.0), _tile(1000.0), _tile(2000.0)]
+
+
+def _read_message_payload(queue, message) -> bytes:
+    if message.payload_nbytes == 0:
+        queue.output.read_into(message, None)
+        return b""
+    output = bytearray(message.payload_nbytes)
+    queue.output.read_into(message, output)
+    return bytes(output)
 
 
 def run_l3_l2_message_queue_example(platform: str, device_id: int) -> None:
@@ -133,23 +177,19 @@ def run_l3_l2_message_queue_example(platform: str, device_id: int) -> None:
             task_args = TaskArgs()
             for scalar in queue.l2_task_arg_scalars():
                 task_args.add_scalar(int(scalar))
-            task_args.add_scalar(scalar_to_uint64(_SCALAR))
             orch_handle.submit_next_level(handle, task_args, cfg, worker=0)
 
-            payloads = [_make_input_payload(round_idx) for round_idx in range(1, _ROUNDS + 1)]
-            for payload, _expected in payloads:
+            payloads = _input_payloads()
+            expected_outputs = _expected_outputs()
+
+            for payload in payloads[:2]:
+                queue.input.enqueue(payload, nbytes=len(payload), timeout=_TIMEOUT_S)
+            _read_expected_outputs(queue, expected_outputs[:3])
+
+            for payload in payloads[2:]:
                 queue.input.enqueue(payload, nbytes=len(payload), timeout=_TIMEOUT_S)
             queue.request_stop(timeout=_TIMEOUT_S)
-
-            for seq, (payload, expected) in enumerate(payloads, start=1):
-                message = queue.output.peek(timeout=_TIMEOUT_S)
-                assert message.seq == seq
-                assert message.opcode == L3L2QueueOpcode.DATA
-                assert message.payload_nbytes == len(payload)
-                output = bytearray(message.payload_nbytes)
-                queue.output.read_into(message, output)
-                _assert_output_matches(output, expected)
-                queue.output.release(message)
+            _read_expected_outputs(queue, expected_outputs[3:])
 
             queue.free()
 

--- a/examples/workers/l3/l3_l2_orch_comm_stream/kernels/orchestration/l3_l2_orch_comm_orch.cpp
+++ b/examples/workers/l3/l3_l2_orch_comm_stream/kernels/orchestration/l3_l2_orch_comm_orch.cpp
@@ -44,7 +44,7 @@ bool has_endpoint_error(const L3L2OrchEndpoint &endpoint) {
 }
 
 bool read_payload_or_fail(L3L2OrchEndpoint &endpoint, uint64_t offset, uint64_t nbytes, L3L2OrchPayloadView *out) {
-    if (endpoint.payload_read(offset, nbytes, out)) {
+    if (out != nullptr && endpoint.payload_read(offset, nbytes, *out)) {
         return true;
     }
     report_endpoint_error(endpoint);
@@ -83,8 +83,8 @@ __attribute__((visibility("default"))) void l3_l2_orch_comm_orchestration(const 
     uint32_t shape[1] = {numel};
     uint64_t data_ready_counter_addr = 0;
     uint64_t completion_counter_addr = 0;
-    if (!endpoint.counter_addr(data_ready_counter_offset, &data_ready_counter_addr) ||
-        !endpoint.counter_addr(completion_counter_offset, &completion_counter_addr)) {
+    if (!endpoint.counter_addr(data_ready_counter_offset, data_ready_counter_addr) ||
+        !endpoint.counter_addr(completion_counter_offset, completion_counter_addr)) {
         report_endpoint_error(endpoint);
         return;
     }
@@ -92,7 +92,7 @@ __attribute__((visibility("default"))) void l3_l2_orch_comm_orchestration(const 
     for (uint64_t seq = 1;; ++seq) {
         const int32_t signal_value = static_cast<int32_t>(seq);
         int32_t observed = 0;
-        if (!endpoint.signal_wait(data_ready_counter_addr, signal_value, L3L2OrchWaitCmp::GE, timeout, &observed)) {
+        if (!endpoint.signal_wait(data_ready_counter_addr, signal_value, L3L2OrchWaitCmp::GE, timeout, observed)) {
             report_endpoint_error(endpoint);
             return;
         }

--- a/examples/workers/l3/l3_l2_orch_comm_stream/kernels/orchestration/l3_l2_orch_comm_orch.cpp
+++ b/examples/workers/l3/l3_l2_orch_comm_stream/kernels/orchestration/l3_l2_orch_comm_orch.cpp
@@ -33,8 +33,9 @@ void report_endpoint_error(const L3L2OrchEndpoint &endpoint) {
         PTO2_ERROR_EXPLICIT_ORCH_FATAL,
         "L3-L2 endpoint error op=%s kind=%u region=%llu counter_addr=%llu counter_operand=%d observed_counter=%d "
         "msg=%s",
-        err.op, static_cast<unsigned>(err.kind), static_cast<unsigned long long>(err.region_id),
-        static_cast<unsigned long long>(err.counter_addr), err.counter_operand, err.observed_counter, err.message
+        l3_l2_endpoint_op_to_string(err.op), static_cast<unsigned>(err.kind),
+        static_cast<unsigned long long>(err.region_id), static_cast<unsigned long long>(err.counter_addr),
+        err.counter_operand, err.observed_counter, err.message
     );
 }
 

--- a/simpler_setup/kernel_compiler.py
+++ b/simpler_setup/kernel_compiler.py
@@ -210,6 +210,15 @@ class KernelCompiler:
 
         return include_dirs, source_files
 
+    def _get_orchestration_platform_sources(self) -> list[str]:
+        """Sources needed when public AICPU helper headers are used by orchestration SOs."""
+        variant = "sim" if self.platform.endswith("sim") else "onboard"
+        source_dir = self.project_root / "src" / "common" / "platform" / variant / "aicpu"
+        return [
+            str(source_dir / "cache_ops.cpp"),
+            str(source_dir / "device_time.cpp"),
+        ]
+
     def _run_subprocess(
         self, cmd: list[str], label: str, error_hint: str = "Compiler not found"
     ) -> subprocess.CompletedProcess:
@@ -418,6 +427,7 @@ class KernelCompiler:
         orch_includes, orch_sources = self._get_orchestration_config(runtime_name)
         if orch_includes:
             include_dirs = include_dirs + orch_includes
+        orch_sources = list(orch_sources) + self._get_orchestration_platform_sources()
 
         # host_build_graph dlopens the orchestration .so on the host, so it
         # compiles with the host g++ (x86_64) regardless of platform.
@@ -443,7 +453,10 @@ class KernelCompiler:
         else:
             toolchain = self.host_gxx
 
-        # Orchestration uses the ops table via pto_orchestration_api.h (no extra runtime sources needed).
+        # HOST_GXX: simulation build (host execution)
+        # AARCH64_GXX: cross-compilation for supported runtimes
+        # Runtime calls still go through pto_orchestration_api.h; platform helper sources
+        # are linked only for public AICPU utility headers used directly by orchestration code.
         return self._compile_orchestration_shared_lib(
             source_path,
             toolchain,

--- a/simpler_setup/toolchain.py
+++ b/simpler_setup/toolchain.py
@@ -307,7 +307,6 @@ class Aarch64GxxToolchain(Toolchain):
             "-O3",
             "-g",
             "-std=c++17",
-            "-DL3_L2_ORCH_ENDPOINT_ENABLE_CACHE_MAINTENANCE",
         ]
         # -fno-gnu-unique: prevent STB_GNU_UNIQUE binding so dlclose actually unloads the SO.
         if self._gcc:

--- a/src/a2a3/platform/include/aicpu/platform_regs.h
+++ b/src/a2a3/platform/include/aicpu/platform_regs.h
@@ -26,8 +26,9 @@
 #ifndef PLATFORM_AICPU_PLATFORM_REGS_H_
 #define PLATFORM_AICPU_PLATFORM_REGS_H_
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include "aicpu/cache_maintenance.h"
 #include "common/platform_config.h"
 
 #ifdef __cplusplus
@@ -158,32 +159,5 @@ uint64_t inner_get_deinit_timeout_ticks();
  * @return Physical core count (exclusive upper bound)
  */
 uint32_t platform_get_physical_cores_count();
-
-/**
- * Invalidate data cache for a memory range.
- *
- * On ARM64 AICPU, DMA writes from the host (rtMemcpy) go directly to HBM
- * without invalidating the AICPU's data cache.  When rtMalloc returns the
- * same device address across rounds, the AICPU may read stale cached data
- * instead of the fresh values written by the host.
- *
- * On real hardware (onboard): performs DC CIVAC per cache line + DSB/ISB.
- * On simulation (sim): no-op.
- *
- * @param addr  Start address of the memory range
- * @param size  Size of the memory range in bytes
- */
-void cache_invalidate_range(const void *addr, size_t size);
-
-/**
- * Clean data cache for a memory range back to global memory.
- *
- * On real hardware (onboard): performs DC CVAC per cache line + DSB/ISB.
- * On simulation (sim): no-op.
- *
- * @param addr  Start address of the memory range
- * @param size  Size of the memory range in bytes
- */
-void cache_flush_range(const void *addr, size_t size);
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/a5/platform/include/aicpu/platform_regs.h
+++ b/src/a5/platform/include/aicpu/platform_regs.h
@@ -29,8 +29,9 @@
 #ifndef PLATFORM_AICPU_PLATFORM_REGS_H_
 #define PLATFORM_AICPU_PLATFORM_REGS_H_
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include "aicpu/cache_maintenance.h"
 #include "common/platform_config.h"
 
 #ifdef __cplusplus
@@ -148,32 +149,5 @@ uint64_t inner_get_deinit_timeout_ticks();
  * @return Physical core count (exclusive upper bound)
  */
 uint32_t platform_get_physical_cores_count();
-
-/**
- * Invalidate data cache for a memory range.
- *
- * On ARM64 AICPU, DMA writes from the host (rtMemcpy) go directly to HBM
- * without invalidating the AICPU's data cache.  When rtMalloc returns the
- * same device address across rounds, the AICPU may read stale cached data
- * instead of the fresh values written by the host.
- *
- * On real hardware (onboard): performs DC CIVAC per cache line + DSB/ISB.
- * On simulation (sim): no-op.
- *
- * @param addr  Start address of the memory range
- * @param size  Size of the memory range in bytes
- */
-void cache_invalidate_range(const void *addr, size_t size);
-
-/**
- * Clean data cache for a memory range back to global memory.
- *
- * On real hardware (onboard): performs DC CVAC per cache line + DSB/ISB.
- * On simulation (sim): no-op.
- *
- * @param addr  Start address of the memory range
- * @param size  Size of the memory range in bytes
- */
-void cache_flush_range(const void *addr, size_t size);
 
 #endif  // PLATFORM_AICPU_PLATFORM_REGS_H_

--- a/src/common/platform/include/aicpu/cache_maintenance.h
+++ b/src/common/platform/include/aicpu/cache_maintenance.h
@@ -8,14 +8,23 @@
  * See LICENSE in the root of the software repository for the full text of the License.
  * -----------------------------------------------------------------------------------------------------------
  */
-#include <cstddef>
 
-#include "aicpu/cache_maintenance.h"
+#ifndef SRC_COMMON_PLATFORM_INCLUDE_AICPU_CACHE_MAINTENANCE_H_
+#define SRC_COMMON_PLATFORM_INCLUDE_AICPU_CACHE_MAINTENANCE_H_
+
+#include <stddef.h>
 
 namespace aicpu_cache_maintenance {
 
-void invalidate_range_impl(const void * /* addr */, size_t /* size */) {}
-
-void flush_range_impl(const void * /* addr */, size_t /* size */) {}
+void invalidate_range_impl(const void *addr, size_t size);
+void flush_range_impl(const void *addr, size_t size);
 
 }  // namespace aicpu_cache_maintenance
+
+inline void cache_invalidate_range(const void *addr, size_t size) {
+    aicpu_cache_maintenance::invalidate_range_impl(addr, size);
+}
+
+inline void cache_flush_range(const void *addr, size_t size) { aicpu_cache_maintenance::flush_range_impl(addr, size); }
+
+#endif  // SRC_COMMON_PLATFORM_INCLUDE_AICPU_CACHE_MAINTENANCE_H_

--- a/src/common/platform/include/aicpu/device_time.h
+++ b/src/common/platform/include/aicpu/device_time.h
@@ -23,7 +23,12 @@
 #ifndef SRC_COMMON_PLATFORM_INCLUDE_AICPU_DEVICE_TIME_H_
 #define SRC_COMMON_PLATFORM_INCLUDE_AICPU_DEVICE_TIME_H_
 
+#if !defined(__aarch64__)
+#include <chrono>
+#endif
 #include <cstdint>
+
+#include "common/platform_config.h"
 
 /**
  * AICPU system counter for performance profiling.
@@ -34,5 +39,45 @@
  * @return Counter ticks
  */
 uint64_t get_sys_cnt_aicpu();
+
+inline uint64_t device_time_now_ticks() {
+#if defined(__aarch64__)
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, cntvct_el0" : "=r"(value));
+    return value;
+#else
+    return static_cast<uint64_t>(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
+            .count()
+    );
+#endif
+}
+
+inline uint64_t device_time_frequency_hz() {
+#if defined(__aarch64__)
+    uint64_t value = 0;
+    __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(value));
+    return value;
+#else
+    return 1'000'000'000ULL;
+#endif
+}
+
+inline uint64_t get_sys_cnt_aicpu_frequency_hz() { return PLATFORM_PROF_SYS_CNT_FREQ; }
+
+inline uint64_t sys_cnt_ticks_to_ns(uint64_t ticks, uint64_t frequency_hz) {
+    if (frequency_hz == 0) {
+        return UINT64_MAX;
+    }
+    __uint128_t elapsed_ns = static_cast<__uint128_t>(ticks) * 1'000'000'000ULL / frequency_hz;
+    if (elapsed_ns > UINT64_MAX) {
+        return UINT64_MAX;
+    }
+    return static_cast<uint64_t>(elapsed_ns);
+}
+
+inline uint64_t sys_cnt_elapsed_ns(uint64_t start, uint64_t end, uint64_t frequency_hz) {
+    return sys_cnt_ticks_to_ns(end - start, frequency_hz);
+}
 
 #endif  // SRC_COMMON_PLATFORM_INCLUDE_AICPU_DEVICE_TIME_H_

--- a/src/common/platform/include/aicpu/l3_l2_message_queue.h
+++ b/src/common/platform/include/aicpu/l3_l2_message_queue.h
@@ -35,7 +35,7 @@ static constexpr uint64_t L3L2_QUEUE_L2_ABORT_FLAG_OFFSET = 320;
 static constexpr uint64_t L3L2_QUEUE_COUNTER_BYTES = 384;
 static constexpr uint64_t L3L2_QUEUE_MAX_DEPTH = 1ull << 30;
 static constexpr uint64_t L3L2_QUEUE_MAGIC_VERSION =
-    l3_l2_orch_comm_pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR);
+    l3_l2_orch_comm::pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR);
 
 struct L3L2QueueDescSlot {
     uint64_t seq;
@@ -151,11 +151,13 @@ struct L3L2QueueOutputReservation {
     bool valid;
 };
 
-static inline uint64_t l3_l2_queue_magic_version() { return L3L2_QUEUE_MAGIC_VERSION; }
+namespace l3_l2_message_queue {
 
-static inline bool l3_l2_queue_is_power_of_two(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+static inline uint64_t magic_version() { return L3L2_QUEUE_MAGIC_VERSION; }
 
-static inline uint64_t l3_l2_queue_align_up(uint64_t value, uint64_t align) {
+static inline bool is_power_of_two(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
+
+static inline uint64_t align_up(uint64_t value, uint64_t align) {
     if (align == 0) {
         return value;
     }
@@ -163,54 +165,54 @@ static inline uint64_t l3_l2_queue_align_up(uint64_t value, uint64_t align) {
     return remainder == 0 ? value : value + (align - remainder);
 }
 
-static inline bool l3_l2_queue_align_up_checked(uint64_t value, uint64_t align, uint64_t *out) {
+static inline bool align_up_checked(uint64_t value, uint64_t align, uint64_t *out) {
     if (out == nullptr || align == 0) {
         return false;
     }
     uint64_t remainder = value % align;
     uint64_t bump = remainder == 0 ? 0 : align - remainder;
-    if (l3_l2_orch_comm_add_overflows(value, bump)) {
+    if (l3_l2_orch_comm::add_overflows(value, bump)) {
         return false;
     }
     *out = value + bump;
     return true;
 }
 
-static inline bool l3_l2_queue_valid_opcode(L3L2QueueOpcode opcode) {
+static inline bool valid_opcode(L3L2QueueOpcode opcode) {
     return opcode == L3L2QueueOpcode::DATA || opcode == L3L2QueueOpcode::STOP || opcode == L3L2QueueOpcode::ERROR;
 }
 
 static inline bool
-l3_l2_queue_make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout &out) {
-    if (!l3_l2_queue_is_power_of_two(depth) || depth > L3L2_QUEUE_MAX_DEPTH || input_arena_bytes == 0 ||
-        output_arena_bytes == 0 || input_arena_bytes % L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT != 0 ||
+make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout &out) {
+    if (!is_power_of_two(depth) || depth > L3L2_QUEUE_MAX_DEPTH || input_arena_bytes == 0 || output_arena_bytes == 0 ||
+        input_arena_bytes % L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT != 0 ||
         output_arena_bytes % L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT != 0) {
         return false;
     }
 
     uint64_t desc_ring_bytes = depth * L3L2_QUEUE_DESC_SLOT_BYTES;
     uint64_t input_desc_offset = 0;
-    if (l3_l2_orch_comm_add_overflows(input_desc_offset, desc_ring_bytes)) {
+    if (l3_l2_orch_comm::add_overflows(input_desc_offset, desc_ring_bytes)) {
         return false;
     }
     uint64_t output_desc_offset = input_desc_offset + desc_ring_bytes;
-    if (l3_l2_orch_comm_add_overflows(output_desc_offset, desc_ring_bytes)) {
+    if (l3_l2_orch_comm::add_overflows(output_desc_offset, desc_ring_bytes)) {
         return false;
     }
     uint64_t desc_end = output_desc_offset + desc_ring_bytes;
     uint64_t input_arena_offset = 0;
-    if (!l3_l2_queue_align_up_checked(desc_end, L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT, &input_arena_offset)) {
+    if (!align_up_checked(desc_end, L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT, &input_arena_offset)) {
         return false;
     }
-    if (l3_l2_orch_comm_add_overflows(input_arena_offset, input_arena_bytes)) {
+    if (l3_l2_orch_comm::add_overflows(input_arena_offset, input_arena_bytes)) {
         return false;
     }
     uint64_t input_arena_end = input_arena_offset + input_arena_bytes;
     uint64_t output_arena_offset = 0;
-    if (!l3_l2_queue_align_up_checked(input_arena_end, L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT, &output_arena_offset)) {
+    if (!align_up_checked(input_arena_end, L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT, &output_arena_offset)) {
         return false;
     }
-    if (l3_l2_orch_comm_add_overflows(output_arena_offset, output_arena_bytes)) {
+    if (l3_l2_orch_comm::add_overflows(output_arena_offset, output_arena_bytes)) {
         return false;
     }
     uint64_t payload_bytes = output_arena_offset + output_arena_bytes;
@@ -238,11 +240,11 @@ l3_l2_queue_make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t out
 }
 
 static inline bool
-l3_l2_queue_validate_region(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args, L3L2QueueLayout *out_layout) {
+validate_region(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args, L3L2QueueLayout *out_layout) {
     L3L2QueueLayout layout{};
-    if (args.magic_version != l3_l2_queue_magic_version() ||
-        l3_l2_orch_comm_validate_desc(desc) != L3L2OrchCommValidationError::OK ||
-        !l3_l2_queue_make_layout(args.depth, args.input_arena_bytes, args.output_arena_bytes, layout)) {
+    if (args.magic_version != magic_version() ||
+        l3_l2_orch_comm::validate_desc(desc) != L3L2OrchCommValidationError::OK ||
+        !make_layout(args.depth, args.input_arena_bytes, args.output_arena_bytes, layout)) {
         return false;
     }
     if (args.payload_bytes != layout.payload_bytes || args.counter_bytes != layout.counter_bytes ||
@@ -255,7 +257,7 @@ l3_l2_queue_validate_region(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs 
     return true;
 }
 
-static inline void l3_l2_queue_encode_desc(
+static inline void encode_desc(
     L3L2QueueDescSlot *slot, uint64_t seq, L3L2QueueOpcode opcode, uint64_t payload_offset, uint64_t payload_nbytes
 ) {
     if (slot == nullptr) {
@@ -267,7 +269,7 @@ static inline void l3_l2_queue_encode_desc(
     slot->payload_nbytes = payload_nbytes;
 }
 
-static inline bool l3_l2_queue_reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t &local_value) {
+static inline bool reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t &local_value) {
     if (depth > L3L2_QUEUE_MAX_DEPTH) {
         return false;
     }
@@ -278,40 +280,6 @@ static inline bool l3_l2_queue_reconstruct_counter(int32_t observed_low32, uint6
     }
     local_value += static_cast<uint64_t>(delta);
     return true;
-}
-
-namespace l3_l2_message_queue {
-
-static inline uint64_t magic_version() { return ::l3_l2_queue_magic_version(); }
-
-static inline bool is_power_of_two(uint64_t value) { return ::l3_l2_queue_is_power_of_two(value); }
-
-static inline uint64_t align_up(uint64_t value, uint64_t align) { return ::l3_l2_queue_align_up(value, align); }
-
-static inline bool align_up_checked(uint64_t value, uint64_t align, uint64_t *out) {
-    return ::l3_l2_queue_align_up_checked(value, align, out);
-}
-
-static inline bool valid_opcode(L3L2QueueOpcode opcode) { return ::l3_l2_queue_valid_opcode(opcode); }
-
-static inline bool
-make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout &out) {
-    return ::l3_l2_queue_make_layout(depth, input_arena_bytes, output_arena_bytes, out);
-}
-
-static inline bool
-validate_region(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args, L3L2QueueLayout *out_layout) {
-    return ::l3_l2_queue_validate_region(desc, args, out_layout);
-}
-
-static inline void encode_desc(
-    L3L2QueueDescSlot *slot, uint64_t seq, L3L2QueueOpcode opcode, uint64_t payload_offset, uint64_t payload_nbytes
-) {
-    ::l3_l2_queue_encode_desc(slot, seq, opcode, payload_offset, payload_nbytes);
-}
-
-static inline bool reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t &local_value) {
-    return ::l3_l2_queue_reconstruct_counter(observed_low32, depth, local_value);
 }
 
 }  // namespace l3_l2_message_queue

--- a/src/common/platform/include/aicpu/l3_l2_message_queue.h
+++ b/src/common/platform/include/aicpu/l3_l2_message_queue.h
@@ -34,6 +34,8 @@ static constexpr uint64_t L3L2_QUEUE_L3_ABORT_FLAG_OFFSET = 256;
 static constexpr uint64_t L3L2_QUEUE_L2_ABORT_FLAG_OFFSET = 320;
 static constexpr uint64_t L3L2_QUEUE_COUNTER_BYTES = 384;
 static constexpr uint64_t L3L2_QUEUE_MAX_DEPTH = 1ull << 30;
+static constexpr uint64_t L3L2_QUEUE_MAGIC_VERSION =
+    l3_l2_orch_comm_pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR);
 
 struct L3L2QueueDescSlot {
     uint64_t seq;
@@ -149,9 +151,7 @@ struct L3L2QueueOutputReservation {
     bool valid;
 };
 
-static inline uint64_t l3_l2_queue_magic_version() {
-    return l3_l2_orch_comm_pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR);
-}
+static inline uint64_t l3_l2_queue_magic_version() { return L3L2_QUEUE_MAGIC_VERSION; }
 
 static inline bool l3_l2_queue_is_power_of_two(uint64_t value) { return value != 0 && (value & (value - 1)) == 0; }
 
@@ -181,10 +181,9 @@ static inline bool l3_l2_queue_valid_opcode(L3L2QueueOpcode opcode) {
 }
 
 static inline bool
-l3_l2_queue_make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout *out) {
-    if (out == nullptr || !l3_l2_queue_is_power_of_two(depth) || depth > L3L2_QUEUE_MAX_DEPTH ||
-        input_arena_bytes == 0 || output_arena_bytes == 0 ||
-        input_arena_bytes % L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT != 0 ||
+l3_l2_queue_make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout &out) {
+    if (!l3_l2_queue_is_power_of_two(depth) || depth > L3L2_QUEUE_MAX_DEPTH || input_arena_bytes == 0 ||
+        output_arena_bytes == 0 || input_arena_bytes % L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT != 0 ||
         output_arena_bytes % L3L2_QUEUE_PAYLOAD_ARENA_ALIGNMENT != 0) {
         return false;
     }
@@ -216,7 +215,7 @@ l3_l2_queue_make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t out
     }
     uint64_t payload_bytes = output_arena_offset + output_arena_bytes;
 
-    *out = L3L2QueueLayout{
+    out = L3L2QueueLayout{
         depth,
         input_desc_offset,
         output_desc_offset,
@@ -243,7 +242,7 @@ l3_l2_queue_validate_region(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs 
     L3L2QueueLayout layout{};
     if (args.magic_version != l3_l2_queue_magic_version() ||
         l3_l2_orch_comm_validate_desc(desc) != L3L2OrchCommValidationError::OK ||
-        !l3_l2_queue_make_layout(args.depth, args.input_arena_bytes, args.output_arena_bytes, &layout)) {
+        !l3_l2_queue_make_layout(args.depth, args.input_arena_bytes, args.output_arena_bytes, layout)) {
         return false;
     }
     if (args.payload_bytes != layout.payload_bytes || args.counter_bytes != layout.counter_bytes ||
@@ -268,16 +267,16 @@ static inline void l3_l2_queue_encode_desc(
     slot->payload_nbytes = payload_nbytes;
 }
 
-static inline bool l3_l2_queue_reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t *local_value) {
-    if (local_value == nullptr || depth > L3L2_QUEUE_MAX_DEPTH) {
+static inline bool l3_l2_queue_reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t &local_value) {
+    if (depth > L3L2_QUEUE_MAX_DEPTH) {
         return false;
     }
-    uint32_t local_low32 = static_cast<uint32_t>(*local_value);
+    uint32_t local_low32 = static_cast<uint32_t>(local_value);
     int32_t delta = static_cast<int32_t>(static_cast<uint32_t>(observed_low32) - local_low32);
     if (delta < 0 || static_cast<uint64_t>(delta) > depth) {
         return false;
     }
-    *local_value += static_cast<uint64_t>(delta);
+    local_value += static_cast<uint64_t>(delta);
     return true;
 }
 
@@ -296,7 +295,7 @@ static inline bool align_up_checked(uint64_t value, uint64_t align, uint64_t *ou
 static inline bool valid_opcode(L3L2QueueOpcode opcode) { return ::l3_l2_queue_valid_opcode(opcode); }
 
 static inline bool
-make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout *out) {
+make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout &out) {
     return ::l3_l2_queue_make_layout(depth, input_arena_bytes, output_arena_bytes, out);
 }
 
@@ -311,7 +310,7 @@ static inline void encode_desc(
     ::l3_l2_queue_encode_desc(slot, seq, opcode, payload_offset, payload_nbytes);
 }
 
-static inline bool reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t *local_value) {
+static inline bool reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t &local_value) {
     return ::l3_l2_queue_reconstruct_counter(observed_low32, depth, local_value);
 }
 
@@ -354,17 +353,18 @@ public:
             active_head_ = 0;
             active_count_ = 0;
             active_non_stop_count_ = 0;
-            input_acquire_ = parent_->input_head_;
+            input_head_ = 0;
+            input_tail_ = 0;
+            input_payload_head_ = 0;
+            input_payload_acquire_head_ = 0;
+            input_acquire_ = input_head_;
             stop_observed_ = false;
             drained_ = false;
             return true;
         }
 
     public:
-        bool peek(uint64_t timeout_ns, L3L2QueueInputHandle *out) {
-            if (out == nullptr) {
-                return false;
-            }
+        bool peek(uint64_t timeout_ns, L3L2QueueInputHandle &out) {
             uint64_t start = device_time_now_ticks();
             uint64_t frequency_hz = device_time_frequency_hz();
             uint64_t spins = 0;
@@ -386,27 +386,28 @@ public:
             }
         }
 
-        bool try_peek(L3L2QueueInputHandle *out) {
-            if (out != nullptr) {
-                *out = L3L2QueueInputHandle{0, L3L2QueueOpcode::INVALID, 0, 0, L3L2OrchPayloadView{0, 0}};
-            }
-            if (!parent_->ensure_live(L3L2QueueOp::INPUT_TRY_PEEK) || out == nullptr) {
+        bool try_peek(L3L2QueueInputHandle &out) {
+            out = L3L2QueueInputHandle{0, L3L2QueueOpcode::INVALID, 0, 0, L3L2OrchPayloadView{0, 0}};
+            if (!parent_->ensure_live()) {
                 return false;
             }
-            if (MaxInflight == 1 && active_count_ != 0) {
-                parent_->poison(
-                    L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::INPUT_TRY_PEEK, "input handle already active"
-                );
-                return false;
+            const L3L2QueueLayout &layout = parent_->layout_;
+            L3L2OrchEndpoint &endpoint = parent_->endpoint_;
+            if constexpr (MaxInflight == 1) {
+                if (active_count_ != 0) {
+                    parent_->poison(
+                        L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::INPUT_TRY_PEEK, "input handle already active"
+                    );
+                    return false;
+                }
             }
             if (!parent_->refresh_counter(
-                    parent_->layout_.input_desc_tail_offset, parent_->input_tail_, parent_->layout_.depth,
-                    L3L2QueueOp::INPUT_TRY_PEEK
+                    layout.input_desc_tail_offset, input_tail_, layout.depth, L3L2QueueOp::INPUT_TRY_PEEK
                 )) {
                 return false;
             }
             if (stop_observed_) {
-                if (parent_->input_tail_ != input_acquire_) {
+                if (input_tail_ != input_acquire_) {
                     parent_->poison(
                         L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
                         "input descriptor published after STOP"
@@ -414,11 +415,11 @@ public:
                 }
                 return false;
             }
-            if (parent_->input_tail_ == input_acquire_) {
+            if (input_tail_ == input_acquire_) {
                 return false;
             }
-            if (parent_->input_tail_ - parent_->input_head_ > parent_->layout_.depth ||
-                input_acquire_ < parent_->input_head_ || input_acquire_ > parent_->input_tail_) {
+            if (input_tail_ - input_head_ > layout.depth || input_acquire_ < input_head_ ||
+                input_acquire_ > input_tail_) {
                 parent_->poison(
                     L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
                     "input descriptor state invalid"
@@ -427,8 +428,8 @@ public:
             }
 
             L3L2QueueDescSlot slot{};
-            uint64_t slot_index = input_acquire_ & (parent_->layout_.depth - 1);
-            uint64_t slot_offset = parent_->layout_.input_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
+            uint64_t slot_index = input_acquire_ & (layout.depth - 1);
+            uint64_t slot_offset = layout.input_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
             if (!parent_->read_desc_slot(slot_offset, &slot, L3L2QueueOp::INPUT_TRY_PEEK)) {
                 return false;
             }
@@ -472,35 +473,33 @@ public:
                     return false;
                 }
             } else if (!parent_->payload_in_arena(
-                           slot.payload_offset, slot.payload_nbytes, parent_->layout_.input_arena_offset,
-                           parent_->layout_.input_arena_bytes
+                           slot.payload_offset, slot.payload_nbytes, layout.input_arena_offset, layout.input_arena_bytes
                        )) {
                 parent_->poison(
                     L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK, "input payload out of arena"
                 );
                 return false;
             } else if (!parent_->payload_matches_head(
-                           parent_->input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
-                           parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes,
-                           L3L2QueueOp::INPUT_TRY_PEEK
+                           input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
+                           layout.input_arena_offset, layout.input_arena_bytes, L3L2QueueOp::INPUT_TRY_PEEK
                        )) {
                 return false;
-            } else if (!parent_->endpoint_.payload_read(slot.payload_offset, slot.payload_nbytes, &view)) {
+            } else if (!endpoint.payload_read(slot.payload_offset, slot.payload_nbytes, view)) {
                 parent_->poison(
-                    L3L2QueueErrorKind::ENDPOINT_ERROR, L3L2QueueOp::INPUT_TRY_PEEK, parent_->endpoint_.error().message
+                    L3L2QueueErrorKind::ENDPOINT_ERROR, L3L2QueueOp::INPUT_TRY_PEEK, endpoint.error().message
                 );
                 return false;
             } else {
                 parent_->advance_payload_head(
-                    parent_->input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
-                    parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, L3L2QueueOp::INPUT_TRY_PEEK
+                    input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes, layout.input_arena_offset,
+                    layout.input_arena_bytes, L3L2QueueOp::INPUT_TRY_PEEK
                 );
                 if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
                     return false;
                 }
             }
 
-            *out = L3L2QueueInputHandle{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view};
+            out = L3L2QueueInputHandle{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view};
             uint64_t insert_index = (active_head_ + active_count_) % kEntryCapacity;
             active_entries_[insert_index] =
                 ActiveInputEntry{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view, false};
@@ -511,7 +510,7 @@ public:
             input_acquire_ += 1;
             if (opcode == L3L2QueueOpcode::STOP) {
                 stop_observed_ = true;
-                if (parent_->input_tail_ != input_acquire_) {
+                if (input_tail_ != input_acquire_) {
                     parent_->poison(
                         L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
                         "input descriptor published after STOP"
@@ -523,11 +522,10 @@ public:
         }
 
         bool release(const L3L2QueueInputHandle &handle) {
-            if (!parent_->ensure_live(L3L2QueueOp::INPUT_RELEASE)) {
+            if (!parent_->ensure_live()) {
                 return false;
             }
-            uint64_t entry_index = 0;
-            ActiveInputEntry *entry = find_active_entry(handle.seq, &entry_index);
+            ActiveInputEntry *entry = entry_for_seq(handle.seq);
             if (entry == nullptr || handle.opcode != entry->opcode || handle.payload_offset != entry->payload_offset ||
                 handle.payload_nbytes != entry->payload_nbytes || handle.payload.gm_addr != entry->payload.gm_addr ||
                 handle.payload.nbytes != entry->payload.nbytes) {
@@ -542,7 +540,6 @@ public:
                 );
                 return false;
             }
-            (void)entry_index;
             entry->completed = true;
             return release_completed_prefix();
         }
@@ -550,17 +547,17 @@ public:
         bool drained() const { return drained_; }
 
     private:
-        ActiveInputEntry *find_active_entry(uint64_t seq, uint64_t *entry_index) {
-            for (uint64_t i = 0; i < active_count_; ++i) {
-                uint64_t index = (active_head_ + i) % kEntryCapacity;
-                if (active_entries_[index].seq == seq) {
-                    if (entry_index != nullptr) {
-                        *entry_index = index;
-                    }
-                    return &active_entries_[index];
-                }
+        ActiveInputEntry *entry_for_seq(uint64_t seq) {
+            uint64_t first_seq = input_head_ + 1;
+            if (seq < first_seq) {
+                return nullptr;
             }
-            return nullptr;
+            uint64_t ordinal = seq - first_seq;
+            if (ordinal >= active_count_) {
+                return nullptr;
+            }
+            uint64_t index = (active_head_ + ordinal) % kEntryCapacity;
+            return active_entries_[index].seq == seq ? &active_entries_[index] : nullptr;
         }
 
         bool release_completed_prefix() {
@@ -568,7 +565,7 @@ public:
                 ActiveInputEntry entry = active_entries_[active_head_];
                 if (entry.payload_nbytes != 0) {
                     parent_->advance_payload_head(
-                        parent_->input_payload_head_, entry.payload_offset, entry.payload_nbytes,
+                        input_payload_head_, entry.payload_offset, entry.payload_nbytes,
                         parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes,
                         L3L2QueueOp::INPUT_RELEASE
                     );
@@ -576,7 +573,7 @@ public:
                         return false;
                     }
                 }
-                parent_->input_head_ += 1;
+                input_head_ += 1;
                 if (entry.opcode == L3L2QueueOpcode::DATA || entry.opcode == L3L2QueueOpcode::ERROR) {
                     active_non_stop_count_ -= 1;
                 }
@@ -587,7 +584,7 @@ public:
                 active_head_ = (active_head_ + 1) % kEntryCapacity;
                 active_count_ -= 1;
                 if (!parent_->notify_counter(
-                        parent_->layout_.input_desc_head_offset, static_cast<int32_t>(parent_->input_head_),
+                        parent_->layout_.input_desc_head_offset, static_cast<int32_t>(input_head_),
                         L3L2QueueOp::INPUT_RELEASE
                     )) {
                     return false;
@@ -601,6 +598,10 @@ public:
         uint64_t active_head_{0};
         uint64_t active_count_{0};
         uint64_t active_non_stop_count_{0};
+        uint64_t input_head_{0};
+        uint64_t input_tail_{0};
+        uint64_t input_payload_head_{0};
+        uint64_t input_payload_acquire_head_{0};
         uint64_t input_acquire_{0};
         bool stop_observed_{false};
         bool drained_{false};
@@ -611,10 +612,19 @@ public:
         explicit OutputQueue(L3L2QueueEndpoint *parent) :
             parent_(parent) {}
 
-        bool reserve(uint64_t nbytes, uint64_t timeout_ns, L3L2QueueOutputReservation *out) {
-            if (out == nullptr) {
-                return false;
-            }
+        bool initialize() {
+            output_head_ = 0;
+            output_tail_ = 0;
+            output_payload_head_ = 0;
+            output_payload_tail_ = 0;
+            reservation_active_ = false;
+            reservation_seq_ = 0;
+            reservation_offset_ = 0;
+            reservation_nbytes_ = 0;
+            return true;
+        }
+
+        bool reserve(uint64_t nbytes, uint64_t timeout_ns, L3L2QueueOutputReservation &out) {
             uint64_t start = device_time_now_ticks();
             uint64_t frequency_hz = device_time_frequency_hz();
             uint64_t spins = 0;
@@ -636,67 +646,65 @@ public:
             }
         }
 
-        bool try_reserve(uint64_t nbytes, L3L2QueueOutputReservation *out) {
-            if (out != nullptr) {
-                *out = L3L2QueueOutputReservation{0, 0, 0, L3L2OrchPayloadView{0, 0}, false};
-            }
-            if (!parent_->ensure_live(L3L2QueueOp::OUTPUT_TRY_RESERVE) || out == nullptr) {
+        bool try_reserve(uint64_t nbytes, L3L2QueueOutputReservation &out) {
+            out = L3L2QueueOutputReservation{0, 0, 0, L3L2OrchPayloadView{0, 0}, false};
+            if (!parent_->ensure_live()) {
                 return false;
             }
+            const L3L2QueueLayout &layout = parent_->layout_;
             if (reservation_active_) {
                 parent_->poison(
                     L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::OUTPUT_TRY_RESERVE, "output reservation already active"
                 );
                 return false;
             }
-            if (nbytes > parent_->layout_.output_arena_bytes) {
+            if (nbytes > layout.output_arena_bytes) {
                 return false;
             }
-            uint64_t old_head = parent_->output_head_;
+            uint64_t old_head = output_head_;
             if (!parent_->refresh_counter(
-                    parent_->layout_.output_desc_head_offset, parent_->output_head_, parent_->layout_.depth,
-                    L3L2QueueOp::OUTPUT_TRY_RESERVE
+                    layout.output_desc_head_offset, output_head_, layout.depth, L3L2QueueOp::OUTPUT_TRY_RESERVE
                 )) {
                 return false;
             }
-            if (parent_->output_head_ != old_head &&
-                !parent_->replay_output_releases(old_head, parent_->output_head_, L3L2QueueOp::OUTPUT_TRY_RESERVE)) {
+            if (output_head_ != old_head &&
+                !replay_output_releases(old_head, output_head_, L3L2QueueOp::OUTPUT_TRY_RESERVE)) {
                 return false;
             }
-            if (parent_->output_tail_ - parent_->output_head_ >= parent_->layout_.depth) {
+            if (output_tail_ - output_head_ >= layout.depth) {
                 return false;
             }
 
             uint64_t payload_offset = 0;
             L3L2OrchPayloadView view{0, 0};
             if (nbytes != 0) {
-                uint64_t arena_base = parent_->layout_.output_arena_offset;
-                uint64_t arena_bytes = parent_->layout_.output_arena_bytes;
-                uint64_t arena_pos = parent_->output_payload_tail_ % arena_bytes;
+                uint64_t arena_base = layout.output_arena_offset;
+                uint64_t arena_bytes = layout.output_arena_bytes;
+                uint64_t arena_pos = output_payload_tail_ % arena_bytes;
                 if (arena_pos + nbytes > arena_bytes) {
                     // Payloads are never split across arena wrap. The skipped tail bytes are retired in the
                     // monotonic virtual cursor even if this reservation later finds the arena full.
-                    parent_->output_payload_tail_ += arena_bytes - arena_pos;
+                    output_payload_tail_ += arena_bytes - arena_pos;
                     arena_pos = 0;
                 }
-                if (parent_->output_payload_tail_ + nbytes - parent_->output_payload_head_ > arena_bytes) {
+                if (output_payload_tail_ + nbytes - output_payload_head_ > arena_bytes) {
                     return false;
                 }
                 payload_offset = arena_base + arena_pos;
                 view = L3L2OrchPayloadView{parent_->endpoint_.descriptor().payload_base + payload_offset, nbytes};
-                parent_->output_payload_tail_ += nbytes;
+                output_payload_tail_ += nbytes;
             }
 
             reservation_active_ = true;
-            reservation_seq_ = parent_->output_tail_ + 1;
+            reservation_seq_ = output_tail_ + 1;
             reservation_offset_ = payload_offset;
             reservation_nbytes_ = nbytes;
-            *out = L3L2QueueOutputReservation{reservation_seq_, payload_offset, nbytes, view, true};
+            out = L3L2QueueOutputReservation{reservation_seq_, payload_offset, nbytes, view, true};
             return true;
         }
 
         bool publish(const L3L2QueueOutputReservation &reservation, L3L2QueueOpcode opcode) {
-            if (!parent_->ensure_live(L3L2QueueOp::OUTPUT_PUBLISH)) {
+            if (!parent_->ensure_live()) {
                 return false;
             }
             if (!reservation_active_ || !reservation.valid || reservation.seq != reservation_seq_ ||
@@ -715,24 +723,55 @@ public:
             }
             L3L2QueueDescSlot slot{};
             l3_l2_message_queue::encode_desc(&slot, 0, opcode, reservation.payload_offset, reservation.payload_nbytes);
-            uint64_t slot_index = parent_->output_tail_ & (parent_->layout_.depth - 1);
+            uint64_t slot_index = output_tail_ & (parent_->layout_.depth - 1);
             uint64_t slot_offset = parent_->layout_.output_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
             if (!parent_->write_desc_slot(slot_offset, slot, reservation.seq, L3L2QueueOp::OUTPUT_PUBLISH)) {
                 return false;
             }
-            parent_->output_tail_ += 1;
+            output_tail_ += 1;
             reservation_active_ = false;
             reservation_seq_ = 0;
             reservation_offset_ = 0;
             reservation_nbytes_ = 0;
             return parent_->notify_counter(
-                parent_->layout_.output_desc_tail_offset, static_cast<int32_t>(parent_->output_tail_),
+                parent_->layout_.output_desc_tail_offset, static_cast<int32_t>(output_tail_),
                 L3L2QueueOp::OUTPUT_PUBLISH
             );
         }
 
     private:
+        bool replay_output_releases(uint64_t old_head, uint64_t new_head, L3L2QueueOp op) {
+            uint64_t cursor = old_head;
+            while (cursor < new_head) {
+                L3L2QueueDescSlot slot{};
+                uint64_t slot_index = cursor & (parent_->layout_.depth - 1);
+                uint64_t slot_offset = parent_->layout_.output_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
+                if (!parent_->read_desc_slot(slot_offset, &slot, op)) {
+                    return false;
+                }
+                if (slot.seq != cursor + 1) {
+                    parent_->poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, op, "output release replay seq mismatch");
+                    return false;
+                }
+                if (slot.payload_nbytes != 0) {
+                    parent_->advance_payload_head(
+                        output_payload_head_, slot.payload_offset, slot.payload_nbytes,
+                        parent_->layout_.output_arena_offset, parent_->layout_.output_arena_bytes, op
+                    );
+                    if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
+                        return false;
+                    }
+                }
+                cursor += 1;
+            }
+            return true;
+        }
+
         L3L2QueueEndpoint *parent_;
+        uint64_t output_head_{0};
+        uint64_t output_tail_{0};
+        uint64_t output_payload_head_{0};
+        uint64_t output_payload_tail_{0};
         bool reservation_active_{false};
         uint64_t reservation_seq_{0};
         uint64_t reservation_offset_{0};
@@ -755,6 +794,7 @@ public:
             return;
         }
         input_queue_.initialize();
+        output_queue_.initialize();
     }
 
     L3L2QueueEndpoint(const L3L2QueueEndpoint &) = delete;
@@ -774,8 +814,8 @@ public:
         }
         L3L2OrchSignalTestResult result{};
         uint64_t addr = 0;
-        if (!endpoint_.counter_addr(layout_.l3_abort_flag_offset, &addr) ||
-            !endpoint_.signal_test(addr, 1, L3L2OrchWaitCmp::GE, &result)) {
+        if (!endpoint_.counter_addr(layout_.l3_abort_flag_offset, addr) ||
+            !endpoint_.signal_test(addr, 1, L3L2OrchWaitCmp::GE, result)) {
             poison(L3L2QueueErrorKind::ENDPOINT_ERROR, L3L2QueueOp::TIMEOUT, endpoint_.error().message);
             return L3L2QueueTimeoutStatus::ORDINARY_TIMEOUT;
         }
@@ -790,11 +830,10 @@ public:
     }
 
 private:
-    bool ensure_live(L3L2QueueOp op) {
+    bool ensure_live() {
         if (error_.kind == L3L2QueueErrorKind::NONE) {
             return true;
         }
-        (void)op;
         return false;
     }
 
@@ -810,7 +849,7 @@ private:
         set_error(kind, op, endpoint_.descriptor().region_id, message);
         if (kind != L3L2QueueErrorKind::REMOTE_ABORTED) {
             uint64_t addr = 0;
-            if (endpoint_.counter_addr(layout_.l2_abort_flag_offset, &addr)) {
+            if (endpoint_.counter_addr(layout_.l2_abort_flag_offset, addr)) {
                 endpoint_.signal_notify(addr, 1, L3L2OrchNotifyOp::Set);
             }
         }
@@ -818,7 +857,7 @@ private:
 
     bool notify_counter(uint64_t offset, int32_t value, L3L2QueueOp op) {
         uint64_t addr = 0;
-        if (!endpoint_.counter_addr(offset, &addr) || !endpoint_.signal_notify(addr, value, L3L2OrchNotifyOp::Set)) {
+        if (!endpoint_.counter_addr(offset, addr) || !endpoint_.signal_notify(addr, value, L3L2OrchNotifyOp::Set)) {
             poison(L3L2QueueErrorKind::ENDPOINT_ERROR, op, endpoint_.error().message);
             return false;
         }
@@ -828,15 +867,15 @@ private:
     bool refresh_counter(uint64_t offset, uint64_t &local, uint64_t depth, L3L2QueueOp op) {
         uint64_t addr = 0;
         L3L2OrchSignalTestResult result{};
-        if (!endpoint_.counter_addr(offset, &addr) ||
-            !endpoint_.signal_test(addr, static_cast<int32_t>(local), L3L2OrchWaitCmp::NE, &result)) {
+        if (!endpoint_.counter_addr(offset, addr) ||
+            !endpoint_.signal_test(addr, static_cast<int32_t>(local), L3L2OrchWaitCmp::NE, result)) {
             poison(L3L2QueueErrorKind::ENDPOINT_ERROR, op, endpoint_.error().message);
             return false;
         }
         if (!result.matched) {
             return true;
         }
-        if (!l3_l2_message_queue::reconstruct_counter(result.observed, depth, &local)) {
+        if (!l3_l2_message_queue::reconstruct_counter(result.observed, depth, local)) {
             poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, op, "counter reconstruction failed");
             return false;
         }
@@ -845,7 +884,7 @@ private:
 
     bool read_desc_slot(uint64_t slot_offset, L3L2QueueDescSlot *slot, L3L2QueueOp op) {
         L3L2OrchPayloadView view{};
-        if (!endpoint_.payload_read(slot_offset, sizeof(L3L2QueueDescSlot), &view)) {
+        if (!endpoint_.payload_read(slot_offset, sizeof(L3L2QueueDescSlot), view)) {
             poison(L3L2QueueErrorKind::ENDPOINT_ERROR, op, endpoint_.error().message);
             return false;
         }
@@ -911,44 +950,9 @@ private:
         cursor += nbytes;
     }
 
-    bool replay_output_releases(uint64_t old_head, uint64_t new_head, L3L2QueueOp op) {
-        uint64_t cursor = old_head;
-        while (cursor < new_head) {
-            L3L2QueueDescSlot slot{};
-            uint64_t slot_index = cursor & (layout_.depth - 1);
-            uint64_t slot_offset = layout_.output_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
-            if (!read_desc_slot(slot_offset, &slot, op)) {
-                return false;
-            }
-            if (slot.seq != cursor + 1) {
-                poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, op, "output release replay seq mismatch");
-                return false;
-            }
-            if (slot.payload_nbytes != 0) {
-                advance_payload_head(
-                    output_payload_head_, slot.payload_offset, slot.payload_nbytes, layout_.output_arena_offset,
-                    layout_.output_arena_bytes, op
-                );
-                if (error_.kind != L3L2QueueErrorKind::NONE) {
-                    return false;
-                }
-            }
-            cursor += 1;
-        }
-        return true;
-    }
-
     L3L2OrchEndpoint endpoint_;
     L3L2QueueLayout layout_{};
     L3L2QueueError error_{L3L2QueueErrorKind::NONE, L3L2QueueOp::INIT, 0, ""};
-    uint64_t input_head_{0};
-    uint64_t input_tail_{0};
-    uint64_t output_head_{0};
-    uint64_t output_tail_{0};
-    uint64_t input_payload_head_{0};
-    uint64_t input_payload_acquire_head_{0};
-    uint64_t output_payload_head_{0};
-    uint64_t output_payload_tail_{0};
     InputQueue input_queue_;
     OutputQueue output_queue_;
 };

--- a/src/common/platform/include/aicpu/l3_l2_message_queue.h
+++ b/src/common/platform/include/aicpu/l3_l2_message_queue.h
@@ -14,6 +14,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <new>
 #include <string.h>
 
 #include "aicpu/l3_l2_orch_endpoint.h"
@@ -102,6 +103,10 @@ struct L3L2QueueArgs {
     uint64_t output_arena_bytes;
     uint64_t payload_bytes;
     uint64_t counter_bytes;
+};
+
+struct L3L2QueueEndpointConfig {
+    uint64_t max_l2_input_inflight;
 };
 
 struct L3L2QueueInputHandle {
@@ -255,10 +260,53 @@ static inline bool l3_l2_queue_reconstruct_counter(int32_t observed_low32, uint6
 class L3L2QueueEndpoint {
 public:
     class InputQueue {
+        struct ActiveInputEntry {
+            uint64_t seq;
+            L3L2QueueOpcode opcode;
+            uint64_t payload_offset;
+            uint64_t payload_nbytes;
+            L3L2OrchPayloadView payload;
+            bool completed;
+        };
+
     public:
         explicit InputQueue(L3L2QueueEndpoint *parent) :
             parent_(parent) {}
 
+        InputQueue(const InputQueue &) = delete;
+        InputQueue &operator=(const InputQueue &) = delete;
+        InputQueue(InputQueue &&) = delete;
+        InputQueue &operator=(InputQueue &&) = delete;
+
+        ~InputQueue() { delete[] active_entries_; }
+
+        friend class L3L2QueueEndpoint;
+
+    private:
+        bool initialize(uint64_t max_l2_input_inflight) {
+            delete[] active_entries_;
+            active_entries_ = nullptr;
+            entry_capacity_ = 0;
+            active_count_ = 0;
+            active_non_stop_count_ = 0;
+            input_acquire_ = parent_->input_head_;
+            stop_observed_ = false;
+            drained_ = false;
+
+            ActiveInputEntry *entries = new (std::nothrow) ActiveInputEntry[max_l2_input_inflight + 1];
+            if (entries == nullptr) {
+                parent_->set_error(
+                    L3L2QueueErrorKind::ENDPOINT_ERROR, "init", parent_->endpoint_.descriptor().region_id,
+                    "input window allocation failed"
+                );
+                return false;
+            }
+            active_entries_ = entries;
+            entry_capacity_ = max_l2_input_inflight + 1;
+            return true;
+        }
+
+    public:
         bool peek(uint64_t timeout_ns, L3L2QueueInputHandle *out) {
             if (out == nullptr) {
                 return false;
@@ -291,7 +339,7 @@ public:
             if (!parent_->ensure_live("input.try_peek") || out == nullptr) {
                 return false;
             }
-            if (active_) {
+            if (parent_->config_.max_l2_input_inflight == 1 && active_count_ != 0) {
                 parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.try_peek", "input handle already active");
                 return false;
             }
@@ -301,8 +349,8 @@ public:
                 )) {
                 return false;
             }
-            if (stopped_) {
-                if (parent_->input_tail_ != parent_->input_head_) {
+            if (stop_observed_) {
+                if (parent_->input_tail_ != input_acquire_) {
                     parent_->poison(
                         L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek",
                         "input descriptor published after STOP"
@@ -310,10 +358,11 @@ public:
                 }
                 return false;
             }
-            if (parent_->input_tail_ == parent_->input_head_) {
+            if (parent_->input_tail_ == input_acquire_) {
                 return false;
             }
-            if (parent_->input_tail_ - parent_->input_head_ > parent_->layout_.depth) {
+            if (parent_->input_tail_ - parent_->input_head_ > parent_->layout_.depth ||
+                input_acquire_ < parent_->input_head_ || input_acquire_ > parent_->input_tail_) {
                 parent_->poison(
                     L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "input descriptor state invalid"
                 );
@@ -321,12 +370,12 @@ public:
             }
 
             L3L2QueueDescSlot slot{};
-            uint64_t slot_index = parent_->input_head_ & (parent_->layout_.depth - 1);
+            uint64_t slot_index = input_acquire_ & (parent_->layout_.depth - 1);
             uint64_t slot_offset = parent_->layout_.input_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
             if (!parent_->read_desc_slot(slot_offset, &slot, "input.try_peek")) {
                 return false;
             }
-            uint64_t expected_seq = parent_->input_head_ + 1;
+            uint64_t expected_seq = input_acquire_ + 1;
             if (slot.seq != expected_seq) {
                 parent_->poison(
                     L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "input descriptor seq mismatch"
@@ -342,6 +391,14 @@ public:
                 parent_->poison(
                     L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "STOP descriptor must be zero-byte"
                 );
+                return false;
+            }
+            bool counts_against_window = opcode == L3L2QueueOpcode::DATA || opcode == L3L2QueueOpcode::ERROR;
+            if (counts_against_window && active_non_stop_count_ >= parent_->config_.max_l2_input_inflight) {
+                return false;
+            }
+            if (active_count_ >= entry_capacity_) {
+                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.try_peek", "input window state full");
                 return false;
             }
 
@@ -361,7 +418,7 @@ public:
                 parent_->poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "input payload out of arena");
                 return false;
             } else if (!parent_->payload_matches_head(
-                           parent_->input_payload_head_, slot.payload_offset, slot.payload_nbytes,
+                           parent_->input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
                            parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.try_peek"
                        )) {
                 return false;
@@ -370,14 +427,34 @@ public:
                     L3L2QueueErrorKind::ENDPOINT_ERROR, "input.try_peek", parent_->endpoint_.error().message
                 );
                 return false;
+            } else {
+                parent_->advance_payload_head(
+                    parent_->input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
+                    parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.try_peek"
+                );
+                if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
+                    return false;
+                }
             }
 
             *out = L3L2QueueInputHandle{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view};
-            active_ = true;
-            active_seq_ = slot.seq;
-            active_opcode_ = opcode;
-            active_payload_offset_ = slot.payload_offset;
-            active_payload_nbytes_ = slot.payload_nbytes;
+            active_entries_[active_count_] =
+                ActiveInputEntry{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view, false};
+            active_count_ += 1;
+            if (counts_against_window) {
+                active_non_stop_count_ += 1;
+            }
+            input_acquire_ += 1;
+            if (opcode == L3L2QueueOpcode::STOP) {
+                stop_observed_ = true;
+                if (parent_->input_tail_ != input_acquire_) {
+                    parent_->poison(
+                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek",
+                        "input descriptor published after STOP"
+                    );
+                    return false;
+                }
+            }
             return true;
         }
 
@@ -385,43 +462,83 @@ public:
             if (!parent_->ensure_live("input.release")) {
                 return false;
             }
-            if (!active_ || handle.seq != active_seq_ || handle.seq != parent_->input_head_ + 1 ||
-                handle.opcode != active_opcode_ || handle.payload_offset != active_payload_offset_ ||
-                handle.payload_nbytes != active_payload_nbytes_) {
+            uint64_t entry_index = 0;
+            ActiveInputEntry *entry = find_active_entry(handle.seq, &entry_index);
+            if (entry == nullptr || handle.opcode != entry->opcode || handle.payload_offset != entry->payload_offset ||
+                handle.payload_nbytes != entry->payload_nbytes || handle.payload.gm_addr != entry->payload.gm_addr ||
+                handle.payload.nbytes != entry->payload.nbytes) {
                 parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.release", "input handle is not active");
                 return false;
             }
-            if (active_payload_nbytes_ != 0) {
-                parent_->advance_payload_head(
-                    parent_->input_payload_head_, active_payload_offset_, active_payload_nbytes_,
-                    parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.release"
-                );
-                if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
+            if (entry->completed) {
+                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.release", "input handle already released");
+                return false;
+            }
+            (void)entry_index;
+            entry->completed = true;
+            return release_completed_prefix();
+        }
+
+        bool drained() const { return drained_; }
+
+    private:
+        ActiveInputEntry *find_active_entry(uint64_t seq, uint64_t *entry_index) {
+            for (uint64_t i = 0; i < active_count_; ++i) {
+                if (active_entries_[i].seq == seq) {
+                    if (entry_index != nullptr) {
+                        *entry_index = i;
+                    }
+                    return &active_entries_[i];
+                }
+            }
+            return nullptr;
+        }
+
+        void remove_first_entry() {
+            for (uint64_t i = 1; i < active_count_; ++i) {
+                active_entries_[i - 1] = active_entries_[i];
+            }
+            active_count_ -= 1;
+        }
+
+        bool release_completed_prefix() {
+            while (active_count_ != 0 && active_entries_[0].completed) {
+                ActiveInputEntry entry = active_entries_[0];
+                if (entry.payload_nbytes != 0) {
+                    parent_->advance_payload_head(
+                        parent_->input_payload_head_, entry.payload_offset, entry.payload_nbytes,
+                        parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.release"
+                    );
+                    if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
+                        return false;
+                    }
+                }
+                parent_->input_head_ += 1;
+                if (entry.opcode == L3L2QueueOpcode::DATA || entry.opcode == L3L2QueueOpcode::ERROR) {
+                    active_non_stop_count_ -= 1;
+                }
+                if (entry.opcode == L3L2QueueOpcode::STOP) {
+                    drained_ = true;
+                }
+                remove_first_entry();
+                if (!parent_->notify_counter(
+                        parent_->layout_.input_desc_head_offset, static_cast<int32_t>(parent_->input_head_),
+                        "input.release"
+                    )) {
                     return false;
                 }
             }
-            parent_->input_head_ += 1;
-            if (active_opcode_ == L3L2QueueOpcode::STOP) {
-                stopped_ = true;
-            }
-            active_ = false;
-            active_seq_ = 0;
-            active_opcode_ = L3L2QueueOpcode::INVALID;
-            active_payload_offset_ = 0;
-            active_payload_nbytes_ = 0;
-            return parent_->notify_counter(
-                parent_->layout_.input_desc_head_offset, static_cast<int32_t>(parent_->input_head_), "input.release"
-            );
+            return true;
         }
 
-    private:
         L3L2QueueEndpoint *parent_;
-        bool active_{false};
-        uint64_t active_seq_{0};
-        L3L2QueueOpcode active_opcode_{L3L2QueueOpcode::INVALID};
-        uint64_t active_payload_offset_{0};
-        uint64_t active_payload_nbytes_{0};
-        bool stopped_{false};
+        ActiveInputEntry *active_entries_{nullptr};
+        uint64_t entry_capacity_{0};
+        uint64_t active_count_{0};
+        uint64_t active_non_stop_count_{0};
+        uint64_t input_acquire_{0};
+        bool stop_observed_{false};
+        bool drained_{false};
     };
 
     class OutputQueue {
@@ -553,14 +670,31 @@ public:
     };
 
     L3L2QueueEndpoint(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args) :
+        L3L2QueueEndpoint(desc, args, L3L2QueueEndpointConfig{1}) {}
+
+    L3L2QueueEndpoint(
+        const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args, const L3L2QueueEndpointConfig &config
+    ) :
         endpoint_(desc),
+        config_(config),
         input_queue_(this),
         output_queue_(this) {
         if (endpoint_.error().kind != L3L2EndpointErrorKind::NONE ||
             !l3_l2_queue_validate_region(desc, args, &layout_)) {
             set_error(L3L2QueueErrorKind::BAD_DESCRIPTOR, "init", desc.region_id, "invalid queue descriptor");
+            return;
         }
+        if (config_.max_l2_input_inflight == 0 || config_.max_l2_input_inflight > layout_.depth) {
+            set_error(L3L2QueueErrorKind::BAD_ARGUMENT, "init", desc.region_id, "invalid endpoint config");
+            return;
+        }
+        input_queue_.initialize(config_.max_l2_input_inflight);
     }
+
+    L3L2QueueEndpoint(const L3L2QueueEndpoint &) = delete;
+    L3L2QueueEndpoint &operator=(const L3L2QueueEndpoint &) = delete;
+    L3L2QueueEndpoint(L3L2QueueEndpoint &&) = delete;
+    L3L2QueueEndpoint &operator=(L3L2QueueEndpoint &&) = delete;
 
     const L3L2QueueError &error() const { return error_; }
     const L3L2QueueLayout &layout() const { return layout_; }
@@ -730,6 +864,7 @@ private:
     }
 
     L3L2OrchEndpoint endpoint_;
+    L3L2QueueEndpointConfig config_{1};
     L3L2QueueLayout layout_{};
     L3L2QueueError error_{L3L2QueueErrorKind::NONE, "", 0, ""};
     uint64_t input_head_{0};
@@ -737,6 +872,7 @@ private:
     uint64_t output_head_{0};
     uint64_t output_tail_{0};
     uint64_t input_payload_head_{0};
+    uint64_t input_payload_acquire_head_{0};
     uint64_t output_payload_head_{0};
     uint64_t output_payload_tail_{0};
     InputQueue input_queue_;

--- a/src/common/platform/include/aicpu/l3_l2_message_queue.h
+++ b/src/common/platform/include/aicpu/l3_l2_message_queue.h
@@ -71,11 +71,39 @@ enum class L3L2QueueTimeoutStatus : uint32_t {
     REMOTE_ABORTED = 1,
 };
 
+enum class L3L2QueueOp : uint32_t {
+    INIT = 1,
+    TIMEOUT = 2,
+    INPUT_TRY_PEEK = 3,
+    INPUT_RELEASE = 4,
+    OUTPUT_TRY_RESERVE = 5,
+    OUTPUT_PUBLISH = 6,
+};
+
+inline const char *l3_l2_queue_op_to_string(L3L2QueueOp op) {
+    switch (op) {
+    case L3L2QueueOp::INIT:
+        return "init";
+    case L3L2QueueOp::TIMEOUT:
+        return "timeout";
+    case L3L2QueueOp::INPUT_TRY_PEEK:
+        return "input.try_peek";
+    case L3L2QueueOp::INPUT_RELEASE:
+        return "input.release";
+    case L3L2QueueOp::OUTPUT_TRY_RESERVE:
+        return "output.try_reserve";
+    case L3L2QueueOp::OUTPUT_PUBLISH:
+        return "output.publish";
+    default:
+        return "unknown";
+    }
+}
+
 struct L3L2QueueError {
     L3L2QueueErrorKind kind;
-    const char *op;
+    L3L2QueueOp op;
     uint64_t region_id;
-    const char *message;
+    char message[256];
 };
 
 struct L3L2QueueLayout {
@@ -103,10 +131,6 @@ struct L3L2QueueArgs {
     uint64_t output_arena_bytes;
     uint64_t payload_bytes;
     uint64_t counter_bytes;
-};
-
-struct L3L2QueueEndpointConfig {
-    uint64_t max_l2_input_inflight;
 };
 
 struct L3L2QueueInputHandle {
@@ -257,8 +281,50 @@ static inline bool l3_l2_queue_reconstruct_counter(int32_t observed_low32, uint6
     return true;
 }
 
+namespace l3_l2_message_queue {
+
+static inline uint64_t magic_version() { return ::l3_l2_queue_magic_version(); }
+
+static inline bool is_power_of_two(uint64_t value) { return ::l3_l2_queue_is_power_of_two(value); }
+
+static inline uint64_t align_up(uint64_t value, uint64_t align) { return ::l3_l2_queue_align_up(value, align); }
+
+static inline bool align_up_checked(uint64_t value, uint64_t align, uint64_t *out) {
+    return ::l3_l2_queue_align_up_checked(value, align, out);
+}
+
+static inline bool valid_opcode(L3L2QueueOpcode opcode) { return ::l3_l2_queue_valid_opcode(opcode); }
+
+static inline bool
+make_layout(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes, L3L2QueueLayout *out) {
+    return ::l3_l2_queue_make_layout(depth, input_arena_bytes, output_arena_bytes, out);
+}
+
+static inline bool
+validate_region(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args, L3L2QueueLayout *out_layout) {
+    return ::l3_l2_queue_validate_region(desc, args, out_layout);
+}
+
+static inline void encode_desc(
+    L3L2QueueDescSlot *slot, uint64_t seq, L3L2QueueOpcode opcode, uint64_t payload_offset, uint64_t payload_nbytes
+) {
+    ::l3_l2_queue_encode_desc(slot, seq, opcode, payload_offset, payload_nbytes);
+}
+
+static inline bool reconstruct_counter(int32_t observed_low32, uint64_t depth, uint64_t *local_value) {
+    return ::l3_l2_queue_reconstruct_counter(observed_low32, depth, local_value);
+}
+
+}  // namespace l3_l2_message_queue
+
+template <uint64_t MaxInflight = 1>
 class L3L2QueueEndpoint {
+    static_assert(MaxInflight > 0, "MaxInflight must be positive");
+
 public:
+    static constexpr uint64_t kStopEntrySlots = 1;
+    static constexpr uint64_t kEntryCapacity = MaxInflight + kStopEntrySlots;
+
     class InputQueue {
         struct ActiveInputEntry {
             uint64_t seq;
@@ -278,31 +344,19 @@ public:
         InputQueue(InputQueue &&) = delete;
         InputQueue &operator=(InputQueue &&) = delete;
 
-        ~InputQueue() { delete[] active_entries_; }
-
-        friend class L3L2QueueEndpoint;
+        friend class L3L2QueueEndpoint<MaxInflight>;
 
     private:
-        bool initialize(uint64_t max_l2_input_inflight) {
-            delete[] active_entries_;
-            active_entries_ = nullptr;
-            entry_capacity_ = 0;
+        bool initialize() {
+            for (uint64_t i = 0; i < kEntryCapacity; ++i) {
+                active_entries_[i] = ActiveInputEntry{};
+            }
+            active_head_ = 0;
             active_count_ = 0;
             active_non_stop_count_ = 0;
             input_acquire_ = parent_->input_head_;
             stop_observed_ = false;
             drained_ = false;
-
-            ActiveInputEntry *entries = new (std::nothrow) ActiveInputEntry[max_l2_input_inflight + 1];
-            if (entries == nullptr) {
-                parent_->set_error(
-                    L3L2QueueErrorKind::ENDPOINT_ERROR, "init", parent_->endpoint_.descriptor().region_id,
-                    "input window allocation failed"
-                );
-                return false;
-            }
-            active_entries_ = entries;
-            entry_capacity_ = max_l2_input_inflight + 1;
             return true;
         }
 
@@ -311,8 +365,8 @@ public:
             if (out == nullptr) {
                 return false;
             }
-            uint64_t start = l3_l2_orch_endpoint_now();
-            uint64_t frequency_hz = l3_l2_orch_endpoint_timer_frequency_hz();
+            uint64_t start = device_time_now_ticks();
+            uint64_t frequency_hz = device_time_frequency_hz();
             uint64_t spins = 0;
             while (true) {
                 if (try_peek(out)) {
@@ -323,8 +377,8 @@ public:
                 }
                 spins += 1;
                 if (timeout_ns == 0 || (spins & 1023ull) == 0) {
-                    uint64_t now = l3_l2_orch_endpoint_now();
-                    if (timeout_ns == 0 || l3_l2_orch_endpoint_elapsed_ns(start, now, frequency_hz) >= timeout_ns) {
+                    uint64_t now = device_time_now_ticks();
+                    if (timeout_ns == 0 || sys_cnt_elapsed_ns(start, now, frequency_hz) >= timeout_ns) {
                         parent_->disambiguate_timeout();
                         return false;
                     }
@@ -336,23 +390,25 @@ public:
             if (out != nullptr) {
                 *out = L3L2QueueInputHandle{0, L3L2QueueOpcode::INVALID, 0, 0, L3L2OrchPayloadView{0, 0}};
             }
-            if (!parent_->ensure_live("input.try_peek") || out == nullptr) {
+            if (!parent_->ensure_live(L3L2QueueOp::INPUT_TRY_PEEK) || out == nullptr) {
                 return false;
             }
-            if (parent_->config_.max_l2_input_inflight == 1 && active_count_ != 0) {
-                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.try_peek", "input handle already active");
+            if (MaxInflight == 1 && active_count_ != 0) {
+                parent_->poison(
+                    L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::INPUT_TRY_PEEK, "input handle already active"
+                );
                 return false;
             }
             if (!parent_->refresh_counter(
                     parent_->layout_.input_desc_tail_offset, parent_->input_tail_, parent_->layout_.depth,
-                    "input.try_peek"
+                    L3L2QueueOp::INPUT_TRY_PEEK
                 )) {
                 return false;
             }
             if (stop_observed_) {
                 if (parent_->input_tail_ != input_acquire_) {
                     parent_->poison(
-                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek",
+                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
                         "input descriptor published after STOP"
                     );
                 }
@@ -364,7 +420,8 @@ public:
             if (parent_->input_tail_ - parent_->input_head_ > parent_->layout_.depth ||
                 input_acquire_ < parent_->input_head_ || input_acquire_ > parent_->input_tail_) {
                 parent_->poison(
-                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "input descriptor state invalid"
+                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
+                    "input descriptor state invalid"
                 );
                 return false;
             }
@@ -372,33 +429,36 @@ public:
             L3L2QueueDescSlot slot{};
             uint64_t slot_index = input_acquire_ & (parent_->layout_.depth - 1);
             uint64_t slot_offset = parent_->layout_.input_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
-            if (!parent_->read_desc_slot(slot_offset, &slot, "input.try_peek")) {
+            if (!parent_->read_desc_slot(slot_offset, &slot, L3L2QueueOp::INPUT_TRY_PEEK)) {
                 return false;
             }
             uint64_t expected_seq = input_acquire_ + 1;
             if (slot.seq != expected_seq) {
                 parent_->poison(
-                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "input descriptor seq mismatch"
+                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK, "input descriptor seq mismatch"
                 );
                 return false;
             }
             L3L2QueueOpcode opcode = static_cast<L3L2QueueOpcode>(slot.opcode);
-            if (!l3_l2_queue_valid_opcode(opcode)) {
-                parent_->poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "invalid input opcode");
+            if (!l3_l2_message_queue::valid_opcode(opcode)) {
+                parent_->poison(
+                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK, "invalid input opcode"
+                );
                 return false;
             }
             if (opcode == L3L2QueueOpcode::STOP && (slot.payload_offset != 0 || slot.payload_nbytes != 0)) {
                 parent_->poison(
-                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "STOP descriptor must be zero-byte"
+                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
+                    "STOP descriptor must be zero-byte"
                 );
                 return false;
             }
             bool counts_against_window = opcode == L3L2QueueOpcode::DATA || opcode == L3L2QueueOpcode::ERROR;
-            if (counts_against_window && active_non_stop_count_ >= parent_->config_.max_l2_input_inflight) {
+            if (counts_against_window && active_non_stop_count_ >= MaxInflight) {
                 return false;
             }
-            if (active_count_ >= entry_capacity_) {
-                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.try_peek", "input window state full");
+            if (active_count_ >= kEntryCapacity) {
+                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::INPUT_TRY_PEEK, "input window state full");
                 return false;
             }
 
@@ -406,7 +466,7 @@ public:
             if (slot.payload_nbytes == 0) {
                 if (slot.payload_offset != 0) {
                     parent_->poison(
-                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek",
+                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
                         "zero-byte descriptor uses nonzero payload offset"
                     );
                     return false;
@@ -415,22 +475,25 @@ public:
                            slot.payload_offset, slot.payload_nbytes, parent_->layout_.input_arena_offset,
                            parent_->layout_.input_arena_bytes
                        )) {
-                parent_->poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek", "input payload out of arena");
+                parent_->poison(
+                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK, "input payload out of arena"
+                );
                 return false;
             } else if (!parent_->payload_matches_head(
                            parent_->input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
-                           parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.try_peek"
+                           parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes,
+                           L3L2QueueOp::INPUT_TRY_PEEK
                        )) {
                 return false;
             } else if (!parent_->endpoint_.payload_read(slot.payload_offset, slot.payload_nbytes, &view)) {
                 parent_->poison(
-                    L3L2QueueErrorKind::ENDPOINT_ERROR, "input.try_peek", parent_->endpoint_.error().message
+                    L3L2QueueErrorKind::ENDPOINT_ERROR, L3L2QueueOp::INPUT_TRY_PEEK, parent_->endpoint_.error().message
                 );
                 return false;
             } else {
                 parent_->advance_payload_head(
                     parent_->input_payload_acquire_head_, slot.payload_offset, slot.payload_nbytes,
-                    parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.try_peek"
+                    parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, L3L2QueueOp::INPUT_TRY_PEEK
                 );
                 if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
                     return false;
@@ -438,7 +501,8 @@ public:
             }
 
             *out = L3L2QueueInputHandle{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view};
-            active_entries_[active_count_] =
+            uint64_t insert_index = (active_head_ + active_count_) % kEntryCapacity;
+            active_entries_[insert_index] =
                 ActiveInputEntry{slot.seq, opcode, slot.payload_offset, slot.payload_nbytes, view, false};
             active_count_ += 1;
             if (counts_against_window) {
@@ -449,7 +513,7 @@ public:
                 stop_observed_ = true;
                 if (parent_->input_tail_ != input_acquire_) {
                     parent_->poison(
-                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, "input.try_peek",
+                        L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::INPUT_TRY_PEEK,
                         "input descriptor published after STOP"
                     );
                     return false;
@@ -459,7 +523,7 @@ public:
         }
 
         bool release(const L3L2QueueInputHandle &handle) {
-            if (!parent_->ensure_live("input.release")) {
+            if (!parent_->ensure_live(L3L2QueueOp::INPUT_RELEASE)) {
                 return false;
             }
             uint64_t entry_index = 0;
@@ -467,11 +531,15 @@ public:
             if (entry == nullptr || handle.opcode != entry->opcode || handle.payload_offset != entry->payload_offset ||
                 handle.payload_nbytes != entry->payload_nbytes || handle.payload.gm_addr != entry->payload.gm_addr ||
                 handle.payload.nbytes != entry->payload.nbytes) {
-                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.release", "input handle is not active");
+                parent_->poison(
+                    L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::INPUT_RELEASE, "input handle is not active"
+                );
                 return false;
             }
             if (entry->completed) {
-                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "input.release", "input handle already released");
+                parent_->poison(
+                    L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::INPUT_RELEASE, "input handle already released"
+                );
                 return false;
             }
             (void)entry_index;
@@ -484,30 +552,25 @@ public:
     private:
         ActiveInputEntry *find_active_entry(uint64_t seq, uint64_t *entry_index) {
             for (uint64_t i = 0; i < active_count_; ++i) {
-                if (active_entries_[i].seq == seq) {
+                uint64_t index = (active_head_ + i) % kEntryCapacity;
+                if (active_entries_[index].seq == seq) {
                     if (entry_index != nullptr) {
-                        *entry_index = i;
+                        *entry_index = index;
                     }
-                    return &active_entries_[i];
+                    return &active_entries_[index];
                 }
             }
             return nullptr;
         }
 
-        void remove_first_entry() {
-            for (uint64_t i = 1; i < active_count_; ++i) {
-                active_entries_[i - 1] = active_entries_[i];
-            }
-            active_count_ -= 1;
-        }
-
         bool release_completed_prefix() {
-            while (active_count_ != 0 && active_entries_[0].completed) {
-                ActiveInputEntry entry = active_entries_[0];
+            while (active_count_ != 0 && active_entries_[active_head_].completed) {
+                ActiveInputEntry entry = active_entries_[active_head_];
                 if (entry.payload_nbytes != 0) {
                     parent_->advance_payload_head(
                         parent_->input_payload_head_, entry.payload_offset, entry.payload_nbytes,
-                        parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes, "input.release"
+                        parent_->layout_.input_arena_offset, parent_->layout_.input_arena_bytes,
+                        L3L2QueueOp::INPUT_RELEASE
                     );
                     if (parent_->error_.kind != L3L2QueueErrorKind::NONE) {
                         return false;
@@ -520,10 +583,12 @@ public:
                 if (entry.opcode == L3L2QueueOpcode::STOP) {
                     drained_ = true;
                 }
-                remove_first_entry();
+                active_entries_[active_head_] = ActiveInputEntry{};
+                active_head_ = (active_head_ + 1) % kEntryCapacity;
+                active_count_ -= 1;
                 if (!parent_->notify_counter(
                         parent_->layout_.input_desc_head_offset, static_cast<int32_t>(parent_->input_head_),
-                        "input.release"
+                        L3L2QueueOp::INPUT_RELEASE
                     )) {
                     return false;
                 }
@@ -532,8 +597,8 @@ public:
         }
 
         L3L2QueueEndpoint *parent_;
-        ActiveInputEntry *active_entries_{nullptr};
-        uint64_t entry_capacity_{0};
+        ActiveInputEntry active_entries_[kEntryCapacity]{};
+        uint64_t active_head_{0};
         uint64_t active_count_{0};
         uint64_t active_non_stop_count_{0};
         uint64_t input_acquire_{0};
@@ -550,8 +615,8 @@ public:
             if (out == nullptr) {
                 return false;
             }
-            uint64_t start = l3_l2_orch_endpoint_now();
-            uint64_t frequency_hz = l3_l2_orch_endpoint_timer_frequency_hz();
+            uint64_t start = device_time_now_ticks();
+            uint64_t frequency_hz = device_time_frequency_hz();
             uint64_t spins = 0;
             while (true) {
                 if (try_reserve(nbytes, out)) {
@@ -562,8 +627,8 @@ public:
                 }
                 spins += 1;
                 if (timeout_ns == 0 || (spins & 1023ull) == 0) {
-                    uint64_t now = l3_l2_orch_endpoint_now();
-                    if (timeout_ns == 0 || l3_l2_orch_endpoint_elapsed_ns(start, now, frequency_hz) >= timeout_ns) {
+                    uint64_t now = device_time_now_ticks();
+                    if (timeout_ns == 0 || sys_cnt_elapsed_ns(start, now, frequency_hz) >= timeout_ns) {
                         parent_->disambiguate_timeout();
                         return false;
                     }
@@ -575,12 +640,12 @@ public:
             if (out != nullptr) {
                 *out = L3L2QueueOutputReservation{0, 0, 0, L3L2OrchPayloadView{0, 0}, false};
             }
-            if (!parent_->ensure_live("output.try_reserve") || out == nullptr) {
+            if (!parent_->ensure_live(L3L2QueueOp::OUTPUT_TRY_RESERVE) || out == nullptr) {
                 return false;
             }
             if (reservation_active_) {
                 parent_->poison(
-                    L3L2QueueErrorKind::OWNERSHIP, "output.try_reserve", "output reservation already active"
+                    L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::OUTPUT_TRY_RESERVE, "output reservation already active"
                 );
                 return false;
             }
@@ -590,12 +655,12 @@ public:
             uint64_t old_head = parent_->output_head_;
             if (!parent_->refresh_counter(
                     parent_->layout_.output_desc_head_offset, parent_->output_head_, parent_->layout_.depth,
-                    "output.try_reserve"
+                    L3L2QueueOp::OUTPUT_TRY_RESERVE
                 )) {
                 return false;
             }
             if (parent_->output_head_ != old_head &&
-                !parent_->replay_output_releases(old_head, parent_->output_head_, "output.try_reserve")) {
+                !parent_->replay_output_releases(old_head, parent_->output_head_, L3L2QueueOp::OUTPUT_TRY_RESERVE)) {
                 return false;
             }
             if (parent_->output_tail_ - parent_->output_head_ >= parent_->layout_.depth) {
@@ -631,24 +696,28 @@ public:
         }
 
         bool publish(const L3L2QueueOutputReservation &reservation, L3L2QueueOpcode opcode) {
-            if (!parent_->ensure_live("output.publish")) {
+            if (!parent_->ensure_live(L3L2QueueOp::OUTPUT_PUBLISH)) {
                 return false;
             }
             if (!reservation_active_ || !reservation.valid || reservation.seq != reservation_seq_ ||
                 reservation.payload_offset != reservation_offset_ ||
                 reservation.payload_nbytes != reservation_nbytes_) {
-                parent_->poison(L3L2QueueErrorKind::OWNERSHIP, "output.publish", "unknown output reservation");
+                parent_->poison(
+                    L3L2QueueErrorKind::OWNERSHIP, L3L2QueueOp::OUTPUT_PUBLISH, "unknown output reservation"
+                );
                 return false;
             }
-            if (opcode == L3L2QueueOpcode::STOP || !l3_l2_queue_valid_opcode(opcode)) {
-                parent_->poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, "output.publish", "invalid output opcode");
+            if (opcode == L3L2QueueOpcode::STOP || !l3_l2_message_queue::valid_opcode(opcode)) {
+                parent_->poison(
+                    L3L2QueueErrorKind::INVALID_DESCRIPTOR, L3L2QueueOp::OUTPUT_PUBLISH, "invalid output opcode"
+                );
                 return false;
             }
             L3L2QueueDescSlot slot{};
-            l3_l2_queue_encode_desc(&slot, 0, opcode, reservation.payload_offset, reservation.payload_nbytes);
+            l3_l2_message_queue::encode_desc(&slot, 0, opcode, reservation.payload_offset, reservation.payload_nbytes);
             uint64_t slot_index = parent_->output_tail_ & (parent_->layout_.depth - 1);
             uint64_t slot_offset = parent_->layout_.output_desc_offset + slot_index * sizeof(L3L2QueueDescSlot);
-            if (!parent_->write_desc_slot(slot_offset, slot, reservation.seq, "output.publish")) {
+            if (!parent_->write_desc_slot(slot_offset, slot, reservation.seq, L3L2QueueOp::OUTPUT_PUBLISH)) {
                 return false;
             }
             parent_->output_tail_ += 1;
@@ -657,7 +726,8 @@ public:
             reservation_offset_ = 0;
             reservation_nbytes_ = 0;
             return parent_->notify_counter(
-                parent_->layout_.output_desc_tail_offset, static_cast<int32_t>(parent_->output_tail_), "output.publish"
+                parent_->layout_.output_desc_tail_offset, static_cast<int32_t>(parent_->output_tail_),
+                L3L2QueueOp::OUTPUT_PUBLISH
             );
         }
 
@@ -670,25 +740,21 @@ public:
     };
 
     L3L2QueueEndpoint(const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args) :
-        L3L2QueueEndpoint(desc, args, L3L2QueueEndpointConfig{1}) {}
-
-    L3L2QueueEndpoint(
-        const L3L2OrchRegionDesc &desc, const L3L2QueueArgs &args, const L3L2QueueEndpointConfig &config
-    ) :
         endpoint_(desc),
-        config_(config),
         input_queue_(this),
         output_queue_(this) {
         if (endpoint_.error().kind != L3L2EndpointErrorKind::NONE ||
-            !l3_l2_queue_validate_region(desc, args, &layout_)) {
-            set_error(L3L2QueueErrorKind::BAD_DESCRIPTOR, "init", desc.region_id, "invalid queue descriptor");
+            !l3_l2_message_queue::validate_region(desc, args, &layout_)) {
+            set_error(
+                L3L2QueueErrorKind::BAD_DESCRIPTOR, L3L2QueueOp::INIT, desc.region_id, "invalid queue descriptor"
+            );
             return;
         }
-        if (config_.max_l2_input_inflight == 0 || config_.max_l2_input_inflight > layout_.depth) {
-            set_error(L3L2QueueErrorKind::BAD_ARGUMENT, "init", desc.region_id, "invalid endpoint config");
+        if (MaxInflight > layout_.depth) {
+            set_error(L3L2QueueErrorKind::BAD_ARGUMENT, L3L2QueueOp::INIT, desc.region_id, "invalid input window");
             return;
         }
-        input_queue_.initialize(config_.max_l2_input_inflight);
+        input_queue_.initialize();
     }
 
     L3L2QueueEndpoint(const L3L2QueueEndpoint &) = delete;
@@ -710,18 +776,21 @@ public:
         uint64_t addr = 0;
         if (!endpoint_.counter_addr(layout_.l3_abort_flag_offset, &addr) ||
             !endpoint_.signal_test(addr, 1, L3L2OrchWaitCmp::GE, &result)) {
-            poison(L3L2QueueErrorKind::ENDPOINT_ERROR, "timeout", endpoint_.error().message);
+            poison(L3L2QueueErrorKind::ENDPOINT_ERROR, L3L2QueueOp::TIMEOUT, endpoint_.error().message);
             return L3L2QueueTimeoutStatus::ORDINARY_TIMEOUT;
         }
         if (result.matched) {
-            set_error(L3L2QueueErrorKind::REMOTE_ABORTED, "timeout", endpoint_.descriptor().region_id, "remote abort");
+            set_error(
+                L3L2QueueErrorKind::REMOTE_ABORTED, L3L2QueueOp::TIMEOUT, endpoint_.descriptor().region_id,
+                "remote abort"
+            );
             return L3L2QueueTimeoutStatus::REMOTE_ABORTED;
         }
         return L3L2QueueTimeoutStatus::ORDINARY_TIMEOUT;
     }
 
 private:
-    bool ensure_live(const char *op) {
+    bool ensure_live(L3L2QueueOp op) {
         if (error_.kind == L3L2QueueErrorKind::NONE) {
             return true;
         }
@@ -729,14 +798,15 @@ private:
         return false;
     }
 
-    void set_error(L3L2QueueErrorKind kind, const char *op, uint64_t region_id, const char *message) {
+    void set_error(L3L2QueueErrorKind kind, L3L2QueueOp op, uint64_t region_id, const char *message) {
         if (error_.kind != L3L2QueueErrorKind::NONE) {
             return;
         }
-        error_ = L3L2QueueError{kind, op, region_id, message};
+        error_ = L3L2QueueError{kind, op, region_id, ""};
+        l3_l2_orch_comm::copy_error_message(error_.message, sizeof(error_.message), message);
     }
 
-    void poison(L3L2QueueErrorKind kind, const char *op, const char *message) {
+    void poison(L3L2QueueErrorKind kind, L3L2QueueOp op, const char *message) {
         set_error(kind, op, endpoint_.descriptor().region_id, message);
         if (kind != L3L2QueueErrorKind::REMOTE_ABORTED) {
             uint64_t addr = 0;
@@ -746,7 +816,7 @@ private:
         }
     }
 
-    bool notify_counter(uint64_t offset, int32_t value, const char *op) {
+    bool notify_counter(uint64_t offset, int32_t value, L3L2QueueOp op) {
         uint64_t addr = 0;
         if (!endpoint_.counter_addr(offset, &addr) || !endpoint_.signal_notify(addr, value, L3L2OrchNotifyOp::Set)) {
             poison(L3L2QueueErrorKind::ENDPOINT_ERROR, op, endpoint_.error().message);
@@ -755,7 +825,7 @@ private:
         return true;
     }
 
-    bool refresh_counter(uint64_t offset, uint64_t &local, uint64_t depth, const char *op) {
+    bool refresh_counter(uint64_t offset, uint64_t &local, uint64_t depth, L3L2QueueOp op) {
         uint64_t addr = 0;
         L3L2OrchSignalTestResult result{};
         if (!endpoint_.counter_addr(offset, &addr) ||
@@ -766,14 +836,14 @@ private:
         if (!result.matched) {
             return true;
         }
-        if (!l3_l2_queue_reconstruct_counter(result.observed, depth, &local)) {
+        if (!l3_l2_message_queue::reconstruct_counter(result.observed, depth, &local)) {
             poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, op, "counter reconstruction failed");
             return false;
         }
         return true;
     }
 
-    bool read_desc_slot(uint64_t slot_offset, L3L2QueueDescSlot *slot, const char *op) {
+    bool read_desc_slot(uint64_t slot_offset, L3L2QueueDescSlot *slot, L3L2QueueOp op) {
         L3L2OrchPayloadView view{};
         if (!endpoint_.payload_read(slot_offset, sizeof(L3L2QueueDescSlot), &view)) {
             poison(L3L2QueueErrorKind::ENDPOINT_ERROR, op, endpoint_.error().message);
@@ -783,7 +853,7 @@ private:
         return true;
     }
 
-    bool write_desc_slot(uint64_t slot_offset, const L3L2QueueDescSlot &slot, uint64_t seq, const char *op) {
+    bool write_desc_slot(uint64_t slot_offset, const L3L2QueueDescSlot &slot, uint64_t seq, L3L2QueueOp op) {
         L3L2QueueDescSlot fields = slot;
         fields.seq = 0;
         if (!endpoint_.payload_write(slot_offset + offsetof(L3L2QueueDescSlot, opcode), &fields.opcode, 24)) {
@@ -797,22 +867,27 @@ private:
         return true;
     }
 
-    bool payload_in_arena(uint64_t offset, uint64_t nbytes, uint64_t arena_offset, uint64_t arena_bytes) const {
-        if (nbytes == 0 || l3_l2_orch_comm_add_overflows(offset, nbytes)) {
+    static bool payload_in_arena(uint64_t offset, uint64_t nbytes, uint64_t arena_offset, uint64_t arena_bytes) {
+        if (nbytes == 0 || l3_l2_orch_comm::add_overflows(offset, nbytes)) {
             return false;
         }
         return offset >= arena_offset && offset + nbytes <= arena_offset + arena_bytes;
     }
 
+    static uint64_t
+    payload_expected_offset(uint64_t cursor, uint64_t nbytes, uint64_t arena_offset, uint64_t arena_bytes) {
+        uint64_t arena_pos = cursor % arena_bytes;
+        return arena_pos + nbytes > arena_bytes ? arena_offset : arena_offset + arena_pos;
+    }
+
     bool payload_matches_head(
         uint64_t cursor, uint64_t payload_offset, uint64_t nbytes, uint64_t arena_offset, uint64_t arena_bytes,
-        const char *op
+        L3L2QueueOp op
     ) {
         if (nbytes == 0) {
             return true;
         }
-        uint64_t arena_pos = cursor % arena_bytes;
-        uint64_t expected_offset = arena_pos + nbytes > arena_bytes ? arena_offset : arena_offset + arena_pos;
+        uint64_t expected_offset = payload_expected_offset(cursor, nbytes, arena_offset, arena_bytes);
         if (payload_offset != expected_offset) {
             poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, op, "payload replay offset mismatch");
             return false;
@@ -822,10 +897,10 @@ private:
 
     void advance_payload_head(
         uint64_t &cursor, uint64_t payload_offset, uint64_t nbytes, uint64_t arena_offset, uint64_t arena_bytes,
-        const char *op
+        L3L2QueueOp op
     ) {
         uint64_t arena_pos = cursor % arena_bytes;
-        uint64_t expected_offset = arena_pos + nbytes > arena_bytes ? arena_offset : arena_offset + arena_pos;
+        uint64_t expected_offset = payload_expected_offset(cursor, nbytes, arena_offset, arena_bytes);
         if (expected_offset != payload_offset) {
             poison(L3L2QueueErrorKind::INVALID_DESCRIPTOR, op, "payload replay offset mismatch");
             return;
@@ -836,7 +911,7 @@ private:
         cursor += nbytes;
     }
 
-    bool replay_output_releases(uint64_t old_head, uint64_t new_head, const char *op) {
+    bool replay_output_releases(uint64_t old_head, uint64_t new_head, L3L2QueueOp op) {
         uint64_t cursor = old_head;
         while (cursor < new_head) {
             L3L2QueueDescSlot slot{};
@@ -864,9 +939,8 @@ private:
     }
 
     L3L2OrchEndpoint endpoint_;
-    L3L2QueueEndpointConfig config_{1};
     L3L2QueueLayout layout_{};
-    L3L2QueueError error_{L3L2QueueErrorKind::NONE, "", 0, ""};
+    L3L2QueueError error_{L3L2QueueErrorKind::NONE, L3L2QueueOp::INIT, 0, ""};
     uint64_t input_head_{0};
     uint64_t input_tail_{0};
     uint64_t output_head_{0};

--- a/src/common/platform/include/aicpu/l3_l2_orch_endpoint.h
+++ b/src/common/platform/include/aicpu/l3_l2_orch_endpoint.h
@@ -100,18 +100,9 @@ public:
 
     const L3L2OrchRegionDesc &descriptor() const { return desc_; }
 
-    bool counter_addr(uint64_t offset, uint64_t *out_addr) {
-        if (out_addr != nullptr) {
-            *out_addr = 0;
-        }
+    bool counter_addr(uint64_t offset, uint64_t &out_addr) {
+        out_addr = 0;
         if (has_error()) {
-            return false;
-        }
-        if (out_addr == nullptr) {
-            set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::COUNTER_ADDR, desc_.region_id, 0, 0,
-                "null counter address output"
-            );
             return false;
         }
         if (l3_l2_orch_comm_add_overflows(desc_.counter_base, offset)) {
@@ -127,7 +118,7 @@ public:
             )) {
             return false;
         }
-        *out_addr = addr;
+        out_addr = addr;
         return true;
     }
 
@@ -135,18 +126,9 @@ public:
         return l3_l2_orch_comm::validate_counter_addr(desc_, counter_addr) == L3L2OrchCommValidationError::OK;
     }
 
-    bool payload_read(uint64_t offset, uint64_t nbytes, L3L2OrchPayloadView *out) {
-        if (out != nullptr) {
-            *out = L3L2OrchPayloadView{0, 0};
-        }
+    bool payload_read(uint64_t offset, uint64_t nbytes, L3L2OrchPayloadView &out) {
+        out = L3L2OrchPayloadView{0, 0};
         if (has_error()) {
-            return false;
-        }
-        if (out == nullptr) {
-            set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::PAYLOAD_READ, desc_.region_id, 0, 0,
-                "null payload view output"
-            );
             return false;
         }
         if (!validate_payload_range(L3L2EndpointOp::PAYLOAD_READ, offset, nbytes)) {
@@ -156,7 +138,7 @@ public:
         cache_invalidate_range(
             reinterpret_cast<const void *>(static_cast<uintptr_t>(gm_addr)), static_cast<size_t>(nbytes)
         );
-        *out = L3L2OrchPayloadView{gm_addr, nbytes};
+        out = L3L2OrchPayloadView{gm_addr, nbytes};
         return true;
     }
 
@@ -210,18 +192,9 @@ public:
         return true;
     }
 
-    bool signal_test(uint64_t counter_addr, int32_t cmp_value, L3L2OrchWaitCmp cmp, L3L2OrchSignalTestResult *out) {
-        if (out != nullptr) {
-            *out = L3L2OrchSignalTestResult{false, 0};
-        }
+    bool signal_test(uint64_t counter_addr, int32_t cmp_value, L3L2OrchWaitCmp cmp, L3L2OrchSignalTestResult &out) {
+        out = L3L2OrchSignalTestResult{false, 0};
         if (has_error()) {
-            return false;
-        }
-        if (out == nullptr) {
-            set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::SIGNAL_TEST, desc_.region_id, counter_addr,
-                cmp_value, "null signal test output"
-            );
             return false;
         }
         if (!validate_counter_addr_for_op(
@@ -237,23 +210,14 @@ public:
             return false;
         }
         int32_t observed = load_counter(counter_addr);
-        *out = L3L2OrchSignalTestResult{l3_l2_orch_comm::compare_counter(observed, cmp_value, cmp), observed};
+        out = L3L2OrchSignalTestResult{l3_l2_orch_comm::compare_counter(observed, cmp_value, cmp), observed};
         return true;
     }
 
     bool
-    signal_wait(uint64_t counter_addr, int32_t cmp_value, L3L2OrchWaitCmp cmp, uint64_t timeout, int32_t *observed) {
-        if (observed != nullptr) {
-            *observed = 0;
-        }
+    signal_wait(uint64_t counter_addr, int32_t cmp_value, L3L2OrchWaitCmp cmp, uint64_t timeout, int32_t &observed) {
+        observed = 0;
         if (has_error()) {
-            return false;
-        }
-        if (observed == nullptr) {
-            set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::SIGNAL_WAIT, desc_.region_id, counter_addr,
-                cmp_value, "null signal wait output"
-            );
             return false;
         }
         if (!validate_counter_addr_for_op(
@@ -273,7 +237,7 @@ public:
         uint64_t frequency_hz = device_time_frequency_hz();
         while (true) {
             int32_t current = load_counter(counter_addr);
-            *observed = current;
+            observed = current;
             if (l3_l2_orch_comm::compare_counter(current, cmp_value, cmp)) {
                 return true;
             }

--- a/src/common/platform/include/aicpu/l3_l2_orch_endpoint.h
+++ b/src/common/platform/include/aicpu/l3_l2_orch_endpoint.h
@@ -105,7 +105,7 @@ public:
         if (has_error()) {
             return false;
         }
-        if (l3_l2_orch_comm_add_overflows(desc_.counter_base, offset)) {
+        if (l3_l2_orch_comm::add_overflows(desc_.counter_base, offset)) {
             set_error(
                 L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::COUNTER_ADDR, desc_.region_id, 0, 0,
                 "counter offset is out of bounds"

--- a/src/common/platform/include/aicpu/l3_l2_orch_endpoint.h
+++ b/src/common/platform/include/aicpu/l3_l2_orch_endpoint.h
@@ -12,52 +12,13 @@
 #ifndef SRC_COMMON_PLATFORM_INCLUDE_AICPU_L3_L2_ORCH_ENDPOINT_H_
 #define SRC_COMMON_PLATFORM_INCLUDE_AICPU_L3_L2_ORCH_ENDPOINT_H_
 
-#if !defined(__aarch64__)
-#include <chrono>
-#endif
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
 
+#include "aicpu/cache_maintenance.h"
+#include "aicpu/device_time.h"
 #include "common/l3_l2_orch_comm.h"
-
-inline void l3_l2_orch_endpoint_cache_invalidate_range(const void *addr, size_t size) {
-#if defined(L3_L2_ORCH_ENDPOINT_ENABLE_CACHE_MAINTENANCE) && defined(__aarch64__)
-    if (size == 0) {
-        return;
-    }
-    const size_t kCacheLineSize = 64;
-    uintptr_t start = reinterpret_cast<uintptr_t>(addr) & ~(kCacheLineSize - 1);
-    uintptr_t end = (reinterpret_cast<uintptr_t>(addr) + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
-    for (uintptr_t p = start; p < end; p += kCacheLineSize) {
-        __asm__ __volatile__("dc civac, %0" ::"r"(p) : "memory");
-    }
-    __asm__ __volatile__("dsb sy" ::: "memory");
-    __asm__ __volatile__("isb" ::: "memory");
-#else
-    (void)addr;
-    (void)size;
-#endif
-}
-
-inline void l3_l2_orch_endpoint_cache_flush_range(const void *addr, size_t size) {
-#if defined(L3_L2_ORCH_ENDPOINT_ENABLE_CACHE_MAINTENANCE) && defined(__aarch64__)
-    if (size == 0) {
-        return;
-    }
-    const size_t kCacheLineSize = 64;
-    uintptr_t start = reinterpret_cast<uintptr_t>(addr) & ~(kCacheLineSize - 1);
-    uintptr_t end = (reinterpret_cast<uintptr_t>(addr) + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
-    for (uintptr_t p = start; p < end; p += kCacheLineSize) {
-        __asm__ __volatile__("dc cvac, %0" ::"r"(p) : "memory");
-    }
-    __asm__ __volatile__("dsb sy" ::: "memory");
-    __asm__ __volatile__("isb" ::: "memory");
-#else
-    (void)addr;
-    (void)size;
-#endif
-}
 
 struct L3L2OrchPayloadView {
     uint64_t gm_addr;
@@ -72,78 +33,66 @@ enum class L3L2EndpointErrorKind : uint32_t {
     SIGNAL_PROTOCOL = 4,
 };
 
+enum class L3L2EndpointOp : uint32_t {
+    INIT = 1,
+    COUNTER_ADDR = 2,
+    PAYLOAD_READ = 3,
+    PAYLOAD_WRITE = 4,
+    SIGNAL_NOTIFY = 5,
+    SIGNAL_TEST = 6,
+    SIGNAL_WAIT = 7,
+};
+
+inline const char *l3_l2_endpoint_op_to_string(L3L2EndpointOp op) {
+    switch (op) {
+    case L3L2EndpointOp::INIT:
+        return "init";
+    case L3L2EndpointOp::COUNTER_ADDR:
+        return "counter_addr";
+    case L3L2EndpointOp::PAYLOAD_READ:
+        return "payload_read";
+    case L3L2EndpointOp::PAYLOAD_WRITE:
+        return "payload_write";
+    case L3L2EndpointOp::SIGNAL_NOTIFY:
+        return "signal_notify";
+    case L3L2EndpointOp::SIGNAL_TEST:
+        return "signal_test";
+    case L3L2EndpointOp::SIGNAL_WAIT:
+        return "signal_wait";
+    default:
+        return "unknown";
+    }
+}
+
 struct L3L2EndpointError {
     L3L2EndpointErrorKind kind;
-    const char *op;
+    L3L2EndpointOp op;
     uint64_t region_id;
     uint64_t counter_addr;
     int32_t counter_operand;
     int32_t observed_counter;
-    const char *message;
+    char message[256];
 };
-
-inline uint64_t l3_l2_orch_endpoint_now() {
-#if defined(__aarch64__)
-    uint64_t value = 0;
-    __asm__ volatile("mrs %0, cntvct_el0" : "=r"(value));
-    return value;
-#elif defined(__x86_64__)
-    return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
-            .count()
-    );
-#else
-    return static_cast<uint64_t>(
-        std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch())
-            .count()
-    );
-#endif
-}
-
-inline uint64_t l3_l2_orch_endpoint_timer_frequency_hz() {
-#if defined(__aarch64__)
-    uint64_t value = 0;
-    __asm__ volatile("mrs %0, cntfrq_el0" : "=r"(value));
-    return value;
-#else
-    return 1'000'000'000ULL;
-#endif
-}
-
-inline uint64_t l3_l2_orch_endpoint_ticks_to_ns(uint64_t elapsed_ticks, uint64_t frequency_hz) {
-    if (frequency_hz == 0) {
-        return UINT64_MAX;
-    }
-    __uint128_t elapsed_ns = static_cast<__uint128_t>(elapsed_ticks) * 1'000'000'000ULL / frequency_hz;
-    if (elapsed_ns > UINT64_MAX) {
-        return UINT64_MAX;
-    }
-    return static_cast<uint64_t>(elapsed_ns);
-}
-
-inline uint64_t l3_l2_orch_endpoint_elapsed_ns(uint64_t start_tick, uint64_t now_tick, uint64_t frequency_hz) {
-#if defined(__aarch64__)
-    return l3_l2_orch_endpoint_ticks_to_ns(now_tick - start_tick, frequency_hz);
-#else
-    (void)frequency_hz;
-    return now_tick - start_tick;
-#endif
-}
 
 class L3L2OrchEndpoint {
 public:
     explicit L3L2OrchEndpoint(const L3L2OrchRegionDesc &desc) :
         desc_(desc) {
-        if (l3_l2_orch_comm_validate_desc(desc_) != L3L2OrchCommValidationError::OK) {
-            set_error(L3L2EndpointErrorKind::BAD_DESCRIPTOR, "init", desc_.region_id, 0, 0, "invalid descriptor");
+        if (l3_l2_orch_comm::validate_desc(desc_) != L3L2OrchCommValidationError::OK) {
+            set_error(
+                L3L2EndpointErrorKind::BAD_DESCRIPTOR, L3L2EndpointOp::INIT, desc_.region_id, 0, 0, "invalid descriptor"
+            );
         }
     }
 
     L3L2OrchEndpoint(const uint64_t *scalars, size_t scalar_count) {
         L3L2OrchCommValidationError error = L3L2OrchCommValidationError::OK;
-        if (!l3_l2_orch_comm_decode_desc(scalars, scalar_count, &desc_, &error)) {
+        if (!l3_l2_orch_comm::decode_desc(scalars, scalar_count, &desc_, &error)) {
             uint64_t region_id = scalar_count > 1 && scalars != nullptr ? scalars[1] : 0;
-            set_error(L3L2EndpointErrorKind::BAD_DESCRIPTOR, "init", region_id, 0, 0, "invalid descriptor scalars");
+            set_error(
+                L3L2EndpointErrorKind::BAD_DESCRIPTOR, L3L2EndpointOp::INIT, region_id, 0, 0,
+                "invalid descriptor scalars"
+            );
         }
     }
 
@@ -160,20 +109,22 @@ public:
         }
         if (out_addr == nullptr) {
             set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, "counter_addr", desc_.region_id, 0, 0,
+                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::COUNTER_ADDR, desc_.region_id, 0, 0,
                 "null counter address output"
             );
             return false;
         }
         if (l3_l2_orch_comm_add_overflows(desc_.counter_base, offset)) {
             set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, "counter_addr", desc_.region_id, 0, 0,
+                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::COUNTER_ADDR, desc_.region_id, 0, 0,
                 "counter offset is out of bounds"
             );
             return false;
         }
         uint64_t addr = desc_.counter_base + offset;
-        if (!validate_counter_addr_for_op("counter_addr", addr, 0, 0, "counter offset is out of bounds")) {
+        if (!validate_counter_addr_for_op(
+                L3L2EndpointOp::COUNTER_ADDR, addr, 0, 0, "counter offset is out of bounds"
+            )) {
             return false;
         }
         *out_addr = addr;
@@ -181,7 +132,7 @@ public:
     }
 
     bool validate_counter_addr(uint64_t counter_addr) const {
-        return l3_l2_orch_comm_validate_counter_addr(desc_, counter_addr) == L3L2OrchCommValidationError::OK;
+        return l3_l2_orch_comm::validate_counter_addr(desc_, counter_addr) == L3L2OrchCommValidationError::OK;
     }
 
     bool payload_read(uint64_t offset, uint64_t nbytes, L3L2OrchPayloadView *out) {
@@ -193,15 +144,16 @@ public:
         }
         if (out == nullptr) {
             set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, "payload_read", desc_.region_id, 0, 0, "null payload view output"
+                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::PAYLOAD_READ, desc_.region_id, 0, 0,
+                "null payload view output"
             );
             return false;
         }
-        if (!validate_payload_range("payload_read", offset, nbytes)) {
+        if (!validate_payload_range(L3L2EndpointOp::PAYLOAD_READ, offset, nbytes)) {
             return false;
         }
         uint64_t gm_addr = desc_.payload_base + offset;
-        l3_l2_orch_endpoint_cache_invalidate_range(
+        cache_invalidate_range(
             reinterpret_cast<const void *>(static_cast<uintptr_t>(gm_addr)), static_cast<size_t>(nbytes)
         );
         *out = L3L2OrchPayloadView{gm_addr, nbytes};
@@ -214,16 +166,17 @@ public:
         }
         if (src == nullptr) {
             set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, "payload_write", desc_.region_id, 0, 0, "null payload source"
+                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::PAYLOAD_WRITE, desc_.region_id, 0, 0,
+                "null payload source"
             );
             return false;
         }
-        if (!validate_payload_range("payload_write", offset, nbytes)) {
+        if (!validate_payload_range(L3L2EndpointOp::PAYLOAD_WRITE, offset, nbytes)) {
             return false;
         }
         void *dst = reinterpret_cast<void *>(static_cast<uintptr_t>(desc_.payload_base + offset));
         memcpy(dst, src, static_cast<size_t>(nbytes));
-        l3_l2_orch_endpoint_cache_flush_range(dst, static_cast<size_t>(nbytes));
+        cache_flush_range(dst, static_cast<size_t>(nbytes));
         return true;
     }
 
@@ -231,13 +184,15 @@ public:
         if (has_error()) {
             return false;
         }
-        if (!validate_counter_addr_for_op("signal_notify", counter_addr, value, 0, "invalid counter address")) {
+        if (!validate_counter_addr_for_op(
+                L3L2EndpointOp::SIGNAL_NOTIFY, counter_addr, value, 0, "invalid counter address"
+            )) {
             return false;
         }
-        if (!l3_l2_orch_comm_valid_notify_op(op)) {
+        if (!l3_l2_orch_comm::valid_notify_op(op)) {
             set_error(
-                L3L2EndpointErrorKind::SIGNAL_PROTOCOL, "signal_notify", desc_.region_id, counter_addr, value,
-                "invalid notify operation"
+                L3L2EndpointErrorKind::SIGNAL_PROTOCOL, L3L2EndpointOp::SIGNAL_NOTIFY, desc_.region_id, counter_addr,
+                value, "invalid notify operation"
             );
             return false;
         }
@@ -246,14 +201,12 @@ public:
         if (op == L3L2OrchNotifyOp::Set) {
             *counter = value;
         } else {
-            l3_l2_orch_endpoint_cache_invalidate_range(
+            cache_invalidate_range(
                 reinterpret_cast<const void *>(static_cast<uintptr_t>(counter_addr)), sizeof(*counter)
             );
             *counter = static_cast<int32_t>(*counter + value);
         }
-        l3_l2_orch_endpoint_cache_flush_range(
-            reinterpret_cast<const void *>(static_cast<uintptr_t>(counter_addr)), sizeof(*counter)
-        );
+        cache_flush_range(reinterpret_cast<const void *>(static_cast<uintptr_t>(counter_addr)), sizeof(*counter));
         return true;
     }
 
@@ -266,23 +219,25 @@ public:
         }
         if (out == nullptr) {
             set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, "signal_test", desc_.region_id, counter_addr, cmp_value,
-                "null signal test output"
+                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::SIGNAL_TEST, desc_.region_id, counter_addr,
+                cmp_value, "null signal test output"
             );
             return false;
         }
-        if (!validate_counter_addr_for_op("signal_test", counter_addr, cmp_value, 0, "invalid counter address")) {
+        if (!validate_counter_addr_for_op(
+                L3L2EndpointOp::SIGNAL_TEST, counter_addr, cmp_value, 0, "invalid counter address"
+            )) {
             return false;
         }
-        if (!l3_l2_orch_comm_valid_wait_cmp(cmp)) {
+        if (!l3_l2_orch_comm::valid_wait_cmp(cmp)) {
             set_error(
-                L3L2EndpointErrorKind::SIGNAL_PROTOCOL, "signal_test", desc_.region_id, counter_addr, cmp_value,
-                "invalid wait comparison"
+                L3L2EndpointErrorKind::SIGNAL_PROTOCOL, L3L2EndpointOp::SIGNAL_TEST, desc_.region_id, counter_addr,
+                cmp_value, "invalid wait comparison"
             );
             return false;
         }
         int32_t observed = load_counter(counter_addr);
-        *out = L3L2OrchSignalTestResult{l3_l2_orch_comm_compare_counter(observed, cmp_value, cmp), observed};
+        *out = L3L2OrchSignalTestResult{l3_l2_orch_comm::compare_counter(observed, cmp_value, cmp), observed};
         return true;
     }
 
@@ -296,35 +251,37 @@ public:
         }
         if (observed == nullptr) {
             set_error(
-                L3L2EndpointErrorKind::OUT_OF_BOUNDS, "signal_wait", desc_.region_id, counter_addr, cmp_value,
-                "null signal wait output"
+                L3L2EndpointErrorKind::OUT_OF_BOUNDS, L3L2EndpointOp::SIGNAL_WAIT, desc_.region_id, counter_addr,
+                cmp_value, "null signal wait output"
             );
             return false;
         }
-        if (!validate_counter_addr_for_op("signal_wait", counter_addr, cmp_value, 0, "invalid counter address")) {
+        if (!validate_counter_addr_for_op(
+                L3L2EndpointOp::SIGNAL_WAIT, counter_addr, cmp_value, 0, "invalid counter address"
+            )) {
             return false;
         }
-        if (!l3_l2_orch_comm_valid_wait_cmp(cmp)) {
+        if (!l3_l2_orch_comm::valid_wait_cmp(cmp)) {
             set_error(
-                L3L2EndpointErrorKind::SIGNAL_PROTOCOL, "signal_wait", desc_.region_id, counter_addr, cmp_value,
-                "invalid wait comparison"
+                L3L2EndpointErrorKind::SIGNAL_PROTOCOL, L3L2EndpointOp::SIGNAL_WAIT, desc_.region_id, counter_addr,
+                cmp_value, "invalid wait comparison"
             );
             return false;
         }
 
-        uint64_t start = l3_l2_orch_endpoint_now();
-        uint64_t frequency_hz = l3_l2_orch_endpoint_timer_frequency_hz();
+        uint64_t start = device_time_now_ticks();
+        uint64_t frequency_hz = device_time_frequency_hz();
         while (true) {
             int32_t current = load_counter(counter_addr);
             *observed = current;
-            if (l3_l2_orch_comm_compare_counter(current, cmp_value, cmp)) {
+            if (l3_l2_orch_comm::compare_counter(current, cmp_value, cmp)) {
                 return true;
             }
-            uint64_t now = l3_l2_orch_endpoint_now();
-            if (timeout == 0 || l3_l2_orch_endpoint_elapsed_ns(start, now, frequency_hz) >= timeout) {
+            uint64_t now = device_time_now_ticks();
+            if (timeout == 0 || sys_cnt_elapsed_ns(start, now, frequency_hz) >= timeout) {
                 set_error(
-                    L3L2EndpointErrorKind::SIGNAL_TIMEOUT, "signal_wait", desc_.region_id, counter_addr, cmp_value,
-                    current, "wait timed out"
+                    L3L2EndpointErrorKind::SIGNAL_TIMEOUT, L3L2EndpointOp::SIGNAL_WAIT, desc_.region_id, counter_addr,
+                    cmp_value, current, "wait timed out"
                 );
                 return false;
             }
@@ -334,9 +291,9 @@ public:
 private:
     bool has_error() const { return error_.kind != L3L2EndpointErrorKind::NONE; }
 
-    bool validate_payload_range(const char *op, uint64_t offset, uint64_t nbytes) {
+    bool validate_payload_range(L3L2EndpointOp op, uint64_t offset, uint64_t nbytes) {
         L3L2OrchCommValidationError error =
-            l3_l2_orch_comm_validate_payload_bounds(offset, nbytes, desc_.payload_bytes);
+            l3_l2_orch_comm::validate_payload_bounds(offset, nbytes, desc_.payload_bytes);
         if (error == L3L2OrchCommValidationError::OK) {
             return true;
         }
@@ -345,9 +302,9 @@ private:
     }
 
     bool validate_counter_addr_for_op(
-        const char *op, uint64_t counter_addr, int32_t counter_operand, int32_t observed_counter, const char *message
+        L3L2EndpointOp op, uint64_t counter_addr, int32_t counter_operand, int32_t observed_counter, const char *message
     ) {
-        if (l3_l2_orch_comm_validate_counter_addr(desc_, counter_addr) == L3L2OrchCommValidationError::OK) {
+        if (l3_l2_orch_comm::validate_counter_addr(desc_, counter_addr) == L3L2OrchCommValidationError::OK) {
             return true;
         }
         set_error(
@@ -357,37 +314,36 @@ private:
         return false;
     }
 
-    volatile int32_t *counter_ptr(uint64_t counter_addr) {
+    static volatile int32_t *counter_ptr(uint64_t counter_addr) {
         return reinterpret_cast<volatile int32_t *>(static_cast<uintptr_t>(counter_addr));
     }
 
-    int32_t load_counter(uint64_t counter_addr) {
+    static int32_t load_counter(uint64_t counter_addr) {
         volatile int32_t *counter = counter_ptr(counter_addr);
-        l3_l2_orch_endpoint_cache_invalidate_range(
-            reinterpret_cast<const void *>(static_cast<uintptr_t>(counter_addr)), sizeof(*counter)
-        );
+        cache_invalidate_range(reinterpret_cast<const void *>(static_cast<uintptr_t>(counter_addr)), sizeof(*counter));
         return *counter;
     }
 
     void set_error(
-        L3L2EndpointErrorKind kind, const char *op, uint64_t region_id, uint64_t counter_addr, int32_t counter_operand,
-        const char *message
+        L3L2EndpointErrorKind kind, L3L2EndpointOp op, uint64_t region_id, uint64_t counter_addr,
+        int32_t counter_operand, const char *message
     ) {
         set_error(kind, op, region_id, counter_addr, counter_operand, 0, message);
     }
 
     void set_error(
-        L3L2EndpointErrorKind kind, const char *op, uint64_t region_id, uint64_t counter_addr, int32_t counter_operand,
-        int32_t observed_counter, const char *message
+        L3L2EndpointErrorKind kind, L3L2EndpointOp op, uint64_t region_id, uint64_t counter_addr,
+        int32_t counter_operand, int32_t observed_counter, const char *message
     ) {
         if (has_error()) {
             return;
         }
-        error_ = L3L2EndpointError{kind, op, region_id, counter_addr, counter_operand, observed_counter, message};
+        error_ = L3L2EndpointError{kind, op, region_id, counter_addr, counter_operand, observed_counter, ""};
+        l3_l2_orch_comm::copy_error_message(error_.message, sizeof(error_.message), message);
     }
 
     L3L2OrchRegionDesc desc_{};
-    L3L2EndpointError error_{L3L2EndpointErrorKind::NONE, "", 0, 0, 0, 0, ""};
+    L3L2EndpointError error_{L3L2EndpointErrorKind::NONE, L3L2EndpointOp::INIT, 0, 0, 0, 0, ""};
 };
 
 #endif  // SRC_COMMON_PLATFORM_INCLUDE_AICPU_L3_L2_ORCH_ENDPOINT_H_

--- a/src/common/platform/include/common/l3_l2_orch_comm.h
+++ b/src/common/platform/include/common/l3_l2_orch_comm.h
@@ -110,13 +110,14 @@ static inline void copy_error_message(char *dst, size_t dst_size, const char *me
 
 }  // namespace l3_l2_orch_comm
 
-static inline uint64_t l3_l2_orch_comm_pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
+static constexpr uint64_t l3_l2_orch_comm_pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
     return (static_cast<uint64_t>(magic) << 32) | (static_cast<uint64_t>(major) << 16) | static_cast<uint64_t>(minor);
 }
 
-static inline uint64_t l3_l2_orch_comm_magic_version() {
-    return l3_l2_orch_comm_pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR);
-}
+static constexpr uint64_t L3L2_ORCH_COMM_MAGIC_VERSION =
+    l3_l2_orch_comm_pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR);
+
+static inline uint64_t l3_l2_orch_comm_magic_version() { return L3L2_ORCH_COMM_MAGIC_VERSION; }
 
 static inline uint32_t l3_l2_orch_comm_magic(uint64_t magic_version) {
     return static_cast<uint32_t>(magic_version >> 32);
@@ -130,17 +131,39 @@ static inline uint16_t l3_l2_orch_comm_abi_minor(uint64_t magic_version) {
     return static_cast<uint16_t>(magic_version & 0xFFFFu);
 }
 
-static inline bool l3_l2_orch_comm_add_overflows(uint64_t a, uint64_t b) { return a > UINT64_MAX - b; }
+static inline bool l3_l2_orch_comm_add_overflows(uint64_t a, uint64_t b) {
+#if defined(__clang__) || defined(__GNUC__)
+    uint64_t result = 0;
+    return __builtin_add_overflow(a, b, &result);
+#else
+    return a > UINT64_MAX - b;
+#endif
+}
 
-static inline bool l3_l2_orch_comm_is_aligned(uint64_t value, uint64_t align) {
-    return align != 0 && (value % align) == 0;
+static inline uint64_t l3_l2_orch_comm_add_sat(uint64_t a, uint64_t b) {
+#if defined(__clang__) || defined(__GNUC__)
+    uint64_t result = 0;
+    return __builtin_add_overflow(a, b, &result) ? UINT64_MAX : result;
+#else
+    return l3_l2_orch_comm_add_overflows(a, b) ? UINT64_MAX : a + b;
+#endif
+}
+
+template <uint64_t Align>
+static constexpr bool l3_l2_orch_comm_is_aligned(uint64_t value) {
+    static_assert(Align > 0 && (Align & (Align - 1)) == 0, "Align must be a power of two");
+    return (value & (Align - 1)) == 0;
+}
+
+static inline bool l3_l2_orch_comm_is_aligned_runtime(uint64_t value, uint64_t align) {
+    return align != 0 && (align & (align - 1)) == 0 && (value & (align - 1)) == 0;
 }
 
 static inline bool l3_l2_orch_comm_range_contains(uint64_t base, uint64_t size, uint64_t value) {
     if (size == 0 || l3_l2_orch_comm_add_overflows(base, size)) {
         return false;
     }
-    return value >= base && value < base + size;
+    return value >= base && value - base < size;
 }
 
 static inline bool
@@ -149,23 +172,26 @@ l3_l2_orch_comm_ranges_overlap(uint64_t first_base, uint64_t first_size, uint64_
         l3_l2_orch_comm_add_overflows(second_base, second_size)) {
         return false;
     }
-    return first_base < second_base + second_size && second_base < first_base + first_size;
+    if (first_base < second_base) {
+        return second_base - first_base < first_size;
+    }
+    return first_base - second_base < second_size;
 }
 
 static inline L3L2OrchCommValidationError
 l3_l2_orch_comm_validate_payload_bounds(uint64_t offset, uint64_t nbytes, uint64_t payload_bytes) {
-    if (nbytes == 0 || payload_bytes == 0 || l3_l2_orch_comm_add_overflows(offset, nbytes)) {
+    if (nbytes == 0 || payload_bytes == 0) {
         return L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE;
     }
-    if (offset > payload_bytes || offset + nbytes > payload_bytes) {
+    if (l3_l2_orch_comm_add_overflows(offset, nbytes) || l3_l2_orch_comm_add_sat(offset, nbytes) > payload_bytes) {
         return L3L2OrchCommValidationError::OUT_OF_BOUNDS;
     }
     return L3L2OrchCommValidationError::OK;
 }
 
 static inline L3L2OrchCommValidationError l3_l2_orch_comm_validate_counter_range(const L3L2OrchRegionDesc &desc) {
-    if (desc.counter_base == 0 || desc.counter_bytes == 0 ||
-        !l3_l2_orch_comm_is_aligned(desc.counter_base, L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT) ||
+    if (desc.counter_bytes == 0 ||
+        !l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(desc.counter_base) ||
         (desc.counter_bytes % L3L2_ORCH_COMM_COUNTER_BYTES) != 0 ||
         l3_l2_orch_comm_add_overflows(desc.counter_base, desc.counter_bytes)) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
@@ -184,8 +210,7 @@ static inline L3L2OrchCommValidationError l3_l2_orch_comm_validate_desc(const L3
     if (desc.region_id == 0) {
         return L3L2OrchCommValidationError::BAD_REGION_ID;
     }
-    if (desc.payload_base == 0 || desc.payload_bytes == 0 ||
-        l3_l2_orch_comm_add_overflows(desc.payload_base, desc.payload_bytes)) {
+    if (desc.payload_bytes == 0 || l3_l2_orch_comm_add_overflows(desc.payload_base, desc.payload_bytes)) {
         return L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE;
     }
     L3L2OrchCommValidationError counter_error = l3_l2_orch_comm_validate_counter_range(desc);
@@ -268,16 +293,17 @@ static inline L3L2OrchCommValidationError
 l3_l2_orch_comm_validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t counter_addr) {
     // Address validity is 4-byte; wrapper protocols must keep different
     // counter writers off the same cache line.
-    if (!l3_l2_orch_comm_is_aligned(counter_addr, L3L2_ORCH_COMM_COUNTER_BYTES)) {
+    if (!l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BYTES>(counter_addr)) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
     }
-    if (l3_l2_orch_comm_validate_counter_range(desc) != L3L2OrchCommValidationError::OK ||
-        l3_l2_orch_comm_add_overflows(counter_addr, L3L2_ORCH_COMM_COUNTER_BYTES) ||
-        l3_l2_orch_comm_add_overflows(desc.counter_base, desc.counter_bytes)) {
+    if (l3_l2_orch_comm_validate_counter_range(desc) != L3L2OrchCommValidationError::OK) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
     }
-    if (counter_addr < desc.counter_base ||
-        counter_addr + L3L2_ORCH_COMM_COUNTER_BYTES > desc.counter_base + desc.counter_bytes) {
+    if (desc.counter_bytes < L3L2_ORCH_COMM_COUNTER_BYTES) {
+        return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
+    }
+    uint64_t max_counter_addr = desc.counter_base + desc.counter_bytes - L3L2_ORCH_COMM_COUNTER_BYTES;
+    if (counter_addr < desc.counter_base || counter_addr > max_counter_addr) {
         return L3L2OrchCommValidationError::OUT_OF_BOUNDS;
     }
     return L3L2OrchCommValidationError::OK;
@@ -285,7 +311,7 @@ l3_l2_orch_comm_validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t c
 
 namespace l3_l2_orch_comm {
 
-static inline uint64_t pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
+static constexpr uint64_t pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
     return ::l3_l2_orch_comm_pack_magic_version(magic, major, minor);
 }
 
@@ -303,7 +329,16 @@ static inline uint16_t abi_minor(uint64_t magic_version_value) {
 
 static inline bool add_overflows(uint64_t a, uint64_t b) { return ::l3_l2_orch_comm_add_overflows(a, b); }
 
-static inline bool is_aligned(uint64_t value, uint64_t align) { return ::l3_l2_orch_comm_is_aligned(value, align); }
+static inline uint64_t add_sat(uint64_t a, uint64_t b) { return ::l3_l2_orch_comm_add_sat(a, b); }
+
+template <uint64_t Align>
+static constexpr bool is_aligned(uint64_t value) {
+    return ::l3_l2_orch_comm_is_aligned<Align>(value);
+}
+
+static inline bool is_aligned_runtime(uint64_t value, uint64_t align) {
+    return ::l3_l2_orch_comm_is_aligned_runtime(value, align);
+}
 
 static inline bool range_contains(uint64_t base, uint64_t size, uint64_t value) {
     return ::l3_l2_orch_comm_range_contains(base, size, value);

--- a/src/common/platform/include/common/l3_l2_orch_comm.h
+++ b/src/common/platform/include/common/l3_l2_orch_comm.h
@@ -108,30 +108,26 @@ static inline void copy_error_message(char *dst, size_t dst_size, const char *me
     dst[n] = '\0';
 }
 
-}  // namespace l3_l2_orch_comm
-
-static constexpr uint64_t l3_l2_orch_comm_pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
+static constexpr uint64_t pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
     return (static_cast<uint64_t>(magic) << 32) | (static_cast<uint64_t>(major) << 16) | static_cast<uint64_t>(minor);
 }
 
 static constexpr uint64_t L3L2_ORCH_COMM_MAGIC_VERSION =
-    l3_l2_orch_comm_pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR);
+    pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR);
 
-static inline uint64_t l3_l2_orch_comm_magic_version() { return L3L2_ORCH_COMM_MAGIC_VERSION; }
+static inline uint64_t magic_version() { return L3L2_ORCH_COMM_MAGIC_VERSION; }
 
-static inline uint32_t l3_l2_orch_comm_magic(uint64_t magic_version) {
-    return static_cast<uint32_t>(magic_version >> 32);
+static inline uint32_t magic(uint64_t magic_version_value) { return static_cast<uint32_t>(magic_version_value >> 32); }
+
+static inline uint16_t abi_major(uint64_t magic_version_value) {
+    return static_cast<uint16_t>((magic_version_value >> 16) & 0xFFFFu);
 }
 
-static inline uint16_t l3_l2_orch_comm_abi_major(uint64_t magic_version) {
-    return static_cast<uint16_t>((magic_version >> 16) & 0xFFFFu);
+static inline uint16_t abi_minor(uint64_t magic_version_value) {
+    return static_cast<uint16_t>(magic_version_value & 0xFFFFu);
 }
 
-static inline uint16_t l3_l2_orch_comm_abi_minor(uint64_t magic_version) {
-    return static_cast<uint16_t>(magic_version & 0xFFFFu);
-}
-
-static inline bool l3_l2_orch_comm_add_overflows(uint64_t a, uint64_t b) {
+static inline bool add_overflows(uint64_t a, uint64_t b) {
 #if defined(__clang__) || defined(__GNUC__)
     uint64_t result = 0;
     return __builtin_add_overflow(a, b, &result);
@@ -140,36 +136,36 @@ static inline bool l3_l2_orch_comm_add_overflows(uint64_t a, uint64_t b) {
 #endif
 }
 
-static inline uint64_t l3_l2_orch_comm_add_sat(uint64_t a, uint64_t b) {
+static inline uint64_t add_sat(uint64_t a, uint64_t b) {
 #if defined(__clang__) || defined(__GNUC__)
     uint64_t result = 0;
     return __builtin_add_overflow(a, b, &result) ? UINT64_MAX : result;
 #else
-    return l3_l2_orch_comm_add_overflows(a, b) ? UINT64_MAX : a + b;
+    return add_overflows(a, b) ? UINT64_MAX : a + b;
 #endif
 }
 
 template <uint64_t Align>
-static constexpr bool l3_l2_orch_comm_is_aligned(uint64_t value) {
+static constexpr bool is_aligned(uint64_t value) {
     static_assert(Align > 0 && (Align & (Align - 1)) == 0, "Align must be a power of two");
     return (value & (Align - 1)) == 0;
 }
 
-static inline bool l3_l2_orch_comm_is_aligned_runtime(uint64_t value, uint64_t align) {
+static inline bool is_aligned_runtime(uint64_t value, uint64_t align) {
     return align != 0 && (align & (align - 1)) == 0 && (value & (align - 1)) == 0;
 }
 
-static inline bool l3_l2_orch_comm_range_contains(uint64_t base, uint64_t size, uint64_t value) {
-    if (size == 0 || l3_l2_orch_comm_add_overflows(base, size)) {
+static inline bool range_contains(uint64_t base, uint64_t size, uint64_t value) {
+    if (size == 0 || add_overflows(base, size)) {
         return false;
     }
     return value >= base && value - base < size;
 }
 
 static inline bool
-l3_l2_orch_comm_ranges_overlap(uint64_t first_base, uint64_t first_size, uint64_t second_base, uint64_t second_size) {
-    if (first_size == 0 || second_size == 0 || l3_l2_orch_comm_add_overflows(first_base, first_size) ||
-        l3_l2_orch_comm_add_overflows(second_base, second_size)) {
+ranges_overlap(uint64_t first_base, uint64_t first_size, uint64_t second_base, uint64_t second_size) {
+    if (first_size == 0 || second_size == 0 || add_overflows(first_base, first_size) ||
+        add_overflows(second_base, second_size)) {
         return false;
     }
     if (first_base < second_base) {
@@ -179,48 +175,47 @@ l3_l2_orch_comm_ranges_overlap(uint64_t first_base, uint64_t first_size, uint64_
 }
 
 static inline L3L2OrchCommValidationError
-l3_l2_orch_comm_validate_payload_bounds(uint64_t offset, uint64_t nbytes, uint64_t payload_bytes) {
+validate_payload_bounds(uint64_t offset, uint64_t nbytes, uint64_t payload_bytes) {
     if (nbytes == 0 || payload_bytes == 0) {
         return L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE;
     }
-    if (l3_l2_orch_comm_add_overflows(offset, nbytes) || l3_l2_orch_comm_add_sat(offset, nbytes) > payload_bytes) {
+    if (add_overflows(offset, nbytes) || add_sat(offset, nbytes) > payload_bytes) {
         return L3L2OrchCommValidationError::OUT_OF_BOUNDS;
     }
     return L3L2OrchCommValidationError::OK;
 }
 
-static inline L3L2OrchCommValidationError l3_l2_orch_comm_validate_counter_range(const L3L2OrchRegionDesc &desc) {
-    if (desc.counter_bytes == 0 ||
-        !l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(desc.counter_base) ||
+static inline L3L2OrchCommValidationError validate_counter_range(const L3L2OrchRegionDesc &desc) {
+    if (desc.counter_bytes == 0 || !is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(desc.counter_base) ||
         (desc.counter_bytes % L3L2_ORCH_COMM_COUNTER_BYTES) != 0 ||
-        l3_l2_orch_comm_add_overflows(desc.counter_base, desc.counter_bytes)) {
+        add_overflows(desc.counter_base, desc.counter_bytes)) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
     }
-    if (l3_l2_orch_comm_ranges_overlap(desc.payload_base, desc.payload_bytes, desc.counter_base, desc.counter_bytes)) {
+    if (ranges_overlap(desc.payload_base, desc.payload_bytes, desc.counter_base, desc.counter_bytes)) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
     }
     return L3L2OrchCommValidationError::OK;
 }
 
-static inline L3L2OrchCommValidationError l3_l2_orch_comm_validate_desc(const L3L2OrchRegionDesc &desc) {
-    if (l3_l2_orch_comm_magic(desc.magic_version) != L3L2_ORCH_COMM_MAGIC ||
-        l3_l2_orch_comm_abi_major(desc.magic_version) != L3L2_ORCH_COMM_ABI_MAJOR) {
+static inline L3L2OrchCommValidationError validate_desc(const L3L2OrchRegionDesc &desc) {
+    if (magic(desc.magic_version) != L3L2_ORCH_COMM_MAGIC ||
+        abi_major(desc.magic_version) != L3L2_ORCH_COMM_ABI_MAJOR) {
         return L3L2OrchCommValidationError::BAD_MAGIC_VERSION;
     }
     if (desc.region_id == 0) {
         return L3L2OrchCommValidationError::BAD_REGION_ID;
     }
-    if (desc.payload_bytes == 0 || l3_l2_orch_comm_add_overflows(desc.payload_base, desc.payload_bytes)) {
+    if (desc.payload_bytes == 0 || add_overflows(desc.payload_base, desc.payload_bytes)) {
         return L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE;
     }
-    L3L2OrchCommValidationError counter_error = l3_l2_orch_comm_validate_counter_range(desc);
+    L3L2OrchCommValidationError counter_error = validate_counter_range(desc);
     if (counter_error != L3L2OrchCommValidationError::OK) {
         return counter_error;
     }
     return L3L2OrchCommValidationError::OK;
 }
 
-static inline bool l3_l2_orch_comm_encode_desc(const L3L2OrchRegionDesc &desc, uint64_t *scalars, size_t scalar_count) {
+static inline bool encode_desc(const L3L2OrchRegionDesc &desc, uint64_t *scalars, size_t scalar_count) {
     if (scalars == nullptr || scalar_count < L3L2_ORCH_REGION_DESC_SCALAR_COUNT) {
         return false;
     }
@@ -233,7 +228,7 @@ static inline bool l3_l2_orch_comm_encode_desc(const L3L2OrchRegionDesc &desc, u
     return true;
 }
 
-static inline bool l3_l2_orch_comm_decode_desc(
+static inline bool decode_desc(
     const uint64_t *scalars, size_t scalar_count, L3L2OrchRegionDesc *out_desc, L3L2OrchCommValidationError *out_error
 ) {
     if (out_error != nullptr) {
@@ -254,23 +249,23 @@ static inline bool l3_l2_orch_comm_decode_desc(
     *out_desc = L3L2OrchRegionDesc{
         scalars[0], scalars[1], scalars[2], scalars[3], scalars[4], scalars[5],
     };
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(*out_desc);
+    L3L2OrchCommValidationError error = validate_desc(*out_desc);
     if (out_error != nullptr) {
         *out_error = error;
     }
     return error == L3L2OrchCommValidationError::OK;
 }
 
-static inline bool l3_l2_orch_comm_valid_notify_op(L3L2OrchNotifyOp op) {
+static inline bool valid_notify_op(L3L2OrchNotifyOp op) {
     return op == L3L2OrchNotifyOp::Set || op == L3L2OrchNotifyOp::Add;
 }
 
-static inline bool l3_l2_orch_comm_valid_wait_cmp(L3L2OrchWaitCmp cmp) {
+static inline bool valid_wait_cmp(L3L2OrchWaitCmp cmp) {
     return cmp == L3L2OrchWaitCmp::EQ || cmp == L3L2OrchWaitCmp::NE || cmp == L3L2OrchWaitCmp::GT ||
            cmp == L3L2OrchWaitCmp::GE || cmp == L3L2OrchWaitCmp::LT || cmp == L3L2OrchWaitCmp::LE;
 }
 
-static inline bool l3_l2_orch_comm_compare_counter(int32_t observed, int32_t cmp_value, L3L2OrchWaitCmp cmp) {
+static inline bool compare_counter(int32_t observed, int32_t cmp_value, L3L2OrchWaitCmp cmp) {
     switch (cmp) {
     case L3L2OrchWaitCmp::EQ:
         return observed == cmp_value;
@@ -289,14 +284,13 @@ static inline bool l3_l2_orch_comm_compare_counter(int32_t observed, int32_t cmp
     }
 }
 
-static inline L3L2OrchCommValidationError
-l3_l2_orch_comm_validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t counter_addr) {
+static inline L3L2OrchCommValidationError validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t counter_addr) {
     // Address validity is 4-byte; wrapper protocols must keep different
     // counter writers off the same cache line.
-    if (!l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BYTES>(counter_addr)) {
+    if (!is_aligned<L3L2_ORCH_COMM_COUNTER_BYTES>(counter_addr)) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
     }
-    if (l3_l2_orch_comm_validate_counter_range(desc) != L3L2OrchCommValidationError::OK) {
+    if (validate_counter_range(desc) != L3L2OrchCommValidationError::OK) {
         return L3L2OrchCommValidationError::BAD_COUNTER_RANGE;
     }
     if (desc.counter_bytes < L3L2_ORCH_COMM_COUNTER_BYTES) {
@@ -307,81 +301,6 @@ l3_l2_orch_comm_validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t c
         return L3L2OrchCommValidationError::OUT_OF_BOUNDS;
     }
     return L3L2OrchCommValidationError::OK;
-}
-
-namespace l3_l2_orch_comm {
-
-static constexpr uint64_t pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
-    return ::l3_l2_orch_comm_pack_magic_version(magic, major, minor);
-}
-
-static inline uint64_t magic_version() { return ::l3_l2_orch_comm_magic_version(); }
-
-static inline uint32_t magic(uint64_t magic_version_value) { return ::l3_l2_orch_comm_magic(magic_version_value); }
-
-static inline uint16_t abi_major(uint64_t magic_version_value) {
-    return ::l3_l2_orch_comm_abi_major(magic_version_value);
-}
-
-static inline uint16_t abi_minor(uint64_t magic_version_value) {
-    return ::l3_l2_orch_comm_abi_minor(magic_version_value);
-}
-
-static inline bool add_overflows(uint64_t a, uint64_t b) { return ::l3_l2_orch_comm_add_overflows(a, b); }
-
-static inline uint64_t add_sat(uint64_t a, uint64_t b) { return ::l3_l2_orch_comm_add_sat(a, b); }
-
-template <uint64_t Align>
-static constexpr bool is_aligned(uint64_t value) {
-    return ::l3_l2_orch_comm_is_aligned<Align>(value);
-}
-
-static inline bool is_aligned_runtime(uint64_t value, uint64_t align) {
-    return ::l3_l2_orch_comm_is_aligned_runtime(value, align);
-}
-
-static inline bool range_contains(uint64_t base, uint64_t size, uint64_t value) {
-    return ::l3_l2_orch_comm_range_contains(base, size, value);
-}
-
-static inline bool
-ranges_overlap(uint64_t first_base, uint64_t first_size, uint64_t second_base, uint64_t second_size) {
-    return ::l3_l2_orch_comm_ranges_overlap(first_base, first_size, second_base, second_size);
-}
-
-static inline L3L2OrchCommValidationError
-validate_payload_bounds(uint64_t offset, uint64_t nbytes, uint64_t payload_bytes) {
-    return ::l3_l2_orch_comm_validate_payload_bounds(offset, nbytes, payload_bytes);
-}
-
-static inline L3L2OrchCommValidationError validate_counter_range(const L3L2OrchRegionDesc &desc) {
-    return ::l3_l2_orch_comm_validate_counter_range(desc);
-}
-
-static inline L3L2OrchCommValidationError validate_desc(const L3L2OrchRegionDesc &desc) {
-    return ::l3_l2_orch_comm_validate_desc(desc);
-}
-
-static inline bool encode_desc(const L3L2OrchRegionDesc &desc, uint64_t *scalars, size_t scalar_count) {
-    return ::l3_l2_orch_comm_encode_desc(desc, scalars, scalar_count);
-}
-
-static inline bool decode_desc(
-    const uint64_t *scalars, size_t scalar_count, L3L2OrchRegionDesc *out_desc, L3L2OrchCommValidationError *out_error
-) {
-    return ::l3_l2_orch_comm_decode_desc(scalars, scalar_count, out_desc, out_error);
-}
-
-static inline bool valid_notify_op(L3L2OrchNotifyOp op) { return ::l3_l2_orch_comm_valid_notify_op(op); }
-
-static inline bool valid_wait_cmp(L3L2OrchWaitCmp cmp) { return ::l3_l2_orch_comm_valid_wait_cmp(cmp); }
-
-static inline bool compare_counter(int32_t observed, int32_t cmp_value, L3L2OrchWaitCmp cmp) {
-    return ::l3_l2_orch_comm_compare_counter(observed, cmp_value, cmp);
-}
-
-static inline L3L2OrchCommValidationError validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t counter_addr) {
-    return ::l3_l2_orch_comm_validate_counter_addr(desc, counter_addr);
 }
 
 }  // namespace l3_l2_orch_comm

--- a/src/common/platform/include/common/l3_l2_orch_comm.h
+++ b/src/common/platform/include/common/l3_l2_orch_comm.h
@@ -14,6 +14,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 static constexpr uint32_t L3L2_ORCH_COMM_MAGIC = 0x4C334C32u;  // "L3L2"
 static constexpr uint16_t L3L2_ORCH_COMM_ABI_MAJOR = 2;
@@ -94,6 +95,20 @@ struct L3L2OrchCommResponse {
     L3L2OrchRegionDesc desc;
     char message[256];
 };
+
+namespace l3_l2_orch_comm {
+
+static inline void copy_error_message(char *dst, size_t dst_size, const char *message) {
+    if (dst == nullptr || dst_size == 0) {
+        return;
+    }
+    const char *src = message == nullptr ? "" : message;
+    size_t n = strnlen(src, dst_size - 1);
+    memcpy(dst, src, n);
+    dst[n] = '\0';
+}
+
+}  // namespace l3_l2_orch_comm
 
 static inline uint64_t l3_l2_orch_comm_pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
     return (static_cast<uint64_t>(magic) << 32) | (static_cast<uint64_t>(major) << 16) | static_cast<uint64_t>(minor);
@@ -267,5 +282,73 @@ l3_l2_orch_comm_validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t c
     }
     return L3L2OrchCommValidationError::OK;
 }
+
+namespace l3_l2_orch_comm {
+
+static inline uint64_t pack_magic_version(uint32_t magic, uint16_t major, uint16_t minor) {
+    return ::l3_l2_orch_comm_pack_magic_version(magic, major, minor);
+}
+
+static inline uint64_t magic_version() { return ::l3_l2_orch_comm_magic_version(); }
+
+static inline uint32_t magic(uint64_t magic_version_value) { return ::l3_l2_orch_comm_magic(magic_version_value); }
+
+static inline uint16_t abi_major(uint64_t magic_version_value) {
+    return ::l3_l2_orch_comm_abi_major(magic_version_value);
+}
+
+static inline uint16_t abi_minor(uint64_t magic_version_value) {
+    return ::l3_l2_orch_comm_abi_minor(magic_version_value);
+}
+
+static inline bool add_overflows(uint64_t a, uint64_t b) { return ::l3_l2_orch_comm_add_overflows(a, b); }
+
+static inline bool is_aligned(uint64_t value, uint64_t align) { return ::l3_l2_orch_comm_is_aligned(value, align); }
+
+static inline bool range_contains(uint64_t base, uint64_t size, uint64_t value) {
+    return ::l3_l2_orch_comm_range_contains(base, size, value);
+}
+
+static inline bool
+ranges_overlap(uint64_t first_base, uint64_t first_size, uint64_t second_base, uint64_t second_size) {
+    return ::l3_l2_orch_comm_ranges_overlap(first_base, first_size, second_base, second_size);
+}
+
+static inline L3L2OrchCommValidationError
+validate_payload_bounds(uint64_t offset, uint64_t nbytes, uint64_t payload_bytes) {
+    return ::l3_l2_orch_comm_validate_payload_bounds(offset, nbytes, payload_bytes);
+}
+
+static inline L3L2OrchCommValidationError validate_counter_range(const L3L2OrchRegionDesc &desc) {
+    return ::l3_l2_orch_comm_validate_counter_range(desc);
+}
+
+static inline L3L2OrchCommValidationError validate_desc(const L3L2OrchRegionDesc &desc) {
+    return ::l3_l2_orch_comm_validate_desc(desc);
+}
+
+static inline bool encode_desc(const L3L2OrchRegionDesc &desc, uint64_t *scalars, size_t scalar_count) {
+    return ::l3_l2_orch_comm_encode_desc(desc, scalars, scalar_count);
+}
+
+static inline bool decode_desc(
+    const uint64_t *scalars, size_t scalar_count, L3L2OrchRegionDesc *out_desc, L3L2OrchCommValidationError *out_error
+) {
+    return ::l3_l2_orch_comm_decode_desc(scalars, scalar_count, out_desc, out_error);
+}
+
+static inline bool valid_notify_op(L3L2OrchNotifyOp op) { return ::l3_l2_orch_comm_valid_notify_op(op); }
+
+static inline bool valid_wait_cmp(L3L2OrchWaitCmp cmp) { return ::l3_l2_orch_comm_valid_wait_cmp(cmp); }
+
+static inline bool compare_counter(int32_t observed, int32_t cmp_value, L3L2OrchWaitCmp cmp) {
+    return ::l3_l2_orch_comm_compare_counter(observed, cmp_value, cmp);
+}
+
+static inline L3L2OrchCommValidationError validate_counter_addr(const L3L2OrchRegionDesc &desc, uint64_t counter_addr) {
+    return ::l3_l2_orch_comm_validate_counter_addr(desc, counter_addr);
+}
+
+}  // namespace l3_l2_orch_comm
 
 #endif  // SRC_COMMON_PLATFORM_INCLUDE_COMMON_L3_L2_ORCH_COMM_H_

--- a/src/common/platform/onboard/aicpu/cache_ops.cpp
+++ b/src/common/platform/onboard/aicpu/cache_ops.cpp
@@ -11,15 +11,17 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "aicpu/platform_regs.h"
+#include "aicpu/cache_maintenance.h"
 
-void cache_invalidate_range(const void *addr, size_t size) {
+namespace aicpu_cache_maintenance {
+
+void invalidate_range_impl(const void *addr, size_t size) {
     if (size == 0) {
         return;
     }
     const size_t kCacheLineSize = 64;
-    uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
-    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    uintptr_t start = reinterpret_cast<uintptr_t>(addr) & ~(kCacheLineSize - 1);
+    uintptr_t end = (reinterpret_cast<uintptr_t>(addr) + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
     for (uintptr_t p = start; p < end; p += kCacheLineSize) {
         __asm__ __volatile__("dc civac, %0" ::"r"(p) : "memory");
     }
@@ -27,16 +29,18 @@ void cache_invalidate_range(const void *addr, size_t size) {
     __asm__ __volatile__("isb" ::: "memory");
 }
 
-void cache_flush_range(const void *addr, size_t size) {
+void flush_range_impl(const void *addr, size_t size) {
     if (size == 0) {
         return;
     }
     const size_t kCacheLineSize = 64;
-    uintptr_t start = (uintptr_t)addr & ~(kCacheLineSize - 1);
-    uintptr_t end = ((uintptr_t)addr + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
+    uintptr_t start = reinterpret_cast<uintptr_t>(addr) & ~(kCacheLineSize - 1);
+    uintptr_t end = (reinterpret_cast<uintptr_t>(addr) + size + kCacheLineSize - 1) & ~(kCacheLineSize - 1);
     for (uintptr_t p = start; p < end; p += kCacheLineSize) {
         __asm__ __volatile__("dc cvac, %0" ::"r"(p) : "memory");
     }
     __asm__ __volatile__("dsb sy" ::: "memory");
     __asm__ __volatile__("isb" ::: "memory");
 }
+
+}  // namespace aicpu_cache_maintenance

--- a/src/common/platform/shared/host/l3_l2_orch_comm_service.cpp
+++ b/src/common/platform/shared/host/l3_l2_orch_comm_service.cpp
@@ -217,7 +217,7 @@ void L3L2OrchCommService::alloc_region(const L3L2OrchCommRequest &request, L3L2O
     }
 
     response->desc = desc_for_region(region);
-    if (l3_l2_orch_comm_validate_desc(response->desc) != L3L2OrchCommValidationError::OK) {
+    if (l3_l2_orch_comm::validate_desc(response->desc) != L3L2OrchCommValidationError::OK) {
         release_region(region);
         set_response(response, -1, ServiceError::ALLOC_FAILED, 0, "ALLOC_REGION produced invalid descriptor");
         return;
@@ -254,7 +254,7 @@ void L3L2OrchCommService::payload_write(const L3L2OrchCommRequest &request, L3L2
         return;
     }
     L3L2OrchCommValidationError bounds =
-        l3_l2_orch_comm_validate_payload_bounds(request.payload_offset, request.payload_bytes, region->payload_bytes);
+        l3_l2_orch_comm::validate_payload_bounds(request.payload_offset, request.payload_bytes, region->payload_bytes);
     if (request.host_ptr == 0 || bounds != L3L2OrchCommValidationError::OK) {
         set_response(response, -1, ServiceError::BAD_REQUEST, request.region_id, "invalid PAYLOAD_WRITE request");
         return;
@@ -275,7 +275,7 @@ void L3L2OrchCommService::payload_read(const L3L2OrchCommRequest &request, L3L2O
         return;
     }
     L3L2OrchCommValidationError bounds =
-        l3_l2_orch_comm_validate_payload_bounds(request.payload_offset, request.payload_bytes, region->payload_bytes);
+        l3_l2_orch_comm::validate_payload_bounds(request.payload_offset, request.payload_bytes, region->payload_bytes);
     if (request.host_ptr == 0 || bounds != L3L2OrchCommValidationError::OK) {
         set_response(response, -1, ServiceError::BAD_REQUEST, request.region_id, "invalid PAYLOAD_READ request");
         return;
@@ -295,7 +295,7 @@ void L3L2OrchCommService::signal_notify(const L3L2OrchCommRequest &request, L3L2
         return;
     }
     L3L2OrchNotifyOp op = static_cast<L3L2OrchNotifyOp>(request.op);
-    if (!l3_l2_orch_comm_valid_notify_op(op)) {
+    if (!l3_l2_orch_comm::valid_notify_op(op)) {
         set_response(response, -1, ServiceError::BAD_REQUEST, request.region_id, "invalid SIGNAL_NOTIFY request");
         return;
     }
@@ -330,7 +330,7 @@ void L3L2OrchCommService::signal_test(const L3L2OrchCommRequest &request, L3L2Or
         return;
     }
     L3L2OrchWaitCmp cmp = static_cast<L3L2OrchWaitCmp>(request.op);
-    if (!l3_l2_orch_comm_valid_wait_cmp(cmp)) {
+    if (!l3_l2_orch_comm::valid_wait_cmp(cmp)) {
         set_response(response, -1, ServiceError::BAD_REQUEST, request.region_id, "invalid SIGNAL_TEST request");
         return;
     }
@@ -348,7 +348,7 @@ void L3L2OrchCommService::signal_test(const L3L2OrchCommRequest &request, L3L2Or
     }
 
     response->observed_counter = observed;
-    response->matched = l3_l2_orch_comm_compare_counter(observed, request.counter_operand, cmp) ? 1u : 0u;
+    response->matched = l3_l2_orch_comm::compare_counter(observed, request.counter_operand, cmp) ? 1u : 0u;
     if (response->matched != 0) {
         std::atomic_thread_fence(std::memory_order_acquire);
     }
@@ -361,7 +361,7 @@ void L3L2OrchCommService::signal_wait(const L3L2OrchCommRequest &request, L3L2Or
         return;
     }
     L3L2OrchWaitCmp cmp = static_cast<L3L2OrchWaitCmp>(request.op);
-    if (!l3_l2_orch_comm_valid_wait_cmp(cmp)) {
+    if (!l3_l2_orch_comm::valid_wait_cmp(cmp)) {
         set_response(response, -1, ServiceError::BAD_REQUEST, request.region_id, "invalid SIGNAL_WAIT request");
         return;
     }
@@ -380,7 +380,7 @@ void L3L2OrchCommService::signal_wait(const L3L2OrchCommRequest &request, L3L2Or
             return;
         }
         response->observed_counter = observed;
-        response->matched = l3_l2_orch_comm_compare_counter(observed, request.counter_operand, cmp) ? 1u : 0u;
+        response->matched = l3_l2_orch_comm::compare_counter(observed, request.counter_operand, cmp) ? 1u : 0u;
         if (response->matched != 0) {
             std::atomic_thread_fence(std::memory_order_acquire);
             set_response(response, 0, ServiceError::OK, request.region_id, "");
@@ -412,7 +412,7 @@ L3L2OrchCommService::Region *L3L2OrchCommService::find_live_region(uint64_t regi
 
 L3L2OrchRegionDesc L3L2OrchCommService::desc_for_region(const Region &region) const {
     return L3L2OrchRegionDesc{
-        l3_l2_orch_comm_magic_version(),
+        l3_l2_orch_comm::magic_version(),
         region.region_id,
         reinterpret_cast<uint64_t>(region.payload_dev),
         region.payload_bytes,
@@ -425,7 +425,7 @@ void *L3L2OrchCommService::counter_ptr(
     L3L2OrchCommService::Region &region, uint64_t counter_addr, L3L2OrchCommResponse *response
 ) {
     L3L2OrchRegionDesc desc = desc_for_region(region);
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_counter_addr(desc, counter_addr);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_counter_addr(desc, counter_addr);
     if (error != L3L2OrchCommValidationError::OK) {
         set_response(response, -1, ServiceError::BAD_REQUEST, region.region_id, "invalid counter address");
         return nullptr;

--- a/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
@@ -29,7 +29,7 @@ struct RegionStorage {
 
 L3L2OrchRegionDesc make_desc(RegionStorage *storage, uint64_t payload_bytes = 512, uint64_t counter_bytes = 512) {
     return L3L2OrchRegionDesc{
-        l3_l2_orch_comm_magic_version(),
+        l3_l2_orch_comm::magic_version(),
         19,
         reinterpret_cast<uint64_t>(storage->payload.data()),
         payload_bytes,
@@ -42,7 +42,7 @@ size_t counter_index(uint64_t offset) { return static_cast<size_t>(offset / size
 
 L3L2QueueArgs make_args(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes) {
     L3L2QueueLayout layout{};
-    EXPECT_TRUE(l3_l2_queue_make_layout(depth, input_arena_bytes, output_arena_bytes, layout));
+    EXPECT_TRUE(l3_l2_message_queue::make_layout(depth, input_arena_bytes, output_arena_bytes, layout));
     return L3L2QueueArgs{
         L3L2_QUEUE_MAGIC_VERSION, depth, input_arena_bytes, output_arena_bytes, layout.payload_bytes,
         layout.counter_bytes,
@@ -58,7 +58,7 @@ void publish_input_desc(
     uint64_t payload_offset = 0, uint64_t payload_nbytes = 0
 ) {
     L3L2QueueDescSlot slot{};
-    l3_l2_queue_encode_desc(&slot, seq, opcode, payload_offset, payload_nbytes);
+    l3_l2_message_queue::encode_desc(&slot, seq, opcode, payload_offset, payload_nbytes);
     uint64_t desc_offset = layout.input_desc_offset + ((seq - 1) & (layout.depth - 1)) * sizeof(L3L2QueueDescSlot);
     std::memcpy(storage->payload.data() + desc_offset, &slot, sizeof(slot));
     storage->counters[counter_index(layout.input_desc_tail_offset)] = static_cast<int32_t>(seq);
@@ -67,16 +67,16 @@ void publish_input_desc(
 TEST(L3L2MessageQueueTest, MagicVersionConstantMatchesCompatibilityWrapper) {
     EXPECT_EQ(
         L3L2_QUEUE_MAGIC_VERSION,
-        l3_l2_orch_comm_pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR)
+        l3_l2_orch_comm::pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR)
     );
-    EXPECT_EQ(l3_l2_queue_magic_version(), L3L2_QUEUE_MAGIC_VERSION);
+    EXPECT_EQ(l3_l2_message_queue::magic_version(), L3L2_QUEUE_MAGIC_VERSION);
     EXPECT_EQ(l3_l2_message_queue::magic_version(), L3L2_QUEUE_MAGIC_VERSION);
 }
 
 TEST(L3L2MessageQueueTest, LayoutAssignsPayloadAndAbortCounterOffsets) {
     L3L2QueueLayout layout{};
 
-    ASSERT_TRUE(l3_l2_queue_make_layout(4, 128, 192, layout));
+    ASSERT_TRUE(l3_l2_message_queue::make_layout(4, 128, 192, layout));
 
     EXPECT_EQ(layout.input_desc_offset, 0u);
     EXPECT_EQ(layout.output_desc_offset, 4u * sizeof(L3L2QueueDescSlot));
@@ -112,7 +112,9 @@ TEST(L3L2MessageQueueTest, LayoutLockstepCasesMatchPythonMirrorExpectations) {
     for (const auto &test_case : cases) {
         L3L2QueueLayout layout{};
         ASSERT_TRUE(
-            l3_l2_queue_make_layout(test_case.depth, test_case.input_arena_bytes, test_case.output_arena_bytes, layout)
+            l3_l2_message_queue::make_layout(
+                test_case.depth, test_case.input_arena_bytes, test_case.output_arena_bytes, layout
+            )
         );
 
         EXPECT_EQ(layout.input_desc_offset, 0u);
@@ -134,16 +136,16 @@ TEST(L3L2MessageQueueTest, LayoutLockstepCasesMatchPythonMirrorExpectations) {
 TEST(L3L2MessageQueueTest, LayoutRejectsInvalidDepthArenaAndCounterBytes) {
     L3L2QueueLayout layout{};
 
-    EXPECT_FALSE(l3_l2_queue_make_layout(3, 64, 64, layout));
-    EXPECT_FALSE(l3_l2_queue_make_layout((1ull << 30) + 1, 64, 64, layout));
-    EXPECT_FALSE(l3_l2_queue_make_layout(2, 0, 64, layout));
-    EXPECT_FALSE(l3_l2_queue_make_layout(2, 65, 64, layout));
+    EXPECT_FALSE(l3_l2_message_queue::make_layout(3, 64, 64, layout));
+    EXPECT_FALSE(l3_l2_message_queue::make_layout((1ull << 30) + 1, 64, 64, layout));
+    EXPECT_FALSE(l3_l2_message_queue::make_layout(2, 0, 64, layout));
+    EXPECT_FALSE(l3_l2_message_queue::make_layout(2, 65, 64, layout));
 
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    EXPECT_FALSE(l3_l2_queue_validate_region(make_desc(&storage, 256, 320), args, &layout));
-    EXPECT_FALSE(l3_l2_queue_validate_region(make_desc(&storage, 512, 384), args, &layout));
-    EXPECT_TRUE(l3_l2_queue_validate_region(make_desc(&storage, args), args, &layout));
+    EXPECT_FALSE(l3_l2_message_queue::validate_region(make_desc(&storage, 256, 320), args, &layout));
+    EXPECT_FALSE(l3_l2_message_queue::validate_region(make_desc(&storage, 512, 384), args, &layout));
+    EXPECT_TRUE(l3_l2_message_queue::validate_region(make_desc(&storage, args), args, &layout));
 }
 
 TEST(L3L2MessageQueueTest, LayoutOverflowFailsClosedWithoutModifyingOutput) {
@@ -152,7 +154,7 @@ TEST(L3L2MessageQueueTest, LayoutOverflowFailsClosedWithoutModifyingOutput) {
     };
     const L3L2QueueLayout original = layout;
 
-    EXPECT_FALSE(l3_l2_queue_make_layout(2, std::numeric_limits<uint64_t>::max() - 63, 64, layout));
+    EXPECT_FALSE(l3_l2_message_queue::make_layout(2, std::numeric_limits<uint64_t>::max() - 63, 64, layout));
 
     EXPECT_EQ(layout.depth, original.depth);
     EXPECT_EQ(layout.input_desc_offset, original.input_desc_offset);
@@ -179,7 +181,7 @@ TEST(L3L2MessageQueueTest, DescriptorSlotEncodingIsStable) {
     EXPECT_EQ(sizeof(L3L2QueueError::message), 256u);
 
     L3L2QueueDescSlot slot{};
-    l3_l2_queue_encode_desc(&slot, 7, L3L2QueueOpcode::ERROR, 128, 16);
+    l3_l2_message_queue::encode_desc(&slot, 7, L3L2QueueOpcode::ERROR, 128, 16);
     EXPECT_EQ(slot.seq, 7u);
     EXPECT_EQ(slot.opcode, 3u);
     EXPECT_EQ(slot.payload_offset, 128u);
@@ -211,22 +213,22 @@ TEST(L3L2MessageQueueTest, ErrorOperationStringsAndMessageCopyAreStable) {
 TEST(L3L2MessageQueueTest, Low32ReconstructionAcceptsWrapAndRejectsImpossibleDeltas) {
     uint64_t value = 0xFFFF'FFFFull;
 
-    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(0, 4, value));
+    EXPECT_TRUE(l3_l2_message_queue::reconstruct_counter(0, 4, value));
     EXPECT_EQ(value, 0x1'0000'0000ull);
 
     value = (1ull << 31) - 2;
-    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(static_cast<int32_t>(0x8000'0001u), 4, value));
+    EXPECT_TRUE(l3_l2_message_queue::reconstruct_counter(static_cast<int32_t>(0x8000'0001u), 4, value));
     EXPECT_EQ(value, (1ull << 31) + 1);
 
     value = 100;
-    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(104, 4, value));
+    EXPECT_TRUE(l3_l2_message_queue::reconstruct_counter(104, 4, value));
     EXPECT_EQ(value, 104u);
 
     value = 100;
-    EXPECT_FALSE(l3_l2_queue_reconstruct_counter(99, 4, value));
+    EXPECT_FALSE(l3_l2_message_queue::reconstruct_counter(99, 4, value));
 
     value = 100;
-    EXPECT_FALSE(l3_l2_queue_reconstruct_counter(105, 4, value));
+    EXPECT_FALSE(l3_l2_message_queue::reconstruct_counter(105, 4, value));
 }
 
 TEST(L3L2MessageQueueTest, L2InputPeekHandlesZeroByteDescriptorBeforeArenaValidation) {
@@ -236,7 +238,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekHandlesZeroByteDescriptorBeforeArenaValida
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueDescSlot slot{};
-    l3_l2_queue_encode_desc(&slot, 1, L3L2QueueOpcode::DATA, 0, 0);
+    l3_l2_message_queue::encode_desc(&slot, 1, L3L2QueueOpcode::DATA, 0, 0);
     std::memcpy(storage.payload.data() + queue.layout().input_desc_offset, &slot, sizeof(slot));
     storage.counters[0] = 1;
 
@@ -258,7 +260,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekPoisonsZeroByteDescriptorWithNonzeroOffset
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueDescSlot slot{};
-    l3_l2_queue_encode_desc(&slot, 1, L3L2QueueOpcode::DATA, 8, 0);
+    l3_l2_message_queue::encode_desc(&slot, 1, L3L2QueueOpcode::DATA, 8, 0);
     std::memcpy(storage.payload.data() + queue.layout().input_desc_offset, &slot, sizeof(slot));
     storage.counters[0] = 1;
 

--- a/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
@@ -539,4 +539,234 @@ TEST(L3L2MessageQueueTest, InputSecondPeekBeforeReleasePoisonsOwnershipAndSetsOw
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
 }
 
+TEST(L3L2MessageQueueTest, InvalidEndpointConfigSetsBadArgumentWithoutAbortFlag) {
+    RegionStorage zero_storage{};
+    RegionStorage too_large_storage{};
+    L3L2QueueArgs args = make_args(2, 64, 64);
+
+    L3L2QueueEndpoint zero(make_desc(&zero_storage, args), args, L3L2QueueEndpointConfig{0});
+    EXPECT_EQ(zero.error().kind, L3L2QueueErrorKind::BAD_ARGUMENT);
+    EXPECT_EQ(zero_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
+
+    L3L2QueueEndpoint too_large(make_desc(&too_large_storage, args), args, L3L2QueueEndpointConfig{3});
+    EXPECT_EQ(too_large.error().kind, L3L2QueueErrorKind::BAD_ARGUMENT);
+    EXPECT_EQ(too_large_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
+}
+
+TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsSeveralDataInputs) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{3});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 3, L3L2QueueOpcode::DATA);
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    L3L2QueueInputHandle third{};
+    EXPECT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    EXPECT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    EXPECT_TRUE(queue.input().try_peek(&third)) << queue.error().message;
+
+    EXPECT_EQ(first.seq, 1u);
+    EXPECT_EQ(second.seq, 2u);
+    EXPECT_EQ(third.seq, 3u);
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
+}
+
+TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsNonZeroPayloadOffsetsBeforeRelease) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{3});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    const uint64_t first_offset = queue.layout().input_arena_offset;
+    const uint64_t second_offset = first_offset + 16;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, first_offset, 16);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA, second_offset, 16);
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+
+    EXPECT_EQ(first.payload_offset, first_offset);
+    EXPECT_EQ(first.payload_nbytes, 16u);
+    EXPECT_EQ(second.payload_offset, second_offset);
+    EXPECT_EQ(second.payload_nbytes, 16u);
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
+}
+
+TEST(L3L2MessageQueueTest, ErrorCountsAgainstInputWindowAndFullDoesNotPoison) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::ERROR);
+    publish_input_desc(&storage, queue.layout(), 3, L3L2QueueOpcode::DATA);
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    L3L2QueueInputHandle third{};
+    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    EXPECT_FALSE(queue.input().try_peek(&third));
+
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
+}
+
+TEST(L3L2MessageQueueTest, OutOfOrderInputReleaseOnlyAdvancesCompletedFifoPrefix) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{3});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 3, L3L2QueueOpcode::DATA);
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    L3L2QueueInputHandle third{};
+    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&third)) << queue.error().message;
+
+    ASSERT_TRUE(queue.input().release(second)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
+
+    ASSERT_TRUE(queue.input().release(first)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 2);
+
+    ASSERT_TRUE(queue.input().release(third)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 3);
+}
+
+TEST(L3L2MessageQueueTest, StopDoesNotCountAgainstWindowAndDrainsAfterEarlierInputs) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 3, L3L2QueueOpcode::STOP);
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    L3L2QueueInputHandle stop{};
+    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
+    EXPECT_EQ(stop.opcode, L3L2QueueOpcode::STOP);
+
+    ASSERT_TRUE(queue.input().release(stop)) << queue.error().message;
+    EXPECT_FALSE(queue.input().drained());
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
+
+    ASSERT_TRUE(queue.input().release(first)) << queue.error().message;
+    EXPECT_FALSE(queue.input().drained());
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 1);
+
+    ASSERT_TRUE(queue.input().release(second)) << queue.error().message;
+    EXPECT_TRUE(queue.input().drained());
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 3);
+}
+
+TEST(L3L2MessageQueueTest, TryPeekAfterStopAcquireIsNoProgressWithoutPoison) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::STOP);
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle stop{};
+    L3L2QueueInputHandle later{};
+    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
+    EXPECT_FALSE(queue.input().try_peek(&later));
+
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
+}
+
+TEST(L3L2MessageQueueTest, StopAcquirePoisonsIfLaterInputAlreadyObserved) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::STOP);
+    publish_input_desc(&storage, queue.layout(), 3, L3L2QueueOpcode::DATA);
+
+    L3L2QueueInputHandle input{};
+    L3L2QueueInputHandle stop{};
+    ASSERT_TRUE(queue.input().try_peek(&input)) << queue.error().message;
+    EXPECT_FALSE(queue.input().try_peek(&stop));
+
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::INVALID_DESCRIPTOR);
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
+}
+
+TEST(L3L2MessageQueueTest, InputReleaseRejectsStaleAndDoubleRelease) {
+    RegionStorage stale_storage{};
+    RegionStorage double_storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+
+    L3L2QueueEndpoint stale_queue(make_desc(&stale_storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(stale_queue.error().kind, L3L2QueueErrorKind::NONE) << stale_queue.error().message;
+    publish_input_desc(&stale_storage, stale_queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&stale_storage, stale_queue.layout(), 2, L3L2QueueOpcode::DATA);
+    L3L2QueueInputHandle stale_first{};
+    L3L2QueueInputHandle stale_second{};
+    ASSERT_TRUE(stale_queue.input().try_peek(&stale_first)) << stale_queue.error().message;
+    ASSERT_TRUE(stale_queue.input().try_peek(&stale_second)) << stale_queue.error().message;
+    ASSERT_TRUE(stale_queue.input().release(stale_first)) << stale_queue.error().message;
+    ASSERT_TRUE(stale_queue.input().release(stale_second)) << stale_queue.error().message;
+    EXPECT_FALSE(stale_queue.input().release(stale_first));
+    EXPECT_EQ(stale_queue.error().kind, L3L2QueueErrorKind::OWNERSHIP);
+    EXPECT_EQ(stale_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
+
+    L3L2QueueEndpoint double_queue(make_desc(&double_storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(double_queue.error().kind, L3L2QueueErrorKind::NONE) << double_queue.error().message;
+    publish_input_desc(&double_storage, double_queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&double_storage, double_queue.layout(), 2, L3L2QueueOpcode::DATA);
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    ASSERT_TRUE(double_queue.input().try_peek(&first)) << double_queue.error().message;
+    ASSERT_TRUE(double_queue.input().try_peek(&second)) << double_queue.error().message;
+    ASSERT_TRUE(double_queue.input().release(second)) << double_queue.error().message;
+    EXPECT_FALSE(double_queue.input().release(second));
+    EXPECT_EQ(double_queue.error().kind, L3L2QueueErrorKind::OWNERSHIP);
+    EXPECT_EQ(double_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
+}
+
+TEST(L3L2MessageQueueTest, OutputReservePublishWorksDuringStopDrain) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+    publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
+    publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::STOP);
+
+    L3L2QueueInputHandle input{};
+    L3L2QueueInputHandle stop{};
+    ASSERT_TRUE(queue.input().try_peek(&input)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
+    ASSERT_TRUE(queue.input().release(stop)) << queue.error().message;
+
+    L3L2QueueOutputReservation reservation{};
+    ASSERT_TRUE(queue.output().try_reserve(16, &reservation)) << queue.error().message;
+    ASSERT_TRUE(queue.output().publish(reservation, L3L2QueueOpcode::DATA)) << queue.error().message;
+
+    EXPECT_FALSE(queue.input().drained());
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_OUTPUT_DESC_TAIL_OFFSET)], 1);
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
+}
+
 }  // namespace

--- a/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
@@ -159,12 +159,15 @@ TEST(L3L2MessageQueueTest, LayoutOverflowFailsClosedWithoutModifyingOutput) {
 TEST(L3L2MessageQueueTest, DescriptorSlotEncodingIsStable) {
     static_assert(std::is_standard_layout<L3L2QueueDescSlot>::value, "descriptor must be POD-like");
     static_assert(std::is_trivially_copyable<L3L2QueueDescSlot>::value, "descriptor must be fixed-size");
+    static_assert(std::is_standard_layout<L3L2QueueError>::value, "error must be POD-like");
+    static_assert(std::is_trivially_copyable<L3L2QueueError>::value, "error must be fixed-size");
 
     EXPECT_EQ(sizeof(L3L2QueueDescSlot), 32u);
     EXPECT_EQ(offsetof(L3L2QueueDescSlot, seq), 0u);
     EXPECT_EQ(offsetof(L3L2QueueDescSlot, opcode), 8u);
     EXPECT_EQ(offsetof(L3L2QueueDescSlot, payload_offset), 16u);
     EXPECT_EQ(offsetof(L3L2QueueDescSlot, payload_nbytes), 24u);
+    EXPECT_EQ(sizeof(L3L2QueueError::message), 256u);
 
     L3L2QueueDescSlot slot{};
     l3_l2_queue_encode_desc(&slot, 7, L3L2QueueOpcode::ERROR, 128, 16);
@@ -172,6 +175,28 @@ TEST(L3L2MessageQueueTest, DescriptorSlotEncodingIsStable) {
     EXPECT_EQ(slot.opcode, 3u);
     EXPECT_EQ(slot.payload_offset, 128u);
     EXPECT_EQ(slot.payload_nbytes, 16u);
+}
+
+TEST(L3L2MessageQueueTest, ErrorOperationStringsAndMessageCopyAreStable) {
+    EXPECT_STREQ(l3_l2_queue_op_to_string(L3L2QueueOp::INIT), "init");
+    EXPECT_STREQ(l3_l2_queue_op_to_string(L3L2QueueOp::INPUT_TRY_PEEK), "input.try_peek");
+    EXPECT_STREQ(l3_l2_queue_op_to_string(L3L2QueueOp::INPUT_RELEASE), "input.release");
+    EXPECT_STREQ(l3_l2_queue_op_to_string(L3L2QueueOp::OUTPUT_TRY_RESERVE), "output.try_reserve");
+    EXPECT_STREQ(l3_l2_queue_op_to_string(L3L2QueueOp::OUTPUT_PUBLISH), "output.publish");
+    EXPECT_STREQ(l3_l2_queue_op_to_string(L3L2QueueOp::TIMEOUT), "timeout");
+    EXPECT_STREQ(l3_l2_queue_op_to_string(static_cast<L3L2QueueOp>(99)), "unknown");
+
+    char message[256];
+    l3_l2_orch_comm::copy_error_message(message, sizeof(message), nullptr);
+    EXPECT_STREQ(message, "");
+
+    std::array<char, 300> long_message{};
+    long_message.fill('x');
+    long_message.back() = '\0';
+    l3_l2_orch_comm::copy_error_message(message, sizeof(message), long_message.data());
+    EXPECT_EQ(std::strlen(message), sizeof(message) - 1);
+    EXPECT_EQ(message[254], 'x');
+    EXPECT_EQ(message[255], '\0');
 }
 
 TEST(L3L2MessageQueueTest, Low32ReconstructionAcceptsWrapAndRejectsImpossibleDeltas) {
@@ -198,7 +223,7 @@ TEST(L3L2MessageQueueTest, Low32ReconstructionAcceptsWrapAndRejectsImpossibleDel
 TEST(L3L2MessageQueueTest, L2InputPeekHandlesZeroByteDescriptorBeforeArenaValidation) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueDescSlot slot{};
@@ -220,7 +245,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekHandlesZeroByteDescriptorBeforeArenaValida
 TEST(L3L2MessageQueueTest, L2InputPeekPoisonsZeroByteDescriptorWithNonzeroOffset) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueDescSlot slot{};
@@ -238,7 +263,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekPoisonsZeroByteDescriptorWithNonzeroOffset
 TEST(L3L2MessageQueueTest, L2InputPeekExposesNonzeroPayloadBytes) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     const std::array<uint8_t, 4> payload{{0x11, 0x22, 0x33, 0x44}};
     std::memcpy(storage.payload.data() + queue.layout().input_arena_offset, payload.data(), payload.size());
@@ -259,7 +284,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekExposesNonzeroPayloadBytes) {
 TEST(L3L2MessageQueueTest, L2InputPeekAllowsArenaWrapAtExpectedPayloadHead) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 128, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset, 80);
@@ -280,7 +305,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekAllowsArenaWrapAtExpectedPayloadHead) {
 TEST(L3L2MessageQueueTest, L2InputPeekRejectsPayloadOffsetMismatchBeforeRelease) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 128, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset + 64, 16);
 
@@ -295,7 +320,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekRejectsPayloadOffsetMismatchBeforeRelease)
 TEST(L3L2MessageQueueTest, L2OutputReservePublishWritesDescriptorAndTail) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
@@ -316,7 +341,7 @@ TEST(L3L2MessageQueueTest, L2OutputReservePublishWritesDescriptorAndTail) {
 TEST(L3L2MessageQueueTest, L2OutputReserveReplaysReleasedDescriptorsBeforeReusingArena) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 64, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation first{};
@@ -334,7 +359,7 @@ TEST(L3L2MessageQueueTest, L2OutputReserveReplaysReleasedDescriptorsBeforeReusin
 TEST(L3L2MessageQueueTest, RemoteAbortObservationDoesNotSetOwnAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     storage.counters[64] = 1;
 
@@ -347,7 +372,7 @@ TEST(L3L2MessageQueueTest, RemoteAbortObservationDoesNotSetOwnAbortFlag) {
 TEST(L3L2MessageQueueTest, OrdinaryTimeoutDoesNotSetOwnAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     EXPECT_EQ(queue.disambiguate_timeout(), L3L2QueueTimeoutStatus::ORDINARY_TIMEOUT);
@@ -359,7 +384,7 @@ TEST(L3L2MessageQueueTest, OrdinaryTimeoutDoesNotSetOwnAbortFlag) {
 TEST(L3L2MessageQueueTest, OutputCapacityEqualsDepthAndFullIsNoProgressWithoutAbort) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     for (int i = 0; i < 2; ++i) {
@@ -378,7 +403,7 @@ TEST(L3L2MessageQueueTest, OutputCapacityEqualsDepthAndFullIsNoProgressWithoutAb
 TEST(L3L2MessageQueueTest, FullAndEmptyUseMonotonicCountersNotMaskedIndices) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     for (int i = 0; i < 2; ++i) {
@@ -401,7 +426,7 @@ TEST(L3L2MessageQueueTest, FullAndEmptyUseMonotonicCountersNotMaskedIndices) {
 TEST(L3L2MessageQueueTest, OutputReserveTooLargeIsPreMutationNoProgressWithoutAbort) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
@@ -415,7 +440,7 @@ TEST(L3L2MessageQueueTest, OutputReserveTooLargeIsPreMutationNoProgressWithoutAb
 TEST(L3L2MessageQueueTest, OutputPublishApplicationErrorDoesNotSetAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
@@ -432,7 +457,7 @@ TEST(L3L2MessageQueueTest, OutputPublishApplicationErrorDoesNotSetAbortFlag) {
 TEST(L3L2MessageQueueTest, OutputPublishStaleReservationPoisonsAndSetsOwnAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
@@ -447,7 +472,7 @@ TEST(L3L2MessageQueueTest, OutputPublishStaleReservationPoisonsAndSetsOwnAbortFl
 TEST(L3L2MessageQueueTest, InputApplicationErrorIsNormalMessageAndDoesNotSetAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::ERROR);
 
@@ -463,7 +488,7 @@ TEST(L3L2MessageQueueTest, InputApplicationErrorIsNormalMessageAndDoesNotSetAbor
 TEST(L3L2MessageQueueTest, InputReleaseRejectsCallerMutatedHandleMetadata) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset, 16);
 
@@ -481,7 +506,7 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsCallerMutatedHandleMetadata) {
 TEST(L3L2MessageQueueTest, InputStopReleaseRejectsLaterPublishedInputAsInvalidState) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::STOP);
 
@@ -500,7 +525,7 @@ TEST(L3L2MessageQueueTest, InputStopReleaseRejectsLaterPublishedInputAsInvalidSt
 TEST(L3L2MessageQueueTest, InputStopWithPayloadMetadataPoisonsAndSetsOwnAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::STOP, queue.layout().input_arena_offset, 8);
 
@@ -514,7 +539,7 @@ TEST(L3L2MessageQueueTest, InputStopWithPayloadMetadataPoisonsAndSetsOwnAbortFla
 TEST(L3L2MessageQueueTest, NullInputPeekOutputIsPreMutationRejectionWithoutAbort) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     EXPECT_FALSE(queue.input().try_peek(nullptr));
@@ -526,7 +551,7 @@ TEST(L3L2MessageQueueTest, NullInputPeekOutputIsPreMutationRejectionWithoutAbort
 TEST(L3L2MessageQueueTest, InputSecondPeekBeforeReleasePoisonsOwnershipAndSetsOwnAbortFlag) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args);
+    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
 
@@ -536,27 +561,25 @@ TEST(L3L2MessageQueueTest, InputSecondPeekBeforeReleasePoisonsOwnershipAndSetsOw
     EXPECT_FALSE(queue.input().try_peek(&second));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::OWNERSHIP);
+    EXPECT_EQ(queue.error().op, L3L2QueueOp::INPUT_TRY_PEEK);
+    EXPECT_STREQ(l3_l2_queue_op_to_string(queue.error().op), "input.try_peek");
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
 }
 
-TEST(L3L2MessageQueueTest, InvalidEndpointConfigSetsBadArgumentWithoutAbortFlag) {
-    RegionStorage zero_storage{};
+TEST(L3L2MessageQueueTest, MaxInflightGreaterThanDepthSetsBadArgumentWithoutAbortFlag) {
     RegionStorage too_large_storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
 
-    L3L2QueueEndpoint zero(make_desc(&zero_storage, args), args, L3L2QueueEndpointConfig{0});
-    EXPECT_EQ(zero.error().kind, L3L2QueueErrorKind::BAD_ARGUMENT);
-    EXPECT_EQ(zero_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
-
-    L3L2QueueEndpoint too_large(make_desc(&too_large_storage, args), args, L3L2QueueEndpointConfig{3});
+    L3L2QueueEndpoint<3> too_large(make_desc(&too_large_storage, args), args);
     EXPECT_EQ(too_large.error().kind, L3L2QueueErrorKind::BAD_ARGUMENT);
+    EXPECT_EQ(too_large.error().op, L3L2QueueOp::INIT);
     EXPECT_EQ(too_large_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
 }
 
 TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsSeveralDataInputs) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{3});
+    L3L2QueueEndpoint<3> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
@@ -579,7 +602,7 @@ TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsSeveralDataInputs) {
 TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsNonZeroPayloadOffsetsBeforeRelease) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{3});
+    L3L2QueueEndpoint<3> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     const uint64_t first_offset = queue.layout().input_arena_offset;
     const uint64_t second_offset = first_offset + 16;
@@ -602,7 +625,7 @@ TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsNonZeroPayloadOffsetsBefore
 TEST(L3L2MessageQueueTest, ErrorCountsAgainstInputWindowAndFullDoesNotPoison) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::ERROR);
@@ -623,7 +646,7 @@ TEST(L3L2MessageQueueTest, ErrorCountsAgainstInputWindowAndFullDoesNotPoison) {
 TEST(L3L2MessageQueueTest, OutOfOrderInputReleaseOnlyAdvancesCompletedFifoPrefix) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{3});
+    L3L2QueueEndpoint<3> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
@@ -646,10 +669,51 @@ TEST(L3L2MessageQueueTest, OutOfOrderInputReleaseOnlyAdvancesCompletedFifoPrefix
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 3);
 }
 
+TEST(L3L2MessageQueueTest, RingWrapReleaseKeepsLogicalFifoOrder) {
+    RegionStorage storage{};
+    L3L2QueueArgs args = make_args(4, 128, 128);
+    L3L2QueueEndpoint<3> queue(make_desc(&storage, args), args);
+    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
+
+    for (uint64_t seq = 1; seq <= 3; ++seq) {
+        publish_input_desc(&storage, queue.layout(), seq, L3L2QueueOpcode::DATA);
+    }
+
+    L3L2QueueInputHandle first{};
+    L3L2QueueInputHandle second{};
+    L3L2QueueInputHandle third{};
+    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&third)) << queue.error().message;
+    ASSERT_TRUE(queue.input().release(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().release(second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().release(third)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 3);
+
+    for (uint64_t seq = 4; seq <= 6; ++seq) {
+        publish_input_desc(&storage, queue.layout(), seq, L3L2QueueOpcode::DATA);
+    }
+
+    L3L2QueueInputHandle fourth{};
+    L3L2QueueInputHandle fifth{};
+    L3L2QueueInputHandle sixth{};
+    ASSERT_TRUE(queue.input().try_peek(&fourth)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&fifth)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(&sixth)) << queue.error().message;
+
+    ASSERT_TRUE(queue.input().release(fifth)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 3);
+    ASSERT_TRUE(queue.input().release(fourth)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 5);
+    ASSERT_TRUE(queue.input().release(sixth)) << queue.error().message;
+    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 6);
+    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
+}
+
 TEST(L3L2MessageQueueTest, StopDoesNotCountAgainstWindowAndDrainsAfterEarlierInputs) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
@@ -679,7 +743,7 @@ TEST(L3L2MessageQueueTest, StopDoesNotCountAgainstWindowAndDrainsAfterEarlierInp
 TEST(L3L2MessageQueueTest, TryPeekAfterStopAcquireIsNoProgressWithoutPoison) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::STOP);
@@ -698,7 +762,7 @@ TEST(L3L2MessageQueueTest, TryPeekAfterStopAcquireIsNoProgressWithoutPoison) {
 TEST(L3L2MessageQueueTest, StopAcquirePoisonsIfLaterInputAlreadyObserved) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::STOP);
@@ -718,7 +782,7 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsStaleAndDoubleRelease) {
     RegionStorage double_storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
 
-    L3L2QueueEndpoint stale_queue(make_desc(&stale_storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> stale_queue(make_desc(&stale_storage, args), args);
     ASSERT_EQ(stale_queue.error().kind, L3L2QueueErrorKind::NONE) << stale_queue.error().message;
     publish_input_desc(&stale_storage, stale_queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&stale_storage, stale_queue.layout(), 2, L3L2QueueOpcode::DATA);
@@ -732,7 +796,7 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsStaleAndDoubleRelease) {
     EXPECT_EQ(stale_queue.error().kind, L3L2QueueErrorKind::OWNERSHIP);
     EXPECT_EQ(stale_storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
 
-    L3L2QueueEndpoint double_queue(make_desc(&double_storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> double_queue(make_desc(&double_storage, args), args);
     ASSERT_EQ(double_queue.error().kind, L3L2QueueErrorKind::NONE) << double_queue.error().message;
     publish_input_desc(&double_storage, double_queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&double_storage, double_queue.layout(), 2, L3L2QueueOpcode::DATA);
@@ -749,7 +813,7 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsStaleAndDoubleRelease) {
 TEST(L3L2MessageQueueTest, OutputReservePublishWorksDuringStopDrain) {
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(4, 128, 128);
-    L3L2QueueEndpoint queue(make_desc(&storage, args), args, L3L2QueueEndpointConfig{2});
+    L3L2QueueEndpoint<2> queue(make_desc(&storage, args), args);
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::STOP);

--- a/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_message_queue.cpp
@@ -42,9 +42,9 @@ size_t counter_index(uint64_t offset) { return static_cast<size_t>(offset / size
 
 L3L2QueueArgs make_args(uint64_t depth, uint64_t input_arena_bytes, uint64_t output_arena_bytes) {
     L3L2QueueLayout layout{};
-    EXPECT_TRUE(l3_l2_queue_make_layout(depth, input_arena_bytes, output_arena_bytes, &layout));
+    EXPECT_TRUE(l3_l2_queue_make_layout(depth, input_arena_bytes, output_arena_bytes, layout));
     return L3L2QueueArgs{
-        l3_l2_queue_magic_version(), depth, input_arena_bytes, output_arena_bytes, layout.payload_bytes,
+        L3L2_QUEUE_MAGIC_VERSION, depth, input_arena_bytes, output_arena_bytes, layout.payload_bytes,
         layout.counter_bytes,
     };
 }
@@ -64,10 +64,19 @@ void publish_input_desc(
     storage->counters[counter_index(layout.input_desc_tail_offset)] = static_cast<int32_t>(seq);
 }
 
+TEST(L3L2MessageQueueTest, MagicVersionConstantMatchesCompatibilityWrapper) {
+    EXPECT_EQ(
+        L3L2_QUEUE_MAGIC_VERSION,
+        l3_l2_orch_comm_pack_magic_version(L3L2_QUEUE_MAGIC, L3L2_QUEUE_ABI_MAJOR, L3L2_QUEUE_ABI_MINOR)
+    );
+    EXPECT_EQ(l3_l2_queue_magic_version(), L3L2_QUEUE_MAGIC_VERSION);
+    EXPECT_EQ(l3_l2_message_queue::magic_version(), L3L2_QUEUE_MAGIC_VERSION);
+}
+
 TEST(L3L2MessageQueueTest, LayoutAssignsPayloadAndAbortCounterOffsets) {
     L3L2QueueLayout layout{};
 
-    ASSERT_TRUE(l3_l2_queue_make_layout(4, 128, 192, &layout));
+    ASSERT_TRUE(l3_l2_queue_make_layout(4, 128, 192, layout));
 
     EXPECT_EQ(layout.input_desc_offset, 0u);
     EXPECT_EQ(layout.output_desc_offset, 4u * sizeof(L3L2QueueDescSlot));
@@ -103,7 +112,7 @@ TEST(L3L2MessageQueueTest, LayoutLockstepCasesMatchPythonMirrorExpectations) {
     for (const auto &test_case : cases) {
         L3L2QueueLayout layout{};
         ASSERT_TRUE(
-            l3_l2_queue_make_layout(test_case.depth, test_case.input_arena_bytes, test_case.output_arena_bytes, &layout)
+            l3_l2_queue_make_layout(test_case.depth, test_case.input_arena_bytes, test_case.output_arena_bytes, layout)
         );
 
         EXPECT_EQ(layout.input_desc_offset, 0u);
@@ -125,10 +134,10 @@ TEST(L3L2MessageQueueTest, LayoutLockstepCasesMatchPythonMirrorExpectations) {
 TEST(L3L2MessageQueueTest, LayoutRejectsInvalidDepthArenaAndCounterBytes) {
     L3L2QueueLayout layout{};
 
-    EXPECT_FALSE(l3_l2_queue_make_layout(3, 64, 64, &layout));
-    EXPECT_FALSE(l3_l2_queue_make_layout((1ull << 30) + 1, 64, 64, &layout));
-    EXPECT_FALSE(l3_l2_queue_make_layout(2, 0, 64, &layout));
-    EXPECT_FALSE(l3_l2_queue_make_layout(2, 65, 64, &layout));
+    EXPECT_FALSE(l3_l2_queue_make_layout(3, 64, 64, layout));
+    EXPECT_FALSE(l3_l2_queue_make_layout((1ull << 30) + 1, 64, 64, layout));
+    EXPECT_FALSE(l3_l2_queue_make_layout(2, 0, 64, layout));
+    EXPECT_FALSE(l3_l2_queue_make_layout(2, 65, 64, layout));
 
     RegionStorage storage{};
     L3L2QueueArgs args = make_args(2, 64, 64);
@@ -143,7 +152,7 @@ TEST(L3L2MessageQueueTest, LayoutOverflowFailsClosedWithoutModifyingOutput) {
     };
     const L3L2QueueLayout original = layout;
 
-    EXPECT_FALSE(l3_l2_queue_make_layout(2, std::numeric_limits<uint64_t>::max() - 63, 64, &layout));
+    EXPECT_FALSE(l3_l2_queue_make_layout(2, std::numeric_limits<uint64_t>::max() - 63, 64, layout));
 
     EXPECT_EQ(layout.depth, original.depth);
     EXPECT_EQ(layout.input_desc_offset, original.input_desc_offset);
@@ -202,22 +211,22 @@ TEST(L3L2MessageQueueTest, ErrorOperationStringsAndMessageCopyAreStable) {
 TEST(L3L2MessageQueueTest, Low32ReconstructionAcceptsWrapAndRejectsImpossibleDeltas) {
     uint64_t value = 0xFFFF'FFFFull;
 
-    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(0, 4, &value));
+    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(0, 4, value));
     EXPECT_EQ(value, 0x1'0000'0000ull);
 
     value = (1ull << 31) - 2;
-    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(static_cast<int32_t>(0x8000'0001u), 4, &value));
+    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(static_cast<int32_t>(0x8000'0001u), 4, value));
     EXPECT_EQ(value, (1ull << 31) + 1);
 
     value = 100;
-    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(104, 4, &value));
+    EXPECT_TRUE(l3_l2_queue_reconstruct_counter(104, 4, value));
     EXPECT_EQ(value, 104u);
 
     value = 100;
-    EXPECT_FALSE(l3_l2_queue_reconstruct_counter(99, 4, &value));
+    EXPECT_FALSE(l3_l2_queue_reconstruct_counter(99, 4, value));
 
     value = 100;
-    EXPECT_FALSE(l3_l2_queue_reconstruct_counter(105, 4, &value));
+    EXPECT_FALSE(l3_l2_queue_reconstruct_counter(105, 4, value));
 }
 
 TEST(L3L2MessageQueueTest, L2InputPeekHandlesZeroByteDescriptorBeforeArenaValidation) {
@@ -232,7 +241,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekHandlesZeroByteDescriptorBeforeArenaValida
     storage.counters[0] = 1;
 
     L3L2QueueInputHandle handle{};
-    ASSERT_TRUE(queue.input().try_peek(&handle)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(handle)) << queue.error().message;
 
     EXPECT_EQ(handle.seq, 1u);
     EXPECT_EQ(handle.opcode, L3L2QueueOpcode::DATA);
@@ -254,7 +263,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekPoisonsZeroByteDescriptorWithNonzeroOffset
     storage.counters[0] = 1;
 
     L3L2QueueInputHandle handle{};
-    EXPECT_FALSE(queue.input().try_peek(&handle));
+    EXPECT_FALSE(queue.input().try_peek(handle));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::INVALID_DESCRIPTOR);
     EXPECT_EQ(storage.counters[80], 1);
@@ -272,7 +281,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekExposesNonzeroPayloadBytes) {
     );
 
     L3L2QueueInputHandle handle{};
-    ASSERT_TRUE(queue.input().try_peek(&handle)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(handle)) << queue.error().message;
 
     ASSERT_EQ(handle.payload_nbytes, payload.size());
     const auto *observed = reinterpret_cast<const uint8_t *>(static_cast<uintptr_t>(handle.payload.gm_addr));
@@ -289,12 +298,12 @@ TEST(L3L2MessageQueueTest, L2InputPeekAllowsArenaWrapAtExpectedPayloadHead) {
 
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset, 80);
     L3L2QueueInputHandle first{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
     ASSERT_TRUE(queue.input().release(first)) << queue.error().message;
 
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset, 64);
     L3L2QueueInputHandle second{};
-    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(second)) << queue.error().message;
 
     EXPECT_EQ(second.payload_offset, queue.layout().input_arena_offset);
     EXPECT_EQ(second.payload_nbytes, 64u);
@@ -310,7 +319,7 @@ TEST(L3L2MessageQueueTest, L2InputPeekRejectsPayloadOffsetMismatchBeforeRelease)
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset + 64, 16);
 
     L3L2QueueInputHandle handle{};
-    EXPECT_FALSE(queue.input().try_peek(&handle));
+    EXPECT_FALSE(queue.input().try_peek(handle));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::INVALID_DESCRIPTOR);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
@@ -324,7 +333,7 @@ TEST(L3L2MessageQueueTest, L2OutputReservePublishWritesDescriptorAndTail) {
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
-    ASSERT_TRUE(queue.output().try_reserve(16, &reservation)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(16, reservation)) << queue.error().message;
     EXPECT_EQ(reservation.payload_nbytes, 16u);
     EXPECT_NE(reservation.payload.gm_addr, 0u);
 
@@ -345,13 +354,13 @@ TEST(L3L2MessageQueueTest, L2OutputReserveReplaysReleasedDescriptorsBeforeReusin
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation first{};
-    ASSERT_TRUE(queue.output().try_reserve(80, &first)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(80, first)) << queue.error().message;
     ASSERT_EQ(first.payload_offset, queue.layout().output_arena_offset);
     ASSERT_TRUE(queue.output().publish(first, L3L2QueueOpcode::DATA)) << queue.error().message;
 
     storage.counters[48] = 1;
     L3L2QueueOutputReservation second{};
-    ASSERT_TRUE(queue.output().try_reserve(80, &second)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(80, second)) << queue.error().message;
 
     EXPECT_EQ(second.payload_offset, queue.layout().output_arena_offset);
 }
@@ -389,11 +398,11 @@ TEST(L3L2MessageQueueTest, OutputCapacityEqualsDepthAndFullIsNoProgressWithoutAb
 
     for (int i = 0; i < 2; ++i) {
         L3L2QueueOutputReservation reservation{};
-        ASSERT_TRUE(queue.output().try_reserve(0, &reservation)) << queue.error().message;
+        ASSERT_TRUE(queue.output().try_reserve(0, reservation)) << queue.error().message;
         ASSERT_TRUE(queue.output().publish(reservation, L3L2QueueOpcode::DATA)) << queue.error().message;
     }
     L3L2QueueOutputReservation third{};
-    EXPECT_FALSE(queue.output().try_reserve(0, &third));
+    EXPECT_FALSE(queue.output().try_reserve(0, third));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_OUTPUT_DESC_TAIL_OFFSET)], 2);
@@ -408,13 +417,13 @@ TEST(L3L2MessageQueueTest, FullAndEmptyUseMonotonicCountersNotMaskedIndices) {
 
     for (int i = 0; i < 2; ++i) {
         L3L2QueueOutputReservation reservation{};
-        ASSERT_TRUE(queue.output().try_reserve(0, &reservation)) << queue.error().message;
+        ASSERT_TRUE(queue.output().try_reserve(0, reservation)) << queue.error().message;
         ASSERT_TRUE(queue.output().publish(reservation, L3L2QueueOpcode::DATA)) << queue.error().message;
     }
     storage.counters[counter_index(L3L2_QUEUE_OUTPUT_DESC_HEAD_OFFSET)] = 1;
 
     L3L2QueueOutputReservation third{};
-    ASSERT_TRUE(queue.output().try_reserve(0, &third)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(0, third)) << queue.error().message;
     ASSERT_TRUE(queue.output().publish(third, L3L2QueueOpcode::DATA)) << queue.error().message;
 
     EXPECT_EQ(third.seq, 3u);
@@ -430,7 +439,7 @@ TEST(L3L2MessageQueueTest, OutputReserveTooLargeIsPreMutationNoProgressWithoutAb
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
-    EXPECT_FALSE(queue.output().try_reserve(65, &reservation));
+    EXPECT_FALSE(queue.output().try_reserve(65, reservation));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_OUTPUT_DESC_TAIL_OFFSET)], 0);
@@ -444,7 +453,7 @@ TEST(L3L2MessageQueueTest, OutputPublishApplicationErrorDoesNotSetAbortFlag) {
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
-    ASSERT_TRUE(queue.output().try_reserve(0, &reservation)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(0, reservation)) << queue.error().message;
     ASSERT_TRUE(queue.output().publish(reservation, L3L2QueueOpcode::ERROR)) << queue.error().message;
 
     L3L2QueueDescSlot slot{};
@@ -461,7 +470,7 @@ TEST(L3L2MessageQueueTest, OutputPublishStaleReservationPoisonsAndSetsOwnAbortFl
     ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
-    ASSERT_TRUE(queue.output().try_reserve(0, &reservation)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(0, reservation)) << queue.error().message;
     ASSERT_TRUE(queue.output().publish(reservation, L3L2QueueOpcode::DATA)) << queue.error().message;
     EXPECT_FALSE(queue.output().publish(reservation, L3L2QueueOpcode::DATA));
 
@@ -477,7 +486,7 @@ TEST(L3L2MessageQueueTest, InputApplicationErrorIsNormalMessageAndDoesNotSetAbor
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::ERROR);
 
     L3L2QueueInputHandle handle{};
-    ASSERT_TRUE(queue.input().try_peek(&handle)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(handle)) << queue.error().message;
     EXPECT_EQ(handle.opcode, L3L2QueueOpcode::ERROR);
     ASSERT_TRUE(queue.input().release(handle)) << queue.error().message;
 
@@ -493,7 +502,7 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsCallerMutatedHandleMetadata) {
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA, queue.layout().input_arena_offset, 16);
 
     L3L2QueueInputHandle handle{};
-    ASSERT_TRUE(queue.input().try_peek(&handle)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(handle)) << queue.error().message;
     handle.payload_nbytes = 0;
 
     EXPECT_FALSE(queue.input().release(handle));
@@ -511,12 +520,12 @@ TEST(L3L2MessageQueueTest, InputStopReleaseRejectsLaterPublishedInputAsInvalidSt
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::STOP);
 
     L3L2QueueInputHandle stop{};
-    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(stop)) << queue.error().message;
     ASSERT_TRUE(queue.input().release(stop)) << queue.error().message;
 
     publish_input_desc(&storage, queue.layout(), 2, L3L2QueueOpcode::DATA);
     L3L2QueueInputHandle later{};
-    EXPECT_FALSE(queue.input().try_peek(&later));
+    EXPECT_FALSE(queue.input().try_peek(later));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::INVALID_DESCRIPTOR);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
@@ -530,22 +539,10 @@ TEST(L3L2MessageQueueTest, InputStopWithPayloadMetadataPoisonsAndSetsOwnAbortFla
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::STOP, queue.layout().input_arena_offset, 8);
 
     L3L2QueueInputHandle handle{};
-    EXPECT_FALSE(queue.input().try_peek(&handle));
+    EXPECT_FALSE(queue.input().try_peek(handle));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::INVALID_DESCRIPTOR);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
-}
-
-TEST(L3L2MessageQueueTest, NullInputPeekOutputIsPreMutationRejectionWithoutAbort) {
-    RegionStorage storage{};
-    L3L2QueueArgs args = make_args(2, 64, 64);
-    L3L2QueueEndpoint<> queue(make_desc(&storage, args), args);
-    ASSERT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE) << queue.error().message;
-
-    EXPECT_FALSE(queue.input().try_peek(nullptr));
-
-    EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
-    EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
 }
 
 TEST(L3L2MessageQueueTest, InputSecondPeekBeforeReleasePoisonsOwnershipAndSetsOwnAbortFlag) {
@@ -556,9 +553,9 @@ TEST(L3L2MessageQueueTest, InputSecondPeekBeforeReleasePoisonsOwnershipAndSetsOw
     publish_input_desc(&storage, queue.layout(), 1, L3L2QueueOpcode::DATA);
 
     L3L2QueueInputHandle handle{};
-    ASSERT_TRUE(queue.input().try_peek(&handle)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(handle)) << queue.error().message;
     L3L2QueueInputHandle second{};
-    EXPECT_FALSE(queue.input().try_peek(&second));
+    EXPECT_FALSE(queue.input().try_peek(second));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::OWNERSHIP);
     EXPECT_EQ(queue.error().op, L3L2QueueOp::INPUT_TRY_PEEK);
@@ -588,9 +585,9 @@ TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsSeveralDataInputs) {
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
     L3L2QueueInputHandle third{};
-    EXPECT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    EXPECT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
-    EXPECT_TRUE(queue.input().try_peek(&third)) << queue.error().message;
+    EXPECT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    EXPECT_TRUE(queue.input().try_peek(second)) << queue.error().message;
+    EXPECT_TRUE(queue.input().try_peek(third)) << queue.error().message;
 
     EXPECT_EQ(first.seq, 1u);
     EXPECT_EQ(second.seq, 2u);
@@ -611,8 +608,8 @@ TEST(L3L2MessageQueueTest, MultiInflightAcquireAllowsNonZeroPayloadOffsetsBefore
 
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(second)) << queue.error().message;
 
     EXPECT_EQ(first.payload_offset, first_offset);
     EXPECT_EQ(first.payload_nbytes, 16u);
@@ -634,9 +631,9 @@ TEST(L3L2MessageQueueTest, ErrorCountsAgainstInputWindowAndFullDoesNotPoison) {
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
     L3L2QueueInputHandle third{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
-    EXPECT_FALSE(queue.input().try_peek(&third));
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(second)) << queue.error().message;
+    EXPECT_FALSE(queue.input().try_peek(third));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
@@ -655,9 +652,9 @@ TEST(L3L2MessageQueueTest, OutOfOrderInputReleaseOnlyAdvancesCompletedFifoPrefix
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
     L3L2QueueInputHandle third{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&third)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(third)) << queue.error().message;
 
     ASSERT_TRUE(queue.input().release(second)) << queue.error().message;
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 0);
@@ -682,9 +679,9 @@ TEST(L3L2MessageQueueTest, RingWrapReleaseKeepsLogicalFifoOrder) {
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
     L3L2QueueInputHandle third{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&third)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(third)) << queue.error().message;
     ASSERT_TRUE(queue.input().release(first)) << queue.error().message;
     ASSERT_TRUE(queue.input().release(second)) << queue.error().message;
     ASSERT_TRUE(queue.input().release(third)) << queue.error().message;
@@ -697,9 +694,9 @@ TEST(L3L2MessageQueueTest, RingWrapReleaseKeepsLogicalFifoOrder) {
     L3L2QueueInputHandle fourth{};
     L3L2QueueInputHandle fifth{};
     L3L2QueueInputHandle sixth{};
-    ASSERT_TRUE(queue.input().try_peek(&fourth)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&fifth)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&sixth)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(fourth)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(fifth)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(sixth)) << queue.error().message;
 
     ASSERT_TRUE(queue.input().release(fifth)) << queue.error().message;
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_INPUT_DESC_HEAD_OFFSET)], 3);
@@ -722,9 +719,9 @@ TEST(L3L2MessageQueueTest, StopDoesNotCountAgainstWindowAndDrainsAfterEarlierInp
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
     L3L2QueueInputHandle stop{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&second)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(second)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(stop)) << queue.error().message;
     EXPECT_EQ(stop.opcode, L3L2QueueOpcode::STOP);
 
     ASSERT_TRUE(queue.input().release(stop)) << queue.error().message;
@@ -751,9 +748,9 @@ TEST(L3L2MessageQueueTest, TryPeekAfterStopAcquireIsNoProgressWithoutPoison) {
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle stop{};
     L3L2QueueInputHandle later{};
-    ASSERT_TRUE(queue.input().try_peek(&first)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
-    EXPECT_FALSE(queue.input().try_peek(&later));
+    ASSERT_TRUE(queue.input().try_peek(first)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(stop)) << queue.error().message;
+    EXPECT_FALSE(queue.input().try_peek(later));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::NONE);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 0);
@@ -770,8 +767,8 @@ TEST(L3L2MessageQueueTest, StopAcquirePoisonsIfLaterInputAlreadyObserved) {
 
     L3L2QueueInputHandle input{};
     L3L2QueueInputHandle stop{};
-    ASSERT_TRUE(queue.input().try_peek(&input)) << queue.error().message;
-    EXPECT_FALSE(queue.input().try_peek(&stop));
+    ASSERT_TRUE(queue.input().try_peek(input)) << queue.error().message;
+    EXPECT_FALSE(queue.input().try_peek(stop));
 
     EXPECT_EQ(queue.error().kind, L3L2QueueErrorKind::INVALID_DESCRIPTOR);
     EXPECT_EQ(storage.counters[counter_index(L3L2_QUEUE_L2_ABORT_FLAG_OFFSET)], 1);
@@ -788,8 +785,8 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsStaleAndDoubleRelease) {
     publish_input_desc(&stale_storage, stale_queue.layout(), 2, L3L2QueueOpcode::DATA);
     L3L2QueueInputHandle stale_first{};
     L3L2QueueInputHandle stale_second{};
-    ASSERT_TRUE(stale_queue.input().try_peek(&stale_first)) << stale_queue.error().message;
-    ASSERT_TRUE(stale_queue.input().try_peek(&stale_second)) << stale_queue.error().message;
+    ASSERT_TRUE(stale_queue.input().try_peek(stale_first)) << stale_queue.error().message;
+    ASSERT_TRUE(stale_queue.input().try_peek(stale_second)) << stale_queue.error().message;
     ASSERT_TRUE(stale_queue.input().release(stale_first)) << stale_queue.error().message;
     ASSERT_TRUE(stale_queue.input().release(stale_second)) << stale_queue.error().message;
     EXPECT_FALSE(stale_queue.input().release(stale_first));
@@ -802,8 +799,8 @@ TEST(L3L2MessageQueueTest, InputReleaseRejectsStaleAndDoubleRelease) {
     publish_input_desc(&double_storage, double_queue.layout(), 2, L3L2QueueOpcode::DATA);
     L3L2QueueInputHandle first{};
     L3L2QueueInputHandle second{};
-    ASSERT_TRUE(double_queue.input().try_peek(&first)) << double_queue.error().message;
-    ASSERT_TRUE(double_queue.input().try_peek(&second)) << double_queue.error().message;
+    ASSERT_TRUE(double_queue.input().try_peek(first)) << double_queue.error().message;
+    ASSERT_TRUE(double_queue.input().try_peek(second)) << double_queue.error().message;
     ASSERT_TRUE(double_queue.input().release(second)) << double_queue.error().message;
     EXPECT_FALSE(double_queue.input().release(second));
     EXPECT_EQ(double_queue.error().kind, L3L2QueueErrorKind::OWNERSHIP);
@@ -820,12 +817,12 @@ TEST(L3L2MessageQueueTest, OutputReservePublishWorksDuringStopDrain) {
 
     L3L2QueueInputHandle input{};
     L3L2QueueInputHandle stop{};
-    ASSERT_TRUE(queue.input().try_peek(&input)) << queue.error().message;
-    ASSERT_TRUE(queue.input().try_peek(&stop)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(input)) << queue.error().message;
+    ASSERT_TRUE(queue.input().try_peek(stop)) << queue.error().message;
     ASSERT_TRUE(queue.input().release(stop)) << queue.error().message;
 
     L3L2QueueOutputReservation reservation{};
-    ASSERT_TRUE(queue.output().try_reserve(16, &reservation)) << queue.error().message;
+    ASSERT_TRUE(queue.output().try_reserve(16, reservation)) << queue.error().message;
     ASSERT_TRUE(queue.output().publish(reservation, L3L2QueueOpcode::DATA)) << queue.error().message;
 
     EXPECT_FALSE(queue.input().drained());

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm.cpp
@@ -22,24 +22,24 @@ namespace {
 
 L3L2OrchRegionDesc valid_desc() {
     return L3L2OrchRegionDesc{
-        L3L2_ORCH_COMM_MAGIC_VERSION, 7, 0x1000, 4096, 0x3000, 128,
+        l3_l2_orch_comm::L3L2_ORCH_COMM_MAGIC_VERSION, 7, 0x1000, 4096, 0x3000, 128,
     };
 }
 
 TEST(L3L2OrchCommTest, MagicVersionConstantMatchesCompatibilityWrapper) {
     EXPECT_EQ(
-        L3L2_ORCH_COMM_MAGIC_VERSION,
-        l3_l2_orch_comm_pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR)
+        l3_l2_orch_comm::L3L2_ORCH_COMM_MAGIC_VERSION,
+        l3_l2_orch_comm::pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR)
     );
-    EXPECT_EQ(l3_l2_orch_comm_magic_version(), L3L2_ORCH_COMM_MAGIC_VERSION);
-    EXPECT_EQ(l3_l2_orch_comm::magic_version(), L3L2_ORCH_COMM_MAGIC_VERSION);
+    EXPECT_EQ(l3_l2_orch_comm::magic_version(), l3_l2_orch_comm::L3L2_ORCH_COMM_MAGIC_VERSION);
+    EXPECT_EQ(l3_l2_orch_comm::magic_version(), l3_l2_orch_comm::L3L2_ORCH_COMM_MAGIC_VERSION);
 }
 
 TEST(L3L2OrchCommTest, DescriptorRoundTripsThroughSixTaskArgScalars) {
     L3L2OrchRegionDesc desc = valid_desc();
     std::array<uint64_t, L3L2_ORCH_REGION_DESC_SCALAR_COUNT> scalars{};
 
-    EXPECT_TRUE(l3_l2_orch_comm_encode_desc(desc, scalars.data(), scalars.size()));
+    EXPECT_TRUE(l3_l2_orch_comm::encode_desc(desc, scalars.data(), scalars.size()));
     EXPECT_EQ(scalars[0], desc.magic_version);
     EXPECT_EQ(scalars[1], desc.region_id);
     EXPECT_EQ(scalars[2], desc.payload_base);
@@ -49,7 +49,7 @@ TEST(L3L2OrchCommTest, DescriptorRoundTripsThroughSixTaskArgScalars) {
 
     L3L2OrchRegionDesc decoded{};
     L3L2OrchCommValidationError error{};
-    EXPECT_TRUE(l3_l2_orch_comm_decode_desc(scalars.data(), scalars.size(), &decoded, &error));
+    EXPECT_TRUE(l3_l2_orch_comm::decode_desc(scalars.data(), scalars.size(), &decoded, &error));
     EXPECT_EQ(error, L3L2OrchCommValidationError::OK);
     EXPECT_EQ(decoded.magic_version, desc.magic_version);
     EXPECT_EQ(decoded.region_id, desc.region_id);
@@ -61,9 +61,9 @@ TEST(L3L2OrchCommTest, DescriptorRoundTripsThroughSixTaskArgScalars) {
 
 TEST(L3L2OrchCommTest, DescriptorRejectsBadMajorVersion) {
     L3L2OrchRegionDesc desc = valid_desc();
-    desc.magic_version = l3_l2_orch_comm_pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR + 1, 0);
+    desc.magic_version = l3_l2_orch_comm::pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR + 1, 0);
 
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_MAGIC_VERSION);
 }
 
@@ -71,7 +71,7 @@ TEST(L3L2OrchCommTest, DescriptorKeepsRegionIdZeroAsInvalidSentinel) {
     L3L2OrchRegionDesc desc = valid_desc();
     desc.region_id = 0;
 
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_REGION_ID);
 }
 
@@ -81,21 +81,21 @@ TEST(L3L2OrchCommTest, DescriptorAcceptsZeroBaseAddressesWhenRangesAreValid) {
     desc.payload_bytes = 128;
     desc.counter_base = 256;
     desc.counter_bytes = 64;
-    EXPECT_EQ(l3_l2_orch_comm_validate_desc(desc), L3L2OrchCommValidationError::OK);
+    EXPECT_EQ(l3_l2_orch_comm::validate_desc(desc), L3L2OrchCommValidationError::OK);
 
     desc = valid_desc();
     desc.payload_base = 128;
     desc.payload_bytes = 128;
     desc.counter_base = 0;
     desc.counter_bytes = 64;
-    EXPECT_EQ(l3_l2_orch_comm_validate_desc(desc), L3L2OrchCommValidationError::OK);
+    EXPECT_EQ(l3_l2_orch_comm::validate_desc(desc), L3L2OrchCommValidationError::OK);
 }
 
 TEST(L3L2OrchCommTest, DescriptorRejectsZeroPayloadBytes) {
     L3L2OrchRegionDesc desc = valid_desc();
     desc.payload_bytes = 0;
 
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE);
 }
 
@@ -106,7 +106,7 @@ TEST(L3L2OrchCommTest, DescriptorRejectsPayloadCounterOverlapWithZeroBase) {
     desc.counter_base = 64;
     desc.counter_bytes = 64;
 
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
 }
 
@@ -115,7 +115,7 @@ TEST(L3L2OrchCommTest, DescriptorRejectsOverflowingPayloadRange) {
     desc.payload_base = UINT64_MAX - 7;
     desc.payload_bytes = 16;
 
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE);
 }
 
@@ -123,86 +123,86 @@ TEST(L3L2OrchCommTest, DescriptorRejectsUnalignedCounterBase) {
     L3L2OrchRegionDesc desc = valid_desc();
     desc.counter_base = 0x3041;
 
-    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    L3L2OrchCommValidationError error = l3_l2_orch_comm::validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
 }
 
 TEST(L3L2OrchCommTest, DescriptorRejectsInvalidCounterBytes) {
     L3L2OrchRegionDesc desc = valid_desc();
     desc.counter_bytes = 0;
-    EXPECT_EQ(l3_l2_orch_comm_validate_desc(desc), L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
+    EXPECT_EQ(l3_l2_orch_comm::validate_desc(desc), L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
 
     desc = valid_desc();
     desc.counter_bytes = 6;
-    EXPECT_EQ(l3_l2_orch_comm_validate_desc(desc), L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
+    EXPECT_EQ(l3_l2_orch_comm::validate_desc(desc), L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
 }
 
 TEST(L3L2OrchCommTest, CounterAddressValidationRejectsUnalignedAndOutOfRange) {
     const L3L2OrchRegionDesc desc = valid_desc();
 
-    EXPECT_EQ(l3_l2_orch_comm_validate_counter_addr(desc, desc.counter_base), L3L2OrchCommValidationError::OK);
+    EXPECT_EQ(l3_l2_orch_comm::validate_counter_addr(desc, desc.counter_base), L3L2OrchCommValidationError::OK);
     EXPECT_EQ(
-        l3_l2_orch_comm_validate_counter_addr(desc, desc.counter_base + desc.counter_bytes - sizeof(int32_t)),
+        l3_l2_orch_comm::validate_counter_addr(desc, desc.counter_base + desc.counter_bytes - sizeof(int32_t)),
         L3L2OrchCommValidationError::OK
     );
     EXPECT_EQ(
-        l3_l2_orch_comm_validate_counter_addr(desc, desc.counter_base + 2),
+        l3_l2_orch_comm::validate_counter_addr(desc, desc.counter_base + 2),
         L3L2OrchCommValidationError::BAD_COUNTER_RANGE
     );
     EXPECT_EQ(
-        l3_l2_orch_comm_validate_counter_addr(desc, desc.counter_base - sizeof(int32_t)),
+        l3_l2_orch_comm::validate_counter_addr(desc, desc.counter_base - sizeof(int32_t)),
         L3L2OrchCommValidationError::OUT_OF_BOUNDS
     );
     EXPECT_EQ(
-        l3_l2_orch_comm_validate_counter_addr(desc, desc.counter_base + desc.counter_bytes),
+        l3_l2_orch_comm::validate_counter_addr(desc, desc.counter_base + desc.counter_bytes),
         L3L2OrchCommValidationError::OUT_OF_BOUNDS
     );
 }
 
 TEST(L3L2OrchCommTest, PayloadBoundsRejectOverflowAndOutOfRange) {
-    EXPECT_EQ(l3_l2_orch_comm_validate_payload_bounds(16, 8, 32), L3L2OrchCommValidationError::OK);
+    EXPECT_EQ(l3_l2_orch_comm::validate_payload_bounds(16, 8, 32), L3L2OrchCommValidationError::OK);
     EXPECT_EQ(
-        l3_l2_orch_comm_validate_payload_bounds(UINT64_MAX - 3, 8, UINT64_MAX),
+        l3_l2_orch_comm::validate_payload_bounds(UINT64_MAX - 3, 8, UINT64_MAX),
         L3L2OrchCommValidationError::OUT_OF_BOUNDS
     );
-    EXPECT_EQ(l3_l2_orch_comm_validate_payload_bounds(24, 16, 32), L3L2OrchCommValidationError::OUT_OF_BOUNDS);
-    EXPECT_EQ(l3_l2_orch_comm_validate_payload_bounds(0, 0, 32), L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE);
+    EXPECT_EQ(l3_l2_orch_comm::validate_payload_bounds(24, 16, 32), L3L2OrchCommValidationError::OUT_OF_BOUNDS);
+    EXPECT_EQ(l3_l2_orch_comm::validate_payload_bounds(0, 0, 32), L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE);
 }
 
 TEST(L3L2OrchCommTest, AddSatAndOverflowHelpersHandleUint64Edges) {
-    EXPECT_FALSE(l3_l2_orch_comm_add_overflows(7, 9));
-    EXPECT_TRUE(l3_l2_orch_comm_add_overflows(UINT64_MAX - 1, 2));
-    EXPECT_EQ(l3_l2_orch_comm_add_sat(7, 9), 16u);
-    EXPECT_EQ(l3_l2_orch_comm_add_sat(UINT64_MAX - 1, 2), UINT64_MAX);
+    EXPECT_FALSE(l3_l2_orch_comm::add_overflows(7, 9));
+    EXPECT_TRUE(l3_l2_orch_comm::add_overflows(UINT64_MAX - 1, 2));
+    EXPECT_EQ(l3_l2_orch_comm::add_sat(7, 9), 16u);
+    EXPECT_EQ(l3_l2_orch_comm::add_sat(UINT64_MAX - 1, 2), UINT64_MAX);
 }
 
 TEST(L3L2OrchCommTest, CompileTimeAlignmentRequiresPowerOfTwoAbiAlignment) {
-    static_assert(l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BYTES>(16), "counter alignment must work");
-    EXPECT_TRUE(l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(0x3000));
-    EXPECT_FALSE(l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(0x3041));
-    EXPECT_TRUE(l3_l2_orch_comm_is_aligned_runtime(24, 8));
-    EXPECT_FALSE(l3_l2_orch_comm_is_aligned_runtime(24, 3));
+    static_assert(l3_l2_orch_comm::is_aligned<L3L2_ORCH_COMM_COUNTER_BYTES>(16), "counter alignment must work");
+    EXPECT_TRUE(l3_l2_orch_comm::is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(0x3000));
+    EXPECT_FALSE(l3_l2_orch_comm::is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(0x3041));
+    EXPECT_TRUE(l3_l2_orch_comm::is_aligned_runtime(24, 8));
+    EXPECT_FALSE(l3_l2_orch_comm::is_aligned_runtime(24, 3));
 }
 
 TEST(L3L2OrchCommTest, NotifyOpAndWaitCmpValidationRejectUnknownValues) {
-    EXPECT_TRUE(l3_l2_orch_comm_valid_notify_op(L3L2OrchNotifyOp::Set));
-    EXPECT_TRUE(l3_l2_orch_comm_valid_notify_op(L3L2OrchNotifyOp::Add));
-    EXPECT_FALSE(l3_l2_orch_comm_valid_notify_op(static_cast<L3L2OrchNotifyOp>(2)));
+    EXPECT_TRUE(l3_l2_orch_comm::valid_notify_op(L3L2OrchNotifyOp::Set));
+    EXPECT_TRUE(l3_l2_orch_comm::valid_notify_op(L3L2OrchNotifyOp::Add));
+    EXPECT_FALSE(l3_l2_orch_comm::valid_notify_op(static_cast<L3L2OrchNotifyOp>(2)));
 
-    EXPECT_TRUE(l3_l2_orch_comm_valid_wait_cmp(L3L2OrchWaitCmp::EQ));
-    EXPECT_TRUE(l3_l2_orch_comm_valid_wait_cmp(L3L2OrchWaitCmp::LE));
-    EXPECT_FALSE(l3_l2_orch_comm_valid_wait_cmp(static_cast<L3L2OrchWaitCmp>(6)));
+    EXPECT_TRUE(l3_l2_orch_comm::valid_wait_cmp(L3L2OrchWaitCmp::EQ));
+    EXPECT_TRUE(l3_l2_orch_comm::valid_wait_cmp(L3L2OrchWaitCmp::LE));
+    EXPECT_FALSE(l3_l2_orch_comm::valid_wait_cmp(static_cast<L3L2OrchWaitCmp>(6)));
 }
 
 TEST(L3L2OrchCommTest, WaitCmpComparisonCoversAllPredicates) {
-    EXPECT_TRUE(l3_l2_orch_comm_compare_counter(5, 5, L3L2OrchWaitCmp::EQ));
-    EXPECT_FALSE(l3_l2_orch_comm_compare_counter(4, 5, L3L2OrchWaitCmp::EQ));
-    EXPECT_TRUE(l3_l2_orch_comm_compare_counter(4, 5, L3L2OrchWaitCmp::NE));
-    EXPECT_TRUE(l3_l2_orch_comm_compare_counter(6, 5, L3L2OrchWaitCmp::GT));
-    EXPECT_TRUE(l3_l2_orch_comm_compare_counter(5, 5, L3L2OrchWaitCmp::GE));
-    EXPECT_TRUE(l3_l2_orch_comm_compare_counter(4, 5, L3L2OrchWaitCmp::LT));
-    EXPECT_TRUE(l3_l2_orch_comm_compare_counter(5, 5, L3L2OrchWaitCmp::LE));
-    EXPECT_FALSE(l3_l2_orch_comm_compare_counter(5, 5, static_cast<L3L2OrchWaitCmp>(6)));
+    EXPECT_TRUE(l3_l2_orch_comm::compare_counter(5, 5, L3L2OrchWaitCmp::EQ));
+    EXPECT_FALSE(l3_l2_orch_comm::compare_counter(4, 5, L3L2OrchWaitCmp::EQ));
+    EXPECT_TRUE(l3_l2_orch_comm::compare_counter(4, 5, L3L2OrchWaitCmp::NE));
+    EXPECT_TRUE(l3_l2_orch_comm::compare_counter(6, 5, L3L2OrchWaitCmp::GT));
+    EXPECT_TRUE(l3_l2_orch_comm::compare_counter(5, 5, L3L2OrchWaitCmp::GE));
+    EXPECT_TRUE(l3_l2_orch_comm::compare_counter(4, 5, L3L2OrchWaitCmp::LT));
+    EXPECT_TRUE(l3_l2_orch_comm::compare_counter(5, 5, L3L2OrchWaitCmp::LE));
+    EXPECT_FALSE(l3_l2_orch_comm::compare_counter(5, 5, static_cast<L3L2OrchWaitCmp>(6)));
 }
 
 TEST(L3L2OrchCommTest, RequestAndResponseAreFixedSizePodDescriptorsOnly) {

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm.cpp
@@ -22,8 +22,17 @@ namespace {
 
 L3L2OrchRegionDesc valid_desc() {
     return L3L2OrchRegionDesc{
-        l3_l2_orch_comm_magic_version(), 7, 0x1000, 4096, 0x3000, 128,
+        L3L2_ORCH_COMM_MAGIC_VERSION, 7, 0x1000, 4096, 0x3000, 128,
     };
+}
+
+TEST(L3L2OrchCommTest, MagicVersionConstantMatchesCompatibilityWrapper) {
+    EXPECT_EQ(
+        L3L2_ORCH_COMM_MAGIC_VERSION,
+        l3_l2_orch_comm_pack_magic_version(L3L2_ORCH_COMM_MAGIC, L3L2_ORCH_COMM_ABI_MAJOR, L3L2_ORCH_COMM_ABI_MINOR)
+    );
+    EXPECT_EQ(l3_l2_orch_comm_magic_version(), L3L2_ORCH_COMM_MAGIC_VERSION);
+    EXPECT_EQ(l3_l2_orch_comm::magic_version(), L3L2_ORCH_COMM_MAGIC_VERSION);
 }
 
 TEST(L3L2OrchCommTest, DescriptorRoundTripsThroughSixTaskArgScalars) {
@@ -58,12 +67,47 @@ TEST(L3L2OrchCommTest, DescriptorRejectsBadMajorVersion) {
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_MAGIC_VERSION);
 }
 
+TEST(L3L2OrchCommTest, DescriptorKeepsRegionIdZeroAsInvalidSentinel) {
+    L3L2OrchRegionDesc desc = valid_desc();
+    desc.region_id = 0;
+
+    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_REGION_ID);
+}
+
+TEST(L3L2OrchCommTest, DescriptorAcceptsZeroBaseAddressesWhenRangesAreValid) {
+    L3L2OrchRegionDesc desc = valid_desc();
+    desc.payload_base = 0;
+    desc.payload_bytes = 128;
+    desc.counter_base = 256;
+    desc.counter_bytes = 64;
+    EXPECT_EQ(l3_l2_orch_comm_validate_desc(desc), L3L2OrchCommValidationError::OK);
+
+    desc = valid_desc();
+    desc.payload_base = 128;
+    desc.payload_bytes = 128;
+    desc.counter_base = 0;
+    desc.counter_bytes = 64;
+    EXPECT_EQ(l3_l2_orch_comm_validate_desc(desc), L3L2OrchCommValidationError::OK);
+}
+
 TEST(L3L2OrchCommTest, DescriptorRejectsZeroPayloadBytes) {
     L3L2OrchRegionDesc desc = valid_desc();
     desc.payload_bytes = 0;
 
     L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
     EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE);
+}
+
+TEST(L3L2OrchCommTest, DescriptorRejectsPayloadCounterOverlapWithZeroBase) {
+    L3L2OrchRegionDesc desc = valid_desc();
+    desc.payload_base = 0;
+    desc.payload_bytes = 128;
+    desc.counter_base = 64;
+    desc.counter_bytes = 64;
+
+    L3L2OrchCommValidationError error = l3_l2_orch_comm_validate_desc(desc);
+    EXPECT_EQ(error, L3L2OrchCommValidationError::BAD_COUNTER_RANGE);
 }
 
 TEST(L3L2OrchCommTest, DescriptorRejectsOverflowingPayloadRange) {
@@ -119,10 +163,25 @@ TEST(L3L2OrchCommTest, PayloadBoundsRejectOverflowAndOutOfRange) {
     EXPECT_EQ(l3_l2_orch_comm_validate_payload_bounds(16, 8, 32), L3L2OrchCommValidationError::OK);
     EXPECT_EQ(
         l3_l2_orch_comm_validate_payload_bounds(UINT64_MAX - 3, 8, UINT64_MAX),
-        L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE
+        L3L2OrchCommValidationError::OUT_OF_BOUNDS
     );
     EXPECT_EQ(l3_l2_orch_comm_validate_payload_bounds(24, 16, 32), L3L2OrchCommValidationError::OUT_OF_BOUNDS);
     EXPECT_EQ(l3_l2_orch_comm_validate_payload_bounds(0, 0, 32), L3L2OrchCommValidationError::BAD_PAYLOAD_RANGE);
+}
+
+TEST(L3L2OrchCommTest, AddSatAndOverflowHelpersHandleUint64Edges) {
+    EXPECT_FALSE(l3_l2_orch_comm_add_overflows(7, 9));
+    EXPECT_TRUE(l3_l2_orch_comm_add_overflows(UINT64_MAX - 1, 2));
+    EXPECT_EQ(l3_l2_orch_comm_add_sat(7, 9), 16u);
+    EXPECT_EQ(l3_l2_orch_comm_add_sat(UINT64_MAX - 1, 2), UINT64_MAX);
+}
+
+TEST(L3L2OrchCommTest, CompileTimeAlignmentRequiresPowerOfTwoAbiAlignment) {
+    static_assert(l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BYTES>(16), "counter alignment must work");
+    EXPECT_TRUE(l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(0x3000));
+    EXPECT_FALSE(l3_l2_orch_comm_is_aligned<L3L2_ORCH_COMM_COUNTER_BASE_ALIGNMENT>(0x3041));
+    EXPECT_TRUE(l3_l2_orch_comm_is_aligned_runtime(24, 8));
+    EXPECT_FALSE(l3_l2_orch_comm_is_aligned_runtime(24, 3));
 }
 
 TEST(L3L2OrchCommTest, NotifyOpAndWaitCmpValidationRejectUnknownValues) {

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm_service.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm_service.cpp
@@ -96,7 +96,7 @@ struct ServiceFixture : public ::testing::Test {
         req.counter_bytes = counter_bytes;
         L3L2OrchCommResponse resp = submit(req);
         EXPECT_EQ(resp.status, 0) << resp.message;
-        EXPECT_EQ(l3_l2_orch_comm_validate_desc(resp.desc), L3L2OrchCommValidationError::OK);
+        EXPECT_EQ(l3_l2_orch_comm::validate_desc(resp.desc), L3L2OrchCommValidationError::OK);
         return resp.desc;
     }
 

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
@@ -55,7 +55,7 @@ TEST(L3L2OrchCommSimRunnerTest, RunnerOwnedServiceHandlesPayloadSignalAndFree) {
     alloc.counter_bytes = 128;
     L3L2OrchCommResponse alloc_resp = submit(client, alloc);
     ASSERT_EQ(alloc_resp.status, 0) << alloc_resp.message;
-    ASSERT_EQ(l3_l2_orch_comm_validate_desc(alloc_resp.desc), L3L2OrchCommValidationError::OK);
+    ASSERT_EQ(l3_l2_orch_comm::validate_desc(alloc_resp.desc), L3L2OrchCommValidationError::OK);
 
     const uint8_t src[4] = {2, 4, 6, 8};
     uint8_t dst[4] = {};

--- a/tests/ut/cpp/common/test_l3_l2_orch_endpoint.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_endpoint.cpp
@@ -29,7 +29,7 @@ struct RegionStorage {
 
 L3L2OrchRegionDesc make_desc(RegionStorage *storage) {
     return L3L2OrchRegionDesc{
-        l3_l2_orch_comm_magic_version(),
+        l3_l2_orch_comm::magic_version(),
         17,
         reinterpret_cast<uint64_t>(storage->payload.data()),
         storage->payload.size(),
@@ -42,7 +42,7 @@ TEST(L3L2OrchEndpointTest, DecodesDescriptorScalarsAndCounterRange) {
     RegionStorage storage{};
     L3L2OrchRegionDesc desc = make_desc(&storage);
     std::array<uint64_t, L3L2_ORCH_REGION_DESC_SCALAR_COUNT> scalars{};
-    ASSERT_TRUE(l3_l2_orch_comm_encode_desc(desc, scalars.data(), scalars.size()));
+    ASSERT_TRUE(l3_l2_orch_comm::encode_desc(desc, scalars.data(), scalars.size()));
 
     L3L2OrchEndpoint endpoint(scalars.data(), scalars.size());
 

--- a/tests/ut/cpp/common/test_l3_l2_orch_endpoint.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_endpoint.cpp
@@ -51,7 +51,7 @@ TEST(L3L2OrchEndpointTest, DecodesDescriptorScalarsAndCounterRange) {
     EXPECT_EQ(endpoint.descriptor().counter_bytes, desc.counter_bytes);
 
     uint64_t counter_addr = 0;
-    ASSERT_TRUE(endpoint.counter_addr(8, &counter_addr)) << endpoint.error().message;
+    ASSERT_TRUE(endpoint.counter_addr(8, counter_addr)) << endpoint.error().message;
     EXPECT_EQ(counter_addr, desc.counter_base + 8);
 }
 
@@ -91,7 +91,7 @@ TEST(L3L2OrchEndpointTest, PayloadReadViewSeesChangingHeaderAcrossRounds) {
     RegionStorage storage{};
     L3L2OrchEndpoint endpoint(make_desc(&storage));
     L3L2OrchPayloadView view{};
-    ASSERT_TRUE(endpoint.payload_read(0, sizeof(uint32_t), &view)) << endpoint.error().message;
+    ASSERT_TRUE(endpoint.payload_read(0, sizeof(uint32_t), view)) << endpoint.error().message;
     ASSERT_NE(view.gm_addr, 0u);
     auto *header = reinterpret_cast<uint32_t *>(static_cast<uintptr_t>(view.gm_addr));
 
@@ -108,7 +108,7 @@ TEST(L3L2OrchEndpointTest, PayloadBoundsErrorCarriesStructuredMetadata) {
 
     L3L2OrchPayloadView view{0xCAFE, 0xBEEF};
 
-    EXPECT_FALSE(endpoint.payload_read(120, 16, &view));
+    EXPECT_FALSE(endpoint.payload_read(120, 16, view));
     EXPECT_EQ(view.gm_addr, 0u);
     EXPECT_EQ(view.nbytes, 0u);
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::OUT_OF_BOUNDS);
@@ -123,7 +123,7 @@ TEST(L3L2OrchEndpointTest, CounterAddrRejectsBadOffsets) {
     L3L2OrchEndpoint endpoint(make_desc(&storage));
     uint64_t counter_addr = 0xCAFE;
 
-    EXPECT_FALSE(endpoint.counter_addr(2, &counter_addr));
+    EXPECT_FALSE(endpoint.counter_addr(2, counter_addr));
 
     EXPECT_EQ(counter_addr, 0u);
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::OUT_OF_BOUNDS);
@@ -136,7 +136,7 @@ TEST(L3L2OrchEndpointTest, SignalNotifySetAndAddUpdateCounters) {
     RegionStorage storage{};
     L3L2OrchEndpoint endpoint(make_desc(&storage));
     uint64_t counter_addr = 0;
-    ASSERT_TRUE(endpoint.counter_addr(0, &counter_addr)) << endpoint.error().message;
+    ASSERT_TRUE(endpoint.counter_addr(0, counter_addr)) << endpoint.error().message;
 
     EXPECT_TRUE(endpoint.signal_notify(counter_addr, 5, L3L2OrchNotifyOp::Set)) << endpoint.error().message;
     EXPECT_EQ(storage.counters[0], 5);
@@ -149,26 +149,26 @@ TEST(L3L2OrchEndpointTest, SignalTestCoversAllComparisonsAndMismatchIsNotError) 
     RegionStorage storage{};
     L3L2OrchEndpoint endpoint(make_desc(&storage));
     uint64_t counter_addr = 0;
-    ASSERT_TRUE(endpoint.counter_addr(4, &counter_addr)) << endpoint.error().message;
+    ASSERT_TRUE(endpoint.counter_addr(4, counter_addr)) << endpoint.error().message;
     storage.counters[1] = 7;
 
     L3L2OrchSignalTestResult result{};
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 7, L3L2OrchWaitCmp::EQ, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 7, L3L2OrchWaitCmp::EQ, result)) << endpoint.error().message;
     EXPECT_TRUE(result.matched);
     EXPECT_EQ(result.observed, 7);
 
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 8, L3L2OrchWaitCmp::NE, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 8, L3L2OrchWaitCmp::NE, result)) << endpoint.error().message;
     EXPECT_TRUE(result.matched);
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 6, L3L2OrchWaitCmp::GT, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 6, L3L2OrchWaitCmp::GT, result)) << endpoint.error().message;
     EXPECT_TRUE(result.matched);
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 7, L3L2OrchWaitCmp::GE, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 7, L3L2OrchWaitCmp::GE, result)) << endpoint.error().message;
     EXPECT_TRUE(result.matched);
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 8, L3L2OrchWaitCmp::LT, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 8, L3L2OrchWaitCmp::LT, result)) << endpoint.error().message;
     EXPECT_TRUE(result.matched);
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 7, L3L2OrchWaitCmp::LE, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 7, L3L2OrchWaitCmp::LE, result)) << endpoint.error().message;
     EXPECT_TRUE(result.matched);
 
-    EXPECT_TRUE(endpoint.signal_test(counter_addr, 8, L3L2OrchWaitCmp::EQ, &result)) << endpoint.error().message;
+    EXPECT_TRUE(endpoint.signal_test(counter_addr, 8, L3L2OrchWaitCmp::EQ, result)) << endpoint.error().message;
     EXPECT_FALSE(result.matched);
     EXPECT_EQ(result.observed, 7);
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::NONE);
@@ -178,10 +178,10 @@ TEST(L3L2OrchEndpointTest, SignalWaitTimeoutCarriesStructuredMetadata) {
     RegionStorage storage{};
     L3L2OrchEndpoint endpoint(make_desc(&storage));
     uint64_t counter_addr = 0;
-    ASSERT_TRUE(endpoint.counter_addr(0, &counter_addr)) << endpoint.error().message;
+    ASSERT_TRUE(endpoint.counter_addr(0, counter_addr)) << endpoint.error().message;
     int32_t observed = 0;
 
-    EXPECT_FALSE(endpoint.signal_wait(counter_addr, 1, L3L2OrchWaitCmp::EQ, 1, &observed));
+    EXPECT_FALSE(endpoint.signal_wait(counter_addr, 1, L3L2OrchWaitCmp::EQ, 1, observed));
 
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::SIGNAL_TIMEOUT);
     EXPECT_EQ(endpoint.error().op, L3L2EndpointOp::SIGNAL_WAIT);
@@ -196,11 +196,11 @@ TEST(L3L2OrchEndpointTest, SignalWaitDoesNotTreatGreaterObservedValueAsProtocolE
     RegionStorage storage{};
     L3L2OrchEndpoint endpoint(make_desc(&storage));
     uint64_t counter_addr = 0;
-    ASSERT_TRUE(endpoint.counter_addr(0, &counter_addr)) << endpoint.error().message;
+    ASSERT_TRUE(endpoint.counter_addr(0, counter_addr)) << endpoint.error().message;
     storage.counters[0] = 9;
     int32_t observed = 0;
 
-    EXPECT_TRUE(endpoint.signal_wait(counter_addr, 8, L3L2OrchWaitCmp::GE, 1'000'000, &observed))
+    EXPECT_TRUE(endpoint.signal_wait(counter_addr, 8, L3L2OrchWaitCmp::GE, 1'000'000, observed))
         << endpoint.error().message;
 
     EXPECT_EQ(observed, 9);

--- a/tests/ut/cpp/common/test_l3_l2_orch_endpoint.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_endpoint.cpp
@@ -12,9 +12,11 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 
 #include <gtest/gtest.h>
 
+#include "aicpu/device_time.h"
 #include "aicpu/l3_l2_orch_endpoint.h"
 #include "common/l3_l2_orch_comm.h"
 
@@ -54,7 +56,23 @@ TEST(L3L2OrchEndpointTest, DecodesDescriptorScalarsAndCounterRange) {
 }
 
 TEST(L3L2OrchEndpointTest, ConvertsCounterTicksToNanoseconds) {
-    EXPECT_EQ(l3_l2_orch_endpoint_ticks_to_ns(50'000'000, 50'000'000), 1'000'000'000);
+    EXPECT_EQ(sys_cnt_ticks_to_ns(50'000'000, 50'000'000), 1'000'000'000);
+    EXPECT_EQ(sys_cnt_elapsed_ns(10, 25, 1'000'000'000), 15u);
+}
+
+TEST(L3L2OrchEndpointTest, ErrorOperationStringsAndMessageCopyAreStable) {
+    static_assert(std::is_standard_layout<L3L2EndpointError>::value, "error must be POD-like");
+    static_assert(std::is_trivially_copyable<L3L2EndpointError>::value, "error must be fixed-size");
+    EXPECT_EQ(sizeof(L3L2EndpointError::message), 256u);
+
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::INIT), "init");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::COUNTER_ADDR), "counter_addr");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::PAYLOAD_READ), "payload_read");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::PAYLOAD_WRITE), "payload_write");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::SIGNAL_NOTIFY), "signal_notify");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::SIGNAL_TEST), "signal_test");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(L3L2EndpointOp::SIGNAL_WAIT), "signal_wait");
+    EXPECT_STREQ(l3_l2_endpoint_op_to_string(static_cast<L3L2EndpointOp>(99)), "unknown");
 }
 
 TEST(L3L2OrchEndpointTest, PayloadWriteCopiesSmallMetadataIntoPayloadRange) {
@@ -94,10 +112,10 @@ TEST(L3L2OrchEndpointTest, PayloadBoundsErrorCarriesStructuredMetadata) {
     EXPECT_EQ(view.gm_addr, 0u);
     EXPECT_EQ(view.nbytes, 0u);
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::OUT_OF_BOUNDS);
-    EXPECT_STREQ(endpoint.error().op, "payload_read");
+    EXPECT_EQ(endpoint.error().op, L3L2EndpointOp::PAYLOAD_READ);
     EXPECT_EQ(endpoint.error().region_id, 17u);
     EXPECT_EQ(endpoint.error().counter_addr, 0u);
-    EXPECT_NE(endpoint.error().message, nullptr);
+    EXPECT_STRNE(endpoint.error().message, "");
 }
 
 TEST(L3L2OrchEndpointTest, CounterAddrRejectsBadOffsets) {
@@ -109,7 +127,7 @@ TEST(L3L2OrchEndpointTest, CounterAddrRejectsBadOffsets) {
 
     EXPECT_EQ(counter_addr, 0u);
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::OUT_OF_BOUNDS);
-    EXPECT_STREQ(endpoint.error().op, "counter_addr");
+    EXPECT_EQ(endpoint.error().op, L3L2EndpointOp::COUNTER_ADDR);
     EXPECT_EQ(endpoint.error().region_id, 17u);
     EXPECT_EQ(endpoint.error().counter_addr, make_desc(&storage).counter_base + 2);
 }
@@ -166,7 +184,7 @@ TEST(L3L2OrchEndpointTest, SignalWaitTimeoutCarriesStructuredMetadata) {
     EXPECT_FALSE(endpoint.signal_wait(counter_addr, 1, L3L2OrchWaitCmp::EQ, 1, &observed));
 
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::SIGNAL_TIMEOUT);
-    EXPECT_STREQ(endpoint.error().op, "signal_wait");
+    EXPECT_EQ(endpoint.error().op, L3L2EndpointOp::SIGNAL_WAIT);
     EXPECT_EQ(endpoint.error().region_id, 17u);
     EXPECT_EQ(endpoint.error().counter_addr, counter_addr);
     EXPECT_EQ(endpoint.error().counter_operand, 1);
@@ -195,8 +213,8 @@ TEST(L3L2OrchEndpointTest, RejectsBadDescriptorScalars) {
     L3L2OrchEndpoint endpoint(scalars.data(), scalars.size());
 
     EXPECT_EQ(endpoint.error().kind, L3L2EndpointErrorKind::BAD_DESCRIPTOR);
-    EXPECT_STREQ(endpoint.error().op, "init");
-    EXPECT_NE(endpoint.error().message, nullptr);
+    EXPECT_EQ(endpoint.error().op, L3L2EndpointOp::INIT);
+    EXPECT_STRNE(endpoint.error().message, "");
 }
 
 }  // namespace

--- a/tests/ut/cpp/stubs/test_stubs.cpp
+++ b/tests/ut/cpp/stubs/test_stubs.cpp
@@ -25,6 +25,7 @@
 #include <stdexcept>
 #include <string>
 
+#include "aicpu/cache_maintenance.h"
 #include "aicpu/platform_regs.h"  // get_reg_ptr / RegId (arch header picked up via rt_objs include path)
 
 // =============================================================================
@@ -76,12 +77,25 @@ void unified_log_info_v(const char *func, int v, const char *fmt, ...) {
 
 uint64_t get_sys_cnt_aicpu() {
     auto now = std::chrono::steady_clock::now();
-    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count());
+    uint64_t elapsed_ns =
+        static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now.time_since_epoch()).count());
+    constexpr uint64_t kNsPerSec = std::nano::den;
+    uint64_t seconds = elapsed_ns / kNsPerSec;
+    uint64_t remaining_ns = elapsed_ns % kNsPerSec;
+    return seconds * PLATFORM_PROF_SYS_CNT_FREQ + (remaining_ns * PLATFORM_PROF_SYS_CNT_FREQ) / kNsPerSec;
 }
 
-void cache_invalidate_range(const void * /* addr */, size_t /* size */) {}
+// =============================================================================
+// cache_maintenance.h stub
+// =============================================================================
 
-void cache_flush_range(const void * /* addr */, size_t /* size */) {}
+namespace aicpu_cache_maintenance {
+
+void invalidate_range_impl(const void * /* addr */, size_t /* size */) {}
+
+void flush_range_impl(const void * /* addr */, size_t /* size */) {}
+
+}  // namespace aicpu_cache_maintenance
 
 // =============================================================================
 // platform_regs.h stub (get_reg_ptr)


### PR DESCRIPTION
## Summary

  - This is a stacked PR based on PR #1187.
  - Add L2-side input-window support to the L3-L2 message queue through local endpoint config:
    `L3L2QueueEndpointConfig{.max_l2_input_inflight = N}`.
  - Support multiple active L2 DATA / ERROR input handles, FIFO-safe delayed physical release, STOP drain, and `queue.input().drained()`.
  - Fold the input-window scenario into the existing `tensormap_and_ringbuffer/l3_l2_message_queue` example, using PTO-ISA AIV tile compute while L2 keeps a persistent receive/process/publish loop.
