### PR TITLE
Refactor: move per-run simpler_run state to its correct lifecycle

### DIFF
--- a/docs/chip-level-arch.md
+++ b/docs/chip-level-arch.md
@@ -106,7 +106,7 @@ DeviceRunner runner;
 void *ptr = runner.allocate_tensor(bytes);
 runner.copy_to_device(dev_ptr, host_ptr, bytes);
 runner.set_executors(aicpu_binary, aicore_binary);   // once, at init time
-runner.run(runtime, block_dim, launch_aicpu_num);
+runner.run(runtime, config);                         // config carries block_dim, aicpu_thread_num, diagnostics
 runner.finalize();
 ```
 
@@ -123,9 +123,9 @@ simpler_init(ctx, device_id,                          // attach + binary takeove
              aicore_binary, aicore_size);
 size_t size = get_runtime_size();
 register_callable(ctx, cid, callable);                 // one-time per callable
-simpler_run(ctx, runtime, cid, args, block_dim,      // per-launch — no binaries
-             aicpu_thread_num,
-             enable_l2_swimlane, enable_dump_tensor, enable_pmu, output_prefix);
+simpler_run(ctx, runtime, cid, args, config);        // per-launch — no binaries; config
+                                                       // carries block_dim, aicpu_thread_num,
+                                                       // diagnostics + ring overrides
 unregister_callable(ctx, cid);
 finalize_device(ctx);
 destroy_device_context(ctx);

--- a/docs/dynamic-linking.md
+++ b/docs/dynamic-linking.md
@@ -296,11 +296,10 @@ ChipWorker.init(device_id, bins)                       # Python wrapper
       DeviceRunner::set_executors(aicpu, aicore)       binaries owned by runner
 
 ChipWorker.run(handle, args, config)                   # public wrapper path
-  simpler_run(ctx, buf, internal callable entry, args, block_dim, aicpu_thread_num, …)
+  simpler_run(ctx, buf, internal callable entry, args, config)
     new (buf) Runtime()
-    bind_prepared_callable_to_runtime(r, internal callable entry)
-    bind_prepared_to_runtime_impl(r, args)
-    DeviceRunner::run(r, block_dim, aicpu_thread_num)
+    DeviceRunner::bind_callable_to_runtime(r, cid, api, args, rings)  # replay + per-run bind
+    DeviceRunner::run(r, config)                        # applies config, resolves block_dim
       clear_cpu_sim_shared_storage()
       ensure_binaries_loaded()               dlopen aicpu/aicore SOs once
       launch AICPU + AICore threads
@@ -350,10 +349,9 @@ device_worker_main(device_id)
             upload child kernels, copy orch SO to device buffer
         for each launch with that handle:
           ChipWorker.run(handle, args, config)
-            simpler_run(ctx, buf, internal callable entry, args, block_dim, aicpu_thread_num, …)
+            simpler_run(ctx, buf, internal callable entry, args, config)
               new (buf) Runtime()
-              bind_prepared_callable_to_runtime()
-              bind_prepared_to_runtime_impl()  rtMalloc, rtMemcpy to device
+              bind_callable_to_runtime()       replay + rtMalloc, rtMemcpy to device
               DeviceRunner::run()
                 ensure_binaries_loaded()       already done by init
                 rtsLaunchCpuKernel()           cached rtFuncHandle

--- a/src/a2a3/platform/onboard/host/device_runner.cpp
+++ b/src/a2a3/platform/onboard/host/device_runner.cpp
@@ -35,6 +35,7 @@
 #include "aicpu_topology_probe.h"
 #include "callable.h"
 #include "callable_protocol.h"
+#include "call_config.h"
 #include "chip_callable_layout.h"
 #include "utils/elf_build_id.h"
 #include "host/host_regs.h"  // Register address retrieval
@@ -184,7 +185,12 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
 // live on `DeviceRunnerBase` — see
 // `src/common/platform/onboard/host/device_runner_base.cpp`.
 
-int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
+int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+    // Latch this run's diagnostic enables onto the runner before the collector
+    // paths below read them; block_dim/aicpu_thread_num are consumed locally.
+    apply_call_config(config);
+    int block_dim = config.block_dim;
+    const int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade into
     // rtMalloc 507899 / halResMap rc=62 (init_aicore_register_addresses). A soft

--- a/src/a2a3/platform/onboard/host/device_runner.h
+++ b/src/a2a3/platform/onboard/host/device_runner.h
@@ -112,7 +112,7 @@ public:
      * are captured once by simpler_init (binaries) / libsimpler_log.so (log)
      * and read off DeviceRunner state / HostLogger here — no per-run args.
      */
-    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) override;
+    int run(Runtime &runtime, const CallConfig &config) override;
 
     /**
      * a2a3-only `dep_gen` enablement setter. The shared

--- a/src/a2a3/platform/sim/host/device_runner.cpp
+++ b/src/a2a3/platform/sim/host/device_runner.cpp
@@ -31,6 +31,7 @@
 
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/platform_aicpu_affinity.h"
+#include "call_config.h"
 #include "callable_protocol.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
@@ -205,7 +206,10 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
+int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+    apply_call_config(config);
+    int block_dim = config.block_dim;
+    const int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);

--- a/src/a2a3/platform/sim/host/device_runner.h
+++ b/src/a2a3/platform/sim/host/device_runner.h
@@ -33,7 +33,7 @@ public:
     DeviceRunner() = default;
     ~DeviceRunner() override;
 
-    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) override;
+    int run(Runtime &runtime, const CallConfig &config) override;
     int finalize() override;
     void set_dep_gen_enabled(bool enable) override { enable_dep_gen_ = enable; }
 

--- a/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a2a3/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -1145,7 +1145,21 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // 1. Invalidate AICPU cache for Runtime address range.
     //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
-    cache_invalidate_range(runtime, sizeof(Runtime));
+    //    Invalidate exactly the uploaded prefix (offsetof(tasks) + populated
+    //    tasks): the device buffer is allocated at that size (see
+    //    runtime_device_copy_size / init_runtime_args), so invalidating
+    //    sizeof(Runtime) would iterate cache lines past the allocation into
+    //    unrelated memory. A short invalidate is also sufficient — every run
+    //    reads only tasks[0..next_task_id) for its OWN next_task_id (get_task()
+    //    bounds-checks), and the H2D DMA wrote exactly that, so no run ever
+    //    observes a task line beyond its own prefix. cache_invalidate_range
+    //    rounds the end up to a 64-byte line, covering a partial trailing line.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+    const size_t runtime_prefix_bytes =
+        offsetof(Runtime, tasks) + static_cast<size_t>(runtime->get_task_count()) * sizeof(Task);
+#pragma GCC diagnostic pop
+    cache_invalidate_range(runtime, runtime_prefix_bytes);
     if (runtime->get_tensor_info_storage() != nullptr && runtime->get_tensor_info_storage_bytes() > 0) {
         cache_invalidate_range(
             runtime->get_tensor_info_storage(), static_cast<size_t>(runtime->get_tensor_info_storage_bytes())

--- a/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a2a3/runtime/host_build_graph/host/runtime_maker.cpp
@@ -372,9 +372,8 @@ int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(c
 /**
  * Per-run binding for hbg: invoke the previously-resolved orchestration entry
  * point against the supplied args, then upload tensor info / allocation
- * storage. The c_api caller passes `host_orch_func_ptr` straight through from
- * DeviceRunner::bind_callable_to_runtime (which read it from
- * CallableState for this run's callable_id).
+ * storage. DeviceRunner::bind_callable_to_runtime passes `host_orch_func_ptr`
+ * straight through from CallableState for this run's callable_id.
  */
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.cpp
@@ -208,6 +208,14 @@ void Runtime::print_runtime() const {
     LOG_DEBUG("========================================================================");
 }
 
-// host_build_graph uploads the whole Runtime object (AICore reads tasks[] etc.
-// by offset), so the device copy size is the full struct.
-size_t runtime_device_copy_size(const Runtime &) { return sizeof(Runtime); }
+// host_build_graph uploads a variable-length prefix of the Runtime object:
+// everything up to and including the populated task slots. tasks[] is the last
+// device-read member, so this ships every device-read field while truncating the
+// unpopulated task tail and the host-only members declared after tasks[]. See
+// the static_asserts in runtime.h.
+size_t runtime_device_copy_size(const Runtime &rt) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+    return offsetof(Runtime, tasks) + static_cast<size_t>(rt.get_task_count()) * sizeof(Task);
+#pragma GCC diagnostic pop
+}

--- a/src/a2a3/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a2a3/runtime/host_build_graph/runtime/runtime.h
@@ -30,6 +30,7 @@
 #define SRC_A2A3_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_
 
 #include <stdbool.h>
+#include <stddef.h>  // for offsetof (layout static_asserts)
 #include <stdint.h>
 #include <stdio.h>   // for fprintf, printf
 #include <string.h>  // for memset
@@ -174,7 +175,17 @@ typedef struct {
  */
 class Runtime {
 public:
-    // Handshake buffers for AICPU-AICore communication
+    // ===================== Device-read prefix =====================
+    // Everything from here through `tasks[]` is uploaded to the device. The
+    // ordering is load-bearing: AICore reads `workers[]` at offset 0 and
+    // `tasks[i]` by offset, and `tasks[]` is the LAST device-read member so a
+    // variable-length H2D copy of `offsetof(tasks) + get_task_count()*sizeof(Task)`
+    // (see runtime_device_copy_size) keeps every preceding field at its fixed
+    // offset while shipping only the populated task slots. All fields device
+    // code may read must therefore precede `tasks[]`; the offsetof static_asserts
+    // after the class enforce this. These are public (not hidden behind the
+    // accessors) because they form the host/device ABI, mirroring trb's
+    // DeviceRuntimeLaunchDesc.
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
@@ -183,38 +194,50 @@ public:
     // round-robin across the assigned cores. See AicpuExecutor::init.
     int aicpu_thread_num;
 
-    // Task storage
-    Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
-
-    // Filter-style affinity gate input (a2a3 onboard). Placed AFTER `tasks`
-    // because AICore reads runtime->tasks[] by offset. Host fills these before
+    // Filter-style affinity gate input (a2a3 onboard). Host fills these before
     // launch from AICPU OCCUPY; the device gate keeps threads whose
-    // sched_getcpu() lands on one of the cpu_ids. The array position is the
-    // deterministic exec_idx used by AicpuExecutor for stable core assignment.
+    // sched_getcpu() lands on one of the cpu_ids. Read device-side in kernel.cpp,
+    // so it must precede `tasks[]`.
     int32_t aicpu_allowed_cpus[MAX_GATE_THREADS];
     int32_t aicpu_allowed_cpu_count;
     int32_t aicpu_launch_count;
 
-private:
-    int next_task_id;  // Next available task ID
+    // Next available task ID. Device-read via get_task_count() (AICPU task loop
+    // bound), so it lives in the prefix.
+    int next_task_id;
 
-    // Initial ready tasks (computed once, read-only after)
-    int initial_ready_tasks[RUNTIME_MAX_TASKS];
-    int initial_ready_count;
-
-    // Function address mapping (for API compatibility with rt2)
+    // Function address mapping (for API compatibility with rt2). Device-read
+    // under PTO2_PROFILING (dump-args path), so it lives in the prefix.
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Tensor info metadata for tensor dump
+    // Tensor info metadata for tensor dump. Device-read via get_tensor_info()
+    // under PTO2_PROFILING, so it lives in the prefix.
     void *tensor_info_storage_;
     uint64_t tensor_info_storage_bytes_;
     uint32_t tensor_info_offsets_[RUNTIME_MAX_TASKS];
     uint16_t tensor_info_counts_[RUNTIME_MAX_TASKS];
 
-    // Device allocation ranges used to recover tensor buffer addresses from task.args[]
+    // Device allocation ranges used to recover tensor buffer addresses from
+    // task.args[]. Device-read via is_tensor_buffer_addr() under PTO2_PROFILING,
+    // so it lives in the prefix.
     void *tensor_allocation_storage_;
     uint64_t tensor_allocation_storage_bytes_;
     uint32_t tensor_allocation_count_;
+
+    // Task storage — LAST device-read member. The variable-length H2D copy stops
+    // at offsetof(tasks) + get_task_count()*sizeof(Task); the unpopulated tail is
+    // never read device-side (get_task() bounds-checks task_id < next_task_id,
+    // and AICore only touches AICPU-dispatched ids).
+    Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
+
+private:
+    // ===================== Host-only tail =====================
+    // Never crosses to the device (physically after `tasks[]`, excluded from the
+    // H2D copy). See also active_callable_id_ / tensor_pairs_ declared below.
+
+    // Initial ready tasks (computed once, read-only after)
+    int initial_ready_tasks[RUNTIME_MAX_TASKS];
+    int initial_ready_count;
 
 public:
     /**
@@ -428,15 +451,44 @@ public:
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time; iterated in
-    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
-    // Runtime image carries the std::vector control block as harmless
-    // garbage. No fixed cap.
+    // validate_runtime_impl. Not read by AICPU/AICore and — being after
+    // `tasks[]` in the host-only tail — is not uploaded to the device at all.
+    // No fixed cap.
     std::vector<TensorPair> tensor_pairs_;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+// Layout invariants for the variable-length H2D copy (runtime_device_copy_size).
+// workers[] must be first (AICore reads runtime->workers[block_idx] at offset 0),
+// and tasks[] must be the highest-offset device-read member so copying
+// offsetof(tasks) + n*sizeof(Task) covers every field the device reads while
+// truncating only the unpopulated task tail. The host-only tail
+// (initial_ready_*, registered_*, active_callable_id_, tensor_pairs_) sits after
+// tasks[] and is excluded from the copy. (offsetof over Runtime is technically
+// non-standard-layout due to the std::vector tail; the pragma silences that —
+// the device-read prefix is all standard-layout scalars/arrays.)
+static_assert(offsetof(Runtime, workers) == 0, "workers[] must be first: AICore reads offset 0");
+static_assert(
+    offsetof(Runtime, tasks) > offsetof(Runtime, aicpu_allowed_cpus),
+    "tasks[] must follow the affinity gate array (device-read at fixed offset)"
+);
+static_assert(
+    offsetof(Runtime, tasks) > offsetof(Runtime, func_id_to_addr_),
+    "tasks[] must follow func_id_to_addr_ (device-read under profiling)"
+);
+static_assert(
+    offsetof(Runtime, tasks) > offsetof(Runtime, tensor_allocation_count_),
+    "tasks[] must be the last device-read member (all profiling metadata precedes it)"
+);
+#pragma GCC diagnostic pop
+
 // Number of bytes of the Runtime image copied to the device. host_build_graph
-// uploads the whole object (AICore reads tasks[] etc. by offset), so this is
-// sizeof(Runtime). Mirrors the trb declaration so the shared
+// uploads a variable-length prefix: everything from offset 0 up to and including
+// the populated task slots, i.e. offsetof(Runtime, tasks) + n*sizeof(Task).
+// tasks[] is the last device-read member (static_asserts above), so this ships
+// every device-read field while truncating the unpopulated task tail and the
+// host-only members after tasks[]. Mirrors the trb declaration so the shared
 // device_runner_helpers.cpp copy path is runtime-agnostic.
 size_t runtime_device_copy_size(const Runtime &rt);
 

--- a/src/a5/platform/onboard/host/device_runner.cpp
+++ b/src/a5/platform/onboard/host/device_runner.cpp
@@ -34,6 +34,7 @@
 #include "aicpu_topology_probe.h"
 #include "callable.h"
 #include "callable_protocol.h"
+#include "call_config.h"
 #include "utils/elf_build_id.h"
 #include "utils/fnv1a_64.h"
 #include "host/host_regs.h"  // Register address retrieval
@@ -142,7 +143,12 @@ int DeviceRunner::destroy_comm_stream(void *stream) {
     return 0;
 }
 
-int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
+int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+    // Latch this run's diagnostic enables onto the runner before the collector
+    // paths below read them; block_dim/aicpu_thread_num are consumed locally.
+    apply_call_config(config);
+    int block_dim = config.block_dim;
+    const int launch_aicpu_num = config.aicpu_thread_num;
     // A prior AICore launch/sync error poisoned the device context and the
     // in-place drain could not clear it. Refuse to run rather than cascade
     // into halResMap rc=62 (init_aicore_register_addresses) or rtMalloc

--- a/src/a5/platform/onboard/host/device_runner.h
+++ b/src/a5/platform/onboard/host/device_runner.h
@@ -105,7 +105,7 @@ public:
      * are captured once by simpler_init (binaries) / libsimpler_log.so (log)
      * and read off DeviceRunner state / HostLogger here — no per-run args.
      */
-    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) override;
+    int run(Runtime &runtime, const CallConfig &config) override;
 
     // `set_l2_swimlane_enabled`, `set_dump_tensor_enabled`,
     // `set_pmu_enabled`, `set_scope_stats_enabled`, `set_output_prefix`,

--- a/src/a5/platform/sim/host/device_runner.cpp
+++ b/src/a5/platform/sim/host/device_runner.cpp
@@ -32,6 +32,7 @@
 
 #include "aicpu/device_phase_aicpu.h"
 #include "aicpu/platform_aicpu_affinity.h"
+#include "call_config.h"
 #include "callable_protocol.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
@@ -206,7 +207,10 @@ int DeviceRunner::invoke_device_register(const RegisterCallableArgs &reg_args) {
     return aicpu_register_callable_func_(const_cast<RegisterCallableArgs *>(&reg_args));
 }
 
-int DeviceRunner::run(Runtime &runtime, int block_dim, int launch_aicpu_num) {
+int DeviceRunner::run(Runtime &runtime, const CallConfig &config) {
+    apply_call_config(config);
+    int block_dim = config.block_dim;
+    const int launch_aicpu_num = config.aicpu_thread_num;
     clear_cpu_sim_shared_storage();
     if (launch_aicpu_num < 1 || launch_aicpu_num > PLATFORM_MAX_AICPU_THREADS) {
         LOG_ERROR("launch_aicpu_num (%d) must be in range [1, %d]", launch_aicpu_num, PLATFORM_MAX_AICPU_THREADS);

--- a/src/a5/platform/sim/host/device_runner.h
+++ b/src/a5/platform/sim/host/device_runner.h
@@ -32,7 +32,7 @@ public:
     DeviceRunner() = default;
     ~DeviceRunner() override;
 
-    int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) override;
+    int run(Runtime &runtime, const CallConfig &config) override;
     int finalize() override;
     // a5 dep_gen enablement setter, overriding the base no-op (the c_api
     // unconditionally calls it).

--- a/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
+++ b/src/a5/runtime/host_build_graph/aicpu/aicpu_executor.cpp
@@ -1140,7 +1140,21 @@ void AicpuExecutor::deinit(Runtime *runtime) {
     // 1. Invalidate AICPU cache for Runtime address range.
     //    Next round's Host DMA (rtMemcpy) writes fresh Runtime to HBM but
     //    bypasses this cache. Invalidating now ensures next round reads from HBM.
-    cache_invalidate_range(runtime, sizeof(Runtime));
+    //    Invalidate exactly the uploaded prefix (offsetof(tasks) + populated
+    //    tasks): the device buffer is allocated at that size (see
+    //    runtime_device_copy_size / init_runtime_args), so invalidating
+    //    sizeof(Runtime) would iterate cache lines past the allocation into
+    //    unrelated memory. A short invalidate is also sufficient — every run
+    //    reads only tasks[0..next_task_id) for its OWN next_task_id (get_task()
+    //    bounds-checks), and the H2D DMA wrote exactly that, so no run ever
+    //    observes a task line beyond its own prefix. cache_invalidate_range
+    //    rounds the end up to a 64-byte line, covering a partial trailing line.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+    const size_t runtime_prefix_bytes =
+        offsetof(Runtime, tasks) + static_cast<size_t>(runtime->get_task_count()) * sizeof(Task);
+#pragma GCC diagnostic pop
+    cache_invalidate_range(runtime, runtime_prefix_bytes);
     if (runtime->get_tensor_info_storage() != nullptr && runtime->get_tensor_info_storage_bytes() > 0) {
         cache_invalidate_range(
             runtime->get_tensor_info_storage(), static_cast<size_t>(runtime->get_tensor_info_storage_bytes())

--- a/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
+++ b/src/a5/runtime/host_build_graph/host/runtime_maker.cpp
@@ -372,9 +372,8 @@ int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(c
 /**
  * Per-run binding for hbg: invoke the previously-resolved orchestration entry
  * point against the supplied args, then upload tensor info / allocation
- * storage. The c_api caller passes `host_orch_func_ptr` straight through from
- * DeviceRunner::bind_callable_to_runtime (which read it from
- * CallableState for this run's callable_id).
+ * storage. DeviceRunner::bind_callable_to_runtime passes `host_orch_func_ptr`
+ * straight through from CallableState for this run's callable_id.
  */
 int bind_callable_to_runtime_impl(
     Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,

--- a/src/a5/runtime/host_build_graph/runtime/runtime.cpp
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.cpp
@@ -208,6 +208,14 @@ void Runtime::print_runtime() const {
     LOG_DEBUG("========================================================================");
 }
 
-// host_build_graph uploads the whole Runtime object (AICore reads tasks[] etc.
-// by offset), so the device copy size is the full struct.
-size_t runtime_device_copy_size(const Runtime &) { return sizeof(Runtime); }
+// host_build_graph uploads a variable-length prefix of the Runtime object:
+// everything up to and including the populated task slots. tasks[] is the last
+// device-read member, so this ships every device-read field while truncating the
+// unpopulated task tail and the host-only members declared after tasks[]. See
+// the static_asserts in runtime.h.
+size_t runtime_device_copy_size(const Runtime &rt) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+    return offsetof(Runtime, tasks) + static_cast<size_t>(rt.get_task_count()) * sizeof(Task);
+#pragma GCC diagnostic pop
+}

--- a/src/a5/runtime/host_build_graph/runtime/runtime.h
+++ b/src/a5/runtime/host_build_graph/runtime/runtime.h
@@ -30,6 +30,7 @@
 #define SRC_A5_RUNTIME_HOST_BUILD_GRAPH_RUNTIME_RUNTIME_H_
 
 #include <stdbool.h>
+#include <stddef.h>  // for offsetof (layout static_asserts)
 #include <stdint.h>
 #include <stdio.h>   // for fprintf, printf
 #include <string.h>  // for memset
@@ -180,7 +181,17 @@ typedef struct {
  */
 class Runtime {
 public:
-    // Handshake buffers for AICPU-AICore communication
+    // ===================== Device-read prefix =====================
+    // Everything from here through `tasks[]` is uploaded to the device. The
+    // ordering is load-bearing: AICore reads `workers[]` at offset 0 and
+    // `tasks[i]` by offset, and `tasks[]` is the LAST device-read member so a
+    // variable-length H2D copy of `offsetof(tasks) + get_task_count()*sizeof(Task)`
+    // (see runtime_device_copy_size) keeps every preceding field at its fixed
+    // offset while shipping only the populated task slots. All fields device
+    // code may read must therefore precede `tasks[]`; the offsetof static_asserts
+    // after the class enforce this. These are public (not hidden behind the
+    // accessors) because they form the host/device ABI, mirroring trb's
+    // DeviceRuntimeLaunchDesc.
     Handshake workers[RUNTIME_MAX_WORKER];  // Worker (AICore) handshake buffers
     int worker_count;                       // Number of active workers
 
@@ -189,21 +200,15 @@ public:
     // round-robin across the assigned cores. See AicpuExecutor::init.
     int aicpu_thread_num;
 
-    // Task storage
-    Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
-
-    // Filter-style affinity gate input (a5 onboard). Placed AFTER `tasks`
-    // because AICore reads runtime->tasks[] by offset (see
-    // src/a5/runtime/host_build_graph/aicore/aicore_executor.cpp); inserting
-    // fields before `tasks` shifts that offset and silently produces NaN
-    // outputs in any test that exercises the AICore task-execute path.
-    // Host fills before launch from device-side OCCUPY + DSMI CPU_TOPO via
-    // pto::a5::compute_allowed_cpus. The on-device gate keeps threads whose
-    // sched_getcpu() lands on one of these cpu_ids; exec_idx = position in
-    // this array drives sched/orch role assignment. Indices 0..count-2 are
-    // scheduler slots, index count-1 is the orchestrator slot. Sized to
-    // MAX_GATE_THREADS (the shared gate/ABI bound, ≥ any launch count) for
-    // headroom — current policy is 4 sched + 1 orch = 5 active.
+    // Filter-style affinity gate input (a5 onboard). Read device-side by the
+    // affinity gate, so it must precede `tasks[]`. Host fills before launch from
+    // device-side OCCUPY + DSMI CPU_TOPO via pto::a5::compute_allowed_cpus. The
+    // on-device gate keeps threads whose sched_getcpu() lands on one of these
+    // cpu_ids; exec_idx = position in this array drives sched/orch role
+    // assignment. Indices 0..count-2 are scheduler slots, index count-1 is the
+    // orchestrator slot. Sized to MAX_GATE_THREADS (the shared gate/ABI bound,
+    // ≥ any launch count) for headroom — current policy is 4 sched + 1 orch = 5
+    // active.
     int32_t aicpu_allowed_cpus[MAX_GATE_THREADS];
     int32_t aicpu_allowed_cpu_count;
     // Actual AICPU thread launch count for this run. Set by the host
@@ -214,26 +219,44 @@ public:
     // PLATFORM_MAX_AICPU_THREADS_JUST_FOR_LAUNCH bound).
     int32_t aicpu_launch_count;
 
-private:
-    int next_task_id;  // Next available task ID
+    // Next available task ID. Device-read via get_task_count() (AICPU task loop
+    // bound), so it lives in the prefix.
+    int next_task_id;
 
-    // Initial ready tasks (computed once, read-only after)
-    int initial_ready_tasks[RUNTIME_MAX_TASKS];
-    int initial_ready_count;
-
-    // Function address mapping (for API compatibility with rt2)
+    // Function address mapping (for API compatibility with rt2). Device-read
+    // under PTO2_PROFILING (dump-args path), so it lives in the prefix.
     uint64_t func_id_to_addr_[RUNTIME_MAX_FUNC_ID];
 
-    // Tensor info metadata for tensor dump
+    // Tensor info metadata for tensor dump. Device-read via get_tensor_info()
+    // under PTO2_PROFILING, so it lives in the prefix.
     void *tensor_info_storage_;
     uint64_t tensor_info_storage_bytes_;
     uint32_t tensor_info_offsets_[RUNTIME_MAX_TASKS];
     uint16_t tensor_info_counts_[RUNTIME_MAX_TASKS];
 
-    // Device allocation ranges used to recover tensor buffer addresses from task.args[]
+    // Device allocation ranges used to recover tensor buffer addresses from
+    // task.args[]. Device-read via is_tensor_buffer_addr() under PTO2_PROFILING,
+    // so it lives in the prefix.
     void *tensor_allocation_storage_;
     uint64_t tensor_allocation_storage_bytes_;
     uint32_t tensor_allocation_count_;
+
+    // Task storage — LAST device-read member. The variable-length H2D copy stops
+    // at offsetof(tasks) + get_task_count()*sizeof(Task); the unpopulated tail is
+    // never read device-side (get_task() bounds-checks task_id < next_task_id,
+    // and AICore only touches AICPU-dispatched ids). Inserting a device-read
+    // field after `tasks` would shift its offset and silently produce NaN
+    // outputs in any AICore task-execute test.
+    Task tasks[RUNTIME_MAX_TASKS];  // Fixed-size task array
+
+private:
+    // ===================== Host-only tail =====================
+    // Never crosses to the device (physically after `tasks[]`, excluded from the
+    // H2D copy). See also active_callable_id_ / tensor_pairs_ declared below.
+
+    // Initial ready tasks (computed once, read-only after)
+    int initial_ready_tasks[RUNTIME_MAX_TASKS];
+    int initial_ready_count;
 
 public:
     /**
@@ -446,15 +469,44 @@ public:
 
     // Host-side tensor ledger for D2H copy-back at finalize. Populated by
     // runtime_maker.cpp from orch_args at bind time; iterated in
-    // validate_runtime_impl. Not read by AICPU/AICore — the device-side
-    // Runtime image carries the std::vector control block as harmless
-    // garbage. No fixed cap.
+    // validate_runtime_impl. Not read by AICPU/AICore and — being after
+    // `tasks[]` in the host-only tail — is not uploaded to the device at all.
+    // No fixed cap.
     std::vector<TensorPair> tensor_pairs_;
 };
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
+// Layout invariants for the variable-length H2D copy (runtime_device_copy_size).
+// workers[] must be first (AICore reads runtime->workers[block_idx] at offset 0),
+// and tasks[] must be the highest-offset device-read member so copying
+// offsetof(tasks) + n*sizeof(Task) covers every field the device reads while
+// truncating only the unpopulated task tail. The host-only tail
+// (initial_ready_*, registered_*, active_callable_id_, tensor_pairs_) sits after
+// tasks[] and is excluded from the copy. (offsetof over Runtime is technically
+// non-standard-layout due to the std::vector tail; the pragma silences that —
+// the device-read prefix is all standard-layout scalars/arrays.)
+static_assert(offsetof(Runtime, workers) == 0, "workers[] must be first: AICore reads offset 0");
+static_assert(
+    offsetof(Runtime, tasks) > offsetof(Runtime, aicpu_allowed_cpus),
+    "tasks[] must follow the affinity gate array (device-read at fixed offset)"
+);
+static_assert(
+    offsetof(Runtime, tasks) > offsetof(Runtime, func_id_to_addr_),
+    "tasks[] must follow func_id_to_addr_ (device-read under profiling)"
+);
+static_assert(
+    offsetof(Runtime, tasks) > offsetof(Runtime, tensor_allocation_count_),
+    "tasks[] must be the last device-read member (all profiling metadata precedes it)"
+);
+#pragma GCC diagnostic pop
+
 // Number of bytes of the Runtime image copied to the device. host_build_graph
-// uploads the whole object (AICore reads tasks[] etc. by offset), so this is
-// sizeof(Runtime). Mirrors the trb declaration so the shared
+// uploads a variable-length prefix: everything from offset 0 up to and including
+// the populated task slots, i.e. offsetof(Runtime, tasks) + n*sizeof(Task).
+// tasks[] is the last device-read member (static_asserts above), so this ships
+// every device-read field while truncating the unpopulated task tail and the
+// host-only members after tasks[]. Mirrors the trb declaration so the shared
 // device_runner_helpers.cpp copy path is runtime-agnostic.
 size_t runtime_device_copy_size(const Runtime &rt);
 

--- a/src/common/platform/include/common/host_api.h
+++ b/src/common/platform/include/common/host_api.h
@@ -18,11 +18,14 @@
  * Host API function pointers for device memory operations.
  * Allows a runtime to use pluggable device-memory backends.
  *
- * This is a platform capability, not runtime state: it is populated once per
- * simpler_run by the platform layer (onboard / sim c_api_shared.cpp) and passed
- * explicitly into bind_callable_to_runtime_impl / validate_runtime_impl. Shared
- * by every runtime variant (tensormap_and_ringbuffer / host_build_graph) and
- * arch (a2a3 / a5) so the field set stays defined in exactly one place.
+ * This is a platform capability, not runtime state: the platform layer
+ * (onboard / sim c_api_shared.cpp) builds one shared, const table of
+ * context-free function pointers at load time and passes it by address into
+ * bind_callable_to_runtime_impl / validate_runtime_impl. Each pointer recovers
+ * its runner from a thread-local, so the single table is valid for every runner
+ * and every run — it is not rebuilt per simpler_run. Shared by every runtime
+ * variant (tensormap_and_ringbuffer / host_build_graph) and arch (a2a3 / a5) so
+ * the field set stays defined in exactly one place.
  */
 struct HostApi {
     void *(*device_malloc)(size_t size);

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "callable.h"
+#include "call_config.h"
 #include "device_runner_base.h"
 #include "prepare_callable_common.h"
 #include "pto_runtime_c_api.h"
@@ -56,11 +57,6 @@ extern "C" {
  * Runtime Implementation Functions (defined in each runtime's runtime_maker.cpp)
  * =========================================================================== */
 int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
-int bind_callable_to_runtime_impl(
-    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
-    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
-    const uint64_t *ring_dep_pool
-);
 int validate_runtime_impl(Runtime *runtime, const HostApi *api);
 
 /* ===========================================================================
@@ -183,6 +179,26 @@ static void mark_prebuilt_runtime_arena_cached_wrapper(
         );
     } catch (...) {}
 }
+
+// The HostApi is a set of context-free function pointers: each wrapper above
+// recovers its runner from the thread-local current_runner(), so a single
+// filled table is valid for every runner and every run. Build it once at load
+// time rather than reassembling the 12 pointers on each simpler_run. Passed by
+// address into bind_callable_to_runtime_impl / validate_runtime_impl.
+static const HostApi g_host_api = {
+    .device_malloc = device_malloc,
+    .device_free = device_free,
+    .copy_to_device = copy_to_device,
+    .copy_from_device = copy_from_device,
+    .device_memset = device_memset,
+    .setup_static_arena = setup_static_arena_wrapper,
+    .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
+    .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,
+    .acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper,
+    .lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper,
+    .mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper,
+    .upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper,
+};
 
 /* ===========================================================================
  * Public C API (resolved by ChipWorker via dlsym)
@@ -460,12 +476,9 @@ static void emit_device_phase_markers(DeviceRunnerBase *runner) {
 }
 
 int simpler_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
-    const char *output_prefix
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
 ) {
-    if (ctx == NULL || runtime == NULL) return -1;
+    if (ctx == NULL || runtime == NULL || config == NULL) return -1;
     DeviceRunnerBase *runner = static_cast<DeviceRunnerBase *>(ctx);
 
     if (!runner->has_callable(callable_id)) {
@@ -496,70 +509,40 @@ int simpler_run(
             r->~Runtime();
         });
         // Platform device-memory hooks. host_api is a platform capability, not
-        // runtime state — it lives here (local to simpler_run, covering the whole
-        // bind→run→validate span) and is passed explicitly into the runtime impls
-        // rather than stored on `Runtime`.
-        HostApi api{};
-        api.device_malloc = device_malloc;
-        api.device_free = device_free;
-        api.copy_to_device = copy_to_device;
-        api.copy_from_device = copy_from_device;
-        api.device_memset = device_memset;
-        api.setup_static_arena = setup_static_arena_wrapper;
-        api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
-        api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
-        api.acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper;
-        api.lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper;
-        api.mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper;
-        api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
-
+        // runtime state — the shared g_host_api table (built once at load time)
+        // is passed explicitly into the runtime impls rather than stored on
+        // `Runtime` or reassembled per run.
         {
             STRACE("simpler_run.bind");
-            // Restore kernel addrs + orch symbol names + active_callable_id; the
-            // returned host_orch_func_ptr is non-null only on the hbg path and is
-            // handed straight into bind_callable_to_runtime_impl below. signature
-            // is the cached ChipCallable signature_[]; it's plumbed end-to-end for
-            // per-tensor direction decisions in runtime_maker. trb consumes it to
-            // skip the D2H copy-back of read-only INPUT tensors; hbg still
-            // ignores it — see bind_callable_to_runtime_impl.
-            auto bind_result = runner->bind_callable_to_runtime(*r, callable_id);
-            if (bind_result.rc != 0) {
-                return bind_result.rc;
-            }
-
-            // Per-run binding (tensor args, GM heap, SM alloc)
-            rc = bind_callable_to_runtime_impl(
-                r, &api, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
-                bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
+            // One-step bind: restore kernel addrs + active_callable_id and run
+            // the per-run binding (tensor args, GM heap, SM alloc). The
+            // CallableState-derived host_orch_func_ptr + signature stay inside
+            // the runner — no longer returned across this boundary.
+            rc = runner->bind_callable_to_runtime(
+                *r, callable_id, &g_host_api, args, config->runtime_env.ring_task_window, config->runtime_env.ring_heap,
+                config->runtime_env.ring_dep_pool
             );
         }
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
-            validate_runtime_impl(r, &api);
+            validate_runtime_impl(r, &g_host_api);
             return rc;
         }
 
-        runner->set_l2_swimlane_enabled(enable_l2_swimlane);
-        runner->set_dump_tensor_enabled(enable_dump_tensor);
-        runner->set_pmu_enabled(enable_pmu);
-        // Virtual: a2a3 and a5 wire through to their enable_dep_gen_; an arch
-        // without dep_gen falls through to the base no-op.
-        runner->set_dep_gen_enabled(enable_dep_gen != 0);
-        runner->set_scope_stats_enabled(enable_scope_stats != 0);
-        runner->set_output_prefix(output_prefix);
-
         {
             STRACE("simpler_run.runner_run");
-            rc = runner->run(*r, block_dim, aicpu_thread_num);
+            // run() latches the diagnostic enables from config via
+            // apply_call_config() and consumes block_dim / aicpu_thread_num.
+            rc = runner->run(*r, *config);
         }
         if (rc != 0) {
-            validate_runtime_impl(r, &api);
+            validate_runtime_impl(r, &g_host_api);
             return rc;
         }
 
         {
             STRACE("simpler_run.validate");
-            rc = validate_runtime_impl(r, &api);
+            rc = validate_runtime_impl(r, &g_host_api);
         }
         // Device-domain phase markers: the AICPU subdivision of the on-NPU wall
         // (device_wall + preamble/so_load/graph_build/post_orch/orch/sched).

--- a/src/common/platform/onboard/host/device_runner_base.cpp
+++ b/src/common/platform/onboard/host/device_runner_base.cpp
@@ -36,13 +36,16 @@
 
 #include "callable.h"
 #include "callable_protocol.h"
+#include "call_config.h"
 #include "chip_callable_layout.h"
 #include "common/core_type.h"
+#include "common/host_api.h"
 #include "common/platform_config.h"
 #include "common/unified_log.h"
 #include "host/raii_scope_guard.h"
 #include "host_log.h"
 #include "pto_runtime_c_api.h"
+#include "task_args.h"
 #include "utils/elf_build_id.h"
 // `runtime.h` (pulled in via `device_runner_helpers.h` in the base header)
 // supplies the per-arch `Handshake` + `Runtime` types used by
@@ -885,11 +888,25 @@ uint64_t DeviceRunnerBase::callable_hash(int32_t callable_id) const {
     return it == callables_.end() ? 0 : it->second.hash;
 }
 
-BindCallableResult DeviceRunnerBase::bind_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
+// Per-run binding half, defined in each runtime's runtime_maker.cpp and linked
+// into this same host_runtime.so. Declared here (rather than only in
+// c_api_shared.cpp) so bind_callable_to_runtime can call it directly, keeping
+// the CallableState-derived host_orch_func_ptr / signature internal to the
+// runner instead of returning them across the c_api boundary.
+extern "C" int bind_callable_to_runtime_impl(
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
+);
+
+int DeviceRunnerBase::bind_callable_to_runtime(
+    Runtime &runtime, int32_t callable_id, const HostApi *api, const void *orch_args, const uint64_t *ring_task_window,
+    const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+) {
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
         LOG_ERROR("bind_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return {-1, nullptr, nullptr, 0};
+        return -1;
     }
     const auto &state = it->second;
 
@@ -900,20 +917,35 @@ BindCallableResult DeviceRunnerBase::bind_callable_to_runtime(Runtime &runtime, 
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);
-            return {-1, nullptr, nullptr, 0};
+            return -1;
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
     // Tell the AICPU which orch_so_table_ slot this run dispatches. The orch SO
     // descriptor itself was delivered at register time via RegisterCallableArgs.
     runtime.set_active_callable_id(callable_id);
-    // hbg path: host_orch_func_ptr travels back to the c_api caller, which
-    // hands it to bind_callable_to_runtime_impl. trb path: stays null and
-    // the device-side orch SO was resolved at register time.
-    return {
-        0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
-        static_cast<int>(state.signature.size())
-    };
+
+    // Per-run binding (tensor args, GM heap, SM alloc). host_orch_func_ptr is
+    // non-null only on the hbg path; signature is the cached ChipCallable
+    // signature_[], plumbed end-to-end for per-tensor H2D/D2H direction
+    // decisions in runtime_maker (trb consumes it, hbg ignores it). Both stay
+    // internal to the runner now — they are no longer returned to the c_api.
+    return bind_callable_to_runtime_impl(
+        &runtime, api, reinterpret_cast<const ChipStorageTaskArgs *>(orch_args), state.host_orch_func_ptr,
+        state.signature.empty() ? nullptr : state.signature.data(), static_cast<int>(state.signature.size()),
+        ring_task_window, ring_heap, ring_dep_pool
+    );
+}
+
+void DeviceRunnerBase::apply_call_config(const CallConfig &config) {
+    set_l2_swimlane_enabled(config.enable_l2_swimlane);
+    set_dump_tensor_enabled(config.enable_dump_tensor);
+    set_pmu_enabled(config.enable_pmu);
+    // Virtual: a2a3 and a5 wire through to their enable_dep_gen_; an arch
+    // without dep_gen falls through to the base no-op.
+    set_dep_gen_enabled(config.enable_dep_gen != 0);
+    set_scope_stats_enabled(config.enable_scope_stats != 0);
+    set_output_prefix(config.output_prefix);
 }
 
 // =============================================================================

--- a/src/common/platform/onboard/host/device_runner_base.h
+++ b/src/common/platform/onboard/host/device_runner_base.h
@@ -64,6 +64,9 @@
 #include "host/tensor_dump_collector.h"
 #include "prepare_callable_common.h"
 
+struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
+struct CallConfig;  // task_interface/call_config.h — per-run config threaded into run()
+
 /**
  * Common base class for both a2a3 and a5 onboard `DeviceRunner`s.
  *
@@ -328,14 +331,23 @@ public:
     uint64_t callable_hash(int32_t callable_id) const;
 
     /**
-     * Replay a previously-registered callable's state onto a fresh
-     * Runtime for a per-run binding. Writes back kernel addrs, orch
-     * entry-symbol names, and active_callable_id; returns the hbg
-     * `host_orch_func_ptr` (or nullptr on trb / on error) inside a
-     * `BindCallableResult` so the caller can destructure with
-     * structured bindings.
+     * Replay a previously-registered callable's state onto a fresh Runtime and
+     * complete the per-run binding in one step. Writes back kernel addrs and
+     * active_callable_id, then calls the runtime's bind_callable_to_runtime_impl
+     * with the CallableState-derived host_orch_func_ptr + signature (kept
+     * internal to the runner rather than returned across the c_api boundary).
+     *
+     * @param api               Platform device-memory hooks (g_host_api).
+     * @param orch_args         const ChipStorageTaskArgs* for this run (void* to
+     *                          keep task_interface headers out of this header).
+     * @param ring_task_window  Per-ring overrides (trb); ignored by hbg.
+     * @return 0 on success, non-zero on failure (unregistered id, out-of-range
+     *         func_id, or the underlying bind_callable_to_runtime_impl rc).
      */
-    BindCallableResult bind_callable_to_runtime(Runtime &runtime, int32_t callable_id);
+    int bind_callable_to_runtime(
+        Runtime &runtime, int32_t callable_id, const HostApi *api, const void *orch_args,
+        const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+    );
 
     /**
      * Number of distinct callable_ids the AICPU has been asked to
@@ -384,9 +396,11 @@ public:
      * Execute a Runtime. Each arch implements its own `run()` — the bodies
      * are too divergent for a shared implementation (FFTS / dep_gen / ACL
      * register init on a2a3; MIX core handling on a5). See the subclass
-     * docs for the per-arch contract.
+     * docs for the per-arch contract. `config` carries block_dim (0 = auto),
+     * aicpu_thread_num, and the diagnostic enables; each arch calls
+     * `apply_call_config(config)` at entry to latch the `enable_*_` members.
      */
-    virtual int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) = 0;
+    virtual int run(Runtime &runtime, const CallConfig &config) = 0;
 
     /**
      * Cleanup all resources. Each arch's `finalize()` wraps
@@ -452,8 +466,9 @@ public:
 
     /**
      * Enablement setters for the four shared diagnostics sub-features.
-     * Called by the c_api entry point before `run()`; downstream `run()`
-     * paths read the corresponding `enable_*_` members directly.
+     * Applied from the per-run CallConfig by `apply_call_config()` at `run()`
+     * entry; downstream `run()` paths read the corresponding `enable_*_`
+     * members directly.
      *
      * `set_dep_gen_enabled` is a2a3-only and lives on the subclass.
      */
@@ -470,6 +485,15 @@ public:
         pmu_event_type_ = resolve_pmu_event_type(enable_pmu);
     }
     void set_scope_stats_enabled(bool enable) { enable_scope_stats_ = enable; }
+
+    /**
+     * Latch this run's per-run diagnostic config onto the runner's `enable_*_`
+     * members before `run()` uses them. Each arch's `run()` calls this once at
+     * entry — the c_api no longer reaches in with individual set_*_enabled
+     * calls; it just threads the CallConfig through. Defined in the .cpp so this
+     * header does not need the full CallConfig definition.
+     */
+    void apply_call_config(const CallConfig &config);
 
     /**
      * Directory under which all diagnostic artifacts

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -24,6 +24,7 @@
 #include "pto_runtime_c_api.h"
 
 #include "callable.h"
+#include "call_config.h"
 #include "device_runner_base.h"
 #include "prepare_callable_common.h"
 #include "task_args.h"
@@ -51,11 +52,6 @@ extern "C" {
  * Runtime Implementation Functions (defined in runtime_maker.cpp)
  * =========================================================================== */
 int register_callable_impl(const ChipCallable *callable, uint64_t (*upload_fn)(const void *), CallableArtifacts *out);
-int bind_callable_to_runtime_impl(
-    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
-    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
-    const uint64_t *ring_dep_pool
-);
 int validate_runtime_impl(Runtime *runtime, const HostApi *api);
 
 /* ===========================================================================
@@ -180,6 +176,26 @@ static void mark_prebuilt_runtime_arena_cached_wrapper(
         );
     } catch (...) {}
 }
+
+// The HostApi is a set of context-free function pointers: each wrapper above
+// recovers its runner from the thread-local current_runner(), so a single
+// filled table is valid for every runner and every run. Build it once at load
+// time rather than reassembling the 12 pointers on each simpler_run. Passed by
+// address into bind_callable_to_runtime_impl / validate_runtime_impl.
+static const HostApi g_host_api = {
+    .device_malloc = device_malloc,
+    .device_free = device_free,
+    .copy_to_device = copy_to_device,
+    .copy_from_device = copy_from_device,
+    .device_memset = device_memset,
+    .setup_static_arena = setup_static_arena_wrapper,
+    .acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper,
+    .acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper,
+    .acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper,
+    .lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper,
+    .mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper,
+    .upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper,
+};
 
 /* ===========================================================================
  * Public C API (resolved by ChipWorker via dlsym)
@@ -417,12 +433,9 @@ static void emit_device_phase_markers(SimDeviceRunnerBase *runner) {
 }
 
 int simpler_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
-    const char *output_prefix
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
 ) {
-    if (ctx == NULL || runtime == NULL) return -1;
+    if (ctx == NULL || runtime == NULL || config == NULL) return -1;
     SimDeviceRunnerBase *runner = static_cast<SimDeviceRunnerBase *>(ctx);
 
     if (!runner->has_callable(callable_id)) {
@@ -447,64 +460,41 @@ int simpler_run(
         });
 
         // Platform device-memory hooks. host_api is a platform capability, not
-        // runtime state — it lives here (local to simpler_run, covering the whole
-        // bind→run→validate span) and is passed explicitly into the runtime impls
-        // rather than stored on `Runtime`.
-        HostApi api{};
-        api.device_malloc = device_malloc;
-        api.device_free = device_free;
-        api.copy_to_device = copy_to_device;
-        api.copy_from_device = copy_from_device;
-        api.device_memset = device_memset;
-        api.setup_static_arena = setup_static_arena_wrapper;
-        api.acquire_pooled_gm_heap = acquire_pooled_gm_heap_wrapper;
-        api.acquire_pooled_gm_sm = acquire_pooled_gm_sm_wrapper;
-        api.acquire_pooled_runtime_arena = acquire_pooled_runtime_arena_wrapper;
-        api.lookup_prebuilt_runtime_arena_cache = lookup_prebuilt_runtime_arena_cache_wrapper;
-        api.mark_prebuilt_runtime_arena_cached = mark_prebuilt_runtime_arena_cached_wrapper;
-        api.upload_chip_callable_buffer = upload_chip_callable_buffer_wrapper;
-
-        auto bind_result = runner->bind_callable_to_runtime(*r, callable_id);
-        int rc = bind_result.rc;
-        if (rc != 0) {
-            pthread_setspecific(g_runner_key, nullptr);
-            return rc;
-        }
-
+        // runtime state — the shared g_host_api table (built once at load time)
+        // is passed explicitly into the runtime impls rather than stored on
+        // `Runtime` or reassembled per run.
+        int rc;
         {
             STRACE("simpler_run.bind");
-            rc = bind_callable_to_runtime_impl(
-                r, &api, reinterpret_cast<const ChipStorageTaskArgs *>(args), bind_result.host_orch_func_ptr,
-                bind_result.signature, bind_result.sig_count, ring_task_window, ring_heap, ring_dep_pool
+            // One-step bind: replay CallableState + run the per-run binding. The
+            // host_orch_func_ptr + signature stay inside the runner.
+            rc = runner->bind_callable_to_runtime(
+                *r, callable_id, &g_host_api, args, config->runtime_env.ring_task_window, config->runtime_env.ring_heap,
+                config->runtime_env.ring_dep_pool
             );
         }
         if (rc != 0) {
             r->set_gm_sm_ptr(nullptr);
-            validate_runtime_impl(r, &api);
+            validate_runtime_impl(r, &g_host_api);
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
-        runner->set_l2_swimlane_enabled(enable_l2_swimlane);
-        runner->set_dump_tensor_enabled(enable_dump_tensor);
-        runner->set_pmu_enabled(enable_pmu);
-        runner->set_dep_gen_enabled(enable_dep_gen != 0);
-        runner->set_scope_stats_enabled(enable_scope_stats != 0);
-        runner->set_output_prefix(output_prefix);
-
         {
             STRACE("simpler_run.runner_run");
-            rc = runner->run(*r, block_dim, aicpu_thread_num);
+            // run() latches the diagnostic enables from config via
+            // apply_call_config() and consumes block_dim / aicpu_thread_num.
+            rc = runner->run(*r, *config);
         }
         if (rc != 0) {
-            validate_runtime_impl(r, &api);
+            validate_runtime_impl(r, &g_host_api);
             pthread_setspecific(g_runner_key, nullptr);
             return rc;
         }
 
         {
             STRACE("simpler_run.validate");
-            rc = validate_runtime_impl(r, &api);
+            rc = validate_runtime_impl(r, &g_host_api);
         }
         pthread_setspecific(g_runner_key, nullptr);
         emit_device_phase_markers(runner);

--- a/src/common/platform/sim/host/device_runner_base.cpp
+++ b/src/common/platform/sim/host/device_runner_base.cpp
@@ -22,9 +22,12 @@
 
 #include "callable.h"
 #include "callable_protocol.h"
+#include "call_config.h"
 #include "chip_callable_layout.h"
+#include "common/host_api.h"
 #include "cpu_sim_context.h"
 #include "host/raii_scope_guard.h"
+#include "task_args.h"
 #include "utils/elf_build_id.h"
 
 namespace simpler::common::sim_host {
@@ -512,27 +515,55 @@ int SimDeviceRunnerBase::unregister_callable(int32_t callable_id) {
 
 bool SimDeviceRunnerBase::has_callable(int32_t callable_id) const { return callables_.count(callable_id) != 0; }
 
-BindCallableResult SimDeviceRunnerBase::bind_callable_to_runtime(Runtime &runtime, int32_t callable_id) {
+// Per-run binding half, defined in each runtime's runtime_maker.cpp and linked
+// into this same sim runtime .so. Declared here (rather than only in
+// c_api_shared.cpp) so bind_callable_to_runtime can call it directly, keeping
+// the CallableState-derived host_orch_func_ptr / signature internal to the
+// runner instead of returning them across the c_api boundary.
+extern "C" int bind_callable_to_runtime_impl(
+    Runtime *runtime, const HostApi *api, const ChipStorageTaskArgs *orch_args, void *host_orch_func_ptr,
+    const ArgDirection *signature, int sig_count, const uint64_t *ring_task_window, const uint64_t *ring_heap,
+    const uint64_t *ring_dep_pool
+);
+
+int SimDeviceRunnerBase::bind_callable_to_runtime(
+    Runtime &runtime, int32_t callable_id, const HostApi *api, const void *orch_args, const uint64_t *ring_task_window,
+    const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+) {
     auto it = callables_.find(callable_id);
     if (it == callables_.end()) {
         LOG_ERROR("bind_callable_to_runtime: callable_id=%d not registered", callable_id);
-        return {-1, nullptr, nullptr, 0};
+        return -1;
     }
     const auto &state = it->second;
     for (const auto &kv : state.kernel_addrs) {
         if (kv.first < 0 || kv.first >= RUNTIME_MAX_FUNC_ID) {
             LOG_ERROR("bind_callable_to_runtime: func_id=%d out of range", kv.first);
-            return {-1, nullptr, nullptr, 0};
+            return -1;
         }
         runtime.replay_function_bin_addr(kv.first, kv.second);
     }
     // The AICPU dispatches the orch SO via this callable_id; the SO descriptor
     // was already delivered at launch_device_register time.
     runtime.set_active_callable_id(callable_id);
-    return {
-        0, state.host_orch_func_ptr, state.signature.empty() ? nullptr : state.signature.data(),
-        static_cast<int>(state.signature.size())
-    };
+
+    // Per-run binding. host_orch_func_ptr + signature come from CallableState and
+    // stay inside the runner — no longer returned to the c_api.
+    return bind_callable_to_runtime_impl(
+        &runtime, api, reinterpret_cast<const ChipStorageTaskArgs *>(orch_args), state.host_orch_func_ptr,
+        state.signature.empty() ? nullptr : state.signature.data(), static_cast<int>(state.signature.size()),
+        ring_task_window, ring_heap, ring_dep_pool
+    );
+}
+
+void SimDeviceRunnerBase::apply_call_config(const CallConfig &config) {
+    set_l2_swimlane_enabled(config.enable_l2_swimlane);
+    set_dump_tensor_enabled(config.enable_dump_tensor);
+    set_pmu_enabled(config.enable_pmu);
+    // a2a3 and a5 override set_dep_gen_enabled; an arch without dep_gen no-ops.
+    set_dep_gen_enabled(config.enable_dep_gen != 0);
+    set_scope_stats_enabled(config.enable_scope_stats != 0);
+    set_output_prefix(config.output_prefix);
 }
 
 uint64_t SimDeviceRunnerBase::upload_chip_callable_buffer(const ChipCallable *callable) {

--- a/src/common/platform/sim/host/device_runner_base.h
+++ b/src/common/platform/sim/host/device_runner_base.h
@@ -53,6 +53,9 @@
 #include "host/scope_stats_collector.h"
 #include "runtime.h"
 
+struct HostApi;     // common/host_api.h — fwd-declared to keep task_interface headers out
+struct CallConfig;  // task_interface/call_config.h — per-run config threaded into run()
+
 class SimDeviceRunnerBase : public L3L2OrchCommBackend {
 public:
     SimDeviceRunnerBase() :
@@ -65,7 +68,7 @@ public:
     ~SimDeviceRunnerBase() override = default;
 
     // --- Pure / no-op virtuals dispatched from the shared c_api glue ----
-    virtual int run(Runtime &runtime, int block_dim, int launch_aicpu_num = 1) = 0;
+    virtual int run(Runtime &runtime, const CallConfig &config) = 0;
     virtual int finalize() = 0;
     // a2a3 and a5 both override; an arch without dep_gen leaves the no-op.
     virtual void set_dep_gen_enabled(bool /*enable*/) {}
@@ -108,7 +111,15 @@ public:
     );
     int unregister_callable(int32_t callable_id);
     bool has_callable(int32_t callable_id) const;
-    BindCallableResult bind_callable_to_runtime(Runtime &runtime, int32_t callable_id);
+    // One-step bind: replay CallableState (kernel addrs + active_callable_id)
+    // then run the per-run bind_callable_to_runtime_impl with the state's
+    // host_orch_func_ptr + signature. `api` is g_host_api; `orch_args` is a
+    // const ChipStorageTaskArgs* (void* keeps task_interface headers out of this
+    // header). Returns 0 on success, non-zero on failure.
+    int bind_callable_to_runtime(
+        Runtime &runtime, int32_t callable_id, const HostApi *api, const void *orch_args,
+        const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool
+    );
     uint64_t upload_chip_callable_buffer(const ChipCallable *callable);
     int launch_device_register(int32_t callable_id);
     int commit_device_register(int32_t callable_id);
@@ -149,6 +160,12 @@ public:
     // upstream when any diagnostic is enabled).
     void set_output_prefix(const char *prefix) { output_prefix_ = (prefix != nullptr) ? prefix : ""; }
     const std::string &output_prefix() const { return output_prefix_; }
+
+    // Latch this run's per-run diagnostic config onto the runner's enable_*_
+    // members before run() uses them. Each arch's run() calls this at entry; the
+    // c_api threads the CallConfig through instead of calling set_*_enabled.
+    // Defined in the .cpp so this header does not need the full CallConfig.
+    void apply_call_config(const CallConfig &config);
 
     size_t aicpu_dlopen_count() const { return aicpu_dlopen_total_; }
     size_t host_dlopen_count() const { return host_dlopen_total_; }

--- a/src/common/task_interface/prepare_callable_common.h
+++ b/src/common/task_interface/prepare_callable_common.h
@@ -70,30 +70,6 @@ struct CallableArtifacts {
 };
 
 /**
- * Result of DeviceRunner::bind_callable_to_runtime — what the c_api
- * needs to pass on to bind_callable_to_runtime_impl for a per-run binding.
- *
- * Returning a struct (rather than a `void**` out-parameter) keeps the caller
- * site idiomatic — destructure with C++17 structured bindings:
- *
- *     auto [rc, host_orch_func_ptr] =
- *         runner->bind_callable_to_runtime(*r, callable_id);
- *
- * `host_orch_func_ptr` is type-erased as `void *` (rather than the concrete
- * OrchestrationFunc) so this header stays runtime-agnostic; only the hbg path
- * sets it. trb leaves it null and bind_callable_to_runtime_impl asserts so.
- */
-struct BindCallableResult {
-    int rc{0};
-    void *host_orch_func_ptr{nullptr};
-    // Pointer into CallableState's cached signature vector — valid
-    // until the callable_id is unregistered. Nullptr + 0 when the callable
-    // had no recorded signature (legacy path).
-    const ArgDirection *signature{nullptr};
-    int sig_count{0};
-};
-
-/**
  * Upload the ChipCallable buffer via `upload_fn` and compute the device-side
  * address of every child kernel.
  *

--- a/src/common/worker/chip_worker.cpp
+++ b/src/common/worker/chip_worker.cpp
@@ -332,13 +332,9 @@ void ChipWorker::run(int32_t callable_id, const ChipStorageTaskArgs *args, const
 
     void *rt = runtime_buf_.data();
     // Per-stage timing is emitted by the platform as `[STRACE]` log markers, not
-    // returned (see chip_worker.h::run).
-    int rc = run_fn_(
-        device_ctx_, rt, callable_id, args, config.block_dim, config.aicpu_thread_num, config.enable_l2_swimlane,
-        config.enable_dump_tensor, config.enable_pmu, config.enable_dep_gen, config.enable_scope_stats,
-        config.runtime_env.ring_task_window, config.runtime_env.ring_heap, config.runtime_env.ring_dep_pool,
-        config.output_prefix
-    );
+    // returned (see chip_worker.h::run). CallConfig is threaded through to the C
+    // ABI as a single pointer rather than unpacked into per-field args.
+    int rc = run_fn_(device_ctx_, rt, callable_id, args, &config);
     if (rc != 0) {
         throw std::runtime_error("run failed with code " + std::to_string(rc));
     }

--- a/src/common/worker/chip_worker.h
+++ b/src/common/worker/chip_worker.h
@@ -145,10 +145,7 @@ private:
     using SimplerInitFn =
         int (*)(void *, int, const uint8_t *, size_t, const uint8_t *, size_t, const uint8_t *, size_t);
     using SimplerRegisterCallableFn = int (*)(void *, int32_t, const void *);
-    using SimplerRunFn = int (*)(
-        void *, void *, int32_t, const void *, int, int, int, int, int, int, int, const uint64_t *, const uint64_t *,
-        const uint64_t *, const char *
-    );
+    using SimplerRunFn = int (*)(void *, void *, int32_t, const void *, const CallConfig *);
     using SimplerUnregisterCallableFn = int (*)(void *, int32_t);
     using GetAicpuDlopenCountFn = size_t (*)(void *);
     using FinalizeDeviceFn = int (*)(void *);

--- a/src/common/worker/pto_runtime_c_api.h
+++ b/src/common/worker/pto_runtime_c_api.h
@@ -43,6 +43,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+// simpler_run takes a pointer to the C++ CallConfig POD (task_interface/
+// call_config.h). Forward-declared so this C-linkage header needn't pull the
+// full C++ definition; both the ChipWorker consumer and the platform producers
+// include call_config.h in their .cpp before calling / defining simpler_run.
+#ifdef __cplusplus
+struct CallConfig;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -185,21 +193,19 @@ int simpler_register_callable(DeviceContextHandle ctx, int32_t callable_id, cons
  * Per-stage run timing is not returned — the platform emits it as `[STRACE]`
  * log markers (see docs/dfx/host-trace.md).
  *
- * `ring_task_window` / `ring_heap` / `ring_dep_pool` are per-task ring sizing
- * overrides, each a per-scope-depth-ring array of RUNTIME_ENV_RING_COUNT
- * entries (0 = unset). A nonzero entry overrides that ring; a 0 entry falls
- * through. Precedence per ring: per-ring entry > PTO2_RING_* env var >
- * compile-time default. A "size every ring the same" request is broadcast to
- * all entries by the caller. Consumed by tensormap_and_ringbuffer only; other
- * runtime variants accept and ignore them.
+ * `config` carries block_dim (0 = auto), aicpu_thread_num, the five diagnostic
+ * enables + output_prefix, and the per-task ring sizing overrides
+ * (`runtime_env.ring_task_window` / `.ring_heap` / `.ring_dep_pool`, each a
+ * per-scope-depth-ring array of RUNTIME_ENV_RING_COUNT entries; 0 = unset,
+ * precedence per ring: per-ring entry > PTO2_RING_* env var > compile-time
+ * default). Ring overrides are consumed by tensormap_and_ringbuffer only; other
+ * runtime variants accept and ignore them. Wire-compatible POD; the platform
+ * reads it by pointer without copying.
  *
- * @return 0 on success, negative on error (no prep state, NULL ctx, etc.).
+ * @return 0 on success, negative on error (no prep state, NULL ctx/config, etc.).
  */
 int simpler_run(
-    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, int block_dim,
-    int aicpu_thread_num, int enable_l2_swimlane, int enable_dump_tensor, int enable_pmu, int enable_dep_gen,
-    int enable_scope_stats, const uint64_t *ring_task_window, const uint64_t *ring_heap, const uint64_t *ring_dep_pool,
-    const char *output_prefix
+    DeviceContextHandle ctx, RuntimeHandle runtime, int32_t callable_id, const void *args, const CallConfig *config
 );
 
 /**

--- a/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
+++ b/tests/ut/cpp/common/test_l3_l2_orch_comm_sim_runner.cpp
@@ -22,7 +22,7 @@ namespace {
 
 class TestSimRunner : public SimDeviceRunnerBase {
 public:
-    int run(Runtime &, int, int) override { return 0; }
+    int run(Runtime &, const CallConfig &) override { return 0; }
     int finalize() override {
         l3_l2_orch_comm_shutdown();
         mem_alloc_.finalize();

--- a/tests/ut/cpp/hardware/test_l3_l2_orch_comm_onboard_runner.cpp
+++ b/tests/ut/cpp/hardware/test_l3_l2_orch_comm_onboard_runner.cpp
@@ -20,7 +20,7 @@ namespace {
 
 class UnsupportedL3L2Runner : public DeviceRunnerBase {
 public:
-    int run(Runtime &, int, int) override { return 0; }
+    int run(Runtime &, const CallConfig &) override { return 0; }
     int finalize() override { return 0; }
     bool l3_l2_orch_comm_supported() const override { return false; }
 };

--- a/tests/ut/cpp/stubs/test_stubs.cpp
+++ b/tests/ut/cpp/stubs/test_stubs.cpp
@@ -98,6 +98,25 @@ volatile uint32_t *get_reg_ptr(uint64_t /* reg_base_addr */, RegId /* reg */) {
 }
 
 // =============================================================================
+// runtime_maker.cpp stub (bind_callable_to_runtime_impl)
+// =============================================================================
+
+// DeviceRunnerBase::bind_callable_to_runtime (the merged bind facade) calls the
+// runtime's bind_callable_to_runtime_impl, which is defined in runtime_maker.cpp
+// and only present in the production host_runtime.so. These runner-only unit
+// tests link device_runner_base.cpp without any runtime_maker, and their mock
+// runners never bind (TestSimRunner::run returns 0), so the impl is never
+// invoked — it only has to resolve at link time. C linkage matches by symbol
+// name, so this opaque-pointer signature satisfies the reference.
+extern "C" int bind_callable_to_runtime_impl(
+    void * /* runtime */, const void * /* api */, const void * /* orch_args */, void * /* host_orch_func_ptr */,
+    const void * /* signature */, int /* sig_count */, const uint64_t * /* ring_task_window */,
+    const uint64_t * /* ring_heap */, const uint64_t * /* ring_dep_pool */
+) {
+    return -1;
+}
+
+// =============================================================================
 // common.h stubs (assert_impl, get_stacktrace, AssertionError)
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Four related cleanups that stop `simpler_run` from doing per-run work that belongs to longer-lived scopes, plus a shrink of the host_build_graph `Runtime` upload. Each is independent; grouped here as one reviewable change.

- **HostApi built once at load time.** The 12-pointer `HostApi` table was reassembled on every `simpler_run` (onboard + sim). Its wrappers are context-free — each recovers its runner from a thread-local — so a single `static const` table is valid for every runner and run. Completes the #1227 direction (which moved HostApi off `Runtime` but left it a per-run local).

- **hbg Runtime upload shrunk to the populated task prefix.** `host_build_graph` uploaded the whole ~92 MB `Runtime` image every run, dominated by the fixed `tasks[131072]` array. Members are reordered so all device-read fields form a contiguous prefix ending in `tasks[]`, with a host-only tail after it. `runtime_device_copy_size()` now returns `offsetof(tasks) + get_task_count()*sizeof(Task)`, uploading only populated slots; the AICPU cache-invalidate matches. `offsetof` static_asserts guard the layout. Safe because the device never reads `tasks[i]` for `i >= next_task_id` (`get_task()` bounds-checks). The trb `dev` sub-struct pattern is inapplicable here because hbg embeds `std::atomic<int> fanin` in the uploaded image, so this is an explicit prefix boundary rather than a nested descriptor.

- **Two-step callable bind merged into one facade.** `bind_callable_to_runtime` returned a `BindCallableResult` carrying a raw pointer into `CallableState`'s cached signature, which the c_api then handed to `bind_callable_to_runtime_impl`. Both halves are folded into one runner facade so that pointer no longer crosses the c_api boundary; `BindCallableResult` is removed.

- **CallConfig threaded through simpler_run.** The C ABI unpacked `CallConfig` into 14 positional params, and the c_api re-scattered them across six `runner->set_*_enabled()` calls. `simpler_run` now takes `const CallConfig*`; `run()` takes `const CallConfig&` and latches the diagnostic enables via `apply_call_config()` at entry. The `enable_*_` members are kept (≈50 downstream readers in the collector paths).

## Testing

- [x] Simulation tests pass — `host_build_graph` on a2a3sim (10 passed) and a5sim (7 passed)
- [x] Hardware tests pass — a2a3 onboard `host_build_graph` (10 passed, 1 skipped) and `tensormap_and_ringbuffer` (33 passed, 1 skipped)

Note: onboard was validated per-refactor before a rebase onto #1234; after rebasing, both sim suites were re-run green. `tests/ut/cpp` has a pre-existing gtest link-ABI failure in this environment (affects untouched binaries too) and was not run.