### PR TITLE
update(distributed): convert all_to_all distributed to push-based lowering

### DIFF
--- a/tests/st/worker/collectives/README.md
+++ b/tests/st/worker/collectives/README.md
@@ -20,6 +20,6 @@ collectives/
 ├── allgather/            # Mesh allgather
 ├── reduce_scatter/       # Mesh reduce-scatter
 ├── broadcast/            # Mesh broadcast
-├── all_to_all/           # Mesh all-to-all
+├── all_to_all/           # Push-based mesh all-to-all (TPUT → barrier → local copy-out)
 └── README.md
 ```

--- a/tests/st/worker/collectives/all_to_all/README.md
+++ b/tests/st/worker/collectives/all_to_all/README.md
@@ -2,20 +2,19 @@
 
 Personalized exchange: each rank sends a different slice to each peer through the HCCL window.
 
-## Algorithm (2-Phase Push)
+## Algorithm (push → barrier → local copy-out)
 
 ```text
-Phase 1: push        for d in 0..P-1: TPUT input[d * C] → peer d's scratch[my_rank * C]
-                     Self-rank handled naturally — CommRemotePtr to self returns local pointer
-Phase 2: barrier     mesh barrier (all-to-all notify/wait); no post-exchange barrier needed
-Phase 3: copy-out    for s in 0..P-1: TLOAD(local scratch[s * C]) → output[s * C]  (purely local)
+push        for d in 0..P-1: TPUT input[d * C] → peer d's scratch[my_rank * C]
+            Self-rank: CommRemotePtr to self returns the local pointer
+barrier     mesh notify/wait (all-to-all)
+copy-out    for s in 0..P-1: TLOAD(local scratch[s * C]) → output[s * C]
 ```
 
 **Input**: Each rank owns `nranks * COUNT_PER_RANK=64` floats. Chunk d is payload for rank d.
 **Output**: Each rank receives `nranks * 64` floats — the data every peer sent to it.
 
-After Phase 1, scratch at offset `src * C` holds the chunk rank `src` pushed here.
-After the barrier, the result is in scratch — Phase 3 is a purely local copy to the output tensor.
+Scratch at offset `src * C` holds the chunk rank `src` pushed here; after the barrier, copy-out is local.
 
 ## Golden Check
 

--- a/tests/st/worker/collectives/all_to_all/README.md
+++ b/tests/st/worker/collectives/all_to_all/README.md
@@ -2,14 +2,20 @@
 
 Personalized exchange: each rank sends a different slice to each peer through the HCCL window.
 
-## Algorithm (3-Phase Mesh)
+## Algorithm (2-Phase Push)
 
-1. **Stage-in**: for d in 0..P-1: `input[d*C] → scratch[d*C]` (chunk d is for rank d)
-2. **Barrier**: mesh barrier (all-to-all notify/wait)
-3. **Exchange**: for s in 0..P-1: `TLOAD(peer s scratch[my_rank*C]) → output[s*C]`
+```text
+Phase 1: push        for d in 0..P-1: TPUT input[d * C] → peer d's scratch[my_rank * C]
+                     Self-rank handled naturally — CommRemotePtr to self returns local pointer
+Phase 2: barrier     mesh barrier (all-to-all notify/wait); no post-exchange barrier needed
+Phase 3: copy-out    for s in 0..P-1: TLOAD(local scratch[s * C]) → output[s * C]  (purely local)
+```
 
 **Input**: Each rank owns `nranks * COUNT_PER_RANK=64` floats. Chunk d is payload for rank d.
 **Output**: Each rank receives `nranks * 64` floats — the data every peer sent to it.
+
+After Phase 1, scratch at offset `src * C` holds the chunk rank `src` pushed here.
+After the barrier, the result is in scratch — Phase 3 is a purely local copy to the output tensor.
 
 ## Golden Check
 

--- a/tests/st/worker/collectives/all_to_all/kernels/aiv/all_to_all_kernel.cpp
+++ b/tests/st/worker/collectives/all_to_all/kernels/aiv/all_to_all_kernel.cpp
@@ -9,13 +9,23 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * AllToAll kernel — symmetric, 3-phase, HCCL-window scratch pattern.
+ * AllToAll kernel — symmetric, 2-phase push-based pattern.
  *
- * Phase 1 (stage-in):   for dest in 0..nranks-1: input[dest*C..) → scratch[dest*C..)
- * Phase 2 (barrier):    signal matrix + TWAIT cross-rank sync
- * Phase 3 (exchange):   for src in 0..nranks-1: TLOAD(peer src scratch[my_rank*C]) → output[src*C..)
+ * Phase 1 (push):     for dest in 0..nranks-1:
+ *                       TPUT input[dest*C..) → peer dest's scratch[my_rank*C..)
+ *                     Self-rank handled naturally: CommRemotePtr to self
+ *                     returns the local pointer, so TPUT degenerates to a
+ *                     local GM write.
+ * Phase 2 (barrier):  signal matrix + TWAIT cross-rank sync.
+ *                     No post-exchange barrier needed — input is read-only
+ *                     and the scratch is write-only from peers, so there is
+ *                     no WAR hazard on the scratch.
+ * Phase 3 (copy-out): for src in 0..nranks-1:
+ *                       TLOAD(local scratch[src*C..)) → TSTORE(output[src*C..))
+ *                     Purely local copy — the scratch already holds the
+ *                     result after the barrier.
  *
- * Scratch is indexed by destination rank: scratch[dest*C] holds the chunk sent to dest.
+ * Scratch at offset src*C holds the chunk that rank src pushed here.
  *
  * args layout:
  *   tensor(0) = input    nranks*COUNT_PER_RANK floats  (INPUT)
@@ -74,35 +84,34 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
         return;
     }
 
-    // signal_base follows the nranks * COUNT_PER_RANK float staging region.
+    // signal_base follows the nranks * COUNT_PER_RANK float data region.
     __gm__ int32_t *signal_base = reinterpret_cast<__gm__ int32_t *>(scratch + nranks * COUNT_PER_RANK);
 
     ShapeDyn shape(1, 1, 1, 1, COUNT_PER_RANK);
     StrideDyn stride(COUNT_PER_RANK, COUNT_PER_RANK, COUNT_PER_RANK, COUNT_PER_RANK, 1);
 
-    TileData stageTile(1, COUNT_PER_RANK);
-    TileData recvTile(1, COUNT_PER_RANK);
-    TASSIGN(stageTile, 0x0);
-    TASSIGN(recvTile, 0x10000);
+    // Single push tile — reused for both Phase 1 push and Phase 3 copy-out.
+    TileData pushTile(1, COUNT_PER_RANK);
+    TASSIGN(pushTile, 0x0);
 
     // ------------------------------------------------------------------
-    // Phase 1: stage-in — copy each destination chunk into scratch so
-    // every peer can read the slice destined for them in Phase 3.
+    // Phase 1: push — TPUT each destination chunk directly into the
+    // corresponding peer's scratch at offset my_rank*C. When dest == my_rank
+    // CommRemotePtr returns the local pointer, so TPUT is a local GM write.
     // ------------------------------------------------------------------
+    __gm__ float *scratch_dst_local = scratch + my_rank * COUNT_PER_RANK;
     for (int dest = 0; dest < nranks; ++dest) {
+        __gm__ float *scratch_dst_remote = CommRemotePtr(commCtx, scratch_dst_local, dest);
+
         Global inputChunkG(input + dest * COUNT_PER_RANK, shape, stride);
-        Global scratchChunkG(scratch + dest * COUNT_PER_RANK, shape, stride);
-        TLOAD(stageTile, inputChunkG);
-        set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        TSTORE(scratchChunkG, stageTile);
-        set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
-        wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
+        Global scratchChunkG(scratch_dst_remote, shape, stride);
+
+        pto::comm::TPUT(scratchChunkG, inputChunkG, pushTile);
     }
     pipe_barrier(PIPE_ALL);
 
     // ------------------------------------------------------------------
-    // Phase 2: device barrier — notify every peer that stage-in is done,
+    // Phase 2: device barrier — notify every peer that our pushes are done,
     // then wait until every peer has notified us.
     // ------------------------------------------------------------------
     for (int peer = 0; peer < nranks; ++peer) {
@@ -119,19 +128,17 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     pipe_barrier(PIPE_ALL);
 
     // ------------------------------------------------------------------
-    // Phase 3: exchange — read chunk my_rank from every rank's scratch and
-    // write it into the corresponding slice of the output tensor.
-    // CommRemotePtr with pe==my_rank returns localPtr unchanged, so the
-    // self-read goes through the same code path as the remote reads.
+    // Phase 3: copy-out — every peer has pushed into our scratch at their
+    // rank's offset. Copy each slot into the output tensor. Purely local
+    // reads — no CommRemotePtr needed here.
     // ------------------------------------------------------------------
     for (int src = 0; src < nranks; ++src) {
-        __gm__ float *remote_chunk = CommRemotePtr(commCtx, scratch + my_rank * COUNT_PER_RANK, src);
-        Global remoteG(remote_chunk, shape, stride);
+        Global scratchSlotG(scratch + src * COUNT_PER_RANK, shape, stride);
         Global outputSlotG(output + src * COUNT_PER_RANK, shape, stride);
-        TLOAD(recvTile, remoteG);
+        TLOAD(pushTile, scratchSlotG);
         set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
-        TSTORE(outputSlotG, recvTile);
+        TSTORE(outputSlotG, pushTile);
         set_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_MTE2, EVENT_ID0);
     }

--- a/tests/st/worker/collectives/all_to_all/kernels/aiv/all_to_all_kernel.cpp
+++ b/tests/st/worker/collectives/all_to_all/kernels/aiv/all_to_all_kernel.cpp
@@ -9,23 +9,16 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * AllToAll kernel — symmetric, 2-phase push-based pattern.
+ * AllToAll kernel — push-based (TPUT → barrier → local copy-out).
  *
- * Phase 1 (push):     for dest in 0..nranks-1:
- *                       TPUT input[dest*C..) → peer dest's scratch[my_rank*C..)
- *                     Self-rank handled naturally: CommRemotePtr to self
- *                     returns the local pointer, so TPUT degenerates to a
- *                     local GM write.
- * Phase 2 (barrier):  signal matrix + TWAIT cross-rank sync.
- *                     No post-exchange barrier needed — input is read-only
- *                     and the scratch is write-only from peers, so there is
- *                     no WAR hazard on the scratch.
- * Phase 3 (copy-out): for src in 0..nranks-1:
- *                       TLOAD(local scratch[src*C..)) → TSTORE(output[src*C..))
- *                     Purely local copy — the scratch already holds the
- *                     result after the barrier.
+ *   push:      TPUT input[dest*C..) → peer dest scratch[my_rank*C..)
+ *              (CommRemotePtr to self returns localPtr → local write)
+ *   barrier:   signal matrix TNOTIFY / TWAIT
+ *   copy-out:  TLOAD(local scratch[src*C..)) → TSTORE(output[src*C..))
  *
- * Scratch at offset src*C holds the chunk that rank src pushed here.
+ * Scratch invariant: slot src*C holds the chunk rank src pushed here.
+ * Input is read-only and peer writes land in distinct scratch slots, so no
+ * post-exchange barrier is required before copy-out.
  *
  * args layout:
  *   tensor(0) = input    nranks*COUNT_PER_RANK floats  (INPUT)
@@ -90,15 +83,11 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     ShapeDyn shape(1, 1, 1, 1, COUNT_PER_RANK);
     StrideDyn stride(COUNT_PER_RANK, COUNT_PER_RANK, COUNT_PER_RANK, COUNT_PER_RANK, 1);
 
-    // Single push tile — reused for both Phase 1 push and Phase 3 copy-out.
+    // Reused for push staging and local copy-out.
     TileData pushTile(1, COUNT_PER_RANK);
     TASSIGN(pushTile, 0x0);
 
-    // ------------------------------------------------------------------
-    // Phase 1: push — TPUT each destination chunk directly into the
-    // corresponding peer's scratch at offset my_rank*C. When dest == my_rank
-    // CommRemotePtr returns the local pointer, so TPUT is a local GM write.
-    // ------------------------------------------------------------------
+    // Push each destination chunk into peer dest's scratch[my_rank*C].
     __gm__ float *scratch_dst_local = scratch + my_rank * COUNT_PER_RANK;
     for (int dest = 0; dest < nranks; ++dest) {
         __gm__ float *scratch_dst_remote = CommRemotePtr(commCtx, scratch_dst_local, dest);
@@ -110,10 +99,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
     pipe_barrier(PIPE_ALL);
 
-    // ------------------------------------------------------------------
-    // Phase 2: device barrier — notify every peer that our pushes are done,
-    // then wait until every peer has notified us.
-    // ------------------------------------------------------------------
+    // Device barrier: notify peers that our pushes are done, then wait.
     for (int peer = 0; peer < nranks; ++peer) {
         if (peer == my_rank) continue;
         __gm__ int32_t *remote_signal = CommRemotePtr(commCtx, signal_base + my_rank, peer);
@@ -127,11 +113,7 @@ extern "C" __aicore__ __attribute__((always_inline)) void kernel_entry(__gm__ in
     }
     pipe_barrier(PIPE_ALL);
 
-    // ------------------------------------------------------------------
-    // Phase 3: copy-out — every peer has pushed into our scratch at their
-    // rank's offset. Copy each slot into the output tensor. Purely local
-    // reads — no CommRemotePtr needed here.
-    // ------------------------------------------------------------------
+    // Local copy-out from scratch slots into output.
     for (int src = 0; src < nranks; ++src) {
         Global scratchSlotG(scratch + src * COUNT_PER_RANK, shape, stride);
         Global outputSlotG(output + src * COUNT_PER_RANK, shape, stride);

--- a/tests/st/worker/collectives/all_to_all/kernels/orchestration/all_to_all_orch.cpp
+++ b/tests/st/worker/collectives/all_to_all/kernels/orchestration/all_to_all_orch.cpp
@@ -9,11 +9,11 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * AllToAll orchestration shim — push-based (2 kernel phases + local copy-out).
+ * AllToAll orchestration shim — push-based (TPUT → barrier → local copy-out).
  *
  *   tensor(0) input   INPUT           (nranks*COUNT_PER_RANK floats)
  *   tensor(1) output  OUTPUT_EXISTING (nranks*COUNT_PER_RANK floats)
- *   tensor(2) scratch INOUT           (HCCL window slot — holds result after barrier)
+ *   tensor(2) scratch INOUT           (HCCL window; result lives here after barrier)
  *   scalar(0) nranks
  *   scalar(1) CommContext device pointer
  */

--- a/tests/st/worker/collectives/all_to_all/kernels/orchestration/all_to_all_orch.cpp
+++ b/tests/st/worker/collectives/all_to_all/kernels/orchestration/all_to_all_orch.cpp
@@ -9,11 +9,11 @@
  * -----------------------------------------------------------------------------------------------------------
  */
 /**
- * AllToAll orchestration shim.
+ * AllToAll orchestration shim — push-based (2 kernel phases + local copy-out).
  *
  *   tensor(0) input   INPUT           (nranks*COUNT_PER_RANK floats)
  *   tensor(1) output  OUTPUT_EXISTING (nranks*COUNT_PER_RANK floats)
- *   tensor(2) scratch INOUT           (HCCL window slot)
+ *   tensor(2) scratch INOUT           (HCCL window slot — holds result after barrier)
  *   scalar(0) nranks
  *   scalar(1) CommContext device pointer
  */


### PR DESCRIPTION
## Summary

Replace the pull-based all_to_all kernel (stage-in → barrier → remote TLOAD)
with a push-based kernel (TPUT → barrier → local copy-out), mirroring the
approach in pypto#1937.

Collective demos were relocated to `tests/st/worker/collectives/` in #1294;
this PR applies the push rewrite in that ST home (not under
`examples/workers/l3/all_to_all_distributed/`).

### Benefits

- **No separate stage-in loop**: peers receive chunks via `TPUT` instead of
  staging locally for remote reads.
- **No remote reads on copy-out**: after the barrier, scratch already holds
  the result — only local `TLOAD`/`TSTORE`.
- **Fewer tiles**: single `pushTile` (was `stageTile` + `recvTile`).
- **No post-exchange barrier**: input is read-only; peer writes land in
  distinct scratch slots (no WAR on scratch).
- **Simpler data flow**: linear push → sync → local copy-out.

### What changed

| File | Change |
|------|--------|
| `tests/st/worker/collectives/all_to_all/kernels/aiv/all_to_all_kernel.cpp` | Pull → push using `pto::comm::TPUT` |
| `…/orchestration/all_to_all_orch.cpp` | Comments updated for push flow |
| `…/all_to_all/README.md` | Algorithm description (push → barrier → local copy-out) |
| `tests/st/worker/collectives/README.md` | Index line notes push-based all_to_all |

### How it works

```text
push        for dest in 0..NR-1:
              TPUT input[dest*C..] → peer dest's scratch[my_rank*C..]
            Self-rank: CommRemotePtr to self → local pointer → local write
barrier     TNOTIFY all, TWAIT all (unchanged shape)
copy-out    for src in 0..NR-1:
              TLOAD(local scratch[src*C..]) → TSTORE(output[src*C..])
```

`pto::comm::TPUT` follows the pattern in
`examples/workers/l3/ep_dispatch_combine/kernels/aiv/combine.cpp`.

### Verification

- [x] Pre-commit (headers, cpplint, clang-format, markdownlint, …)
- [x] Docker sim (`Dockerfile.simpler.sim.ubuntu22.04`): `TestAllToAllP2` PASS
- [x] Docker sim: `TestAllToAllP4` PASS
- [ ] Hardware P=2, P=4 (pending)

### References

- pypto#1937: push-based all_to_all proposal by @YunjiQin
- `ep_dispatch_combine/kernels/aiv/combine.cpp`: existing TPUT usage
- simpler#1294: collectives relocated into `tests/st/worker/collectives/`