### PR TITLE
Fix: wake L3 scheduler on root ready tasks

### DIFF
--- a/src/common/hierarchical/orchestrator.cpp
+++ b/src/common/hierarchical/orchestrator.cpp
@@ -20,7 +20,7 @@
 
 void Orchestrator::init(
     TensorMap *tensormap, Ring *allocator, Scope *scope, ReadyQueue *ready_next_level_queue,
-    ReadyQueue *ready_sub_queue, WorkerManager *manager
+    ReadyQueue *ready_sub_queue, WorkerManager *manager, std::function<void()> ready_notify_cb
 ) {
     tensormap_ = tensormap;
     allocator_ = allocator;
@@ -28,6 +28,7 @@ void Orchestrator::init(
     ready_next_level_queue_ = ready_next_level_queue;
     ready_sub_queue_ = ready_sub_queue;
     manager_ = manager;
+    ready_notify_cb_ = std::move(ready_notify_cb);
     active_tasks_.store(0, std::memory_order_relaxed);
 }
 
@@ -310,6 +311,7 @@ SubmitResult Orchestrator::submit_impl(
     if (live_fanins == 0) {
         s.state.store(TaskState::READY, std::memory_order_release);
         ready_queue_for(worker_type)->push(slot);
+        if (ready_notify_cb_) ready_notify_cb_();
     } else {
         s.state.store(TaskState::PENDING, std::memory_order_release);
     }

--- a/src/common/hierarchical/orchestrator.h
+++ b/src/common/hierarchical/orchestrator.h
@@ -33,6 +33,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -73,7 +74,7 @@ public:
     // the Scheduler's dispatch_ready walks each queue independently.
     void init(
         TensorMap *tensormap, Ring *allocator, Scope *scope, ReadyQueue *ready_next_level_queue,
-        ReadyQueue *ready_sub_queue, WorkerManager *manager = nullptr
+        ReadyQueue *ready_sub_queue, WorkerManager *manager = nullptr, std::function<void()> ready_notify_cb = {}
     );
 
     // Allocate an intermediate buffer from the Worker's HeapRing (MAP_SHARED,
@@ -162,6 +163,7 @@ private:
     Ring *allocator_ = nullptr;
     Scope *scope_ = nullptr;
     WorkerManager *manager_ = nullptr;
+    std::function<void()> ready_notify_cb_;
     // Strict-4 per-worker-type ready queues. Each queue handles tasks of
     // exactly one WorkerType so the Scheduler can dispatch from an idle pool
     // without being blocked by another pool's saturation.

--- a/src/common/hierarchical/scheduler.cpp
+++ b/src/common/hierarchical/scheduler.cpp
@@ -152,6 +152,11 @@ void Scheduler::worker_done(WorkerCompletion completion) {
     completion_cv_.notify_one();
 }
 
+void Scheduler::notify_ready() {
+    std::lock_guard<std::mutex> lk(completion_mu_);
+    completion_cv_.notify_one();
+}
+
 // =============================================================================
 // Scheduler loop
 // =============================================================================
@@ -161,8 +166,9 @@ void Scheduler::run() {
         // Wait until there's something to process
         {
             std::unique_lock<std::mutex> lk(completion_mu_);
-            completion_cv_.wait_for(lk, std::chrono::milliseconds(1), [this] {
-                return !completion_queue_.empty() || stop_requested_.load(std::memory_order_acquire);
+            completion_cv_.wait(lk, [this] {
+                return !completion_queue_.empty() || !cfg_.ready_next_level_queue->empty() ||
+                       !cfg_.ready_sub_queue->empty() || stop_requested_.load(std::memory_order_acquire);
             });
         }
 

--- a/src/common/hierarchical/scheduler.h
+++ b/src/common/hierarchical/scheduler.h
@@ -19,7 +19,7 @@
  * delegated to WorkerManager. The Scheduler only drives the DAG state machine.
  *
  * Flow:
- *   Orch: submit() → ready_queue.push(slot) + cv.notify()
+ *   Orch: submit() → ready_queue.push(slot) + Scheduler::notify_ready()
  *
  *   Scheduler thread:
  *     wait on cv (ready_queue OR completion_queue non-empty)
@@ -72,6 +72,10 @@ public:
     // Called by WorkerManager (from WorkerThread) after endpoint run() reaches
     // a terminal outcome.
     void worker_done(WorkerCompletion completion);
+
+    // Called by Orchestrator after it pushes a newly-ready root task. ReadyQueue
+    // has its own condition variable, but the Scheduler waits on completion_cv_.
+    void notify_ready();
 
     // Mutex held by run() across each loop iteration's slot-touching body
     // (completion processing + dispatch). Orchestrator::drain() acquires it

--- a/src/common/hierarchical/types.cpp
+++ b/src/common/hierarchical/types.cpp
@@ -75,6 +75,11 @@ bool ReadyQueue::try_pop(TaskSlot &out) {
     return true;
 }
 
+bool ReadyQueue::empty() const {
+    std::lock_guard<std::mutex> lk(mu_);
+    return q_.empty();
+}
+
 bool ReadyQueue::wait_pop(TaskSlot &out) {
     std::unique_lock<std::mutex> lk(mu_);
     cv_.wait(lk, [this] {

--- a/src/common/hierarchical/types.h
+++ b/src/common/hierarchical/types.h
@@ -425,6 +425,8 @@ public:
     // Non-blocking: returns false immediately if empty.
     bool try_pop(TaskSlot &out);
 
+    bool empty() const;
+
     // Blocking: waits until a slot is available or shutdown() is called.
     // Returns false only when shutdown and queue is empty.
     bool wait_pop(TaskSlot &out);
@@ -433,7 +435,7 @@ public:
 
 private:
     std::queue<TaskSlot> q_;
-    std::mutex mu_;
+    mutable std::mutex mu_;
     std::condition_variable cv_;
     bool shutdown_{false};
 };

--- a/src/common/hierarchical/worker.cpp
+++ b/src/common/hierarchical/worker.cpp
@@ -94,7 +94,11 @@ void Worker::add_remote_l3_socket(
 void Worker::init() {
     if (initialized_) throw std::runtime_error("Worker: already initialized");
 
-    orchestrator_.init(&tensormap_, &allocator_, &scope_, &ready_next_level_queue_, &ready_sub_queue_, &manager_);
+    orchestrator_.init(
+        &tensormap_, &allocator_, &scope_, &ready_next_level_queue_, &ready_sub_queue_, &manager_, [this] {
+            scheduler_.notify_ready();
+        }
+    );
 
     // Start WorkerManager first — creates WorkerThreads.
     // The on_complete callback routes through the Scheduler's worker_done().


### PR DESCRIPTION
## Summary
- Wake the L3 Scheduler when Orchestrator publishes a root ready task.
- Include ready queues in the Scheduler wait predicate.
- Replace the previous 1 ms `wait_for` polling fallback with event-driven `wait`.

## Why
Root L3 tasks were pushed into `ReadyQueue`, but the Scheduler waited on its
own `completion_cv_`. Since the wait predicate only checked completions and
stop, root ready tasks could sit until the 1 ms timeout fired before dispatching
to the L2 child.

Measured on pypto-serving Qwen3-14B decode, the L3-to-L2 median gap dropped
from 1.627 ms to 0.602 ms. The pre-L2 startup portion dropped from 1.340 ms to
0.471 ms.

## Testing
- `pip install --no-build-isolation -e .`
- `python -m pytest tests/ut/py/test_worker/test_host_worker.py tests/ut/py/test_worker/test_group_task.py tests/ut/py/test_worker/test_error_propagation.py -q`
- `python -m pytest tests/st/a2a3/tensormap_and_ringbuffer/test_l3_dependency.py tests/st/a2a3/tensormap_and_ringbuffer/test_l3_group.py --platform a2a3sim --device 0-1 -q`
- pypto-serving Qwen3-14B decode smoke/perf run through `task-submit`, 16 tokens
