### PR TITLE
test(dfx): mirror a2a3 DFX scene tests to a5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,9 +188,7 @@ jobs:
             sudo apt-get install -y g++-15 || sudo apt-get install -y g++
             if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
             # graphviz: required by the dep_gen smoke (deps_viewer -> dot).
-            # Installed unconditionally so both a2a3 and a5 sim jobs stay
-            # uniform — the dep_gen test is a2a3-only today but the cost is
-            # negligible and the alternative branch sprawls the install logic.
+            # Both a2a3 and a5 sim jobs run dep_gen, so install it in both.
             sudo apt-get install -y graphviz
           else
             brew install ninja
@@ -277,9 +275,7 @@ jobs:
             sudo apt-get install -y g++-15 || sudo apt-get install -y g++
             if ! command -v g++-15; then sudo ln -s $(which g++) /usr/local/bin/g++-15; fi
             # graphviz: required by the dep_gen smoke (deps_viewer -> dot).
-            # Installed unconditionally so both a2a3 and a5 sim jobs stay
-            # uniform — the dep_gen test is a2a3-only today but the cost is
-            # negligible and the alternative branch sprawls the install logic.
+            # Both a2a3 and a5 sim jobs run dep_gen, so install it in both.
             sudo apt-get install -y graphviz
           else
             brew install ninja

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/kernels/orchestration/partial_dump_orch.cpp
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 3,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_a = orch_args.tensor(0).ref();
+    const Tensor &ext_b = orch_args.tensor(1).ref();
+    const Tensor &ext_f = orch_args.tensor(2).ref();
+
+    uint32_t size = orch_args.tensor(0).ref().shapes[0];
+    uint32_t inter_shapes[1] = {size};
+    TensorCreateInfo inter_ci(inter_shapes, 1, DataType::FLOAT32);
+
+    L0TaskArgs params_t0;
+    params_t0.add_input(ext_a);
+    params_t0.add_input(ext_b);
+    params_t0.add_output(inter_ci);
+    TaskOutputTensors outs_t0 = rt_submit_aiv_task(0, params_t0);
+    const Tensor &c = outs_t0.get_ref(0);
+
+    PTO2_SCOPE() {
+        L0TaskArgs params_t1;
+        params_t1.add_input(c);
+        params_t1.add_output(inter_ci);
+        float t1_addend = 1.0f;
+        uint32_t t1_count = 3u;
+        params_t1.add_scalar(t1_addend, t1_count);
+        // Partial dump, task granularity: no-arg dump() selects every tensor
+        // and scalar arg on this Arg.
+        params_t1.dump();
+        TaskOutputTensors outs_t1 = rt_submit_aiv_task(1, params_t1);
+        const Tensor &d = outs_t1.get_ref(0);
+
+        L0TaskArgs params_t2;
+        params_t2.add_input(c);
+        params_t2.add_output(inter_ci);
+        float t2_addend = 2.0f;
+        uint32_t t2_count = 3u;
+        params_t2.add_scalar(t2_addend, t2_count);
+        // Scalar-only selection: t2_count has the same value as t1_count
+        // but is left unmarked, so only t2_addend should be dumped.
+        params_t2.dump(t2_addend);
+        TaskOutputTensors outs_t2 = rt_submit_aiv_task(1, params_t2);
+        const Tensor &e = outs_t2.get_ref(0);
+
+        L0TaskArgs params_t3;
+        params_t3.add_input(d);
+        params_t3.add_input(e);
+        params_t3.add_output(inter_ci);
+        uint32_t t3_count = 3u;
+        params_t3.add_scalar(t3_count, t3_count);
+        // Mixed selection: input d + the output + one scalar. The scalar lvalue
+        // is added twice, so dump(t3_count) selects the first matching scalar
+        // arg and marks its JSON arg_index as ambiguous. Input e is left
+        // unmarked.
+        params_t3.dump(d, inter_ci, t3_count);
+        TaskOutputTensors outs_t3 = rt_submit_aiv_task(2, params_t3);
+        const Tensor &g = outs_t3.get_ref(0);
+
+        L0TaskArgs params_t4;
+        params_t4.add_input(g);
+        params_t4.add_input(c);
+        params_t4.add_output(ext_f);
+        // Tensor-only task granularity: no-arg dump() still selects every
+        // tensor arg on this Arg.
+        params_t4.dump();
+        rt_submit_aiv_task(0, params_t4);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/args_dump/test_args_dump.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""args_dump profiling smoke — capture pipeline produces a usable
+``args_dump/`` directory.
+
+Re-uses ``vector_example`` (5 submit_task calls). With ``--dump-args`` the
+AICPU writer captures task dump records into a unified manifest + raw-byte
+payload pair under ``<output_prefix>/args_dump/``. Smoke asserts:
+manifest exists + parses, the ``bin_file`` field it names exists, entries
+use the unified schema, and no legacy args-only manifest is emitted.
+"""
+
+import json
+import subprocess
+import sys
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestArgsDump(SceneTestCase):
+    """args_dump capture smoke, level-aware on the ``--dump-args`` level.
+
+    Uses ``partial_dump_orch`` (5 tasks; four carry ``dump(...)`` markers) so a
+    single orchestration exercises both modes:
+
+    - ``--dump-args 1`` (partial): only marked args are captured — task
+      ``0x..00`` via no-arg ``dump()`` (all tensor + scalar args), task
+      ``0x..01`` via ``dump(t2_addend)`` (scalar-only), task ``0x..02`` via
+      ``dump(d, inter_ci, t3_count)`` (mixed tensor + scalar, input ``e``
+      excluded), and task ``0x..03`` via no-arg ``dump()`` (all tensor args).
+      Mode is latched host-side before dispatch, so it is race-free regardless
+      of submission order.
+    - ``--dump-args 2`` (full): markers are ignored, every task is dumped.
+
+    The dump level comes straight from the CLI ``--dump-args`` value
+    (no per-case override).
+    """
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/partial_dump_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        level = int(request.config.getoption("--dump-args", default=0))
+        if not level:
+            return
+        safe_label = _sanitize_for_filename("TestArgsDump_default")
+        matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        assert matches, "args dump output directory missing"
+        dump_dir = matches[-1] / "args_dump"
+        assert dump_dir.is_dir(), f"args_dump/ missing under {matches[-1]} — dump capture failed?"
+        manifest = dump_dir / "args_dump.json"
+        assert manifest.exists(), f"args_dump.json missing under {dump_dir} — collector finalize failed?"
+        with manifest.open() as f:
+            data = json.load(f)
+        bin_name = data.get("bin_file")
+        tensors = data.get("args", [])
+        assert tensors, f"args_dump.json has no entries: {data}"
+        if level == 3:
+            # full_json_only: metadata only, no payload and no .bin file.
+            assert bin_name is None, f"level 3 manifest should have bin_file=null: {data}"
+            assert not (dump_dir / "args.bin").exists(), "level 3 must not write args.bin"
+            assert all(t.get("bin_size") == 0 for t in tensors), tensors
+        else:
+            assert bin_name, f"manifest missing bin_file field: {data}"
+            bin_path = dump_dir / bin_name
+            assert bin_path.exists(), f"manifest names bin_file={bin_name!r} but {bin_path} not found"
+            assert bin_path.stat().st_size > 0, "args.bin is empty"
+
+        # Unified manifest (#792): tensors and scalar args share one
+        # args_dump.json keyed by a "kind" field; no separate legacy sidecar files.
+        assert not (dump_dir / "tensor_dump.json").exists(), "tensor_dump.json should not be emitted"
+        assert not (dump_dir / "kernel_args_dump.json").exists(), "kernel_args_dump.json should not be emitted"
+        assert all("kind" in t for t in tensors), tensors
+        scalar_entries = [t for t in tensors if t.get("kind") == "scalar"]
+        assert all(t.get("stage") == "before_dispatch" for t in scalar_entries), scalar_entries
+        assert all(t.get("bin_size") == 0 for t in scalar_entries), scalar_entries
+        assert all("value" in t for t in scalar_entries), scalar_entries
+
+        # func_id array (#1181): every entry carries its task's active-subtask
+        # membership. partial_dump_orch dispatches all tasks via single-kernel
+        # rt_submit_aiv_task, so each func_id must be a one-element array holding
+        # a declared func_id, consistent across that task's entries; and all three
+        # dispatched kernels (0/1/2) appear. Without this a wholly broken func_id
+        # emit still PASSes. (Exact task_id->func mapping is not pinned: it shifts
+        # between partial/full modes and add/mul are structurally indistinguishable.)
+        per_task_func = {}
+        seen_func = set()
+        for t in tensors:
+            fid = t.get("func_id")
+            assert isinstance(fid, list) and len(fid) == 1, (
+                f"{t['task_id']} arg {t.get('arg_index')} ({t.get('kind')}): "
+                f"func_id={fid} — single-kernel task must be a one-element array"
+            )
+            assert fid[0] in (0, 1, 2), f"{t['task_id']}: func_id {fid} outside declared range 0/1/2"
+            prev = per_task_func.setdefault(t["task_id"], fid[0])
+            assert prev == fid[0], f"{t['task_id']}: func_id differs across entries ({prev} vs {fid[0]})"
+            seen_func.add(fid[0])
+        assert seen_func == {0, 1, 2}, f"dump should cover all dispatched kernels 0/1/2, got {sorted(seen_func)}"
+
+        # Level-aware checks operate on the tensor entries.
+        tensor_entries = [t for t in tensors if t.get("kind") == "tensor"]
+        task_ids = {t["task_id"] for t in tensor_entries}
+        if level == 1:
+            # Partial: only the selected tensor/scalar args, race-free (host-latched).
+            assert len(tensor_entries) == 7, f"partial expected 7 tensor entries, got {len(tensor_entries)}"
+            assert task_ids == {
+                "0x0000000100000000",
+                "0x0000000100000002",
+                "0x0000000100000003",
+            }
+            # Task granularity: dump() captured all tensor args on task 0.
+            t00 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000000")
+            assert t00 == [0, 1]
+            # Mixed granularity: dump(d, inter_ci, t3_count) captured tensor args
+            # 0 + 2, not arg 1 (e).
+            t02 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000002")
+            assert t02 == [0, 2]
+            # Tensor-only task granularity: dump() captured all three tensor args.
+            t03 = sorted(t["arg_index"] for t in tensor_entries if t["task_id"] == "0x0000000100000003")
+            assert t03 == [0, 1, 2]
+            scalar_by_task = {
+                task_id: sorted(t["arg_index"] for t in scalar_entries if t["task_id"] == task_id)
+                for task_id in {t["task_id"] for t in scalar_entries}
+            }
+            assert scalar_by_task == {
+                "0x0000000100000000": [2, 3],
+                "0x0000000100000001": [2],
+                "0x0000000100000002": [3],
+            }
+            ambiguous_scalars = [
+                (t["task_id"], t["arg_index"]) for t in scalar_entries if t.get("arg_index_ambiguous", False)
+            ]
+            assert ambiguous_scalars == [("0x0000000100000002", 3)]
+        else:
+            # Full (level 2 or 3): markers ignored — every one of the 5 tasks is dumped.
+            assert len(task_ids) >= 5, f"full dump should cover all 5 tasks, got {sorted(task_ids)}"
+
+        # ---- Tool smoke: dump_viewer ----
+        # Exit-code-only check; the no-filter default lists every captured
+        # arg without exporting. A schema change that breaks the viewer
+        # fires here in the same CI step that produced the dump.
+        subprocess.run(
+            [sys.executable, "-m", "simpler_setup.tools.dump_viewer", str(dump_dir)],
+            check=True,
+            timeout=60,
+        )
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/__init__.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/_swimlane_validate.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/_swimlane_validate.py
@@ -1,0 +1,240 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Shared l2_swimlane post-case validation.
+
+The vector_example and paged_attention swimlane tests run the same capture →
+tool smoke → differential gate sequence; the only difference between them is
+the workload itself. The helpers below are workload-agnostic so each test
+file owns only its CALLABLE + cases.
+
+The differential gate is the load-bearing assertion: it parses the script's
+printed Pop / Fanout / Fanin totals and cross-checks them against an oracle
+computed straight from the raw artifacts. The paged_attention test exercises
+the per-task dedup branch in ``compute_dag_stats_from_deps`` because mixed
+AIC+AIV tasks produce multiple perf rows per ``task_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+from simpler_setup.tools.swimlane_converter import read_perf_data
+
+_REQUIRED_TASK_FIELDS = (
+    "task_id",
+    "func_id",
+    "core_id",
+    "core_type",
+    "start_time_us",
+    "end_time_us",
+    # receive_time_us / local_setup_us are populated unconditionally by the
+    # AICore-side capture (v3 schema). propagation_us requires AICPU dispatch_ts
+    # and is therefore only present at level≥2 — not in this required-set.
+    "receive_time_us",
+    "local_setup_us",
+)
+
+
+def validate_perf_artifact(case_label: str, *, expected_task_count: int | None = None) -> None:
+    """Locate the latest output dir for ``case_label`` and run the full
+    capture-→-tools-→-differential sequence.
+
+    Args:
+        case_label: full SceneTest case label (``f"{cls_name}_{case_name}"``)
+            used to glob the per-case ``outputs/<label>_<ts>/`` directory.
+        expected_task_count: when provided, assert ``len(tasks) == N``.
+            Workloads whose task count varies with sim/onboard timing should
+            leave this ``None`` and rely on the differential gate.
+    """
+    safe_label = _sanitize_for_filename(case_label)
+    matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+    if not matches:
+        return
+    perf = matches[-1] / "l2_swimlane_records.json"
+    assert perf.exists(), f"l2_swimlane_records.json missing under {matches[-1]} — swimlane capture failed?"
+
+    # Read via the swimlane_converter loader so v2 host JSON gets joined into
+    # the v1-shaped dict the rest of this validator (and the differential
+    # oracle below) expects. Direct json.load(perf) would see only raw
+    # aicore_tasks / aicpu_tasks arrays under v2.
+    data = read_perf_data(perf)
+    assert data.get("l2_swimlane_level") in (1, 2, 3, 4), (
+        f"unexpected l2_swimlane_level: {data.get('l2_swimlane_level')}"
+    )
+    tasks = data.get("tasks")
+    assert isinstance(tasks, list), "tasks field missing or not a list"
+    assert len(tasks) > 0, f"perf records empty under {perf}"
+    if expected_task_count is not None:
+        assert len(tasks) == expected_task_count, (
+            f"got {len(tasks)} perf records, expected {expected_task_count} under {perf}"
+        )
+    # Spot-check a single record's required fields — guards against drift in
+    # the swimlane schema that swimlane_converter.py / deps_viewer.py rely on.
+    first = tasks[0]
+    for key in _REQUIRED_TASK_FIELDS:
+        assert key in first, f"perf record missing required field '{key}': {first}"
+
+    # ---- Tool smoke: swimlane_converter ----
+    # Exit-code-only check; we don't validate the Perfetto JSON content. A
+    # schema change that breaks the converter fires here in the same CI
+    # step that produced the artifact.
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "simpler_setup.tools.swimlane_converter",
+            str(perf),
+            "-o",
+            str(matches[-1] / "_smoke_swimlane.json"),
+        ],
+        check=True,
+        timeout=60,
+    )
+
+    # ---- Tool smoke: sched_overhead_analysis ----
+    # pop_hit / pop_miss come from the dispatch-phase extras the runtime writes
+    # (l2_swimlane_collector.cpp). The differential block below cross-validates
+    # the script's printed numbers against an independent oracle computed
+    # straight from the raw artifacts — any regression in either the runtime
+    # capture path or the parser arithmetic fails here in the same CI step
+    # that produced the data.
+    # sched_overhead_analysis now REQUIRES the DAG (deps.json). The l2_swimlane
+    # CI smoke captures it alongside the perf JSON (--enable-dep-gen), so pass it
+    # explicitly. (For accurate user-facing timing, deps must be a SEPARATE
+    # capture — dep_gen perturbs timing — but the count-based differential below
+    # is timing-independent, so the co-run smoke is fine here.)
+    sched_cmd = [
+        sys.executable,
+        "-m",
+        "simpler_setup.tools.sched_overhead_analysis",
+        "--l2-swimlane-records-json",
+        str(perf),
+    ]
+    deps_sibling = Path(perf).parent / "deps.json"
+    if deps_sibling.exists():
+        sched_cmd += ["--deps-json", str(deps_sibling)]
+    result = subprocess.run(sched_cmd, check=True, timeout=120, capture_output=True, text=True)
+    for header in ("Part 1:", "Part 2:", "Part 5:", "Part 6:"):
+        assert header in result.stdout, f"sched_overhead missing section header '{header}'\nstdout:\n{result.stdout}"
+    # Bad pattern: AICPU didn't capture real cycle counters → tool "succeeds"
+    # but every metric is 0. Match the loop-iteration line printed unconditionally
+    # in Part 6 and assert its value is non-zero (reported in ns now).
+    m = re.search(r"Avg scheduler loop iteration:\s+([\d.]+)\s+ns", result.stdout)
+    assert m, f"sched_overhead stdout missing 'Avg scheduler loop iteration'\nstdout:\n{result.stdout}"
+    assert float(m.group(1)) > 0.0, (
+        f"sched_overhead reports zero loop iteration (avg_loop_us={m.group(1)}). "
+        f"AICPU likely didn't capture dispatch_time/finish_time cycle counters — "
+        f"the L2 perf collector path may have regressed.\nstdout:\n{result.stdout}"
+    )
+    verify_sched_overhead_differential(result.stdout, data, matches[-1])
+
+
+def verify_sched_overhead_differential(stdout: str, perf: dict, artifact_dir: Path) -> None:
+    """Cross-check the script's printed Pop / Fanout / Fanin totals against
+    an oracle computed independently from the raw artifacts. The script and
+    the oracle should agree exactly — if they don't, either the runtime
+    capture regressed or the parser arithmetic drifted, and the bug is
+    caught in the same CI step that produced the data.
+
+    Args:
+        stdout: captured ``sched_overhead_analysis`` stdout.
+        perf: parsed ``l2_swimlane_records.json`` dict — passed in by the caller
+            so we don't re-read multi-MB profiling artifacts here.
+        artifact_dir: per-case output directory. ``deps.json`` is looked up
+            beside the perf JSON; absent → fanout / fanin half is skipped.
+
+    The per-task dedup branch is exercised on mixed AIC+AIV workloads where
+    the perf JSON emits one row per subtask/core for a single ``task_id``.
+    """
+    # Oracle: pop_hit / pop_miss are the sum across all dispatch records.
+    # Compares against the "Pop: hit=N, miss=M" line the script prints.
+    phases = perf.get("aicpu_scheduler_phases", [])
+    oracle_pop_hit = sum(r.get("pop_hit", 0) for thr_recs in phases for r in thr_recs if r.get("phase") == "dispatch")
+    oracle_pop_miss = sum(r.get("pop_miss", 0) for thr_recs in phases for r in thr_recs if r.get("phase") == "dispatch")
+    pop_match = re.search(r"Pop:\s*hit=(\d+),\s*miss=(\d+)", stdout)
+    assert pop_match, f"sched_overhead stdout missing 'Pop: hit=N, miss=M' line\nstdout:\n{stdout}"
+    printed_pop_hit, printed_pop_miss = int(pop_match.group(1)), int(pop_match.group(2))
+    assert printed_pop_hit == oracle_pop_hit, (
+        f"Pop hit mismatch: printed={printed_pop_hit}, oracle={oracle_pop_hit} "
+        f"(summed from dispatch-record extras)\nstdout:\n{stdout}"
+    )
+    assert printed_pop_miss == oracle_pop_miss, (
+        f"Pop miss mismatch: printed={printed_pop_miss}, oracle={oracle_pop_miss}\nstdout:\n{stdout}"
+    )
+
+    # Fanout / fanin differential — only meaningful when deps.json is
+    # colocated (i.e. --enable-dep-gen was also on). When absent, skip.
+    deps_path = artifact_dir / "deps.json"
+    if not deps_path.exists():
+        return
+    with deps_path.open() as f:
+        deps = json.load(f)
+    unique_edges = set()
+    for e in deps.get("edges", []):
+        try:
+            pred, succ = int(e["pred"]), int(e["succ"])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if pred < 0:
+            pred &= (1 << 64) - 1
+        if succ < 0:
+            succ &= (1 << 64) - 1
+        unique_edges.add((pred, succ))
+
+    # Per-thread oracle: a task's fanout is billed to the thread that
+    # retired it (core_to_thread[task.core_id]). Sum across threads ==
+    # total edges (modulo unattributed tasks, e.g. alloc-only with no
+    # core_id). The script prints the sum-across-threads total.
+    core_to_thread = perf.get("core_to_thread") or []
+    edges_by_pred: dict[int, set[int]] = {}
+    edges_by_succ: dict[int, set[int]] = {}
+    for pred, succ in unique_edges:
+        edges_by_pred.setdefault(pred, set()).add(succ)
+        edges_by_succ.setdefault(succ, set()).add(pred)
+    # Dedup by task_id: mixed tasks emit one perf row per subtask/core.
+    oracle_fanout = 0
+    oracle_fanin = 0
+    seen_tids: set[int] = set()
+    for task in perf.get("tasks", []):
+        cid = task.get("core_id")
+        if not isinstance(cid, int) or not (0 <= cid < len(core_to_thread)):
+            continue
+        if core_to_thread[cid] < 0:
+            continue
+        try:
+            tid = int(task["task_id"])
+        except (TypeError, ValueError, KeyError):
+            continue
+        if tid < 0:
+            tid &= (1 << 64) - 1
+        if tid in seen_tids:
+            continue
+        seen_tids.add(tid)
+        oracle_fanout += len(edges_by_pred.get(tid, ()))
+        oracle_fanin += len(edges_by_succ.get(tid, ()))
+
+    fanout_match = re.search(r"Fanout \(.*?\):\s*total edges=(\d+),\s*max_degree=(\d+)", stdout)
+    fanin_match = re.search(r"Fanin\s+\(.*?\):\s*total edges=(\d+),\s*max_degree=(\d+)", stdout)
+    assert fanout_match, f"sched_overhead stdout missing 'Fanout' line\nstdout:\n{stdout}"
+    assert fanin_match, f"sched_overhead stdout missing 'Fanin' line\nstdout:\n{stdout}"
+    printed_fanout = int(fanout_match.group(1))
+    printed_fanin = int(fanin_match.group(1))
+    assert printed_fanout == oracle_fanout, (
+        f"Fanout edges mismatch: printed={printed_fanout}, oracle={oracle_fanout} "
+        f"(derived from {len(unique_edges)} unique deps.json edges + core_to_thread)\n"
+        f"stdout:\n{stdout}"
+    )
+    assert printed_fanin == oracle_fanin, (
+        f"Fanin edges mismatch: printed={printed_fanin}, oracle={oracle_fanin}\nstdout:\n{stdout}"
+    )

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/kernels/orchestration/chained_mix_orch.cpp
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/kernels/orchestration/chained_mix_orch.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+ * CANN Open Software License Agreement Version 2.0 (the "License").
+ * Please refer to the License for details. You may not use this file except in compliance with the License.
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+ * See LICENSE in the root of the software repository for the full text of the License.
+ * -----------------------------------------------------------------------------------------------------------
+ */
+/**
+ * Chained MIX orchestration — three MIX tasks where each step reads the
+ * previous step's output. Purpose-built for the l2_swimlane differential
+ * gate: produces MIX tasks (multiple perf rows per task_id) AND non-zero
+ * deps.json edges, so the ``seen_tids`` dedup in
+ * ``compute_dag_stats_from_deps`` has an arithmetically observable effect.
+ *
+ * Each MIX task runs ``aic_matmul`` (kernel_matmul.cpp, 128x128 GEMM) and
+ * ``aiv_add`` (kernel_add.cpp, elementwise add). Inputs are reshaped from
+ * the flat 16384-element tensors the test allocates.
+ *
+ * Arg layout (8 args, all 1-D 16384 float32 except workspaces which are
+ * 32768):
+ *   [A, B, D, E, ws_aic, ws_aiv, aic_out, aiv_out]
+ *
+ * Chain (each line is one MIX task; AIC ↑ AIV ↓):
+ *   step 1:  ws_aic[0:T]      ← matmul(A, B)              edges: (none)
+ *            ws_aiv[0:T]      ← add(D, E)
+ *   step 2:  ws_aic[T:2T]     ← matmul(ws_aic[0:T], B)    edges: 1→2 (×2 tensors)
+ *            ws_aiv[T:2T]     ← add(ws_aiv[0:T], E)
+ *   step 3:  aic_out          ← matmul(ws_aic[T:2T], B)   edges: 2→3 (×2 tensors)
+ *            aiv_out          ← add(ws_aiv[T:2T], E)
+ *
+ * dep_gen collapses the per-tensor flows to unique (pred, succ) pairs,
+ * so deps.json reports 2 edges: (step1, step2) and (step2, step3).
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "pto_orchestration_api.h"  // NOLINT(build/include_subdir)
+
+#define FUNC_MATMUL 0  // AIC kernel — reads first 3 args of the MIX bundle
+#define FUNC_ADD 1     // AIV kernel — reads next 3 args of the MIX bundle
+
+static constexpr uint32_t TILE_ELEMS = 128 * 128;
+
+extern "C" {
+
+__attribute__((visibility("default"))) PTO2OrchestrationConfig aicpu_orchestration_config(const L2TaskArgs &orch_args) {
+    (void)orch_args;
+    return PTO2OrchestrationConfig{
+        .expected_arg_count = 8,
+    };
+}
+
+__attribute__((visibility("default"))) void aicpu_orchestration_entry(const L2TaskArgs &orch_args) {
+    const Tensor &ext_A = orch_args.tensor(0).ref();
+    const Tensor &ext_B = orch_args.tensor(1).ref();
+    const Tensor &ext_D = orch_args.tensor(2).ref();
+    const Tensor &ext_E = orch_args.tensor(3).ref();
+    const Tensor &ext_ws_aic = orch_args.tensor(4).ref();
+    const Tensor &ext_ws_aiv = orch_args.tensor(5).ref();
+    const Tensor &ext_aic_out = orch_args.tensor(6).ref();
+    const Tensor &ext_aiv_out = orch_args.tensor(7).ref();
+
+    uint32_t slot_shape[1] = {TILE_ELEMS};
+    uint32_t off_slot0[1] = {0};
+    uint32_t off_slot1[1] = {TILE_ELEMS};
+
+    Tensor ws_aic_slot0 = ext_ws_aic.view(slot_shape, off_slot0);
+    Tensor ws_aic_slot1 = ext_ws_aic.view(slot_shape, off_slot1);
+    Tensor ws_aiv_slot0 = ext_ws_aiv.view(slot_shape, off_slot0);
+    Tensor ws_aiv_slot1 = ext_ws_aiv.view(slot_shape, off_slot1);
+
+    LOG_INFO_V0("[chained_mix_orch] launching 3-step chained MIX (AIC + AIV)");
+
+    // Step 1: heads of both chains read external inputs.
+    {
+        MixedKernels mk;
+        mk.aic_kernel_id = FUNC_MATMUL;
+        mk.aiv0_kernel_id = FUNC_ADD;
+        L0TaskArgs args;
+        args.add_input(ext_A);
+        args.add_input(ext_B);
+        args.add_output(ws_aic_slot0);
+        args.add_input(ext_D);
+        args.add_input(ext_E);
+        args.add_output(ws_aiv_slot0);
+        rt_submit_task(mk, args);
+    }
+
+    // Step 2: AIC reads ws_aic_slot0 (step 1 AIC output) and AIV reads
+    // ws_aiv_slot0 (step 1 AIV output). Two tensors flow from step 1 to
+    // step 2; dep_gen collapses to a single (step1, step2) edge.
+    {
+        MixedKernels mk;
+        mk.aic_kernel_id = FUNC_MATMUL;
+        mk.aiv0_kernel_id = FUNC_ADD;
+        L0TaskArgs args;
+        args.add_input(ws_aic_slot0);
+        args.add_input(ext_B);
+        args.add_output(ws_aic_slot1);
+        args.add_input(ws_aiv_slot0);
+        args.add_input(ext_E);
+        args.add_output(ws_aiv_slot1);
+        rt_submit_task(mk, args);
+    }
+
+    // Step 3: writes the final user-visible outputs.
+    {
+        MixedKernels mk;
+        mk.aic_kernel_id = FUNC_MATMUL;
+        mk.aiv0_kernel_id = FUNC_ADD;
+        L0TaskArgs args;
+        args.add_input(ws_aic_slot1);
+        args.add_input(ext_B);
+        args.add_output(ext_aic_out);
+        args.add_input(ws_aiv_slot1);
+        args.add_input(ext_E);
+        args.add_output(ext_aiv_out);
+        rt_submit_task(mk, args);
+    }
+}
+
+}  // extern "C"

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L2 swimlane profiling smoke — capture pipeline produces a usable
+``l2_swimlane_records.json``.
+
+Re-uses ``vector_example`` as a known-good 5-task AIV-only workload. When the
+``--enable-l2-swimlane`` flag is on, the helper in :mod:`_swimlane_validate`
+asserts schema, runs the converter / sched_overhead tool smokes, and fires a
+differential gate over Pop / Fanout / Fanin. Without the flag the assertions
+are skipped — the test still runs the case so the default ``pytest tests/st``
+invocation doesn't pay an extra step.
+
+A mixed AIC+AIV companion lives in ``test_l2_swimlane_mixed.py`` —
+that variant exercises the per-task dedup branch in
+``compute_dag_stats_from_deps`` which this AIV-only workload doesn't.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+
+from ._swimlane_validate import validate_perf_artifact
+
+KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
+# example_orchestration.cpp issues 5 submit_task calls.
+_EXPECTED_TASK_COUNT = 5
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestL2Swimlane(SceneTestCase):
+    """Vector example with --enable-l2-swimlane, then assert l2_swimlane_records.json."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        if not request.config.getoption("--enable-l2-swimlane", default=0):
+            return
+        for case in self.CASES:
+            if st_platform in case["platforms"]:
+                validate_perf_artifact(f"TestL2Swimlane_{case['name']}", expected_task_count=_EXPECTED_TASK_COUNT)
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/l2_swimlane/test_l2_swimlane_mixed.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""L2 swimlane profiling on a chained MIX-task workload.
+
+Companion to ``test_l2_swimlane.py``. vector_example is AIV-only and emits
+one perf row per ``task_id`` — the dedup branch in
+``compute_dag_stats_from_deps`` (and the matching dedup in the oracle
+inside :mod:`_swimlane_validate`) sits idle. ``chained_mix_orch.cpp`` runs
+3 MIX tasks where each step's output feeds the next step's input, so
+the workload produces *both*:
+
+  - MIX rows: each MIX task_id emits one perf row per subtask/core
+  - deps.json edges: 2 unique (pred, succ) pairs from the chain
+
+That combination is what makes the dedup arithmetically observable. Without
+``seen_tids`` the oracle would compute fanout = 4 instead of 2 (each MIX
+task's fanout being counted once per perf row), and the differential gate
+would fire.
+"""
+
+import json
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+from ._swimlane_validate import validate_perf_artifact
+
+_MATMUL_SIZE = 128
+_TILE_ELEMS = _MATMUL_SIZE * _MATMUL_SIZE
+# ws_aic / ws_aiv hold two intermediate slots — step 1's output (slot 0)
+# is read by step 2, step 2's output (slot 1) is read by step 3.
+_WS_SLOTS = 2
+_WS_ELEMS = _WS_SLOTS * _TILE_ELEMS
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestL2SwimlaneMixed(SceneTestCase):
+    """Chained MIX workload (3 steps, each step is AIC matmul + AIV add).
+
+    Step N reads workspace slot N-1 and writes workspace slot N. Step 3
+    writes the user-visible outputs. dep_gen collapses the multi-tensor
+    flow between adjacent steps into a single (pred, succ) edge per pair,
+    giving 2 unique edges across 3 MIX task_ids.
+    """
+
+    RTOL = 1e-3
+    ATOL = 1e-3
+
+    CALLABLE = {
+        "orchestration": {
+            "source": "kernels/orchestration/chained_mix_orch.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.IN, D.IN, D.INOUT, D.INOUT, D.OUT, D.OUT],
+        },
+        # No arg_index: both incores declare the FULL 6-tensor mix signature
+        # (chained_mix_orch.cpp bundles MATMUL's 3 args + ADD's 3 args); the dump
+        # maps signature entry i to payload slot i positionally.
+        "incores": [
+            {
+                "func_id": 0,
+                "name": "MATMUL",
+                "source": "../../mixed_example/kernels/aic/kernel_matmul.cpp",
+                "core_type": "aic",
+                "signature": [D.IN, D.IN, D.OUT, D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "name": "ADD",
+                "source": "../../mixed_example/kernels/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT, D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        torch.manual_seed(42)
+        A = torch.randn(_MATMUL_SIZE, _MATMUL_SIZE, dtype=torch.float32) * 0.01
+        B = torch.randn(_MATMUL_SIZE, _MATMUL_SIZE, dtype=torch.float32) * 0.01
+        D_t = torch.randn(_TILE_ELEMS, dtype=torch.float32) * 0.01
+        E = torch.randn(_TILE_ELEMS, dtype=torch.float32) * 0.01
+
+        return TaskArgsBuilder(
+            Tensor("A", A.flatten()),
+            Tensor("B", B.flatten()),
+            Tensor("D", D_t),
+            Tensor("E", E),
+            Tensor("ws_aic", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
+            Tensor("ws_aiv", torch.zeros(_WS_ELEMS, dtype=torch.float32)),
+            Tensor("aic_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
+            Tensor("aiv_out", torch.zeros(_TILE_ELEMS, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        A_mat = args.A.reshape(_MATMUL_SIZE, _MATMUL_SIZE)
+        B_mat = args.B.reshape(_MATMUL_SIZE, _MATMUL_SIZE)
+        # AIC chain: B applied three times via matmul.
+        s1_aic = torch.matmul(A_mat, B_mat)
+        s2_aic = torch.matmul(s1_aic, B_mat)
+        s3_aic = torch.matmul(s2_aic, B_mat)
+        # AIV chain: E added three times → D + 3E.
+        s1_aiv = args.D + args.E
+        s2_aiv = s1_aiv + args.E
+        s3_aiv = s2_aiv + args.E
+
+        args.aic_out[:] = s3_aic.flatten()
+        args.aiv_out[:] = s3_aiv
+        # Final workspace state — slot 0 holds step 1's output, slot 1
+        # holds step 2's output.
+        args.ws_aic[0:_TILE_ELEMS] = s1_aic.flatten()
+        args.ws_aic[_TILE_ELEMS:_WS_ELEMS] = s2_aic.flatten()
+        args.ws_aiv[0:_TILE_ELEMS] = s1_aiv
+        args.ws_aiv[_TILE_ELEMS:_WS_ELEMS] = s2_aiv
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        if request.config.getoption("--enable-l2-swimlane", default=False):
+            for case in self.CASES:
+                if st_platform in case["platforms"]:
+                    # Rely on the differential gate (Pop / Fanout / Fanin) —
+                    # the chain produces 3 MIX task_ids × 2 subtask rows = 6
+                    # perf rows and 2 deps.json edges, so the dedup branch in
+                    # the oracle has an arithmetically observable effect.
+                    validate_perf_artifact(f"TestL2SwimlaneMixed_{case['name']}")
+        # Full-dump modes give the func_id array its regression barrier on the
+        # cooperative-mix path (single-kernel coverage lives in test_args_dump).
+        if int(request.config.getoption("--dump-args", default=0)) >= 2:
+            self._validate_dump_func_ids()
+
+    def _validate_dump_func_ids(self):
+        """#1181: every chained_mix task is a 2-way cooperative MIX (MATMUL
+        func 0 + AIV ADD func 1) sharing one 6-tensor payload, so every dumped
+        slot must carry the same active-subtask membership ``func_id == [0, 1]``,
+        and each ``(task, slot, stage)`` is emitted exactly once — not
+        duplicated per subtask as the pre-#1181 geometry did.
+        """
+        safe_label = _sanitize_for_filename("TestL2SwimlaneMixed_default")
+        matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        assert matches, "args dump output directory missing"
+        manifest = matches[-1] / "args_dump" / "args_dump.json"
+        assert manifest.exists(), f"args_dump.json missing under {matches[-1]}"
+        with manifest.open() as f:
+            data = json.load(f)
+        tensors = [t for t in data.get("args", []) if t.get("kind") == "tensor"]
+        assert tensors, f"no tensor entries dumped: {data}"
+        for t in tensors:
+            assert sorted(t.get("func_id", [])) == [0, 1], (
+                f"mix slot {t['task_id']}:{t.get('arg_index')} func_id={t.get('func_id')} — expected membership [0, 1]"
+            )
+        seen = [(t["task_id"], t["arg_index"], t.get("stage")) for t in tensors]
+        assert len(seen) == len(set(seen)), f"a payload slot was emitted more than once: {seen}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/pmu/test_pmu.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""PMU profiling smoke — capture pipeline produces a usable ``pmu.csv``.
+
+Re-uses ``vector_example`` (5 submit_task calls). With ``--enable-pmu N``
+the AICore counters land in ``<output_prefix>/pmu.csv``, one data row per
+task. The schema is fixed (see docs/dfx/pmu-profiling.md and
+src/a5/platform/shared/host/pmu_collector.cpp's "Build CSV header"
+block). Smoke asserts: file exists, header starts with the documented
+prefix, at least one data row present.
+"""
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
+# Required leading columns — keep in sync with build_csv_header() in
+# pmu_collector.cpp. Counter columns follow these and vary per event_type.
+_REQUIRED_HEADER_PREFIX = ("thread_id", "core_id", "task_id", "func_id", "core_type", "pmu_total_cycles")
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestPmu(SceneTestCase):
+    """Vector example with --enable-pmu, then assert pmu.csv."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        if not request.config.getoption("--enable-pmu", default=0):
+            return
+        for case in self.CASES:
+            if st_platform in case["platforms"]:
+                self._validate_pmu_artifact(case)
+
+    def _validate_pmu_artifact(self, case):
+        safe_label = _sanitize_for_filename(f"TestPmu_{case['name']}")
+        matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        if not matches:
+            return
+        csv = matches[-1] / "pmu.csv"
+        assert csv.exists(), f"pmu.csv missing under {matches[-1]} — PMU capture failed?"
+        lines = csv.read_text().splitlines()
+        assert lines, "pmu.csv is empty"
+        header_cols = lines[0].split(",")
+        for col in _REQUIRED_HEADER_PREFIX:
+            assert col in header_cols, f"header missing required column '{col}': {header_cols}"
+        # At least one data row — sim runs all 5 vector_example tasks; expect ≥1
+        # to keep the assertion robust if a future scheduler change collapses
+        # / batches per-task PMU sampling.
+        assert len(lines) >= 2, f"pmu.csv has no data rows (only header): {lines}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)

--- a/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
+++ b/tests/st/a5/tensormap_and_ringbuffer/dfx/scope_stats/test_scope_stats.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""scope_stats smoke — capture pipeline produces a usable ``scope_stats.jsonl``.
+
+Re-uses ``vector_example`` (outer executor scope + one inner ``PTO2_SCOPE()``).
+With ``--enable-scope-stats`` the platform collector
+(``scope_stats_collector_aicpu.h``) appends one record per scope boundary
+(begin and end) into a pooled buffer that streams to the host, which writes
+NDJSON. Enabling the flag is the entire user surface for the new API — the
+runtime takes care of the ``set_pending_site`` / ``scope_stats_begin`` /
+``scope_stats_end`` calls. Schema lives in ``docs/dfx/scope-stats.md`` §3.
+
+Output (``scope_stats.jsonl``): line 1 is run metadata
+(``{"version":6,"fatal":bool,"dropped":uint,"total":uint}``); each subsequent
+line is one scope-boundary record carrying task/heap/dep_pool start-end.
+"""
+
+import json
+
+import torch
+from simpler.task_interface import ArgDirection as D
+
+from simpler_setup import SceneTestCase, TaskArgsBuilder, Tensor, scene_test
+from simpler_setup.scene_test import _outputs_dir, _sanitize_for_filename
+
+KERNELS_BASE = "../../../../../../examples/a5/tensormap_and_ringbuffer/vector_example/kernels"
+_REQUIRED_RECORD_FIELDS = {
+    "site",
+    "phase",
+    "depth",
+    "ring",
+    "task_window_start",
+    "task_window_end",
+    "heap_start",
+    "heap_end",
+    "dep_pool_start",
+    "dep_pool_end",
+    "tensormap",
+}
+
+
+@scene_test(level=2, runtime="tensormap_and_ringbuffer")
+class TestScopeStats(SceneTestCase):
+    """Vector example with --enable-scope-stats, then assert scope_stats.jsonl."""
+
+    CALLABLE = {
+        "orchestration": {
+            "source": f"{KERNELS_BASE}/orchestration/example_orchestration.cpp",
+            "function_name": "aicpu_orchestration_entry",
+            "signature": [D.IN, D.IN, D.OUT],
+        },
+        "incores": [
+            {
+                "func_id": 0,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+            {
+                "func_id": 1,
+                "source": f"{KERNELS_BASE}/aiv/kernel_add_scalar.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.OUT],
+            },
+            {
+                "func_id": 2,
+                "source": f"{KERNELS_BASE}/aiv/kernel_mul.cpp",
+                "core_type": "aiv",
+                "signature": [D.IN, D.IN, D.OUT],
+            },
+        ],
+    }
+
+    CASES = [
+        {
+            "name": "default",
+            "platforms": ["a5sim", "a5"],
+            "config": {"aicpu_thread_num": 4, "block_dim": 3},
+            "params": {},
+        },
+    ]
+
+    def generate_args(self, params):
+        SIZE = 128 * 128
+        return TaskArgsBuilder(
+            Tensor("a", torch.full((SIZE,), 2.0, dtype=torch.float32)),
+            Tensor("b", torch.full((SIZE,), 3.0, dtype=torch.float32)),
+            Tensor("f", torch.zeros(SIZE, dtype=torch.float32)),
+        )
+
+    def compute_golden(self, args, params):
+        args.f[:] = (args.a + args.b + 1) * (args.a + args.b + 2) + (args.a + args.b)
+
+    def test_run(self, st_platform, st_worker, request):
+        super().test_run(st_platform, st_worker, request)
+        if not request.config.getoption("--enable-scope-stats", default=False):
+            return
+        for case in self.CASES:
+            if st_platform in case["platforms"]:
+                self._validate_scope_stats_artifact(case)
+
+    def _validate_scope_stats_artifact(self, case):
+        safe_label = _sanitize_for_filename(f"TestScopeStats_{case['name']}")
+        matches = sorted(_outputs_dir().glob(f"{safe_label}_*"), key=lambda p: p.stat().st_mtime)
+        assert matches, (
+            f"no output directory under {_outputs_dir()} matching {safe_label}_* — "
+            f"--enable-scope-stats was on but the run produced no per-case output dir"
+        )
+        path = matches[-1] / "scope_stats" / "scope_stats.jsonl"
+        assert path.exists(), f"scope_stats.jsonl missing under {matches[-1]} — collector finalize failed?"
+        lines = [ln for ln in path.read_text().splitlines() if ln.strip()]
+        assert lines, f"scope_stats.jsonl empty under {matches[-1]}"
+        meta = json.loads(lines[0])
+        assert meta.get("version") == 6, f"unexpected schema version: {meta!r}"
+        assert meta.get("fatal") is False, f"run latched fatal: {meta!r}"
+        assert meta.get("dropped", 0) == 0, f"records dropped on device: {meta!r}"
+        assert "dep_pool_max" in meta, f"metadata missing dep_pool_max: {meta!r}"
+        records = [json.loads(ln) for ln in lines[1:]]
+        # outer (executor) + inner PTO2_SCOPE, each emitting a begin and an end
+        # record → ≥4 records.
+        assert len(records) >= 4, f"expected ≥4 begin/end records, got {records!r}"
+        for rec in records:
+            assert _REQUIRED_RECORD_FIELDS <= rec.keys(), f"record missing fields: {rec!r}"
+
+
+if __name__ == "__main__":
+    SceneTestCase.run_module(__name__)


### PR DESCRIPTION
## What

a5 only had `dep_gen` under `tensormap_and_ringbuffer/dfx`. This mirrors the
remaining a2a3 DFX scene tests so the two arches stay aligned:

- **args_dump** — `--dump-args` capture + manifest schema
- **l2_swimlane** — swimlane records + mixed AIC/AIV variant
- **pmu** — `--enable-pmu` pmu.csv
- **scope_stats** — `--enable-scope-stats` NDJSON

Verbatim copies for the platform-agnostic helpers and orchestration kernels;
test files only swap the platform tokens (`examples/a2a3` → `examples/a5`,
`["a2a3sim","a2a3"]` → `["a5sim","a5"]`, `src/a2a3` → `src/a5`). All required
a5 platform collectors and example/mixed_example kernels already exist.

## Test

All 7 a5 DFX cases pass on a5 hardware:

\`\`\`
7 passed in 41.01s
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)