### PR TITLE
[WIP] feat(kernels): thread runtime lane id into TPipe via setSubBlockId

### DIFF
--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/aic/fa_fused_aic.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/aic/fa_fused_aic.cpp
@@ -466,7 +466,7 @@ static __aicore__ void fa_fused_aic(
 static __aicore__ void fa_fused_aiv(
     __gm__ int32_t *v1, __gm__ float *v2, __gm__ float *v3, __gm__ float *v4, __gm__ int32_t *v5, __gm__ int32_t *v6,
     __gm__ int32_t *v7, __gm__ bfloat16_t *v8, __gm__ bfloat16_t *v9, __gm__ bfloat16_t *v10, __gm__ float *v11,
-    int64_t v12, int64_t v13, int32_t v14, int32_t v15
+    int64_t v12, int64_t v13, int32_t v14, int32_t v15, int32_t sub_block_id
 ) {
     SaturationMode v16 = SaturationMode::OFF;
     RoundMode v17 = RoundMode::CAST_ROUND;
@@ -492,8 +492,10 @@ static __aicore__ void fa_fused_aiv(
 #if defined(__DAV_VEC__)
     set_mask_norm();
     set_vector_mask(-1, -1);
-    int64_t v35 = get_subblockid();
+    int64_t v35 = sub_block_id;
     auto v36 = TPipe<0, Direction::DIR_BOTH, 8192, 4, 4, false>(v11, v34, v34);
+    // Thread the runtime AIV lane id into the ISA TPipe (see fa_fused_aiv.cpp).
+    v36.setSubBlockId(sub_block_id);
     int32_t v37 = v1[v23];
     set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
     set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);

--- a/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/aiv/fa_fused_aiv.cpp
+++ b/examples/a2a3/tensormap_and_ringbuffer/qwen3_14b_decode/kernels/aiv/fa_fused_aiv.cpp
@@ -494,13 +494,12 @@ static __aicore__ void fa_fused_aiv(
     set_vector_mask(-1, -1);
     int64_t v35 = sub_block_id;
     auto v36 = TPipe<0, Direction::DIR_BOTH, 8192, 4, 4, false>(v11, v34, v34);
-    // simpler's runtime leaves the AICore sub-block register at 0 for both AIV
-    // lanes, so the library's TILE_UP_DOWN auto-split (get_subblockid() * bytes)
-    // contributes nothing. Supply the per-lane offset explicitly from the
-    // runtime lane id, as spmd_paged_attention does. Tiles are 8x128:
-    // cons = C2V float pop, prod = V2C bf16 push.
-    v36.cons.setEntryOffset(static_cast<int>(sub_block_id) * 8 * 128 * static_cast<int>(sizeof(float)));
-    v36.prod.setEntryOffset(static_cast<int>(sub_block_id) * 8 * 128 * static_cast<int>(sizeof(bfloat16_t)));
+    // Thread the runtime AIV lane id (0/1) into the ISA TPipe so the library's
+    // TILE_UP_DOWN auto-split (laneId() * bytes) places each lane in its own
+    // GM ring-buffer half. simpler's PTO2 runtime leaves the CCE sub-block
+    // register at 0 for both lanes, so the lane must come from the runtime
+    // (get_sub_block_id / sub_block_id), not get_subblockid().
+    v36.setSubBlockId(sub_block_id);
     int32_t v37 = v1[v23];
     set_flag(PIPE_V, PIPE_MTE2, EVENT_ID0);
     set_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);

--- a/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
+++ b/examples/a5/tensormap_and_ringbuffer/bgemm/kernels/mix/kernel_bgemm.cpp
@@ -31,6 +31,7 @@
 #include <pto/common/fifo.hpp>
 
 #include "tensor.h"
+#include "intrinsic.h"
 
 using pto::BLayout;
 using pto::Direction;
@@ -159,7 +160,12 @@ extern "C" __aicore__ void kernel_entry(__gm__ int64_t *args) {
     // Vector side: TPOP result from cube → TLOAD C from GM → TADD → TSTORE
     // =========================================================================
     if constexpr (DAV_VEC) {
-        uint32_t subBlockIdx = get_subblockid();
+        // simpler's PTO2 runtime leaves the CCE sub-block register at 0 for both
+        // AIV lanes, so read the lane from the runtime GlobalContext and thread
+        // it into the ISA TPipe: the library's TILE_UP_DOWN auto-split then uses
+        // laneId() (the runtime lane) instead of the stale get_subblockid().
+        uint32_t subBlockIdx = static_cast<uint32_t>(get_sub_block_id(args));
+        mPipe.setSubBlockId(static_cast<int>(subBlockIdx));
 
         __gm__ float *c_ptr = reinterpret_cast<__gm__ float *>(c_tensor->buffer.addr) + c_tensor->start_offset;
         // Each vector sub-core handles its half: sub-core 0 → rows [0, VEC_M),

--- a/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
+++ b/tests/st/a2a3/tensormap_and_ringbuffer/spmd_paged_attention/kernels/mix/paged_attention_parallel.cpp
@@ -718,16 +718,15 @@ static __aicore__ void run_aiv(
     int32_t sub_block_id = get_sub_block_id(args);
     int64_t row_offset = sub_block_id * Cfg::SUB_QT;
 
-    // Entry offsets depend on the actual tile width (block_size for sij/pij, HEAD_DIM for oi).
-    // TILE_UP_DOWN splits Q_TILE rows into two SUB_QT halves; AIV1's data starts at
-    // SUB_QT * tile_width * sizeof(element) within the contiguous TPUSH'd tile.
-    int sij_sub_offset = sub_block_id * Cfg::SUB_QT * static_cast<int>(block_size) * static_cast<int>(sizeof(float));
-    int pij_sub_offset =
-        sub_block_id * Cfg::SUB_QT * static_cast<int>(block_size) * static_cast<int>(sizeof(bfloat16_t));
-    int oi_sub_offset = sub_block_id * Cfg::SUB_QT * HEAD_DIM * static_cast<int>(sizeof(float));
-    sij_pipe.cons.setEntryOffset(sij_sub_offset);
-    pij_pipe.prod.setEntryOffset(pij_sub_offset);
-    oi_pipe.cons.setEntryOffset(oi_sub_offset);
+    // Thread the runtime AIV lane id (0/1) into each ISA TPipe so the library's
+    // TILE_UP_DOWN auto-split (laneId() * bytes) places each lane in its own
+    // GM ring-buffer half. simpler's PTO2 runtime leaves the CCE sub-block
+    // register at 0 for both lanes, so the lane must come from the runtime
+    // (get_sub_block_id), not get_subblockid(). Replaces the prior manual
+    // cons/prod.setEntryOffset(lane * SUB_QT * tile_width * sizeof(T)) workaround.
+    sij_pipe.setSubBlockId(sub_block_id);
+    pij_pipe.setSubBlockId(sub_block_id);
+    oi_pipe.setSubBlockId(sub_block_id);
 
     // Mirror reverse-dependency disable on the AIV side (see run_aic for
     // the full forward-chain argument).


### PR DESCRIPTION
Under simpler PTO2 dispatch the CCE sub-block register is not programmed, so get_subblockid() returns 0 for both AIV lanes and TILE_UP_DOWN auto-split picks the wrong ring-buffer half. Replace direct get_subblockid() reads and manual cons/prod.setEntryOffset(lane * tile_bytes) workarounds with TPipe::setSubBlockId(get_sub_block_id(args)) from pto-isa PR #186.

Kernel changes (4 files):
- examples/a5/.../bgemm/kernels/mix/kernel_bgemm.cpp get_subblockid() -> get_sub_block_id(args) + mPipe.setSubBlockId; +intrinsic.h
- examples/a2a3/.../qwen3_14b_decode/kernels/aiv/fa_fused_aiv.cpp v36 setEntryOffset workaround -> v36.setSubBlockId(sub_block_id)
- examples/a2a3/.../qwen3_14b_decode/kernels/aic/fa_fused_aic.cpp dead __DAV_VEC__ block: sub_block_id param + setSubBlockId (consistency only)
- tests/st/a2a3/.../spmd_paged_attention/.../paged_attention_parallel.cpp sij/pij/oi pipe setEntryOffset workaround -> setSubBlockId(sub_block_id)

Excluded per instruction: src/{a2a3,a5}/platform/onboard/aicore/kernel.cpp.

Onboard 3-state verification (pto-isa 5d211ba8, task-submit):
- a2a3 qwen3_14b_decode: A PASS / B FAIL (k_cache max_diff=nan) / C PASS
- a5 bgemm: A PASS / B PASS / C PASS

Execution plan and verification report are kept outside this repo:
  ../setsubblockid_plan.md, ../setsubblockid_verify_report.md