### PR TITLE
Refactor: remove verified dead code in common/python (zero callers)

### DIFF
--- a/python/simpler/callable_identity.py
+++ b/python/simpler/callable_identity.py
@@ -52,10 +52,6 @@ _PY_CALLABLE_SERIALIZER_CLOUDPICKLE = 1
 _PY_CALLABLE_HEADER = struct.Struct("<4sBBHQ")
 
 
-def _pack_u8(value: int) -> bytes:
-    return struct.pack("<B", int(value))
-
-
 def _pack_u32(value: int) -> bytes:
     return struct.pack("<I", int(value))
 

--- a/simpler_setup/goldens/paged_attention.py
+++ b/simpler_setup/goldens/paged_attention.py
@@ -218,30 +218,3 @@ def compute_golden(tensors: dict, params: dict) -> None:
     )
 
     tensors["out"][:] = out
-
-
-def run_golden_test(all_cases: dict, default_case: str, generate_inputs_fn, label: str = "Paged Attention"):
-    """Run golden test for __main__ blocks."""
-    params = {"name": default_case, **all_cases[default_case]}
-    result = generate_inputs_fn(params)
-    tensors = {name: tensor for name, tensor in result if isinstance(tensor, torch.Tensor)}
-    compute_golden(tensors, params)
-
-    print(f"=== {label} Golden Test ({params['name']}) ===")
-    print(f"batch={params['batch']}, num_heads={params['num_heads']}, head_dim={params['head_dim']}")
-    print(f"kv_head_num={params['kv_head_num']}, block_size={params['block_size']}")
-    if params.get("context_lens_list"):
-        ctx_list = params["context_lens_list"]
-        print(f"context_lens (variable): {ctx_list[:8]}{'...' if len(ctx_list) > 8 else ''}")
-    else:
-        print(f"context_len={params['context_len']}")
-
-    max_num_blocks = params["max_model_len"] // params["block_size"]
-    q_tile = min(params["num_heads"], 128)
-    print(f"max_num_blocks_per_req={max_num_blocks}, q_tile_size={q_tile}")
-
-    out = tensors["out"].reshape(params["batch"] * params["num_heads"], params["head_dim"])
-    print(f"Output shape: {out.shape}")
-    print(f"Output range: [{out.min():.4f}, {out.max():.4f}]")
-    print(f"Output mean: {out.mean():.4f}")
-    print("Golden test passed!")

--- a/simpler_setup/platform_info.py
+++ b/simpler_setup/platform_info.py
@@ -62,14 +62,6 @@ def discover_runtimes(arch: str) -> list[str]:
     return sorted(d.name for d in runtime_base.iterdir() if d.is_dir() and (d / "build_config.py").exists())
 
 
-def discover_variants(arch: str) -> list[str]:
-    """Return sorted list of platform variants (excluding include/src dirs)."""
-    platform_base = PROJECT_ROOT / "src" / arch / "platform"
-    if not platform_base.is_dir():
-        return []
-    return sorted(d.name for d in platform_base.iterdir() if d.is_dir() and d.name not in ("include", "src"))
-
-
 def load_build_config(config_path: Path) -> dict:
     """Load BUILD_CONFIG dict from a build_config.py file."""
     spec = importlib.util.spec_from_file_location("build_config", config_path)

--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -12,7 +12,6 @@
 #include "orchestrator.h"
 
 #include <cstdint>
-#include <cstring>
 #include <stdexcept>
 #include <unordered_set>
 

--- a/src/common/platform/include/host/scope_stats_collector.h
+++ b/src/common/platform/include/host/scope_stats_collector.h
@@ -172,7 +172,6 @@ public:
 
 private:
     bool initialized_ = false;
-    int num_threads_ = 0;
 
     // Shared memory region (ScopeStatsDataHeader + ScopeStatsBufferState).
     // shm_host_ / shm_size_ / device_id_ live on ProfilerBase (set via

--- a/src/common/platform/include/host/tensor_dump_collector.h
+++ b/src/common/platform/include/host/tensor_dump_collector.h
@@ -289,7 +289,6 @@ private:
     // on_buffer_collected and joined by export_dump_files).
     std::chrono::steady_clock::time_point run_start_time_;
     std::chrono::steady_clock::time_point last_progress_time_;
-    uint64_t buffers_collected_{0};
     bool writer_started_{false};
 
     void process_dump_buffer(const DumpReadyBufferInfo &info);

--- a/src/common/platform/onboard/aicpu/device_malloc.cpp
+++ b/src/common/platform/onboard/aicpu/device_malloc.cpp
@@ -21,7 +21,6 @@
 #include "common/unified_log.h"
 
 #include <dlfcn.h>
-#include <cstdlib>
 
 using HalMemAllocFn = int (*)(void **pp, unsigned long long size, unsigned long long flag);
 using HalMemFreeFn = int (*)(void *pp);

--- a/src/common/platform/onboard/host/c_api_shared.cpp
+++ b/src/common/platform/onboard/host/c_api_shared.cpp
@@ -34,7 +34,6 @@
 #include <dlfcn.h>
 #include <pthread.h>
 
-#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <utility>

--- a/src/common/platform/shared/host/scope_stats_collector.cpp
+++ b/src/common/platform/shared/host/scope_stats_collector.cpp
@@ -33,7 +33,6 @@
 #include <cassert>
 #include <cinttypes>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <system_error>
@@ -61,7 +60,6 @@ int ScopeStatsCollector::init(
         return -1;
     }
 
-    num_threads_ = num_threads;
     total_collected_ = 0;
     records_.clear();
     recovered_current_buf_ = 0;
@@ -378,7 +376,6 @@ void ScopeStatsCollector::finalize(ScopeStatsUnregisterCallback unregister_cb, c
     manager_.clear_mappings();
 
     initialized_ = false;
-    num_threads_ = 0;
     total_collected_ = 0;
     clear_memory_context();
     LOG_INFO_V0("ScopeStats collector finalized");

--- a/src/common/platform/shared/host/tensor_dump_collector.cpp
+++ b/src/common/platform/shared/host/tensor_dump_collector.cpp
@@ -186,7 +186,6 @@ void TensorDumpCollector::start_writer_thread_once() {
     bytes_written_.store(0);
     run_start_time_ = std::chrono::steady_clock::now();
     last_progress_time_ = run_start_time_;
-    buffers_collected_ = 0;
 
     writer_thread_ = std::thread(&TensorDumpCollector::writer_loop, this);
 }
@@ -322,7 +321,6 @@ void TensorDumpCollector::process_dump_buffer(const DumpReadyBufferInfo &info) {
 void TensorDumpCollector::on_buffer_collected(const DumpReadyBufferInfo &info) {
     start_writer_thread_once();
     process_dump_buffer(info);
-    buffers_collected_++;
 
     auto now = std::chrono::steady_clock::now();
     if (std::chrono::duration_cast<std::chrono::seconds>(now - last_progress_time_).count() >= 5) {

--- a/src/common/platform/sim/aicpu/orch_so_file.cpp
+++ b/src/common/platform/sim/aicpu/orch_so_file.cpp
@@ -17,7 +17,6 @@
 
 #include "aicpu/orch_so_file.h"
 
-#include <fcntl.h>
 #include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>

--- a/src/common/platform/sim/host/c_api_shared.cpp
+++ b/src/common/platform/sim/host/c_api_shared.cpp
@@ -32,7 +32,6 @@
 #include <dlfcn.h>
 #include <pthread.h>
 
-#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <new>


### PR DESCRIPTION
## Summary

A caller-reachability audit of the **non-arch** dirs (`src/common`, `python`, `simpler_setup`) — not a marker grep — surfaced symbols with no reachable use anywhere in the repo. Each candidate was grepped across `src/` (incl. a2a3/a5), `tests/`, `examples/`, `python/`, `simpler_setup/`, and checked for indirect use (function-pointer tables, nanobind bindings, string/reflection, device-side reads of host structs) before removal.

**Python:**
- `callable_identity.py::_pack_u8` — siblings `_pack_u32`/`_pack_string` are used (13/5 callers); this one has 0.
- `platform_info.py::discover_variants` — sibling `discover_runtimes` has 3 callers; this has 0.
- `goldens/paged_attention.py::run_golden_test` — a `__main__` helper no example/test calls. The module's real shared API (`compute_golden`/`generate_inputs`, imported by many tests) is untouched.

**C++ (`src/common`, host-only):**
- `TensorDumpCollector::buffers_collected_` — incremented/reset, never read.
- `ScopeStatsCollector::num_threads_` — assigned/reset, never read (the init log uses the local param, not the member).
- 6 unused includes (`<cstdlib>`, `<fcntl.h>`, `<cstring>`, `<chrono>`×2) whose symbols aren't used in the including file.

## Deliberately NOT removed

- **Protocol/interface surface in actively-churning files** — the `remote_l3` wire codec (`encode_digest_callable_command`) and worker mailbox helpers (`_read_error_msg`). A zero *in-repo* caller doesn't imply dead for a cross-process protocol: the peer/sender may be cross-repo or in-flight (these files changed within the last week).
- **Identically-dead members in the a2a3/a5 `pmu`/`dep_gen` collectors** — out of scope for this common-only pass.

Net: **−51 lines**, 12 files, no behavior change.

## Testing

- [x] All four runtimes build clean under `-Wall -Wextra`, no warnings (a2a3/a5 × host_build_graph/tensormap_and_ringbuffer)
- [x] `callable_identity` unit tests 79/79
- [x] Collector + golden simulation tests pass — a2a3sim 7/7, a5sim 8/8 (`dfx`, `dump_tensor`, `paged_attention*`)
- [ ] Hardware tests (no behavior change; every removed symbol had zero callers)