### PR TITLE
perf: prefetch dispatch buffers and inline timestamp reads

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_completion.cpp
@@ -18,6 +18,7 @@
 #include "common/l2_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "device_time_fast.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -506,7 +507,7 @@ void SchedulerContext::drain_worker_dispatch(int32_t block_num) {
         uint64_t dispatch_ts = 0;
 #if PTO2_PROFILING
         if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
-            dispatch_ts = get_sys_cnt_aicpu();
+            dispatch_ts = fast_sys_cnt_aicpu();
         }
 #endif
         for (int i = 0; i < handle_count; i++) {

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -161,6 +161,10 @@ SchedulerContext::PublishHandle SchedulerContext::prepare_subtask_to_core(
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
     DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][buf_idx];
+    // Pull ownership of the per-core dispatch buffers before the hot stores below.
+    __builtin_prefetch(reinterpret_cast<const char *>(&payload), 1, 3);
+    __builtin_prefetch(reinterpret_cast<const char *>(&payload) + 64, 1, 3);
+    __builtin_prefetch(reinterpret_cast<const char *>(deferred_slab), 1, 3);
     deferred_slab->count = 0;
     deferred_slab->error_code = PTO2_ERROR_NONE;
     AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -24,6 +24,7 @@
 #include "common/l2_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "device_time_fast.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -350,7 +351,7 @@ void SchedulerContext::dispatch_shape(
             uint64_t dispatch_ts = 0;
 #if PTO2_PROFILING
             if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
-                dispatch_ts = get_sys_cnt_aicpu();
+                dispatch_ts = fast_sys_cnt_aicpu();
             }
 #endif
             for (int i = 0; i < handle_count; i++) {
@@ -647,7 +648,7 @@ int32_t SchedulerContext::stage_consumer_blocks(
     CoreTracker &tracker = core_trackers_[thread_idx];
     // Stamp the real pre-stage time (NOT 0) so the swimlane shows these blocks
     // dispatched during the producer's run, not at trace start.
-    uint64_t early_dispatch_ts = get_sys_cnt_aicpu();
+    uint64_t early_dispatch_ts = fast_sys_cnt_aicpu();
     uint64_t my_cores[PTO2_SPEC_CORE_MASK_WORDS] = {0};  // cores this thread gated (for self-ring)
     int32_t staged = 0;
     int32_t block = start;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -145,6 +145,10 @@ void SchedulerContext::dispatch_subtask_to_core(
     uint32_t buf_idx = reg_task_id & 1u;
     PTO2DispatchPayload &payload = payload_per_core_[core_id][buf_idx];
     DeferredCompletionSlab *deferred_slab = &deferred_slab_per_core_[core_id][buf_idx];
+    // Pull ownership of the per-core dispatch buffers before the hot stores below.
+    __builtin_prefetch(reinterpret_cast<const char *>(&payload), 1, 3);
+    __builtin_prefetch(reinterpret_cast<const char *>(&payload) + 64, 1, 3);
+    __builtin_prefetch(reinterpret_cast<const char *>(deferred_slab), 1, 3);
     deferred_slab->count = 0;
     deferred_slab->error_code = PTO2_ERROR_NONE;
     AsyncCtx async_ctx = AsyncCtx::make(slot_state.task->task_id, deferred_slab);

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/scheduler/scheduler_dispatch.cpp
@@ -23,6 +23,7 @@
 #include "common/l2_swimlane_profiling.h"
 #include "common/memory_barrier.h"
 #include "common/platform_config.h"
+#include "device_time_fast.h"
 #include "pto_runtime2.h"
 #include "runtime.h"
 #include "spin_hint.h"
@@ -193,7 +194,7 @@ void SchedulerContext::dispatch_subtask_to_core(
     // immediately before the DATA_MAIN_BASE write.
 #if PTO2_PROFILING
     if (l2_swimlane_level_ >= L2SwimlaneLevel::AICPU_TIMING) {
-        uint64_t dispatch_ts = get_sys_cnt_aicpu();
+        uint64_t dispatch_ts = fast_sys_cnt_aicpu();
         if (to_pending) {
             core_exec_state.pending_dispatch_timestamp = dispatch_ts;
         } else {

--- a/src/common/platform/onboard/aicpu/device_time_fast.h
+++ b/src/common/platform/onboard/aicpu/device_time_fast.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_COMMON_PLATFORM_ONBOARD_AICPU_DEVICE_TIME_FAST_H_
+#define SRC_COMMON_PLATFORM_ONBOARD_AICPU_DEVICE_TIME_FAST_H_
+
+#include <cstdint>
+
+static inline __attribute__((always_inline)) uint64_t fast_sys_cnt_aicpu() {
+    uint64_t ticks;
+    asm volatile("mrs %0, cntvct_el0" : "=r"(ticks));
+    return ticks;
+}
+
+#endif  // SRC_COMMON_PLATFORM_ONBOARD_AICPU_DEVICE_TIME_FAST_H_

--- a/src/common/platform/sim/aicpu/device_time_fast.h
+++ b/src/common/platform/sim/aicpu/device_time_fast.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#ifndef SRC_COMMON_PLATFORM_SIM_AICPU_DEVICE_TIME_FAST_H_
+#define SRC_COMMON_PLATFORM_SIM_AICPU_DEVICE_TIME_FAST_H_
+
+#include <cstdint>
+
+#include "aicpu/device_time.h"
+
+static inline uint64_t fast_sys_cnt_aicpu() { return get_sys_cnt_aicpu(); }
+
+#endif  // SRC_COMMON_PLATFORM_SIM_AICPU_DEVICE_TIME_FAST_H_


### PR DESCRIPTION
## Summary

Add two small dispatch-path optimizations from issue #1103:

1. Write-prefetch per-core dispatch buffers before initializing them.
2. Inline the AICPU dispatch timestamp counter read near the doorbell publish path.

The prefetch change warms:
- the first cache line of `PTO2DispatchPayload`
- the second cache line of `PTO2DispatchPayload`
- the associated `DeferredCompletionSlab`

The fast-counter change adds platform-selected `device_time_fast.h` helpers:
- onboard AICPU: inline `mrs cntvct_el0`
- sim AICPU: fall back to `get_sys_cnt_aicpu()` so CPU-sim keeps its chrono-backed tick scale

The changes are applied to both a2a3 and a5 dispatch paths. They do not change ABI layout, task state transitions, ring-buffer publishing, or completion semantics.

## Motivation

Issue #1103 tracks remaining dispatch-path optimizations from the scheduler optimization branch. The AICPU scheduler writes per-core dispatch payloads and deferred completion slabs on every subtask dispatch. These buffers can be cold, so the first writes may pay cache-line ownership/RFO latency. Pulling ownership slightly earlier can hide part of that cost behind the existing dispatch setup work.

For L2 swimlane AICPU timing, dispatch timestamps are sampled immediately before publishing the DATA_MAIN_BASE doorbell. The onboard implementation of `get_sys_cnt_aicpu()` already reads `cntvct_el0`, but it is an out-of-line function call. Inlining this read at the dispatch timestamp sites reduces profiling overhead and keeps the timestamp closer to the doorbell write.

## Test

Built and installed the branch:

```bash
PTO_ISA_ROOT=/data/pyptouser/zhangtao/zt/simpler/build/pto-isa python -m pip install --no-build-isolation .
```

Hardware tests submitted through `task-submit`:

```bash
task-submit --device auto --device-num 1 --max-time 3600 --timeout 7200 --run "bash /data/pyptouser/zhangtao/zt/issue-1103-prefetch-results/run_after.sh"
task-submit --device auto --device-num 1 --max-time 3600 --timeout 7200 --run "bash /data/pyptouser/zhangtao/zt/issue-1103-prefetch-results/run_fastcnt.sh"
```

Task ids:

```text
prefetch: task_20260701_193641_390821221439
fastcnt:  task_20260701_200145_44514130629
```

All tested cases passed.

Default performance comparison, baseline -> prefetch:

| Case | Rounds | Baseline Sched | After Sched | Delta |
|---|---:|---:|---:|---:|
| `spmd_multiblock_mix` | 20 | 72.0 us | 73.0 us | +1.0 us / +1.39% |
| `spmd_sync_start_stress` | 10 | 397.8 us | 389.4 us | -8.4 us / -2.11% |
| `qwen3_14b_decode` | 5 | 2113.5 us | 2110.8 us | -2.7 us / -0.13% |

Default performance comparison, prefetch -> prefetch + fast counter:

| Case | Rounds | Prefetch Sched | Fast counter Sched | Delta |
|---|---:|---:|---:|---:|
| `spmd_multiblock_mix` | 20 | 73.0 us | 71.1 us | -1.9 us / -2.60% |
| `spmd_sync_start_stress` | 10 | 389.4 us | 390.8 us | +1.4 us / +0.29% |
| `qwen3_14b_decode` | 5 | 2110.8 us | 2108.9 us | -2.1 us / -0.10% |

L2 swimlane AICPU timing smoke tests with `--enable-l2-swimlane 2`:

| Case | Rounds | Result | Sched |
|---|---:|---|---:|
| `spmd_multiblock_mix` | 1 | PASS | 186.4 us |
| `spmd_sync_start_stress` | 1 | PASS | 644.8 us |
| `qwen3_14b_decode` | 1 | PASS | 2241.5 us |

Note: `spmd_serial_chain_mix` was not present in the latest upstream tree used for this branch, so `spmd_multiblock_mix` was used as the available SPMD mix coverage.
