### PR TITLE
Refactor: remove dead set_function_bin_addr kernel-tracking machinery

### DIFF
--- a/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a2a3/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -6,7 +6,7 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 
 ## Core Data Structures
 
-- `Runtime` owns the task table, handshake buffers, and host-side device APIs. See `src/runtime/host_build_graph/runtime/runtime.h`.
+- `Runtime` owns the task table, handshake buffers, and host-side device APIs. See `src/a2a3/runtime/host_build_graph/runtime/runtime.h`.
 - `Task` is a fixed-size record that stores `func_id`, argument array, `fanin`, `fanout`, `core_type`, and `function_bin_addr`.
 - `Handshake` is the shared per-core control block used by AICPU and AICore for dispatch and completion.
 - `HostApi` provides device memory ops used by host orchestration (`device_malloc`, `copy_to_device`, `upload_chip_callable_buffer`, etc.).
@@ -14,7 +14,7 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 ## Build And Init Flow
 
 1. Python tooling compiles kernels and orchestration into shared objects.
-2. `register_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and stores it in `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
+2. `register_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and records it in the callable's `kernel_addrs` table; `bind_callable_to_runtime` later replays those into `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::replay_function_bin_addr` before each run. See `src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp`.
 3. The orchestration function runs on the host and builds the graph. Because it runs on host, it can (and sometimes must) dereference entry-tensor host pointers — e.g. to read a control tensor that drives per-block dispatch. So the orch owns its own H2D: it allocates device buffers, copies inputs to device, and registers outputs for copy-back via `record_tensor_pair(runtime, ...)`. It adds tasks via `add_task(runtime, ...)` and adds dependency edges via `add_successor(runtime, ...)`. (Contrast with `tensormap_and_ringbuffer`, where the orch runs on device AICPU and `runtime_maker.cpp` centralizes H2D using the chip-level `ArgDirection` signature.)
 4. The populated `Runtime` is copied to device memory by the platform layer. AICPU then runs the executor with this Runtime snapshot.
 
@@ -28,11 +28,11 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 
 ## Finalize And Cleanup
 
-`validate_runtime_impl` copies all recorded output tensors back to the host and frees device allocations recorded in tensor pairs. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
+`validate_runtime_impl` copies all recorded output tensors back to the host and frees device allocations recorded in tensor pairs. See `src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp`.
 
 ## Key Files
 
-- `src/runtime/host_build_graph/runtime/runtime.h`
-- `src/runtime/host_build_graph/runtime/runtime.cpp`
-- `src/runtime/host_build_graph/host/runtime_maker.cpp`
-- `src/runtime/host_build_graph/aicpu/aicpu_executor.cpp`
+- `src/a2a3/runtime/host_build_graph/runtime/runtime.h`
+- `src/a2a3/runtime/host_build_graph/runtime/runtime.cpp`
+- `src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp`
+- `src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp`

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -503,20 +503,6 @@ int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     }
     LOG_INFO_V0("Freed %d device tensors", tensor_pair_count);
 
-    // Clear the per-run dispatch-table entries staged by register_callable_impl.
-    // The underlying chip-callable device buffer is pool-managed by
-    // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize().
-    int kernel_count = runtime->get_registered_kernel_count();
-    for (int i = 0; i < kernel_count; i++) {
-        int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->set_function_bin_addr(func_id, 0);
-    }
-    if (kernel_count > 0) {
-        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
-    }
-    runtime->clear_registered_kernels();
-
     if (runtime->get_tensor_info_storage() != nullptr) {
         api->device_free(runtime->get_tensor_info_storage());
         runtime->clear_tensor_info_storage();

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -54,9 +54,6 @@ Runtime::Runtime() {
     tensor_allocation_storage_bytes_ = 0;
     tensor_allocation_count_ = 0;
 
-    // Initialize kernel binary tracking
-    registered_kernel_count_ = 0;
-
     // Initialize function address mapping
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         func_id_to_addr_[i] = 0;
@@ -209,28 +206,6 @@ void Runtime::print_runtime() const {
     }
 
     LOG_DEBUG("========================================================================");
-}
-
-// =============================================================================
-// Kernel Binary Address Management
-// =============================================================================
-
-void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-        return;
-    }
-    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
-        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-        } else {
-            LOG_ERROR(
-                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
-                func_id
-            );
-        }
-    }
-    func_id_to_addr_[func_id] = addr;
 }
 
 // host_build_graph uploads the whole Runtime object (AICore reads tasks[] etc.

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -205,10 +205,6 @@ private:
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
-
     // Tensor info metadata for tensor dump
     void *tensor_info_storage_;
     uint64_t tensor_info_storage_bytes_;
@@ -408,32 +404,14 @@ public:
     }
 
     /**
-     * Set function binary address for a func_id.
-     * Called by platform layer after kernel registration.
-     */
-    void set_function_bin_addr(int func_id, uint64_t addr);
-
-    /**
-     * Replay a previously-uploaded kernel address onto a fresh Runtime
-     * without recording it in registered_kernel_func_ids_. Used by
-     * DeviceRunner::bind_callable_to_runtime when restoring kernels
-     * across simpler_run invocations: the prepared callable owns the
-     * kernel binaries' device memory until unregister, so
-     * validate_runtime_impl must NOT free them.
+     * Replay a previously-uploaded kernel address onto a fresh Runtime.
+     * Used by DeviceRunner::bind_callable_to_runtime to rebind prepared
+     * kernel binaries onto the runtime before each simpler_run invocation.
      */
     void replay_function_bin_addr(int func_id, uint64_t addr) {
         if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return;
         func_id_to_addr_[func_id] = addr;
     }
-
-    int get_registered_kernel_count() const { return registered_kernel_count_; }
-
-    int get_registered_kernel_func_id(int index) const {
-        if (index < 0 || index >= registered_kernel_count_) return -1;
-        return registered_kernel_func_ids_[index];
-    }
-
-    void clear_registered_kernels() { registered_kernel_count_ = 0; }
 
     // =========================================================================
     // Host-only state (not copied to device)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -882,21 +882,6 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     }
     LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);
 
-    // Clear the per-run dispatch-table entries staged by register_callable_impl.
-    // The underlying chip-callable device buffer is pool-managed by
-    // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(); re-running the same callable repeatedly
-    // should not re-upload.
-    int kernel_count = runtime->get_registered_kernel_count();
-    for (int i = 0; i < kernel_count; i++) {
-        int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->set_function_bin_addr(func_id, 0);
-    }
-    if (kernel_count > 0) {
-        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
-    }
-    runtime->clear_registered_kernels();
-
     // Clear tensor pairs
     runtime->tensor_pairs_.clear();
 

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -218,14 +218,6 @@ public:
     // copies sizeof(DeviceRuntimeLaunchDesc) bytes from offset 0.
     DeviceRuntimeLaunchDesc dev;
 
-private:
-    // ---- host-only tail (never uploaded to device) ----
-
-    // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
-
-public:
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -284,18 +276,12 @@ public:
     int32_t get_active_callable_id() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
-    void set_function_bin_addr(int func_id, uint64_t addr);
     /**
-     * Replay a previously-uploaded kernel address onto a fresh Runtime
-     * without recording it in registered_kernel_func_ids_. Used by
-     * DeviceRunner::bind_callable_to_runtime so prepared kernel
-     * binaries are not freed by validate_runtime_impl across runs.
+     * Replay a previously-uploaded kernel address onto a fresh Runtime.
+     * Used by DeviceRunner::bind_callable_to_runtime to rebind prepared
+     * kernel binaries onto the runtime before each run.
      */
     void replay_function_bin_addr(int func_id, uint64_t addr);
-
-    int get_registered_kernel_count() const;
-    int get_registered_kernel_func_id(int index) const;
-    void clear_registered_kernels();
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -46,9 +46,6 @@ Runtime::Runtime() {
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         dev.func_id_to_addr_[i] = 0;
     }
-
-    // Initialize host-only tail.
-    registered_kernel_count_ = 0;
 }
 
 // =============================================================================
@@ -76,24 +73,6 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
     return dev.func_id_to_addr_[func_id];
 }
 
-void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-        return;
-    }
-    if (addr != 0 && dev.func_id_to_addr_[func_id] == 0) {
-        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-        } else {
-            LOG_ERROR(
-                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
-                func_id
-            );
-        }
-    }
-    dev.func_id_to_addr_[func_id] = addr;
-}
-
 void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
@@ -101,15 +80,6 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     }
     dev.func_id_to_addr_[func_id] = addr;
 }
-
-int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
-
-int Runtime::get_registered_kernel_func_id(int index) const {
-    if (index < 0 || index >= registered_kernel_count_) return -1;
-    return registered_kernel_func_ids_[index];
-}
-
-void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }
 
 // trb's device image is just the `dev` descriptor (the rest of Runtime is
 // host-only). Mirrors the host_build_graph definition (= sizeof(Runtime)).

--- a/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
+++ b/src/a5/runtime/host_build_graph/docs/RUNTIME_LOGIC.md
@@ -6,7 +6,7 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 
 ## Core Data Structures
 
-- `Runtime` owns the task table, handshake buffers, and host-side device APIs. See `src/runtime/host_build_graph/runtime/runtime.h`.
+- `Runtime` owns the task table, handshake buffers, and host-side device APIs. See `src/a5/runtime/host_build_graph/runtime/runtime.h`.
 - `Task` is a fixed-size record that stores `func_id`, argument array, `fanin`, `fanout`, `core_type`, and `function_bin_addr`.
 - `Handshake` is the shared per-core control block used by AICPU and AICore for dispatch and completion.
 - `HostApi` provides device memory ops used by host orchestration (`device_malloc`, `copy_to_device`, `upload_chip_callable_buffer`, etc.).
@@ -14,7 +14,7 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 ## Build And Init Flow
 
 1. Python tooling compiles kernels and orchestration into shared objects.
-2. `register_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and stores it in `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::set_function_bin_addr`. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
+2. `register_callable_impl` uploads the entire ChipCallable buffer (orch SO + all child kernel binaries) in one shot via `host_api.upload_chip_callable_buffer`, then dlopens the orchestration SO and resolves the entry symbol. For each child, host computes `chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)` and records it in the callable's `kernel_addrs` table; `bind_callable_to_runtime` later replays those into `Runtime::func_id_to_addr_[child_func_id(i)]` via `Runtime::replay_function_bin_addr` before each run. See `src/a5/runtime/host_build_graph/host/runtime_maker.cpp`.
 3. The orchestration function runs on the host and builds the graph. Because it runs on host, it can (and sometimes must) dereference entry-tensor host pointers — e.g. to read a control tensor that drives per-block dispatch. So the orch owns its own H2D: it allocates device buffers, copies inputs to device, and registers outputs for copy-back via `record_tensor_pair(runtime, ...)`. It adds tasks via `add_task(runtime, ...)` and adds dependency edges via `add_successor(runtime, ...)`. (Contrast with `tensormap_and_ringbuffer`, where the orch runs on device AICPU and `runtime_maker.cpp` centralizes H2D using the chip-level `ArgDirection` signature.)
 4. The populated `Runtime` is copied to device memory by the platform layer. AICPU then runs the executor with this Runtime snapshot.
 
@@ -28,11 +28,11 @@ The host_build_graph runtime builds a static task graph on the host, copies the 
 
 ## Finalize And Cleanup
 
-`validate_runtime_impl` copies all recorded output tensors back to the host and frees device allocations recorded in tensor pairs. See `src/runtime/host_build_graph/host/runtime_maker.cpp`.
+`validate_runtime_impl` copies all recorded output tensors back to the host and frees device allocations recorded in tensor pairs. See `src/a5/runtime/host_build_graph/host/runtime_maker.cpp`.
 
 ## Key Files
 
-- `src/runtime/host_build_graph/runtime/runtime.h`
-- `src/runtime/host_build_graph/runtime/runtime.cpp`
-- `src/runtime/host_build_graph/host/runtime_maker.cpp`
-- `src/runtime/host_build_graph/aicpu/aicpu_executor.cpp`
+- `src/a5/runtime/host_build_graph/runtime/runtime.h`
+- `src/a5/runtime/host_build_graph/runtime/runtime.cpp`
+- `src/a5/runtime/host_build_graph/host/runtime_maker.cpp`
+- `src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp`

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -503,20 +503,6 @@ int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     }
     LOG_INFO_V0("Freed %d device tensors", tensor_pair_count);
 
-    // Clear the per-run dispatch-table entries staged by register_callable_impl.
-    // The underlying chip-callable device buffer is pool-managed by
-    // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize().
-    int kernel_count = runtime->get_registered_kernel_count();
-    for (int i = 0; i < kernel_count; i++) {
-        int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->set_function_bin_addr(func_id, 0);
-    }
-    if (kernel_count > 0) {
-        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
-    }
-    runtime->clear_registered_kernels();
-
     if (runtime->get_tensor_info_storage() != nullptr) {
         api->device_free(runtime->get_tensor_info_storage());
         runtime->clear_tensor_info_storage();

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -54,9 +54,6 @@ Runtime::Runtime() {
     tensor_allocation_storage_bytes_ = 0;
     tensor_allocation_count_ = 0;
 
-    // Initialize kernel binary tracking
-    registered_kernel_count_ = 0;
-
     // Initialize function address mapping
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         func_id_to_addr_[i] = 0;
@@ -209,28 +206,6 @@ void Runtime::print_runtime() const {
     }
 
     LOG_DEBUG("========================================================================");
-}
-
-// =============================================================================
-// Kernel Binary Address Management
-// =============================================================================
-
-void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-        return;
-    }
-    if (addr != 0 && func_id_to_addr_[func_id] == 0) {
-        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-        } else {
-            LOG_ERROR(
-                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
-                func_id
-            );
-        }
-    }
-    func_id_to_addr_[func_id] = addr;
 }
 
 // host_build_graph uploads the whole Runtime object (AICore reads tasks[] etc.

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -224,10 +224,6 @@ private:
     // Function address mapping (for API compatibility with rt2)
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
-
     // Tensor info metadata for tensor dump
     void *tensor_info_storage_;
     uint64_t tensor_info_storage_bytes_;
@@ -427,29 +423,13 @@ public:
     }
 
     /**
-     * Set function binary address for a func_id.
-     * Called by platform layer after kernel registration.
-     */
-    void set_function_bin_addr(int func_id, uint64_t addr);
-
-    /**
-     * Replay a previously-uploaded kernel address onto a fresh Runtime
-     * without recording it in registered_kernel_func_ids_. See a2a3 hbg
-     * runtime.h for the full contract.
+     * Replay a previously-uploaded kernel address onto a fresh Runtime.
+     * See a2a3 hbg runtime.h for the full contract.
      */
     void replay_function_bin_addr(int func_id, uint64_t addr) {
         if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) return;
         func_id_to_addr_[func_id] = addr;
     }
-
-    int get_registered_kernel_count() const { return registered_kernel_count_; }
-
-    int get_registered_kernel_func_id(int index) const {
-        if (index < 0 || index >= registered_kernel_count_) return -1;
-        return registered_kernel_func_ids_[index];
-    }
-
-    void clear_registered_kernels() { registered_kernel_count_ = 0; }
 
     // =========================================================================
     // Host-only state (not copied to device)

--- a/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/host/runtime_maker.cpp
@@ -882,21 +882,6 @@ extern "C" int validate_runtime_impl(Runtime *runtime, const HostApi *api) {
     }
     LOG_INFO_V0("Freed %d device allocations", tensor_pair_count);
 
-    // Clear the per-run dispatch-table entries staged by register_callable_impl.
-    // The underlying chip-callable device buffer is pool-managed by
-    // DeviceRunner (keyed by content hash) and bulk-freed in
-    // DeviceRunner::finalize(); re-running the same callable repeatedly
-    // should not re-upload.
-    int kernel_count = runtime->get_registered_kernel_count();
-    for (int i = 0; i < kernel_count; i++) {
-        int func_id = runtime->get_registered_kernel_func_id(i);
-        runtime->set_function_bin_addr(func_id, 0);
-    }
-    if (kernel_count > 0) {
-        LOG_INFO_V0("Cleared %d kernel dispatch-table entries", kernel_count);
-    }
-    runtime->clear_registered_kernels();
-
     // Clear tensor pairs
     runtime->tensor_pairs_.clear();
 

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/runtime.h
@@ -232,14 +232,6 @@ public:
     // copies sizeof(DeviceRuntimeLaunchDesc) bytes from offset 0.
     DeviceRuntimeLaunchDesc dev;
 
-private:
-    // ---- host-only tail (never uploaded to device) ----
-
-    // Kernel binary tracking for cleanup
-    int registered_kernel_func_ids_[RUNTIME_MAX_FUNC_ID];
-    int registered_kernel_count_;
-
-public:
     /**
      * Constructor - zero-initialize all arrays
      */
@@ -298,18 +290,12 @@ public:
     int32_t get_active_callable_id() const;
 
     uint64_t get_function_bin_addr(int func_id) const;
-    void set_function_bin_addr(int func_id, uint64_t addr);
     /**
-     * Replay a previously-uploaded kernel address onto a fresh Runtime
-     * without recording it in registered_kernel_func_ids_. Used by
-     * DeviceRunner::bind_callable_to_runtime so prepared kernel
-     * binaries are not freed by validate_runtime_impl across runs.
+     * Replay a previously-uploaded kernel address onto a fresh Runtime.
+     * Used by DeviceRunner::bind_callable_to_runtime to rebind prepared
+     * kernel binaries onto the runtime before each run.
      */
     void replay_function_bin_addr(int func_id, uint64_t addr);
-
-    int get_registered_kernel_count() const;
-    int get_registered_kernel_func_id(int index) const;
-    void clear_registered_kernels();
 
     // =========================================================================
     // Deprecated API (for platform compatibility, always returns 0/nullptr)

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/shared/runtime.cpp
@@ -46,9 +46,6 @@ Runtime::Runtime() {
     for (int i = 0; i < RUNTIME_MAX_FUNC_ID; i++) {
         dev.func_id_to_addr_[i] = 0;
     }
-
-    // Initialize host-only tail.
-    registered_kernel_count_ = 0;
 }
 
 // =============================================================================
@@ -76,24 +73,6 @@ uint64_t Runtime::get_function_bin_addr(int func_id) const {
     return dev.func_id_to_addr_[func_id];
 }
 
-void Runtime::set_function_bin_addr(int func_id, uint64_t addr) {
-    if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
-        LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
-        return;
-    }
-    if (addr != 0 && dev.func_id_to_addr_[func_id] == 0) {
-        if (registered_kernel_count_ < RUNTIME_MAX_FUNC_ID) {
-            registered_kernel_func_ids_[registered_kernel_count_++] = func_id;
-        } else {
-            LOG_ERROR(
-                "[Runtime] Registration limit reached (%d). Cannot track func_id=%d for cleanup.", RUNTIME_MAX_FUNC_ID,
-                func_id
-            );
-        }
-    }
-    dev.func_id_to_addr_[func_id] = addr;
-}
-
 void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     if (func_id < 0 || func_id >= RUNTIME_MAX_FUNC_ID) {
         LOG_ERROR("[Runtime] func_id=%d is out of range [0, %d)", func_id, RUNTIME_MAX_FUNC_ID);
@@ -101,15 +80,6 @@ void Runtime::replay_function_bin_addr(int func_id, uint64_t addr) {
     }
     dev.func_id_to_addr_[func_id] = addr;
 }
-
-int Runtime::get_registered_kernel_count() const { return registered_kernel_count_; }
-
-int Runtime::get_registered_kernel_func_id(int index) const {
-    if (index < 0 || index >= registered_kernel_count_) return -1;
-    return registered_kernel_func_ids_[index];
-}
-
-void Runtime::clear_registered_kernels() { registered_kernel_count_ = 0; }
 
 // trb's device image is just the `dev` descriptor (the rest of Runtime is
 // host-only). Mirrors the host_build_graph definition (= sizeof(Runtime)).

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -76,7 +76,9 @@ struct HostApi {
     // bulk-freed in DeviceRunner::finalize(). Returns 0 on error or when
     // child_count() == 0. Caller computes child addrs as
     //     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
-    // and stores them via runtime->set_function_bin_addr(fid, child_dev).
+    // and records them in the CallableArtifacts kernel_addrs table, which
+    // DeviceRunner::bind_callable_to_runtime replays onto the runtime's
+    // func_id_to_addr_ before each run.
     uint64_t (*upload_chip_callable_buffer)(const void *callable);
 };
 

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -893,11 +893,10 @@ BindCallableResult DeviceRunnerBase::bind_callable_to_runtime(Runtime &runtime, 
     }
     const auto &state = it->second;
 
-    // Replay kernel addresses directly into runtime.func_id_to_addr_ without
-    // going through set_function_bin_addr. The latter records func_ids in
-    // registered_kernel_func_ids_, which validate_runtime_impl iterates to
-    // free kernel binaries — but registered kernels must survive across runs
-    // and are only freed by `finalize()` / `unregister_callable`.
+    // Replay each prepared kernel address into runtime.func_id_to_addr_.
+    // The kernel binaries are owned by the shared DeviceRunner pool and
+    // survive across runs — freed only by `finalize()`, never by
+    // validate_runtime_impl or `unregister_callable`.
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -247,8 +247,9 @@ public:
      *
      * Callers compute child addresses as
      *     chip_dev + offsetof(ChipCallable, storage_) + child_offset(i)
-     * and write them to Runtime::func_id_to_addr_[fid] via
-     * Runtime::set_function_bin_addr().
+     * and record them in the callable's kernel_addrs table, which
+     * bind_callable_to_runtime replays into Runtime::func_id_to_addr_[fid]
+     * before each run.
      *
      * @param callable  Host-side ChipCallable pointer.
      * @return Device GM address of the ChipCallable header, or 0 on


### PR DESCRIPTION
## Summary

The prepared/cache callable model binds kernel addresses onto the runtime via `replay_function_bin_addr` (`DeviceRunner::bind_callable_to_runtime`), which deliberately does **not** record func_ids. Nothing calls `set_function_bin_addr` with a real address anymore, so `registered_kernel_count_` stays `0` forever — and the validate-time cleanup loops that iterated it were provable no-ops (zero iterations every run).

This removes the whole dead mechanism across a2a3/a5 × host_build_graph/tensormap_and_ringbuffer:

- `set_function_bin_addr()` and its four zero-writing cleanup loops in the validate/finalize paths
- `registered_kernel_func_ids_[]` / `registered_kernel_count_` members and the `get_registered_kernel_count` / `get_registered_kernel_func_id` / `clear_registered_kernels` accessors

The live dispatch path is untouched: `func_id_to_addr_[]`, `get_function_bin_addr()`, and `replay_function_bin_addr()`.

Stale comments/docs that still described the removed API are updated to describe the actual `kernel_addrs` → `replay_function_bin_addr` flow (`host_api.h`, `device_runner_base.{h,cpp}`, both `RUNTIME_LOGIC.md`).

Net: **+23 / −259** across 17 files, no behavior change.

## Testing

- [x] All four runtimes build clean (a2a3/a5 × hbg/tmarb; Host + AICPU + AICore)
- [x] Rebind-lifecycle simulation tests pass — a2a3sim 5/5, a5sim 6/6 (`prepared_callable`, `orch_so_cache`, `dynamic_register`)
- [ ] Hardware tests (no behavior change; the removed loops were no-ops, so onboard behavior is unchanged)