### PR TITLE
Refactor: remove unused BufferPoolManager::mirror_shm_to_device

### DIFF
--- a/src/common/platform/include/host/buffer_pool_manager.h
+++ b/src/common/platform/include/host/buffer_pool_manager.h
@@ -39,11 +39,10 @@
  *   1. Calls `mirror_shm_from_device` once per tick to refresh the host
  *      shadow, then writes back only the fields it actually modifies via
  *      narrow `write_range_to_device(field_ptr, sizeof(field))` calls.
- *      The bulk `mirror_shm_to_device` is kept for init/teardown but is
- *      NOT used by the mgmt loop — bulk write-back races with AICPU writes
- *      to device-only fields (current_buf_ptr, total/dropped/mismatch
- *      counters, queue_tails, free_queue.head, and on a5
- *      L2SwimlaneAicpuPhaseHeader::magic).
+ *      A bulk host→device write-back is deliberately avoided — it would
+ *      race with AICPU writes to device-only fields (current_buf_ptr,
+ *      total/dropped/mismatch counters, queue_tails, free_queue.head, and
+ *      on a5 L2SwimlaneAicpuPhaseHeader::magic).
  *   2. Pulls each popped buffer's contents from device via
  *      `copy_buffer_from_device` inside ProfilerAlgorithms::process_entry
  *      before delivering it to the collector.
@@ -309,29 +308,6 @@ public:
         }
         if (!ops_.copy_from_device) return 0;
         return ops_.copy_from_device(shared_mem_host_, shared_mem_dev_, shm_size_);
-    }
-
-    /**
-     * Push the host-side modifications (advanced `queue_heads`, refilled
-     * free_queues) back to the device. Called at the bottom of every mgmt
-     * tick.
-     *
-     * NOTE: deprecated for a5 — bulk write_back races with AICPU writes to
-     * device-owned fields (BufferState::current_buf_ptr, total/dropped/mismatch
-     * counters, queue_tails, free_queue.head, and on a5
-     * L2SwimlaneAicpuPhaseHeader::magic, ...).
-     * The bulk write rolls those updates back to whatever was in the host
-     * shadow at mirror_from_device time. Keep the method around so callers
-     * outside the mgmt loop (init/teardown) still have a way to push the
-     * whole region, but the mgmt loop now uses `write_field_to_device` /
-     * `write_range_to_device` for the few fields host actually modifies.
-     */
-    int mirror_shm_to_device() {
-        if (shared_mem_host_ == nullptr || shared_mem_dev_ == nullptr || shm_size_ == 0) {
-            return 0;
-        }
-        if (!ops_.copy_to_device) return 0;
-        return ops_.copy_to_device(shared_mem_dev_, shared_mem_host_, shm_size_);
     }
 
     /**

--- a/src/common/platform/include/host/profiler_base.h
+++ b/src/common/platform/include/host/profiler_base.h
@@ -113,11 +113,11 @@
  *     host shadow at the top of every tick (`mirror_shm_from_device`) and
  *     pushes the few host-modified fields (`queue_heads[q]` after pop,
  *     `free_queue.tail` + `buffer_ptrs[]` after refill) back as narrow
- *     `write_range_to_device` writes. The bulk `mirror_shm_to_device` is
- *     intentionally NOT called from mgmt_loop: it raced with AICPU writes
- *     to device-only fields (current_buf_ptr, total/dropped/mismatch
+ *     `write_range_to_device` writes. A bulk host→device write-back is
+ *     intentionally avoided: it would race with AICPU writes to
+ *     device-only fields (current_buf_ptr, total/dropped/mismatch
  *     counters, queue_tails, free_queue.head, and on a5
- *     L2SwimlaneAicpuPhaseHeader::magic) and rolled them back to the
+ *     L2SwimlaneAicpuPhaseHeader::magic) and roll them back to the
  *     host-shadow values mirrored in at the top of the tick. Buffer
  *     contents are mirrored on demand inside ProfilerAlgorithms.
  *   - On these platforms `reg` always allocates a paired host shadow; the
@@ -335,8 +335,9 @@ struct ProfilerAlgorithms {
         head = (head + 1) % Module::kReadyQueueSize;
         header->queue_heads[q] = head;
         wmb();
-        // Push the new head value back to device. The bulk mirror_shm_to_device
-        // is intentionally not used here — see buffer_pool_manager.h.
+        // Push the new head value back to device with a narrow write — a
+        // bulk host→device write-back is intentionally avoided here; see
+        // buffer_pool_manager.h.
         mgr.write_range_to_device(&header->queue_heads[q], sizeof(header->queue_heads[q]));
         return true;
     }
@@ -761,10 +762,10 @@ private:
      *      queues.
      *   4) Sleep 10 us if no work was done.
      *
-     * The bulk `mirror_shm_to_device` deliberately is NOT called: it races
+     * A bulk host→device write-back deliberately is NOT done: it would race
      * with AICPU writes to device-only fields (current_buf_ptr, total/dropped/
      * mismatch counters, queue_tails, free_queue.head, core_to_thread[],
-     * and on a5 L2SwimlaneAicpuPhaseHeader::magic) and rolls them back to
+     * and on a5 L2SwimlaneAicpuPhaseHeader::magic) and roll them back to
      * whatever was mirrored in at the start of the tick. Each host-side
      * modification is written back as a narrow field write inside Alg.
      *


### PR DESCRIPTION
## Summary

`BufferPoolManager::mirror_shm_to_device()` (bulk host→device write-back of the profiler shared-memory region) was **deprecated when the mgmt loop switched to narrow `write_field_to_device` / `write_range_to_device` writes** — the bulk write raced with AICPU writes to device-owned fields (`current_buf_ptr`, total/dropped/mismatch counters, `queue_tails`, `free_queue.head`, and on a5 `L2SwimlaneAicpuPhaseHeader::magic`), rolling them back to stale host-shadow values.

It was left in place as an "init/teardown escape hatch," but **no caller remains** — every reference in the tree is a comment explaining why it is *not* called. This removes the method and rewords those four comments to describe the invariant directly (a bulk write-back is avoided because it races with AICPU-owned fields) instead of naming a symbol that no longer exists.

The read half, `mirror_shm_from_device()` (called once per mgmt tick), is unchanged.

Net: **+13 / −36** across 2 shared headers.

## Testing

- [x] All four runtimes build clean (a2a3/a5 × host_build_graph/tensormap_and_ringbuffer)
- [x] DFX/profiling simulation tests that instantiate `BufferPoolManager` pass — a2a3sim 8/8, a5sim 3/3 (`dfx`, `l3_l2_orch_comm`, `dump_tensor`)
- [ ] Hardware tests (no behavior change; the removed method had zero callers)