### PR TITLE
Fix clock backstop comments

### DIFF
--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -653,7 +653,8 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
             }
             // Absolute-time backstop, matching the task allocator: stable across
             // chips/contention, unlike a fixed spin count. get_sys_cnt_aicpu()
-            // is an MMIO read, so sample it only once per 1024 spins.
+            // is a cheap cntvct_el0 read; the 1024-spin gate keeps fatal-flag
+            // polling and timeout bookkeeping out of every entry-pool wait spin.
             uint64_t now = get_sys_cnt_aicpu();
             if (!block_timing) {
                 block_cycle0 = now;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -79,7 +79,8 @@ bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
             }
             // Absolute-time backstop, matching the task allocator: stable across
             // chips/contention, unlike a fixed spin count. get_sys_cnt_aicpu()
-            // is an MMIO read, so sample it only once per 1024 spins.
+            // is a cheap cntvct_el0 read; the 1024-spin gate keeps fatal-flag
+            // polling and timeout bookkeeping out of every reclaim spin.
             uint64_t now = get_sys_cnt_aicpu();
             if (!block_timing) {
                 block_cycle0 = now;

--- a/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a2a3/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -180,10 +180,11 @@ public:
                     return {-1, -1, nullptr, nullptr};
                 }
                 // Reclaim watermark is stuck. Run the deadlock checks only once
-                // per 1024 spins: get_sys_cnt_aicpu() is an MMIO read and
-                // head_blocked_on_scope_end() walks the head slot, neither of
-                // which needs to fire on every hot spin (1024 spins is far below
-                // the wall-clock timeout, so detection latency is unaffected).
+                // per 1024 spins to keep the hot reclaim loop tight:
+                // get_sys_cnt_aicpu() is a cheap cntvct_el0 read, while this
+                // block polls the fatal flag and head_blocked_on_scope_end()
+                // walks the head slot (1024 spins is far below the wall-clock
+                // timeout, so detection latency is unaffected).
                 // (1) Structural, immediate: if the head task is COMPLETED with
                 // every consumer released but its scope still open, only
                 // scope_end can free it and a blocked orchestrator can never

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_orchestrator.cpp
@@ -658,7 +658,8 @@ static bool ensure_tensormap_capacity(PTO2OrchestratorState *orch, int32_t neede
             }
             // Absolute-time backstop, matching the task allocator: stable across
             // chips/contention, unlike a fixed spin count. get_sys_cnt_aicpu()
-            // is an MMIO read, so sample it only once per 1024 spins.
+            // is a cheap cntvct_el0 read; the 1024-spin gate keeps fatal-flag
+            // polling and timeout bookkeeping out of every entry-pool wait spin.
             uint64_t now = get_sys_cnt_aicpu();
             if (!block_timing) {
                 block_cycle0 = now;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.cpp
@@ -79,7 +79,8 @@ bool PTO2FaninPool::ensure_space(PTO2SharedMemoryRingHeader &ring, int32_t neede
             }
             // Absolute-time backstop, matching the task allocator: stable across
             // chips/contention, unlike a fixed spin count. get_sys_cnt_aicpu()
-            // is an MMIO read, so sample it only once per 1024 spins.
+            // is a cheap cntvct_el0 read; the 1024-spin gate keeps fatal-flag
+            // polling and timeout bookkeeping out of every reclaim spin.
             uint64_t now = get_sys_cnt_aicpu();
             if (!block_timing) {
                 block_cycle0 = now;

--- a/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
+++ b/src/a5/runtime/tensormap_and_ringbuffer/runtime/pto_ring_buffer.h
@@ -180,10 +180,11 @@ public:
                     return {-1, -1, nullptr, nullptr};
                 }
                 // Reclaim watermark is stuck. Run the deadlock checks only once
-                // per 1024 spins: get_sys_cnt_aicpu() is an MMIO read and
-                // head_blocked_on_scope_end() walks the head slot, neither of
-                // which needs to fire on every hot spin (1024 spins is far below
-                // the wall-clock timeout, so detection latency is unaffected).
+                // per 1024 spins to keep the hot reclaim loop tight:
+                // get_sys_cnt_aicpu() is a cheap cntvct_el0 read, while this
+                // block polls the fatal flag and head_blocked_on_scope_end()
+                // walks the head slot (1024 spins is far below the wall-clock
+                // timeout, so detection latency is unaffected).
                 // (1) Structural, immediate: if the head task is COMPLETED with
                 // every consumer released but its scope still open, only
                 // scope_end can free it and a blocked orchestrator can never


### PR DESCRIPTION
## Summary

Fixes #1248.

Rewords the ring-buffer and orchestrator deadlock backstop comments that incorrectly described `get_sys_cnt_aicpu()` as an MMIO read. The updated comments describe it as a cheap `cntvct_el0` read and clarify that the 1024-spin gate exists to keep the hot reclaim/deadlock-check loops tight by avoiding per-spin fatal-flag polling, timeout bookkeeping, and the head-slot walk in the DepList/ring reclaim path.

## Impact

Comment-only cleanup. No behavior changes.

## Validation

- `git diff --check`
- `rg "MMIO read|get_sys_cnt_aicpu\\(\\).*MMIO|is an MMIO|sample it only once" src/{a2a3,a5}/runtime/tensormap_and_ringbuffer/runtime`
- pre-commit hooks during commit: headers, english-only, large-file check, EOF/whitespace, clang-format, clang-tidy, cpplint